### PR TITLE
Add per-show resources, audience blurbs, X timelines, and enhanced su…

### DIFF
--- a/env-intel.html
+++ b/env-intel.html
@@ -167,6 +167,9 @@
                     <span style="background:var(--nn-card);border:1px solid var(--nn-border);padding:2px 10px;border-radius:6px;">~10 min</span>
                 </div>
                 <p class="show-hero-desc">Environmental regulatory, science, and compliance briefing for BC professionals. Covers contaminated sites, CEPA, emissions, carbon policy, PFAS, and remediation developments.</p>
+                
+                <p style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);margin-bottom:var(--sp-4);font-style:italic;">For Canadian environmental professionals — contaminated sites consultants, regulators, lawyers, and lab scientists.</p>
+                
                 <div class="show-hero-actions">
                     <a href="#episodes" class="nn-btn nn-btn-primary">Listen Now</a>
                     <a href="env-intel-summaries.html" class="nn-btn">View Summaries</a>
@@ -201,6 +204,9 @@
                 <h2>Recent Episodes</h2>
             </div>
             <div id="episodes-grid" class="episodes-grid"></div>
+            <div style="text-align:center;margin-top:var(--sp-6);">
+                <a href="env-intel-summaries.html" class="nn-btn">View All Episodes</a>
+            </div>
         </div>
     </section>
 
@@ -219,6 +225,68 @@
         </div>
     </section>
 
+    <!-- Resources -->
+    
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources & Further Reading</h2>
+            </div>
+            <div class="resources-grid">
+                
+                <a href="https://www.gazette.gc.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Canada Gazette</div>
+                    <div class="resource-card-desc">Official source for federal regulations and proposed amendments</div>
+                    <div class="resource-card-url">www.gazette.gc.ca</div>
+                </a>
+                
+                <a href="https://www.canada.ca/en/environment-climate-change.html" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">ECCC</div>
+                    <div class="resource-card-desc">Environment and Climate Change Canada — federal policy and enforcement</div>
+                    <div class="resource-card-url">www.canada.ca/en/environment-climate-change.html</div>
+                </a>
+                
+                <a href="https://ccme.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">CCME</div>
+                    <div class="resource-card-desc">Canadian Council of Ministers of the Environment — guidelines and standards</div>
+                    <div class="resource-card-url">ccme.ca</div>
+                </a>
+                
+                <a href="https://www2.gov.bc.ca/gov/content/environment/air-land-water/site-remediation" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">BC Site Remediation</div>
+                    <div class="resource-card-desc">BC contaminated sites registry, guidance, and CSR protocols</div>
+                    <div class="resource-card-url">www2.gov.bc.ca/gov/content/environment/air-land-water/site-remediation</div>
+                </a>
+                
+                <a href="https://thenarwhal.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">The Narwhal</div>
+                    <div class="resource-card-desc">Independent Canadian environmental investigative journalism</div>
+                    <div class="resource-card-url">thenarwhal.ca</div>
+                </a>
+                
+                <a href="https://ecojustice.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Ecojustice</div>
+                    <div class="resource-card-desc">Canada's leading environmental law charity</div>
+                    <div class="resource-card-url">ecojustice.ca</div>
+                </a>
+                
+            </div>
+        </div>
+    </section>
+    
+
+    
+    <!-- X Feed -->
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:700px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Latest from @teslashortstime</h2>
+            </div>
+            <div class="glass-card" style="padding:var(--sp-4);overflow:hidden;max-height:600px;overflow-y:auto;">
+                <a class="twitter-timeline" data-theme="dark" data-chrome="noheader nofooter noborders transparent" data-height="500" href="https://twitter.com/teslashortstime">Posts by @teslashortstime</a>
+            </div>
+        </div>
+    </section>
     
 
     <!-- Related Show Recommendation -->
@@ -363,6 +431,8 @@
     </footer>
 
     
+    
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     
     <script>
         const JSON_URL = 'digests/env_intel/summaries_env_intel.json';

--- a/fascinating_frontiers.html
+++ b/fascinating_frontiers.html
@@ -167,6 +167,9 @@
                     <span style="background:var(--nn-card);border:1px solid var(--nn-border);padding:2px 10px;border-radius:6px;">~15 min</span>
                 </div>
                 <p class="show-hero-desc">Daily space and astronomy news covering mission updates, cosmic discoveries, exoplanet breakthroughs, and rocket launches. From NASA and ESA to SpaceX and beyond.</p>
+                
+                <p style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);margin-bottom:var(--sp-4);font-style:italic;">For space enthusiasts, amateur astronomers, students, and anyone who looks up and wonders what's out there.</p>
+                
                 <div class="show-hero-actions">
                     <a href="#episodes" class="nn-btn nn-btn-primary">Listen Now</a>
                     <a href="fascinating-frontiers-summaries.html" class="nn-btn">View Summaries</a>
@@ -201,6 +204,9 @@
                 <h2>Recent Episodes</h2>
             </div>
             <div id="episodes-grid" class="episodes-grid"></div>
+            <div style="text-align:center;margin-top:var(--sp-6);">
+                <a href="fascinating-frontiers-summaries.html" class="nn-btn">View All Episodes</a>
+            </div>
         </div>
     </section>
 
@@ -219,6 +225,68 @@
         </div>
     </section>
 
