### PR TITLE
Transform show pages into resource hubs with categorized libraries, t…

### DIFF
--- a/env-intel.html
+++ b/env-intel.html
@@ -129,6 +129,8 @@
 <a href="env-intel-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
+<a href="#faq" onclick="document.getElementById('mobileMenu').classList.remove('open')">FAQ</a>
 
         <a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">GitHub</a>
         <div class="nn-mobile-shows">
@@ -255,52 +257,268 @@
         </div>
     </section>
 
-    <!-- Resources -->
+    <!-- Resources (categorized) -->
+    
+    <section id="resources" class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources &amp; Further Reading</h2>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Federal Regulation</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.gazette.gc.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Canada Gazette</div>
+                        <div class="resource-card-desc">Official source for proposed and enacted federal regulations — Part I (proposals) and Part II (final)</div>
+                        <div class="resource-card-url">www.gazette.gc.ca</div>
+                    </a>
+                    
+                    <a href="https://www.canada.ca/en/environment-climate-change.html" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">ECCC</div>
+                        <div class="resource-card-desc">Environment and Climate Change Canada — federal environmental policy, enforcement, and data</div>
+                        <div class="resource-card-url">www.canada.ca/en/environment-climate-change.html</div>
+                    </a>
+                    
+                    <a href="https://www.canada.ca/en/environment-climate-change/services/canadian-environmental-protection-act-registry.html" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">CEPA Registry</div>
+                        <div class="resource-card-desc">Canadian Environmental Protection Act registry — substance assessments and regulations</div>
+                        <div class="resource-card-url">www.canada.ca/en/environment-climate-change/services/canadian-environmental-protection-act-registry.html</div>
+                    </a>
+                    
+                    <a href="https://www.canada.ca/en/impact-assessment-agency.html" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Impact Assessment Agency</div>
+                        <div class="resource-card-desc">Federal impact assessments for major projects — pipelines, mines, and infrastructure</div>
+                        <div class="resource-card-url">www.canada.ca/en/impact-assessment-agency.html</div>
+                    </a>
+                    
+                    <a href="https://ccme.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">CCME</div>
+                        <div class="resource-card-desc">Canadian Council of Ministers of the Environment — national guidelines, standards, and water quality objectives</div>
+                        <div class="resource-card-url">ccme.ca</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">BC & Provincial</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www2.gov.bc.ca/gov/content/environment/air-land-water/site-remediation" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">BC Site Remediation</div>
+                        <div class="resource-card-desc">BC contaminated sites registry, CSR protocols, technical guidance, and site profiles</div>
+                        <div class="resource-card-url">www2.gov.bc.ca/gov/content/environment/air-land-water/site-remediation</div>
+                    </a>
+                    
+                    <a href="https://www2.gov.bc.ca/gov/content/environment" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">BC ENV</div>
+                        <div class="resource-card-desc">BC Ministry of Environment — permits, compliance, air/water quality, and wildlife</div>
+                        <div class="resource-card-url">www2.gov.bc.ca/gov/content/environment</div>
+                    </a>
+                    
+                    <a href="https://www.projects.eao.gov.bc.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">BC Environmental Assessment Office</div>
+                        <div class="resource-card-desc">Track BC environmental assessments for major projects — mines, LNG, pipelines</div>
+                        <div class="resource-card-url">www.projects.eao.gov.bc.ca</div>
+                    </a>
+                    
+                    <a href="https://www.aer.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Alberta Energy Regulator</div>
+                        <div class="resource-card-desc">Alberta's energy and environmental regulator — oil sands, pipelines, and reclamation</div>
+                        <div class="resource-card-url">www.aer.ca</div>
+                    </a>
+                    
+                    <a href="https://www.ontario.ca/page/ministry-environment-conservation-parks" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Ontario MOE</div>
+                        <div class="resource-card-desc">Ontario environmental regulation — brownfields, air quality, and water resources</div>
+                        <div class="resource-card-url">www.ontario.ca/page/ministry-environment-conservation-parks</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Professional Associations</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://csapsociety.bc.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">CSAP (BC)</div>
+                        <div class="resource-card-desc">Contaminated Sites Approved Professionals Society — BC's roster of qualified environmental professionals</div>
+                        <div class="resource-card-url">csapsociety.bc.ca</div>
+                    </a>
+                    
+                    <a href="https://eco.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">ECO Canada</div>
+                        <div class="resource-card-desc">Environmental careers, training, and professional development across Canada</div>
+                        <div class="resource-card-url">eco.ca</div>
+                    </a>
+                    
+                    <a href="https://www.apega.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">APEGA</div>
+                        <div class="resource-card-desc">Association of Professional Engineers and Geoscientists of Alberta — licensing and practice</div>
+                        <div class="resource-card-url">www.apega.ca</div>
+                    </a>
+                    
+                    <a href="https://www.egbc.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">EGBC</div>
+                        <div class="resource-card-desc">Engineers and Geoscientists BC — professional regulation for BC environmental practitioners</div>
+                        <div class="resource-card-url">www.egbc.ca</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Contaminated Sites & Remediation</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.tbs-sct.canada.ca/fcsi-rscf/home-accueil-eng.aspx" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Federal Contaminated Sites Inventory</div>
+                        <div class="resource-card-desc">Database of 24,000+ federal contaminated sites across Canada — searchable by province</div>
+                        <div class="resource-card-url">www.tbs-sct.canada.ca/fcsi-rscf/home-accueil-eng.aspx</div>
+                    </a>
+                    
+                    <a href="https://www.itrcweb.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">ITRC</div>
+                        <div class="resource-card-desc">Interstate Technology and Regulatory Council — technical guidance on PFAS, vapour intrusion, and remediation</div>
+                        <div class="resource-card-url">www.itrcweb.org</div>
+                    </a>
+                    
+                    <a href="https://clu-in.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">CLU-IN</div>
+                        <div class="resource-card-desc">US EPA's contaminated site cleanup information — technologies, training, and case studies</div>
+                        <div class="resource-card-url">clu-in.org</div>
+                    </a>
+                    
+                    <a href="https://www.astm.org/products-services/standards-and-publications/standards/environmental-standards.html" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">ASTM Environmental Standards</div>
+                        <div class="resource-card-desc">Phase I/II ESA standards (E1527, E1903) and environmental assessment protocols</div>
+                        <div class="resource-card-url">www.astm.org/products-services/standards-and-publications/standards/environmental-standards.html</div>
+                    </a>
+                    
+                    <a href="https://www.esaa.org/remtech/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">RemTech Symposium</div>
+                        <div class="resource-card-desc">Canada's premier remediation technology conference — ESAA annual event in Banff</div>
+                        <div class="resource-card-url">www.esaa.org/remtech/</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Environmental Science & Journalism</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://thenarwhal.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">The Narwhal</div>
+                        <div class="resource-card-desc">Independent Canadian environmental investigative journalism — in-depth, evidence-based</div>
+                        <div class="resource-card-url">thenarwhal.ca</div>
+                    </a>
+                    
+                    <a href="https://ecojustice.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Ecojustice</div>
+                        <div class="resource-card-desc">Canada's leading environmental law charity — legal actions and policy advocacy</div>
+                        <div class="resource-card-url">ecojustice.ca</div>
+                    </a>
+                    
+                    <a href="https://www.nature.com/nclimate/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Nature Climate Change</div>
+                        <div class="resource-card-desc">Peer-reviewed journal on climate change science, impacts, and policy</div>
+                        <div class="resource-card-url">www.nature.com/nclimate/</div>
+                    </a>
+                    
+                    <a href="https://insideclimatenews.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Inside Climate News</div>
+                        <div class="resource-card-desc">Pulitzer Prize-winning climate and energy journalism — US and global coverage</div>
+                        <div class="resource-card-url">insideclimatenews.org</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+        </div>
+    </section>
+    
+
+    <!-- Recommended Tools -->
     
     <section class="nn-section" style="padding-top:0;">
         <div class="container">
             <div class="nn-section-header" style="text-align:left;">
-                <h2>Resources & Further Reading</h2>
+                <h2>Recommended Tools</h2>
             </div>
-            <div class="resources-grid">
+            <div class="tools-grid">
                 
-                <a href="https://www.gazette.gc.ca" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Canada Gazette</div>
-                    <div class="resource-card-desc">Official source for federal regulations and proposed amendments</div>
-                    <div class="resource-card-url">www.gazette.gc.ca</div>
+                <a href="https://www2.gov.bc.ca/gov/content/environment/air-land-water/site-remediation/contaminated-sites" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">BC CSR Database</div>
+                    <div class="tool-card-desc">Search BC's contaminated sites registry — site profiles, risk classifications, and remediation status</div>
                 </a>
                 
-                <a href="https://www.canada.ca/en/environment-climate-change.html" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">ECCC</div>
-                    <div class="resource-card-desc">Environment and Climate Change Canada — federal policy and enforcement</div>
-                    <div class="resource-card-url">www.canada.ca/en/environment-climate-change.html</div>
+                <a href="https://ccme.ca/en/current-activities/canadian-environmental-quality-guidelines" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">CCME Guidelines</div>
+                    <div class="tool-card-desc">Canadian soil, water, and sediment quality guidelines — the foundation for site assessments</div>
                 </a>
                 
-                <a href="https://ccme.ca" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">CCME</div>
-                    <div class="resource-card-desc">Canadian Council of Ministers of the Environment — guidelines and standards</div>
-                    <div class="resource-card-url">ccme.ca</div>
+                <a href="https://www.eris.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Paid</span>
+                    <div class="tool-card-name">ERIS</div>
+                    <div class="tool-card-desc">Environmental risk information services — Phase I ESA database searches for Canadian and US sites</div>
                 </a>
                 
-                <a href="https://www2.gov.bc.ca/gov/content/environment/air-land-water/site-remediation" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">BC Site Remediation</div>
-                    <div class="resource-card-desc">BC contaminated sites registry, guidance, and CSR protocols</div>
-                    <div class="resource-card-url">www2.gov.bc.ca/gov/content/environment/air-land-water/site-remediation</div>
+                <a href="https://www.gazette.gc.ca/cg-gc/subscribe-abonner-eng.html" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Canada Gazette Alerts</div>
+                    <div class="tool-card-desc">Subscribe to alerts for new federal environmental regulations and amendments</div>
                 </a>
                 
-                <a href="https://thenarwhal.ca" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">The Narwhal</div>
-                    <div class="resource-card-desc">Independent Canadian environmental investigative journalism</div>
-                    <div class="resource-card-url">thenarwhal.ca</div>
-                </a>
-                
-                <a href="https://ecojustice.ca" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Ecojustice</div>
-                    <div class="resource-card-desc">Canada's leading environmental law charity</div>
-                    <div class="resource-card-url">ecojustice.ca</div>
+                <a href="https://www.esri.com/en-us/industries/environment/overview" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Paid</span>
+                    <div class="tool-card-name">ArcGIS Environmental</div>
+                    <div class="tool-card-desc">GIS mapping for environmental data — contaminated sites, watersheds, and monitoring wells</div>
                 </a>
                 
             </div>
+        </div>
+    </section>
+    
+
+    <!-- Key Concepts / FAQ -->
+    
+    <section id="faq" class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:800px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Key Concepts</h2>
+            </div>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is CEPA?</summary>
+                <div class="faq-answer">The Canadian Environmental Protection Act (CEPA 1999) is Canada's primary federal environmental law. It governs the assessment and management of toxic substances, pollution prevention, and environmental emergencies. CEPA gives the federal government authority to regulate chemicals, fuels, and wastes that pose risks to human health or the environment. It was significantly updated in 2023 (Bill S-5) to recognize the right to a healthy environment.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is a contaminated site?</summary>
+                <div class="faq-answer">A contaminated site is land or water where hazardous substances exceed regulatory standards and may pose risks to human health or the environment. Common contaminants include petroleum hydrocarbons (from gas stations), heavy metals (from industrial operations), chlorinated solvents (from dry cleaners), and PFAS (from firefighting foam). In BC, the Contaminated Sites Regulation (CSR) defines standards and the process for investigation, risk assessment, and remediation.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What are PFAS?</summary>
+                <div class="faq-answer">PFAS (Per- and Polyfluoroalkyl Substances) are a group of 12,000+ synthetic chemicals known as 'forever chemicals' because they don't break down in the environment. Used since the 1950s in non-stick coatings, food packaging, firefighting foam, and waterproof clothing, PFAS contaminate groundwater, soil, and drinking water worldwide. Health concerns include cancer, thyroid disease, and immune system effects. Canada is developing federal PFAS regulations, and remediation is extremely challenging and costly.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is the CSR (Contaminated Sites Regulation)?</summary>
+                <div class="faq-answer">BC's Contaminated Sites Regulation sets numerical standards for soil, groundwater, vapour, and sediment quality. It defines when a site is 'contaminated' (exceeds standards) and the process for investigation, risk assessment, and remediation. Key concepts include: site profiles (disclosure triggers), preliminary and detailed site investigations, risk-based standards vs. generic standards, and certificates of compliance issued upon successful remediation.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What does 'remediation' mean?</summary>
+                <div class="faq-answer">Remediation is the process of cleaning up contaminated land or groundwater to make it safe for its intended use. Methods include: excavation and disposal (dig-and-dump), in-situ treatment (treating contamination in place using bioremediation, chemical oxidation, or thermal treatment), pump-and-treat (extracting and treating groundwater), and risk management (containing contamination with barriers or institutional controls). The approach depends on contaminant type, site geology, and intended land use.</div>
+            </details>
+            
         </div>
     </section>
     
@@ -342,7 +560,7 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
-                <p>Seven daily shows keeping you informed.</p>
+                <p>Nine daily shows keeping you informed.</p>
             </div>
             <div class="cross-network-grid">
                 

--- a/fascinating_frontiers.html
+++ b/fascinating_frontiers.html
@@ -129,6 +129,8 @@
 <a href="fascinating-frontiers-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
+<a href="#faq" onclick="document.getElementById('mobileMenu').classList.remove('open')">FAQ</a>
 
         <a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">GitHub</a>
         <div class="nn-mobile-shows">
@@ -255,52 +257,280 @@
         </div>
     </section>
 
-    <!-- Resources -->
+    <!-- Resources (categorized) -->
+    
+    <section id="resources" class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources &amp; Further Reading</h2>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Space Agencies</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.nasa.gov" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">NASA</div>
+                        <div class="resource-card-desc">Official NASA mission updates, images, and research — the world's largest space agency</div>
+                        <div class="resource-card-url">www.nasa.gov</div>
+                    </a>
+                    
+                    <a href="https://www.esa.int" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">ESA</div>
+                        <div class="resource-card-desc">European Space Agency — Rosalind Franklin rover, Ariane rockets, and Earth observation</div>
+                        <div class="resource-card-url">www.esa.int</div>
+                    </a>
+                    
+                    <a href="https://global.jaxa.jp" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">JAXA</div>
+                        <div class="resource-card-desc">Japan Aerospace Exploration Agency — Hayabusa asteroid missions and lunar exploration</div>
+                        <div class="resource-card-url">global.jaxa.jp</div>
+                    </a>
+                    
+                    <a href="https://www.isro.gov.in" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">ISRO</div>
+                        <div class="resource-card-desc">Indian Space Research Organisation — Chandrayaan lunar missions and Mars Orbiter</div>
+                        <div class="resource-card-url">www.isro.gov.in</div>
+                    </a>
+                    
+                    <a href="https://www.asc-csa.gc.ca/eng/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">CSA</div>
+                        <div class="resource-card-desc">Canadian Space Agency — Canadarm, Chris Hadfield's agency, and Arctic Earth observation</div>
+                        <div class="resource-card-url">www.asc-csa.gc.ca/eng/</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">News & Journalism</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.space.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Space.com</div>
+                        <div class="resource-card-desc">Space news, stargazing guides, and astronomy explainers — the go-to popular source</div>
+                        <div class="resource-card-url">www.space.com</div>
+                    </a>
+                    
+                    <a href="https://spacenews.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SpaceNews</div>
+                        <div class="resource-card-desc">Industry-focused space journalism — policy, launches, satellites, and business</div>
+                        <div class="resource-card-url">spacenews.com</div>
+                    </a>
+                    
+                    <a href="https://spaceflightnow.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Spaceflight Now</div>
+                        <div class="resource-card-desc">Launch tracking, mission updates, and real-time coverage of rocket launches</div>
+                        <div class="resource-card-url">spaceflightnow.com</div>
+                    </a>
+                    
+                    <a href="https://www.universetoday.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Universe Today</div>
+                        <div class="resource-card-desc">Astronomy and space exploration news written for enthusiasts by enthusiasts</div>
+                        <div class="resource-card-url">www.universetoday.com</div>
+                    </a>
+                    
+                    <a href="https://www.planetary.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">The Planetary Society</div>
+                        <div class="resource-card-desc">Space exploration advocacy, citizen science, and Carl Sagan's legacy organization</div>
+                        <div class="resource-card-url">www.planetary.org</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Citizen Science & Stargazing</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://apod.nasa.gov" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">NASA APOD</div>
+                        <div class="resource-card-desc">Astronomy Picture of the Day — a stunning new cosmic image with expert explanation every day</div>
+                        <div class="resource-card-url">apod.nasa.gov</div>
+                    </a>
+                    
+                    <a href="https://www.heavens-above.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Heavens-Above</div>
+                        <div class="resource-card-desc">Track satellites, ISS passes, and planets for your location — essential for observers</div>
+                        <div class="resource-card-url">www.heavens-above.com</div>
+                    </a>
+                    
+                    <a href="https://www.zooniverse.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Zooniverse</div>
+                        <div class="resource-card-desc">Citizen science projects — help classify galaxies, discover exoplanets, and hunt asteroids</div>
+                        <div class="resource-card-url">www.zooniverse.org</div>
+                    </a>
+                    
+                    <a href="https://www.globeatnight.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Globe at Night</div>
+                        <div class="resource-card-desc">Citizen science program measuring light pollution — contribute from your backyard</div>
+                        <div class="resource-card-url">www.globeatnight.org</div>
+                    </a>
+                    
+                    <a href="https://skyandtelescope.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Sky & Telescope</div>
+                        <div class="resource-card-desc">Observing guides, equipment reviews, and astronomical event calendars for amateur astronomers</div>
+                        <div class="resource-card-url">skyandtelescope.org</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Telescopes & Missions</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://webbtelescope.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Webb Telescope</div>
+                        <div class="resource-card-desc">James Webb Space Telescope — the most powerful space telescope ever built, images and science</div>
+                        <div class="resource-card-url">webbtelescope.org</div>
+                    </a>
+                    
+                    <a href="https://hubblesite.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Hubble Site</div>
+                        <div class="resource-card-desc">Hubble Space Telescope gallery, news, and 35+ years of iconic cosmic images</div>
+                        <div class="resource-card-url">hubblesite.org</div>
+                    </a>
+                    
+                    <a href="https://mars.nasa.gov" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">NASA Mars Exploration</div>
+                        <div class="resource-card-desc">Perseverance rover, Ingenuity helicopter, and the journey to send humans to Mars</div>
+                        <div class="resource-card-url">mars.nasa.gov</div>
+                    </a>
+                    
+                    <a href="https://exoplanetarchive.ipac.caltech.edu" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">NASA Exoplanet Archive</div>
+                        <div class="resource-card-desc">Database of 5,700+ confirmed exoplanets — search, filter, and explore alien worlds</div>
+                        <div class="resource-card-url">exoplanetarchive.ipac.caltech.edu</div>
+                    </a>
+                    
+                    <a href="https://www.spacex.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SpaceX</div>
+                        <div class="resource-card-desc">Starship development, Falcon 9 launches, and the mission to make humanity multiplanetary</div>
+                        <div class="resource-card-url">www.spacex.com</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Learning & Courses</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.youtube.com/playlist?list=PL8dPuuaLjXtPAJr1ysd5yGIyiSFuh0mIL" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Crash Course Astronomy</div>
+                        <div class="resource-card-desc">46 free episodes covering the solar system to cosmology — fun, fast, and accurate</div>
+                        <div class="resource-card-url">www.youtube.com/playlist?list=PL8dPuuaLjXtPAJr1ysd5yGIyiSFuh0mIL</div>
+                    </a>
+                    
+                    <a href="https://www.khanacademy.org/science/cosmology-and-astronomy" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Khan Academy Cosmology</div>
+                        <div class="resource-card-desc">Free lessons on stars, galaxies, and the Big Bang — great for students</div>
+                        <div class="resource-card-url">www.khanacademy.org/science/cosmology-and-astronomy</div>
+                    </a>
+                    
+                    <a href="https://astrobites.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">AstroBites</div>
+                        <div class="resource-card-desc">Graduate students summarize the latest astrophysics papers in plain language — daily</div>
+                        <div class="resource-card-url">astrobites.org</div>
+                    </a>
+                    
+                    <a href="https://www.esa.int/kids/en/home" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">ESA Kids</div>
+                        <div class="resource-card-desc">Space explained for young learners — games, activities, and mission guides from ESA</div>
+                        <div class="resource-card-url">www.esa.int/kids/en/home</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+        </div>
+    </section>
+    
+
+    <!-- Recommended Tools -->
     
     <section class="nn-section" style="padding-top:0;">
         <div class="container">
             <div class="nn-section-header" style="text-align:left;">
-                <h2>Resources & Further Reading</h2>
+                <h2>Recommended Tools</h2>
             </div>
-            <div class="resources-grid">
+            <div class="tools-grid">
                 
-                <a href="https://www.nasa.gov" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">NASA</div>
-                    <div class="resource-card-desc">Official NASA mission updates, images, and research</div>
-                    <div class="resource-card-url">www.nasa.gov</div>
+                <a href="https://stellarium-web.org" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Stellarium</div>
+                    <div class="tool-card-desc">Free planetarium in your browser — see tonight's sky from any location on Earth</div>
                 </a>
                 
-                <a href="https://apod.nasa.gov" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">NASA APOD</div>
-                    <div class="resource-card-desc">Astronomy Picture of the Day — daily cosmic imagery with explanations</div>
-                    <div class="resource-card-url">apod.nasa.gov</div>
+                <a href="https://eyes.nasa.gov" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">NASA Eyes</div>
+                    <div class="tool-card-desc">3D visualization of the solar system, Earth, and active NASA missions in real time</div>
                 </a>
                 
-                <a href="https://www.space.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Space.com</div>
-                    <div class="resource-card-desc">Space news, astronomy guides, and stargazing tips</div>
-                    <div class="resource-card-url">www.space.com</div>
+                <a href="https://www.heavens-above.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Heavens-Above</div>
+                    <div class="tool-card-desc">Track the ISS, Starlink trains, and bright satellites passing over your city</div>
                 </a>
                 
-                <a href="https://webbtelescope.org" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Webb Telescope</div>
-                    <div class="resource-card-desc">James Webb Space Telescope images and science results</div>
-                    <div class="resource-card-url">webbtelescope.org</div>
+                <a href="https://skysafariastronomy.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Freemium</span>
+                    <div class="tool-card-name">SkySafari</div>
+                    <div class="tool-card-desc">Point your phone at the sky to identify stars, planets, and constellations instantly</div>
                 </a>
                 
-                <a href="https://www.heavens-above.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Heavens-Above</div>
-                    <div class="resource-card-desc">Track satellites, ISS passes, and night sky objects for your location</div>
-                    <div class="resource-card-url">www.heavens-above.com</div>
+                <a href="https://www.spacex.com/launches/" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">SpaceX Launch Tracker</div>
+                    <div class="tool-card-desc">Upcoming and past SpaceX launches — schedules, webcasts, and mission details</div>
                 </a>
                 
-                <a href="https://www.planetary.org" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">The Planetary Society</div>
-                    <div class="resource-card-desc">Space exploration advocacy and citizen science projects</div>
-                    <div class="resource-card-url">www.planetary.org</div>
+                <a href="https://spotthestation.nasa.gov" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Spot The Station</div>
+                    <div class="tool-card-desc">NASA's official ISS sighting tool — get alerts when the station flies over your area</div>
                 </a>
                 
             </div>
