### PR TITLE
Fix off-by-one date display in episode cards across all HTML pages

### DIFF
--- a/env-intel.html
+++ b/env-intel.html
@@ -380,7 +380,7 @@
     function formatDate(d) {
       try {
         const date = new Date(d);
-        return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+        return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
       } catch { return d; }
     }
 

--- a/fascinating-frontiers-summaries.html
+++ b/fascinating-frontiers-summaries.html
@@ -642,7 +642,8 @@
                     year: 'numeric',
                     month: 'long',
                     day: 'numeric',
-                    weekday: 'long'
+                    weekday: 'long',
+                    timeZone: 'UTC'
                 });
             } catch {
                 return dateString;

--- a/fascinating_frontiers.html
+++ b/fascinating_frontiers.html
@@ -420,7 +420,7 @@
     function formatDate(d) {
       try {
         const date = new Date(d);
-        return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+        return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
       } catch { return d; }
     }
 

--- a/index.html
+++ b/index.html
@@ -456,7 +456,7 @@
     function formatDate(d) {
       try {
         const date = new Date(d);
-        return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+        return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
       } catch { return d; }
     }
 

--- a/models-agents-summaries.html
+++ b/models-agents-summaries.html
@@ -63,7 +63,7 @@
                     let dateStr = '';
                     try {
                         const d = new Date(ep.date);
-                        dateStr = d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+                        dateStr = d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
                     } catch { dateStr = ep.date || ''; }
 
                     let contentHtml = '';

--- a/models-agents.html
+++ b/models-agents.html
@@ -405,7 +405,7 @@
     function formatDate(d) {
       try {
         const date = new Date(d);
-        return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+        return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
       } catch { return d; }
     }
 

--- a/omni-view-summaries.html
+++ b/omni-view-summaries.html
@@ -1124,7 +1124,8 @@
                     year: 'numeric',
                     month: 'long',
                     day: 'numeric',
-                    weekday: 'long'
+                    weekday: 'long',
+                    timeZone: 'UTC'
                 });
             } catch {
                 return dateString;

--- a/omni-view.html
+++ b/omni-view.html
@@ -422,7 +422,7 @@
     function formatDate(d) {
       try {
         const date = new Date(d);
-        return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+        return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
       } catch { return d; }
     }
 

--- a/planetterrian-summaries.html
+++ b/planetterrian-summaries.html
@@ -700,7 +700,8 @@
                     year: 'numeric',
                     month: 'long',
                     day: 'numeric',
-                    weekday: 'long'
+                    weekday: 'long',
+                    timeZone: 'UTC'
                 });
             } catch {
                 return dateString;

--- a/planetterrian.html
+++ b/planetterrian.html
@@ -388,7 +388,7 @@
     function formatDate(d) {
       try {
         const date = new Date(d);
-        return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+        return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
       } catch { return d; }
     }
 

--- a/podcast-player.html
+++ b/podcast-player.html
@@ -334,10 +334,11 @@
         function formatDate(dateString) {
             try {
                 const date = new Date(dateString);
-                return date.toLocaleDateString('en-US', { 
-                    year: 'numeric', 
-                    month: 'long', 
-                    day: 'numeric' 
+                return date.toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                    timeZone: 'UTC'
                 });
             } catch {
                 return dateString;

--- a/tesla-summaries.html
+++ b/tesla-summaries.html
@@ -637,7 +637,8 @@
                     year: 'numeric',
                     month: 'long',
                     day: 'numeric',
-                    weekday: 'long'
+                    weekday: 'long',
+                    timeZone: 'UTC'
                 });
             } catch {
                 return dateString;


### PR DESCRIPTION
Add timeZone: 'UTC' to all toLocaleDateString() calls to prevent dates from shifting back one day for users in timezones behind UTC. Date strings like "2026-02-27" are parsed as UTC midnight, but toLocaleDateString() without timeZone uses local time, causing e.g. Feb 27 episodes to show as Feb 26 for PST users.

Fixed in 12 files: 6 show player pages, 5 summaries pages, and the podcast-player page.

https://claude.ai/code/session_01VgkRnECEHWoRpMN3yWR9EF