+    <!-- Resources -->
+    
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources & Further Reading</h2>
+            </div>
+            <div class="resources-grid">
+                
+                <a href="https://www.nasa.gov" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">NASA</div>
+                    <div class="resource-card-desc">Official NASA mission updates, images, and research</div>
+                    <div class="resource-card-url">www.nasa.gov</div>
+                </a>
+                
+                <a href="https://apod.nasa.gov" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">NASA APOD</div>
+                    <div class="resource-card-desc">Astronomy Picture of the Day — daily cosmic imagery with explanations</div>
+                    <div class="resource-card-url">apod.nasa.gov</div>
+                </a>
+                
+                <a href="https://www.space.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Space.com</div>
+                    <div class="resource-card-desc">Space news, astronomy guides, and stargazing tips</div>
+                    <div class="resource-card-url">www.space.com</div>
+                </a>
+                
+                <a href="https://webbtelescope.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Webb Telescope</div>
+                    <div class="resource-card-desc">James Webb Space Telescope images and science results</div>
+                    <div class="resource-card-url">webbtelescope.org</div>
+                </a>
+                
+                <a href="https://www.heavens-above.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Heavens-Above</div>
+                    <div class="resource-card-desc">Track satellites, ISS passes, and night sky objects for your location</div>
+                    <div class="resource-card-url">www.heavens-above.com</div>
+                </a>
+                
+                <a href="https://www.planetary.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">The Planetary Society</div>
+                    <div class="resource-card-desc">Space exploration advocacy and citizen science projects</div>
+                    <div class="resource-card-url">www.planetary.org</div>
+                </a>
+                
+            </div>
+        </div>
+    </section>
+    
+
+    
+    <!-- X Feed -->
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:700px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Latest from @planetterrian</h2>
+            </div>
+            <div class="glass-card" style="padding:var(--sp-4);overflow:hidden;max-height:600px;overflow-y:auto;">
+                <a class="twitter-timeline" data-theme="dark" data-chrome="noheader nofooter noborders transparent" data-height="500" href="https://twitter.com/planetterrian">Posts by @planetterrian</a>
+            </div>
+        </div>
+    </section>
     
 
     <!-- Related Show Recommendation -->
@@ -363,6 +431,8 @@
     </footer>
 
     
+    
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     
     <script>
         const JSON_URL = 'digests/fascinating_frontiers/summaries_space.json';

