### PR TITLE
fix: make podcast network cards clickable and improve episode loading

### DIFF
--- a/env-intel.html
+++ b/env-intel.html
@@ -84,7 +84,7 @@
     .network-section h2 { font-size: 1.8rem; font-weight: 900; margin-bottom: 0.5rem; }
     .network-section .network-subtitle { color: var(--text-muted); margin-bottom: 2rem; font-size: 1rem; }
     .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; }
-    .network-card { display: flex; flex-direction: column; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #1a3020; transition: border-color 0.2s, transform 0.2s; }
+    .network-card { display: flex; flex-direction: column; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #1a3020; transition: border-color 0.2s, transform 0.2s; cursor: pointer; }
     .network-card:hover { border-color: var(--brand-alt); transform: translateY(-2px); }
     .network-card.current { border-color: var(--brand-alt); background: rgba(76,175,80,0.05); }
     .network-card-header { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
@@ -167,7 +167,7 @@
       <p class="network-subtitle">Five daily shows covering Tesla, world news, space, science, and the environment.</p>
       <div class="network-grid">
 
-        <div class="network-card">
+        <div class="network-card" data-href="index.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#9889;</span>
             <span class="network-card-name">Tesla Shorts Time</span>
@@ -181,7 +181,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="omni-view.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#128065;</span>
             <span class="network-card-name">Omni View</span>
@@ -195,7 +195,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="fascinating_frontiers.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#128640;</span>
             <span class="network-card-name">Fascinating Frontiers</span>
@@ -209,7 +209,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="planetterrian.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#127758;</span>
             <span class="network-card-name">Planetterrian Daily</span>
@@ -270,7 +270,7 @@
     }
 
     function renderFromJSON(episodes) {
-      if (!episodes || !episodes.length) return;
+      if (!episodes || !episodes.length) { showNoEpisodes(); return; }
       const latest = episodes[0];
       document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';
       document.getElementById('latest-audio').src = latest.audio_url || '';
@@ -356,9 +356,12 @@
             grid.appendChild(card);
           });
         })
-        .catch(() => {
-          document.getElementById('latest-title').textContent = 'Unable to load episodes';
-        });
+        .catch(() => { showNoEpisodes(); });
+    }
+
+    function showNoEpisodes() {
+      document.getElementById('latest-title').textContent = 'No episodes available yet';
+      document.getElementById('episodes-grid').innerHTML = '<p style="color:var(--text-muted);grid-column:1/-1;text-align:center;padding:2rem 0;">Episodes will appear here once available. Check back soon!</p>';
     }
 
     function formatDate(d) {
@@ -373,6 +376,14 @@
       el.textContent = s;
       return el.innerHTML;
     }
+
+    // Make network cards clickable
+    document.querySelectorAll('.network-card[data-href]').forEach(card => {
+      card.addEventListener('click', (e) => {
+        if (e.target.closest('a')) return;
+        window.location.href = card.dataset.href;
+      });
+    });
 
     loadEpisodes();
   </script>

--- a/fascinating_frontiers.html
+++ b/fascinating_frontiers.html
@@ -111,7 +111,7 @@
     .network-section h2 { font-size: 1.75rem; font-weight: 800; margin-bottom: 0.5rem; text-align: center; }
     .network-subtitle { color: var(--text-muted); text-align: center; margin-bottom: 2rem; font-size: 0.95rem; }
     .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; }
-    .network-card { display: block; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #1a1f35; color: var(--text); transition: border-color 0.2s, background 0.2s; }
+    .network-card { display: block; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #1a1f35; color: var(--text); transition: border-color 0.2s, background 0.2s; cursor: pointer; }
     .network-card:hover { border-color: var(--brand); background: var(--card-hover); text-decoration: none; }
     .network-card.current { border-color: var(--brand); background: var(--card-hover); }
     .network-card-header { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
@@ -194,7 +194,7 @@
       <p class="network-subtitle">Five daily shows covering space, science, Tesla, news, and the environment.</p>
       <div class="network-grid">
 
-        <div class="network-card">
+        <div class="network-card" data-href="index.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#9889;</span>
             <span class="network-card-name">Tesla Shorts Time</span>
@@ -208,7 +208,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="omni-view.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#128065;</span>
             <span class="network-card-name">Omni View</span>
@@ -237,7 +237,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="planetterrian.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#127758;</span>
             <span class="network-card-name">Planetterrian Daily</span>
@@ -251,7 +251,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="env-intel.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#127793;</span>
             <span class="network-card-name">Environmental Intelligence</span>
@@ -314,7 +314,7 @@
     }
 
     function renderFromJSON(episodes) {
-      if (!episodes || !episodes.length) return;
+      if (!episodes || !episodes.length) { showNoEpisodes(); return; }
       const latest = episodes[0];
       document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';
       document.getElementById('latest-audio').src = latest.audio_url || '';
@@ -383,9 +383,12 @@
             grid.appendChild(card);
           });
         })
