### PR TITLE
Enable Cloudflare R2 storage for all 6 podcast shows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Cloudflare R2 Storage (podcast audio hosting)
+R2_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=

--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -234,6 +234,10 @@ jobs:
       - name: Run show pipeline
         run: python run_show.py ${{ matrix.show }} 2>&1
         timeout-minutes: 30
+        env:
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
 
       - name: Validate output
         run: |

--- a/scripts/migrate_audio_to_r2.py
+++ b/scripts/migrate_audio_to_r2.py
@@ -33,6 +33,8 @@ RSS_FEEDS = [
     ("omni_view_podcast.rss", "omni_view"),
     ("fascinating_frontiers_podcast.rss", "fascinating_frontiers"),
     ("planetterrian_podcast.rss", "planetterrian"),
+    ("env_intel_podcast.rss", "env_intel"),
+    ("models_agents_podcast.rss", "models_agents"),
 ]
 
 

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -158,6 +158,14 @@ audio:
   fade_volume: 0.25
   outro_volume: 0.3
 
+storage:
+  provider: r2
+  bucket: podcast-audio
+  endpoint_env: R2_ENDPOINT_URL
+  access_key_env: R2_ACCESS_KEY_ID
+  secret_key_env: R2_SECRET_ACCESS_KEY
+  public_base_url: "https://audio.nerranetwork.com"
+
 publishing:
   rss_file: env_intel_podcast.rss
   rss_title: "Environmental Intelligence"

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -144,6 +144,14 @@ audio:
   fade_volume: 0.4
   outro_volume: 0.4
 
+storage:
+  provider: r2
+  bucket: podcast-audio
+  endpoint_env: R2_ENDPOINT_URL
+  access_key_env: R2_ACCESS_KEY_ID
+  secret_key_env: R2_SECRET_ACCESS_KEY
+  public_base_url: "https://audio.nerranetwork.com"
+
 publishing:
   rss_file: fascinating_frontiers_podcast.rss
   rss_title: Fascinating Frontiers

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -154,6 +154,14 @@ audio:
   fade_volume: 0.4
   outro_volume: 0.4
 
+storage:
+  provider: r2
+  bucket: podcast-audio
+  endpoint_env: R2_ENDPOINT_URL
+  access_key_env: R2_ACCESS_KEY_ID
+  secret_key_env: R2_SECRET_ACCESS_KEY
+  public_base_url: "https://audio.nerranetwork.com"
+
 publishing:
   rss_file: models_agents_podcast.rss
   rss_title: "Models & Agents"

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -135,6 +135,14 @@ audio:
   fade_volume: 0.3
   outro_volume: 0.3
 
+storage:
+  provider: r2
+  bucket: podcast-audio
+  endpoint_env: R2_ENDPOINT_URL
+  access_key_env: R2_ACCESS_KEY_ID
+  secret_key_env: R2_SECRET_ACCESS_KEY
+  public_base_url: "https://audio.nerranetwork.com"
+
 publishing:
   rss_file: omni_view_podcast.rss
   rss_title: "Omni View - Balanced News Perspectives"

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -122,6 +122,14 @@ audio:
   fade_volume: 0.4
   outro_volume: 0.4
 
+storage:
+  provider: r2
+  bucket: podcast-audio
+  endpoint_env: R2_ENDPOINT_URL
+  access_key_env: R2_ACCESS_KEY_ID
+  secret_key_env: R2_SECRET_ACCESS_KEY
+  public_base_url: "https://audio.nerranetwork.com"
+
 publishing:
   rss_file: planetterrian_podcast.rss
   rss_title: Planetterrian Daily

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -101,6 +101,14 @@ audio:
   fade_volume: 0.4
   outro_volume: 0.4
 
+storage:
+  provider: r2
+  bucket: podcast-audio
+  endpoint_env: R2_ENDPOINT_URL
+  access_key_env: R2_ACCESS_KEY_ID
+  secret_key_env: R2_SECRET_ACCESS_KEY
+  public_base_url: "https://audio.nerranetwork.com"
+
 publishing:
   rss_file: podcast.rss
   rss_title: Tesla Shorts Time Daily


### PR DESCRIPTION
- Add storage block (provider: r2, bucket: podcast-audio, public_base_url: audio.nerranetwork.com) to all 6 show YAML configs
- Add env_intel and models_agents to RSS_FEEDS in migrate_audio_to_r2.py
- Pass R2 env vars (R2_ENDPOINT_URL, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY) to the run_show.py step in run-show.yml
- Create .env.example documenting required R2 environment variables

https://claude.ai/code/session_01VgkRnECEHWoRpMN3yWR9EF