--- a/generate_html.py
+++ b/generate_html.py
@@ -55,6 +55,16 @@ NETWORK_SHOWS = {
         "theme_color": "#E31937",
         "meta_description": "Daily Tesla Shorts Time podcast — Tesla news, TSLA stock, FSD updates, and sustainable energy progress.",
         "meta_keywords": "Tesla podcast, TSLA news, Tesla stock, EV analysis, Tesla Shorts Time, daily digests",
+        "audience": "For Tesla owners, TSLA investors, EV enthusiasts, and anyone following the transition to sustainable energy.",
+        "source_highlights": ["Teslarati", "CleanTechnica", "InsideEVs", "The Verge"],
+        "resources": [
+            {"name": "Tesla Investor Relations", "url": "https://ir.tesla.com", "desc": "Official SEC filings, earnings calls, and shareholder letters"},
+            {"name": "Tesla Blog", "url": "https://www.tesla.com/blog", "desc": "Official Tesla announcements and product updates"},
+            {"name": "TSLA on Yahoo Finance", "url": "https://finance.yahoo.com/quote/TSLA", "desc": "Real-time stock price, charts, and financial data"},
+            {"name": "Teslarati", "url": "https://www.teslarati.com", "desc": "Independent Tesla and SpaceX news coverage"},
+            {"name": "Not A Tesla App", "url": "https://www.notateslaapp.com", "desc": "Tesla software updates and feature tracking"},
+            {"name": "CleanTechnica", "url": "https://cleantechnica.com", "desc": "Clean energy and electric vehicle industry news"},
+        ],
     },
     "omni_view": {
         "name": "Omni View",
@@ -82,6 +92,16 @@ NETWORK_SHOWS = {
         "theme_color": "#0B6FD6",
         "meta_description": "Omni View — Daily balanced news summaries from diverse sources. Multiple perspectives on the stories that matter.",
         "meta_keywords": "balanced news, diverse perspectives, media literacy, news analysis, unbiased reporting",
+        "audience": "For thoughtful news consumers who want every side of the story — not just the one their algorithm picks.",
+        "source_highlights": ["NPR", "BBC", "Reuters", "WSJ", "Al Jazeera", "The Guardian"],
+        "resources": [
+            {"name": "AllSides Media Bias Chart", "url": "https://www.allsides.com/media-bias/ratings", "desc": "See where news sources fall on the political spectrum"},
+            {"name": "Ground News", "url": "https://ground.news", "desc": "Compare how different outlets cover the same story"},
+            {"name": "Ad Fontes Media Bias Chart", "url": "https://adfontesmedia.com", "desc": "Independent media reliability and bias ratings"},
+            {"name": "Reuters", "url": "https://www.reuters.com", "desc": "Wire service known for factual, neutral reporting"},
+            {"name": "AP News", "url": "https://apnews.com", "desc": "Non-profit global news wire with minimal editorial bias"},
+            {"name": "FactCheck.org", "url": "https://www.factcheck.org", "desc": "Non-partisan fact-checking from the Annenberg Public Policy Center"},
+        ],
     },
     "fascinating_frontiers": {
         "name": "Fascinating Frontiers",
@@ -109,6 +129,16 @@ NETWORK_SHOWS = {
         "theme_color": "#7C5CFF",
         "meta_description": "Fascinating Frontiers — Daily space and astronomy news podcast. Mission updates, cosmic discoveries, and rocket launches.",
         "meta_keywords": "space podcast, astronomy news, NASA discoveries, space exploration, Fascinating Frontiers",
+        "audience": "For space enthusiasts, amateur astronomers, students, and anyone who looks up and wonders what's out there.",
+        "source_highlights": ["NASA", "ESA", "Space.com", "SpaceNews"],
+        "resources": [
+            {"name": "NASA", "url": "https://www.nasa.gov", "desc": "Official NASA mission updates, images, and research"},
+            {"name": "NASA APOD", "url": "https://apod.nasa.gov", "desc": "Astronomy Picture of the Day — daily cosmic imagery with explanations"},
+            {"name": "Space.com", "url": "https://www.space.com", "desc": "Space news, astronomy guides, and stargazing tips"},
+            {"name": "Webb Telescope", "url": "https://webbtelescope.org", "desc": "James Webb Space Telescope images and science results"},
+            {"name": "Heavens-Above", "url": "https://www.heavens-above.com", "desc": "Track satellites, ISS passes, and night sky objects for your location"},
+            {"name": "The Planetary Society", "url": "https://www.planetary.org", "desc": "Space exploration advocacy and citizen science projects"},
+        ],
     },
     "planetterrian": {
         "name": "Planetterrian Daily",
@@ -136,6 +166,16 @@ NETWORK_SHOWS = {
         "theme_color": "#018DB1",
         "meta_description": "Planetterrian Daily — Science, longevity, and health discoveries. Genetics, biotech, CRISPR, and more.",
         "meta_keywords": "science podcast, longevity research, health discoveries, Planetterrian Daily, biotech news",
+        "audience": "For the health-curious, longevity enthusiasts, biohackers, and anyone who wants tomorrow's medicine explained today.",
+        "source_highlights": ["Nature", "Science", "Cell", "New Scientist"],
+        "resources": [
+            {"name": "PubMed", "url": "https://pubmed.ncbi.nlm.nih.gov", "desc": "Free access to biomedical and life science research papers"},
+            {"name": "ClinicalTrials.gov", "url": "https://clinicaltrials.gov", "desc": "Database of clinical studies and trials worldwide"},
+            {"name": "Nature", "url": "https://www.nature.com", "desc": "Premier multidisciplinary science journal"},
+            {"name": "Quanta Magazine", "url": "https://www.quantamagazine.org", "desc": "Accessible coverage of math, physics, and biology research"},
+            {"name": "Lifespan.io", "url": "https://www.lifespan.io", "desc": "Longevity research news and rejuvenation science tracker"},
+            {"name": "Examine.com", "url": "https://examine.com", "desc": "Evidence-based supplement and nutrition research"},
+        ],
     },
     "env_intel": {
         "name": "Environmental Intelligence",
@@ -163,6 +203,16 @@ NETWORK_SHOWS = {
         "theme_color": "#1B5E20",
         "meta_description": "Environmental Intelligence — Daily environmental regulatory and compliance briefing for BC professionals.",
         "meta_keywords": "environmental intelligence, regulatory compliance, environmental briefings, Canadian environment",
+        "audience": "For Canadian environmental professionals — contaminated sites consultants, regulators, lawyers, and lab scientists.",
+        "source_highlights": ["Canada Gazette", "ECCC", "BC Ministry of Environment", "The Narwhal"],
+        "resources": [
+            {"name": "Canada Gazette", "url": "https://www.gazette.gc.ca", "desc": "Official source for federal regulations and proposed amendments"},
+            {"name": "ECCC", "url": "https://www.canada.ca/en/environment-climate-change.html", "desc": "Environment and Climate Change Canada — federal policy and enforcement"},
+            {"name": "CCME", "url": "https://ccme.ca", "desc": "Canadian Council of Ministers of the Environment — guidelines and standards"},
+            {"name": "BC Site Remediation", "url": "https://www2.gov.bc.ca/gov/content/environment/air-land-water/site-remediation", "desc": "BC contaminated sites registry, guidance, and CSR protocols"},
+            {"name": "The Narwhal", "url": "https://thenarwhal.ca", "desc": "Independent Canadian environmental investigative journalism"},
+            {"name": "Ecojustice", "url": "https://ecojustice.ca", "desc": "Canada's leading environmental law charity"},
+        ],
     },
     "models_agents": {
         "name": "Models & Agents",
@@ -190,6 +240,16 @@ NETWORK_SHOWS = {
         "theme_color": "#8B5CF6",
         "meta_description": "Models & Agents — Daily AI briefing on models, agent frameworks, and practical AI developments.",
         "meta_keywords": "AI models, agent frameworks, LLM news, AI briefings, Models and Agents",
+        "audience": "For developers building with AI, professionals adopting AI tools, and anyone who wants to stay ahead of the most transformative technology of our generation.",
+        "source_highlights": ["OpenAI", "Anthropic", "Hugging Face", "arXiv"],
+        "resources": [
+            {"name": "Hugging Face", "url": "https://huggingface.co", "desc": "Open-source models, datasets, demos, and the model Hub"},
+            {"name": "Papers With Code", "url": "https://paperswithcode.com", "desc": "ML papers with code, benchmarks, and leaderboards"},
+            {"name": "arXiv AI", "url": "https://arxiv.org/list/cs.AI/recent", "desc": "Latest AI research preprints from the research community"},
+            {"name": "LM Arena", "url": "https://lmarena.ai", "desc": "Chatbot Arena — crowdsourced LLM rankings and leaderboard"},
+            {"name": "Latent Space", "url": "https://www.latent.space", "desc": "AI engineering podcast, newsletter, and community"},
+            {"name": "The Decoder", "url": "https://the-decoder.com", "desc": "AI news focused on practical developments and new releases"},
+        ],
     },
 }
 
@@ -209,6 +269,7 @@ def _build_all_shows_list():
             "schedule": cfg.get("schedule", "Daily"),
             "episode_length": cfg.get("episode_length", ""),
             "description_long": cfg.get("description_long", cfg["description"]),
+            "source_highlights": cfg.get("source_highlights", []),
         }
         for cfg in NETWORK_SHOWS.values()
     ]

--- a/index.html
+++ b/index.html
@@ -177,6 +177,9 @@
                     <span style="background:var(--nn-card);border:1px solid var(--nn-border);padding:2px 10px;border-radius:6px;">~15 min</span>
                 </div>
                 <p class="show-hero-desc">Tesla Shorts Time is a daily podcast delivering the most important Tesla news and developments. We focus on how Tesla is advancing its mission to accelerate the world's transition to sustainable energy, saving lives through safer vehicles, and making the world a better place.</p>
+                
+                <p style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);margin-bottom:var(--sp-4);font-style:italic;">For Tesla owners, TSLA investors, EV enthusiasts, and anyone following the transition to sustainable energy.</p>
+                
                 <div class="show-hero-actions">
                     <a href="#episodes" class="nn-btn nn-btn-primary">Listen Now</a>
                     <a href="tesla-summaries.html" class="nn-btn">View Summaries</a>
@@ -219,6 +222,9 @@
                 <h2>Recent Episodes</h2>
             </div>
             <div id="episodes-grid" class="episodes-grid"></div>
+            <div style="text-align:center;margin-top:var(--sp-6);">
+                <a href="tesla-summaries.html" class="nn-btn">View All Episodes</a>
+            </div>
         </div>
     </section>
 
@@ -236,6 +242,56 @@
             </div>
         </div>
     </section>
+
+    <!-- Resources -->
+    
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources & Further Reading</h2>
+            </div>
+            <div class="resources-grid">
+                
+                <a href="https://ir.tesla.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Tesla Investor Relations</div>
+                    <div class="resource-card-desc">Official SEC filings, earnings calls, and shareholder letters</div>
+                    <div class="resource-card-url">ir.tesla.com</div>
+                </a>
+                
+                <a href="https://www.tesla.com/blog" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Tesla Blog</div>
+                    <div class="resource-card-desc">Official Tesla announcements and product updates</div>
+                    <div class="resource-card-url">www.tesla.com/blog</div>
+                </a>
+                
+                <a href="https://finance.yahoo.com/quote/TSLA" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">TSLA on Yahoo Finance</div>
+                    <div class="resource-card-desc">Real-time stock price, charts, and financial data</div>
+                    <div class="resource-card-url">finance.yahoo.com/quote/TSLA</div>
+                </a>
+                
+                <a href="https://www.teslarati.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Teslarati</div>
+                    <div class="resource-card-desc">Independent Tesla and SpaceX news coverage</div>
+                    <div class="resource-card-url">www.teslarati.com</div>
+                </a>
+                
+                <a href="https://www.notateslaapp.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Not A Tesla App</div>
+                    <div class="resource-card-desc">Tesla software updates and feature tracking</div>
+                    <div class="resource-card-url">www.notateslaapp.com</div>
+                </a>
+                
+                <a href="https://cleantechnica.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">CleanTechnica</div>
+                    <div class="resource-card-desc">Clean energy and electric vehicle industry news</div>
+                    <div class="resource-card-url">cleantechnica.com</div>
+                </a>
+                
+            </div>
+        </div>
+    </section>
+    
 
     
     <!-- X Feed -->

--- a/models-agents.html
+++ b/models-agents.html
@@ -167,6 +167,9 @@
                     <span style="background:var(--nn-card);border:1px solid var(--nn-border);padding:2px 10px;border-radius:6px;">~15 min</span>
                 </div>
                 <p class="show-hero-desc">Daily AI briefing covering new model releases, agent frameworks, and practical developments. From GPT and Claude to OpenClaw and Agent Zero — stay on top of the most exciting developments of our generation.</p>
+                
+                <p style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);margin-bottom:var(--sp-4);font-style:italic;">For developers building with AI, professionals adopting AI tools, and anyone who wants to stay ahead of the most transformative technology of our generation.</p>
+                
                 <div class="show-hero-actions">
                     <a href="#episodes" class="nn-btn nn-btn-primary">Listen Now</a>
                     <a href="models-agents-summaries.html" class="nn-btn">View Summaries</a>
