### PR TITLE
Fix podcast sound quality: larger Fish chunks, longer crossfade, PT t…

### DIFF
--- a/engine/generator.py
+++ b/engine/generator.py
@@ -175,6 +175,16 @@ def _validate_llm_output(
                     stage, show_name, phrase, count,
                 )
 
+    # Warn if podcast script is too short to fill target duration
+    if stage == "podcast_script":
+        word_count = len(text.split())
+        if word_count < 1500:
+            logger.warning(
+                "Podcast script for '%s' is too short (%d words, target >1500). "
+                "Consider regenerating with more depth.",
+                show_name, word_count,
+            )
+
 
 # ---------------------------------------------------------------------------
 # Public generation functions

--- a/engine/tts.py
+++ b/engine/tts.py
@@ -1068,7 +1068,7 @@ def synthesize_fish(
                 "ffmpeg", "-y",
                 "-i", str(chunk_files[0]), "-i", str(chunk_files[1]),
                 "-filter_complex",
-                "[0:a][1:a]acrossfade=d=0.08:c1=log:c2=log[out]",
+                "[0:a][1:a]acrossfade=d=0.25:c1=log:c2=log[out]",
                 "-map", "[out]",
                 "-ar", "44100",
                 "-c:a", "pcm_s16le",
@@ -1086,7 +1086,7 @@ def synthesize_fish(
         for j in range(1, len(chunk_files)):
             out_label = f"[cf{j}]" if j < len(chunk_files) - 1 else "[out]"
             fc_parts.append(
-                f"{prev}[{j}:a]acrossfade=d=0.08:c1=log:c2=log{out_label}"
+                f"{prev}[{j}:a]acrossfade=d=0.25:c1=log:c2=log{out_label}"
             )
             prev = out_label
         filter_complex = ";".join(fc_parts)

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -131,8 +131,10 @@ tts:
   fish_repetition_penalty: 1.5
   fish_format: mp3
   fish_mp3_bitrate: 192
-  max_chars: 2000
-  validate_transcription: false
+  max_chars: 4000
+  validate_transcription: true
+  whisper_model: base
+  whisper_threshold: 0.85
 
 audio:
   music_file: assets/music/tesla_shorts_time.mp3

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -117,10 +117,10 @@ tts:
   fish_repetition_penalty: 1.5
   fish_format: mp3
   fish_mp3_bitrate: 192
-  max_chars: 2000
+  max_chars: 4000
   validate_transcription: true
   whisper_model: base
-  whisper_threshold: 0.7
+  whisper_threshold: 0.85
 
 audio:
   music_file: assets/music/tesla_shorts_time.mp3

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -96,8 +96,9 @@ llm:
   digest_prompt_file: shows/prompts/planetterrian_digest.txt
   podcast_prompt_file: shows/prompts/planetterrian_podcast.txt
   digest_temperature: 0.5
-  podcast_temperature: 0.75
+  podcast_temperature: 0.70
   max_tokens: 3500
+  podcast_max_tokens: 8000
 
 tts:
   voice_id: dTrBzPvD2GpAqkk1MUzA


### PR DESCRIPTION
…oken limit

1. MAB & Finansy Prosto: increase Fish Speech max_chars from 2000 to 4000 to halve chunk boundaries where voice resets and quality degrades. Raise Whisper validation threshold from 0.7 to 0.85 (MAB) and enable validation for Finansy Prosto at 0.85.

2. engine/tts.py: increase Fish Audio crossfade from 0.08s to 0.25s to smooth pitch/energy mismatches at chunk boundaries.

3. Planetterrian: add podcast_max_tokens: 8000 so the LLM has headroom to generate full 10-13 minute scripts (was falling back to max_tokens: 3500, producing 3-4 minute episodes). Lower podcast_temperature from 0.75 to 0.70 for more consistent output length.

4. engine/generator.py: add word count warning in _validate_llm_output() for podcast scripts under 1500 words, to catch fragment episodes before they reach the final mix.

https://claude.ai/code/session_01SoZV9YikuTpoBv1KFJJQzw