### PR TITLE
Switch MAB from Kokoro to Fish Audio TTS with voice cloning

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -182,32 +182,12 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
-      - name: Cache Kokoro + Whisper model files
+      - name: Cache Whisper / HuggingFace model files
         if: matrix.show == 'models_agents_beginners'
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/huggingface/hub
-            ~/.cache/kokoro
-          key: kokoro-whisper-v1-${{ runner.os }}
-
-      - name: Download Kokoro model files
-        if: matrix.show == 'models_agents_beginners'
-        run: |
-          KOKORO_DIR="$HOME/.cache/kokoro"
-          mkdir -p "$KOKORO_DIR"
-          if [ ! -f "$KOKORO_DIR/kokoro-v1.0.onnx" ]; then
-            echo "Downloading Kokoro ONNX model..."
-            curl -L -o "$KOKORO_DIR/kokoro-v1.0.onnx" \
-              "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx"
-          fi
-          if [ ! -f "$KOKORO_DIR/voices-v1.0.bin" ]; then
-            echo "Downloading Kokoro voices..."
-            curl -L -o "$KOKORO_DIR/voices-v1.0.bin" \
-              "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin"
-          fi
-          echo "Kokoro model files ready in $KOKORO_DIR"
-          ls -lh "$KOKORO_DIR"
+          path: ~/.cache/huggingface/hub
+          key: whisper-v1-${{ runner.os }}
 
       - name: Install Python dependencies
         run: |
@@ -242,6 +222,7 @@ jobs:
           OMNI_VIEW_NEWSLETTER_API_KEY=${{ secrets.OMNI_VIEW_NEWSLETTER_API_KEY }}
           ENV_INTEL_NEWSLETTER_API_KEY=${{ secrets.ENV_INTEL_NEWSLETTER_API_KEY }}
           MODELS_AGENTS_NEWSLETTER_API_KEY=${{ secrets.MODELS_AGENTS_NEWSLETTER_API_KEY }}
+          FISH_AUDIO_API_KEY=${{ secrets.FISH_AUDIO_API_KEY }}
           ENVEOF
           # Strip leading whitespace from heredoc lines (YAML indentation artifact)
           sed -i 's/^[[:space:]]*//' .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,10 @@
 
 Automated daily podcast generation system running 7 shows via a unified
 `run_show.py` runner + per-show YAML configs, plus 4 legacy standalone scripts
-(deprecated — see note below). Shows use **ElevenLabs TTS**, **Chatterbox TTS**
-(with voice cloning), or **Kokoro TTS** (configurable per show via
-`tts.provider` in YAML) and post to X/Twitter via `engine/publisher.post_to_x()`.
+(deprecated — see note below). Shows use **ElevenLabs TTS**, **Fish Audio TTS**
+(with voice cloning), **Kokoro TTS**, or **Chatterbox TTS** (configurable per
+show via `tts.provider` in YAML) and post to X/Twitter via
+`engine/publisher.post_to_x()`.
 
 | Show | Legacy Script | YAML Config | Schedule | X Account | TTS |
 |------|--------------|-------------|----------|-----------|-----|
@@ -16,7 +17,7 @@ Automated daily podcast generation system running 7 shows via a unified
 | Planetterrian Daily | `digests/planetterrian.py` (deprecated) | `shows/planetterrian.yaml` | Daily | `@planetterrian` | ElevenLabs |
 | Env Intel | — | `shows/env_intel.yaml` | Weekdays | `@teslashortstime` | ElevenLabs |
 | Models & Agents | — | `shows/models_agents.yaml` | Daily | — (X disabled) | ElevenLabs |
-| Models & Agents for Beginners | — | `shows/models_agents_beginners.yaml` | Daily | — (X disabled) | Kokoro |
+| Models & Agents for Beginners | — | `shows/models_agents_beginners.yaml` | Daily | — (X disabled) | Fish Audio |
 
 **Science That Changes Everything** (`digests/science_that_changes.py`, ~83 lines)
 is a standalone X-posting script, not a podcast show.
@@ -28,7 +29,7 @@ is a standalone X-posting script, not a podcast show.
 1. **Fetch** news sources (RSS, xAI/Grok web search, yfinance for Tesla)
 2. **Dedup** via ContentTracker (cross-episode) + entity dedup
 3. **Generate** digest text via xAI/Grok API