@@ -199,6 +202,9 @@
                 <h2>Recent Episodes</h2>
             </div>
             <div id="episodes-grid" class="episodes-grid"></div>
+            <div style="text-align:center;margin-top:var(--sp-6);">
+                <a href="models-agents-summaries.html" class="nn-btn">View All Episodes</a>
+            </div>
         </div>
     </section>
 
@@ -216,6 +222,56 @@
             </div>
         </div>
     </section>
+
+    <!-- Resources -->
+    
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources & Further Reading</h2>
+            </div>
+            <div class="resources-grid">
+                
+                <a href="https://huggingface.co" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Hugging Face</div>
+                    <div class="resource-card-desc">Open-source models, datasets, demos, and the model Hub</div>
+                    <div class="resource-card-url">huggingface.co</div>
+                </a>
+                
+                <a href="https://paperswithcode.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Papers With Code</div>
+                    <div class="resource-card-desc">ML papers with code, benchmarks, and leaderboards</div>
+                    <div class="resource-card-url">paperswithcode.com</div>
+                </a>
+                
+                <a href="https://arxiv.org/list/cs.AI/recent" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">arXiv AI</div>
+                    <div class="resource-card-desc">Latest AI research preprints from the research community</div>
+                    <div class="resource-card-url">arxiv.org/list/cs.AI/recent</div>
+                </a>
+                
+                <a href="https://lmarena.ai" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">LM Arena</div>
+                    <div class="resource-card-desc">Chatbot Arena — crowdsourced LLM rankings and leaderboard</div>
+                    <div class="resource-card-url">lmarena.ai</div>
+                </a>
+                
+                <a href="https://www.latent.space" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Latent Space</div>
+                    <div class="resource-card-desc">AI engineering podcast, newsletter, and community</div>
+                    <div class="resource-card-url">www.latent.space</div>
+                </a>
+                
+                <a href="https://the-decoder.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">The Decoder</div>
+                    <div class="resource-card-desc">AI news focused on practical developments and new releases</div>
+                    <div class="resource-card-url">the-decoder.com</div>
+                </a>
+                
+            </div>
+        </div>
+    </section>
+    
 
     
 