+        </div>
+    </section>
+    
+
+    <!-- Key Concepts / FAQ -->
+    
+    <section id="faq" class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:800px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Key Concepts</h2>
+            </div>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is an exoplanet?</summary>
+                <div class="faq-answer">An exoplanet is a planet that orbits a star outside our solar system. Over 5,700 exoplanets have been confirmed as of 2026, with thousands more candidates awaiting verification. They range from scorching hot Jupiters to potentially habitable rocky worlds. NASA's TESS and the James Webb Space Telescope are the primary tools for finding and studying them.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">How does the James Webb Space Telescope work?</summary>
+                <div class="faq-answer">JWST is an infrared space telescope with a 6.5-meter gold-coated mirror (compared to Hubble's 2.4m). It orbits the Sun at the L2 Lagrange point, 1.5 million km from Earth, where its sunshield keeps instruments at -233C. By observing in infrared, Webb can see through cosmic dust, study the atmospheres of exoplanets, and detect light from the earliest galaxies formed after the Big Bang.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is a light-year?</summary>
+                <div class="faq-answer">A light-year is the distance light travels in one year — about 9.46 trillion kilometers (5.88 trillion miles). It's used because space distances are so vast that kilometers become meaningless. For scale: the nearest star (Proxima Centauri) is 4.24 light-years away. The Milky Way galaxy is about 100,000 light-years across. The observable universe extends 46 billion light-years in every direction.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What's the difference between NASA, ESA, and SpaceX?</summary>
+                <div class="faq-answer">NASA (US) and ESA (Europe) are government space agencies funded by taxpayers — they do science, exploration, and Earth observation. SpaceX is a private company founded by Elon Musk that builds rockets and spacecraft. SpaceX focuses on making space access cheaper (reusable Falcon 9, Starship), while NASA and ESA define scientific missions. They often work together — SpaceX launches NASA astronauts to the ISS.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">How can I see the ISS?</summary>
+                <div class="faq-answer">The International Space Station is the third brightest object in the night sky (after the Sun and Moon). It looks like a fast-moving bright star crossing the sky in 3-5 minutes. Use NASA's Spot The Station website or the Heavens-Above app to get exact times for your location. Best sightings happen just after sunset or before sunrise when the station catches sunlight against a dark sky.</div>
+            </details>
+            
         </div>
     </section>
     
@@ -342,7 +572,7 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
-                <p>Seven daily shows keeping you informed.</p>
+                <p>Nine daily shows keeping you informed.</p>
             </div>
             <div class="cross-network-grid">
                 

--- a/generate_html.py
+++ b/generate_html.py
@@ -57,13 +57,70 @@ NETWORK_SHOWS = {
         "meta_keywords": "Tesla podcast, TSLA news, Tesla stock, EV analysis, Tesla Shorts Time, daily digests",
         "audience": "For Tesla owners, TSLA investors, EV enthusiasts, and anyone following the transition to sustainable energy.",
         "source_highlights": ["Teslarati", "CleanTechnica", "InsideEVs", "The Verge"],
-        "resources": [
-            {"name": "Tesla Investor Relations", "url": "https://ir.tesla.com", "desc": "Official SEC filings, earnings calls, and shareholder letters"},
-            {"name": "Tesla Blog", "url": "https://www.tesla.com/blog", "desc": "Official Tesla announcements and product updates"},
-            {"name": "TSLA on Yahoo Finance", "url": "https://finance.yahoo.com/quote/TSLA", "desc": "Real-time stock price, charts, and financial data"},
-            {"name": "Teslarati", "url": "https://www.teslarati.com", "desc": "Independent Tesla and SpaceX news coverage"},
-            {"name": "Not A Tesla App", "url": "https://www.notateslaapp.com", "desc": "Tesla software updates and feature tracking"},
-            {"name": "CleanTechnica", "url": "https://cleantechnica.com", "desc": "Clean energy and electric vehicle industry news"},
+        "resource_categories": [
+            {
+                "title": "Investor Resources",
+                "resources": [
+                    {"name": "Tesla Investor Relations", "url": "https://ir.tesla.com", "desc": "Official SEC filings, earnings calls, and shareholder letters"},
+                    {"name": "TSLA on Yahoo Finance", "url": "https://finance.yahoo.com/quote/TSLA", "desc": "Real-time stock price, charts, and financial data"},
+                    {"name": "Tesla Daily (Rob Maurer)", "url": "https://www.youtube.com/@TeslaDaily", "desc": "Daily TSLA analysis from the most-followed Tesla stock commentator"},
+                    {"name": "Hypercharts Tesla", "url": "https://hypercharts.co/tsla", "desc": "Tesla financial data visualizations — revenue, margins, deliveries"},
+                    {"name": "Macrotrends TSLA", "url": "https://www.macrotrends.net/stocks/charts/TSLA/tesla/revenue", "desc": "Historical Tesla financials, ratios, and growth metrics"},
+                ],
+            },
+            {
+                "title": "News Sources",
+                "resources": [
+                    {"name": "Teslarati", "url": "https://www.teslarati.com", "desc": "Independent Tesla and SpaceX news — the largest dedicated Tesla news outlet"},
+                    {"name": "Not A Tesla App", "url": "https://www.notateslaapp.com", "desc": "Tesla software updates, feature tracking, and release notes"},
+                    {"name": "CleanTechnica", "url": "https://cleantechnica.com", "desc": "Clean energy and EV industry analysis and commentary"},
+                    {"name": "InsideEVs", "url": "https://insideevs.com", "desc": "Electric vehicle news, reviews, and sales data across all brands"},
+                    {"name": "Drive Tesla Canada", "url": "https://driveteslacanada.ca", "desc": "Canadian Tesla ownership news, tips, and community coverage"},
+                    {"name": "Electrek", "url": "https://electrek.co", "desc": "Electric transport and clean energy news — Tesla, EVs, solar, and storage"},
+                ],
+            },
+            {
+                "title": "Community & Forums",
+                "resources": [
+                    {"name": "Tesla Motors Club", "url": "https://teslamotorsclub.com", "desc": "The largest Tesla owner forum — 500K+ members discussing ownership, mods, and tips"},
+                    {"name": "r/TeslaMotors", "url": "https://www.reddit.com/r/TeslaMotors/", "desc": "Reddit's main Tesla community — news, reviews, and owner discussions"},
+                    {"name": "r/TSLALounge", "url": "https://www.reddit.com/r/TSLALounge/", "desc": "Tesla investor community focused on TSLA stock and market analysis"},
+                    {"name": "Tesla Owners Online", "url": "https://teslaownersonline.com", "desc": "Owner forum with detailed guides for Model 3, Y, S, X, and Cybertruck"},
+                ],
+            },
+            {
+                "title": "Tesla Data & Tools",
+                "resources": [
+                    {"name": "Tesla Blog", "url": "https://www.tesla.com/blog", "desc": "Official Tesla announcements and product updates"},
+                    {"name": "PlugShare", "url": "https://www.plugshare.com", "desc": "Find EV charging stations — Supercharger network and third-party chargers"},
+                    {"name": "A Better Route Planner", "url": "https://abetterrouteplanner.com", "desc": "EV trip planner with real-time range estimation for Tesla and other EVs"},
+                    {"name": "TeslaFi", "url": "https://teslafi.com", "desc": "Tesla data logger — track efficiency, battery health, trips, and charging"},
+                ],
+            },
+            {
+                "title": "Learning & Deep Dives",
+                "resources": [
+                    {"name": "Tesla AI Day Presentations", "url": "https://www.youtube.com/results?search_query=tesla+ai+day", "desc": "Technical presentations on FSD, Optimus robot, and Dojo supercomputer"},
+                    {"name": "Sandy Munro", "url": "https://www.youtube.com/@MunroLive", "desc": "Engineering teardowns and manufacturing analysis of Tesla vehicles"},
+                    {"name": "Tesla Master Plan", "url": "https://www.tesla.com/blog/master-plan-part-3", "desc": "Tesla's vision for sustainable energy — Master Plan Part 3"},
+                    {"name": "Third Row Tesla", "url": "https://www.youtube.com/@thirdrowtesla", "desc": "In-depth Tesla interviews and analysis from the community"},
+                ],
+            },
+        ],
+        "tools": [
+            {"name": "TradingView", "url": "https://www.tradingview.com/symbols/NASDAQ-TSLA/", "desc": "Advanced TSLA charting, technical analysis, and community ideas", "badge": "Free tier"},
+            {"name": "Yahoo Finance", "url": "https://finance.yahoo.com/quote/TSLA", "desc": "Real-time TSLA quotes, financials, analyst ratings, and news", "badge": "Free"},
+            {"name": "PlugShare", "url": "https://www.plugshare.com", "desc": "Find Superchargers and charging stations anywhere — essential for road trips", "badge": "Free"},
+            {"name": "A Better Route Planner", "url": "https://abetterrouteplanner.com", "desc": "Plan EV road trips with accurate range estimates and charging stops", "badge": "Free"},
+            {"name": "TeslaFi", "url": "https://teslafi.com", "desc": "Track your Tesla's efficiency, charging, battery degradation, and trip data", "badge": "Paid"},
+            {"name": "Optiwatt", "url": "https://getoptiwatt.com", "desc": "Smart Tesla charging — schedule charging for the cheapest electricity rates", "badge": "Free"},
+        ],
+        "faq": [
+            {"q": "What is FSD (Full Self-Driving)?", "a": "FSD is Tesla's advanced driver-assistance system that aims to enable fully autonomous driving. It uses cameras and neural networks to navigate roads, handle intersections, and park. As of 2026, FSD (Supervised) requires driver attention at all times — it's not yet fully autonomous, but Tesla is working toward unsupervised capability with its robotaxi program."},
+            {"q": "What does 'shorts' mean in Tesla Shorts Time?", "a": "In stock market terminology, 'shorting' means betting that a stock's price will go down. Tesla has historically been one of the most-shorted stocks on the market. 'Tesla Shorts Time' plays on this — suggesting that time is running out for those betting against Tesla, as the company continues to grow and prove skeptics wrong."},
+            {"q": "What is a Gigafactory?", "a": "A Gigafactory is Tesla's term for its massive manufacturing facilities. The name comes from 'giga' (billion) — these factories produce batteries and vehicles at a scale measured in gigawatt-hours. Tesla operates Gigafactories in Nevada, Shanghai, Berlin, and Texas, each producing hundreds of thousands of vehicles per year."},
+            {"q": "What is the Tesla Megapack?", "a": "The Megapack is Tesla's utility-scale battery storage product. Each unit stores up to 4 MWh of energy — enough to power about 3,600 homes for one hour. Utilities and grid operators use Megapacks to store renewable energy from solar and wind farms, stabilize the grid, and replace fossil fuel peaker plants."},
+            {"q": "What does TSLA's P/E ratio mean?", "a": "The Price-to-Earnings (P/E) ratio shows how much investors pay per dollar of Tesla's earnings. A high P/E (Tesla's is often 50-100+) means investors expect strong future growth. For comparison, traditional automakers trade at P/E ratios of 5-15. Tesla's premium reflects the market pricing in its AI, energy, and robotaxi potential beyond just car sales."},
         ],
     },
     "omni_view": {
@@ -94,13 +151,77 @@ NETWORK_SHOWS = {
         "meta_keywords": "balanced news, diverse perspectives, media literacy, news analysis, unbiased reporting",
         "audience": "For thoughtful news consumers who want every side of the story — not just the one their algorithm picks.",
         "source_highlights": ["NPR", "BBC", "Reuters", "WSJ", "Al Jazeera", "The Guardian"],
-        "resources": [
-            {"name": "AllSides Media Bias Chart", "url": "https://www.allsides.com/media-bias/ratings", "desc": "See where news sources fall on the political spectrum"},
-            {"name": "Ground News", "url": "https://ground.news", "desc": "Compare how different outlets cover the same story"},
-            {"name": "Ad Fontes Media Bias Chart", "url": "https://adfontesmedia.com", "desc": "Independent media reliability and bias ratings"},
-            {"name": "Reuters", "url": "https://www.reuters.com", "desc": "Wire service known for factual, neutral reporting"},
-            {"name": "AP News", "url": "https://apnews.com", "desc": "Non-profit global news wire with minimal editorial bias"},
-            {"name": "FactCheck.org", "url": "https://www.factcheck.org", "desc": "Non-partisan fact-checking from the Annenberg Public Policy Center"},
+        "resource_categories": [
+            {
+                "title": "Media Bias & Literacy Tools",
+                "resources": [
+                    {"name": "AllSides Media Bias Ratings", "url": "https://www.allsides.com/media-bias/ratings", "desc": "See where 800+ news sources fall on the political spectrum — crowd-sourced and editorial ratings"},
+                    {"name": "Ad Fontes Media Bias Chart", "url": "https://adfontesmedia.com", "desc": "Interactive chart rating news sources on reliability and political bias"},
+                    {"name": "Media Bias/Fact Check", "url": "https://mediabiasfactcheck.com", "desc": "Independent media bias and factual reporting database — 7,000+ sources rated"},
+                    {"name": "The News Literacy Project", "url": "https://newslit.org", "desc": "Free tools and lessons for evaluating news credibility — great for students and adults"},
+                    {"name": "First Draft News", "url": "https://firstdraftnews.org", "desc": "Research and training on misinformation, disinformation, and media manipulation"},
+                ],
+            },
+            {
+                "title": "Wire Services & Neutral Sources",
+                "resources": [
+                    {"name": "Reuters", "url": "https://www.reuters.com", "desc": "Global wire service known for factual, neutral reporting across politics and business"},
+                    {"name": "AP News", "url": "https://apnews.com", "desc": "Non-profit global news wire — one of the most trusted sources for straight news"},
+                    {"name": "BBC News", "url": "https://www.bbc.com/news", "desc": "British public broadcaster — comprehensive international coverage with editorial standards"},
+                    {"name": "NPR", "url": "https://www.npr.org", "desc": "US public radio — in-depth reporting on politics, culture, science, and economics"},
+                    {"name": "PBS NewsHour", "url": "https://www.pbs.org/newshour/", "desc": "US public television news — long-form reporting without commercial pressure"},
+                ],
+            },
+            {
+                "title": "Left-Leaning Sources",
+                "resources": [
+                    {"name": "The Guardian", "url": "https://www.theguardian.com", "desc": "UK-based global coverage with progressive editorial perspective — free, no paywall"},
+                    {"name": "The Intercept", "url": "https://theintercept.com", "desc": "Investigative journalism focused on civil liberties, government accountability, and justice"},
+                    {"name": "Mother Jones", "url": "https://www.motherjones.com", "desc": "Investigative reporting on politics, environment, and social justice"},
+                    {"name": "Vox", "url": "https://www.vox.com", "desc": "Explanatory journalism — complex stories broken down with context and data"},
+                ],
+            },
+            {
+                "title": "Right-Leaning Sources",
+                "resources": [
+                    {"name": "Wall Street Journal", "url": "https://www.wsj.com", "desc": "Business and financial news with center-right editorial perspective"},
+                    {"name": "National Review", "url": "https://www.nationalreview.com", "desc": "Conservative commentary and analysis on politics, culture, and policy"},
+                    {"name": "The Dispatch", "url": "https://thedispatch.com", "desc": "Fact-based conservative journalism — emphasis on accuracy over outrage"},
+                    {"name": "Reason", "url": "https://reason.com", "desc": "Libertarian perspective on politics, culture, and ideas — free markets and individual liberty"},
+                ],
+            },
+            {
+                "title": "International Perspectives",
+                "resources": [
+                    {"name": "Al Jazeera English", "url": "https://www.aljazeera.com", "desc": "Middle East-based global coverage — perspectives often underrepresented in Western media"},
+                    {"name": "Deutsche Welle (DW)", "url": "https://www.dw.com/en/", "desc": "Germany's international broadcaster — European perspective on global events"},
+                    {"name": "France 24", "url": "https://www.france24.com/en/", "desc": "French international news — European and African coverage with global lens"},
+                    {"name": "South China Morning Post", "url": "https://www.scmp.com", "desc": "Hong Kong-based English coverage of China and Asia-Pacific affairs"},
+                ],
+            },
+            {
+                "title": "Fact-Checking",
+                "resources": [
+                    {"name": "FactCheck.org", "url": "https://www.factcheck.org", "desc": "Non-partisan fact-checking from the Annenberg Public Policy Center at UPenn"},
+                    {"name": "PolitiFact", "url": "https://www.politifact.com", "desc": "Pulitzer Prize-winning fact-checking — rates claims on a Truth-O-Meter scale"},
+                    {"name": "Snopes", "url": "https://www.snopes.com", "desc": "The internet's oldest fact-checking site — urban legends, viral claims, and political checks"},
+                    {"name": "Full Fact", "url": "https://fullfact.org", "desc": "UK's independent fact-checking charity — clear verdicts on public claims"},
+                ],
+            },
+        ],
+        "tools": [
+            {"name": "Ground News", "url": "https://ground.news", "desc": "See how left, center, and right outlets cover the same story side by side", "badge": "Freemium"},
+            {"name": "AllSides", "url": "https://www.allsides.com", "desc": "Balanced news feed showing headlines from left, center, and right perspectives", "badge": "Free"},
+            {"name": "Feedly", "url": "https://feedly.com", "desc": "Build your own balanced news feed from multiple sources — organize by topic and bias", "badge": "Free tier"},
+            {"name": "Perplexity", "url": "https://www.perplexity.ai", "desc": "AI-powered research tool — ask questions and get sourced answers from across the web", "badge": "Free tier"},
+            {"name": "Google News", "url": "https://news.google.com", "desc": "Aggregated headlines from thousands of sources — see full coverage of any story", "badge": "Free"},
+        ],
+        "faq": [
+            {"q": "What is media bias?", "a": "Media bias is the tendency of a news outlet to present information in a way that favors a particular political viewpoint, ideology, or narrative. It can appear in story selection (what gets covered), framing (how it's described), word choice, and source selection. Every outlet has some degree of bias — the key is recognizing it and reading multiple perspectives."},
+            {"q": "What's the difference between news and opinion?", "a": "News reporting aims to present facts — who, what, when, where, why — with minimal editorial interpretation. Opinion pieces (editorials, columns, op-eds) express the author's views and arguments about those facts. Many outlets mix both, which is why media literacy matters. Look for labels like 'Opinion,' 'Analysis,' or 'Editorial' to distinguish them."},
+            {"q": "What is a wire service?", "a": "A wire service (like AP, Reuters, or AFP) is a news organization that gathers and distributes news to other media outlets. They focus on straight factual reporting without editorial slant, because their stories are used by newspapers, TV stations, and websites across the political spectrum. Wire service reports are generally considered among the most reliable news sources."},
+            {"q": "How do I identify misinformation?", "a": "Check multiple sources — if only one outlet reports something, be skeptical. Look at the source's track record on fact-checking databases. Check if the story cites primary sources (documents, studies, official statements). Be wary of emotional headlines, anonymous sources without corroboration, and stories that perfectly confirm your existing beliefs. When in doubt, check FactCheck.org or Snopes."},
+            {"q": "Why does Omni View cover sources from 'both sides'?", "a": "Because no single perspective has a monopoly on truth. Stories look different depending on which facts are emphasized, which sources are quoted, and what context is provided. By presenting perspectives from across the political spectrum, Omni View helps you see the full picture and form your own informed opinions — rather than having your views shaped by a single outlet's editorial choices."},
         ],
     },
     "fascinating_frontiers": {
@@ -131,13 +252,71 @@ NETWORK_SHOWS = {
         "meta_keywords": "space podcast, astronomy news, NASA discoveries, space exploration, Fascinating Frontiers",
         "audience": "For space enthusiasts, amateur astronomers, students, and anyone who looks up and wonders what's out there.",
         "source_highlights": ["NASA", "ESA", "Space.com", "SpaceNews"],
-        "resources": [
-            {"name": "NASA", "url": "https://www.nasa.gov", "desc": "Official NASA mission updates, images, and research"},
-            {"name": "NASA APOD", "url": "https://apod.nasa.gov", "desc": "Astronomy Picture of the Day — daily cosmic imagery with explanations"},
-            {"name": "Space.com", "url": "https://www.space.com", "desc": "Space news, astronomy guides, and stargazing tips"},
-            {"name": "Webb Telescope", "url": "https://webbtelescope.org", "desc": "James Webb Space Telescope images and science results"},
-            {"name": "Heavens-Above", "url": "https://www.heavens-above.com", "desc": "Track satellites, ISS passes, and night sky objects for your location"},
-            {"name": "The Planetary Society", "url": "https://www.planetary.org", "desc": "Space exploration advocacy and citizen science projects"},
+        "resource_categories": [
+            {
+                "title": "Space Agencies",
+                "resources": [
+                    {"name": "NASA", "url": "https://www.nasa.gov", "desc": "Official NASA mission updates, images, and research — the world's largest space agency"},
+                    {"name": "ESA", "url": "https://www.esa.int", "desc": "European Space Agency — Rosalind Franklin rover, Ariane rockets, and Earth observation"},
+                    {"name": "JAXA", "url": "https://global.jaxa.jp", "desc": "Japan Aerospace Exploration Agency — Hayabusa asteroid missions and lunar exploration"},
+                    {"name": "ISRO", "url": "https://www.isro.gov.in", "desc": "Indian Space Research Organisation — Chandrayaan lunar missions and Mars Orbiter"},
+                    {"name": "CSA", "url": "https://www.asc-csa.gc.ca/eng/", "desc": "Canadian Space Agency — Canadarm, Chris Hadfield's agency, and Arctic Earth observation"},
+                ],
+            },
+            {
+                "title": "News & Journalism",
+                "resources": [
+                    {"name": "Space.com", "url": "https://www.space.com", "desc": "Space news, stargazing guides, and astronomy explainers — the go-to popular source"},
+                    {"name": "SpaceNews", "url": "https://spacenews.com", "desc": "Industry-focused space journalism — policy, launches, satellites, and business"},
+                    {"name": "Spaceflight Now", "url": "https://spaceflightnow.com", "desc": "Launch tracking, mission updates, and real-time coverage of rocket launches"},
+                    {"name": "Universe Today", "url": "https://www.universetoday.com", "desc": "Astronomy and space exploration news written for enthusiasts by enthusiasts"},
+                    {"name": "The Planetary Society", "url": "https://www.planetary.org", "desc": "Space exploration advocacy, citizen science, and Carl Sagan's legacy organization"},
+                ],
+            },
+            {
+                "title": "Citizen Science & Stargazing",
+                "resources": [
+                    {"name": "NASA APOD", "url": "https://apod.nasa.gov", "desc": "Astronomy Picture of the Day — a stunning new cosmic image with expert explanation every day"},
+                    {"name": "Heavens-Above", "url": "https://www.heavens-above.com", "desc": "Track satellites, ISS passes, and planets for your location — essential for observers"},
+                    {"name": "Zooniverse", "url": "https://www.zooniverse.org", "desc": "Citizen science projects — help classify galaxies, discover exoplanets, and hunt asteroids"},
+                    {"name": "Globe at Night", "url": "https://www.globeatnight.org", "desc": "Citizen science program measuring light pollution — contribute from your backyard"},
+                    {"name": "Sky & Telescope", "url": "https://skyandtelescope.org", "desc": "Observing guides, equipment reviews, and astronomical event calendars for amateur astronomers"},
+                ],
+            },
+            {
+                "title": "Telescopes & Missions",
+                "resources": [
+                    {"name": "Webb Telescope", "url": "https://webbtelescope.org", "desc": "James Webb Space Telescope — the most powerful space telescope ever built, images and science"},
+                    {"name": "Hubble Site", "url": "https://hubblesite.org", "desc": "Hubble Space Telescope gallery, news, and 35+ years of iconic cosmic images"},
+                    {"name": "NASA Mars Exploration", "url": "https://mars.nasa.gov", "desc": "Perseverance rover, Ingenuity helicopter, and the journey to send humans to Mars"},
+                    {"name": "NASA Exoplanet Archive", "url": "https://exoplanetarchive.ipac.caltech.edu", "desc": "Database of 5,700+ confirmed exoplanets — search, filter, and explore alien worlds"},
+                    {"name": "SpaceX", "url": "https://www.spacex.com", "desc": "Starship development, Falcon 9 launches, and the mission to make humanity multiplanetary"},
+                ],
+            },
+            {
+                "title": "Learning & Courses",
+                "resources": [
+                    {"name": "Crash Course Astronomy", "url": "https://www.youtube.com/playlist?list=PL8dPuuaLjXtPAJr1ysd5yGIyiSFuh0mIL", "desc": "46 free episodes covering the solar system to cosmology — fun, fast, and accurate"},
+                    {"name": "Khan Academy Cosmology", "url": "https://www.khanacademy.org/science/cosmology-and-astronomy", "desc": "Free lessons on stars, galaxies, and the Big Bang — great for students"},
+                    {"name": "AstroBites", "url": "https://astrobites.org", "desc": "Graduate students summarize the latest astrophysics papers in plain language — daily"},
+                    {"name": "ESA Kids", "url": "https://www.esa.int/kids/en/home", "desc": "Space explained for young learners — games, activities, and mission guides from ESA"},
+                ],
+            },
+        ],
+        "tools": [
+            {"name": "Stellarium", "url": "https://stellarium-web.org", "desc": "Free planetarium in your browser — see tonight's sky from any location on Earth", "badge": "Free"},
+            {"name": "NASA Eyes", "url": "https://eyes.nasa.gov", "desc": "3D visualization of the solar system, Earth, and active NASA missions in real time", "badge": "Free"},
+            {"name": "Heavens-Above", "url": "https://www.heavens-above.com", "desc": "Track the ISS, Starlink trains, and bright satellites passing over your city", "badge": "Free"},
+            {"name": "SkySafari", "url": "https://skysafariastronomy.com", "desc": "Point your phone at the sky to identify stars, planets, and constellations instantly", "badge": "Freemium"},
+            {"name": "SpaceX Launch Tracker", "url": "https://www.spacex.com/launches/", "desc": "Upcoming and past SpaceX launches — schedules, webcasts, and mission details", "badge": "Free"},
+            {"name": "Spot The Station", "url": "https://spotthestation.nasa.gov", "desc": "NASA's official ISS sighting tool — get alerts when the station flies over your area", "badge": "Free"},
+        ],
+        "faq": [
+            {"q": "What is an exoplanet?", "a": "An exoplanet is a planet that orbits a star outside our solar system. Over 5,700 exoplanets have been confirmed as of 2026, with thousands more candidates awaiting verification. They range from scorching hot Jupiters to potentially habitable rocky worlds. NASA's TESS and the James Webb Space Telescope are the primary tools for finding and studying them."},
+            {"q": "How does the James Webb Space Telescope work?", "a": "JWST is an infrared space telescope with a 6.5-meter gold-coated mirror (compared to Hubble's 2.4m). It orbits the Sun at the L2 Lagrange point, 1.5 million km from Earth, where its sunshield keeps instruments at -233C. By observing in infrared, Webb can see through cosmic dust, study the atmospheres of exoplanets, and detect light from the earliest galaxies formed after the Big Bang."},
+            {"q": "What is a light-year?", "a": "A light-year is the distance light travels in one year — about 9.46 trillion kilometers (5.88 trillion miles). It's used because space distances are so vast that kilometers become meaningless. For scale: the nearest star (Proxima Centauri) is 4.24 light-years away. The Milky Way galaxy is about 100,000 light-years across. The observable universe extends 46 billion light-years in every direction."},
+            {"q": "What's the difference between NASA, ESA, and SpaceX?", "a": "NASA (US) and ESA (Europe) are government space agencies funded by taxpayers — they do science, exploration, and Earth observation. SpaceX is a private company founded by Elon Musk that builds rockets and spacecraft. SpaceX focuses on making space access cheaper (reusable Falcon 9, Starship), while NASA and ESA define scientific missions. They often work together — SpaceX launches NASA astronauts to the ISS."},
+            {"q": "How can I see the ISS?", "a": "The International Space Station is the third brightest object in the night sky (after the Sun and Moon). It looks like a fast-moving bright star crossing the sky in 3-5 minutes. Use NASA's Spot The Station website or the Heavens-Above app to get exact times for your location. Best sightings happen just after sunset or before sunrise when the station catches sunlight against a dark sky."},
         ],
     },
     "planetterrian": {
@@ -168,13 +347,69 @@ NETWORK_SHOWS = {
         "meta_keywords": "science podcast, longevity research, health discoveries, Planetterrian Daily, biotech news",
         "audience": "For the health-curious, longevity enthusiasts, biohackers, and anyone who wants tomorrow's medicine explained today.",
         "source_highlights": ["Nature", "Science", "Cell", "New Scientist"],
-        "resources": [
-            {"name": "PubMed", "url": "https://pubmed.ncbi.nlm.nih.gov", "desc": "Free access to biomedical and life science research papers"},
-            {"name": "ClinicalTrials.gov", "url": "https://clinicaltrials.gov", "desc": "Database of clinical studies and trials worldwide"},
-            {"name": "Nature", "url": "https://www.nature.com", "desc": "Premier multidisciplinary science journal"},
-            {"name": "Quanta Magazine", "url": "https://www.quantamagazine.org", "desc": "Accessible coverage of math, physics, and biology research"},
-            {"name": "Lifespan.io", "url": "https://www.lifespan.io", "desc": "Longevity research news and rejuvenation science tracker"},
-            {"name": "Examine.com", "url": "https://examine.com", "desc": "Evidence-based supplement and nutrition research"},
+        "resource_categories": [
+            {
+                "title": "Journals & Research",
+                "resources": [
+                    {"name": "Nature", "url": "https://www.nature.com", "desc": "The world's premier multidisciplinary science journal — breakthrough research across all fields"},
+                    {"name": "Science (AAAS)", "url": "https://www.science.org", "desc": "Peer-reviewed research and news from the American Association for the Advancement of Science"},
+                    {"name": "Cell", "url": "https://www.cell.com", "desc": "Leading journal for molecular biology, genetics, and cell biology research"},
+                    {"name": "PubMed", "url": "https://pubmed.ncbi.nlm.nih.gov", "desc": "Free database of 36M+ biomedical research papers — search any health or science topic"},
+                    {"name": "Quanta Magazine", "url": "https://www.quantamagazine.org", "desc": "Accessible, beautifully written coverage of math, physics, and biology research"},
+                ],
+            },
+            {
+                "title": "Longevity Science",
+                "resources": [
+                    {"name": "Lifespan.io", "url": "https://www.lifespan.io", "desc": "Longevity research news, rejuvenation science tracker, and clinical trial database"},
+                    {"name": "Longevity Technology", "url": "https://longevity.technology", "desc": "Industry news on longevity biotech, startups, and anti-aging interventions"},
+                    {"name": "David Sinclair Lab", "url": "https://sinclair.hms.harvard.edu", "desc": "Harvard geneticist's lab — NAD+, sirtuins, and aging reversal research"},
+                    {"name": "SENS Research Foundation", "url": "https://www.sens.org", "desc": "Aubrey de Grey's foundation funding damage-repair approaches to aging"},
+                    {"name": "ClinicalTrials.gov", "url": "https://clinicaltrials.gov", "desc": "Database of 450,000+ clinical studies — search for longevity, anti-aging, and health trials"},
+                ],
+            },
+            {
+                "title": "Health & Nutrition",
+                "resources": [
+                    {"name": "Examine.com", "url": "https://examine.com", "desc": "Evidence-based supplement and nutrition research — no ads, no hype, just science"},
+                    {"name": "Healthline", "url": "https://www.healthline.com", "desc": "Medical information reviewed by doctors — conditions, treatments, and wellness"},
+                    {"name": "Nutritionfacts.org", "url": "https://nutritionfacts.org", "desc": "Dr. Michael Greger's free database of nutrition research — video summaries of studies"},
+                    {"name": "Harvard Health", "url": "https://www.health.harvard.edu", "desc": "Health information from Harvard Medical School — trusted, peer-reviewed content"},
+                    {"name": "Mayo Clinic", "url": "https://www.mayoclinic.org", "desc": "Patient-friendly health information from one of the world's top medical centers"},
+                ],
+            },
+            {
+                "title": "Biotech & CRISPR",
+                "resources": [
+                    {"name": "STAT News", "url": "https://www.statnews.com", "desc": "Health and medicine journalism — biotech, pharma, and life science industry coverage"},
+                    {"name": "Genetic Engineering News", "url": "https://www.genengnews.com", "desc": "Biotech industry news — CRISPR, gene therapy, cell therapy, and drug development"},
+                    {"name": "The CRISPR Journal", "url": "https://www.liebertpub.com/loi/crispr", "desc": "Peer-reviewed journal dedicated to CRISPR gene editing research and applications"},
+                    {"name": "Broad Institute", "url": "https://www.broadinstitute.org", "desc": "MIT-Harvard genomics research institute — home of key CRISPR innovations"},
+                ],
+            },
+            {
+                "title": "Mental Health & Neuroscience",
+                "resources": [
+                    {"name": "Huberman Lab", "url": "https://www.hubermanlab.com", "desc": "Stanford neuroscientist Andrew Huberman's podcast and protocols for brain and body optimization"},
+                    {"name": "BrainFacts.org", "url": "https://www.brainfacts.org", "desc": "Neuroscience education from the Society for Neuroscience — brain basics to cutting-edge research"},
+                    {"name": "NIMH", "url": "https://www.nimh.nih.gov", "desc": "National Institute of Mental Health — research, statistics, and clinical trial information"},
+                    {"name": "Neuroscience News", "url": "https://neurosciencenews.com", "desc": "Daily neuroscience research summaries — psychology, AI, and brain science"},
+                ],
+            },
+        ],
+        "tools": [
+            {"name": "PubMed", "url": "https://pubmed.ncbi.nlm.nih.gov", "desc": "Search 36M+ biomedical papers — the essential tool for finding health and science research", "badge": "Free"},
+            {"name": "Examine.com", "url": "https://examine.com", "desc": "Look up any supplement or nutrient — see what the research actually says, not marketing claims", "badge": "Free tier"},
+            {"name": "Cronometer", "url": "https://cronometer.com", "desc": "Track nutrition, micronutrients, and macros with the most detailed food database available", "badge": "Free tier"},
+            {"name": "Oura Ring", "url": "https://ouraring.com", "desc": "Sleep, recovery, and readiness tracking — used by longevity researchers for personal data", "badge": "Hardware"},
+            {"name": "InsideTracker", "url": "https://www.insidetracker.com", "desc": "Blood biomarker analysis with personalized health recommendations based on your biology", "badge": "Paid"},
+        ],
+        "faq": [
+            {"q": "What is healthspan vs lifespan?", "a": "Lifespan is how long you live. Healthspan is how long you live in good health — free from chronic disease and disability. Longevity researchers increasingly focus on healthspan because living to 100 matters less if the last 20 years are spent in poor health. The goal is to compress morbidity — keeping you healthy and active until very late in life."},
+            {"q": "What is CRISPR?", "a": "CRISPR (Clustered Regularly Interspaced Short Palindromic Repeats) is a revolutionary gene-editing tool that allows scientists to precisely cut, delete, or modify DNA sequences. Think of it as molecular scissors with a GPS — you can target a specific gene and change it. It's being used to develop treatments for sickle cell disease, certain cancers, and inherited genetic conditions. The 2020 Nobel Prize in Chemistry was awarded for this technology."},
+            {"q": "What are senolytics?", "a": "Senolytics are drugs that selectively destroy senescent cells — 'zombie cells' that have stopped dividing but refuse to die. These cells accumulate with age and secrete inflammatory signals that damage surrounding tissue, contributing to aging and age-related diseases. Senolytic drugs like dasatinib + quercetin and fisetin are being studied in clinical trials. Early results suggest they may improve physical function and reduce inflammation in older adults."},
+            {"q": "What is NAD+ and why does it matter?", "a": "NAD+ (Nicotinamide Adenine Dinucleotide) is a coenzyme found in every cell that's essential for energy metabolism, DNA repair, and cellular signaling. NAD+ levels decline with age — by age 50, you may have half the NAD+ you had at 20. Researchers like David Sinclair believe boosting NAD+ (via precursors like NMN or NR) could slow aging. Clinical trials are underway, but results are still preliminary."},
+            {"q": "What is a clinical trial?", "a": "A clinical trial is a research study that tests a medical treatment, drug, or intervention in human volunteers. Trials progress through phases: Phase 1 tests safety (small group), Phase 2 tests effectiveness (larger group), Phase 3 compares to existing treatments (thousands of participants), and Phase 4 monitors long-term effects after approval. You can search for trials at ClinicalTrials.gov — some actively recruit participants."},
         ],
     },
     "env_intel": {
@@ -205,13 +440,69 @@ NETWORK_SHOWS = {
         "meta_keywords": "environmental intelligence, regulatory compliance, environmental briefings, Canadian environment",
         "audience": "For Canadian environmental professionals — contaminated sites consultants, regulators, lawyers, and lab scientists.",
         "source_highlights": ["Canada Gazette", "ECCC", "BC Ministry of Environment", "The Narwhal"],
-        "resources": [
-            {"name": "Canada Gazette", "url": "https://www.gazette.gc.ca", "desc": "Official source for federal regulations and proposed amendments"},
-            {"name": "ECCC", "url": "https://www.canada.ca/en/environment-climate-change.html", "desc": "Environment and Climate Change Canada — federal policy and enforcement"},
-            {"name": "CCME", "url": "https://ccme.ca", "desc": "Canadian Council of Ministers of the Environment — guidelines and standards"},
-            {"name": "BC Site Remediation", "url": "https://www2.gov.bc.ca/gov/content/environment/air-land-water/site-remediation", "desc": "BC contaminated sites registry, guidance, and CSR protocols"},
-            {"name": "The Narwhal", "url": "https://thenarwhal.ca", "desc": "Independent Canadian environmental investigative journalism"},
-            {"name": "Ecojustice", "url": "https://ecojustice.ca", "desc": "Canada's leading environmental law charity"},
+        "resource_categories": [
+            {
+                "title": "Federal Regulation",
+                "resources": [
+                    {"name": "Canada Gazette", "url": "https://www.gazette.gc.ca", "desc": "Official source for proposed and enacted federal regulations — Part I (proposals) and Part II (final)"},
+                    {"name": "ECCC", "url": "https://www.canada.ca/en/environment-climate-change.html", "desc": "Environment and Climate Change Canada — federal environmental policy, enforcement, and data"},
+                    {"name": "CEPA Registry", "url": "https://www.canada.ca/en/environment-climate-change/services/canadian-environmental-protection-act-registry.html", "desc": "Canadian Environmental Protection Act registry — substance assessments and regulations"},
+                    {"name": "Impact Assessment Agency", "url": "https://www.canada.ca/en/impact-assessment-agency.html", "desc": "Federal impact assessments for major projects — pipelines, mines, and infrastructure"},
+                    {"name": "CCME", "url": "https://ccme.ca", "desc": "Canadian Council of Ministers of the Environment — national guidelines, standards, and water quality objectives"},
+                ],
+            },
+            {
+                "title": "BC & Provincial",
+                "resources": [
+                    {"name": "BC Site Remediation", "url": "https://www2.gov.bc.ca/gov/content/environment/air-land-water/site-remediation", "desc": "BC contaminated sites registry, CSR protocols, technical guidance, and site profiles"},
+                    {"name": "BC ENV", "url": "https://www2.gov.bc.ca/gov/content/environment", "desc": "BC Ministry of Environment — permits, compliance, air/water quality, and wildlife"},
+                    {"name": "BC Environmental Assessment Office", "url": "https://www.projects.eao.gov.bc.ca", "desc": "Track BC environmental assessments for major projects — mines, LNG, pipelines"},
+                    {"name": "Alberta Energy Regulator", "url": "https://www.aer.ca", "desc": "Alberta's energy and environmental regulator — oil sands, pipelines, and reclamation"},
+                    {"name": "Ontario MOE", "url": "https://www.ontario.ca/page/ministry-environment-conservation-parks", "desc": "Ontario environmental regulation — brownfields, air quality, and water resources"},
+                ],
+            },
+            {
+                "title": "Professional Associations",
+                "resources": [
+                    {"name": "CSAP (BC)", "url": "https://csapsociety.bc.ca", "desc": "Contaminated Sites Approved Professionals Society — BC's roster of qualified environmental professionals"},
+                    {"name": "ECO Canada", "url": "https://eco.ca", "desc": "Environmental careers, training, and professional development across Canada"},
+                    {"name": "APEGA", "url": "https://www.apega.ca", "desc": "Association of Professional Engineers and Geoscientists of Alberta — licensing and practice"},
+                    {"name": "EGBC", "url": "https://www.egbc.ca", "desc": "Engineers and Geoscientists BC — professional regulation for BC environmental practitioners"},
+                ],
+            },
+            {
+                "title": "Contaminated Sites & Remediation",
+                "resources": [
+                    {"name": "Federal Contaminated Sites Inventory", "url": "https://www.tbs-sct.canada.ca/fcsi-rscf/home-accueil-eng.aspx", "desc": "Database of 24,000+ federal contaminated sites across Canada — searchable by province"},
+                    {"name": "ITRC", "url": "https://www.itrcweb.org", "desc": "Interstate Technology and Regulatory Council — technical guidance on PFAS, vapour intrusion, and remediation"},
+                    {"name": "CLU-IN", "url": "https://clu-in.org", "desc": "US EPA's contaminated site cleanup information — technologies, training, and case studies"},
+                    {"name": "ASTM Environmental Standards", "url": "https://www.astm.org/products-services/standards-and-publications/standards/environmental-standards.html", "desc": "Phase I/II ESA standards (E1527, E1903) and environmental assessment protocols"},
+                    {"name": "RemTech Symposium", "url": "https://www.esaa.org/remtech/", "desc": "Canada's premier remediation technology conference — ESAA annual event in Banff"},
+                ],
+            },
+            {
+                "title": "Environmental Science & Journalism",
+                "resources": [
+                    {"name": "The Narwhal", "url": "https://thenarwhal.ca", "desc": "Independent Canadian environmental investigative journalism — in-depth, evidence-based"},
+                    {"name": "Ecojustice", "url": "https://ecojustice.ca", "desc": "Canada's leading environmental law charity — legal actions and policy advocacy"},
+                    {"name": "Nature Climate Change", "url": "https://www.nature.com/nclimate/", "desc": "Peer-reviewed journal on climate change science, impacts, and policy"},
+                    {"name": "Inside Climate News", "url": "https://insideclimatenews.org", "desc": "Pulitzer Prize-winning climate and energy journalism — US and global coverage"},
+                ],
+            },
+        ],
+        "tools": [
+            {"name": "BC CSR Database", "url": "https://www2.gov.bc.ca/gov/content/environment/air-land-water/site-remediation/contaminated-sites", "desc": "Search BC's contaminated sites registry — site profiles, risk classifications, and remediation status", "badge": "Free"},
+            {"name": "CCME Guidelines", "url": "https://ccme.ca/en/current-activities/canadian-environmental-quality-guidelines", "desc": "Canadian soil, water, and sediment quality guidelines — the foundation for site assessments", "badge": "Free"},
+            {"name": "ERIS", "url": "https://www.eris.com", "desc": "Environmental risk information services — Phase I ESA database searches for Canadian and US sites", "badge": "Paid"},
+            {"name": "Canada Gazette Alerts", "url": "https://www.gazette.gc.ca/cg-gc/subscribe-abonner-eng.html", "desc": "Subscribe to alerts for new federal environmental regulations and amendments", "badge": "Free"},
+            {"name": "ArcGIS Environmental", "url": "https://www.esri.com/en-us/industries/environment/overview", "desc": "GIS mapping for environmental data — contaminated sites, watersheds, and monitoring wells", "badge": "Paid"},
+        ],
+        "faq": [
+            {"q": "What is CEPA?", "a": "The Canadian Environmental Protection Act (CEPA 1999) is Canada's primary federal environmental law. It governs the assessment and management of toxic substances, pollution prevention, and environmental emergencies. CEPA gives the federal government authority to regulate chemicals, fuels, and wastes that pose risks to human health or the environment. It was significantly updated in 2023 (Bill S-5) to recognize the right to a healthy environment."},
+            {"q": "What is a contaminated site?", "a": "A contaminated site is land or water where hazardous substances exceed regulatory standards and may pose risks to human health or the environment. Common contaminants include petroleum hydrocarbons (from gas stations), heavy metals (from industrial operations), chlorinated solvents (from dry cleaners), and PFAS (from firefighting foam). In BC, the Contaminated Sites Regulation (CSR) defines standards and the process for investigation, risk assessment, and remediation."},
+            {"q": "What are PFAS?", "a": "PFAS (Per- and Polyfluoroalkyl Substances) are a group of 12,000+ synthetic chemicals known as 'forever chemicals' because they don't break down in the environment. Used since the 1950s in non-stick coatings, food packaging, firefighting foam, and waterproof clothing, PFAS contaminate groundwater, soil, and drinking water worldwide. Health concerns include cancer, thyroid disease, and immune system effects. Canada is developing federal PFAS regulations, and remediation is extremely challenging and costly."},
+            {"q": "What is the CSR (Contaminated Sites Regulation)?", "a": "BC's Contaminated Sites Regulation sets numerical standards for soil, groundwater, vapour, and sediment quality. It defines when a site is 'contaminated' (exceeds standards) and the process for investigation, risk assessment, and remediation. Key concepts include: site profiles (disclosure triggers), preliminary and detailed site investigations, risk-based standards vs. generic standards, and certificates of compliance issued upon successful remediation."},
+            {"q": "What does 'remediation' mean?", "a": "Remediation is the process of cleaning up contaminated land or groundwater to make it safe for its intended use. Methods include: excavation and disposal (dig-and-dump), in-situ treatment (treating contamination in place using bioremediation, chemical oxidation, or thermal treatment), pump-and-treat (extracting and treating groundwater), and risk management (containing contamination with barriers or institutional controls). The approach depends on contaminant type, site geology, and intended land use."},
         ],
     },
     "models_agents": {
@@ -242,13 +533,73 @@ NETWORK_SHOWS = {
         "meta_keywords": "AI models, agent frameworks, LLM news, AI briefings, Models and Agents",
         "audience": "For developers building with AI, professionals adopting AI tools, and anyone who wants to stay ahead of the most transformative technology of our generation.",
         "source_highlights": ["OpenAI", "Anthropic", "Hugging Face", "arXiv"],
-        "resources": [
-            {"name": "Hugging Face", "url": "https://huggingface.co", "desc": "Open-source models, datasets, demos, and the model Hub"},
-            {"name": "Papers With Code", "url": "https://paperswithcode.com", "desc": "ML papers with code, benchmarks, and leaderboards"},
-            {"name": "arXiv AI", "url": "https://arxiv.org/list/cs.AI/recent", "desc": "Latest AI research preprints from the research community"},
-            {"name": "LM Arena", "url": "https://lmarena.ai", "desc": "Chatbot Arena — crowdsourced LLM rankings and leaderboard"},
-            {"name": "Latent Space", "url": "https://www.latent.space", "desc": "AI engineering podcast, newsletter, and community"},
-            {"name": "The Decoder", "url": "https://the-decoder.com", "desc": "AI news focused on practical developments and new releases"},
+        "resource_categories": [
+            {
+                "title": "AI Labs & Research",
+                "resources": [
+                    {"name": "OpenAI", "url": "https://openai.com/research", "desc": "GPT, DALL-E, and Sora — research and blog posts from the makers of ChatGPT"},
+                    {"name": "Anthropic", "url": "https://www.anthropic.com/research", "desc": "Claude model family — constitutional AI, safety research, and responsible scaling"},
+                    {"name": "Google DeepMind", "url": "https://deepmind.google/research/", "desc": "Gemini, AlphaFold, and fundamental AI research — one of the world's top AI labs"},
+                    {"name": "Meta AI (FAIR)", "url": "https://ai.meta.com/research/", "desc": "Llama open-source models, computer vision, and fundamental research"},
+                    {"name": "Mistral AI", "url": "https://mistral.ai", "desc": "European AI lab building efficient open-weight models — Mixtral and Mistral Large"},
+                    {"name": "arXiv AI", "url": "https://arxiv.org/list/cs.AI/recent", "desc": "Latest AI research preprints — papers drop here before journal publication"},
+                ],
+            },
+            {
+                "title": "Developer Tools & Frameworks",
+                "resources": [
+                    {"name": "Hugging Face", "url": "https://huggingface.co", "desc": "The GitHub of ML — 500K+ models, datasets, and Spaces demos. Essential for any AI developer"},
+                    {"name": "LangChain", "url": "https://www.langchain.com", "desc": "Framework for building LLM-powered applications — chains, agents, and retrieval pipelines"},
+                    {"name": "LlamaIndex", "url": "https://www.llamaindex.ai", "desc": "Data framework for LLM apps — connect your data to language models with RAG pipelines"},
+                    {"name": "Ollama", "url": "https://ollama.com", "desc": "Run open-source LLMs locally — Llama, Mistral, Phi, and more on your own hardware"},
+                    {"name": "Vercel AI SDK", "url": "https://sdk.vercel.ai", "desc": "TypeScript toolkit for building AI-powered web applications with streaming UI"},
+                    {"name": "Weights & Biases", "url": "https://wandb.ai", "desc": "ML experiment tracking, model versioning, and dataset management for AI teams"},
+                ],
+            },
+            {
+                "title": "Benchmarks & Leaderboards",
+                "resources": [
+                    {"name": "LM Arena (Chatbot Arena)", "url": "https://lmarena.ai", "desc": "Crowdsourced LLM rankings — users vote on which model gives better responses"},
+                    {"name": "Open LLM Leaderboard", "url": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard", "desc": "Hugging Face's benchmark for open-source models — MMLU, ARC, HellaSwag scores"},
+                    {"name": "Papers With Code", "url": "https://paperswithcode.com", "desc": "ML papers with code implementations and state-of-the-art benchmarks across tasks"},
+                    {"name": "Artificial Analysis", "url": "https://artificialanalysis.ai", "desc": "Compare LLM providers on speed, cost, and quality — essential for API selection"},
+                ],
+            },
+            {
+                "title": "Newsletters & Analysis",
+                "resources": [
+                    {"name": "Latent Space", "url": "https://www.latent.space", "desc": "AI engineering podcast and newsletter — deep dives with builders and researchers"},
+                    {"name": "The Decoder", "url": "https://the-decoder.com", "desc": "Daily AI news focused on practical developments, model releases, and tools"},
+                    {"name": "Import AI", "url": "https://importai.substack.com", "desc": "Jack Clark's weekly AI newsletter — policy, research, and industry analysis"},
+                    {"name": "The Batch (deeplearning.ai)", "url": "https://www.deeplearning.ai/the-batch/", "desc": "Andrew Ng's weekly AI newsletter — news, insights, and research highlights"},
+                    {"name": "Simon Willison's Weblog", "url": "https://simonwillison.net", "desc": "Prolific AI practitioner's blog — LLM tools, prompt engineering, and practical AI"},
+                ],
+            },
+            {
+                "title": "Open-Source Ecosystem",
+                "resources": [
+                    {"name": "Ollama", "url": "https://ollama.com", "desc": "Run Llama 3, Mistral, Phi, and other open models locally with one command"},
+                    {"name": "LM Studio", "url": "https://lmstudio.ai", "desc": "Desktop app for running local LLMs — GUI for model discovery, download, and chat"},
+                    {"name": "vLLM", "url": "https://github.com/vllm-project/vllm", "desc": "High-throughput LLM serving engine — the standard for production model deployment"},
+                    {"name": "llama.cpp", "url": "https://github.com/ggerganov/llama.cpp", "desc": "Run LLMs on CPU/GPU with minimal resources — the engine behind most local AI apps"},
+                    {"name": "Open WebUI", "url": "https://github.com/open-webui/open-webui", "desc": "Self-hosted ChatGPT-like interface for local models — works with Ollama out of the box"},
+                ],
+            },
+        ],
+        "tools": [
+            {"name": "Claude", "url": "https://claude.ai", "desc": "Anthropic's AI assistant — strong at reasoning, coding, and long-context analysis", "badge": "Free tier"},
+            {"name": "ChatGPT", "url": "https://chat.openai.com", "desc": "OpenAI's conversational AI — GPT-4o with vision, code, and browsing capabilities", "badge": "Free tier"},
+            {"name": "Cursor", "url": "https://cursor.com", "desc": "AI-first code editor — autocomplete, chat, and codebase-aware assistance built on LLMs", "badge": "Free tier"},
+            {"name": "Hugging Face", "url": "https://huggingface.co", "desc": "Try 500K+ models in your browser — text, image, audio, and multimodal demos", "badge": "Free"},
+            {"name": "Ollama", "url": "https://ollama.com", "desc": "Run open-source LLMs locally — one command to download and chat with Llama, Mistral, Phi", "badge": "Free"},
+            {"name": "Perplexity", "url": "https://www.perplexity.ai", "desc": "AI-powered search engine — asks follow-up questions and cites sources for every answer", "badge": "Free tier"},
+        ],
+        "faq": [
+            {"q": "What is an LLM?", "a": "A Large Language Model (LLM) is an AI system trained on vast amounts of text data to understand and generate human language. Models like GPT-4, Claude, Gemini, and Llama are LLMs. They work by predicting the most likely next token (word piece) in a sequence, but this simple mechanism produces remarkably capable systems that can write code, analyze documents, reason through problems, and hold conversations."},
+            {"q": "What is an AI agent?", "a": "An AI agent is a system that uses an LLM as its 'brain' to autonomously plan and execute multi-step tasks. Unlike a simple chatbot that responds to one message at a time, an agent can break down complex goals, use tools (web search, code execution, APIs), observe results, and iterate. Examples include coding agents (Cursor, Claude Code), research agents (Perplexity), and browser agents that navigate websites on your behalf."},
+            {"q": "What is RAG?", "a": "Retrieval-Augmented Generation (RAG) is a technique that gives LLMs access to external knowledge by retrieving relevant documents before generating a response. Instead of relying solely on training data, a RAG system searches a database (using vector embeddings), finds relevant passages, and includes them in the LLM's context. This reduces hallucinations and lets you build AI that can answer questions about your own documents, codebase, or data."},
+            {"q": "What is fine-tuning?", "a": "Fine-tuning is the process of further training a pre-trained LLM on a specific dataset to specialize it for a particular task or domain. For example, you might fine-tune Llama on medical literature to create a healthcare-specific model. It's more expensive than RAG but can teach the model new behaviors, styles, or domain expertise that prompt engineering alone can't achieve. Most developers start with RAG and only fine-tune when necessary."},
+            {"q": "What is MCP (Model Context Protocol)?", "a": "MCP is an open protocol (created by Anthropic) that standardizes how AI models connect to external data sources and tools. Think of it as a USB-C port for AI — instead of building custom integrations for every tool, MCP provides a universal interface. An MCP server can expose databases, APIs, file systems, or any tool, and any MCP-compatible AI client can use them. It's rapidly becoming the standard for agent tool connectivity."},
         ],
     },
     "models_agents_beginners": {
@@ -279,13 +630,68 @@ NETWORK_SHOWS = {
         "meta_keywords": "AI for beginners, AI podcast teens, learn AI, beginner AI, Models and Agents for Beginners",
         "audience": "For students, teens, curious parents, career changers, and anyone new to AI who wants to understand what's happening without the jargon.",
         "source_highlights": ["OpenAI", "Google AI", "Hugging Face", "TechCrunch AI"],
-        "resources": [
-            {"name": "Google AI Essentials", "url": "https://grow.google/ai-essentials/", "desc": "Free introductory AI course from Google — no experience needed"},
-            {"name": "Hugging Face", "url": "https://huggingface.co", "desc": "Try AI models in your browser — text, images, and more"},
-            {"name": "Scratch + AI", "url": "https://machinelearningforkids.co.uk", "desc": "Machine Learning for Kids — hands-on AI projects for beginners"},
-            {"name": "Elements of AI", "url": "https://www.elementsofai.com", "desc": "Free online course — understand AI concepts without coding"},
-            {"name": "ChatGPT", "url": "https://chat.openai.com", "desc": "Try conversing with an AI chatbot — the best way to learn is by doing"},
-            {"name": "Khan Academy AI", "url": "https://www.khanacademy.org/computing/ai-for-everyone", "desc": "AI for Everyone — free lessons from Khan Academy"},
+        "resource_categories": [
+            {
+                "title": "Start Here — Free Courses",
+                "resources": [
+                    {"name": "Google AI Essentials", "url": "https://grow.google/ai-essentials/", "desc": "Free introductory AI course from Google — no experience needed, earn a certificate"},
+                    {"name": "Elements of AI", "url": "https://www.elementsofai.com", "desc": "Free online course from University of Helsinki — understand AI concepts without coding"},
+                    {"name": "Khan Academy AI", "url": "https://www.khanacademy.org/computing/ai-for-everyone", "desc": "AI for Everyone — free, self-paced lessons from Khan Academy"},
+                    {"name": "Crash Course AI", "url": "https://www.youtube.com/playlist?list=PL8dPuuaLjXtO65LeD2p4_Sb5XQ51par_b", "desc": "20 fun video episodes explaining AI concepts — great for visual learners"},
+                    {"name": "AI for Everyone (Coursera)", "url": "https://www.coursera.org/learn/ai-for-everyone", "desc": "Andrew Ng's non-technical AI course — understand what AI can and can't do"},
+                ],
+            },
+            {
+                "title": "Try AI Right Now",
+                "resources": [
+                    {"name": "ChatGPT", "url": "https://chat.openai.com", "desc": "The most popular AI chatbot — ask questions, write stories, get homework help, or learn to code"},
+                    {"name": "Claude", "url": "https://claude.ai", "desc": "Anthropic's AI assistant — excellent at explaining concepts, writing, and careful reasoning"},
+                    {"name": "Google Gemini", "url": "https://gemini.google.com", "desc": "Google's AI — integrated with Search, can analyze images, and create content"},
+                    {"name": "Microsoft Copilot", "url": "https://copilot.microsoft.com", "desc": "Free AI assistant from Microsoft — chat, create images, and get help with tasks"},
+                    {"name": "Hugging Face Spaces", "url": "https://huggingface.co/spaces", "desc": "Try thousands of AI demos in your browser — image generation, translation, and more"},
+                ],
+            },
+            {
+                "title": "Hands-On Projects",
+                "resources": [
+                    {"name": "Machine Learning for Kids", "url": "https://machinelearningforkids.co.uk", "desc": "Build AI projects with Scratch — teach a computer to recognize images, text, and sounds"},
+                    {"name": "Teachable Machine", "url": "https://teachablemachine.withgoogle.com", "desc": "Google's tool to train your own AI model in the browser — no code needed, instant results"},
+                    {"name": "AI Experiments with Google", "url": "https://experiments.withgoogle.com/collection/ai", "desc": "Interactive AI demos — draw with AI, make music, play games, and explore neural networks"},
+                    {"name": "Runway ML", "url": "https://runwayml.com", "desc": "Create AI-generated videos, images, and effects — the creative playground for AI art"},
+                ],
+            },
+            {
+                "title": "YouTube Channels & Creators",
+                "resources": [
+                    {"name": "3Blue1Brown", "url": "https://www.youtube.com/@3blue1brown", "desc": "Beautiful math visualizations that explain neural networks and machine learning intuitively"},
+                    {"name": "Two Minute Papers", "url": "https://www.youtube.com/@TwoMinutePapers", "desc": "Quick, exciting summaries of the latest AI research — 'What a time to be alive!'"},
+                    {"name": "Fireship", "url": "https://www.youtube.com/@Fireship", "desc": "Fast-paced tech explainers — AI news in 100 seconds, coding tutorials, and developer culture"},
+                    {"name": "Matt Wolfe", "url": "https://www.youtube.com/@maboroshi", "desc": "Weekly AI tool roundups, tutorials, and news — perfect for staying current as a beginner"},
+                ],
+            },
+            {
+                "title": "Books & Reading",
+                "resources": [
+                    {"name": "Life 3.0 (Max Tegmark)", "url": "https://www.goodreads.com/book/show/34272565-life-3-0", "desc": "Accessible exploration of how AI will transform society — great for teens and adults"},
+                    {"name": "Hello World (Hannah Fry)", "url": "https://www.goodreads.com/book/show/38212157-hello-world", "desc": "How algorithms are changing our lives — fun, readable, and thought-provoking"},
+                    {"name": "AI 2041 (Kai-Fu Lee)", "url": "https://www.goodreads.com/book/show/56377201-ai-2041", "desc": "Ten short stories imagining AI's impact 15 years from now — science fiction meets real science"},
+                    {"name": "You Look Like a Thing and I Love You", "url": "https://www.goodreads.com/book/show/44286534", "desc": "Hilarious, illustrated guide to how AI works (and fails) — by AI researcher Janelle Shane"},
+                ],
+            },
+        ],
+        "tools": [
+            {"name": "ChatGPT", "url": "https://chat.openai.com", "desc": "Start here — ask anything, get homework help, write stories, or learn to code with AI", "badge": "Free"},
+            {"name": "Claude", "url": "https://claude.ai", "desc": "Great for learning — ask it to explain any topic like you're a beginner. Patient and thorough", "badge": "Free"},
+            {"name": "Google Gemini", "url": "https://gemini.google.com", "desc": "Google's AI — analyze images, get study help, and explore topics with web search built in", "badge": "Free"},
+            {"name": "Teachable Machine", "url": "https://teachablemachine.withgoogle.com", "desc": "Train your own AI in minutes — teach it to recognize your face, gestures, or sounds. No code!", "badge": "Free"},
+            {"name": "Canva Magic Studio", "url": "https://www.canva.com/ai-image-generator/", "desc": "Generate images, presentations, and designs with AI — great for school projects", "badge": "Free tier"},
+        ],
+        "faq": [
+            {"q": "What is AI?", "a": "Artificial Intelligence (AI) is technology that enables computers to perform tasks that normally require human intelligence — like understanding language, recognizing images, making decisions, and learning from experience. Modern AI systems learn from huge amounts of data rather than following explicit rules. When you use ChatGPT, Google Translate, or Instagram filters, you're using AI."},
+            {"q": "What is a 'model'?", "a": "An AI model is the trained 'brain' of an AI system. It's created by feeding a computer program enormous amounts of data and letting it find patterns. For example, a language model like GPT or Claude was trained on billions of pages of text, so it learned how language works. The word 'model' just means 'a simplified representation of something' — an AI model is a simplified representation of human knowledge and reasoning."},
+            {"q": "Is AI dangerous?", "a": "Like any powerful technology, AI has risks and benefits. Current AI can spread misinformation, create deepfakes, and be biased against certain groups. Long-term, researchers debate whether very advanced AI could be hard to control. But AI also helps doctors diagnose diseases, scientists discover new medicines, and students learn faster. The key is developing AI responsibly — with safety research, regulation, and public awareness. Understanding AI helps you use it wisely."},
+            {"q": "Can AI replace my job?", "a": "AI is more likely to change jobs than eliminate them entirely. It's very good at repetitive, pattern-based tasks (data entry, basic writing, image sorting) but struggles with creativity, empathy, physical dexterity, and complex judgment. Most experts predict AI will become a powerful tool that makes workers more productive — like how calculators didn't replace mathematicians but changed what they focus on. The best strategy is learning to work WITH AI, not compete against it."},
+            {"q": "What's the difference between ChatGPT and Google Gemini?", "a": "Both are AI chatbots powered by large language models, but they're made by different companies with different strengths. ChatGPT (by OpenAI) was the first widely popular AI chatbot and is known for creative writing and coding. Gemini (by Google) is integrated with Google Search and services, so it's good at finding current information. Claude (by Anthropic) is known for careful reasoning and safety. Try all three — they're all free to use — and see which you prefer!"},
         ],
     },
     "finansy_prosto": {
@@ -316,11 +722,67 @@ NETWORK_SHOWS = {
         "meta_keywords": "финансы, подкаст, русский, Канада, инвестиции, сбережения, бюджет, финансовая грамотность",
         "audience": "Для русскоговорящих женщин в Канаде, которые хотят разобраться в финансах — от TFSA до ипотеки.",
         "source_highlights": ["MoneySense", "Financial Post", "FinTolk", "Tinkoff Journal"],
-        "resources": [
-            {"name": "MoneySense", "url": "https://www.moneysense.ca", "desc": "Canadian personal finance — investing, saving, and retirement"},
-            {"name": "Wealthsimple", "url": "https://www.wealthsimple.com", "desc": "Easy investing platform for Canadians — TFSA, RRSP, and more"},
-            {"name": "RateHub", "url": "https://www.ratehub.ca", "desc": "Compare Canadian mortgage rates, credit cards, and savings accounts"},
-            {"name": "Canada.ca Benefits", "url": "https://www.canada.ca/en/services/benefits.html", "desc": "Government benefits — CCB, EI, CPP, OAS, and tax credits"},
+        "resource_categories": [
+            {
+                "title": "Канадские финансы",
+                "resources": [
+                    {"name": "MoneySense", "url": "https://www.moneysense.ca", "desc": "Канадский портал о финансах — инвестиции, пенсия, ипотека и налоги"},
+                    {"name": "Financial Post", "url": "https://financialpost.com", "desc": "Финансовые новости Канады — рынки, экономика и личные финансы"},
+                    {"name": "Globe and Mail Investing", "url": "https://www.theglobeandmail.com/investing/", "desc": "Инвестиционные новости и аналитика от ведущей канадской газеты"},
+                    {"name": "Canadian Couch Potato", "url": "https://canadiancouchpotato.com", "desc": "Пассивное инвестирование для канадцев — модельные портфели из ETF"},
+                    {"name": "Young and Thrifty", "url": "https://youngandthrifty.ca", "desc": "Финансовые советы для молодых канадцев — бюджет, сбережения, инвестиции"},
+                ],
+            },
+            {
+                "title": "Инвестиционные платформы",
+                "resources": [
+                    {"name": "Wealthsimple", "url": "https://www.wealthsimple.com", "desc": "Инвестиционная платформа для канадцев — TFSA, RRSP, торговля без комиссии"},
+                    {"name": "Questrade", "url": "https://www.questrade.com", "desc": "Канадский онлайн-брокер — ETF без комиссии, TFSA, RRSP, RESP"},
+                    {"name": "Interactive Brokers", "url": "https://www.interactivebrokers.ca", "desc": "Профессиональная торговая платформа — низкие комиссии, доступ к мировым рынкам"},
+                    {"name": "EQ Bank", "url": "https://www.eqbank.ca", "desc": "Высокие ставки по сберегательным счетам и GIC — без ежемесячных комиссий"},
+                ],
+            },
+            {
+                "title": "Калькуляторы и инструменты",
+                "resources": [
+                    {"name": "RateHub", "url": "https://www.ratehub.ca", "desc": "Сравнение ипотечных ставок, кредитных карт и сберегательных счетов в Канаде"},
+                    {"name": "Borrowell", "url": "https://www.borrowell.com", "desc": "Бесплатная проверка кредитного рейтинга и персональные финансовые рекомендации"},
+                    {"name": "Wealthsimple Tax", "url": "https://www.wealthsimple.com/en-ca/tax", "desc": "Бесплатная подача налоговой декларации онлайн — простой и понятный интерфейс"},
+                    {"name": "CRA My Account", "url": "https://www.canada.ca/en/revenue-agency/services/e-services/digital-services-individuals/account-individuals.html", "desc": "Личный кабинет в налоговой — проверка возвратов, лимитов TFSA/RRSP"},
+                ],
+            },
+            {
+                "title": "Государственные ресурсы",
+                "resources": [
+                    {"name": "Canada.ca Benefits", "url": "https://www.canada.ca/en/services/benefits.html", "desc": "Государственные пособия — CCB, EI, CPP, OAS, кредиты на детей и налоговые льготы"},
+                    {"name": "Financial Consumer Agency", "url": "https://www.canada.ca/en/financial-consumer-agency.html", "desc": "Защита прав потребителей финансовых услуг — жалобы, права и образование"},
+                    {"name": "BC Housing", "url": "https://www.bchousing.org", "desc": "Программы доступного жилья в BC — субсидии, аренда, первый дом"},
+                    {"name": "Settlement.org", "url": "https://settlement.org/ontario/employment/financial-information/", "desc": "Финансовая информация для иммигрантов — банки, налоги и кредит в Канаде"},
+                ],
+            },
+            {
+                "title": "Финансовое образование",
+                "resources": [
+                    {"name": "Tinkoff Journal", "url": "https://journal.tinkoff.ru", "desc": "Российский портал о финансовой грамотности — инвестиции, налоги, экономика (на русском)"},
+                    {"name": "FinTolk", "url": "https://fintolk.pro", "desc": "Финансы простым языком на русском — статьи, калькуляторы и советы"},
+                    {"name": "Investopedia", "url": "https://www.investopedia.com", "desc": "Энциклопедия инвестиций и финансов — термины, стратегии и обучение (на английском)"},
+                    {"name": "Khan Academy Finance", "url": "https://www.khanacademy.org/economics-finance-domain", "desc": "Бесплатные уроки по экономике и финансам — от базовых до продвинутых тем"},
+                ],
+            },
+        ],
+        "tools": [
+            {"name": "Wealthsimple", "url": "https://www.wealthsimple.com", "desc": "Инвестируйте без комиссии — TFSA, RRSP, торговля акциями и ETF для начинающих", "badge": "Бесплатно"},
+            {"name": "Questrade", "url": "https://www.questrade.com", "desc": "Канадский брокер — покупайте ETF без комиссии, управляйте RRSP и RESP", "badge": "Бесплатно"},
+            {"name": "YNAB", "url": "https://www.ynab.com", "desc": "You Need A Budget — лучшее приложение для бюджетирования, помогает контролировать расходы", "badge": "Пробный период"},
+            {"name": "Borrowell", "url": "https://www.borrowell.com", "desc": "Бесплатная проверка кредитного рейтинга — следите за вашим Equifax score", "badge": "Бесплатно"},
+            {"name": "Wealthsimple Tax", "url": "https://www.wealthsimple.com/en-ca/tax", "desc": "Подайте налоговую декларацию бесплатно — простой интерфейс на английском", "badge": "Бесплатно"},
+        ],
+        "faq": [
+            {"q": "Что такое TFSA?", "a": "Tax-Free Savings Account (TFSA) — это канадский сберегательный счёт, на котором вся прибыль от инвестиций не облагается налогом. Каждый год правительство увеличивает лимит взносов (в 2026 году — $7,000). Вы можете инвестировать в акции, ETF, облигации и GIC внутри TFSA, и все доходы — дивиденды, проценты, прирост капитала — остаются полностью вашими. Это один из лучших инструментов для долгосрочных сбережений в Канаде."},
+            {"q": "Что такое RRSP?", "a": "Registered Retirement Savings Plan (RRSP) — это пенсионный сберегательный план. Главное отличие от TFSA: взносы в RRSP уменьшают ваш налогооблагаемый доход в текущем году (вы получаете налоговый возврат), но при снятии денег на пенсии вы платите налог. RRSP выгоден, если сейчас ваш доход (и налоговая ставка) выше, чем будет на пенсии. Лимит взносов — 18% от заработка прошлого года."},
+            {"q": "Как начать инвестировать в Канаде?", "a": "Шаг 1: Откройте TFSA (максимально используйте налоговые льготы). Шаг 2: Выберите платформу — Wealthsimple (самая простая для начинающих) или Questrade (больше опций). Шаг 3: Начните с ETF широкого рынка, например XEQT или VGRO — они автоматически диверсифицированы по всему миру. Шаг 4: Инвестируйте регулярно (даже $50-100 в месяц), не пытайтесь угадать рынок. Время на рынке важнее, чем тайминг рынка."},
+            {"q": "Что такое GIC?", "a": "Guaranteed Investment Certificate (GIC) — это гарантированный инвестиционный сертификат. Вы вкладываете деньги в банк на фиксированный срок (от 30 дней до 5 лет), и банк гарантирует возврат + проценты. GIC застрахованы CDIC до $100,000. Ставки зависят от срока и банка — сравнивайте на RateHub.ca. GIC подходят для краткосрочных сбережений (на первый взнос, фонд безопасности), но для долгосрочных целей ETF обычно приносят больше."},
+            {"q": "Что такое кредитный рейтинг?", "a": "Кредитный рейтинг (credit score) — это число от 300 до 900, показывающее вашу кредитоспособность. В Канаде два бюро — Equifax и TransUnion. Рейтинг выше 700 считается хорошим, выше 750 — отличным. Он влияет на одобрение ипотеки, кредитных карт и процентные ставки. Чтобы улучшить рейтинг: платите вовремя, используйте менее 30% кредитного лимита, не закрывайте старые карты. Проверяйте бесплатно через Borrowell."},
         ],
     },
     "privet_russian": {
@@ -351,11 +813,66 @@ NETWORK_SHOWS = {
         "meta_keywords": "learn Russian, Russian podcast, Russian for beginners, Russian language, bilingual podcast",
         "audience": "For students, teens, curious parents, career changers, and anyone who wants to learn Russian — no experience needed.",
         "source_highlights": ["BBC News", "NPR", "National Geographic", "Moscow Times"],
-        "resources": [
-            {"name": "Duolingo Russian", "url": "https://www.duolingo.com/course/ru/en/Learn-Russian", "desc": "Free gamified Russian course — great alongside this podcast"},
-            {"name": "Russian With Max", "url": "https://russianwithmax.com", "desc": "Comprehensible input podcast for intermediate learners"},
-            {"name": "Forvo Russian", "url": "https://forvo.com/languages/ru/", "desc": "Hear native speakers pronounce any Russian word"},
-            {"name": "OpenRussian", "url": "https://en.openrussian.org", "desc": "Free Russian dictionary with declensions, conjugations, and examples"},
+        "resource_categories": [
+            {
+                "title": "Language Learning Apps",
+                "resources": [
+                    {"name": "Duolingo Russian", "url": "https://www.duolingo.com/course/ru/en/Learn-Russian", "desc": "Free gamified Russian course — 5 minutes a day builds vocabulary and grammar habits"},
+                    {"name": "Babbel Russian", "url": "https://www.babbel.com/learn-russian", "desc": "Structured Russian lessons with speech recognition — more grammar-focused than Duolingo"},
+                    {"name": "Busuu Russian", "url": "https://www.busuu.com/en/course/learn-russian-online", "desc": "Russian course with native speaker feedback on your writing and speaking exercises"},
+                    {"name": "Pimsleur Russian", "url": "https://www.pimsleur.com/learn-russian", "desc": "Audio-first method — learn Russian through listening and speaking, great for car commutes"},
+                ],
+            },
+            {
+                "title": "Dictionaries & Grammar",
+                "resources": [
+                    {"name": "OpenRussian", "url": "https://en.openrussian.org", "desc": "Free Russian dictionary with declensions, conjugations, stress marks, and usage examples"},
+                    {"name": "Wiktionary Russian", "url": "https://en.wiktionary.org/wiki/Category:Russian_language", "desc": "Community dictionary with etymologies, pronunciations, and detailed grammar tables"},
+                    {"name": "Russian Grammar Tables", "url": "https://www.russianlessons.net/grammar/", "desc": "Clear grammar reference — cases, verb conjugations, and adjective agreements"},
+                    {"name": "Reverso Context", "url": "https://context.reverso.net/translation/russian-english/", "desc": "See Russian words used in real sentences — context-based translation with examples"},
+                ],
+            },
+            {
+                "title": "Russian Media",
+                "resources": [
+                    {"name": "Russian With Max", "url": "https://russianwithmax.com", "desc": "Comprehensible input podcast — slow, clear Russian with transcripts for A2-B2 learners"},
+                    {"name": "Meduza (English)", "url": "https://meduza.io/en", "desc": "Independent Russian news in English — understand current events and cultural context"},
+                    {"name": "Arzamas Academy", "url": "https://arzamas.academy", "desc": "Russian culture and history courses — literature, art, and philosophy (in Russian with subtitles)"},
+                    {"name": "Kinopoisk", "url": "https://www.kinopoisk.ru", "desc": "Russia's IMDB — find Russian films and TV shows to practice listening comprehension"},
+                ],
+            },
+            {
+                "title": "Practice & Immersion",
+                "resources": [
+                    {"name": "Forvo Russian", "url": "https://forvo.com/languages/ru/", "desc": "Hear native speakers pronounce any Russian word — essential for mastering pronunciation"},
+                    {"name": "Tandem", "url": "https://www.tandem.net", "desc": "Find Russian-speaking language partners for text and voice chat — free language exchange"},
+                    {"name": "italki", "url": "https://www.italki.com/en/teachers/russian", "desc": "Book affordable 1-on-1 lessons with native Russian tutors — from $5/hour"},
+                    {"name": "Clozemaster", "url": "https://www.clozemaster.com/languages/eng-rus", "desc": "Learn Russian through mass sentence exposure — fill in the blanks in context"},
+                ],
+            },
+            {
+                "title": "Culture & History",
+                "resources": [
+                    {"name": "Russia Beyond", "url": "https://www.rbth.com", "desc": "Russian culture, history, food, and travel — English-language articles about Russia"},
+                    {"name": "Moscow Times", "url": "https://www.themoscowtimes.com", "desc": "Independent English-language news about Russia — politics, culture, and society"},
+                    {"name": "Russian Life Magazine", "url": "https://russianlife.com", "desc": "Russian culture, travel, and history — beautifully written long-form articles"},
+                    {"name": "RussianPod101", "url": "https://www.russianpod101.com", "desc": "Comprehensive Russian learning platform — lessons, vocabulary lists, and cultural notes"},
+                ],
+            },
+        ],
+        "tools": [
+            {"name": "Duolingo", "url": "https://www.duolingo.com/course/ru/en/Learn-Russian", "desc": "Start learning Russian with 5-minute daily lessons — gamified, fun, and builds habits", "badge": "Free"},
+            {"name": "Anki", "url": "https://apps.ankiweb.net", "desc": "Spaced repetition flashcards — the most effective way to memorize Russian vocabulary", "badge": "Free"},
+            {"name": "Forvo", "url": "https://forvo.com/languages/ru/", "desc": "Hear any Russian word pronounced by native speakers — type it in, hear it spoken", "badge": "Free"},
+            {"name": "Tandem", "url": "https://www.tandem.net", "desc": "Free language exchange app — find native Russian speakers who want to learn English", "badge": "Free"},
+            {"name": "Google Translate", "url": "https://translate.google.com/?sl=en&tl=ru", "desc": "Instant English-to-Russian translation — use camera mode to translate signs and menus", "badge": "Free"},
+        ],
+        "faq": [
+            {"q": "How hard is Russian to learn?", "a": "The US Foreign Service Institute rates Russian as a Category III language — harder than Spanish or French, but easier than Chinese, Japanese, or Arabic. For English speakers, the main challenges are the Cyrillic alphabet (learnable in a week), six grammatical cases (takes months to internalize), and verb aspect (perfective vs imperfective). The good news: Russian pronunciation is very regular — if you can read a word, you can pronounce it. With daily practice, expect basic conversational ability in 6-12 months."},
+            {"q": "What is the Cyrillic alphabet?", "a": "Cyrillic is the alphabet used to write Russian (and Ukrainian, Bulgarian, Serbian, and others). It has 33 letters — some look and sound like English letters (A, K, M, O, T), some look familiar but sound different (B sounds like V, H sounds like N, P sounds like R, C sounds like S), and some are unique (Ж, Щ, Ы, Э). You can learn all 33 letters in about a week of focused practice. Once you know Cyrillic, you can sound out any Russian word."},
+            {"q": "How many cases does Russian have?", "a": "Russian has six grammatical cases: Nominative (subject), Genitive (possession/of), Dative (to/for), Accusative (direct object), Instrumental (by/with), and Prepositional (about/in). Cases change the endings of nouns, adjectives, and pronouns depending on their role in the sentence. English handles this with word order and prepositions; Russian uses endings. It sounds intimidating, but you learn them gradually — start with Nominative and Accusative, then add others as you progress."},
+            {"q": "What's the difference between ты and вы?", "a": "Both mean 'you,' but ты (tee) is informal/singular and вы (vee) is formal/plural. Use ты with friends, family, children, and pets. Use вы with strangers, older people, professionals, and in formal situations. Вы (capitalized Вы) is also used as a polite singular 'you' — like saying 'sir' or 'ma'am' in English. Using the wrong form isn't a disaster, but switching from вы to ты with someone signals that you've become friends — it's a meaningful social moment in Russian culture."},
+            {"q": "How long does it take to learn Russian?", "a": "It depends on your goals and daily practice. With 30 minutes/day: basic greetings and survival phrases in 1-2 months, simple conversations in 4-6 months, comfortable intermediate level in 12-18 months. The FSI estimates 1,100 classroom hours for professional proficiency. Key accelerators: daily consistency (even 15 minutes beats occasional long sessions), native speaker practice (italki or Tandem), and immersion through media (Russian music, YouTube, Netflix shows with subtitles). This podcast is designed to be one of those daily touchpoints!"},
         ],
     },
 }

--- a/models-agents-beginners.html
+++ b/models-agents-beginners.html
@@ -129,6 +129,8 @@
 <a href="models-agents-beginners-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
+<a href="#faq" onclick="document.getElementById('mobileMenu').classList.remove('open')">FAQ</a>
 
         <a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">GitHub</a>
         <div class="nn-mobile-shows">
@@ -253,52 +255,262 @@
         </div>
     </section>
 
-    <!-- Resources -->
+    <!-- Resources (categorized) -->
+    
+    <section id="resources" class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources &amp; Further Reading</h2>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Start Here — Free Courses</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://grow.google/ai-essentials/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Google AI Essentials</div>
+                        <div class="resource-card-desc">Free introductory AI course from Google — no experience needed, earn a certificate</div>
+                        <div class="resource-card-url">grow.google/ai-essentials/</div>
+                    </a>
+                    
+                    <a href="https://www.elementsofai.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Elements of AI</div>
+                        <div class="resource-card-desc">Free online course from University of Helsinki — understand AI concepts without coding</div>
+                        <div class="resource-card-url">www.elementsofai.com</div>
+                    </a>
+                    
+                    <a href="https://www.khanacademy.org/computing/ai-for-everyone" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Khan Academy AI</div>
+                        <div class="resource-card-desc">AI for Everyone — free, self-paced lessons from Khan Academy</div>
+                        <div class="resource-card-url">www.khanacademy.org/computing/ai-for-everyone</div>
+                    </a>
+                    
+                    <a href="https://www.youtube.com/playlist?list=PL8dPuuaLjXtO65LeD2p4_Sb5XQ51par_b" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Crash Course AI</div>
+                        <div class="resource-card-desc">20 fun video episodes explaining AI concepts — great for visual learners</div>
+                        <div class="resource-card-url">www.youtube.com/playlist?list=PL8dPuuaLjXtO65LeD2p4_Sb5XQ51par_b</div>
+                    </a>
+                    
+                    <a href="https://www.coursera.org/learn/ai-for-everyone" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">AI for Everyone (Coursera)</div>
+                        <div class="resource-card-desc">Andrew Ng's non-technical AI course — understand what AI can and can't do</div>
+                        <div class="resource-card-url">www.coursera.org/learn/ai-for-everyone</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Try AI Right Now</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://chat.openai.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">ChatGPT</div>
+                        <div class="resource-card-desc">The most popular AI chatbot — ask questions, write stories, get homework help, or learn to code</div>
+                        <div class="resource-card-url">chat.openai.com</div>
+                    </a>
+                    
+                    <a href="https://claude.ai" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Claude</div>
+                        <div class="resource-card-desc">Anthropic's AI assistant — excellent at explaining concepts, writing, and careful reasoning</div>
+                        <div class="resource-card-url">claude.ai</div>
+                    </a>
+                    
+                    <a href="https://gemini.google.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Google Gemini</div>
+                        <div class="resource-card-desc">Google's AI — integrated with Search, can analyze images, and create content</div>
+                        <div class="resource-card-url">gemini.google.com</div>
+                    </a>
+                    
+                    <a href="https://copilot.microsoft.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Microsoft Copilot</div>
+                        <div class="resource-card-desc">Free AI assistant from Microsoft — chat, create images, and get help with tasks</div>
+                        <div class="resource-card-url">copilot.microsoft.com</div>
+                    </a>
+                    
+                    <a href="https://huggingface.co/spaces" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Hugging Face Spaces</div>
+                        <div class="resource-card-desc">Try thousands of AI demos in your browser — image generation, translation, and more</div>
+                        <div class="resource-card-url">huggingface.co/spaces</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Hands-On Projects</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://machinelearningforkids.co.uk" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Machine Learning for Kids</div>
+                        <div class="resource-card-desc">Build AI projects with Scratch — teach a computer to recognize images, text, and sounds</div>
+                        <div class="resource-card-url">machinelearningforkids.co.uk</div>
+                    </a>
+                    
+                    <a href="https://teachablemachine.withgoogle.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Teachable Machine</div>
+                        <div class="resource-card-desc">Google's tool to train your own AI model in the browser — no code needed, instant results</div>
+                        <div class="resource-card-url">teachablemachine.withgoogle.com</div>
+                    </a>
+                    
+                    <a href="https://experiments.withgoogle.com/collection/ai" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">AI Experiments with Google</div>
+                        <div class="resource-card-desc">Interactive AI demos — draw with AI, make music, play games, and explore neural networks</div>
+                        <div class="resource-card-url">experiments.withgoogle.com/collection/ai</div>
+                    </a>
+                    
+                    <a href="https://runwayml.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Runway ML</div>
+                        <div class="resource-card-desc">Create AI-generated videos, images, and effects — the creative playground for AI art</div>
+                        <div class="resource-card-url">runwayml.com</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">YouTube Channels & Creators</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.youtube.com/@3blue1brown" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">3Blue1Brown</div>
+                        <div class="resource-card-desc">Beautiful math visualizations that explain neural networks and machine learning intuitively</div>
+                        <div class="resource-card-url">www.youtube.com/@3blue1brown</div>
+                    </a>
+                    
+                    <a href="https://www.youtube.com/@TwoMinutePapers" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Two Minute Papers</div>
+                        <div class="resource-card-desc">Quick, exciting summaries of the latest AI research — 'What a time to be alive!'</div>
+                        <div class="resource-card-url">www.youtube.com/@TwoMinutePapers</div>
+                    </a>
+                    
+                    <a href="https://www.youtube.com/@Fireship" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Fireship</div>
+                        <div class="resource-card-desc">Fast-paced tech explainers — AI news in 100 seconds, coding tutorials, and developer culture</div>
+                        <div class="resource-card-url">www.youtube.com/@Fireship</div>
+                    </a>
+                    
+                    <a href="https://www.youtube.com/@maboroshi" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Matt Wolfe</div>
+                        <div class="resource-card-desc">Weekly AI tool roundups, tutorials, and news — perfect for staying current as a beginner</div>
+                        <div class="resource-card-url">www.youtube.com/@maboroshi</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Books & Reading</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.goodreads.com/book/show/34272565-life-3-0" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Life 3.0 (Max Tegmark)</div>
+                        <div class="resource-card-desc">Accessible exploration of how AI will transform society — great for teens and adults</div>
+                        <div class="resource-card-url">www.goodreads.com/book/show/34272565-life-3-0</div>
+                    </a>
+                    
+                    <a href="https://www.goodreads.com/book/show/38212157-hello-world" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Hello World (Hannah Fry)</div>
+                        <div class="resource-card-desc">How algorithms are changing our lives — fun, readable, and thought-provoking</div>
+                        <div class="resource-card-url">www.goodreads.com/book/show/38212157-hello-world</div>
+                    </a>
+                    
+                    <a href="https://www.goodreads.com/book/show/56377201-ai-2041" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">AI 2041 (Kai-Fu Lee)</div>
+                        <div class="resource-card-desc">Ten short stories imagining AI's impact 15 years from now — science fiction meets real science</div>
+                        <div class="resource-card-url">www.goodreads.com/book/show/56377201-ai-2041</div>
+                    </a>
+                    
+                    <a href="https://www.goodreads.com/book/show/44286534" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">You Look Like a Thing and I Love You</div>
+                        <div class="resource-card-desc">Hilarious, illustrated guide to how AI works (and fails) — by AI researcher Janelle Shane</div>
+                        <div class="resource-card-url">www.goodreads.com/book/show/44286534</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+        </div>
+    </section>
+    
+
+    <!-- Recommended Tools -->
     
     <section class="nn-section" style="padding-top:0;">
         <div class="container">
             <div class="nn-section-header" style="text-align:left;">
-                <h2>Resources & Further Reading</h2>
+                <h2>Recommended Tools</h2>
             </div>
-            <div class="resources-grid">
+            <div class="tools-grid">
                 
-                <a href="https://grow.google/ai-essentials/" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Google AI Essentials</div>
-                    <div class="resource-card-desc">Free introductory AI course from Google — no experience needed</div>
-                    <div class="resource-card-url">grow.google/ai-essentials/</div>
+                <a href="https://chat.openai.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">ChatGPT</div>
+                    <div class="tool-card-desc">Start here — ask anything, get homework help, write stories, or learn to code with AI</div>
                 </a>
                 
-                <a href="https://huggingface.co" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Hugging Face</div>
-                    <div class="resource-card-desc">Try AI models in your browser — text, images, and more</div>
-                    <div class="resource-card-url">huggingface.co</div>
+                <a href="https://claude.ai" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Claude</div>
+                    <div class="tool-card-desc">Great for learning — ask it to explain any topic like you're a beginner. Patient and thorough</div>
                 </a>
                 
-                <a href="https://machinelearningforkids.co.uk" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Scratch + AI</div>
-                    <div class="resource-card-desc">Machine Learning for Kids — hands-on AI projects for beginners</div>
-                    <div class="resource-card-url">machinelearningforkids.co.uk</div>
+                <a href="https://gemini.google.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Google Gemini</div>
+                    <div class="tool-card-desc">Google's AI — analyze images, get study help, and explore topics with web search built in</div>
                 </a>
                 
-                <a href="https://www.elementsofai.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Elements of AI</div>
-                    <div class="resource-card-desc">Free online course — understand AI concepts without coding</div>
-                    <div class="resource-card-url">www.elementsofai.com</div>
+                <a href="https://teachablemachine.withgoogle.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Teachable Machine</div>
+                    <div class="tool-card-desc">Train your own AI in minutes — teach it to recognize your face, gestures, or sounds. No code!</div>
                 </a>
                 
-                <a href="https://chat.openai.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">ChatGPT</div>
-                    <div class="resource-card-desc">Try conversing with an AI chatbot — the best way to learn is by doing</div>
-                    <div class="resource-card-url">chat.openai.com</div>
-                </a>
-                
-                <a href="https://www.khanacademy.org/computing/ai-for-everyone" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Khan Academy AI</div>
-                    <div class="resource-card-desc">AI for Everyone — free lessons from Khan Academy</div>
-                    <div class="resource-card-url">www.khanacademy.org/computing/ai-for-everyone</div>
+                <a href="https://www.canva.com/ai-image-generator/" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free tier</span>
+                    <div class="tool-card-name">Canva Magic Studio</div>
+                    <div class="tool-card-desc">Generate images, presentations, and designs with AI — great for school projects</div>
                 </a>
                 
             </div>
+        </div>
+    </section>
+    
+
+    <!-- Key Concepts / FAQ -->
+    
+    <section id="faq" class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:800px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Key Concepts</h2>
+            </div>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is AI?</summary>
+                <div class="faq-answer">Artificial Intelligence (AI) is technology that enables computers to perform tasks that normally require human intelligence — like understanding language, recognizing images, making decisions, and learning from experience. Modern AI systems learn from huge amounts of data rather than following explicit rules. When you use ChatGPT, Google Translate, or Instagram filters, you're using AI.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is a 'model'?</summary>
+                <div class="faq-answer">An AI model is the trained 'brain' of an AI system. It's created by feeding a computer program enormous amounts of data and letting it find patterns. For example, a language model like GPT or Claude was trained on billions of pages of text, so it learned how language works. The word 'model' just means 'a simplified representation of something' — an AI model is a simplified representation of human knowledge and reasoning.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">Is AI dangerous?</summary>
+                <div class="faq-answer">Like any powerful technology, AI has risks and benefits. Current AI can spread misinformation, create deepfakes, and be biased against certain groups. Long-term, researchers debate whether very advanced AI could be hard to control. But AI also helps doctors diagnose diseases, scientists discover new medicines, and students learn faster. The key is developing AI responsibly — with safety research, regulation, and public awareness. Understanding AI helps you use it wisely.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">Can AI replace my job?</summary>
+                <div class="faq-answer">AI is more likely to change jobs than eliminate them entirely. It's very good at repetitive, pattern-based tasks (data entry, basic writing, image sorting) but struggles with creativity, empathy, physical dexterity, and complex judgment. Most experts predict AI will become a powerful tool that makes workers more productive — like how calculators didn't replace mathematicians but changed what they focus on. The best strategy is learning to work WITH AI, not compete against it.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What's the difference between ChatGPT and Google Gemini?</summary>
+                <div class="faq-answer">Both are AI chatbots powered by large language models, but they're made by different companies with different strengths. ChatGPT (by OpenAI) was the first widely popular AI chatbot and is known for creative writing and coding. Gemini (by Google) is integrated with Google Search and services, so it's good at finding current information. Claude (by Anthropic) is known for careful reasoning and safety. Try all three — they're all free to use — and see which you prefer!</div>
+            </details>
+            
         </div>
     </section>
     
@@ -328,7 +540,7 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
-                <p>Seven daily shows keeping you informed.</p>
+                <p>Nine daily shows keeping you informed.</p>
             </div>
             <div class="cross-network-grid">
                 

--- a/models-agents.html
+++ b/models-agents.html
@@ -129,6 +129,8 @@
 <a href="models-agents-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
+<a href="#faq" onclick="document.getElementById('mobileMenu').classList.remove('open')">FAQ</a>
 
         <a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">GitHub</a>
         <div class="nn-mobile-shows">
@@ -253,52 +255,292 @@
         </div>
     </section>
 
-    <!-- Resources -->
+    <!-- Resources (categorized) -->
+    
+    <section id="resources" class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources &amp; Further Reading</h2>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">AI Labs & Research</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://openai.com/research" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">OpenAI</div>
+                        <div class="resource-card-desc">GPT, DALL-E, and Sora — research and blog posts from the makers of ChatGPT</div>
+                        <div class="resource-card-url">openai.com/research</div>
+                    </a>
+                    
+                    <a href="https://www.anthropic.com/research" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Anthropic</div>
+                        <div class="resource-card-desc">Claude model family — constitutional AI, safety research, and responsible scaling</div>
+                        <div class="resource-card-url">www.anthropic.com/research</div>
+                    </a>
+                    
+                    <a href="https://deepmind.google/research/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Google DeepMind</div>
+                        <div class="resource-card-desc">Gemini, AlphaFold, and fundamental AI research — one of the world's top AI labs</div>
+                        <div class="resource-card-url">deepmind.google/research/</div>
+                    </a>
+                    
+                    <a href="https://ai.meta.com/research/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Meta AI (FAIR)</div>
+                        <div class="resource-card-desc">Llama open-source models, computer vision, and fundamental research</div>
+                        <div class="resource-card-url">ai.meta.com/research/</div>
+                    </a>
+                    
+                    <a href="https://mistral.ai" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Mistral AI</div>
+                        <div class="resource-card-desc">European AI lab building efficient open-weight models — Mixtral and Mistral Large</div>
+                        <div class="resource-card-url">mistral.ai</div>
+                    </a>
+                    
+                    <a href="https://arxiv.org/list/cs.AI/recent" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">arXiv AI</div>
+                        <div class="resource-card-desc">Latest AI research preprints — papers drop here before journal publication</div>
+                        <div class="resource-card-url">arxiv.org/list/cs.AI/recent</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Developer Tools & Frameworks</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://huggingface.co" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Hugging Face</div>
+                        <div class="resource-card-desc">The GitHub of ML — 500K+ models, datasets, and Spaces demos. Essential for any AI developer</div>
+                        <div class="resource-card-url">huggingface.co</div>
+                    </a>
+                    
+                    <a href="https://www.langchain.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">LangChain</div>
+                        <div class="resource-card-desc">Framework for building LLM-powered applications — chains, agents, and retrieval pipelines</div>
+                        <div class="resource-card-url">www.langchain.com</div>
+                    </a>
+                    
+                    <a href="https://www.llamaindex.ai" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">LlamaIndex</div>
+                        <div class="resource-card-desc">Data framework for LLM apps — connect your data to language models with RAG pipelines</div>
+                        <div class="resource-card-url">www.llamaindex.ai</div>
+                    </a>
+                    
+                    <a href="https://ollama.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Ollama</div>
+                        <div class="resource-card-desc">Run open-source LLMs locally — Llama, Mistral, Phi, and more on your own hardware</div>
+                        <div class="resource-card-url">ollama.com</div>
+                    </a>
+                    
+                    <a href="https://sdk.vercel.ai" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Vercel AI SDK</div>
+                        <div class="resource-card-desc">TypeScript toolkit for building AI-powered web applications with streaming UI</div>
+                        <div class="resource-card-url">sdk.vercel.ai</div>
+                    </a>
+                    
+                    <a href="https://wandb.ai" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Weights & Biases</div>
+                        <div class="resource-card-desc">ML experiment tracking, model versioning, and dataset management for AI teams</div>
+                        <div class="resource-card-url">wandb.ai</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Benchmarks & Leaderboards</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://lmarena.ai" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">LM Arena (Chatbot Arena)</div>
+                        <div class="resource-card-desc">Crowdsourced LLM rankings — users vote on which model gives better responses</div>
+                        <div class="resource-card-url">lmarena.ai</div>
+                    </a>
+                    
+                    <a href="https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Open LLM Leaderboard</div>
+                        <div class="resource-card-desc">Hugging Face's benchmark for open-source models — MMLU, ARC, HellaSwag scores</div>
+                        <div class="resource-card-url">huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard</div>
+                    </a>
+                    
+                    <a href="https://paperswithcode.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Papers With Code</div>
+                        <div class="resource-card-desc">ML papers with code implementations and state-of-the-art benchmarks across tasks</div>
+                        <div class="resource-card-url">paperswithcode.com</div>
+                    </a>
+                    
+                    <a href="https://artificialanalysis.ai" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Artificial Analysis</div>
+                        <div class="resource-card-desc">Compare LLM providers on speed, cost, and quality — essential for API selection</div>
+                        <div class="resource-card-url">artificialanalysis.ai</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Newsletters & Analysis</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.latent.space" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Latent Space</div>
+                        <div class="resource-card-desc">AI engineering podcast and newsletter — deep dives with builders and researchers</div>
+                        <div class="resource-card-url">www.latent.space</div>
+                    </a>
+                    
+                    <a href="https://the-decoder.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">The Decoder</div>
+                        <div class="resource-card-desc">Daily AI news focused on practical developments, model releases, and tools</div>
+                        <div class="resource-card-url">the-decoder.com</div>
+                    </a>
+                    
+                    <a href="https://importai.substack.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Import AI</div>
+                        <div class="resource-card-desc">Jack Clark's weekly AI newsletter — policy, research, and industry analysis</div>
+                        <div class="resource-card-url">importai.substack.com</div>
+                    </a>
+                    
+                    <a href="https://www.deeplearning.ai/the-batch/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">The Batch (deeplearning.ai)</div>
+                        <div class="resource-card-desc">Andrew Ng's weekly AI newsletter — news, insights, and research highlights</div>
+                        <div class="resource-card-url">www.deeplearning.ai/the-batch/</div>
+                    </a>
+                    
+                    <a href="https://simonwillison.net" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Simon Willison's Weblog</div>
+                        <div class="resource-card-desc">Prolific AI practitioner's blog — LLM tools, prompt engineering, and practical AI</div>
+                        <div class="resource-card-url">simonwillison.net</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Open-Source Ecosystem</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://ollama.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Ollama</div>
+                        <div class="resource-card-desc">Run Llama 3, Mistral, Phi, and other open models locally with one command</div>
+                        <div class="resource-card-url">ollama.com</div>
+                    </a>
+                    
+                    <a href="https://lmstudio.ai" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">LM Studio</div>
+                        <div class="resource-card-desc">Desktop app for running local LLMs — GUI for model discovery, download, and chat</div>
+                        <div class="resource-card-url">lmstudio.ai</div>
+                    </a>
+                    
+                    <a href="https://github.com/vllm-project/vllm" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">vLLM</div>
+                        <div class="resource-card-desc">High-throughput LLM serving engine — the standard for production model deployment</div>
+                        <div class="resource-card-url">github.com/vllm-project/vllm</div>
+                    </a>
+                    
+                    <a href="https://github.com/ggerganov/llama.cpp" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">llama.cpp</div>
+                        <div class="resource-card-desc">Run LLMs on CPU/GPU with minimal resources — the engine behind most local AI apps</div>
+                        <div class="resource-card-url">github.com/ggerganov/llama.cpp</div>
+                    </a>
+                    
+                    <a href="https://github.com/open-webui/open-webui" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Open WebUI</div>
+                        <div class="resource-card-desc">Self-hosted ChatGPT-like interface for local models — works with Ollama out of the box</div>
+                        <div class="resource-card-url">github.com/open-webui/open-webui</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+        </div>
+    </section>
+    
+
+    <!-- Recommended Tools -->
     
     <section class="nn-section" style="padding-top:0;">
         <div class="container">
             <div class="nn-section-header" style="text-align:left;">
-                <h2>Resources & Further Reading</h2>
+                <h2>Recommended Tools</h2>
             </div>
-            <div class="resources-grid">
+            <div class="tools-grid">
                 
-                <a href="https://huggingface.co" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Hugging Face</div>
-                    <div class="resource-card-desc">Open-source models, datasets, demos, and the model Hub</div>
-                    <div class="resource-card-url">huggingface.co</div>
+                <a href="https://claude.ai" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free tier</span>
+                    <div class="tool-card-name">Claude</div>
+                    <div class="tool-card-desc">Anthropic's AI assistant — strong at reasoning, coding, and long-context analysis</div>
                 </a>
                 
-                <a href="https://paperswithcode.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Papers With Code</div>
-                    <div class="resource-card-desc">ML papers with code, benchmarks, and leaderboards</div>
-                    <div class="resource-card-url">paperswithcode.com</div>
+                <a href="https://chat.openai.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free tier</span>
+                    <div class="tool-card-name">ChatGPT</div>
+                    <div class="tool-card-desc">OpenAI's conversational AI — GPT-4o with vision, code, and browsing capabilities</div>
                 </a>
                 
-                <a href="https://arxiv.org/list/cs.AI/recent" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">arXiv AI</div>
-                    <div class="resource-card-desc">Latest AI research preprints from the research community</div>
-                    <div class="resource-card-url">arxiv.org/list/cs.AI/recent</div>
+                <a href="https://cursor.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free tier</span>
+                    <div class="tool-card-name">Cursor</div>
+                    <div class="tool-card-desc">AI-first code editor — autocomplete, chat, and codebase-aware assistance built on LLMs</div>
                 </a>
                 
-                <a href="https://lmarena.ai" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">LM Arena</div>
-                    <div class="resource-card-desc">Chatbot Arena — crowdsourced LLM rankings and leaderboard</div>
-                    <div class="resource-card-url">lmarena.ai</div>
+                <a href="https://huggingface.co" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Hugging Face</div>
+                    <div class="tool-card-desc">Try 500K+ models in your browser — text, image, audio, and multimodal demos</div>
                 </a>
                 
-                <a href="https://www.latent.space" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Latent Space</div>
-                    <div class="resource-card-desc">AI engineering podcast, newsletter, and community</div>
-                    <div class="resource-card-url">www.latent.space</div>
+                <a href="https://ollama.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Ollama</div>
+                    <div class="tool-card-desc">Run open-source LLMs locally — one command to download and chat with Llama, Mistral, Phi</div>
                 </a>
                 
-                <a href="https://the-decoder.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">The Decoder</div>
-                    <div class="resource-card-desc">AI news focused on practical developments and new releases</div>
-                    <div class="resource-card-url">the-decoder.com</div>
+                <a href="https://www.perplexity.ai" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free tier</span>
+                    <div class="tool-card-name">Perplexity</div>
+                    <div class="tool-card-desc">AI-powered search engine — asks follow-up questions and cites sources for every answer</div>
                 </a>
                 
             </div>
+        </div>
+    </section>
+    
+
+    <!-- Key Concepts / FAQ -->
+    
+    <section id="faq" class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:800px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Key Concepts</h2>
+            </div>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is an LLM?</summary>
+                <div class="faq-answer">A Large Language Model (LLM) is an AI system trained on vast amounts of text data to understand and generate human language. Models like GPT-4, Claude, Gemini, and Llama are LLMs. They work by predicting the most likely next token (word piece) in a sequence, but this simple mechanism produces remarkably capable systems that can write code, analyze documents, reason through problems, and hold conversations.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is an AI agent?</summary>
+                <div class="faq-answer">An AI agent is a system that uses an LLM as its 'brain' to autonomously plan and execute multi-step tasks. Unlike a simple chatbot that responds to one message at a time, an agent can break down complex goals, use tools (web search, code execution, APIs), observe results, and iterate. Examples include coding agents (Cursor, Claude Code), research agents (Perplexity), and browser agents that navigate websites on your behalf.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is RAG?</summary>
+                <div class="faq-answer">Retrieval-Augmented Generation (RAG) is a technique that gives LLMs access to external knowledge by retrieving relevant documents before generating a response. Instead of relying solely on training data, a RAG system searches a database (using vector embeddings), finds relevant passages, and includes them in the LLM's context. This reduces hallucinations and lets you build AI that can answer questions about your own documents, codebase, or data.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is fine-tuning?</summary>
+                <div class="faq-answer">Fine-tuning is the process of further training a pre-trained LLM on a specific dataset to specialize it for a particular task or domain. For example, you might fine-tune Llama on medical literature to create a healthcare-specific model. It's more expensive than RAG but can teach the model new behaviors, styles, or domain expertise that prompt engineering alone can't achieve. Most developers start with RAG and only fine-tune when necessary.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is MCP (Model Context Protocol)?</summary>
+                <div class="faq-answer">MCP is an open protocol (created by Anthropic) that standardizes how AI models connect to external data sources and tools. Think of it as a USB-C port for AI — instead of building custom integrations for every tool, MCP provides a universal interface. An MCP server can expose databases, APIs, file systems, or any tool, and any MCP-compatible AI client can use them. It's rapidly becoming the standard for agent tool connectivity.</div>
+            </details>
+            
         </div>
     </section>
     
@@ -328,7 +570,7 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
-                <p>Seven daily shows keeping you informed.</p>
+                <p>Nine daily shows keeping you informed.</p>
             </div>
             <div class="cross-network-grid">
                 

--- a/network.rss
+++ b/network.rss
@@ -5,7 +5,7 @@
     <description>Nine podcasts in two languages keeping you informed about exciting changes in the world. Unbiased, multi-perspective coverage of Tesla, world news, space, science, AI, the environment, financial literacy, and Russian language learning.</description>
     <link>https://nerranetwork.com/</link>
     <language>en</language>
-    <lastBuildDate>Sat, 14 Mar 2026 20:36:25 +0000</lastBuildDate>
+    <lastBuildDate>Sat, 14 Mar 2026 21:32:45 +0000</lastBuildDate>
     <image>
       <url>https://nerranetwork.com/assets/covers/omni-view.jpg</url>
       <title>Nerra Network</title>

--- a/omni-view.html
+++ b/omni-view.html
@@ -129,6 +129,8 @@
 <a href="omni-view-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
+<a href="#faq" onclick="document.getElementById('mobileMenu').classList.remove('open')">FAQ</a>
 
         <a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">GitHub</a>
         <div class="nn-mobile-shows">
@@ -255,52 +257,293 @@
         </div>
     </section>
 
-    <!-- Resources -->
+    <!-- Resources (categorized) -->
+    
+    <section id="resources" class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources &amp; Further Reading</h2>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Media Bias & Literacy Tools</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.allsides.com/media-bias/ratings" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">AllSides Media Bias Ratings</div>
+                        <div class="resource-card-desc">See where 800+ news sources fall on the political spectrum — crowd-sourced and editorial ratings</div>
+                        <div class="resource-card-url">www.allsides.com/media-bias/ratings</div>
+                    </a>
+                    
+                    <a href="https://adfontesmedia.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Ad Fontes Media Bias Chart</div>
+                        <div class="resource-card-desc">Interactive chart rating news sources on reliability and political bias</div>
+                        <div class="resource-card-url">adfontesmedia.com</div>
+                    </a>
+                    
+                    <a href="https://mediabiasfactcheck.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Media Bias/Fact Check</div>
+                        <div class="resource-card-desc">Independent media bias and factual reporting database — 7,000+ sources rated</div>
+                        <div class="resource-card-url">mediabiasfactcheck.com</div>
+                    </a>
+                    
+                    <a href="https://newslit.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">The News Literacy Project</div>
+                        <div class="resource-card-desc">Free tools and lessons for evaluating news credibility — great for students and adults</div>
+                        <div class="resource-card-url">newslit.org</div>
+                    </a>
+                    
+                    <a href="https://firstdraftnews.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">First Draft News</div>
+                        <div class="resource-card-desc">Research and training on misinformation, disinformation, and media manipulation</div>
+                        <div class="resource-card-url">firstdraftnews.org</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Wire Services & Neutral Sources</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.reuters.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Reuters</div>
+                        <div class="resource-card-desc">Global wire service known for factual, neutral reporting across politics and business</div>
+                        <div class="resource-card-url">www.reuters.com</div>
+                    </a>
+                    
+                    <a href="https://apnews.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">AP News</div>
+                        <div class="resource-card-desc">Non-profit global news wire — one of the most trusted sources for straight news</div>
+                        <div class="resource-card-url">apnews.com</div>
+                    </a>
+                    
+                    <a href="https://www.bbc.com/news" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">BBC News</div>
+                        <div class="resource-card-desc">British public broadcaster — comprehensive international coverage with editorial standards</div>
+                        <div class="resource-card-url">www.bbc.com/news</div>
+                    </a>
+                    
+                    <a href="https://www.npr.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">NPR</div>
+                        <div class="resource-card-desc">US public radio — in-depth reporting on politics, culture, science, and economics</div>
+                        <div class="resource-card-url">www.npr.org</div>
+                    </a>
+                    
+                    <a href="https://www.pbs.org/newshour/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">PBS NewsHour</div>
+                        <div class="resource-card-desc">US public television news — long-form reporting without commercial pressure</div>
+                        <div class="resource-card-url">www.pbs.org/newshour/</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Left-Leaning Sources</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.theguardian.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">The Guardian</div>
+                        <div class="resource-card-desc">UK-based global coverage with progressive editorial perspective — free, no paywall</div>
+                        <div class="resource-card-url">www.theguardian.com</div>
+                    </a>
+                    
+                    <a href="https://theintercept.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">The Intercept</div>
+                        <div class="resource-card-desc">Investigative journalism focused on civil liberties, government accountability, and justice</div>
+                        <div class="resource-card-url">theintercept.com</div>
+                    </a>
+                    
+                    <a href="https://www.motherjones.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Mother Jones</div>
+                        <div class="resource-card-desc">Investigative reporting on politics, environment, and social justice</div>
+                        <div class="resource-card-url">www.motherjones.com</div>
+                    </a>
+                    
+                    <a href="https://www.vox.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Vox</div>
+                        <div class="resource-card-desc">Explanatory journalism — complex stories broken down with context and data</div>
+                        <div class="resource-card-url">www.vox.com</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Right-Leaning Sources</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.wsj.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Wall Street Journal</div>
+                        <div class="resource-card-desc">Business and financial news with center-right editorial perspective</div>
+                        <div class="resource-card-url">www.wsj.com</div>
+                    </a>
+                    
+                    <a href="https://www.nationalreview.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">National Review</div>
+                        <div class="resource-card-desc">Conservative commentary and analysis on politics, culture, and policy</div>
+                        <div class="resource-card-url">www.nationalreview.com</div>
+                    </a>
+                    
+                    <a href="https://thedispatch.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">The Dispatch</div>
+                        <div class="resource-card-desc">Fact-based conservative journalism — emphasis on accuracy over outrage</div>
+                        <div class="resource-card-url">thedispatch.com</div>
+                    </a>
+                    
+                    <a href="https://reason.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Reason</div>
+                        <div class="resource-card-desc">Libertarian perspective on politics, culture, and ideas — free markets and individual liberty</div>
+                        <div class="resource-card-url">reason.com</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">International Perspectives</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.aljazeera.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Al Jazeera English</div>
+                        <div class="resource-card-desc">Middle East-based global coverage — perspectives often underrepresented in Western media</div>
+                        <div class="resource-card-url">www.aljazeera.com</div>
+                    </a>
+                    
+                    <a href="https://www.dw.com/en/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Deutsche Welle (DW)</div>
+                        <div class="resource-card-desc">Germany's international broadcaster — European perspective on global events</div>
+                        <div class="resource-card-url">www.dw.com/en/</div>
+                    </a>
+                    
+                    <a href="https://www.france24.com/en/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">France 24</div>
+                        <div class="resource-card-desc">French international news — European and African coverage with global lens</div>
+                        <div class="resource-card-url">www.france24.com/en/</div>
+                    </a>
+                    
+                    <a href="https://www.scmp.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">South China Morning Post</div>
+                        <div class="resource-card-desc">Hong Kong-based English coverage of China and Asia-Pacific affairs</div>
+                        <div class="resource-card-url">www.scmp.com</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Fact-Checking</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.factcheck.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">FactCheck.org</div>
+                        <div class="resource-card-desc">Non-partisan fact-checking from the Annenberg Public Policy Center at UPenn</div>
+                        <div class="resource-card-url">www.factcheck.org</div>
+                    </a>
+                    
+                    <a href="https://www.politifact.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">PolitiFact</div>
+                        <div class="resource-card-desc">Pulitzer Prize-winning fact-checking — rates claims on a Truth-O-Meter scale</div>
+                        <div class="resource-card-url">www.politifact.com</div>
+                    </a>
+                    
+                    <a href="https://www.snopes.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Snopes</div>
+                        <div class="resource-card-desc">The internet's oldest fact-checking site — urban legends, viral claims, and political checks</div>
+                        <div class="resource-card-url">www.snopes.com</div>
+                    </a>
+                    
+                    <a href="https://fullfact.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Full Fact</div>
+                        <div class="resource-card-desc">UK's independent fact-checking charity — clear verdicts on public claims</div>
+                        <div class="resource-card-url">fullfact.org</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+        </div>
+    </section>
+    
+
+    <!-- Recommended Tools -->
     
     <section class="nn-section" style="padding-top:0;">
         <div class="container">
             <div class="nn-section-header" style="text-align:left;">
-                <h2>Resources & Further Reading</h2>
+                <h2>Recommended Tools</h2>
             </div>
-            <div class="resources-grid">
+            <div class="tools-grid">
                 
-                <a href="https://www.allsides.com/media-bias/ratings" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">AllSides Media Bias Chart</div>
-                    <div class="resource-card-desc">See where news sources fall on the political spectrum</div>
-                    <div class="resource-card-url">www.allsides.com/media-bias/ratings</div>
+                <a href="https://ground.news" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Freemium</span>
+                    <div class="tool-card-name">Ground News</div>
+                    <div class="tool-card-desc">See how left, center, and right outlets cover the same story side by side</div>
                 </a>
                 
-                <a href="https://ground.news" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Ground News</div>
-                    <div class="resource-card-desc">Compare how different outlets cover the same story</div>
-                    <div class="resource-card-url">ground.news</div>
+                <a href="https://www.allsides.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">AllSides</div>
+                    <div class="tool-card-desc">Balanced news feed showing headlines from left, center, and right perspectives</div>
                 </a>
                 
-                <a href="https://adfontesmedia.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Ad Fontes Media Bias Chart</div>
-                    <div class="resource-card-desc">Independent media reliability and bias ratings</div>
-                    <div class="resource-card-url">adfontesmedia.com</div>
+                <a href="https://feedly.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free tier</span>
+                    <div class="tool-card-name">Feedly</div>
+                    <div class="tool-card-desc">Build your own balanced news feed from multiple sources — organize by topic and bias</div>
                 </a>
                 
-                <a href="https://www.reuters.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Reuters</div>
-                    <div class="resource-card-desc">Wire service known for factual, neutral reporting</div>
-                    <div class="resource-card-url">www.reuters.com</div>
+                <a href="https://www.perplexity.ai" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free tier</span>
+                    <div class="tool-card-name">Perplexity</div>
+                    <div class="tool-card-desc">AI-powered research tool — ask questions and get sourced answers from across the web</div>
                 </a>
                 
-                <a href="https://apnews.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">AP News</div>
-                    <div class="resource-card-desc">Non-profit global news wire with minimal editorial bias</div>
-                    <div class="resource-card-url">apnews.com</div>
-                </a>
-                
-                <a href="https://www.factcheck.org" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">FactCheck.org</div>
-                    <div class="resource-card-desc">Non-partisan fact-checking from the Annenberg Public Policy Center</div>
-                    <div class="resource-card-url">www.factcheck.org</div>
+                <a href="https://news.google.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Google News</div>
+                    <div class="tool-card-desc">Aggregated headlines from thousands of sources — see full coverage of any story</div>
                 </a>
                 
             </div>
+        </div>
+    </section>
+    
+
+    <!-- Key Concepts / FAQ -->
+    
+    <section id="faq" class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:800px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Key Concepts</h2>
+            </div>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is media bias?</summary>
+                <div class="faq-answer">Media bias is the tendency of a news outlet to present information in a way that favors a particular political viewpoint, ideology, or narrative. It can appear in story selection (what gets covered), framing (how it's described), word choice, and source selection. Every outlet has some degree of bias — the key is recognizing it and reading multiple perspectives.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What's the difference between news and opinion?</summary>
+                <div class="faq-answer">News reporting aims to present facts — who, what, when, where, why — with minimal editorial interpretation. Opinion pieces (editorials, columns, op-eds) express the author's views and arguments about those facts. Many outlets mix both, which is why media literacy matters. Look for labels like 'Opinion,' 'Analysis,' or 'Editorial' to distinguish them.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is a wire service?</summary>
+                <div class="faq-answer">A wire service (like AP, Reuters, or AFP) is a news organization that gathers and distributes news to other media outlets. They focus on straight factual reporting without editorial slant, because their stories are used by newspapers, TV stations, and websites across the political spectrum. Wire service reports are generally considered among the most reliable news sources.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">How do I identify misinformation?</summary>
+                <div class="faq-answer">Check multiple sources — if only one outlet reports something, be skeptical. Look at the source's track record on fact-checking databases. Check if the story cites primary sources (documents, studies, official statements). Be wary of emotional headlines, anonymous sources without corroboration, and stories that perfectly confirm your existing beliefs. When in doubt, check FactCheck.org or Snopes.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">Why does Omni View cover sources from 'both sides'?</summary>
+                <div class="faq-answer">Because no single perspective has a monopoly on truth. Stories look different depending on which facts are emphasized, which sources are quoted, and what context is provided. By presenting perspectives from across the political spectrum, Omni View helps you see the full picture and form your own informed opinions — rather than having your views shaped by a single outlet's editorial choices.</div>
+            </details>
+            
         </div>
     </section>
     
@@ -342,7 +585,7 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
-                <p>Seven daily shows keeping you informed.</p>
+                <p>Nine daily shows keeping you informed.</p>
             </div>
             <div class="cross-network-grid">
                 

--- a/planetterrian.html
+++ b/planetterrian.html
@@ -129,6 +129,8 @@
 <a href="planetterrian-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
+<a href="#faq" onclick="document.getElementById('mobileMenu').classList.remove('open')">FAQ</a>
 
         <a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">GitHub</a>
         <div class="nn-mobile-shows">
@@ -255,52 +257,268 @@
         </div>
     </section>
 
-    <!-- Resources -->
+    <!-- Resources (categorized) -->
+    
+    <section id="resources" class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources &amp; Further Reading</h2>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Journals & Research</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.nature.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Nature</div>
+                        <div class="resource-card-desc">The world's premier multidisciplinary science journal — breakthrough research across all fields</div>
+                        <div class="resource-card-url">www.nature.com</div>
+                    </a>
+                    
+                    <a href="https://www.science.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Science (AAAS)</div>
+                        <div class="resource-card-desc">Peer-reviewed research and news from the American Association for the Advancement of Science</div>
+                        <div class="resource-card-url">www.science.org</div>
+                    </a>
+                    
+                    <a href="https://www.cell.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Cell</div>
+                        <div class="resource-card-desc">Leading journal for molecular biology, genetics, and cell biology research</div>
+                        <div class="resource-card-url">www.cell.com</div>
+                    </a>
+                    
+                    <a href="https://pubmed.ncbi.nlm.nih.gov" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">PubMed</div>
+                        <div class="resource-card-desc">Free database of 36M+ biomedical research papers — search any health or science topic</div>
+                        <div class="resource-card-url">pubmed.ncbi.nlm.nih.gov</div>
+                    </a>
+                    
+                    <a href="https://www.quantamagazine.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Quanta Magazine</div>
+                        <div class="resource-card-desc">Accessible, beautifully written coverage of math, physics, and biology research</div>
+                        <div class="resource-card-url">www.quantamagazine.org</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Longevity Science</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.lifespan.io" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Lifespan.io</div>
+                        <div class="resource-card-desc">Longevity research news, rejuvenation science tracker, and clinical trial database</div>
+                        <div class="resource-card-url">www.lifespan.io</div>
+                    </a>
+                    
+                    <a href="https://longevity.technology" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Longevity Technology</div>
+                        <div class="resource-card-desc">Industry news on longevity biotech, startups, and anti-aging interventions</div>
+                        <div class="resource-card-url">longevity.technology</div>
+                    </a>
+                    
+                    <a href="https://sinclair.hms.harvard.edu" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">David Sinclair Lab</div>
+                        <div class="resource-card-desc">Harvard geneticist's lab — NAD+, sirtuins, and aging reversal research</div>
+                        <div class="resource-card-url">sinclair.hms.harvard.edu</div>
+                    </a>
+                    
+                    <a href="https://www.sens.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SENS Research Foundation</div>
+                        <div class="resource-card-desc">Aubrey de Grey's foundation funding damage-repair approaches to aging</div>
+                        <div class="resource-card-url">www.sens.org</div>
+                    </a>
+                    
+                    <a href="https://clinicaltrials.gov" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">ClinicalTrials.gov</div>
+                        <div class="resource-card-desc">Database of 450,000+ clinical studies — search for longevity, anti-aging, and health trials</div>
+                        <div class="resource-card-url">clinicaltrials.gov</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Health & Nutrition</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://examine.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Examine.com</div>
+                        <div class="resource-card-desc">Evidence-based supplement and nutrition research — no ads, no hype, just science</div>
+                        <div class="resource-card-url">examine.com</div>
+                    </a>
+                    
+                    <a href="https://www.healthline.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Healthline</div>
+                        <div class="resource-card-desc">Medical information reviewed by doctors — conditions, treatments, and wellness</div>
+                        <div class="resource-card-url">www.healthline.com</div>
+                    </a>
+                    
+                    <a href="https://nutritionfacts.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Nutritionfacts.org</div>
+                        <div class="resource-card-desc">Dr. Michael Greger's free database of nutrition research — video summaries of studies</div>
+                        <div class="resource-card-url">nutritionfacts.org</div>
+                    </a>
+                    
+                    <a href="https://www.health.harvard.edu" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Harvard Health</div>
+                        <div class="resource-card-desc">Health information from Harvard Medical School — trusted, peer-reviewed content</div>
+                        <div class="resource-card-url">www.health.harvard.edu</div>
+                    </a>
+                    
+                    <a href="https://www.mayoclinic.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Mayo Clinic</div>
+                        <div class="resource-card-desc">Patient-friendly health information from one of the world's top medical centers</div>
+                        <div class="resource-card-url">www.mayoclinic.org</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Biotech & CRISPR</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.statnews.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">STAT News</div>
+                        <div class="resource-card-desc">Health and medicine journalism — biotech, pharma, and life science industry coverage</div>
+                        <div class="resource-card-url">www.statnews.com</div>
+                    </a>
+                    
+                    <a href="https://www.genengnews.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Genetic Engineering News</div>
+                        <div class="resource-card-desc">Biotech industry news — CRISPR, gene therapy, cell therapy, and drug development</div>
+                        <div class="resource-card-url">www.genengnews.com</div>
+                    </a>
+                    
+                    <a href="https://www.liebertpub.com/loi/crispr" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">The CRISPR Journal</div>
+                        <div class="resource-card-desc">Peer-reviewed journal dedicated to CRISPR gene editing research and applications</div>
+                        <div class="resource-card-url">www.liebertpub.com/loi/crispr</div>
+                    </a>
+                    
+                    <a href="https://www.broadinstitute.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Broad Institute</div>
+                        <div class="resource-card-desc">MIT-Harvard genomics research institute — home of key CRISPR innovations</div>
+                        <div class="resource-card-url">www.broadinstitute.org</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Mental Health & Neuroscience</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.hubermanlab.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Huberman Lab</div>
+                        <div class="resource-card-desc">Stanford neuroscientist Andrew Huberman's podcast and protocols for brain and body optimization</div>
+                        <div class="resource-card-url">www.hubermanlab.com</div>
+                    </a>
+                    
+                    <a href="https://www.brainfacts.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">BrainFacts.org</div>
+                        <div class="resource-card-desc">Neuroscience education from the Society for Neuroscience — brain basics to cutting-edge research</div>
+                        <div class="resource-card-url">www.brainfacts.org</div>
+                    </a>
+                    
+                    <a href="https://www.nimh.nih.gov" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">NIMH</div>
+                        <div class="resource-card-desc">National Institute of Mental Health — research, statistics, and clinical trial information</div>
+                        <div class="resource-card-url">www.nimh.nih.gov</div>
+                    </a>
+                    
+                    <a href="https://neurosciencenews.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Neuroscience News</div>
+                        <div class="resource-card-desc">Daily neuroscience research summaries — psychology, AI, and brain science</div>
+                        <div class="resource-card-url">neurosciencenews.com</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+        </div>
+    </section>
+    
+
+    <!-- Recommended Tools -->
     
     <section class="nn-section" style="padding-top:0;">
         <div class="container">
             <div class="nn-section-header" style="text-align:left;">
-                <h2>Resources & Further Reading</h2>
+                <h2>Recommended Tools</h2>
             </div>
-            <div class="resources-grid">
+            <div class="tools-grid">
                 
-                <a href="https://pubmed.ncbi.nlm.nih.gov" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">PubMed</div>
-                    <div class="resource-card-desc">Free access to biomedical and life science research papers</div>
-                    <div class="resource-card-url">pubmed.ncbi.nlm.nih.gov</div>
+                <a href="https://pubmed.ncbi.nlm.nih.gov" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">PubMed</div>
+                    <div class="tool-card-desc">Search 36M+ biomedical papers — the essential tool for finding health and science research</div>
                 </a>
                 
-                <a href="https://clinicaltrials.gov" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">ClinicalTrials.gov</div>
-                    <div class="resource-card-desc">Database of clinical studies and trials worldwide</div>
-                    <div class="resource-card-url">clinicaltrials.gov</div>
+                <a href="https://examine.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free tier</span>
+                    <div class="tool-card-name">Examine.com</div>
+                    <div class="tool-card-desc">Look up any supplement or nutrient — see what the research actually says, not marketing claims</div>
                 </a>
                 
-                <a href="https://www.nature.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Nature</div>
-                    <div class="resource-card-desc">Premier multidisciplinary science journal</div>
-                    <div class="resource-card-url">www.nature.com</div>
+                <a href="https://cronometer.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free tier</span>
+                    <div class="tool-card-name">Cronometer</div>
+                    <div class="tool-card-desc">Track nutrition, micronutrients, and macros with the most detailed food database available</div>
                 </a>
                 
-                <a href="https://www.quantamagazine.org" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Quanta Magazine</div>
-                    <div class="resource-card-desc">Accessible coverage of math, physics, and biology research</div>
-                    <div class="resource-card-url">www.quantamagazine.org</div>
+                <a href="https://ouraring.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Hardware</span>
+                    <div class="tool-card-name">Oura Ring</div>
+                    <div class="tool-card-desc">Sleep, recovery, and readiness tracking — used by longevity researchers for personal data</div>
                 </a>
                 
-                <a href="https://www.lifespan.io" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Lifespan.io</div>
-                    <div class="resource-card-desc">Longevity research news and rejuvenation science tracker</div>
-                    <div class="resource-card-url">www.lifespan.io</div>
-                </a>
-                
-                <a href="https://examine.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Examine.com</div>
-                    <div class="resource-card-desc">Evidence-based supplement and nutrition research</div>
-                    <div class="resource-card-url">examine.com</div>
+                <a href="https://www.insidetracker.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Paid</span>
+                    <div class="tool-card-name">InsideTracker</div>
+                    <div class="tool-card-desc">Blood biomarker analysis with personalized health recommendations based on your biology</div>
                 </a>
                 
             </div>
+        </div>
+    </section>
+    
+
+    <!-- Key Concepts / FAQ -->
+    
+    <section id="faq" class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:800px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Key Concepts</h2>
+            </div>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is healthspan vs lifespan?</summary>
+                <div class="faq-answer">Lifespan is how long you live. Healthspan is how long you live in good health — free from chronic disease and disability. Longevity researchers increasingly focus on healthspan because living to 100 matters less if the last 20 years are spent in poor health. The goal is to compress morbidity — keeping you healthy and active until very late in life.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is CRISPR?</summary>
+                <div class="faq-answer">CRISPR (Clustered Regularly Interspaced Short Palindromic Repeats) is a revolutionary gene-editing tool that allows scientists to precisely cut, delete, or modify DNA sequences. Think of it as molecular scissors with a GPS — you can target a specific gene and change it. It's being used to develop treatments for sickle cell disease, certain cancers, and inherited genetic conditions. The 2020 Nobel Prize in Chemistry was awarded for this technology.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What are senolytics?</summary>
+                <div class="faq-answer">Senolytics are drugs that selectively destroy senescent cells — 'zombie cells' that have stopped dividing but refuse to die. These cells accumulate with age and secrete inflammatory signals that damage surrounding tissue, contributing to aging and age-related diseases. Senolytic drugs like dasatinib + quercetin and fisetin are being studied in clinical trials. Early results suggest they may improve physical function and reduce inflammation in older adults.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is NAD+ and why does it matter?</summary>
+                <div class="faq-answer">NAD+ (Nicotinamide Adenine Dinucleotide) is a coenzyme found in every cell that's essential for energy metabolism, DNA repair, and cellular signaling. NAD+ levels decline with age — by age 50, you may have half the NAD+ you had at 20. Researchers like David Sinclair believe boosting NAD+ (via precursors like NMN or NR) could slow aging. Clinical trials are underway, but results are still preliminary.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is a clinical trial?</summary>
+                <div class="faq-answer">A clinical trial is a research study that tests a medical treatment, drug, or intervention in human volunteers. Trials progress through phases: Phase 1 tests safety (small group), Phase 2 tests effectiveness (larger group), Phase 3 compares to existing treatments (thousands of participants), and Phase 4 monitors long-term effects after approval. You can search for trials at ClinicalTrials.gov — some actively recruit participants.</div>
+            </details>
+            
         </div>
     </section>
     
@@ -342,7 +560,7 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
-                <p>Seven daily shows keeping you informed.</p>
+                <p>Nine daily shows keeping you informed.</p>
             </div>
             <div class="cross-network-grid">
                 

--- a/ru/finansy-prosto.html
+++ b/ru/finansy-prosto.html
@@ -129,6 +129,8 @@
 <a href="ru/finansy-prosto-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
+<a href="#faq" onclick="document.getElementById('mobileMenu').classList.remove('open')">FAQ</a>
 
         <a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">GitHub</a>
         <div class="nn-mobile-shows">
@@ -253,40 +255,256 @@
         </div>
     </section>
 
-    <!-- Resources -->
+    <!-- Resources (categorized) -->
+    
+    <section id="resources" class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources &amp; Further Reading</h2>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Канадские финансы</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.moneysense.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">MoneySense</div>
+                        <div class="resource-card-desc">Канадский портал о финансах — инвестиции, пенсия, ипотека и налоги</div>
+                        <div class="resource-card-url">www.moneysense.ca</div>
+                    </a>
+                    
+                    <a href="https://financialpost.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Financial Post</div>
+                        <div class="resource-card-desc">Финансовые новости Канады — рынки, экономика и личные финансы</div>
+                        <div class="resource-card-url">financialpost.com</div>
+                    </a>
+                    
+                    <a href="https://www.theglobeandmail.com/investing/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Globe and Mail Investing</div>
+                        <div class="resource-card-desc">Инвестиционные новости и аналитика от ведущей канадской газеты</div>
+                        <div class="resource-card-url">www.theglobeandmail.com/investing/</div>
+                    </a>
+                    
+                    <a href="https://canadiancouchpotato.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Canadian Couch Potato</div>
+                        <div class="resource-card-desc">Пассивное инвестирование для канадцев — модельные портфели из ETF</div>
+                        <div class="resource-card-url">canadiancouchpotato.com</div>
+                    </a>
+                    
+                    <a href="https://youngandthrifty.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Young and Thrifty</div>
+                        <div class="resource-card-desc">Финансовые советы для молодых канадцев — бюджет, сбережения, инвестиции</div>
+                        <div class="resource-card-url">youngandthrifty.ca</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Инвестиционные платформы</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.wealthsimple.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Wealthsimple</div>
+                        <div class="resource-card-desc">Инвестиционная платформа для канадцев — TFSA, RRSP, торговля без комиссии</div>
+                        <div class="resource-card-url">www.wealthsimple.com</div>
+                    </a>
+                    
+                    <a href="https://www.questrade.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Questrade</div>
+                        <div class="resource-card-desc">Канадский онлайн-брокер — ETF без комиссии, TFSA, RRSP, RESP</div>
+                        <div class="resource-card-url">www.questrade.com</div>
+                    </a>
+                    
+                    <a href="https://www.interactivebrokers.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Interactive Brokers</div>
+                        <div class="resource-card-desc">Профессиональная торговая платформа — низкие комиссии, доступ к мировым рынкам</div>
+                        <div class="resource-card-url">www.interactivebrokers.ca</div>
+                    </a>
+                    
+                    <a href="https://www.eqbank.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">EQ Bank</div>
+                        <div class="resource-card-desc">Высокие ставки по сберегательным счетам и GIC — без ежемесячных комиссий</div>
+                        <div class="resource-card-url">www.eqbank.ca</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Калькуляторы и инструменты</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.ratehub.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">RateHub</div>
+                        <div class="resource-card-desc">Сравнение ипотечных ставок, кредитных карт и сберегательных счетов в Канаде</div>
+                        <div class="resource-card-url">www.ratehub.ca</div>
+                    </a>
+                    
+                    <a href="https://www.borrowell.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Borrowell</div>
+                        <div class="resource-card-desc">Бесплатная проверка кредитного рейтинга и персональные финансовые рекомендации</div>
+                        <div class="resource-card-url">www.borrowell.com</div>
+                    </a>
+                    
+                    <a href="https://www.wealthsimple.com/en-ca/tax" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Wealthsimple Tax</div>
+                        <div class="resource-card-desc">Бесплатная подача налоговой декларации онлайн — простой и понятный интерфейс</div>
+                        <div class="resource-card-url">www.wealthsimple.com/en-ca/tax</div>
+                    </a>
+                    
+                    <a href="https://www.canada.ca/en/revenue-agency/services/e-services/digital-services-individuals/account-individuals.html" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">CRA My Account</div>
+                        <div class="resource-card-desc">Личный кабинет в налоговой — проверка возвратов, лимитов TFSA/RRSP</div>
+                        <div class="resource-card-url">www.canada.ca/en/revenue-agency/services/e-services/digital-services-individuals/account-individuals.html</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Государственные ресурсы</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.canada.ca/en/services/benefits.html" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Canada.ca Benefits</div>
+                        <div class="resource-card-desc">Государственные пособия — CCB, EI, CPP, OAS, кредиты на детей и налоговые льготы</div>
+                        <div class="resource-card-url">www.canada.ca/en/services/benefits.html</div>
+                    </a>
+                    
+                    <a href="https://www.canada.ca/en/financial-consumer-agency.html" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Financial Consumer Agency</div>
+                        <div class="resource-card-desc">Защита прав потребителей финансовых услуг — жалобы, права и образование</div>
+                        <div class="resource-card-url">www.canada.ca/en/financial-consumer-agency.html</div>
+                    </a>
+                    
+                    <a href="https://www.bchousing.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">BC Housing</div>
+                        <div class="resource-card-desc">Программы доступного жилья в BC — субсидии, аренда, первый дом</div>
+                        <div class="resource-card-url">www.bchousing.org</div>
+                    </a>
+                    
+                    <a href="https://settlement.org/ontario/employment/financial-information/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Settlement.org</div>
+                        <div class="resource-card-desc">Финансовая информация для иммигрантов — банки, налоги и кредит в Канаде</div>
+                        <div class="resource-card-url">settlement.org/ontario/employment/financial-information/</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Финансовое образование</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://journal.tinkoff.ru" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Tinkoff Journal</div>
+                        <div class="resource-card-desc">Российский портал о финансовой грамотности — инвестиции, налоги, экономика (на русском)</div>
+                        <div class="resource-card-url">journal.tinkoff.ru</div>
+                    </a>
+                    
+                    <a href="https://fintolk.pro" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">FinTolk</div>
+                        <div class="resource-card-desc">Финансы простым языком на русском — статьи, калькуляторы и советы</div>
+                        <div class="resource-card-url">fintolk.pro</div>
+                    </a>
+                    
+                    <a href="https://www.investopedia.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Investopedia</div>
+                        <div class="resource-card-desc">Энциклопедия инвестиций и финансов — термины, стратегии и обучение (на английском)</div>
+                        <div class="resource-card-url">www.investopedia.com</div>
+                    </a>
+                    
+                    <a href="https://www.khanacademy.org/economics-finance-domain" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Khan Academy Finance</div>
+                        <div class="resource-card-desc">Бесплатные уроки по экономике и финансам — от базовых до продвинутых тем</div>
+                        <div class="resource-card-url">www.khanacademy.org/economics-finance-domain</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+        </div>
+    </section>
+    
+
+    <!-- Recommended Tools -->
     
     <section class="nn-section" style="padding-top:0;">
         <div class="container">
             <div class="nn-section-header" style="text-align:left;">
-                <h2>Resources & Further Reading</h2>
+                <h2>Recommended Tools</h2>
             </div>
-            <div class="resources-grid">
+            <div class="tools-grid">
                 
-                <a href="https://www.moneysense.ca" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">MoneySense</div>
-                    <div class="resource-card-desc">Canadian personal finance — investing, saving, and retirement</div>
-                    <div class="resource-card-url">www.moneysense.ca</div>
+                <a href="https://www.wealthsimple.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Бесплатно</span>
+                    <div class="tool-card-name">Wealthsimple</div>
+                    <div class="tool-card-desc">Инвестируйте без комиссии — TFSA, RRSP, торговля акциями и ETF для начинающих</div>
                 </a>
                 
-                <a href="https://www.wealthsimple.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Wealthsimple</div>
-                    <div class="resource-card-desc">Easy investing platform for Canadians — TFSA, RRSP, and more</div>
-                    <div class="resource-card-url">www.wealthsimple.com</div>
+                <a href="https://www.questrade.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Бесплатно</span>
+                    <div class="tool-card-name">Questrade</div>
+                    <div class="tool-card-desc">Канадский брокер — покупайте ETF без комиссии, управляйте RRSP и RESP</div>
                 </a>
                 
-                <a href="https://www.ratehub.ca" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">RateHub</div>
-                    <div class="resource-card-desc">Compare Canadian mortgage rates, credit cards, and savings accounts</div>
-                    <div class="resource-card-url">www.ratehub.ca</div>
+                <a href="https://www.ynab.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Пробный период</span>
+                    <div class="tool-card-name">YNAB</div>
+                    <div class="tool-card-desc">You Need A Budget — лучшее приложение для бюджетирования, помогает контролировать расходы</div>
                 </a>
                 
-                <a href="https://www.canada.ca/en/services/benefits.html" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Canada.ca Benefits</div>
-                    <div class="resource-card-desc">Government benefits — CCB, EI, CPP, OAS, and tax credits</div>
-                    <div class="resource-card-url">www.canada.ca/en/services/benefits.html</div>
+                <a href="https://www.borrowell.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Бесплатно</span>
+                    <div class="tool-card-name">Borrowell</div>
+                    <div class="tool-card-desc">Бесплатная проверка кредитного рейтинга — следите за вашим Equifax score</div>
+                </a>
+                
+                <a href="https://www.wealthsimple.com/en-ca/tax" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Бесплатно</span>
+                    <div class="tool-card-name">Wealthsimple Tax</div>
+                    <div class="tool-card-desc">Подайте налоговую декларацию бесплатно — простой интерфейс на английском</div>
                 </a>
                 
             </div>
+        </div>
+    </section>
+    
+
+    <!-- Key Concepts / FAQ -->
+    
+    <section id="faq" class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:800px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Key Concepts</h2>
+            </div>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">Что такое TFSA?</summary>
+                <div class="faq-answer">Tax-Free Savings Account (TFSA) — это канадский сберегательный счёт, на котором вся прибыль от инвестиций не облагается налогом. Каждый год правительство увеличивает лимит взносов (в 2026 году — $7,000). Вы можете инвестировать в акции, ETF, облигации и GIC внутри TFSA, и все доходы — дивиденды, проценты, прирост капитала — остаются полностью вашими. Это один из лучших инструментов для долгосрочных сбережений в Канаде.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">Что такое RRSP?</summary>
+                <div class="faq-answer">Registered Retirement Savings Plan (RRSP) — это пенсионный сберегательный план. Главное отличие от TFSA: взносы в RRSP уменьшают ваш налогооблагаемый доход в текущем году (вы получаете налоговый возврат), но при снятии денег на пенсии вы платите налог. RRSP выгоден, если сейчас ваш доход (и налоговая ставка) выше, чем будет на пенсии. Лимит взносов — 18% от заработка прошлого года.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">Как начать инвестировать в Канаде?</summary>
+                <div class="faq-answer">Шаг 1: Откройте TFSA (максимально используйте налоговые льготы). Шаг 2: Выберите платформу — Wealthsimple (самая простая для начинающих) или Questrade (больше опций). Шаг 3: Начните с ETF широкого рынка, например XEQT или VGRO — они автоматически диверсифицированы по всему миру. Шаг 4: Инвестируйте регулярно (даже $50-100 в месяц), не пытайтесь угадать рынок. Время на рынке важнее, чем тайминг рынка.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">Что такое GIC?</summary>
+                <div class="faq-answer">Guaranteed Investment Certificate (GIC) — это гарантированный инвестиционный сертификат. Вы вкладываете деньги в банк на фиксированный срок (от 30 дней до 5 лет), и банк гарантирует возврат + проценты. GIC застрахованы CDIC до $100,000. Ставки зависят от срока и банка — сравнивайте на RateHub.ca. GIC подходят для краткосрочных сбережений (на первый взнос, фонд безопасности), но для долгосрочных целей ETF обычно приносят больше.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">Что такое кредитный рейтинг?</summary>
+                <div class="faq-answer">Кредитный рейтинг (credit score) — это число от 300 до 900, показывающее вашу кредитоспособность. В Канаде два бюро — Equifax и TransUnion. Рейтинг выше 700 считается хорошим, выше 750 — отличным. Он влияет на одобрение ипотеки, кредитных карт и процентные ставки. Чтобы улучшить рейтинг: платите вовремя, используйте менее 30% кредитного лимита, не закрывайте старые карты. Проверяйте бесплатно через Borrowell.</div>
+            </details>
+            
         </div>
     </section>
     
@@ -316,7 +534,7 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
-                <p>Seven daily shows keeping you informed.</p>
+                <p>Nine daily shows keeping you informed.</p>
             </div>
             <div class="cross-network-grid">
                 

--- a/ru/privet-russian.html
+++ b/ru/privet-russian.html
@@ -129,6 +129,8 @@
 <a href="ru/privet-russian-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
+<a href="#faq" onclick="document.getElementById('mobileMenu').classList.remove('open')">FAQ</a>
 
         <a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">GitHub</a>
         <div class="nn-mobile-shows">
@@ -253,40 +255,250 @@
         </div>
     </section>
 
-    <!-- Resources -->
+    <!-- Resources (categorized) -->
+    
+    <section id="resources" class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources &amp; Further Reading</h2>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Language Learning Apps</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.duolingo.com/course/ru/en/Learn-Russian" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Duolingo Russian</div>
+                        <div class="resource-card-desc">Free gamified Russian course — 5 minutes a day builds vocabulary and grammar habits</div>
+                        <div class="resource-card-url">www.duolingo.com/course/ru/en/Learn-Russian</div>
+                    </a>
+                    
+                    <a href="https://www.babbel.com/learn-russian" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Babbel Russian</div>
+                        <div class="resource-card-desc">Structured Russian lessons with speech recognition — more grammar-focused than Duolingo</div>
+                        <div class="resource-card-url">www.babbel.com/learn-russian</div>
+                    </a>
+                    
+                    <a href="https://www.busuu.com/en/course/learn-russian-online" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Busuu Russian</div>
+                        <div class="resource-card-desc">Russian course with native speaker feedback on your writing and speaking exercises</div>
+                        <div class="resource-card-url">www.busuu.com/en/course/learn-russian-online</div>
+                    </a>
+                    
+                    <a href="https://www.pimsleur.com/learn-russian" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Pimsleur Russian</div>
+                        <div class="resource-card-desc">Audio-first method — learn Russian through listening and speaking, great for car commutes</div>
+                        <div class="resource-card-url">www.pimsleur.com/learn-russian</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Dictionaries & Grammar</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://en.openrussian.org" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">OpenRussian</div>
+                        <div class="resource-card-desc">Free Russian dictionary with declensions, conjugations, stress marks, and usage examples</div>
+                        <div class="resource-card-url">en.openrussian.org</div>
+                    </a>
+                    
+                    <a href="https://en.wiktionary.org/wiki/Category:Russian_language" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Wiktionary Russian</div>
+                        <div class="resource-card-desc">Community dictionary with etymologies, pronunciations, and detailed grammar tables</div>
+                        <div class="resource-card-url">en.wiktionary.org/wiki/Category:Russian_language</div>
+                    </a>
+                    
+                    <a href="https://www.russianlessons.net/grammar/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Russian Grammar Tables</div>
+                        <div class="resource-card-desc">Clear grammar reference — cases, verb conjugations, and adjective agreements</div>
+                        <div class="resource-card-url">www.russianlessons.net/grammar/</div>
+                    </a>
+                    
+                    <a href="https://context.reverso.net/translation/russian-english/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Reverso Context</div>
+                        <div class="resource-card-desc">See Russian words used in real sentences — context-based translation with examples</div>
+                        <div class="resource-card-url">context.reverso.net/translation/russian-english/</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Russian Media</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://russianwithmax.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Russian With Max</div>
+                        <div class="resource-card-desc">Comprehensible input podcast — slow, clear Russian with transcripts for A2-B2 learners</div>
+                        <div class="resource-card-url">russianwithmax.com</div>
+                    </a>
+                    
+                    <a href="https://meduza.io/en" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Meduza (English)</div>
+                        <div class="resource-card-desc">Independent Russian news in English — understand current events and cultural context</div>
+                        <div class="resource-card-url">meduza.io/en</div>
+                    </a>
+                    
+                    <a href="https://arzamas.academy" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Arzamas Academy</div>
+                        <div class="resource-card-desc">Russian culture and history courses — literature, art, and philosophy (in Russian with subtitles)</div>
+                        <div class="resource-card-url">arzamas.academy</div>
+                    </a>
+                    
+                    <a href="https://www.kinopoisk.ru" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Kinopoisk</div>
+                        <div class="resource-card-desc">Russia's IMDB — find Russian films and TV shows to practice listening comprehension</div>
+                        <div class="resource-card-url">www.kinopoisk.ru</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Practice & Immersion</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://forvo.com/languages/ru/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Forvo Russian</div>
+                        <div class="resource-card-desc">Hear native speakers pronounce any Russian word — essential for mastering pronunciation</div>
+                        <div class="resource-card-url">forvo.com/languages/ru/</div>
+                    </a>
+                    
+                    <a href="https://www.tandem.net" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Tandem</div>
+                        <div class="resource-card-desc">Find Russian-speaking language partners for text and voice chat — free language exchange</div>
+                        <div class="resource-card-url">www.tandem.net</div>
+                    </a>
+                    
+                    <a href="https://www.italki.com/en/teachers/russian" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">italki</div>
+                        <div class="resource-card-desc">Book affordable 1-on-1 lessons with native Russian tutors — from $5/hour</div>
+                        <div class="resource-card-url">www.italki.com/en/teachers/russian</div>
+                    </a>
+                    
+                    <a href="https://www.clozemaster.com/languages/eng-rus" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Clozemaster</div>
+                        <div class="resource-card-desc">Learn Russian through mass sentence exposure — fill in the blanks in context</div>
+                        <div class="resource-card-url">www.clozemaster.com/languages/eng-rus</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Culture & History</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.rbth.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Russia Beyond</div>
+                        <div class="resource-card-desc">Russian culture, history, food, and travel — English-language articles about Russia</div>
+                        <div class="resource-card-url">www.rbth.com</div>
+                    </a>
+                    
+                    <a href="https://www.themoscowtimes.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Moscow Times</div>
+                        <div class="resource-card-desc">Independent English-language news about Russia — politics, culture, and society</div>
+                        <div class="resource-card-url">www.themoscowtimes.com</div>
+                    </a>
+                    
+                    <a href="https://russianlife.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Russian Life Magazine</div>
+                        <div class="resource-card-desc">Russian culture, travel, and history — beautifully written long-form articles</div>
+                        <div class="resource-card-url">russianlife.com</div>
+                    </a>
+                    
+                    <a href="https://www.russianpod101.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">RussianPod101</div>
+                        <div class="resource-card-desc">Comprehensive Russian learning platform — lessons, vocabulary lists, and cultural notes</div>
+                        <div class="resource-card-url">www.russianpod101.com</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+        </div>
+    </section>
+    
+
+    <!-- Recommended Tools -->
     
     <section class="nn-section" style="padding-top:0;">
         <div class="container">
             <div class="nn-section-header" style="text-align:left;">
-                <h2>Resources & Further Reading</h2>
+                <h2>Recommended Tools</h2>
             </div>
-            <div class="resources-grid">
+            <div class="tools-grid">
                 
-                <a href="https://www.duolingo.com/course/ru/en/Learn-Russian" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Duolingo Russian</div>
-                    <div class="resource-card-desc">Free gamified Russian course — great alongside this podcast</div>
-                    <div class="resource-card-url">www.duolingo.com/course/ru/en/Learn-Russian</div>
+                <a href="https://www.duolingo.com/course/ru/en/Learn-Russian" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Duolingo</div>
+                    <div class="tool-card-desc">Start learning Russian with 5-minute daily lessons — gamified, fun, and builds habits</div>
                 </a>
                 
-                <a href="https://russianwithmax.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Russian With Max</div>
-                    <div class="resource-card-desc">Comprehensible input podcast for intermediate learners</div>
-                    <div class="resource-card-url">russianwithmax.com</div>
+                <a href="https://apps.ankiweb.net" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Anki</div>
+                    <div class="tool-card-desc">Spaced repetition flashcards — the most effective way to memorize Russian vocabulary</div>
                 </a>
                 
-                <a href="https://forvo.com/languages/ru/" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Forvo Russian</div>
-                    <div class="resource-card-desc">Hear native speakers pronounce any Russian word</div>
-                    <div class="resource-card-url">forvo.com/languages/ru/</div>
+                <a href="https://forvo.com/languages/ru/" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Forvo</div>
+                    <div class="tool-card-desc">Hear any Russian word pronounced by native speakers — type it in, hear it spoken</div>
                 </a>
                 
-                <a href="https://en.openrussian.org" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">OpenRussian</div>
-                    <div class="resource-card-desc">Free Russian dictionary with declensions, conjugations, and examples</div>
-                    <div class="resource-card-url">en.openrussian.org</div>
+                <a href="https://www.tandem.net" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Tandem</div>
+                    <div class="tool-card-desc">Free language exchange app — find native Russian speakers who want to learn English</div>
+                </a>
+                
+                <a href="https://translate.google.com/?sl=en&tl=ru" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Google Translate</div>
+                    <div class="tool-card-desc">Instant English-to-Russian translation — use camera mode to translate signs and menus</div>
                 </a>
                 
             </div>
+        </div>
+    </section>
+    
+
+    <!-- Key Concepts / FAQ -->
+    
+    <section id="faq" class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:800px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Key Concepts</h2>
+            </div>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">How hard is Russian to learn?</summary>
+                <div class="faq-answer">The US Foreign Service Institute rates Russian as a Category III language — harder than Spanish or French, but easier than Chinese, Japanese, or Arabic. For English speakers, the main challenges are the Cyrillic alphabet (learnable in a week), six grammatical cases (takes months to internalize), and verb aspect (perfective vs imperfective). The good news: Russian pronunciation is very regular — if you can read a word, you can pronounce it. With daily practice, expect basic conversational ability in 6-12 months.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is the Cyrillic alphabet?</summary>
+                <div class="faq-answer">Cyrillic is the alphabet used to write Russian (and Ukrainian, Bulgarian, Serbian, and others). It has 33 letters — some look and sound like English letters (A, K, M, O, T), some look familiar but sound different (B sounds like V, H sounds like N, P sounds like R, C sounds like S), and some are unique (Ж, Щ, Ы, Э). You can learn all 33 letters in about a week of focused practice. Once you know Cyrillic, you can sound out any Russian word.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">How many cases does Russian have?</summary>
+                <div class="faq-answer">Russian has six grammatical cases: Nominative (subject), Genitive (possession/of), Dative (to/for), Accusative (direct object), Instrumental (by/with), and Prepositional (about/in). Cases change the endings of nouns, adjectives, and pronouns depending on their role in the sentence. English handles this with word order and prepositions; Russian uses endings. It sounds intimidating, but you learn them gradually — start with Nominative and Accusative, then add others as you progress.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What's the difference between ты and вы?</summary>
+                <div class="faq-answer">Both mean 'you,' but ты (tee) is informal/singular and вы (vee) is formal/plural. Use ты with friends, family, children, and pets. Use вы with strangers, older people, professionals, and in formal situations. Вы (capitalized Вы) is also used as a polite singular 'you' — like saying 'sir' or 'ma'am' in English. Using the wrong form isn't a disaster, but switching from вы to ты with someone signals that you've become friends — it's a meaningful social moment in Russian culture.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">How long does it take to learn Russian?</summary>
+                <div class="faq-answer">It depends on your goals and daily practice. With 30 minutes/day: basic greetings and survival phrases in 1-2 months, simple conversations in 4-6 months, comfortable intermediate level in 12-18 months. The FSI estimates 1,100 classroom hours for professional proficiency. Key accelerators: daily consistency (even 15 minutes beats occasional long sessions), native speaker practice (italki or Tandem), and immersion through media (Russian music, YouTube, Netflix shows with subtitles). This podcast is designed to be one of those daily touchpoints!</div>
+            </details>
+            
         </div>
     </section>
     
@@ -316,7 +528,7 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
-                <p>Seven daily shows keeping you informed.</p>
+                <p>Nine daily shows keeping you informed.</p>
             </div>
             <div class="cross-network-grid">
                 

--- a/styles/main.css
+++ b/styles/main.css
@@ -1092,8 +1092,97 @@ button:focus-visible {
   margin-bottom: var(--sp-2);
 }
 
+/* ---------- Resource category headers ---------- */
+.resource-category { margin-bottom: var(--sp-8); }
+.resource-category-title {
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--show-color);
+  margin-bottom: var(--sp-4);
+  padding-bottom: var(--sp-2);
+  border-bottom: 1px solid var(--nn-border);
+}
+
+/* ---------- Tools grid & cards ---------- */
+.tools-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: var(--sp-4);
+}
+.tool-card {
+  padding: var(--sp-5);
+  position: relative;
+  text-decoration: none;
+  color: var(--nn-text);
+  transition: border-color 200ms var(--ease);
+}
+.tool-card:hover { border-color: var(--show-color); }
+.tool-badge {
+  position: absolute;
+  top: var(--sp-3);
+  right: var(--sp-3);
+  background: var(--show-color);
+  color: white;
+  font-family: var(--font-ui);
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.tool-card-name {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--nn-white);
+  margin-bottom: var(--sp-2);
+}
+.tool-card-desc {
+  font-family: var(--font-ui);
+  font-size: 0.88rem;
+  color: var(--nn-text-muted);
+  line-height: 1.5;
+}
+
+/* ---------- FAQ accordion ---------- */
+.faq-item {
+  padding: 0;
+  margin-bottom: var(--sp-3);
+  cursor: pointer;
+}
+.faq-question {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--nn-white);
+  padding: var(--sp-5);
+  list-style: none;
+  user-select: none;
+}
+.faq-question::marker { display: none; }
+.faq-question::-webkit-details-marker { display: none; }
+.faq-question::after {
+  content: '+';
+  float: right;
+  font-size: 1.2rem;
+  color: var(--show-color);
+  font-weight: 400;
+  transition: transform 200ms var(--ease);
+}
+details[open] .faq-question::after { content: '\2212'; }
+.faq-answer {
+  padding: 0 var(--sp-5) var(--sp-5);
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  color: var(--nn-text-muted);
+  line-height: 1.7;
+}
+
 /* ---------- Responsive: new sections ---------- */
 @media (max-width: 639px) {
   .resources-grid { grid-template-columns: 1fr; }
+  .tools-grid { grid-template-columns: 1fr; }
   .subscribe-rss-grid { grid-template-columns: 1fr; }
 }

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -37,6 +37,8 @@
 <a href="{{ summaries_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
+<a href="#faq" onclick="document.getElementById('mobileMenu').classList.remove('open')">FAQ</a>
 {% endblock %}
 
 {% block content %}
@@ -120,12 +122,35 @@
         </div>
     </section>
 
-    <!-- Resources -->
-    {% if resources %}
-    <section class="nn-section" style="padding-top:0;">
+    <!-- Resources (categorized) -->
+    {% if resource_categories %}
+    <section id="resources" class="nn-section" style="padding-top:0;">
         <div class="container">
             <div class="nn-section-header" style="text-align:left;">
-                <h2>Resources & Further Reading</h2>
+                <h2>Resources &amp; Further Reading</h2>
+            </div>
+            {% for cat in resource_categories %}
+            <div class="resource-category">
+                <h3 class="resource-category-title">{{ cat.title }}</h3>
+                <div class="resources-grid">
+                    {% for r in cat.resources %}
+                    <a href="{{ r.url }}" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">{{ r.name }}</div>
+                        <div class="resource-card-desc">{{ r.desc }}</div>
+                        <div class="resource-card-url">{{ r.url | replace('https://', '') | replace('http://', '') }}</div>
+                    </a>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </section>
+    {% elif resources %}
+    <!-- Fallback: flat resources grid (legacy) -->
+    <section id="resources" class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources &amp; Further Reading</h2>
             </div>
             <div class="resources-grid">
                 {% for r in resources %}
@@ -136,6 +161,43 @@
                 </a>
                 {% endfor %}
             </div>
+        </div>
+    </section>
+    {% endif %}
+
+    <!-- Recommended Tools -->
+    {% if tools %}
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Recommended Tools</h2>
+            </div>
+            <div class="tools-grid">
+                {% for t in tools %}
+                <a href="{{ t.url }}" class="tool-card glass-card" target="_blank" rel="noopener">
+                    {% if t.badge %}<span class="tool-badge">{{ t.badge }}</span>{% endif %}
+                    <div class="tool-card-name">{{ t.name }}</div>
+                    <div class="tool-card-desc">{{ t.desc }}</div>
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+    </section>
+    {% endif %}
+
+    <!-- Key Concepts / FAQ -->
+    {% if faq %}
+    <section id="faq" class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:800px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Key Concepts</h2>
+            </div>
+            {% for item in faq %}
+            <details class="faq-item glass-card">
+                <summary class="faq-question">{{ item.q }}</summary>
+                <div class="faq-answer">{{ item.a }}</div>
+            </details>
+            {% endfor %}
         </div>
     </section>
     {% endif %}
@@ -177,7 +239,7 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
-                <p>Seven daily shows keeping you informed.</p>
+                <p>Nine daily shows keeping you informed.</p>
             </div>
             <div class="cross-network-grid">
                 {% for s in all_shows %}

--- a/tesla.html
+++ b/tesla.html
@@ -139,6 +139,8 @@
 <a href="tesla-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
+<a href="#faq" onclick="document.getElementById('mobileMenu').classList.remove('open')">FAQ</a>
 
         <a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">GitHub</a>
         <div class="nn-mobile-shows">
@@ -273,52 +275,274 @@
         </div>
     </section>
 
-    <!-- Resources -->
+    <!-- Resources (categorized) -->
+    
+    <section id="resources" class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources &amp; Further Reading</h2>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Investor Resources</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://ir.tesla.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Tesla Investor Relations</div>
+                        <div class="resource-card-desc">Official SEC filings, earnings calls, and shareholder letters</div>
+                        <div class="resource-card-url">ir.tesla.com</div>
+                    </a>
+                    
+                    <a href="https://finance.yahoo.com/quote/TSLA" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">TSLA on Yahoo Finance</div>
+                        <div class="resource-card-desc">Real-time stock price, charts, and financial data</div>
+                        <div class="resource-card-url">finance.yahoo.com/quote/TSLA</div>
+                    </a>
+                    
+                    <a href="https://www.youtube.com/@TeslaDaily" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Tesla Daily (Rob Maurer)</div>
+                        <div class="resource-card-desc">Daily TSLA analysis from the most-followed Tesla stock commentator</div>
+                        <div class="resource-card-url">www.youtube.com/@TeslaDaily</div>
+                    </a>
+                    
+                    <a href="https://hypercharts.co/tsla" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Hypercharts Tesla</div>
+                        <div class="resource-card-desc">Tesla financial data visualizations — revenue, margins, deliveries</div>
+                        <div class="resource-card-url">hypercharts.co/tsla</div>
+                    </a>
+                    
+                    <a href="https://www.macrotrends.net/stocks/charts/TSLA/tesla/revenue" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Macrotrends TSLA</div>
+                        <div class="resource-card-desc">Historical Tesla financials, ratios, and growth metrics</div>
+                        <div class="resource-card-url">www.macrotrends.net/stocks/charts/TSLA/tesla/revenue</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">News Sources</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.teslarati.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Teslarati</div>
+                        <div class="resource-card-desc">Independent Tesla and SpaceX news — the largest dedicated Tesla news outlet</div>
+                        <div class="resource-card-url">www.teslarati.com</div>
+                    </a>
+                    
+                    <a href="https://www.notateslaapp.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Not A Tesla App</div>
+                        <div class="resource-card-desc">Tesla software updates, feature tracking, and release notes</div>
+                        <div class="resource-card-url">www.notateslaapp.com</div>
+                    </a>
+                    
+                    <a href="https://cleantechnica.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">CleanTechnica</div>
+                        <div class="resource-card-desc">Clean energy and EV industry analysis and commentary</div>
+                        <div class="resource-card-url">cleantechnica.com</div>
+                    </a>
+                    
+                    <a href="https://insideevs.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">InsideEVs</div>
+                        <div class="resource-card-desc">Electric vehicle news, reviews, and sales data across all brands</div>
+                        <div class="resource-card-url">insideevs.com</div>
+                    </a>
+                    
+                    <a href="https://driveteslacanada.ca" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Drive Tesla Canada</div>
+                        <div class="resource-card-desc">Canadian Tesla ownership news, tips, and community coverage</div>
+                        <div class="resource-card-url">driveteslacanada.ca</div>
+                    </a>
+                    
+                    <a href="https://electrek.co" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Electrek</div>
+                        <div class="resource-card-desc">Electric transport and clean energy news — Tesla, EVs, solar, and storage</div>
+                        <div class="resource-card-url">electrek.co</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Community & Forums</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://teslamotorsclub.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Tesla Motors Club</div>
+                        <div class="resource-card-desc">The largest Tesla owner forum — 500K+ members discussing ownership, mods, and tips</div>
+                        <div class="resource-card-url">teslamotorsclub.com</div>
+                    </a>
+                    
+                    <a href="https://www.reddit.com/r/TeslaMotors/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">r/TeslaMotors</div>
+                        <div class="resource-card-desc">Reddit's main Tesla community — news, reviews, and owner discussions</div>
+                        <div class="resource-card-url">www.reddit.com/r/TeslaMotors/</div>
+                    </a>
+                    
+                    <a href="https://www.reddit.com/r/TSLALounge/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">r/TSLALounge</div>
+                        <div class="resource-card-desc">Tesla investor community focused on TSLA stock and market analysis</div>
+                        <div class="resource-card-url">www.reddit.com/r/TSLALounge/</div>
+                    </a>
+                    
+                    <a href="https://teslaownersonline.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Tesla Owners Online</div>
+                        <div class="resource-card-desc">Owner forum with detailed guides for Model 3, Y, S, X, and Cybertruck</div>
+                        <div class="resource-card-url">teslaownersonline.com</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Tesla Data & Tools</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.tesla.com/blog" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Tesla Blog</div>
+                        <div class="resource-card-desc">Official Tesla announcements and product updates</div>
+                        <div class="resource-card-url">www.tesla.com/blog</div>
+                    </a>
+                    
+                    <a href="https://www.plugshare.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">PlugShare</div>
+                        <div class="resource-card-desc">Find EV charging stations — Supercharger network and third-party chargers</div>
+                        <div class="resource-card-url">www.plugshare.com</div>
+                    </a>
+                    
+                    <a href="https://abetterrouteplanner.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">A Better Route Planner</div>
+                        <div class="resource-card-desc">EV trip planner with real-time range estimation for Tesla and other EVs</div>
+                        <div class="resource-card-url">abetterrouteplanner.com</div>
+                    </a>
+                    
+                    <a href="https://teslafi.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">TeslaFi</div>
+                        <div class="resource-card-desc">Tesla data logger — track efficiency, battery health, trips, and charging</div>
+                        <div class="resource-card-url">teslafi.com</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Learning & Deep Dives</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.youtube.com/results?search_query=tesla+ai+day" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Tesla AI Day Presentations</div>
+                        <div class="resource-card-desc">Technical presentations on FSD, Optimus robot, and Dojo supercomputer</div>
+                        <div class="resource-card-url">www.youtube.com/results?search_query=tesla+ai+day</div>
+                    </a>
+                    
+                    <a href="https://www.youtube.com/@MunroLive" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Sandy Munro</div>
+                        <div class="resource-card-desc">Engineering teardowns and manufacturing analysis of Tesla vehicles</div>
+                        <div class="resource-card-url">www.youtube.com/@MunroLive</div>
+                    </a>
+                    
+                    <a href="https://www.tesla.com/blog/master-plan-part-3" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Tesla Master Plan</div>
+                        <div class="resource-card-desc">Tesla's vision for sustainable energy — Master Plan Part 3</div>
+                        <div class="resource-card-url">www.tesla.com/blog/master-plan-part-3</div>
+                    </a>
+                    
+                    <a href="https://www.youtube.com/@thirdrowtesla" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Third Row Tesla</div>
+                        <div class="resource-card-desc">In-depth Tesla interviews and analysis from the community</div>
+                        <div class="resource-card-url">www.youtube.com/@thirdrowtesla</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+        </div>
+    </section>
+    
+
+    <!-- Recommended Tools -->
     
     <section class="nn-section" style="padding-top:0;">
         <div class="container">
             <div class="nn-section-header" style="text-align:left;">
-                <h2>Resources & Further Reading</h2>
+                <h2>Recommended Tools</h2>
             </div>
-            <div class="resources-grid">
+            <div class="tools-grid">
                 
-                <a href="https://ir.tesla.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Tesla Investor Relations</div>
-                    <div class="resource-card-desc">Official SEC filings, earnings calls, and shareholder letters</div>
-                    <div class="resource-card-url">ir.tesla.com</div>
+                <a href="https://www.tradingview.com/symbols/NASDAQ-TSLA/" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free tier</span>
+                    <div class="tool-card-name">TradingView</div>
+                    <div class="tool-card-desc">Advanced TSLA charting, technical analysis, and community ideas</div>
                 </a>
                 
-                <a href="https://www.tesla.com/blog" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Tesla Blog</div>
-                    <div class="resource-card-desc">Official Tesla announcements and product updates</div>
-                    <div class="resource-card-url">www.tesla.com/blog</div>
+                <a href="https://finance.yahoo.com/quote/TSLA" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Yahoo Finance</div>
+                    <div class="tool-card-desc">Real-time TSLA quotes, financials, analyst ratings, and news</div>
                 </a>
                 
-                <a href="https://finance.yahoo.com/quote/TSLA" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">TSLA on Yahoo Finance</div>
-                    <div class="resource-card-desc">Real-time stock price, charts, and financial data</div>
-                    <div class="resource-card-url">finance.yahoo.com/quote/TSLA</div>
+                <a href="https://www.plugshare.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">PlugShare</div>
+                    <div class="tool-card-desc">Find Superchargers and charging stations anywhere — essential for road trips</div>
                 </a>
                 
-                <a href="https://www.teslarati.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Teslarati</div>
-                    <div class="resource-card-desc">Independent Tesla and SpaceX news coverage</div>
-                    <div class="resource-card-url">www.teslarati.com</div>
+                <a href="https://abetterrouteplanner.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">A Better Route Planner</div>
+                    <div class="tool-card-desc">Plan EV road trips with accurate range estimates and charging stops</div>
                 </a>
                 
-                <a href="https://www.notateslaapp.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">Not A Tesla App</div>
-                    <div class="resource-card-desc">Tesla software updates and feature tracking</div>
-                    <div class="resource-card-url">www.notateslaapp.com</div>
+                <a href="https://teslafi.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Paid</span>
+                    <div class="tool-card-name">TeslaFi</div>
+                    <div class="tool-card-desc">Track your Tesla's efficiency, charging, battery degradation, and trip data</div>
                 </a>
                 
-                <a href="https://cleantechnica.com" class="resource-card glass-card" target="_blank" rel="noopener">
-                    <div class="resource-card-name">CleanTechnica</div>
-                    <div class="resource-card-desc">Clean energy and electric vehicle industry news</div>
-                    <div class="resource-card-url">cleantechnica.com</div>
+                <a href="https://getoptiwatt.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Optiwatt</div>
+                    <div class="tool-card-desc">Smart Tesla charging — schedule charging for the cheapest electricity rates</div>
                 </a>
                 
             </div>
+        </div>
+    </section>
+    
+
+    <!-- Key Concepts / FAQ -->
+    
+    <section id="faq" class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:800px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Key Concepts</h2>
+            </div>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is FSD (Full Self-Driving)?</summary>
+                <div class="faq-answer">FSD is Tesla's advanced driver-assistance system that aims to enable fully autonomous driving. It uses cameras and neural networks to navigate roads, handle intersections, and park. As of 2026, FSD (Supervised) requires driver attention at all times — it's not yet fully autonomous, but Tesla is working toward unsupervised capability with its robotaxi program.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What does 'shorts' mean in Tesla Shorts Time?</summary>
+                <div class="faq-answer">In stock market terminology, 'shorting' means betting that a stock's price will go down. Tesla has historically been one of the most-shorted stocks on the market. 'Tesla Shorts Time' plays on this — suggesting that time is running out for those betting against Tesla, as the company continues to grow and prove skeptics wrong.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is a Gigafactory?</summary>
+                <div class="faq-answer">A Gigafactory is Tesla's term for its massive manufacturing facilities. The name comes from 'giga' (billion) — these factories produce batteries and vehicles at a scale measured in gigawatt-hours. Tesla operates Gigafactories in Nevada, Shanghai, Berlin, and Texas, each producing hundreds of thousands of vehicles per year.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is the Tesla Megapack?</summary>
+                <div class="faq-answer">The Megapack is Tesla's utility-scale battery storage product. Each unit stores up to 4 MWh of energy — enough to power about 3,600 homes for one hour. Utilities and grid operators use Megapacks to store renewable energy from solar and wind farms, stabilize the grid, and replace fossil fuel peaker plants.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What does TSLA's P/E ratio mean?</summary>
+                <div class="faq-answer">The Price-to-Earnings (P/E) ratio shows how much investors pay per dollar of Tesla's earnings. A high P/E (Tesla's is often 50-100+) means investors expect strong future growth. For comparison, traditional automakers trade at P/E ratios of 5-15. Tesla's premium reflects the market pricing in its AI, energy, and robotaxi potential beyond just car sales.</div>
+            </details>
+            
         </div>
     </section>
     
@@ -360,7 +584,7 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
-                <p>Seven daily shows keeping you informed.</p>
+                <p>Nine daily shows keeping you informed.</p>
             </div>
             <div class="cross-network-grid">
                 


### PR DESCRIPTION
…ools, and FAQ

Replace flat 4-6 link resource grids on all 9 show pages with comprehensive resource hubs: 15-30+ resources organized into 5-6 topic categories per show, 5-6 recommended tools with badges, and 5 expandable FAQ/Key Concepts items.

- generate_html.py: Add resource_categories, tools, faq data for all 9 shows
- templates/show_page.html.j2: Categorized resources, tools grid, FAQ accordion
- styles/main.css: Category headers, tool cards with badges, FAQ expand/collapse

https://claude.ai/code/session_01SoZV9YikuTpoBv1KFJJQzw