### PR TITLE
Fix RSS test to accept both GitHub and R2 audio URLs

### DIFF
--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -219,14 +219,15 @@ class TestChannelMetadata:
 # ===================================================================
 
 BASE_URL = "https://raw.githubusercontent.com/patricknovak/Tesla-shorts-time/main"
+R2_BASE_URL = "https://audio.nerranetwork.com"
 
 ENCLOSURE_URL_PATTERNS = {
-    "tesla": f"{BASE_URL}/digests/",
-    "omni": f"{BASE_URL}/digests/",
-    "planetterrian": f"{BASE_URL}/digests/planetterrian/",
-    "frontiers": f"{BASE_URL}/digests/fascinating_frontiers/",
-    "env_intel": f"{BASE_URL}/digests/env_intel/",
-    "models_agents": f"{BASE_URL}/digests/models_agents/",
+    "tesla": (f"{BASE_URL}/digests/", f"{R2_BASE_URL}/tesla/"),
+    "omni": (f"{BASE_URL}/digests/", f"{R2_BASE_URL}/omni_view/"),
+    "planetterrian": (f"{BASE_URL}/digests/planetterrian/", f"{R2_BASE_URL}/planetterrian/"),
+    "frontiers": (f"{BASE_URL}/digests/fascinating_frontiers/", f"{R2_BASE_URL}/fascinating_frontiers/"),
+    "env_intel": (f"{BASE_URL}/digests/env_intel/", f"{R2_BASE_URL}/env_intel/"),
+    "models_agents": (f"{BASE_URL}/digests/models_agents/", f"{R2_BASE_URL}/models_agents/"),
 }
 
 
@@ -260,15 +261,15 @@ class TestItemStructure:
     @pytest.mark.parametrize("show", list(RSS_FEEDS.keys()))
     def test_all_items_have_enclosure(self, show):
         _, items = _parse_rss(RSS_FEEDS[show])
-        expected_prefix = ENCLOSURE_URL_PATTERNS[show]
+        expected_prefixes = ENCLOSURE_URL_PATTERNS[show]
         for i, item in enumerate(items):
             enc = item.find("enclosure")
             assert enc is not None, f"{show} item {i}: missing <enclosure>"
             url = enc.get("url")
             assert url, f"{show} item {i}: empty enclosure url"
-            assert url.startswith(expected_prefix), (
+            assert any(url.startswith(p) for p in expected_prefixes), (
                 f"{show} item {i}: enclosure URL doesn't match expected pattern.\n"
-                f"  expected prefix: {expected_prefix}\n"
+                f"  expected prefixes: {expected_prefixes}\n"
                 f"  actual URL: {url}"
             )
             assert enc.get("type") == "audio/mpeg", (


### PR DESCRIPTION
After migrating audio to Cloudflare R2 (audio.nerranetwork.com), the enclosure URL test only checked for the old raw.githubusercontent.com prefix. Updated ENCLOSURE_URL_PATTERNS to accept both old and new URL prefixes since feeds contain a mix during the migration period.

https://claude.ai/code/session_01KjxeLppaLmMAvQ9ydR3Hqg