--- a/network.html
+++ b/network.html
@@ -190,6 +190,9 @@
                         <span class="show-card-badge">~15 min</span>
                     </div>
                     <div class="show-card-tagline">Daily podcast covering how Tesla is advancing its mission to accelerate the transition to sustainable energy. Covers FSD safety milestones, Cybertruck production, energy storage breakthroughs, TSLA stock movements, and why the shorts keep getting it wrong.</div>
+                    
+                    <div class="show-card-sources">Sources: Teslarati, CleanTechnica, InsideEVs, The Verge</div>
+                    
                     <div class="show-card-listen">
                         Listen
                         <svg viewBox="0 0 16 16" fill="none"><path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -204,6 +207,9 @@
                         <span class="show-card-badge">~20 min</span>
                     </div>
                     <div class="show-card-tagline">A neutral, media-literacy-first daily briefing designed for everyone from children to seniors. Covers top world, business, technology, and media stories with perspectives from across the political spectrum — so you can decide for yourself.</div>
+                    
+                    <div class="show-card-sources">Sources: NPR, BBC, Reuters, WSJ, Al Jazeera, The Guardian</div>
+                    
                     <div class="show-card-listen">
                         Listen
                         <svg viewBox="0 0 16 16" fill="none"><path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -218,6 +224,9 @@
                         <span class="show-card-badge">~15 min</span>
                     </div>
                     <div class="show-card-tagline">Daily space and astronomy news covering mission updates, cosmic discoveries, exoplanet breakthroughs, and rocket launches. From NASA and ESA to SpaceX and beyond — the universe is more exciting than you think.</div>
+                    
+                    <div class="show-card-sources">Sources: NASA, ESA, Space.com, SpaceNews</div>
+                    
                     <div class="show-card-listen">
                         Listen
                         <svg viewBox="0 0 16 16" fill="none"><path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -232,6 +241,9 @@
                         <span class="show-card-badge">~15 min</span>
                     </div>
                     <div class="show-card-tagline">Daily discoveries in longevity science, genetics, biotech, CRISPR, neuroscience, and health research. If it could extend your healthspan or change medicine, we cover it.</div>
+                    
+                    <div class="show-card-sources">Sources: Nature, Science, Cell, New Scientist</div>
+                    
                     <div class="show-card-listen">
                         Listen
                         <svg viewBox="0 0 16 16" fill="none"><path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -246,6 +258,9 @@
                         <span class="show-card-badge">~10 min</span>
                     </div>
                     <div class="show-card-tagline">Environmental regulatory, science, and compliance briefing for BC professionals. Covers contaminated sites, CEPA, emissions, carbon policy, PFAS, and remediation developments across Canada.</div>
+                    
+                    <div class="show-card-sources">Sources: Canada Gazette, ECCC, BC Ministry of Environment, The Narwhal</div>
+                    
                     <div class="show-card-listen">
                         Listen
                         <svg viewBox="0 0 16 16" fill="none"><path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -260,6 +275,9 @@
                         <span class="show-card-badge">~15 min</span>
                     </div>
                     <div class="show-card-tagline">Daily AI briefing covering new model releases, agent frameworks, and practical developments. From GPT and Claude to open-source projects — stay on top of the most exciting tech developments of our generation.</div>
+                    
+                    <div class="show-card-sources">Sources: OpenAI, Anthropic, Hugging Face, arXiv</div>
+                    
                     <div class="show-card-listen">
                         Listen
                         <svg viewBox="0 0 16 16" fill="none"><path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -308,17 +326,56 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>Subscribe Everywhere</h2>
-                <p>All shows are available on major podcast platforms. Pick your favorite and never miss an episode.</p>
+                <p>All shows are available via RSS. Pick your favorite podcast app and never miss an episode.</p>
             </div>
             <div class="subscribe-badges">
                 <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939" class="subscribe-badge" target="_blank" rel="noopener">
-                    Apple Podcasts
+                    Apple Podcasts (Tesla Shorts Time)
                 </a>
                 <a href="network.rss" class="subscribe-badge">
-                    RSS Feed
+                    Network RSS (All Shows)
                 </a>
             </div>