-        .catch(() => {
-          document.getElementById('latest-title').textContent = 'Unable to load episodes';
-        });
+        .catch(() => { showNoEpisodes(); });
+    }
+
+    function showNoEpisodes() {
+      document.getElementById('latest-title').textContent = 'No episodes available yet';
+      document.getElementById('episodes-grid').innerHTML = '<p style="color:var(--text-muted);grid-column:1/-1;text-align:center;padding:2rem 0;">Episodes will appear here once available. Check back soon!</p>';
     }
 
     function formatDate(d) {
@@ -400,6 +403,14 @@
       el.textContent = s;
       return el.innerHTML;
     }
+
+    // Make network cards clickable
+    document.querySelectorAll('.network-card[data-href]').forEach(card => {
+      card.addEventListener('click', (e) => {
+        if (e.target.closest('a')) return;
+        window.location.href = card.dataset.href;
+      });
+    });
 
     loadEpisodes();
   </script>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
     .network-header h2 { font-size: 1.8rem; font-weight: 900; margin-bottom: 0.5rem; }
     .network-header p { color: var(--text-muted); max-width: 550px; margin: 0 auto; }
     .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; }
-    .network-card { display: flex; flex-direction: column; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #222; color: var(--text); transition: border-color 0.2s, transform 0.2s; text-decoration: none; }
+    .network-card { display: flex; flex-direction: column; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #222; color: var(--text); transition: border-color 0.2s, transform 0.2s; text-decoration: none; cursor: pointer; }
     .network-card:hover { border-color: var(--brand); transform: translateY(-2px); text-decoration: none; }
     .network-card-head { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
     .network-card-emoji { font-size: 1.8rem; line-height: 1; }
@@ -196,7 +196,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="omni-view.html">
           <div class="network-card-head">
             <span class="network-card-emoji">&#128065;</span>
             <span class="network-card-name">Omni View</span>
@@ -210,7 +210,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="fascinating_frontiers.html">
           <div class="network-card-head">
             <span class="network-card-emoji">&#128640;</span>
             <span class="network-card-name">Fascinating Frontiers</span>
@@ -224,7 +224,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="planetterrian.html">
           <div class="network-card-head">
             <span class="network-card-emoji">&#127758;</span>
             <span class="network-card-name">Planetterrian Daily</span>
@@ -238,7 +238,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="env-intel.html">
           <div class="network-card-head">
             <span class="network-card-emoji">&#127793;</span>
             <span class="network-card-name">Environmental Intelligence</span>
@@ -332,7 +332,7 @@
     }
 
     function renderFromJSON(episodes) {
-      if (!episodes || !episodes.length) return;
+      if (!episodes || !episodes.length) { showNoEpisodes(); return; }
       const latest = episodes[0];
       document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';
       document.getElementById('latest-audio').src = latest.audio_url || '';
@@ -359,7 +359,7 @@
           const parser = new DOMParser();
           const doc = parser.parseFromString(xml, 'text/xml');
           const items = doc.querySelectorAll('item');
-          if (!items.length) return;
+          if (!items.length) { showNoEpisodes(); return; }
 
           const first = items[0];
           document.getElementById('latest-title').textContent = first.querySelector('title')?.textContent || 'Latest Episode';
@@ -385,9 +385,12 @@
             grid.appendChild(card);
           });
         })
-        .catch(() => {
-          document.getElementById('latest-title').textContent = 'Unable to load episodes';
-        });
+        .catch(() => { showNoEpisodes(); });
+    }
+
+    function showNoEpisodes() {
+      document.getElementById('latest-title').textContent = 'No episodes available yet';
+      document.getElementById('episodes-grid').innerHTML = '<p style="color:var(--text-muted);grid-column:1/-1;text-align:center;padding:2rem 0;">Episodes will appear here once available. Check back soon!</p>';
     }
 
     function formatDate(d) {
@@ -423,6 +426,14 @@
         document.getElementById('stock-change').textContent = 'Market data unavailable';
       }
     }