-4. **Synthesize** podcast audio via ElevenLabs TTS, Chatterbox TTS, or Kokoro TTS (per-show config)
+4. **Synthesize** podcast audio via ElevenLabs, Fish Audio, Kokoro, or Chatterbox TTS (per-show config)
 5. **Mix** intro/outro music with voice (ffmpeg) — all shows (configurable per YAML)
 6. **Post** X thread via `engine/publisher.post_to_x()` + update RSS feed + commit output to git
 
@@ -57,7 +58,7 @@ Tesla-shorts-time/
 │   ├── planetterrian/             # PT output + summaries_planet.json
 │   ├── env_intel/                 # EI output + summaries_env_intel.json
 │   ├── models_agents/             # M&A output + summaries_models_agents.json
-│   ├── models_agents_beginners/   # MAB output (Kokoro TTS)
+│   ├── models_agents_beginners/   # MAB output (Fish Audio TTS)
 │   └── *.mp3, *.md, *.txt        # Legacy TST flat output (historical)
 ├── engine/                        # Shared modules
 │   ├── __init__.py
@@ -104,8 +105,9 @@ Tesla-shorts-time/
   `shows/models_agents.yaml`; no legacy script. X posting disabled.
 - **MAB** (Models & Agents for Beginners) runs via `run_show.py` +
   `shows/models_agents_beginners.yaml`; beginner/teen-focused version of M&A.