-            <p style="text-align:center;color:var(--nn-text-muted);font-family:var(--font-ui);font-size:0.88rem;margin-top:var(--sp-6);">More platforms coming soon. Use RSS for immediate access to all shows.</p>
+            <div class="subscribe-rss-grid">
+                
+                <a href="podcast.rss" class="subscribe-rss-item">
+                    <img src="podcast-image-v3.jpg" alt="" loading="lazy">
+                    <span>Tesla Shorts Time</span>
+                    <span class="subscribe-rss-label">RSS</span>
+                </a>
+                
+                <a href="omni_view_podcast.rss" class="subscribe-rss-item">
+                    <img src="omni-view-podcast-image.jpg" alt="" loading="lazy">
+                    <span>Omni View</span>
+                    <span class="subscribe-rss-label">RSS</span>
+                </a>
+                
+                <a href="fascinating_frontiers_podcast.rss" class="subscribe-rss-item">
+                    <img src="Fascinating Frontiers-3000x3000.jpg" alt="" loading="lazy">
+                    <span>Fascinating Frontiers</span>
+                    <span class="subscribe-rss-label">RSS</span>
+                </a>
+                
+                <a href="planetterrian_podcast.rss" class="subscribe-rss-item">
+                    <img src="planetterrian-podcast-image.jpg" alt="" loading="lazy">
+                    <span>Planetterrian Daily</span>
+                    <span class="subscribe-rss-label">RSS</span>
+                </a>
+                
+                <a href="env_intel_podcast.rss" class="subscribe-rss-item">
+                    <img src="env-intel-podcast-image.jpg" alt="" loading="lazy">
+                    <span>Environmental Intelligence</span>
+                    <span class="subscribe-rss-label">RSS</span>
+                </a>
+                
+                <a href="models_agents_podcast.rss" class="subscribe-rss-item">
+                    <img src="models-agents-podcast-image.jpg" alt="" loading="lazy">
+                    <span>Models & Agents</span>
+                    <span class="subscribe-rss-label">RSS</span>
+                </a>
+                
+            </div>
+            <p style="text-align:center;color:var(--nn-text-muted);font-family:var(--font-ui);font-size:0.88rem;margin-top:var(--sp-6);">Copy any RSS link into your podcast app of choice — Apple Podcasts, Spotify, Pocket Casts, Overcast, or any RSS reader.</p>
         </div>
     </section>
 

--- a/omni-view.html
+++ b/omni-view.html
@@ -167,6 +167,9 @@
                     <span style="background:var(--nn-card);border:1px solid var(--nn-border);padding:2px 10px;border-radius:6px;">~20 min</span>
                 </div>
                 <p class="show-hero-desc">Omni View is a neutral, media-literacy-first daily briefing designed for everyone from children to seniors. Covers top world, business, technology, and media stories with perspectives from across the political spectrum.</p>
+                
+                <p style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);margin-bottom:var(--sp-4);font-style:italic;">For thoughtful news consumers who want every side of the story — not just the one their algorithm picks.</p>
+                
                 <div class="show-hero-actions">
                     <a href="#episodes" class="nn-btn nn-btn-primary">Listen Now</a>
                     <a href="omni-view-summaries.html" class="nn-btn">View Summaries</a>
@@ -201,6 +204,9 @@
                 <h2>Recent Episodes</h2>
             </div>
             <div id="episodes-grid" class="episodes-grid"></div>
+            <div style="text-align:center;margin-top:var(--sp-6);">
+                <a href="omni-view-summaries.html" class="nn-btn">View All Episodes</a>
+            </div>
         </div>
     </section>
 
@@ -219,6 +225,68 @@
         </div>
     </section>
 
+    <!-- Resources -->
+    
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources & Further Reading</h2>
+            </div>
+            <div class="resources-grid">
+                
+                <a href="https://www.allsides.com/media-bias/ratings" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">AllSides Media Bias Chart</div>
+                    <div class="resource-card-desc">See where news sources fall on the political spectrum</div>
+                    <div class="resource-card-url">www.allsides.com/media-bias/ratings</div>
+                </a>
+                
+                <a href="https://ground.news" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Ground News</div>
+                    <div class="resource-card-desc">Compare how different outlets cover the same story</div>
+                    <div class="resource-card-url">ground.news</div>
+                </a>
+                
+                <a href="https://adfontesmedia.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Ad Fontes Media Bias Chart</div>
+                    <div class="resource-card-desc">Independent media reliability and bias ratings</div>
+                    <div class="resource-card-url">adfontesmedia.com</div>
+                </a>
+                
+                <a href="https://www.reuters.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Reuters</div>
+                    <div class="resource-card-desc">Wire service known for factual, neutral reporting</div>
+                    <div class="resource-card-url">www.reuters.com</div>
+                </a>
+                
+                <a href="https://apnews.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">AP News</div>
+                    <div class="resource-card-desc">Non-profit global news wire with minimal editorial bias</div>
+                    <div class="resource-card-url">apnews.com</div>
+                </a>
+                
+                <a href="https://www.factcheck.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">FactCheck.org</div>
+                    <div class="resource-card-desc">Non-partisan fact-checking from the Annenberg Public Policy Center</div>
+                    <div class="resource-card-url">www.factcheck.org</div>
+                </a>
+                
+            </div>
+        </div>
+    </section>
+    
+
+    
+    <!-- X Feed -->
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:700px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Latest from @omniviewnews</h2>
+            </div>
+            <div class="glass-card" style="padding:var(--sp-4);overflow:hidden;max-height:600px;overflow-y:auto;">
+                <a class="twitter-timeline" data-theme="dark" data-chrome="noheader nofooter noborders transparent" data-height="500" href="https://twitter.com/omniviewnews">Posts by @omniviewnews</a>
+            </div>
+        </div>
+    </section>
     
 
     <!-- Related Show Recommendation -->
@@ -363,6 +431,8 @@
     </footer>
 
     
+    
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     
     <script>
         const JSON_URL = 'digests/omni_view/summaries_omni.json';

--- a/planetterrian.html
+++ b/planetterrian.html
@@ -167,6 +167,9 @@
                     <span style="background:var(--nn-card);border:1px solid var(--nn-border);padding:2px 10px;border-radius:6px;">~15 min</span>
                 </div>
                 <p class="show-hero-desc">Daily discoveries in longevity science, genetics, biotech, CRISPR, neuroscience, and health research. If it could extend your healthspan or change medicine, we cover it.</p>
