### PR TITLE
add episode summaries and prominent cross-promotion to all 5 podcast …

### DIFF
--- a/env-intel.html
+++ b/env-intel.html
@@ -70,13 +70,35 @@
     .about-section h2 { font-size: 1.5rem; font-weight: 800; margin-bottom: 1rem; }
     .about-section p { color: var(--text-muted); margin-bottom: 0.75rem; }
 
-    .network-section { max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem 3rem; }
-    .network-section h2 { font-size: 1.5rem; font-weight: 800; margin-bottom: 1.5rem; }
-    .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 0.75rem; }
-    .network-card { display: block; background: var(--card); border-radius: var(--radius); padding: 1rem 1.25rem; border: 1px solid #1a3020; font-weight: 600; font-size: 0.95rem; color: var(--text); transition: border-color 0.2s; }
-    .network-card:hover { border-color: var(--brand-alt); text-decoration: none; }
-    .network-card small { display: block; color: var(--text-muted); font-weight: 400; font-size: 0.8rem; margin-top: 0.25rem; }
-    .network-card.current { opacity: 0.5; pointer-events: none; border-color: var(--brand-alt); }
+    /* Episode summary styles */
+    .ep-summary { color: var(--text-muted); font-size: 0.85rem; margin: 0.75rem 0; line-height: 1.7; }
+    .ep-summary-preview { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+    .ep-summary.expanded .ep-summary-preview { display: block; -webkit-line-clamp: unset; }
+    .ep-summary-full { display: none; max-height: 500px; overflow-y: auto; padding-right: 0.5rem; }
+    .ep-summary.expanded .ep-summary-full { display: block; }
+    .ep-summary-toggle { display: inline-block; margin-top: 0.5rem; color: var(--brand-alt); font-size: 0.85rem; font-weight: 600; cursor: pointer; border: none; background: none; padding: 0; }
+    .ep-summary-toggle:hover { text-decoration: underline; }
+
+    /* Network cross-promotion section */
+    .network-section { max-width: 1100px; margin: 0 auto; padding: 3rem 1.5rem 3rem; }
+    .network-section h2 { font-size: 1.8rem; font-weight: 900; margin-bottom: 0.5rem; }
+    .network-section .network-subtitle { color: var(--text-muted); margin-bottom: 2rem; font-size: 1rem; }
+    .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; }
+    .network-card { display: flex; flex-direction: column; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #1a3020; transition: border-color 0.2s, transform 0.2s; }
+    .network-card:hover { border-color: var(--brand-alt); transform: translateY(-2px); }
+    .network-card.current { border-color: var(--brand-alt); background: rgba(76,175,80,0.05); }
+    .network-card-header { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
+    .network-card-emoji { font-size: 2rem; line-height: 1; }
+    .network-card-name { font-weight: 800; font-size: 1.1rem; color: var(--text); }
+    .network-card-tagline { color: var(--brand-alt); font-size: 0.85rem; font-weight: 600; margin-bottom: 0.5rem; font-style: italic; }
+    .network-card-desc { color: var(--text-muted); font-size: 0.85rem; line-height: 1.5; margin-bottom: 1rem; flex-grow: 1; }
+    .network-card-links { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+    .network-card-links a { font-size: 0.8rem; font-weight: 600; color: var(--brand-alt); padding: 0.3rem 0.7rem; border: 1px solid rgba(76,175,80,0.3); border-radius: 6px; transition: background 0.2s; }
+    .network-card-links a:hover { background: rgba(76,175,80,0.15); text-decoration: none; }
+    .network-card-current-badge { display: inline-block; font-size: 0.7rem; font-weight: 700; color: var(--brand-alt); background: rgba(76,175,80,0.15); padding: 0.15rem 0.5rem; border-radius: 10px; margin-left: 0.5rem; text-transform: uppercase; letter-spacing: 0.5px; }
+    .network-see-all { text-align: center; margin-top: 2rem; }
+    .network-see-all a { display: inline-block; padding: 0.7rem 2rem; background: var(--brand); color: var(--text); border-radius: 8px; font-weight: 700; font-size: 0.95rem; transition: background 0.2s; }
+    .network-see-all a:hover { background: var(--brand-dark); text-decoration: none; }
 
     footer { border-top: 1px solid #1a3020; padding: 2rem 1.5rem; text-align: center; }
     .footer-links { display: flex; gap: 1.5rem; justify-content: center; flex-wrap: wrap; margin-bottom: 1rem; }
@@ -90,7 +112,7 @@
       .nav-links.open { display: flex; }
       .hero { padding: 3rem 1.5rem 2rem; }
       .episodes-grid { grid-template-columns: 1fr; }
-      .network-grid { grid-template-columns: 1fr 1fr; }
+      .network-grid { grid-template-columns: 1fr; }
     }
   </style>
 </head>
@@ -101,6 +123,7 @@
       <button class="menu-toggle" aria-label="Menu">&#9776;</button>
       <div class="nav-links">
         <a href="#episodes">Episodes</a>
+        <a href="env-intel-summaries.html">Summaries</a>
         <a href="#about">About</a>
         <a href="env_intel_podcast.rss">RSS</a>
       </div>
@@ -139,14 +162,84 @@
       <p>Hosted by Patrick in Vancouver, each episode distills the latest regulatory updates, scientific findings, and policy developments into a concise, actionable briefing for consultants, regulators, and environmental practitioners.</p>
     </section>
 
-    <section class="network-section">
-      <h2>More from our network</h2>
+    <section class="network-section" id="network">
+      <h2>Explore Our Podcast Network</h2>
+      <p class="network-subtitle">Five daily shows covering Tesla, world news, space, science, and the environment.</p>
       <div class="network-grid">
-        <a href="index.html" class="network-card">Tesla Shorts Time<small>Tesla news and EV analysis</small></a>
-        <a href="omni-view.html" class="network-card">Omni View<small>Balanced news perspectives</small></a>
-        <a href="fascinating_frontiers.html" class="network-card">Fascinating Frontiers<small>Space and astronomy</small></a>
-        <a href="planetterrian.html" class="network-card">Planetterrian Daily<small>Science and longevity</small></a>
-        <a href="env-intel.html" class="network-card current">Environmental Intelligence<small>You are here</small></a>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#9889;</span>
+            <span class="network-card-name">Tesla Shorts Time</span>
+          </div>
+          <div class="network-card-tagline">Shorting Tesla? Time's Up.</div>
+          <div class="network-card-desc">Daily Tesla news, stock analysis, and EV future.</div>
+          <div class="network-card-links">
+            <a href="index.html">Listen</a>
+            <a href="podcast.rss">RSS</a>
+            <a href="https://x.com/teslashortstime" target="_blank" rel="noopener">Follow on X</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#128065;</span>
+            <span class="network-card-name">Omni View</span>
+          </div>
+          <div class="network-card-tagline">See every side. Decide for yourself.</div>
+          <div class="network-card-desc">Balanced daily news briefing for media literacy.</div>
+          <div class="network-card-links">
+            <a href="omni-view.html">Listen</a>
+            <a href="omni_view_podcast.rss">RSS</a>
+            <a href="https://x.com/omniviewnews" target="_blank" rel="noopener">Follow on X</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#128640;</span>
+            <span class="network-card-name">Fascinating Frontiers</span>
+          </div>
+          <div class="network-card-tagline">Journey to the stars.</div>
+          <div class="network-card-desc">Daily space, astronomy, and cosmic discovery news.</div>
+          <div class="network-card-links">
+            <a href="fascinating_frontiers.html">Listen</a>
+            <a href="fascinating_frontiers_podcast.rss">RSS</a>
+            <a href="https://x.com/planetterrian" target="_blank" rel="noopener">Follow on X</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#127758;</span>
+            <span class="network-card-name">Planetterrian Daily</span>
+          </div>
+          <div class="network-card-tagline">Science, longevity, human health.</div>
+          <div class="network-card-desc">Science, longevity, genetics, and health research.</div>
+          <div class="network-card-links">
+            <a href="planetterrian.html">Listen</a>
+            <a href="planetterrian_podcast.rss">RSS</a>
+            <a href="https://x.com/planetterrian" target="_blank" rel="noopener">Follow on X</a>
+          </div>
+        </div>
+
+        <div class="network-card current">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#127793;</span>
+            <span class="network-card-name">Environmental Intelligence</span>
+            <span class="network-card-current-badge">Current</span>
+          </div>
+          <div class="network-card-tagline">Daily environmental briefing.</div>
+          <div class="network-card-desc">Environmental regulatory and compliance briefing.</div>
+          <div class="network-card-links">
+            <a href="env-intel.html">Listen</a>
+            <a href="env_intel_podcast.rss">RSS</a>
+          </div>
+        </div>
+
+      </div>
+      <div class="network-see-all">
+        <a href="network.html">See all shows &rarr;</a>
       </div>
     </section>
   </main>
@@ -184,16 +277,52 @@
 
       const grid = document.getElementById('episodes-grid');
       grid.innerHTML = '';
-      episodes.slice(0, 12).forEach(ep => {
+      episodes.slice(0, 12).forEach((ep, idx) => {
         const card = document.createElement('div');
         card.className = 'episode-card';
+
+        let summaryHtml = '';
+        if (ep.content) {
+          const preview = ep.content.substring(0, 200).replace(/\s+\S*$/, '') + (ep.content.length > 200 ? '...' : '');
+          const fullHtml = renderMarkdown(ep.content);
+          summaryHtml = `
+            <div class="ep-summary" id="summary-${idx}">
+              <div class="ep-summary-preview">${escapeHtml(preview)}</div>
+              <div class="ep-summary-full">${fullHtml}</div>
+              <button class="ep-summary-toggle" onclick="toggleSummary(${idx})">Read full summary</button>
+            </div>
+          `;
+        }
+
         card.innerHTML = `
           <div class="ep-date">${formatDate(ep.date)}</div>
           <div class="ep-title">${escapeHtml(ep.episode_title || 'Episode')}</div>
+          ${summaryHtml}
           <audio controls preload="none" src="${ep.audio_url || ''}"></audio>
         `;
         grid.appendChild(card);
       });
+    }
+
+    function toggleSummary(idx) {
+      const summary = document.getElementById('summary-' + idx);
+      if (!summary) return;
+      const isExpanded = summary.classList.toggle('expanded');
+      const btn = summary.querySelector('.ep-summary-toggle');
+      if (btn) btn.textContent = isExpanded ? 'Collapse summary' : 'Read full summary';
+    }
+
+    function renderMarkdown(text) {
+      let html = escapeHtml(text);
+      // ### headings to <h4>
+      html = html.replace(/^### (.+)$/gm, '<h4 style="color:var(--text);font-size:0.95rem;margin:0.75rem 0 0.25rem;">$1</h4>');
+      // **bold** to <strong>
+      html = html.replace(/\*\*(.+?)\*\*/g, '<strong style="color:var(--text);">$1</strong>');
+      // URLs to clickable links
+      html = html.replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener">$1</a>');
+      // Newlines to <br>
+      html = html.replace(/\n/g, '<br>');
+      return html;
     }
 
     function loadFromRSS() {

--- a/fascinating_frontiers.html
+++ b/fascinating_frontiers.html
@@ -95,13 +95,37 @@
     .about-section h2 { font-size: 1.5rem; font-weight: 800; margin-bottom: 1rem; }
     .about-section p { color: var(--text-muted); margin-bottom: 0.75rem; }
 
-    .network-section { max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem 3rem; }
-    .network-section h2 { font-size: 1.5rem; font-weight: 800; margin-bottom: 1.5rem; }
-    .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 0.75rem; }
-    .network-card { display: block; background: var(--card); border-radius: var(--radius); padding: 1rem 1.25rem; border: 1px solid #1a1f35; font-weight: 600; font-size: 0.95rem; color: var(--text); transition: border-color 0.2s; }
-    .network-card:hover { border-color: var(--brand); text-decoration: none; }
-    .network-card small { display: block; color: var(--text-muted); font-weight: 400; font-size: 0.8rem; margin-top: 0.25rem; }
-    .network-card.current { opacity: 0.5; pointer-events: none; border-color: var(--brand); }
+    /* Episode summary styles */
+    .ep-summary { color: var(--text-muted); font-size: 0.85rem; margin: 0.75rem 0; line-height: 1.7; }
+    .ep-summary-preview { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+    .ep-summary.expanded .ep-summary-preview { display: none; }
+    .ep-summary-full { display: none; max-height: 500px; overflow-y: auto; padding-right: 0.5rem; }
+    .ep-summary.expanded .ep-summary-full { display: block; }
+    .ep-summary-toggle { display: inline-block; margin-top: 0.5rem; color: var(--brand, var(--brand-alt)); font-size: 0.85rem; font-weight: 600; cursor: pointer; border: none; background: none; padding: 0; }
+    .ep-summary-toggle:hover { text-decoration: underline; }
+    .ep-summary-full h4 { font-size: 0.9rem; color: var(--text); margin: 0.75rem 0 0.35rem; font-weight: 700; }
+    .ep-summary-full a { color: var(--brand-alt); word-break: break-all; }
+
+    /* Network section styles */
+    .network-section { max-width: 1100px; margin: 0 auto; padding: 3rem 1.5rem 3rem; }
+    .network-section h2 { font-size: 1.75rem; font-weight: 800; margin-bottom: 0.5rem; text-align: center; }
+    .network-subtitle { color: var(--text-muted); text-align: center; margin-bottom: 2rem; font-size: 0.95rem; }
+    .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; }
+    .network-card { display: block; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #1a1f35; color: var(--text); transition: border-color 0.2s, background 0.2s; }
+    .network-card:hover { border-color: var(--brand); background: var(--card-hover); text-decoration: none; }
+    .network-card.current { border-color: var(--brand); background: var(--card-hover); }
+    .network-card-header { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
+    .network-card-emoji { font-size: 1.75rem; }
+    .network-card-name { font-weight: 700; font-size: 1.05rem; }
+    .network-card-tagline { color: var(--brand-alt); font-size: 0.85rem; font-weight: 600; font-style: italic; margin-bottom: 0.5rem; }
+    .network-card-desc { color: var(--text-muted); font-size: 0.85rem; margin-bottom: 0.75rem; line-height: 1.5; }
+    .network-card-links { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .network-card-links a { font-size: 0.8rem; color: var(--brand-alt); font-weight: 500; }
+    .network-card-links a:hover { text-decoration: underline; }
+    .network-card.current .network-card-badge { display: inline-block; background: var(--brand); color: #fff; font-size: 0.7rem; font-weight: 700; padding: 0.15rem 0.5rem; border-radius: 4px; margin-left: 0.5rem; text-transform: uppercase; letter-spacing: 0.5px; }
+    .network-see-all { text-align: center; margin-top: 1.5rem; }
+    .network-see-all a { display: inline-block; padding: 0.6rem 2rem; border: 1px solid var(--brand); border-radius: 8px; color: var(--brand-alt); font-weight: 600; font-size: 0.9rem; transition: background 0.2s; }
+    .network-see-all a:hover { background: var(--card); text-decoration: none; }
 
     footer { border-top: 1px solid #1a1f35; padding: 2rem 1.5rem; text-align: center; }
     .footer-links { display: flex; gap: 1.5rem; justify-content: center; flex-wrap: wrap; margin-bottom: 1rem; }
@@ -115,7 +139,7 @@
       .nav-links.open { display: flex; }
       .hero { padding: 3rem 1.5rem 2rem; }
       .episodes-grid { grid-template-columns: 1fr; }
-      .network-grid { grid-template-columns: 1fr 1fr; }
+      .network-grid { grid-template-columns: 1fr; }
     }
   </style>
 </head>
@@ -126,6 +150,7 @@
       <button class="menu-toggle" aria-label="Menu">&#9776;</button>
       <div class="nav-links">
         <a href="#episodes">Episodes</a>
+        <a href="fascinating-frontiers-summaries.html">Summaries</a>
         <a href="#about">About</a>
         <a href="https://x.com/planetterrian">@planetterrian</a>
         <a href="fascinating_frontiers_podcast.rss">RSS</a>
@@ -164,14 +189,84 @@
       <p>Hosted by Patrick in Vancouver, each episode covers the most significant developments from space agencies, observatories, and research labs around the world.</p>
     </section>
 
-    <section class="network-section">
-      <h2>More from our network</h2>
+    <section class="network-section" id="network">
+      <h2>Explore Our Podcast Network</h2>
+      <p class="network-subtitle">Five daily shows covering space, science, Tesla, news, and the environment.</p>
       <div class="network-grid">
-        <a href="index.html" class="network-card">Tesla Shorts Time<small>Tesla news and EV analysis</small></a>
-        <a href="omni-view.html" class="network-card">Omni View<small>Balanced news perspectives</small></a>
-        <a href="fascinating_frontiers.html" class="network-card current">Fascinating Frontiers<small>You are here</small></a>
-        <a href="planetterrian.html" class="network-card">Planetterrian Daily<small>Science and longevity</small></a>
-        <a href="env-intel.html" class="network-card">Environmental Intelligence<small>Environmental regulatory briefing</small></a>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#9889;</span>
+            <span class="network-card-name">Tesla Shorts Time</span>
+          </div>
+          <div class="network-card-tagline">Shorting Tesla? Time's Up.</div>
+          <div class="network-card-desc">Daily Tesla news, stock analysis, and EV future.</div>
+          <div class="network-card-links">
+            <a href="index.html">Listen</a>
+            <a href="podcast.rss">RSS</a>
+            <a href="https://x.com/teslashortstime">Follow on X</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#128065;</span>
+            <span class="network-card-name">Omni View</span>
+          </div>
+          <div class="network-card-tagline">See every side. Decide for yourself.</div>
+          <div class="network-card-desc">Balanced daily news briefing for media literacy.</div>
+          <div class="network-card-links">
+            <a href="omni-view.html">Listen</a>
+            <a href="omni_view_podcast.rss">RSS</a>
+            <a href="https://x.com/omniviewnews">Follow on X</a>
+          </div>
+        </div>
+
+        <div class="network-card current">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#128640;</span>
+            <span class="network-card-name">Fascinating Frontiers</span>
+            <span class="network-card-badge">Current</span>
+          </div>
+          <div class="network-card-tagline">Journey to the stars.</div>
+          <div class="network-card-desc">Daily space, astronomy, and cosmic discovery news.</div>
+          <div class="network-card-links">
+            <a href="fascinating_frontiers.html">Listen</a>
+            <a href="fascinating_frontiers_podcast.rss">RSS</a>
+            <a href="https://x.com/planetterrian">Follow on X</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#127758;</span>
+            <span class="network-card-name">Planetterrian Daily</span>
+          </div>
+          <div class="network-card-tagline">Science, longevity, human health.</div>
+          <div class="network-card-desc">Science, longevity, genetics, and health research.</div>
+          <div class="network-card-links">
+            <a href="planetterrian.html">Listen</a>
+            <a href="planetterrian_podcast.rss">RSS</a>
+            <a href="https://x.com/planetterrian">Follow on X</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#127793;</span>
+            <span class="network-card-name">Environmental Intelligence</span>
+          </div>
+          <div class="network-card-tagline">Daily environmental briefing.</div>
+          <div class="network-card-desc">Environmental regulatory and compliance briefing.</div>
+          <div class="network-card-links">
+            <a href="env-intel.html">Listen</a>
+            <a href="env_intel_podcast.rss">RSS</a>
+          </div>
+        </div>
+
+      </div>
+      <div class="network-see-all">
+        <a href="network.html">See all shows</a>
       </div>
     </section>
   </main>
@@ -202,6 +297,22 @@
       }
     }
 
+    function formatMarkdown(text) {
+      if (!text) return '';
+      let html = escapeHtml(text);
+      // Convert ### headings to <h4>
+      html = html.replace(/^### (.+)$/gm, '<h4>$1</h4>');
+      // Convert **bold** to <strong>
+      html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+      // Convert URLs to clickable links
+      html = html.replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener">$1</a>');
+      // Convert newlines to <br> (but not after block elements)
+      html = html.replace(/\n/g, '<br>');
+      // Clean up <br> right after </h4>
+      html = html.replace(/<\/h4><br>/g, '</h4>');
+      return html;
+    }
+
     function renderFromJSON(episodes) {
       if (!episodes || !episodes.length) return;
       const latest = episodes[0];
@@ -210,16 +321,35 @@
 
       const grid = document.getElementById('episodes-grid');
       grid.innerHTML = '';
-      episodes.slice(0, 12).forEach(ep => {
+      episodes.slice(0, 12).forEach((ep, idx) => {
         const card = document.createElement('div');
         card.className = 'episode-card';
+        const content = ep.content || '';
+        const preview = content.substring(0, 200).replace(/\n/g, ' ');
+        const hasContent = content.length > 0;
+        const summaryHtml = hasContent ? `
+          <div class="ep-summary" id="summary-${idx}">
+            <div class="ep-summary-preview">${escapeHtml(preview)}${content.length > 200 ? '...' : ''}</div>
+            <div class="ep-summary-full">${formatMarkdown(content)}</div>
+            <button class="ep-summary-toggle" onclick="toggleSummary(${idx})">Read full summary</button>
+          </div>
+        ` : '';
         card.innerHTML = `
           <div class="ep-date">${formatDate(ep.date)}</div>
           <div class="ep-title">${escapeHtml(ep.episode_title || 'Episode')}</div>
+          ${summaryHtml}
           <audio controls preload="none" src="${ep.audio_url || ''}"></audio>
         `;
         grid.appendChild(card);
       });
+    }
+
+    function toggleSummary(idx) {
+      const summary = document.getElementById('summary-' + idx);
+      if (!summary) return;
+      const expanded = summary.classList.toggle('expanded');
+      const btn = summary.querySelector('.ep-summary-toggle');
+      if (btn) btn.textContent = expanded ? 'Collapse summary' : 'Read full summary';
     }
 
     function loadFromRSS() {

--- a/index.html
+++ b/index.html
@@ -70,19 +70,41 @@
     .episode-card .ep-title { font-weight: 700; font-size: 0.95rem; margin-bottom: 0.75rem; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
     .episode-card audio { width: 100%; }
 
+    /* Episode summaries */
+    .ep-summary { color: var(--text-muted); font-size: 0.85rem; margin: 0.75rem 0; line-height: 1.7; }
+    .ep-summary-preview { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+    .ep-summary.expanded .ep-summary-preview { display: none; }
+    .ep-summary-full { display: none; max-height: 500px; overflow-y: auto; padding-right: 0.5rem; }
+    .ep-summary.expanded .ep-summary-full { display: block; }
+    .ep-summary-toggle { display: inline-block; margin-top: 0.5rem; color: var(--brand); font-size: 0.85rem; font-weight: 600; cursor: pointer; border: none; background: none; padding: 0; }
+    .ep-summary-toggle:hover { text-decoration: underline; }
+
     /* About */
     .about-section { max-width: 700px; margin: 0 auto; padding: 2rem 1.5rem 3rem; }
     .about-section h2 { font-size: 1.5rem; font-weight: 800; margin-bottom: 1rem; }
     .about-section p { color: var(--text-muted); margin-bottom: 0.75rem; }
 
     /* Network */
-    .network-section { max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem 3rem; }
-    .network-section h2 { font-size: 1.5rem; font-weight: 800; margin-bottom: 1.5rem; }
-    .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 0.75rem; }
-    .network-card { display: block; background: var(--card); border-radius: var(--radius); padding: 1rem 1.25rem; border: 1px solid #222; font-weight: 600; font-size: 0.95rem; color: var(--text); transition: border-color 0.2s; }
-    .network-card:hover { border-color: var(--brand); text-decoration: none; }
-    .network-card small { display: block; color: var(--text-muted); font-weight: 400; font-size: 0.8rem; margin-top: 0.25rem; }
-    .network-card.current { opacity: 0.5; pointer-events: none; border-color: var(--brand); }
+    .network-section { max-width: 1100px; margin: 0 auto; padding: 3rem 1.5rem 3rem; border-top: 1px solid #222; }
+    .network-header { text-align: center; margin-bottom: 2rem; }
+    .network-header h2 { font-size: 1.8rem; font-weight: 900; margin-bottom: 0.5rem; }
+    .network-header p { color: var(--text-muted); max-width: 550px; margin: 0 auto; }
+    .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; }
+    .network-card { display: flex; flex-direction: column; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #222; color: var(--text); transition: border-color 0.2s, transform 0.2s; text-decoration: none; }
+    .network-card:hover { border-color: var(--brand); transform: translateY(-2px); text-decoration: none; }
+    .network-card-head { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
+    .network-card-emoji { font-size: 1.8rem; line-height: 1; }
+    .network-card-name { font-weight: 700; font-size: 1.05rem; }
+    .network-card-tagline { color: var(--brand); font-size: 0.85rem; font-weight: 600; font-style: italic; margin-bottom: 0.5rem; }
+    .network-card-desc { color: var(--text-muted); font-size: 0.85rem; line-height: 1.5; margin-bottom: 0.75rem; flex: 1; }
+    .network-card-links { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+    .network-card-links a { font-size: 0.8rem; font-weight: 600; color: var(--brand); }
+    .network-card-links a:hover { text-decoration: underline; }
+    .network-card.current { border-color: var(--brand); background: linear-gradient(135deg, var(--card) 0%, #1f1015 100%); }
+    .network-card.current .network-card-name::after { content: ' (You are here)'; font-weight: 400; font-size: 0.8rem; color: var(--text-muted); }
+    .network-all { text-align: center; margin-top: 1.5rem; }
+    .network-all a { display: inline-block; padding: 0.65rem 2rem; border-radius: 8px; font-weight: 600; font-size: 0.9rem; border: 1px solid var(--brand); color: var(--brand); transition: all 0.2s; }
+    .network-all a:hover { background: var(--brand); color: var(--text); text-decoration: none; }
 
     /* Footer */
     footer { border-top: 1px solid #222; padding: 2rem 1.5rem; text-align: center; }
@@ -98,7 +120,7 @@
       .nav-links.open { display: flex; }
       .hero { padding: 3rem 1.5rem 2rem; }
       .episodes-grid { grid-template-columns: 1fr; }
-      .network-grid { grid-template-columns: 1fr 1fr; }
+      .network-grid { grid-template-columns: 1fr; }
       .stock-widget { flex-direction: column; text-align: center; gap: 0.25rem; }
     }
   </style>
@@ -110,6 +132,7 @@
       <button class="menu-toggle" aria-label="Menu">&#9776;</button>
       <div class="nav-links">
         <a href="#episodes">Episodes</a>
+        <a href="tesla-summaries.html">Summaries</a>
         <a href="#about">About</a>
         <a href="https://x.com/teslashortstime">@teslashortstime</a>
         <a href="podcast.rss">RSS</a>
@@ -153,14 +176,84 @@
       <p>Hosted by Dan and Patrick, each episode covers market movements, breaking news, and the latest developments from Tesla and the broader electric vehicle world.</p>
     </section>
 
-    <section class="network-section">
-      <h2>More from our network</h2>
+    <section id="network" class="network-section">
+      <div class="network-header">
+        <h2>Explore Our Podcast Network</h2>
+        <p>Five daily shows covering Tesla, world news, space, science, and the environment. Subscribe to the ones that matter to you.</p>
+      </div>
       <div class="network-grid">
-        <a href="index.html" class="network-card current">Tesla Shorts Time<small>You are here</small></a>
-        <a href="omni-view.html" class="network-card">Omni View<small>Balanced news perspectives</small></a>
-        <a href="fascinating_frontiers.html" class="network-card">Fascinating Frontiers<small>Space and astronomy</small></a>
-        <a href="planetterrian.html" class="network-card">Planetterrian Daily<small>Science and longevity</small></a>
-        <a href="env-intel.html" class="network-card">Environmental Intelligence<small>Environmental regulatory briefing</small></a>
+
+        <div class="network-card current">
+          <div class="network-card-head">
+            <span class="network-card-emoji">&#9889;</span>
+            <span class="network-card-name">Tesla Shorts Time</span>
+          </div>
+          <div class="network-card-tagline">Shorting Tesla? Time's Up.</div>
+          <div class="network-card-desc">Daily Tesla news, stock analysis, and EV future.</div>
+          <div class="network-card-links">
+            <a href="podcast.rss">RSS</a>
+            <a href="https://x.com/teslashortstime">@teslashortstime</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-head">
+            <span class="network-card-emoji">&#128065;</span>
+            <span class="network-card-name">Omni View</span>
+          </div>
+          <div class="network-card-tagline">See every side. Decide for yourself.</div>
+          <div class="network-card-desc">Balanced daily news briefing for media literacy.</div>
+          <div class="network-card-links">
+            <a href="omni-view.html">Listen</a>
+            <a href="omni_view_podcast.rss">RSS</a>
+            <a href="https://x.com/omniviewnews">@omniviewnews</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-head">
+            <span class="network-card-emoji">&#128640;</span>
+            <span class="network-card-name">Fascinating Frontiers</span>
+          </div>
+          <div class="network-card-tagline">Journey to the stars.</div>
+          <div class="network-card-desc">Daily space, astronomy, and cosmic discovery news.</div>
+          <div class="network-card-links">
+            <a href="fascinating_frontiers.html">Listen</a>
+            <a href="fascinating_frontiers_podcast.rss">RSS</a>
+            <a href="https://x.com/planetterrian">@planetterrian</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-head">
+            <span class="network-card-emoji">&#127758;</span>
+            <span class="network-card-name">Planetterrian Daily</span>
+          </div>
+          <div class="network-card-tagline">Science, longevity, human health.</div>
+          <div class="network-card-desc">Science, longevity, genetics, and health research.</div>
+          <div class="network-card-links">
+            <a href="planetterrian.html">Listen</a>
+            <a href="planetterrian_podcast.rss">RSS</a>
+            <a href="https://x.com/planetterrian">@planetterrian</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-head">
+            <span class="network-card-emoji">&#127793;</span>
+            <span class="network-card-name">Environmental Intelligence</span>
+          </div>
+          <div class="network-card-tagline">Daily environmental briefing.</div>
+          <div class="network-card-desc">Environmental regulatory and compliance briefing.</div>
+          <div class="network-card-links">
+            <a href="env-intel.html">Listen</a>
+            <a href="env_intel_podcast.rss">RSS</a>
+          </div>
+        </div>
+
+      </div>
+      <div class="network-all">
+        <a href="network.html">See All Shows &rarr;</a>
       </div>
     </section>
   </main>
@@ -191,6 +284,53 @@
       }
     }
 
+    function formatMarkdown(text) {
+      if (!text) return '';
+      let html = escapeHtml(text);
+      // Convert ### headers to <h4>
+      html = html.replace(/^###\s+(.+)$/gm, '<h4 style="margin:0.75rem 0 0.25rem;font-size:0.95rem;color:var(--text);">$1</h4>');
+      // Convert **bold** to <strong>
+      html = html.replace(/\*\*(.+?)\*\*/g, '<strong style="color:var(--text);">$1</strong>');
+      // Convert URLs to clickable links (not already inside an href)
+      html = html.replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener">$1</a>');
+      // Convert newlines to <br>
+      html = html.replace(/\n/g, '<br>');
+      return html;
+    }
+
+    function getPreviewText(content) {
+      if (!content) return '';
+      // Strip markdown formatting for a clean preview
+      let plain = content
+        .replace(/^###\s+/gm, '')
+        .replace(/\*\*(.+?)\*\*/g, '$1')
+        .replace(/https?:\/\/[^\s]+/g, '')
+        .replace(/[━─]+/g, '')
+        .replace(/[\n\r]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+      return plain.length > 200 ? plain.substring(0, 200) + '...' : plain;
+    }
+
+    function toggleSummary(btn) {
+      const summary = btn.closest('.ep-summary');
+      const isExpanded = summary.classList.toggle('expanded');
+      btn.textContent = isExpanded ? 'Collapse summary' : 'Read full summary';
+    }
+
+    function buildSummaryHTML(content) {
+      if (!content) return '';
+      const preview = escapeHtml(getPreviewText(content));
+      const full = formatMarkdown(content);
+      return `
+        <div class="ep-summary">
+          <div class="ep-summary-preview">${preview}</div>
+          <div class="ep-summary-full">${full}</div>
+          <button class="ep-summary-toggle" onclick="toggleSummary(this)">Read full summary</button>
+        </div>
+      `;
+    }
+
     function renderFromJSON(episodes) {
       if (!episodes || !episodes.length) return;
       const latest = episodes[0];
@@ -205,6 +345,7 @@
         card.innerHTML = `
           <div class="ep-date">${formatDate(ep.date)}</div>
           <div class="ep-title">${escapeHtml(ep.episode_title || 'Episode')}</div>
+          ${buildSummaryHTML(ep.content)}
           <audio controls preload="none" src="${ep.audio_url || ''}"></audio>
         `;
         grid.appendChild(card);
@@ -232,11 +373,13 @@
             const pubDate = item.querySelector('pubDate')?.textContent || '';
             const enclosure = item.querySelector('enclosure');
             const url = enclosure ? enclosure.getAttribute('url') : '';
+            const description = item.querySelector('description')?.textContent || '';
             const card = document.createElement('div');
             card.className = 'episode-card';
             card.innerHTML = `
               <div class="ep-date">${pubDate ? formatDate(pubDate) : ''}</div>
               <div class="ep-title">${escapeHtml(title)}</div>
+              ${description ? buildSummaryHTML(description) : ''}
               <audio controls preload="none" src="${url}"></audio>
             `;
             grid.appendChild(card);

--- a/omni-view.html
+++ b/omni-view.html
@@ -68,13 +68,37 @@
     .about-section h2 { font-size: 1.5rem; font-weight: 800; margin-bottom: 1rem; }
     .about-section p { color: var(--text-muted); margin-bottom: 0.75rem; }
 
-    .network-section { max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem 3rem; }
-    .network-section h2 { font-size: 1.5rem; font-weight: 800; margin-bottom: 1.5rem; }
-    .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 0.75rem; }
-    .network-card { display: block; background: var(--card); border-radius: var(--radius); padding: 1rem 1.25rem; border: 1px solid #1e2a42; font-weight: 600; font-size: 0.95rem; color: var(--text); transition: border-color 0.2s; }
-    .network-card:hover { border-color: var(--brand); text-decoration: none; }
-    .network-card small { display: block; color: var(--text-muted); font-weight: 400; font-size: 0.8rem; margin-top: 0.25rem; }
-    .network-card.current { opacity: 0.5; pointer-events: none; border-color: var(--brand); }
+    /* Episode summaries */
+    .ep-summary { color: var(--text-muted); font-size: 0.85rem; margin: 0.75rem 0; line-height: 1.7; }
+    .ep-summary-preview { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+    .ep-summary.expanded .ep-summary-preview { display: block; -webkit-line-clamp: unset; }
+    .ep-summary-full { display: none; max-height: 500px; overflow-y: auto; padding-right: 0.5rem; }
+    .ep-summary.expanded .ep-summary-full { display: block; }
+    .ep-summary-toggle { display: inline-block; margin-top: 0.5rem; color: var(--brand); font-size: 0.85rem; font-weight: 600; cursor: pointer; border: none; background: none; padding: 0; }
+    .ep-summary-toggle:hover { text-decoration: underline; }
+    .ep-summary-full h4 { font-size: 0.9rem; color: var(--text); margin: 0.75rem 0 0.25rem; font-weight: 700; }
+    .ep-summary-full a { color: var(--brand); word-break: break-all; }
+    .ep-summary-full a:hover { text-decoration: underline; }
+
+    /* Podcast network section */
+    .network-section { max-width: 1100px; margin: 0 auto; padding: 3rem 1.5rem 4rem; }
+    .network-section h2 { font-size: 1.8rem; font-weight: 900; margin-bottom: 0.5rem; text-align: center; }
+    .network-subtitle { color: var(--text-muted); text-align: center; margin-bottom: 2rem; font-size: 0.95rem; }
+    .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; }
+    .network-card { display: flex; flex-direction: column; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #1e2a42; transition: border-color 0.2s, transform 0.2s; }
+    .network-card:hover { border-color: var(--brand); transform: translateY(-2px); }
+    .network-card.current { border-color: var(--brand); background: #0d1a33; }
+    .network-card-header { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
+    .network-card-emoji { font-size: 1.8rem; line-height: 1; }
+    .network-card-name { font-weight: 800; font-size: 1.05rem; color: var(--text); }
+    .network-card-tagline { color: var(--brand); font-size: 0.8rem; font-weight: 600; margin-bottom: 0.5rem; }
+    .network-card-desc { color: var(--text-muted); font-size: 0.85rem; line-height: 1.5; margin-bottom: 0.75rem; flex-grow: 1; }
+    .network-card-current { display: inline-block; background: var(--brand); color: #fff; font-size: 0.7rem; font-weight: 700; padding: 0.15rem 0.5rem; border-radius: 4px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 0.5rem; }
+    .network-card-links { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+    .network-card-links a { font-size: 0.8rem; font-weight: 600; color: var(--brand); }
+    .network-card-links a:hover { text-decoration: underline; }
+    .network-see-all { text-align: center; margin-top: 1.5rem; }
+    .network-see-all a { font-weight: 700; font-size: 0.95rem; color: var(--brand); }
 
     footer { border-top: 1px solid #1e2a42; padding: 2rem 1.5rem; text-align: center; }
     .footer-links { display: flex; gap: 1.5rem; justify-content: center; flex-wrap: wrap; margin-bottom: 1rem; }
@@ -88,7 +112,7 @@
       .nav-links.open { display: flex; }
       .hero { padding: 3rem 1.5rem 2rem; }
       .episodes-grid { grid-template-columns: 1fr; }
-      .network-grid { grid-template-columns: 1fr 1fr; }
+      .network-grid { grid-template-columns: 1fr; }
     }
   </style>
 </head>
@@ -99,6 +123,7 @@
       <button class="menu-toggle" aria-label="Menu">&#9776;</button>
       <div class="nav-links">
         <a href="#episodes">Episodes</a>
+        <a href="omni-view-summaries.html">Summaries</a>
         <a href="#about">About</a>
         <a href="https://x.com/omniviewnews">@omniviewnews</a>
         <a href="omni_view_podcast.rss">RSS</a>
@@ -141,14 +166,84 @@
       <p>Hosted by Patrick, each episode covers top stories, world news, business, and technology with balanced analysis and source transparency.</p>
     </section>
 
-    <section class="network-section">
-      <h2>More from our network</h2>
+    <section class="network-section" id="network">
+      <h2>Explore Our Podcast Network</h2>
+      <p class="network-subtitle">Five daily shows covering Tesla, world news, space, science, and the environment.</p>
       <div class="network-grid">
-        <a href="index.html" class="network-card">Tesla Shorts Time<small>Tesla news and EV analysis</small></a>
-        <a href="omni-view.html" class="network-card current">Omni View<small>You are here</small></a>
-        <a href="fascinating_frontiers.html" class="network-card">Fascinating Frontiers<small>Space and astronomy</small></a>
-        <a href="planetterrian.html" class="network-card">Planetterrian Daily<small>Science and longevity</small></a>
-        <a href="env-intel.html" class="network-card">Environmental Intelligence<small>Environmental regulatory briefing</small></a>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#9889;</span>
+            <span class="network-card-name">Tesla Shorts Time</span>
+          </div>
+          <div class="network-card-tagline">Shorting Tesla? Time's Up.</div>
+          <div class="network-card-desc">Daily Tesla news, stock analysis, and EV future.</div>
+          <div class="network-card-links">
+            <a href="index.html">Listen</a>
+            <a href="podcast.rss">RSS</a>
+            <a href="https://x.com/teslashortstime">Follow on X</a>
+          </div>
+        </div>
+
+        <div class="network-card current">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#128065;</span>
+            <span class="network-card-name">Omni View</span>
+          </div>
+          <span class="network-card-current">You are here</span>
+          <div class="network-card-tagline">See every side. Decide for yourself.</div>
+          <div class="network-card-desc">Balanced daily news briefing for media literacy.</div>
+          <div class="network-card-links">
+            <a href="omni-view.html">Listen</a>
+            <a href="omni_view_podcast.rss">RSS</a>
+            <a href="https://x.com/omniviewnews">Follow on X</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#128640;</span>
+            <span class="network-card-name">Fascinating Frontiers</span>
+          </div>
+          <div class="network-card-tagline">Journey to the stars.</div>
+          <div class="network-card-desc">Daily space, astronomy, and cosmic discovery news.</div>
+          <div class="network-card-links">
+            <a href="fascinating_frontiers.html">Listen</a>
+            <a href="fascinating_frontiers_podcast.rss">RSS</a>
+            <a href="https://x.com/planetterrian">Follow on X</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#127758;</span>
+            <span class="network-card-name">Planetterrian Daily</span>
+          </div>
+          <div class="network-card-tagline">Science, longevity, human health.</div>
+          <div class="network-card-desc">Science, longevity, genetics, and health research.</div>
+          <div class="network-card-links">
+            <a href="planetterrian.html">Listen</a>
+            <a href="planetterrian_podcast.rss">RSS</a>
+            <a href="https://x.com/planetterrian">Follow on X</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#127793;</span>
+            <span class="network-card-name">Environmental Intelligence</span>
+          </div>
+          <div class="network-card-tagline">Daily environmental briefing.</div>
+          <div class="network-card-desc">Environmental regulatory and compliance briefing.</div>
+          <div class="network-card-links">
+            <a href="env-intel.html">Listen</a>
+            <a href="env_intel_podcast.rss">RSS</a>
+          </div>
+        </div>
+
+      </div>
+      <div class="network-see-all">
+        <a href="network.html">See all shows &rarr;</a>
       </div>
     </section>
   </main>
@@ -179,6 +274,50 @@
       }
     }
 
+    function markdownToHtml(md) {
+      if (!md) return '';
+      let html = md;
+      // Convert ### headings to <h4>
+      html = html.replace(/^### (.+)$/gm, '<h4>$1</h4>');
+      // Convert ## headings to <h4> as well (keep uniform in card)
+      html = html.replace(/^## (.+)$/gm, '<h4>$1</h4>');
+      // Remove # top-level headings (title already shown)
+      html = html.replace(/^# (.+)$/gm, '');
+      // Bold **text**
+      html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+      // Convert markdown links [text](url)
+      html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^\)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+      // Convert bare URLs that aren't already in href
+      html = html.replace(/(?<!href="|">)(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener">$1</a>');
+      // Convert newlines to <br>
+      html = html.replace(/\n/g, '<br>');
+      // Clean up excessive <br> after block elements
+      html = html.replace(/(<\/h4>)<br>/g, '$1');
+      html = html.replace(/<br><br><br>/g, '<br><br>');
+      return html.trim();
+    }
+
+    function getSummaryPreview(content) {
+      if (!content) return '';
+      // Strip markdown formatting for preview
+      let text = content;
+      text = text.replace(/^#{1,3} .+$/gm, '');
+      text = text.replace(/\*\*(.+?)\*\*/g, '$1');
+      text = text.replace(/\[([^\]]+)\]\([^\)]+\)/g, '$1');
+      text = text.replace(/\n+/g, ' ');
+      text = text.trim();
+      if (text.length > 200) {
+        text = text.substring(0, 200).replace(/\s+\S*$/, '') + '...';
+      }
+      return text;
+    }
+
+    function toggleSummary(btn) {
+      const summary = btn.closest('.ep-summary');
+      const isExpanded = summary.classList.toggle('expanded');
+      btn.textContent = isExpanded ? 'Collapse summary' : 'Read full summary';
+    }
+
     function renderFromJSON(episodes) {
       if (!episodes || !episodes.length) return;
       const latest = episodes[0];
@@ -190,9 +329,25 @@
       episodes.slice(0, 12).forEach(ep => {
         const card = document.createElement('div');
         card.className = 'episode-card';
+        const preview = escapeHtml(getSummaryPreview(ep.content || ''));
+        const fullHtml = markdownToHtml(ep.content || '');
+        const hasSummary = ep.content && ep.content.trim().length > 0;
+
+        let summaryBlock = '';
+        if (hasSummary) {
+          summaryBlock = `
+            <div class="ep-summary">
+              <div class="ep-summary-preview">${preview}</div>
+              <div class="ep-summary-full">${fullHtml}</div>
+              <button class="ep-summary-toggle" onclick="toggleSummary(this)">Read full summary</button>
+            </div>
+          `;
+        }
+
         card.innerHTML = `
           <div class="ep-date">${formatDate(ep.date)}</div>
           <div class="ep-title">${escapeHtml(ep.episode_title || 'Episode')}</div>
+          ${summaryBlock}
           <audio controls preload="none" src="${ep.audio_url || ''}"></audio>
         `;
         grid.appendChild(card);

--- a/planetterrian.html
+++ b/planetterrian.html
@@ -67,13 +67,32 @@
     .about-section h2 { font-size: 1.5rem; font-weight: 800; margin-bottom: 1rem; }
     .about-section p { color: var(--text-muted); margin-bottom: 0.75rem; }
 
-    .network-section { max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem 3rem; }
-    .network-section h2 { font-size: 1.5rem; font-weight: 800; margin-bottom: 1.5rem; }
-    .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 0.75rem; }
-    .network-card { display: block; background: var(--card); border-radius: var(--radius); padding: 1rem 1.25rem; border: 1px solid #1a3038; font-weight: 600; font-size: 0.95rem; color: var(--text); transition: border-color 0.2s; }
-    .network-card:hover { border-color: var(--brand); text-decoration: none; }
-    .network-card small { display: block; color: var(--text-muted); font-weight: 400; font-size: 0.8rem; margin-top: 0.25rem; }
-    .network-card.current { opacity: 0.5; pointer-events: none; border-color: var(--brand); }
+    .ep-summary { color: var(--text-muted); font-size: 0.85rem; margin: 0.75rem 0; line-height: 1.7; }
+    .ep-summary-preview { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+    .ep-summary.expanded .ep-summary-preview { display: none; }
+    .ep-summary-full { display: none; max-height: 500px; overflow-y: auto; padding-right: 0.5rem; }
+    .ep-summary.expanded .ep-summary-full { display: block; }
+    .ep-summary-toggle { display: inline-block; margin-top: 0.5rem; color: var(--brand-alt); font-size: 0.85rem; font-weight: 600; cursor: pointer; border: none; background: none; padding: 0; }
+    .ep-summary-toggle:hover { text-decoration: underline; }
+
+    .network-section { max-width: 1100px; margin: 0 auto; padding: 3rem 1.5rem 4rem; }
+    .network-section h2 { font-size: 1.8rem; font-weight: 800; margin-bottom: 0.5rem; }
+    .network-subtitle { color: var(--text-muted); margin-bottom: 2rem; font-size: 1rem; }
+    .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 1.25rem; }
+    .network-card { display: flex; flex-direction: column; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #1a3038; transition: border-color 0.2s, transform 0.2s; }
+    .network-card:hover { border-color: var(--brand); transform: translateY(-2px); }
+    .network-card.current { border-color: var(--brand); background: var(--card-hover); }
+    .network-card-header { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
+    .network-card-emoji { font-size: 1.8rem; line-height: 1; }
+    .network-card-name { font-weight: 700; font-size: 1.1rem; color: var(--text); }
+    .network-card-tagline { color: var(--brand-alt); font-size: 0.85rem; font-weight: 600; margin-bottom: 0.5rem; }
+    .network-card-desc { color: var(--text-muted); font-size: 0.85rem; line-height: 1.5; margin-bottom: 1rem; flex-grow: 1; }
+    .network-card-links { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+    .network-card-links a { font-size: 0.8rem; font-weight: 600; color: var(--brand-alt); padding: 0.3rem 0.7rem; border: 1px solid #1a3038; border-radius: 6px; transition: border-color 0.2s, background 0.2s; }
+    .network-card-links a:hover { border-color: var(--brand); background: rgba(1,141,177,0.1); text-decoration: none; }
+    .network-card-current-badge { display: inline-block; font-size: 0.7rem; font-weight: 700; color: var(--brand); background: rgba(1,141,177,0.15); padding: 0.15rem 0.5rem; border-radius: 4px; margin-left: 0.5rem; text-transform: uppercase; letter-spacing: 0.5px; }
+    .network-see-all { display: inline-block; margin-top: 2rem; font-weight: 700; font-size: 1rem; color: var(--brand-alt); }
+    .network-see-all:hover { text-decoration: underline; }
 
     footer { border-top: 1px solid #1a3038; padding: 2rem 1.5rem; text-align: center; }
     .footer-links { display: flex; gap: 1.5rem; justify-content: center; flex-wrap: wrap; margin-bottom: 1rem; }
@@ -87,7 +106,7 @@
       .nav-links.open { display: flex; }
       .hero { padding: 3rem 1.5rem 2rem; }
       .episodes-grid { grid-template-columns: 1fr; }
-      .network-grid { grid-template-columns: 1fr 1fr; }
+      .network-grid { grid-template-columns: 1fr; }
     }
   </style>
 </head>
@@ -98,6 +117,7 @@
       <button class="menu-toggle" aria-label="Menu">&#9776;</button>
       <div class="nav-links">
         <a href="#episodes">Episodes</a>
+        <a href="planetterrian-summaries.html">Summaries</a>
         <a href="#about">About</a>
         <a href="https://x.com/planetterrian">@planetterrian</a>
         <a href="planetterrian_podcast.rss">RSS</a>
@@ -137,15 +157,83 @@
       <p>Hosted by Patrick in Vancouver, each episode highlights peer-reviewed research, biotech advances, and the innovations pushing the boundaries of human potential.</p>
     </section>
 
-    <section class="network-section">
-      <h2>More from our network</h2>
+    <section id="network" class="network-section">
+      <h2>Explore Our Podcast Network</h2>
+      <p class="network-subtitle">Five daily shows covering science, space, Tesla, news, and the environment.</p>
       <div class="network-grid">
-        <a href="index.html" class="network-card">Tesla Shorts Time<small>Tesla news and EV analysis</small></a>
-        <a href="omni-view.html" class="network-card">Omni View<small>Balanced news perspectives</small></a>
-        <a href="fascinating_frontiers.html" class="network-card">Fascinating Frontiers<small>Space and astronomy</small></a>
-        <a href="planetterrian.html" class="network-card current">Planetterrian Daily<small>You are here</small></a>
-        <a href="env-intel.html" class="network-card">Environmental Intelligence<small>Environmental regulatory briefing</small></a>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#9889;</span>
+            <span class="network-card-name">Tesla Shorts Time</span>
+          </div>
+          <div class="network-card-tagline">Shorting Tesla? Time's Up.</div>
+          <div class="network-card-desc">Daily Tesla news, stock analysis, and EV future.</div>
+          <div class="network-card-links">
+            <a href="index.html">Listen</a>
+            <a href="podcast.rss">RSS</a>
+            <a href="https://x.com/teslashortstime">@teslashortstime</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#128065;</span>
+            <span class="network-card-name">Omni View</span>
+          </div>
+          <div class="network-card-tagline">See every side. Decide for yourself.</div>
+          <div class="network-card-desc">Balanced daily news briefing for media literacy.</div>
+          <div class="network-card-links">
+            <a href="omni-view.html">Listen</a>
+            <a href="omni_view_podcast.rss">RSS</a>
+            <a href="https://x.com/omniviewnews">@omniviewnews</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#128640;</span>
+            <span class="network-card-name">Fascinating Frontiers</span>
+          </div>
+          <div class="network-card-tagline">Journey to the stars.</div>
+          <div class="network-card-desc">Daily space, astronomy, and cosmic discovery news.</div>
+          <div class="network-card-links">
+            <a href="fascinating_frontiers.html">Listen</a>
+            <a href="fascinating_frontiers_podcast.rss">RSS</a>
+            <a href="https://x.com/planetterrian">@planetterrian</a>
+          </div>
+        </div>
+
+        <div class="network-card current">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#127758;</span>
+            <span class="network-card-name">Planetterrian Daily</span>
+            <span class="network-card-current-badge">You are here</span>
+          </div>
+          <div class="network-card-tagline">Science, longevity, human health.</div>
+          <div class="network-card-desc">Science, longevity, genetics, and health research.</div>
+          <div class="network-card-links">
+            <a href="planetterrian.html">Listen</a>
+            <a href="planetterrian_podcast.rss">RSS</a>
+            <a href="https://x.com/planetterrian">@planetterrian</a>
+          </div>
+        </div>
+
+        <div class="network-card">
+          <div class="network-card-header">
+            <span class="network-card-emoji">&#127793;</span>
+            <span class="network-card-name">Environmental Intelligence</span>
+          </div>
+          <div class="network-card-tagline">Daily environmental briefing.</div>
+          <div class="network-card-desc">Environmental regulatory and compliance briefing.</div>
+          <div class="network-card-links">
+            <a href="env-intel.html">Listen</a>
+            <a href="env_intel_podcast.rss">RSS</a>
+          </div>
+        </div>
+
       </div>
+      <a href="network.html" class="network-see-all">See all shows &rarr;</a>
     </section>
   </main>
 
@@ -175,6 +263,26 @@
       }
     }
 
+    function renderMarkdown(text) {
+      if (!text) return '';
+      let html = escapeHtml(text);
+      // ### headings to <h4>
+      html = html.replace(/^### (.+)$/gm, '<h4>$1</h4>');
+      // **bold** to <strong>
+      html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+      // URLs to links
+      html = html.replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener">$1</a>');
+      // newlines to <br>
+      html = html.replace(/\n/g, '<br>');
+      return html;
+    }
+
+    function toggleSummary(btn) {
+      const container = btn.closest('.ep-summary');
+      const isExpanded = container.classList.toggle('expanded');
+      btn.textContent = isExpanded ? 'Collapse summary' : 'Read full summary';
+    }
+
     function renderFromJSON(episodes) {
       if (!episodes || !episodes.length) return;
       const latest = episodes[0];
@@ -186,9 +294,26 @@
       episodes.slice(0, 12).forEach(ep => {
         const card = document.createElement('div');
         card.className = 'episode-card';
+
+        const content = ep.content || '';
+        const preview = content.substring(0, 200) + (content.length > 200 ? '...' : '');
+        const fullHtml = renderMarkdown(content);
+
+        let summaryHtml = '';
+        if (content) {
+          summaryHtml = `
+            <div class="ep-summary">
+              <div class="ep-summary-preview">${escapeHtml(preview)}</div>
+              <div class="ep-summary-full">${fullHtml}</div>
+              <button class="ep-summary-toggle" onclick="toggleSummary(this)">Read full summary</button>
+            </div>
+          `;
+        }
+
         card.innerHTML = `
           <div class="ep-date">${formatDate(ep.date)}</div>
           <div class="ep-title">${escapeHtml(ep.episode_title || 'Episode')}</div>
+          ${summaryHtml}
           <audio controls preload="none" src="${ep.audio_url || ''}"></audio>
         `;
         grid.appendChild(card);


### PR DESCRIPTION
…pages

Each podcast page now displays expandable episode summaries from the JSON data, and features a prominent "Explore Our Podcast Network" section with show descriptions, RSS links, and X/Twitter handles to drive cross-discovery.

https://claude.ai/code/session_01VgkRnECEHWoRpMN3yWR9EF