+
+    // Make network cards clickable
+    document.querySelectorAll('.network-card[data-href]').forEach(card => {
+      card.addEventListener('click', (e) => {
+        if (e.target.closest('a')) return;
+        window.location.href = card.dataset.href;
+      });
+    });
 
     loadEpisodes();
     loadStock();

--- a/network.html
+++ b/network.html
@@ -73,6 +73,7 @@
             text-decoration: none;
             color: var(--text);
             transition: background 0.2s, border-color 0.2s, transform 0.2s;
+            cursor: pointer;
         }
         .show-card:hover {
             background: var(--card-hover);
@@ -188,7 +189,7 @@
 
     <section id="shows" class="shows">
 
-        <div class="show-card tesla">
+        <div class="show-card tesla" data-href="index.html">
             <div class="show-art">&#9889;</div>
             <div class="show-info">
                 <h2>Tesla Shorts Time Daily</h2>
@@ -204,7 +205,7 @@
             </div>
         </div>
 
-        <div class="show-card omni">
+        <div class="show-card omni" data-href="omni-view.html">
             <div class="show-art">&#127760;</div>
             <div class="show-info">
                 <h2>Omni View &mdash; Balanced News</h2>
@@ -220,7 +221,7 @@
             </div>
         </div>
 
-        <div class="show-card frontiers">
+        <div class="show-card frontiers" data-href="fascinating_frontiers.html">
             <div class="show-art">&#128640;</div>
             <div class="show-info">
                 <h2>Fascinating Frontiers</h2>
@@ -236,7 +237,7 @@
             </div>
         </div>
 
-        <div class="show-card planet">
+        <div class="show-card planet" data-href="planetterrian.html">
             <div class="show-art">&#129516;</div>
             <div class="show-info">
                 <h2>Planetterrian Daily</h2>
@@ -252,7 +253,7 @@
             </div>
         </div>
 
-        <div class="show-card envint">
+        <div class="show-card envint" data-href="env-intel.html">
             <div class="show-art">&#127793;</div>
             <div class="show-info">
                 <h2>Environmental Intelligence</h2>
@@ -297,6 +298,14 @@
     <script>
         document.querySelector('.menu-toggle').addEventListener('click', () => {
             document.querySelector('.nav-links').classList.toggle('open');
+        });
+
+        // Make show cards clickable
+        document.querySelectorAll('.show-card[data-href]').forEach(card => {
+            card.addEventListener('click', (e) => {
+                if (e.target.closest('a')) return;
+                window.location.href = card.dataset.href;
+            });
         });
     </script>
 </body>

--- a/omni-view.html
+++ b/omni-view.html
@@ -85,7 +85,7 @@
     .network-section h2 { font-size: 1.8rem; font-weight: 900; margin-bottom: 0.5rem; text-align: center; }
     .network-subtitle { color: var(--text-muted); text-align: center; margin-bottom: 2rem; font-size: 0.95rem; }
     .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; }
-    .network-card { display: flex; flex-direction: column; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #1e2a42; transition: border-color 0.2s, transform 0.2s; }
+    .network-card { display: flex; flex-direction: column; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #1e2a42; transition: border-color 0.2s, transform 0.2s; cursor: pointer; }
     .network-card:hover { border-color: var(--brand); transform: translateY(-2px); }
     .network-card.current { border-color: var(--brand); background: #0d1a33; }
     .network-card-header { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
@@ -171,7 +171,7 @@
       <p class="network-subtitle">Five daily shows covering Tesla, world news, space, science, and the environment.</p>
       <div class="network-grid">
 
-        <div class="network-card">
+        <div class="network-card" data-href="index.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#9889;</span>
             <span class="network-card-name">Tesla Shorts Time</span>
@@ -200,7 +200,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="fascinating_frontiers.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#128640;</span>
             <span class="network-card-name">Fascinating Frontiers</span>
@@ -214,7 +214,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="planetterrian.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#127758;</span>
             <span class="network-card-name">Planetterrian Daily</span>
@@ -228,7 +228,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="env-intel.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#127793;</span>
             <span class="network-card-name">Environmental Intelligence</span>
@@ -319,7 +319,7 @@
     }
 
     function renderFromJSON(episodes) {
-      if (!episodes || !episodes.length) return;
+      if (!episodes || !episodes.length) { showNoEpisodes(); return; }
       const latest = episodes[0];
       document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';
       document.getElementById('latest-audio').src = latest.audio_url || '';
@@ -385,9 +385,12 @@
             grid.appendChild(card);
           });
         })