+                
+                <p style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);margin-bottom:var(--sp-4);font-style:italic;">For the health-curious, longevity enthusiasts, biohackers, and anyone who wants tomorrow's medicine explained today.</p>
+                
                 <div class="show-hero-actions">
                     <a href="#episodes" class="nn-btn nn-btn-primary">Listen Now</a>
                     <a href="planetterrian-summaries.html" class="nn-btn">View Summaries</a>
@@ -201,6 +204,9 @@
                 <h2>Recent Episodes</h2>
             </div>
             <div id="episodes-grid" class="episodes-grid"></div>
+            <div style="text-align:center;margin-top:var(--sp-6);">
+                <a href="planetterrian-summaries.html" class="nn-btn">View All Episodes</a>
+            </div>
         </div>
     </section>
 
@@ -219,6 +225,68 @@
         </div>
     </section>
 
+    <!-- Resources -->
+    
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources & Further Reading</h2>
+            </div>
+            <div class="resources-grid">
+                
+                <a href="https://pubmed.ncbi.nlm.nih.gov" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">PubMed</div>
+                    <div class="resource-card-desc">Free access to biomedical and life science research papers</div>
+                    <div class="resource-card-url">pubmed.ncbi.nlm.nih.gov</div>
+                </a>
+                
+                <a href="https://clinicaltrials.gov" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">ClinicalTrials.gov</div>
+                    <div class="resource-card-desc">Database of clinical studies and trials worldwide</div>
+                    <div class="resource-card-url">clinicaltrials.gov</div>
+                </a>
+                
+                <a href="https://www.nature.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Nature</div>
+                    <div class="resource-card-desc">Premier multidisciplinary science journal</div>
+                    <div class="resource-card-url">www.nature.com</div>
+                </a>
+                
+                <a href="https://www.quantamagazine.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Quanta Magazine</div>
+                    <div class="resource-card-desc">Accessible coverage of math, physics, and biology research</div>
+                    <div class="resource-card-url">www.quantamagazine.org</div>
+                </a>
+                
+                <a href="https://www.lifespan.io" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Lifespan.io</div>
+                    <div class="resource-card-desc">Longevity research news and rejuvenation science tracker</div>
+                    <div class="resource-card-url">www.lifespan.io</div>
+                </a>
+                
+                <a href="https://examine.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">Examine.com</div>
+                    <div class="resource-card-desc">Evidence-based supplement and nutrition research</div>
+                    <div class="resource-card-url">examine.com</div>
+                </a>
+                
+            </div>
+        </div>
+    </section>
+    
+
+    
+    <!-- X Feed -->
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:700px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Latest from @planetterrian</h2>
+            </div>
+            <div class="glass-card" style="padding:var(--sp-4);overflow:hidden;max-height:600px;overflow-y:auto;">
+                <a class="twitter-timeline" data-theme="dark" data-chrome="noheader nofooter noborders transparent" data-height="500" href="https://twitter.com/planetterrian">Posts by @planetterrian</a>
+            </div>
+        </div>
+    </section>
     
 
     <!-- Related Show Recommendation -->
@@ -363,6 +431,8 @@
     </footer>
 
     
+    
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     
     <script>
         const JSON_URL = 'digests/planetterrian/summaries_planet.json';

--- a/styles/main.css
+++ b/styles/main.css
@@ -990,3 +990,110 @@ button:focus-visible {
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
 }
+
+/* ---------- Who This Is For ---------- */
+.show-audience-card {
+  padding: var(--sp-6);
+  text-align: center;
+}
+.show-audience-label {
+  font-family: var(--font-ui);
+  font-size: 0.75rem; font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--show-color, var(--nn-purple));
+  margin-bottom: var(--sp-3);
+}
+.show-audience-text {
+  font-family: var(--font-ui);
+  font-size: 1rem;
+  color: var(--nn-text-muted);
+  line-height: 1.6;
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+/* ---------- Resources Grid ---------- */
+.resources-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--sp-4);
+}
+.resource-card {
+  padding: var(--sp-5);
+  display: flex; flex-direction: column; gap: var(--sp-2);
+  text-decoration: none;
+}
+.resource-card:hover {
+  border-color: var(--show-color, var(--nn-purple));
+}
+.resource-card-name {
+  font-family: var(--font-heading);
+  font-size: 1rem; font-weight: 600;
+  color: var(--nn-white);
+}
+.resource-card-desc {
+  font-family: var(--font-ui);
+  font-size: 0.88rem;
+  color: var(--nn-text-muted);
+  line-height: 1.5;
+  flex: 1;
+}
+.resource-card-url {
+  font-family: var(--font-ui);
+  font-size: 0.78rem;
+  color: var(--show-color, var(--nn-purple));
+  opacity: 0.7;
+}
+
+/* ---------- Network Subscribe RSS Grid ---------- */
+.subscribe-rss-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: var(--sp-3);
+  margin-top: var(--sp-6);
+}
+.subscribe-rss-item {
+  display: flex; align-items: center; gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: 10px;
+  border: 1px solid var(--nn-border);
+  background: var(--nn-card);
+  font-family: var(--font-ui);
+  font-size: 0.9rem; font-weight: 500;
+  color: var(--nn-text);
+  transition: all var(--duration) var(--ease);
+  text-decoration: none;
+}
+.subscribe-rss-item:hover {
+  border-color: var(--nn-border-hover);
+  background: var(--nn-card-hover);
+}
+.subscribe-rss-item img {
+  width: 32px; height: 32px; border-radius: 6px; object-fit: cover; flex-shrink: 0;
+}
+.subscribe-rss-label {
+  margin-left: auto;
+  font-size: 0.72rem; font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--nn-text-muted);
+  border: 1px solid var(--nn-border);
+  padding: 2px var(--sp-2);
+  border-radius: 4px;
+}
+
+/* ---------- Source Highlights ---------- */
+.show-card-sources {
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  color: var(--nn-text-muted);
+  opacity: 0.7;
+  margin-bottom: var(--sp-2);
+}
+
+/* ---------- Responsive: new sections ---------- */
+@media (max-width: 639px) {
+  .resources-grid { grid-template-columns: 1fr; }
+  .subscribe-rss-grid { grid-template-columns: 1fr; }
+}