-  Uses **Kokoro TTS** (Apache 2.0, free, local, 82M params) with
-  `am_adam` voice. Post-TTS Whisper validation enabled. X posting disabled.
+  Uses **Fish Audio TTS** (cloud API, S1 model, #1 TTS-Arena2, 0.008 WER)
+  with zero-shot voice cloning from TST voice reference sample. Post-TTS
+  Whisper validation enabled. X posting disabled.
 - All shows delegate X posting to `engine.publisher.post_to_x()`
 - TST/FF/PT delegate voice normalization to `engine.audio.normalize_voice()`
 - All shows use `engine.audio.mix_with_music()` for music mixing (3 modes:
@@ -121,7 +123,8 @@ Tesla-shorts-time/
 - `ELEVENLABS_API_KEY` — ElevenLabs TTS (all shows)
 - `X_*` / `PLANETTERRIAN_X_*` — two separate X accounts
 - Voice IDs: TST/FF/PT/M&A/EI share `dTrBzPvD2GpAqkk1MUzA`, OV uses `ns7MjJ6c8tJKnvw7U6sN`
-- MAB uses Kokoro TTS (local, free, Apache 2.0) — no API key required
+- `FISH_AUDIO_API_KEY` — Fish Audio TTS (MAB show)
+- MAB uses Fish Audio TTS (cloud API) with voice cloning from TST reference
 - See `docs/env_var_inventory.md` for the complete inventory
 
 ### RSS Feeds
@@ -219,11 +222,10 @@ Phase 3 (current):
    and other legacy scripts. Env var overrides still supported.
 10. **Early episodes deleted** — first 20 Tesla, 10 FF, 10 PT, 10 OV episodes
     removed (quality issues). RSS entries removed where applicable.
-11. **MAB switched back to Kokoro TTS** — Chatterbox TTS produced gibberish
-    on CPU for long-form content (65.9% Whisper match score, "spuzzle spuzzle
-    spuzzle" output, 221 words dropped). Kokoro's original espeak acronym
-    issues are now solved by the massively improved pronunciation pipeline
-    (200+ acronyms pre-expanded to space-separated form, per-show hooks).
-    Post-TTS Whisper validation added to catch quality regressions.
+11. **MAB switched to Fish Audio TTS** — Chatterbox produced gibberish on CPU
+    (65.9% Whisper match, "spuzzle spuzzle spuzzle"). Kokoro had espeak-quality
+    robotic pronunciation. Fish Audio S1 (#1 TTS-Arena2, 0.008 WER) with
+    zero-shot voice cloning from TST voice reference provides natural speech
+    quality. Post-TTS Whisper validation remains enabled.
 12. **Summaries JSONs moved** — all summaries live in per-show subdirectories
     (`digests/<show>/summaries_*.json`), not at the `digests/` top level.

--- a/assets/voice_references/README.md
+++ b/assets/voice_references/README.md
@@ -1,8 +1,8 @@
 # Voice Reference Samples
 
 Stable voice reference audio clips extracted from existing podcast episodes.
-These are used by zero-shot voice cloning TTS models (e.g., Chatterbox,
-Qwen3-TTS, Orpheus) to reproduce the show's voice without training.
+These are used by zero-shot voice cloning TTS models (e.g., Fish Audio,
+Chatterbox, Qwen3-TTS, Orpheus) to reproduce the show's voice without training.
 
 ## Files
 

--- a/engine/config.py
+++ b/engine/config.py
@@ -41,7 +41,7 @@ class LLMConfig:
 
 @dataclass
 class TTSConfig:
-    provider: str = "elevenlabs"  # "elevenlabs", "kokoro", or "chatterbox"
+    provider: str = "elevenlabs"  # "elevenlabs", "kokoro", "chatterbox", or "fish"
     voice_id: str = "dTrBzPvD2GpAqkk1MUzA"
     model: str = "eleven_turbo_v2_5"
     stability: float = 0.65
@@ -58,6 +58,15 @@ class TTSConfig:
     chatterbox_exaggeration: float = 0.5  # Emotional intensity (0.0–1.0)
     chatterbox_cfg_weight: float = 0.5  # Prosody/accent guidance weight
     chatterbox_device: str = "cpu"  # "cpu" or "cuda"
+    # Fish Audio-specific (ignored when provider != fish)
+    fish_reference_id: str = ""  # Persistent voice model ID from Fish Audio
+    fish_voice_reference: str = ""  # Path to WAV for inline zero-shot cloning
+    fish_temperature: float = 0.7  # Expressiveness (0.0–1.0)
+    fish_top_p: float = 0.7  # Diversity via nucleus sampling
+    fish_speed: float = 1.0  # Prosody speed
+    fish_repetition_penalty: float = 1.2  # Reduce repeated audio patterns
+    fish_format: str = "mp3"  # Output format
+    fish_mp3_bitrate: int = 128  # MP3 bitrate
     # Post-TTS transcription validation (opt-in, all providers)
     validate_transcription: bool = False
     whisper_model: str = "base"  # "tiny", "base", "small", "medium"

--- a/engine/tts.py
+++ b/engine/tts.py
@@ -1,9 +1,11 @@
 """TTS helpers for the podcast generation pipeline.
 
-Supports three providers:
+Supports four providers:
   - **ElevenLabs** (default): cloud API, paid, high quality
   - **Kokoro** (kokoro-onnx): local inference, free, Apache 2.0
   - **Chatterbox** (chatterbox-tts): local inference, free, MIT license,
+    zero-shot voice cloning from a reference audio sample
+  - **Fish Audio** (fish-audio-sdk): cloud API, paid, #1 TTS-Arena2,
     zero-shot voice cloning from a reference audio sample
 
 ElevenLabs functions:
@@ -20,6 +22,10 @@ Kokoro functions:
 Chatterbox functions:
   - synthesize_chatterbox(): top-level Chatterbox entry point — text in, audio file out
   - synthesize_chatterbox_sections(): section-aware Chatterbox synthesis
+
+Fish Audio functions:
+  - synthesize_fish(): top-level Fish Audio entry point — text in, audio file out
+  - synthesize_fish_sections(): section-aware Fish Audio synthesis
 """
 
 import logging
@@ -877,6 +883,209 @@ def synthesize_chatterbox_sections(
         section_files.append(section_path)
         logger.info(
             "Chatterbox section %d/%d (%d chars): %s",
+            i + 1, len(sections), len(section_text), section_path.name,
+        )
+
+    return section_files
+
+
+# ---------------------------------------------------------------------------
+# Fish Audio TTS (fish-audio-sdk) — cloud API, voice cloning, #1 TTS-Arena2
+# ---------------------------------------------------------------------------
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    retry=retry_if_exception_type((requests.RequestException, ConnectionError, TimeoutError)),
+)
+def _fish_synthesize_chunk(
+    text: str,
+    output_path: Path,
+    *,
+    api_key: str,
+    reference_id: str = "",
+    voice_reference: str = "",
+    temperature: float = 0.7,
+    top_p: float = 0.7,
+    speed: float = 1.0,
+    repetition_penalty: float = 1.2,
+    format: str = "mp3",
+    mp3_bitrate: int = 128,
+) -> None:
+    """Synthesize a single text chunk via Fish Audio API."""
+    from fishaudio import FishAudio
+    from fishaudio.types.tts import TTSConfig as FishTTSConfig
+
+    client = FishAudio(api_key=api_key)
+
+    # Build config with generation parameters
+    fish_config = FishTTSConfig(
+        format=format,
+        mp3_bitrate=mp3_bitrate,
+        temperature=temperature,
+        top_p=top_p,
+        repetition_penalty=repetition_penalty,
+    )
+
+    convert_kwargs: dict = {
+        "text": text,
+        "config": fish_config,
+    }
+
+    # Speed as a direct parameter on convert()
+    if speed != 1.0:
+        convert_kwargs["speed"] = speed
+
+    # Persistent voice model takes priority over inline cloning
+    if reference_id:
+        convert_kwargs["reference_id"] = reference_id
+    elif voice_reference:
+        from fishaudio.types.tts import ReferenceAudio
+
+        ref_path = Path(voice_reference)
+        if not ref_path.exists():
+            raise FileNotFoundError(f"Voice reference not found: {ref_path}")
+        ref_audio = ref_path.read_bytes()
+        convert_kwargs["references"] = [ReferenceAudio(
+            audio=ref_audio,
+            text="",  # Fish Audio infers from the audio
+        )]
+
+    audio = client.tts.convert(**convert_kwargs)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "wb") as f:
+        f.write(audio)
+    logger.info("Fish Audio chunk: %d chars → %s", len(text), output_path.name)
+
+
+def synthesize_fish(
+    text: str,
+    output_path: str | Path,
+    *,
+    api_key: str,
+    reference_id: str = "",
+    voice_reference: str = "",
+    max_chars: int = 4000,
+    temperature: float = 0.7,
+    top_p: float = 0.7,
+    speed: float = 1.0,
+    repetition_penalty: float = 1.2,
+    format: str = "mp3",
+    mp3_bitrate: int = 128,
+) -> Path:
+    """Top-level Fish Audio entry point: text in, audio file path out.
+
+    Handles chunking and concatenation. Uses zero-shot voice cloning
+    when *voice_reference* is provided, or a persistent voice model
+    when *reference_id* is set.
+    """
+    output_path = Path(output_path)
+    chunks = chunk_text(text, max_chars=max_chars)
+
+    common = dict(
+        api_key=api_key,
+        reference_id=reference_id,
+        voice_reference=voice_reference,
+        temperature=temperature,
+        top_p=top_p,
+        speed=speed,
+        repetition_penalty=repetition_penalty,
+        format=format,
+        mp3_bitrate=mp3_bitrate,
+    )
+
+    if len(chunks) == 1:
+        _fish_synthesize_chunk(text, output_path, **common)
+        return output_path
+
+    # Multi-chunk: synthesize each, then concatenate with ffmpeg
+    chunk_files: List[Path] = []
+    for i, chunk_str in enumerate(chunks):
+        chunk_path = output_path.parent / f"_fish_chunk_{i:03d}.mp3"
+        _fish_synthesize_chunk(chunk_str, chunk_path, **common)
+        chunk_files.append(chunk_path)
+
+    concat_list = output_path.parent / "_fish_concat.txt"
+    with open(concat_list, "w") as f:
+        for cf in chunk_files:
+            f.write(f"file '{cf.absolute()}'\n")
+
+    subprocess.run(
+        [
+            "ffmpeg", "-y",
+            "-f", "concat", "-safe", "0",
+            "-i", str(concat_list),
+            "-c:a", "libmp3lame", "-q:a", "2",
+            str(output_path),
+        ],
+        check=True,
+        capture_output=True,
+        timeout=300,
+    )
+
+    # Cleanup temp files
+    for cf in chunk_files:
+        try:
+            cf.unlink()
+        except OSError:
+            pass
+    try:
+        concat_list.unlink()
+    except OSError:
+        pass
+
+    logger.info("Fish Audio: %d chunks → %s", len(chunks), output_path.name)
+    return output_path
+
+
+def synthesize_fish_sections(
+    sections: List[str],
+    output_dir: Path,
+    *,
+    api_key: str,
+    reference_id: str = "",
+    voice_reference: str = "",
+    section_prefix: str = "section",
+    max_chars: int = 4000,
+    temperature: float = 0.7,
+    top_p: float = 0.7,
+    speed: float = 1.0,
+    repetition_penalty: float = 1.2,
+    format: str = "mp3",
+    mp3_bitrate: int = 128,
+) -> List[Path]:
+    """Synthesize multiple script sections into individual Fish Audio files.
+
+    Mirrors ``synthesize_sections()`` for section-aware TTS.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    section_files: List[Path] = []
+
+    for i, section_text in enumerate(sections):
+        section_text = section_text.strip()
+        if not section_text:
+            logger.warning("Skipping empty section %d", i)
+            continue
+
+        section_path = output_dir / f"{section_prefix}_{i:03d}.mp3"
+        synthesize_fish(
+            section_text,
+            section_path,
+            api_key=api_key,
+            reference_id=reference_id,
+            voice_reference=voice_reference,
+            max_chars=max_chars,
+            temperature=temperature,
+            top_p=top_p,
+            speed=speed,
+            repetition_penalty=repetition_penalty,
+            format=format,
+            mp3_bitrate=mp3_bitrate,
+        )
+        section_files.append(section_path)
+        logger.info(
+            "Fish section %d/%d (%d chars): %s",
             i + 1, len(sections), len(section_text), section_path.name,
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ kokoro-onnx>=0.4.0
 soundfile>=0.12.0
 chatterbox-tts>=0.1.0
 faster-whisper>=1.0.0
+fish-audio-sdk>=0.1.0

--- a/run_show.py
+++ b/run_show.py
@@ -387,7 +387,7 @@ def run(args: argparse.Namespace) -> None:
         tts_script_path.write_text(podcast_script, encoding="utf-8")
         logger.info("TTS script saved: %s", tts_script_path)
 
-        # 9. TTS — route based on provider (elevenlabs, kokoro, or chatterbox)
+        # 9. TTS — route based on provider (elevenlabs, kokoro, chatterbox, or fish)
         tts_provider = getattr(config.tts, "provider", "elevenlabs")
 
         tts_ready = False
@@ -416,6 +416,26 @@ def run(args: argparse.Namespace) -> None:
                             config.tts.kokoro_voice, config.tts.kokoro_speed)
             except Exception as e:
                 logger.error("Kokoro TTS unavailable: %s. Skipping TTS.", e)
+        elif tts_provider == "fish":
+            try:
+                from engine.tts import synthesize_fish, synthesize_fish_sections
+                fish_api_key = (os.getenv("FISH_AUDIO_API_KEY") or "").strip()
+                if not fish_api_key:
+                    logger.error("FISH_AUDIO_API_KEY not set. Skipping TTS.")
+                else:
+                    fish_voice_ref = ""
+                    if config.tts.fish_voice_reference:
+                        fish_voice_ref = str(PROJECT_ROOT / config.tts.fish_voice_reference)
+                    tts_ready = True
+                    logger.info(
+                        "TTS provider: Fish Audio (ref_id=%s, voice_ref=%s, temp=%.2f, speed=%.1f)",
+                        config.tts.fish_reference_id or "(none)",
+                        config.tts.fish_voice_reference or "(none)",
+                        config.tts.fish_temperature,
+                        config.tts.fish_speed,
+                    )
+            except Exception as e:
+                logger.error("Fish Audio TTS unavailable: %s. Skipping TTS.", e)
         else:
             api_key = (os.getenv("ELEVENLABS_API_KEY") or "").strip()
             if not api_key:
@@ -474,6 +494,22 @@ def run(args: argparse.Namespace) -> None:
                             section_prefix=f"sec_ep{episode_num:03d}",
                             max_chars=config.tts.max_chars,
                         )
+                    elif tts_provider == "fish":
+                        section_files = synthesize_fish_sections(
+                            sections,
+                            section_tmp_dir,
+                            api_key=fish_api_key,
+                            reference_id=config.tts.fish_reference_id,
+                            voice_reference=fish_voice_ref,
+                            section_prefix=f"sec_ep{episode_num:03d}",
+                            max_chars=config.tts.max_chars,
+                            temperature=config.tts.fish_temperature,
+                            top_p=config.tts.fish_top_p,
+                            speed=config.tts.fish_speed,
+                            repetition_penalty=config.tts.fish_repetition_penalty,
+                            format=config.tts.fish_format,
+                            mp3_bitrate=config.tts.fish_mp3_bitrate,
+                        )
                     else:
                         from engine.tts import synthesize_sections
                         section_files = synthesize_sections(
@@ -522,6 +558,20 @@ def run(args: argparse.Namespace) -> None:
                             lang=config.tts.kokoro_lang,
                             max_chars=config.tts.max_chars,
                         )
+                    elif tts_provider == "fish":
+                        synthesize_fish(
+                            podcast_script, raw_mp3,
+                            api_key=fish_api_key,
+                            reference_id=config.tts.fish_reference_id,
+                            voice_reference=fish_voice_ref,
+                            max_chars=config.tts.max_chars,
+                            temperature=config.tts.fish_temperature,
+                            top_p=config.tts.fish_top_p,
+                            speed=config.tts.fish_speed,
+                            repetition_penalty=config.tts.fish_repetition_penalty,
+                            format=config.tts.fish_format,
+                            mp3_bitrate=config.tts.fish_mp3_bitrate,
+                        )
                     else:
                         synthesize(
                             podcast_script, config.tts.voice_id, raw_mp3,
@@ -547,6 +597,20 @@ def run(args: argparse.Namespace) -> None:
                         speed=config.tts.kokoro_speed,
                         lang=config.tts.kokoro_lang,
                         max_chars=config.tts.max_chars,
+                    )
+                elif tts_provider == "fish":
+                    synthesize_fish(
+                        podcast_script, raw_mp3,
+                        api_key=fish_api_key,
+                        reference_id=config.tts.fish_reference_id,
+                        voice_reference=fish_voice_ref,
+                        max_chars=config.tts.max_chars,
+                        temperature=config.tts.fish_temperature,
+                        top_p=config.tts.fish_top_p,
+                        speed=config.tts.fish_speed,
+                        repetition_penalty=config.tts.fish_repetition_penalty,
+                        format=config.tts.fish_format,
+                        mp3_bitrate=config.tts.fish_mp3_bitrate,
                     )
                 else:
                     synthesize(

--- a/shows/hooks/models_agents_beginners.py
+++ b/shows/hooks/models_agents_beginners.py
@@ -1,12 +1,14 @@
-"""Models & Agents for Beginners — pronunciation hook for Chatterbox TTS.
+"""Models & Agents for Beginners — pronunciation hook for Fish Audio TTS.
 
-Chatterbox is a neural TTS model that handles standard English pronunciation
-well on its own.  Only override words that Chatterbox genuinely mispronounces.
+Fish Audio S1 is a cloud neural TTS with excellent built-in text normalization
+(0.008 WER, #1 on TTS-Arena2).  The pronunciation pipeline acts as a safety
+net — acronym expansions (AI→"A I", GPU→"G P U") are universal and help all
+providers.  Fish Audio handles standard English, proper names, and most
+technical terms correctly natively.
 
-**Key principle:** Do NOT override common English words or well-known names
-(Gemini, Claude, Llama, Grok, DALL-E) — Chatterbox pronounces these correctly
-natively.  Only override obscure acronyms, non-English names, and compound
-words that need splitting.
+**Key principle:** Keep acronym expansions and non-English name overrides.
+Do NOT add phonetic respellings for common English words — Fish Audio handles
+these natively.
 """
 
 from __future__ import annotations

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -108,11 +108,15 @@ llm:
   max_tokens: 4000
 
 tts:
-  provider: kokoro
-  kokoro_voice: am_adam
-  kokoro_speed: 0.95
-  kokoro_lang: a
-  max_chars: 2000
+  provider: fish
+  fish_voice_reference: assets/voice_references/tst_voice_reference.wav
+  fish_temperature: 0.7
+  fish_top_p: 0.7
+  fish_speed: 1.0
+  fish_repetition_penalty: 1.2
+  fish_format: mp3
+  fish_mp3_bitrate: 128
+  max_chars: 4000
   validate_transcription: true
   whisper_model: base
   whisper_threshold: 0.7


### PR DESCRIPTION
Fish Audio S1 is #1 on TTS-Arena2 with 0.008 WER — far superior to Kokoro's espeak-quality pronunciation and Chatterbox's gibberish output. Uses zero-shot voice cloning from existing TST voice reference sample to maintain consistent network voice identity.

Changes:
- Add fish-audio-sdk to requirements.txt
- Add Fish Audio fields to TTSConfig (reference_id, voice_reference, temperature, top_p, speed, repetition_penalty, format, mp3_bitrate)
- Implement synthesize_fish(), synthesize_fish_sections(), and _fish_synthesize_chunk() in engine/tts.py
- Add fish provider routing in run_show.py (3 synthesis paths)
- Update MAB YAML: provider=fish, voice cloning from TST reference
- Update workflow: add FISH_AUDIO_API_KEY, remove Kokoro model download
- Update CLAUDE.md, pronunciation hook docstring, voice references README

https://claude.ai/code/session_01EGgijnaM1zBrc6HY4LqkCF