-        .catch(() => {
-          document.getElementById('latest-title').textContent = 'Unable to load episodes';
-        });
+        .catch(() => { showNoEpisodes(); });
+    }
+
+    function showNoEpisodes() {
+      document.getElementById('latest-title').textContent = 'No episodes available yet';
+      document.getElementById('episodes-grid').innerHTML = '<p style="color:var(--text-muted);grid-column:1/-1;text-align:center;padding:2rem 0;">Episodes will appear here once available. Check back soon!</p>';
     }
 
     function formatDate(d) {
@@ -402,6 +405,14 @@
       el.textContent = s;
       return el.innerHTML;
     }
+
+    // Make network cards clickable
+    document.querySelectorAll('.network-card[data-href]').forEach(card => {
+      card.addEventListener('click', (e) => {
+        if (e.target.closest('a')) return;
+        window.location.href = card.dataset.href;
+      });
+    });
 
     loadEpisodes();
   </script>

--- a/planetterrian.html
+++ b/planetterrian.html
@@ -79,7 +79,7 @@
     .network-section h2 { font-size: 1.8rem; font-weight: 800; margin-bottom: 0.5rem; }
     .network-subtitle { color: var(--text-muted); margin-bottom: 2rem; font-size: 1rem; }
     .network-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 1.25rem; }
-    .network-card { display: flex; flex-direction: column; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #1a3038; transition: border-color 0.2s, transform 0.2s; }
+    .network-card { display: flex; flex-direction: column; background: var(--card); border-radius: var(--radius); padding: 1.5rem; border: 1px solid #1a3038; transition: border-color 0.2s, transform 0.2s; cursor: pointer; }
     .network-card:hover { border-color: var(--brand); transform: translateY(-2px); }
     .network-card.current { border-color: var(--brand); background: var(--card-hover); }
     .network-card-header { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
@@ -162,7 +162,7 @@
       <p class="network-subtitle">Five daily shows covering science, space, Tesla, news, and the environment.</p>
       <div class="network-grid">
 
-        <div class="network-card">
+        <div class="network-card" data-href="index.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#9889;</span>
             <span class="network-card-name">Tesla Shorts Time</span>
@@ -176,7 +176,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="omni-view.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#128065;</span>
             <span class="network-card-name">Omni View</span>
@@ -190,7 +190,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="fascinating_frontiers.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#128640;</span>
             <span class="network-card-name">Fascinating Frontiers</span>
@@ -219,7 +219,7 @@
           </div>
         </div>
 
-        <div class="network-card">
+        <div class="network-card" data-href="env-intel.html">
           <div class="network-card-header">
             <span class="network-card-emoji">&#127793;</span>
             <span class="network-card-name">Environmental Intelligence</span>
@@ -284,7 +284,7 @@
     }
 
     function renderFromJSON(episodes) {
-      if (!episodes || !episodes.length) return;
+      if (!episodes || !episodes.length) { showNoEpisodes(); return; }
       const latest = episodes[0];
       document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';
       document.getElementById('latest-audio').src = latest.audio_url || '';
@@ -351,9 +351,12 @@
             grid.appendChild(card);
           });
         })
-        .catch(() => {
-          document.getElementById('latest-title').textContent = 'Unable to load episodes';
-        });
+        .catch(() => { showNoEpisodes(); });
+    }
+
+    function showNoEpisodes() {
+      document.getElementById('latest-title').textContent = 'No episodes available yet';
+      document.getElementById('episodes-grid').innerHTML = '<p style="color:var(--text-muted);grid-column:1/-1;text-align:center;padding:2rem 0;">Episodes will appear here once available. Check back soon!</p>';
     }
 
     function formatDate(d) {
@@ -368,6 +371,14 @@
       el.textContent = s;
       return el.innerHTML;
     }
+
+    // Make network cards clickable
+    document.querySelectorAll('.network-card[data-href]').forEach(card => {
+      card.addEventListener('click', (e) => {
+        if (e.target.closest('a')) return;
+        window.location.href = card.dataset.href;
+      });
+    });
 
     loadEpisodes();
   </script>


### PR DESCRIPTION
Network cards in the "Explore Our Podcast Network" sections were plain divs with no navigation. Added data-href attributes and click handlers so clicking anywhere on a card navigates to that show's page (while preserving direct clicks on RSS/X links within cards).

Also improved episode loading error handling across all 5 show pages:
- Show clear "no episodes available" message when JSON and RSS both fail
- Handle empty episode arrays gracefully instead of leaving grid blank
- Fixes env-intel page which has no summaries JSON or RSS feed yet

https://claude.ai/code/session_01VgkRnECEHWoRpMN3yWR9EF