--- a/templates/network_page.html.j2
+++ b/templates/network_page.html.j2
@@ -67,6 +67,9 @@
                         {% if s.episode_length %}<span class="show-card-badge">{{ s.episode_length }}</span>{% endif %}
                     </div>
                     <div class="show-card-tagline">{{ s.description_long | default(s.tagline) }}</div>
+                    {% if s.source_highlights %}
+                    <div class="show-card-sources">Sources: {{ s.source_highlights | join(', ') }}</div>
+                    {% endif %}
                     <div class="show-card-listen">
                         Listen
                         <svg viewBox="0 0 16 16" fill="none"><path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -115,17 +118,26 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>Subscribe Everywhere</h2>
-                <p>All shows are available on major podcast platforms. Pick your favorite and never miss an episode.</p>
+                <p>All shows are available via RSS. Pick your favorite podcast app and never miss an episode.</p>
             </div>
             <div class="subscribe-badges">
                 <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939" class="subscribe-badge" target="_blank" rel="noopener">
-                    Apple Podcasts
+                    Apple Podcasts (Tesla Shorts Time)
                 </a>
                 <a href="network.rss" class="subscribe-badge">
-                    RSS Feed
+                    Network RSS (All Shows)
                 </a>
             </div>
-            <p style="text-align:center;color:var(--nn-text-muted);font-family:var(--font-ui);font-size:0.88rem;margin-top:var(--sp-6);">More platforms coming soon. Use RSS for immediate access to all shows.</p>
+            <div class="subscribe-rss-grid">
+                {% for s in all_shows %}
+                <a href="{{ s.rss_file }}" class="subscribe-rss-item">
+                    <img src="{{ s.podcast_image }}" alt="" loading="lazy">
+                    <span>{{ s.name }}</span>
+                    <span class="subscribe-rss-label">RSS</span>
+                </a>
+                {% endfor %}
+            </div>
+            <p style="text-align:center;color:var(--nn-text-muted);font-family:var(--font-ui);font-size:0.88rem;margin-top:var(--sp-6);">Copy any RSS link into your podcast app of choice — Apple Podcasts, Spotify, Pocket Casts, Overcast, or any RSS reader.</p>
         </div>
     </section>
 {% endblock %}

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -54,6 +54,9 @@
                     {% if episode_length %}<span style="background:var(--nn-card);border:1px solid var(--nn-border);padding:2px 10px;border-radius:6px;">{{ episode_length }}</span>{% endif %}
                 </div>
                 <p class="show-hero-desc">{{ show_description }}</p>
+                {% if audience %}
+                <p style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);margin-bottom:var(--sp-4);font-style:italic;">{{ audience }}</p>
+                {% endif %}
                 <div class="show-hero-actions">
                     <a href="#episodes" class="nn-btn nn-btn-primary">Listen Now</a>
                     <a href="{{ summaries_page }}" class="nn-btn">View Summaries</a>
@@ -96,6 +99,9 @@
                 <h2>Recent Episodes</h2>
             </div>
             <div id="episodes-grid" class="episodes-grid"></div>
+            <div style="text-align:center;margin-top:var(--sp-6);">
+                <a href="{{ summaries_page }}" class="nn-btn">View All Episodes</a>
+            </div>
         </div>
     </section>
 
@@ -114,7 +120,27 @@
         </div>
     </section>
 
-    {% if x_account and show_slug == 'tesla' %}
+    <!-- Resources -->
+    {% if resources %}
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources & Further Reading</h2>
+            </div>
+            <div class="resources-grid">
+                {% for r in resources %}
+                <a href="{{ r.url }}" class="resource-card glass-card" target="_blank" rel="noopener">
+                    <div class="resource-card-name">{{ r.name }}</div>
+                    <div class="resource-card-desc">{{ r.desc }}</div>
+                    <div class="resource-card-url">{{ r.url | replace('https://', '') | replace('http://', '') }}</div>
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+    </section>
+    {% endif %}
+
+    {% if x_account %}
     <!-- X Feed -->
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
@@ -171,7 +197,7 @@
 {% endblock %}
 
 {% block scripts %}
-    {% if x_account and show_slug == 'tesla' %}
+    {% if x_account %}
     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     {% endif %}
     <script>


### PR DESCRIPTION
…bscribe

- Add curated "Resources & Further Reading" section (6 links each) to all 6 show pages
- Add "Who This Show Is For" audience blurb in each show hero
- Expand X/Twitter timeline embed from Tesla-only to all shows with X accounts
- Add "View All Episodes" button linking to summaries from show pages
- Add source highlight badges to network page show cards for credibility
- Replace sparse network subscribe section with per-show RSS grid
- Add CSS for resources grid, audience card, subscribe RSS grid, source badges

https://claude.ai/code/session_01EGgijnaM1zBrc6HY4LqkCF