### PR TITLE
Fix broken CSS and navigation on Russian show pages in ru/ subdirectory

### DIFF
--- a/generate_html.py
+++ b/generate_html.py
@@ -904,6 +904,18 @@ def _url_encode_image(image_path):
     return quote(image_path, safe="/")
 
 
+def _path_prefix(html_path):
+    """Return a relative prefix to reach the repo root from *html_path*.
+
+    For root-level files (e.g. ``tesla.html``) this returns ``""``.
+    For files in subdirectories (e.g. ``ru/finansy-prosto.html``) this
+    returns ``"../"``, so that ``{{ path_prefix }}styles/main.css`` resolves
+    correctly regardless of page depth.
+    """
+    depth = html_path.count("/")
+    return "../" * depth
+
+
 def _get_jinja_env():
     """Create a shared Jinja2 environment."""
     return Environment(
@@ -929,8 +941,11 @@ def generate_summaries_page(slug, *, dry_run=False):
         podcast_logo_url = f"{GITHUB_RAW}/{_url_encode_image(cfg['podcast_image'])}"
         og_image_url = podcast_logo_url
 
+    prefix = _path_prefix(cfg["summaries_page"])
+
     context = {
         **cfg,
+        "path_prefix": prefix,
         "show_name": cfg["name"],
         "show_slug": cfg["slug"],
         "page_title": f"{cfg['name']} | Summaries",
@@ -992,8 +1007,11 @@ def generate_show_page(slug, *, dry_run=False):
             "reason": cfg.get("related_reason", ""),
         }
 
+    prefix = _path_prefix(cfg["show_page"])
+
     context = {
         **cfg,
+        "path_prefix": prefix,
         "show_name": cfg["name"],
         "show_slug": cfg["slug"],
         "show_description": cfg.get("about_text", cfg["description"]),
@@ -1039,6 +1057,7 @@ def generate_network_page(*, dry_run=False):
     template = env.get_template("network_page.html.j2")
 
     context = {
+        "path_prefix": "",
         "page_title": "Nerra Network | 9 Daily Shows",
         "meta_description": "Nerra Network — Nine daily podcasts keeping you informed. Tesla, world news, space, science, environment, AI, Russian finance, and language learning. Independent, daily, free.",
         "meta_keywords": "podcast network, daily podcasts, Nerra Network, Tesla, space, science, AI, environment",

--- a/ru/finansy-prosto-summaries.html
+++ b/ru/finansy-prosto-summaries.html
@@ -25,7 +25,7 @@
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%237C5CFF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/></svg>">
 
     <!-- Shared CSS -->
-    <link rel="stylesheet" href="styles/main.css">
+    <link rel="stylesheet" href="../styles/main.css">
 
     
 
@@ -37,7 +37,7 @@
     <!-- Navigation -->
     <nav class="nn-nav">
         <div class="nn-nav-inner">
-            <a href="index.html" class="nn-nav-logo">
+            <a href="../index.html" class="nn-nav-logo">
                 <span class="gradient-text">Nerra</span> Network
             </a>
 
@@ -49,57 +49,57 @@
                     </button>
                     <div class="nn-nav-dropdown-menu">
                         
-                        <a href="tesla.html">
-                            <img src="assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
+                        <a href="../tesla.html">
+                            <img src="../assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
                             Tesla Shorts Time
                         </a>
                         
-                        <a href="omni-view.html">
-                            <img src="assets/covers/omni-view.jpg" alt="" loading="lazy">
+                        <a href="../omni-view.html">
+                            <img src="../assets/covers/omni-view.jpg" alt="" loading="lazy">
                             Omni View
                         </a>
                         
-                        <a href="fascinating_frontiers.html">
-                            <img src="assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
+                        <a href="../fascinating_frontiers.html">
+                            <img src="../assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
                             Fascinating Frontiers
                         </a>
                         
-                        <a href="planetterrian.html">
-                            <img src="assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
+                        <a href="../planetterrian.html">
+                            <img src="../assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
                             Planetterrian Daily
                         </a>
                         
-                        <a href="env-intel.html">
-                            <img src="assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
+                        <a href="../env-intel.html">
+                            <img src="../assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
                             Environmental Intelligence
                         </a>
                         
-                        <a href="models-agents.html">
-                            <img src="assets/covers/models-agents.jpg" alt="" loading="lazy">
+                        <a href="../models-agents.html">
+                            <img src="../assets/covers/models-agents.jpg" alt="" loading="lazy">
                             Models & Agents
                         </a>
                         
-                        <a href="models-agents-beginners.html">
-                            <img src="assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
+                        <a href="../models-agents-beginners.html">
+                            <img src="../assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
                             Models & Agents for Beginners
                         </a>
                         
-                        <a href="ru/finansy-prosto.html">
-                            <img src="assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
+                        <a href="../ru/finansy-prosto.html">
+                            <img src="../assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
                             Финансы Просто
                         </a>
                         
-                        <a href="ru/privet-russian.html">
-                            <img src="assets/covers/privet-russian.jpg" alt="" loading="lazy">
+                        <a href="../ru/privet-russian.html">
+                            <img src="../assets/covers/privet-russian.jpg" alt="" loading="lazy">
                             Привет, Русский!
                         </a>
                         
                     </div>
                 </li>
                 
-<li><a href="ru/finansy-prosto.html">Финансы Просто</a></li>
-<li><a href="ru/finansy-prosto-summaries.html">Summaries</a></li>
-<li><a href="finansy_prosto_podcast.rss">RSS</a></li>
+<li><a href="../ru/finansy-prosto.html">Финансы Просто</a></li>
+<li><a href="../ru/finansy-prosto-summaries.html">Summaries</a></li>
+<li><a href="../finansy_prosto_podcast.rss">RSS</a></li>
 
 
                 <li><a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener">GitHub</a></li>
@@ -112,57 +112,57 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
-<a href="ru/finansy-prosto.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Финансы Просто</a>
-<a href="ru/finansy-prosto-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
-<a href="finansy_prosto_podcast.rss" onclick="document.getElementById('mobileMenu').classList.remove('open')">RSS</a>
+<a href="../ru/finansy-prosto.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Финансы Просто</a>
+<a href="../ru/finansy-prosto-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
+<a href="../finansy_prosto_podcast.rss" onclick="document.getElementById('mobileMenu').classList.remove('open')">RSS</a>
 
 
         <a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">GitHub</a>
         <div class="nn-mobile-shows">
             <div class="nn-mobile-shows-title">All Shows</div>
             
-            <a href="tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
+            <a href="../tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
                 Tesla Shorts Time
             </a>
             
-            <a href="omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/omni-view.jpg" alt="" loading="lazy">
+            <a href="../omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/omni-view.jpg" alt="" loading="lazy">
                 Omni View
             </a>
             
-            <a href="fascinating_frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
+            <a href="../fascinating_frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
                 Fascinating Frontiers
             </a>
             
-            <a href="planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
+            <a href="../planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
                 Planetterrian Daily
             </a>
             
-            <a href="env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
+            <a href="../env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
                 Environmental Intelligence
             </a>
             
-            <a href="models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/models-agents.jpg" alt="" loading="lazy">
+            <a href="../models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/models-agents.jpg" alt="" loading="lazy">
                 Models & Agents
             </a>
             
-            <a href="models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
+            <a href="../models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
                 Models & Agents for Beginners
             </a>
             
-            <a href="ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
+            <a href="../ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
                 Финансы Просто
             </a>
             
-            <a href="ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/privet-russian.jpg" alt="" loading="lazy">
+            <a href="../ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/privet-russian.jpg" alt="" loading="lazy">
                 Привет, Русский!
             </a>
             
@@ -231,8 +231,8 @@
             <div class="cross-network-grid">
                 
                 
-                <a href="tesla-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/tesla-shorts-time.jpg" alt="Tesla Shorts Time" loading="lazy">
+                <a href="../tesla-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/tesla-shorts-time.jpg" alt="Tesla Shorts Time" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Tesla Shorts Time</div>
                         <div class="cross-network-card-tagline">Shorting Tesla? Time's Up.</div>
@@ -241,8 +241,8 @@
                 
                 
                 
-                <a href="omni-view-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/omni-view.jpg" alt="Omni View" loading="lazy">
+                <a href="../omni-view-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/omni-view.jpg" alt="Omni View" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Omni View</div>
                         <div class="cross-network-card-tagline">See every side. Decide for yourself.</div>
@@ -251,8 +251,8 @@
                 
                 
                 
-                <a href="fascinating-frontiers-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/fascinating-frontiers.jpg" alt="Fascinating Frontiers" loading="lazy">
+                <a href="../fascinating-frontiers-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/fascinating-frontiers.jpg" alt="Fascinating Frontiers" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Fascinating Frontiers</div>
                         <div class="cross-network-card-tagline">Journey to the stars with today's discoveries.</div>
@@ -261,8 +261,8 @@
                 
                 
                 
-                <a href="planetterrian-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/planetterrian-daily.jpg" alt="Planetterrian Daily" loading="lazy">
+                <a href="../planetterrian-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/planetterrian-daily.jpg" alt="Planetterrian Daily" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Planetterrian Daily</div>
                         <div class="cross-network-card-tagline">Science, longevity, and the frontier of human health.</div>
@@ -271,8 +271,8 @@
                 
                 
                 
-                <a href="env-intel-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/environmental-intelligence.jpg" alt="Environmental Intelligence" loading="lazy">
+                <a href="../env-intel-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/environmental-intelligence.jpg" alt="Environmental Intelligence" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Environmental Intelligence</div>
                         <div class="cross-network-card-tagline">Environmental regulatory and compliance briefing.</div>
@@ -281,8 +281,8 @@
                 
                 
                 
-                <a href="models-agents-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/models-agents.jpg" alt="Models & Agents" loading="lazy">
+                <a href="../models-agents-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/models-agents.jpg" alt="Models & Agents" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Models & Agents</div>
                         <div class="cross-network-card-tagline">Daily AI models, agents, and practical developments.</div>
@@ -291,8 +291,8 @@
                 
                 
                 
-                <a href="models-agents-beginners-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/models-agents-beginners.jpg" alt="Models & Agents for Beginners" loading="lazy">
+                <a href="../models-agents-beginners-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/models-agents-beginners.jpg" alt="Models & Agents for Beginners" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Models & Agents for Beginners</div>
                         <div class="cross-network-card-tagline">AI explained simply — for beginners and teens.</div>
@@ -303,8 +303,8 @@
                 
                 
                 
-                <a href="ru/privet-russian-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/privet-russian.jpg" alt="Привет, Русский!" loading="lazy">
+                <a href="../ru/privet-russian-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/privet-russian.jpg" alt="Привет, Русский!" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Привет, Русский!</div>
                         <div class="cross-network-card-tagline">Learn Russian — Привет means hello!</div>
@@ -328,47 +328,47 @@
                 <div class="nn-footer-col">
                     <h4>Shows</h4>
                     
-                    <a href="tesla.html">Tesla Shorts Time</a>
+                    <a href="../tesla.html">Tesla Shorts Time</a>
                     
-                    <a href="omni-view.html">Omni View</a>
+                    <a href="../omni-view.html">Omni View</a>
                     
-                    <a href="fascinating_frontiers.html">Fascinating Frontiers</a>
+                    <a href="../fascinating_frontiers.html">Fascinating Frontiers</a>
                     
-                    <a href="planetterrian.html">Planetterrian Daily</a>
+                    <a href="../planetterrian.html">Planetterrian Daily</a>
                     
-                    <a href="env-intel.html">Environmental Intelligence</a>
+                    <a href="../env-intel.html">Environmental Intelligence</a>
                     
-                    <a href="models-agents.html">Models & Agents</a>
+                    <a href="../models-agents.html">Models & Agents</a>
                     
-                    <a href="models-agents-beginners.html">Models & Agents for Beginners</a>
+                    <a href="../models-agents-beginners.html">Models & Agents for Beginners</a>
                     
-                    <a href="ru/finansy-prosto.html">Финансы Просто</a>
+                    <a href="../ru/finansy-prosto.html">Финансы Просто</a>
                     
-                    <a href="ru/privet-russian.html">Привет, Русский!</a>
+                    <a href="../ru/privet-russian.html">Привет, Русский!</a>
                     
                 </div>
                 <div class="nn-footer-col">
                     <h4>Listen</h4>
                     <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939" target="_blank" rel="noopener">Apple Podcasts</a>
-                    <a href="network.rss">Network RSS</a>
+                    <a href="../network.rss">Network RSS</a>
                     
-                    <a href="podcast.rss">Tesla Shorts Time RSS</a>
+                    <a href="../podcast.rss">Tesla Shorts Time RSS</a>
                     
-                    <a href="omni_view_podcast.rss">Omni View RSS</a>
+                    <a href="../omni_view_podcast.rss">Omni View RSS</a>
                     
-                    <a href="fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
+                    <a href="../fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
                     
-                    <a href="planetterrian_podcast.rss">Planetterrian Daily RSS</a>
+                    <a href="../planetterrian_podcast.rss">Planetterrian Daily RSS</a>
                     
-                    <a href="env_intel_podcast.rss">Environmental Intelligence RSS</a>
+                    <a href="../env_intel_podcast.rss">Environmental Intelligence RSS</a>
                     
-                    <a href="models_agents_podcast.rss">Models & Agents RSS</a>
+                    <a href="../models_agents_podcast.rss">Models & Agents RSS</a>
                     
-                    <a href="models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
+                    <a href="../models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
                     
-                    <a href="finansy_prosto_podcast.rss">Финансы Просто RSS</a>
+                    <a href="../finansy_prosto_podcast.rss">Финансы Просто RSS</a>
                     
-                    <a href="privet_russian_podcast.rss">Привет, Русский! RSS</a>
+                    <a href="../privet_russian_podcast.rss">Привет, Русский! RSS</a>
                     
                 </div>
                 <div class="nn-footer-col">
@@ -381,14 +381,14 @@
             </div>
             <div class="nn-footer-bottom">
                 <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
-                <a href="index.html">nerranetwork.com</a>
+                <a href="../index.html">nerranetwork.com</a>
             </div>
         </div>
     </footer>
 
     
     <script>
-        const JSON_URL = 'digests/finansy_prosto/summaries_finansy_prosto.json';
+        const JSON_URL = '../digests/finansy_prosto/summaries_finansy_prosto.json';
         const JSON_FORMAT = 'wrapped';
         const SHOW_NAME = "\u0424\u0438\u043d\u0430\u043d\u0441\u044b \u041f\u0440\u043e\u0441\u0442\u043e";
 

--- a/ru/finansy-prosto.html
+++ b/ru/finansy-prosto.html
@@ -25,7 +25,7 @@
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%237C5CFF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/></svg>">
 
     <!-- Shared CSS -->
-    <link rel="stylesheet" href="styles/main.css">
+    <link rel="stylesheet" href="../styles/main.css">
 
     
 
@@ -37,7 +37,7 @@
   "name": "\u0424\u0438\u043d\u0430\u043d\u0441\u044b \u041f\u0440\u043e\u0441\u0442\u043e",
   "description": "\u0424\u0438\u043d\u0430\u043d\u0441\u044b \u041f\u0440\u043e\u0441\u0442\u043e \u2014 \u0435\u0436\u0435\u0434\u043d\u0435\u0432\u043d\u044b\u0439 \u043f\u043e\u0434\u043a\u0430\u0441\u0442 \u043e \u0444\u0438\u043d\u0430\u043d\u0441\u0430\u0445 \u043d\u0430 \u0440\u0443\u0441\u0441\u043a\u043e\u043c \u044f\u0437\u044b\u043a\u0435 \u0434\u043b\u044f \u0436\u0435\u043d\u0449\u0438\u043d \u0432 \u041a\u0430\u043d\u0430\u0434\u0435. \u0418\u043d\u0432\u0435\u0441\u0442\u0438\u0446\u0438\u0438, \u0441\u0431\u0435\u0440\u0435\u0436\u0435\u043d\u0438\u044f, \u0431\u044e\u0434\u0436\u0435\u0442.",
   "url": "https://nerranetwork.com/ru/finansy-prosto.html",
-  "webFeed": "finansy_prosto_podcast.rss",
+  "webFeed": "../finansy_prosto_podcast.rss",
   "image": "assets/covers/finansy-prosto.jpg"
 }
 </script>
@@ -51,7 +51,7 @@
     <!-- Navigation -->
     <nav class="nn-nav">
         <div class="nn-nav-inner">
-            <a href="index.html" class="nn-nav-logo">
+            <a href="../index.html" class="nn-nav-logo">
                 <span class="gradient-text">Nerra</span> Network
             </a>
 
@@ -63,56 +63,56 @@
                     </button>
                     <div class="nn-nav-dropdown-menu">
                         
-                        <a href="tesla.html">
-                            <img src="assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
+                        <a href="../tesla.html">
+                            <img src="../assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
                             Tesla Shorts Time
                         </a>
                         
-                        <a href="omni-view.html">
-                            <img src="assets/covers/omni-view.jpg" alt="" loading="lazy">
+                        <a href="../omni-view.html">
+                            <img src="../assets/covers/omni-view.jpg" alt="" loading="lazy">
                             Omni View
                         </a>
                         
-                        <a href="fascinating_frontiers.html">
-                            <img src="assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
+                        <a href="../fascinating_frontiers.html">
+                            <img src="../assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
                             Fascinating Frontiers
                         </a>
                         
-                        <a href="planetterrian.html">
-                            <img src="assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
+                        <a href="../planetterrian.html">
+                            <img src="../assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
                             Planetterrian Daily
                         </a>
                         
-                        <a href="env-intel.html">
-                            <img src="assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
+                        <a href="../env-intel.html">
+                            <img src="../assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
                             Environmental Intelligence
                         </a>
                         
-                        <a href="models-agents.html">
-                            <img src="assets/covers/models-agents.jpg" alt="" loading="lazy">
+                        <a href="../models-agents.html">
+                            <img src="../assets/covers/models-agents.jpg" alt="" loading="lazy">
                             Models & Agents
                         </a>
                         
-                        <a href="models-agents-beginners.html">
-                            <img src="assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
+                        <a href="../models-agents-beginners.html">
+                            <img src="../assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
                             Models & Agents for Beginners
                         </a>
                         
-                        <a href="ru/finansy-prosto.html">
-                            <img src="assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
+                        <a href="../ru/finansy-prosto.html">
+                            <img src="../assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
                             Финансы Просто
                         </a>
                         
-                        <a href="ru/privet-russian.html">
-                            <img src="assets/covers/privet-russian.jpg" alt="" loading="lazy">
+                        <a href="../ru/privet-russian.html">
+                            <img src="../assets/covers/privet-russian.jpg" alt="" loading="lazy">
                             Привет, Русский!
                         </a>
                         
                     </div>
                 </li>
                 
-<li><a href="ru/finansy-prosto-summaries.html">Summaries</a></li>
-<li><a href="finansy_prosto_podcast.rss">RSS</a></li>
+<li><a href="../ru/finansy-prosto-summaries.html">Summaries</a></li>
+<li><a href="../finansy_prosto_podcast.rss">RSS</a></li>
 
 
                 <li><a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener">GitHub</a></li>
@@ -125,8 +125,8 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
-<a href="ru/finansy-prosto.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
-<a href="ru/finansy-prosto-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
+<a href="../ru/finansy-prosto.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
+<a href="../ru/finansy-prosto-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
 <a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
@@ -136,48 +136,48 @@
         <div class="nn-mobile-shows">
             <div class="nn-mobile-shows-title">All Shows</div>
             
-            <a href="tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
+            <a href="../tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
                 Tesla Shorts Time
             </a>
             
-            <a href="omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/omni-view.jpg" alt="" loading="lazy">
+            <a href="../omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/omni-view.jpg" alt="" loading="lazy">
                 Omni View
             </a>
             
-            <a href="fascinating_frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
+            <a href="../fascinating_frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
                 Fascinating Frontiers
             </a>
             
-            <a href="planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
+            <a href="../planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
                 Planetterrian Daily
             </a>
             
-            <a href="env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
+            <a href="../env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
                 Environmental Intelligence
             </a>
             
-            <a href="models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/models-agents.jpg" alt="" loading="lazy">
+            <a href="../models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/models-agents.jpg" alt="" loading="lazy">
                 Models & Agents
             </a>
             
-            <a href="models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
+            <a href="../models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
                 Models & Agents for Beginners
             </a>
             
-            <a href="ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
+            <a href="../ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
                 Финансы Просто
             </a>
             
-            <a href="ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/privet-russian.jpg" alt="" loading="lazy">
+            <a href="../ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/privet-russian.jpg" alt="" loading="lazy">
                 Привет, Русский!
             </a>
             
@@ -189,7 +189,7 @@
     <section class="show-hero">
         <div class="show-hero-bg"></div>
         <div class="show-hero-inner">
-            <img src="assets/covers/finansy-prosto.jpg" alt="Финансы Просто" class="show-hero-art"
+            <img src="../assets/covers/finansy-prosto.jpg" alt="Финансы Просто" class="show-hero-art"
                  onerror="this.style.display='none'">
             <div class="show-hero-info">
                 <h1>Финансы Просто</h1>
@@ -204,9 +204,9 @@
                 
                 <div class="show-hero-actions">
                     <a href="#episodes" class="nn-btn nn-btn-primary">Listen Now</a>
-                    <a href="ru/finansy-prosto-summaries.html" class="nn-btn">View Summaries</a>
+                    <a href="../ru/finansy-prosto-summaries.html" class="nn-btn">View Summaries</a>
                     
-                    <a href="finansy_prosto_podcast.rss" class="nn-btn">RSS Feed</a>
+                    <a href="../finansy_prosto_podcast.rss" class="nn-btn">RSS Feed</a>
                     
                 </div>
                 
@@ -235,7 +235,7 @@
             </div>
             <div id="episodes-grid" class="episodes-grid"></div>
             <div style="text-align:center;margin-top:var(--sp-6);">
-                <a href="ru/finansy-prosto-summaries.html" class="nn-btn">View All Episodes</a>
+                <a href="../ru/finansy-prosto-summaries.html" class="nn-btn">View All Episodes</a>
             </div>
         </div>
     </section>
@@ -517,8 +517,8 @@
         <div class="container" style="max-width:700px;">
             <div class="glass-card" style="padding:var(--sp-6);border-color:color-mix(in srgb, var(--show-color) 30%, var(--nn-border));">
                 <div style="font-family:var(--font-ui);font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;color:var(--show-color);margin-bottom:var(--sp-3);">Recommended for you</div>
-                <a href="ru/privet-russian.html" style="display:flex;align-items:center;gap:var(--sp-4);text-decoration:none;">
-                    <img src="assets/covers/privet-russian.jpg" alt="Привет, Русский!" style="width:72px;height:72px;border-radius:12px;object-fit:cover;flex-shrink:0;" loading="lazy">
+                <a href="../ru/privet-russian.html" style="display:flex;align-items:center;gap:var(--sp-4);text-decoration:none;">
+                    <img src="../assets/covers/privet-russian.jpg" alt="Привет, Русский!" style="width:72px;height:72px;border-radius:12px;object-fit:cover;flex-shrink:0;" loading="lazy">
                     <div>
                         <div style="font-family:var(--font-heading);font-weight:600;color:var(--nn-white);font-size:1.05rem;margin-bottom:var(--sp-1);">Привет, Русский!</div>
                         <div style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);line-height:1.5;">If you enjoy Финансы Просто, you might also like Привет, Русский! — learn Russian through fun, themed episodes.</div>
@@ -539,8 +539,8 @@
             <div class="cross-network-grid">
                 
                 
-                <a href="tesla.html" class="cross-network-card">
-                    <img src="assets/covers/tesla-shorts-time.jpg" alt="Tesla Shorts Time" loading="lazy">
+                <a href="../tesla.html" class="cross-network-card">
+                    <img src="../assets/covers/tesla-shorts-time.jpg" alt="Tesla Shorts Time" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Tesla Shorts Time</div>
                         <div class="cross-network-card-tagline">Shorting Tesla? Time's Up.</div>
@@ -549,8 +549,8 @@
                 
                 
                 
-                <a href="omni-view.html" class="cross-network-card">
-                    <img src="assets/covers/omni-view.jpg" alt="Omni View" loading="lazy">
+                <a href="../omni-view.html" class="cross-network-card">
+                    <img src="../assets/covers/omni-view.jpg" alt="Omni View" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Omni View</div>
                         <div class="cross-network-card-tagline">See every side. Decide for yourself.</div>
@@ -559,8 +559,8 @@
                 
                 
                 
-                <a href="fascinating_frontiers.html" class="cross-network-card">
-                    <img src="assets/covers/fascinating-frontiers.jpg" alt="Fascinating Frontiers" loading="lazy">
+                <a href="../fascinating_frontiers.html" class="cross-network-card">
+                    <img src="../assets/covers/fascinating-frontiers.jpg" alt="Fascinating Frontiers" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Fascinating Frontiers</div>
                         <div class="cross-network-card-tagline">Journey to the stars with today's discoveries.</div>
@@ -569,8 +569,8 @@
                 
                 
                 
-                <a href="planetterrian.html" class="cross-network-card">
-                    <img src="assets/covers/planetterrian-daily.jpg" alt="Planetterrian Daily" loading="lazy">
+                <a href="../planetterrian.html" class="cross-network-card">
+                    <img src="../assets/covers/planetterrian-daily.jpg" alt="Planetterrian Daily" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Planetterrian Daily</div>
                         <div class="cross-network-card-tagline">Science, longevity, and the frontier of human health.</div>
@@ -579,8 +579,8 @@
                 
                 
                 
-                <a href="env-intel.html" class="cross-network-card">
-                    <img src="assets/covers/environmental-intelligence.jpg" alt="Environmental Intelligence" loading="lazy">
+                <a href="../env-intel.html" class="cross-network-card">
+                    <img src="../assets/covers/environmental-intelligence.jpg" alt="Environmental Intelligence" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Environmental Intelligence</div>
                         <div class="cross-network-card-tagline">Environmental regulatory and compliance briefing.</div>
@@ -589,8 +589,8 @@
                 
                 
                 
-                <a href="models-agents.html" class="cross-network-card">
-                    <img src="assets/covers/models-agents.jpg" alt="Models & Agents" loading="lazy">
+                <a href="../models-agents.html" class="cross-network-card">
+                    <img src="../assets/covers/models-agents.jpg" alt="Models & Agents" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Models & Agents</div>
                         <div class="cross-network-card-tagline">Daily AI models, agents, and practical developments.</div>
@@ -599,8 +599,8 @@
                 
                 
                 
-                <a href="models-agents-beginners.html" class="cross-network-card">
-                    <img src="assets/covers/models-agents-beginners.jpg" alt="Models & Agents for Beginners" loading="lazy">
+                <a href="../models-agents-beginners.html" class="cross-network-card">
+                    <img src="../assets/covers/models-agents-beginners.jpg" alt="Models & Agents for Beginners" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Models & Agents for Beginners</div>
                         <div class="cross-network-card-tagline">AI explained simply — for beginners and teens.</div>
@@ -611,8 +611,8 @@
                 
                 
                 
-                <a href="ru/privet-russian.html" class="cross-network-card">
-                    <img src="assets/covers/privet-russian.jpg" alt="Привет, Русский!" loading="lazy">
+                <a href="../ru/privet-russian.html" class="cross-network-card">
+                    <img src="../assets/covers/privet-russian.jpg" alt="Привет, Русский!" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Привет, Русский!</div>
                         <div class="cross-network-card-tagline">Learn Russian — Привет means hello!</div>
@@ -636,47 +636,47 @@
                 <div class="nn-footer-col">
                     <h4>Shows</h4>
                     
-                    <a href="tesla.html">Tesla Shorts Time</a>
+                    <a href="../tesla.html">Tesla Shorts Time</a>
                     
-                    <a href="omni-view.html">Omni View</a>
+                    <a href="../omni-view.html">Omni View</a>
                     
-                    <a href="fascinating_frontiers.html">Fascinating Frontiers</a>
+                    <a href="../fascinating_frontiers.html">Fascinating Frontiers</a>
                     
-                    <a href="planetterrian.html">Planetterrian Daily</a>
+                    <a href="../planetterrian.html">Planetterrian Daily</a>
                     
-                    <a href="env-intel.html">Environmental Intelligence</a>
+                    <a href="../env-intel.html">Environmental Intelligence</a>
                     
-                    <a href="models-agents.html">Models & Agents</a>
+                    <a href="../models-agents.html">Models & Agents</a>
                     
-                    <a href="models-agents-beginners.html">Models & Agents for Beginners</a>
+                    <a href="../models-agents-beginners.html">Models & Agents for Beginners</a>
                     
-                    <a href="ru/finansy-prosto.html">Финансы Просто</a>
+                    <a href="../ru/finansy-prosto.html">Финансы Просто</a>
                     
-                    <a href="ru/privet-russian.html">Привет, Русский!</a>
+                    <a href="../ru/privet-russian.html">Привет, Русский!</a>
                     
                 </div>
                 <div class="nn-footer-col">
                     <h4>Listen</h4>
                     <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939" target="_blank" rel="noopener">Apple Podcasts</a>
-                    <a href="network.rss">Network RSS</a>
+                    <a href="../network.rss">Network RSS</a>
                     
-                    <a href="podcast.rss">Tesla Shorts Time RSS</a>
+                    <a href="../podcast.rss">Tesla Shorts Time RSS</a>
                     
-                    <a href="omni_view_podcast.rss">Omni View RSS</a>
+                    <a href="../omni_view_podcast.rss">Omni View RSS</a>
                     
-                    <a href="fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
+                    <a href="../fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
                     
-                    <a href="planetterrian_podcast.rss">Planetterrian Daily RSS</a>
+                    <a href="../planetterrian_podcast.rss">Planetterrian Daily RSS</a>
                     
-                    <a href="env_intel_podcast.rss">Environmental Intelligence RSS</a>
+                    <a href="../env_intel_podcast.rss">Environmental Intelligence RSS</a>
                     
-                    <a href="models_agents_podcast.rss">Models & Agents RSS</a>
+                    <a href="../models_agents_podcast.rss">Models & Agents RSS</a>
                     
-                    <a href="models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
+                    <a href="../models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
                     
-                    <a href="finansy_prosto_podcast.rss">Финансы Просто RSS</a>
+                    <a href="../finansy_prosto_podcast.rss">Финансы Просто RSS</a>
                     
-                    <a href="privet_russian_podcast.rss">Привет, Русский! RSS</a>
+                    <a href="../privet_russian_podcast.rss">Привет, Русский! RSS</a>
                     
                 </div>
                 <div class="nn-footer-col">
@@ -689,7 +689,7 @@
             </div>
             <div class="nn-footer-bottom">
                 <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
-                <a href="index.html">nerranetwork.com</a>
+                <a href="../index.html">nerranetwork.com</a>
             </div>
         </div>
     </footer>
@@ -697,9 +697,9 @@
     
     
     <script>
-        const JSON_URL = 'digests/finansy_prosto/summaries_finansy_prosto.json';
+        const JSON_URL = '../digests/finansy_prosto/summaries_finansy_prosto.json';
         const JSON_FORMAT = 'wrapped';
-        const RSS_URL = 'finansy_prosto_podcast.rss';
+        const RSS_URL = '../finansy_prosto_podcast.rss';
         const SHOW_NAME = "\u0424\u0438\u043d\u0430\u043d\u0441\u044b \u041f\u0440\u043e\u0441\u0442\u043e";
 
         // --- Helpers ---

--- a/ru/privet-russian-summaries.html
+++ b/ru/privet-russian-summaries.html
@@ -25,7 +25,7 @@
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%237C5CFF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/></svg>">
 
     <!-- Shared CSS -->
-    <link rel="stylesheet" href="styles/main.css">
+    <link rel="stylesheet" href="../styles/main.css">
 
     
 
@@ -37,7 +37,7 @@
     <!-- Navigation -->
     <nav class="nn-nav">
         <div class="nn-nav-inner">
-            <a href="index.html" class="nn-nav-logo">
+            <a href="../index.html" class="nn-nav-logo">
                 <span class="gradient-text">Nerra</span> Network
             </a>
 
@@ -49,57 +49,57 @@
                     </button>
                     <div class="nn-nav-dropdown-menu">
                         
-                        <a href="tesla.html">
-                            <img src="assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
+                        <a href="../tesla.html">
+                            <img src="../assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
                             Tesla Shorts Time
                         </a>
                         
-                        <a href="omni-view.html">
-                            <img src="assets/covers/omni-view.jpg" alt="" loading="lazy">
+                        <a href="../omni-view.html">
+                            <img src="../assets/covers/omni-view.jpg" alt="" loading="lazy">
                             Omni View
                         </a>
                         
-                        <a href="fascinating_frontiers.html">
-                            <img src="assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
+                        <a href="../fascinating_frontiers.html">
+                            <img src="../assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
                             Fascinating Frontiers
                         </a>
                         
-                        <a href="planetterrian.html">
-                            <img src="assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
+                        <a href="../planetterrian.html">
+                            <img src="../assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
                             Planetterrian Daily
                         </a>
                         
-                        <a href="env-intel.html">
-                            <img src="assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
+                        <a href="../env-intel.html">
+                            <img src="../assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
                             Environmental Intelligence
                         </a>
                         
-                        <a href="models-agents.html">
-                            <img src="assets/covers/models-agents.jpg" alt="" loading="lazy">
+                        <a href="../models-agents.html">
+                            <img src="../assets/covers/models-agents.jpg" alt="" loading="lazy">
                             Models & Agents
                         </a>
                         
-                        <a href="models-agents-beginners.html">
-                            <img src="assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
+                        <a href="../models-agents-beginners.html">
+                            <img src="../assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
                             Models & Agents for Beginners
                         </a>
                         
-                        <a href="ru/finansy-prosto.html">
-                            <img src="assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
+                        <a href="../ru/finansy-prosto.html">
+                            <img src="../assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
                             Финансы Просто
                         </a>
                         
-                        <a href="ru/privet-russian.html">
-                            <img src="assets/covers/privet-russian.jpg" alt="" loading="lazy">
+                        <a href="../ru/privet-russian.html">
+                            <img src="../assets/covers/privet-russian.jpg" alt="" loading="lazy">
                             Привет, Русский!
                         </a>
                         
                     </div>
                 </li>
                 
-<li><a href="ru/privet-russian.html">Привет, Русский!</a></li>
-<li><a href="ru/privet-russian-summaries.html">Summaries</a></li>
-<li><a href="privet_russian_podcast.rss">RSS</a></li>
+<li><a href="../ru/privet-russian.html">Привет, Русский!</a></li>
+<li><a href="../ru/privet-russian-summaries.html">Summaries</a></li>
+<li><a href="../privet_russian_podcast.rss">RSS</a></li>
 
 
                 <li><a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener">GitHub</a></li>
@@ -112,57 +112,57 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
-<a href="ru/privet-russian.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Привет, Русский!</a>
-<a href="ru/privet-russian-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
-<a href="privet_russian_podcast.rss" onclick="document.getElementById('mobileMenu').classList.remove('open')">RSS</a>
+<a href="../ru/privet-russian.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Привет, Русский!</a>
+<a href="../ru/privet-russian-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
+<a href="../privet_russian_podcast.rss" onclick="document.getElementById('mobileMenu').classList.remove('open')">RSS</a>
 
 
         <a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">GitHub</a>
         <div class="nn-mobile-shows">
             <div class="nn-mobile-shows-title">All Shows</div>
             
-            <a href="tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
+            <a href="../tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
                 Tesla Shorts Time
             </a>
             
-            <a href="omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/omni-view.jpg" alt="" loading="lazy">
+            <a href="../omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/omni-view.jpg" alt="" loading="lazy">
                 Omni View
             </a>
             
-            <a href="fascinating_frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
+            <a href="../fascinating_frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
                 Fascinating Frontiers
             </a>
             
-            <a href="planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
+            <a href="../planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
                 Planetterrian Daily
             </a>
             
-            <a href="env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
+            <a href="../env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
                 Environmental Intelligence
             </a>
             
-            <a href="models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/models-agents.jpg" alt="" loading="lazy">
+            <a href="../models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/models-agents.jpg" alt="" loading="lazy">
                 Models & Agents
             </a>
             
-            <a href="models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
+            <a href="../models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
                 Models & Agents for Beginners
             </a>
             
-            <a href="ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
+            <a href="../ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
                 Финансы Просто
             </a>
             
-            <a href="ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/privet-russian.jpg" alt="" loading="lazy">
+            <a href="../ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/privet-russian.jpg" alt="" loading="lazy">
                 Привет, Русский!
             </a>
             
@@ -231,8 +231,8 @@
             <div class="cross-network-grid">
                 
                 
-                <a href="tesla-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/tesla-shorts-time.jpg" alt="Tesla Shorts Time" loading="lazy">
+                <a href="../tesla-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/tesla-shorts-time.jpg" alt="Tesla Shorts Time" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Tesla Shorts Time</div>
                         <div class="cross-network-card-tagline">Shorting Tesla? Time's Up.</div>
@@ -241,8 +241,8 @@
                 
                 
                 
-                <a href="omni-view-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/omni-view.jpg" alt="Omni View" loading="lazy">
+                <a href="../omni-view-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/omni-view.jpg" alt="Omni View" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Omni View</div>
                         <div class="cross-network-card-tagline">See every side. Decide for yourself.</div>
@@ -251,8 +251,8 @@
                 
                 
                 
-                <a href="fascinating-frontiers-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/fascinating-frontiers.jpg" alt="Fascinating Frontiers" loading="lazy">
+                <a href="../fascinating-frontiers-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/fascinating-frontiers.jpg" alt="Fascinating Frontiers" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Fascinating Frontiers</div>
                         <div class="cross-network-card-tagline">Journey to the stars with today's discoveries.</div>
@@ -261,8 +261,8 @@
                 
                 
                 
-                <a href="planetterrian-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/planetterrian-daily.jpg" alt="Planetterrian Daily" loading="lazy">
+                <a href="../planetterrian-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/planetterrian-daily.jpg" alt="Planetterrian Daily" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Planetterrian Daily</div>
                         <div class="cross-network-card-tagline">Science, longevity, and the frontier of human health.</div>
@@ -271,8 +271,8 @@
                 
                 
                 
-                <a href="env-intel-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/environmental-intelligence.jpg" alt="Environmental Intelligence" loading="lazy">
+                <a href="../env-intel-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/environmental-intelligence.jpg" alt="Environmental Intelligence" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Environmental Intelligence</div>
                         <div class="cross-network-card-tagline">Environmental regulatory and compliance briefing.</div>
@@ -281,8 +281,8 @@
                 
                 
                 
-                <a href="models-agents-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/models-agents.jpg" alt="Models & Agents" loading="lazy">
+                <a href="../models-agents-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/models-agents.jpg" alt="Models & Agents" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Models & Agents</div>
                         <div class="cross-network-card-tagline">Daily AI models, agents, and practical developments.</div>
@@ -291,8 +291,8 @@
                 
                 
                 
-                <a href="models-agents-beginners-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/models-agents-beginners.jpg" alt="Models & Agents for Beginners" loading="lazy">
+                <a href="../models-agents-beginners-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/models-agents-beginners.jpg" alt="Models & Agents for Beginners" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Models & Agents for Beginners</div>
                         <div class="cross-network-card-tagline">AI explained simply — for beginners and teens.</div>
@@ -301,8 +301,8 @@
                 
                 
                 
-                <a href="ru/finansy-prosto-summaries.html" class="cross-network-card">
-                    <img src="assets/covers/finansy-prosto.jpg" alt="Финансы Просто" loading="lazy">
+                <a href="../ru/finansy-prosto-summaries.html" class="cross-network-card">
+                    <img src="../assets/covers/finansy-prosto.jpg" alt="Финансы Просто" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Финансы Просто</div>
                         <div class="cross-network-card-tagline">Finances Made Simple.</div>
@@ -328,47 +328,47 @@
                 <div class="nn-footer-col">
                     <h4>Shows</h4>
                     
-                    <a href="tesla.html">Tesla Shorts Time</a>
+                    <a href="../tesla.html">Tesla Shorts Time</a>
                     
-                    <a href="omni-view.html">Omni View</a>
+                    <a href="../omni-view.html">Omni View</a>
                     
-                    <a href="fascinating_frontiers.html">Fascinating Frontiers</a>
+                    <a href="../fascinating_frontiers.html">Fascinating Frontiers</a>
                     
-                    <a href="planetterrian.html">Planetterrian Daily</a>
+                    <a href="../planetterrian.html">Planetterrian Daily</a>
                     
-                    <a href="env-intel.html">Environmental Intelligence</a>
+                    <a href="../env-intel.html">Environmental Intelligence</a>
                     
-                    <a href="models-agents.html">Models & Agents</a>
+                    <a href="../models-agents.html">Models & Agents</a>
                     
-                    <a href="models-agents-beginners.html">Models & Agents for Beginners</a>
+                    <a href="../models-agents-beginners.html">Models & Agents for Beginners</a>
                     
-                    <a href="ru/finansy-prosto.html">Финансы Просто</a>
+                    <a href="../ru/finansy-prosto.html">Финансы Просто</a>
                     
-                    <a href="ru/privet-russian.html">Привет, Русский!</a>
+                    <a href="../ru/privet-russian.html">Привет, Русский!</a>
                     
                 </div>
                 <div class="nn-footer-col">
                     <h4>Listen</h4>
                     <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939" target="_blank" rel="noopener">Apple Podcasts</a>
-                    <a href="network.rss">Network RSS</a>
+                    <a href="../network.rss">Network RSS</a>
                     
-                    <a href="podcast.rss">Tesla Shorts Time RSS</a>
+                    <a href="../podcast.rss">Tesla Shorts Time RSS</a>
                     
-                    <a href="omni_view_podcast.rss">Omni View RSS</a>
+                    <a href="../omni_view_podcast.rss">Omni View RSS</a>
                     
-                    <a href="fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
+                    <a href="../fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
                     
-                    <a href="planetterrian_podcast.rss">Planetterrian Daily RSS</a>
+                    <a href="../planetterrian_podcast.rss">Planetterrian Daily RSS</a>
                     
-                    <a href="env_intel_podcast.rss">Environmental Intelligence RSS</a>
+                    <a href="../env_intel_podcast.rss">Environmental Intelligence RSS</a>
                     
-                    <a href="models_agents_podcast.rss">Models & Agents RSS</a>
+                    <a href="../models_agents_podcast.rss">Models & Agents RSS</a>
                     
-                    <a href="models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
+                    <a href="../models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
                     
-                    <a href="finansy_prosto_podcast.rss">Финансы Просто RSS</a>
+                    <a href="../finansy_prosto_podcast.rss">Финансы Просто RSS</a>
                     
-                    <a href="privet_russian_podcast.rss">Привет, Русский! RSS</a>
+                    <a href="../privet_russian_podcast.rss">Привет, Русский! RSS</a>
                     
                 </div>
                 <div class="nn-footer-col">
@@ -381,14 +381,14 @@
             </div>
             <div class="nn-footer-bottom">
                 <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
-                <a href="index.html">nerranetwork.com</a>
+                <a href="../index.html">nerranetwork.com</a>
             </div>
         </div>
     </footer>
 
     
     <script>
-        const JSON_URL = 'digests/privet_russian/summaries_privet_russian.json';
+        const JSON_URL = '../digests/privet_russian/summaries_privet_russian.json';
         const JSON_FORMAT = 'wrapped';
         const SHOW_NAME = "\u041f\u0440\u0438\u0432\u0435\u0442, \u0420\u0443\u0441\u0441\u043a\u0438\u0439!";
 

--- a/ru/privet-russian.html
+++ b/ru/privet-russian.html
@@ -25,7 +25,7 @@
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%237C5CFF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/></svg>">
 
     <!-- Shared CSS -->
-    <link rel="stylesheet" href="styles/main.css">
+    <link rel="stylesheet" href="../styles/main.css">
 
     
 
@@ -37,7 +37,7 @@
   "name": "\u041f\u0440\u0438\u0432\u0435\u0442, \u0420\u0443\u0441\u0441\u043a\u0438\u0439!",
   "description": "\u041f\u0440\u0438\u0432\u0435\u0442, \u0420\u0443\u0441\u0441\u043a\u0438\u0439! \u2014 Learn Russian with fun bilingual podcast episodes. Vocabulary, phrases, grammar, and culture for beginners.",
   "url": "https://nerranetwork.com/ru/privet-russian.html",
-  "webFeed": "privet_russian_podcast.rss",
+  "webFeed": "../privet_russian_podcast.rss",
   "image": "assets/covers/privet-russian.jpg"
 }
 </script>
@@ -51,7 +51,7 @@
     <!-- Navigation -->
     <nav class="nn-nav">
         <div class="nn-nav-inner">
-            <a href="index.html" class="nn-nav-logo">
+            <a href="../index.html" class="nn-nav-logo">
                 <span class="gradient-text">Nerra</span> Network
             </a>
 
@@ -63,56 +63,56 @@
                     </button>
                     <div class="nn-nav-dropdown-menu">
                         
-                        <a href="tesla.html">
-                            <img src="assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
+                        <a href="../tesla.html">
+                            <img src="../assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
                             Tesla Shorts Time
                         </a>
                         
-                        <a href="omni-view.html">
-                            <img src="assets/covers/omni-view.jpg" alt="" loading="lazy">
+                        <a href="../omni-view.html">
+                            <img src="../assets/covers/omni-view.jpg" alt="" loading="lazy">
                             Omni View
                         </a>
                         
-                        <a href="fascinating_frontiers.html">
-                            <img src="assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
+                        <a href="../fascinating_frontiers.html">
+                            <img src="../assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
                             Fascinating Frontiers
                         </a>
                         
-                        <a href="planetterrian.html">
-                            <img src="assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
+                        <a href="../planetterrian.html">
+                            <img src="../assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
                             Planetterrian Daily
                         </a>
                         
-                        <a href="env-intel.html">
-                            <img src="assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
+                        <a href="../env-intel.html">
+                            <img src="../assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
                             Environmental Intelligence
                         </a>
                         
-                        <a href="models-agents.html">
-                            <img src="assets/covers/models-agents.jpg" alt="" loading="lazy">
+                        <a href="../models-agents.html">
+                            <img src="../assets/covers/models-agents.jpg" alt="" loading="lazy">
                             Models & Agents
                         </a>
                         
-                        <a href="models-agents-beginners.html">
-                            <img src="assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
+                        <a href="../models-agents-beginners.html">
+                            <img src="../assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
                             Models & Agents for Beginners
                         </a>
                         
-                        <a href="ru/finansy-prosto.html">
-                            <img src="assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
+                        <a href="../ru/finansy-prosto.html">
+                            <img src="../assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
                             Финансы Просто
                         </a>
                         
-                        <a href="ru/privet-russian.html">
-                            <img src="assets/covers/privet-russian.jpg" alt="" loading="lazy">
+                        <a href="../ru/privet-russian.html">
+                            <img src="../assets/covers/privet-russian.jpg" alt="" loading="lazy">
                             Привет, Русский!
                         </a>
                         
                     </div>
                 </li>
                 
-<li><a href="ru/privet-russian-summaries.html">Summaries</a></li>
-<li><a href="privet_russian_podcast.rss">RSS</a></li>
+<li><a href="../ru/privet-russian-summaries.html">Summaries</a></li>
+<li><a href="../privet_russian_podcast.rss">RSS</a></li>
 
 
                 <li><a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener">GitHub</a></li>
@@ -125,8 +125,8 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
-<a href="ru/privet-russian.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
-<a href="ru/privet-russian-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
+<a href="../ru/privet-russian.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
+<a href="../ru/privet-russian-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
 <a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
@@ -136,48 +136,48 @@
         <div class="nn-mobile-shows">
             <div class="nn-mobile-shows-title">All Shows</div>
             
-            <a href="tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
+            <a href="../tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/tesla-shorts-time.jpg" alt="" loading="lazy">
                 Tesla Shorts Time
             </a>
             
-            <a href="omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/omni-view.jpg" alt="" loading="lazy">
+            <a href="../omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/omni-view.jpg" alt="" loading="lazy">
                 Omni View
             </a>
             
-            <a href="fascinating_frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
+            <a href="../fascinating_frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/fascinating-frontiers.jpg" alt="" loading="lazy">
                 Fascinating Frontiers
             </a>
             
-            <a href="planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
+            <a href="../planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/planetterrian-daily.jpg" alt="" loading="lazy">
                 Planetterrian Daily
             </a>
             
-            <a href="env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
+            <a href="../env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/environmental-intelligence.jpg" alt="" loading="lazy">
                 Environmental Intelligence
             </a>
             
-            <a href="models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/models-agents.jpg" alt="" loading="lazy">
+            <a href="../models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/models-agents.jpg" alt="" loading="lazy">
                 Models & Agents
             </a>
             
-            <a href="models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
+            <a href="../models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/models-agents-beginners.jpg" alt="" loading="lazy">
                 Models & Agents for Beginners
             </a>
             
-            <a href="ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
+            <a href="../ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/finansy-prosto.jpg" alt="" loading="lazy">
                 Финансы Просто
             </a>
             
-            <a href="ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="assets/covers/privet-russian.jpg" alt="" loading="lazy">
+            <a href="../ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="../assets/covers/privet-russian.jpg" alt="" loading="lazy">
                 Привет, Русский!
             </a>
             
@@ -189,7 +189,7 @@
     <section class="show-hero">
         <div class="show-hero-bg"></div>
         <div class="show-hero-inner">
-            <img src="assets/covers/privet-russian.jpg" alt="Привет, Русский!" class="show-hero-art"
+            <img src="../assets/covers/privet-russian.jpg" alt="Привет, Русский!" class="show-hero-art"
                  onerror="this.style.display='none'">
             <div class="show-hero-info">
                 <h1>Привет, Русский!</h1>
@@ -204,9 +204,9 @@
                 
                 <div class="show-hero-actions">
                     <a href="#episodes" class="nn-btn nn-btn-primary">Listen Now</a>
-                    <a href="ru/privet-russian-summaries.html" class="nn-btn">View Summaries</a>
+                    <a href="../ru/privet-russian-summaries.html" class="nn-btn">View Summaries</a>
                     
-                    <a href="privet_russian_podcast.rss" class="nn-btn">RSS Feed</a>
+                    <a href="../privet_russian_podcast.rss" class="nn-btn">RSS Feed</a>
                     
                 </div>
                 
@@ -235,7 +235,7 @@
             </div>
             <div id="episodes-grid" class="episodes-grid"></div>
             <div style="text-align:center;margin-top:var(--sp-6);">
-                <a href="ru/privet-russian-summaries.html" class="nn-btn">View All Episodes</a>
+                <a href="../ru/privet-russian-summaries.html" class="nn-btn">View All Episodes</a>
             </div>
         </div>
     </section>
@@ -511,8 +511,8 @@
         <div class="container" style="max-width:700px;">
             <div class="glass-card" style="padding:var(--sp-6);border-color:color-mix(in srgb, var(--show-color) 30%, var(--nn-border));">
                 <div style="font-family:var(--font-ui);font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;color:var(--show-color);margin-bottom:var(--sp-3);">Recommended for you</div>
-                <a href="ru/finansy-prosto.html" style="display:flex;align-items:center;gap:var(--sp-4);text-decoration:none;">
-                    <img src="assets/covers/finansy-prosto.jpg" alt="Финансы Просто" style="width:72px;height:72px;border-radius:12px;object-fit:cover;flex-shrink:0;" loading="lazy">
+                <a href="../ru/finansy-prosto.html" style="display:flex;align-items:center;gap:var(--sp-4);text-decoration:none;">
+                    <img src="../assets/covers/finansy-prosto.jpg" alt="Финансы Просто" style="width:72px;height:72px;border-radius:12px;object-fit:cover;flex-shrink:0;" loading="lazy">
                     <div>
                         <div style="font-family:var(--font-heading);font-weight:600;color:var(--nn-white);font-size:1.05rem;margin-bottom:var(--sp-1);">Финансы Просто</div>
                         <div style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);line-height:1.5;">If you enjoy Привет, Русский!, you might also like Финансы Просто — a Russian-language finance podcast for women in Canada.</div>
@@ -533,8 +533,8 @@
             <div class="cross-network-grid">
                 
                 
-                <a href="tesla.html" class="cross-network-card">
-                    <img src="assets/covers/tesla-shorts-time.jpg" alt="Tesla Shorts Time" loading="lazy">
+                <a href="../tesla.html" class="cross-network-card">
+                    <img src="../assets/covers/tesla-shorts-time.jpg" alt="Tesla Shorts Time" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Tesla Shorts Time</div>
                         <div class="cross-network-card-tagline">Shorting Tesla? Time's Up.</div>
@@ -543,8 +543,8 @@
                 
                 
                 
-                <a href="omni-view.html" class="cross-network-card">
-                    <img src="assets/covers/omni-view.jpg" alt="Omni View" loading="lazy">
+                <a href="../omni-view.html" class="cross-network-card">
+                    <img src="../assets/covers/omni-view.jpg" alt="Omni View" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Omni View</div>
                         <div class="cross-network-card-tagline">See every side. Decide for yourself.</div>
@@ -553,8 +553,8 @@
                 
                 
                 
-                <a href="fascinating_frontiers.html" class="cross-network-card">
-                    <img src="assets/covers/fascinating-frontiers.jpg" alt="Fascinating Frontiers" loading="lazy">
+                <a href="../fascinating_frontiers.html" class="cross-network-card">
+                    <img src="../assets/covers/fascinating-frontiers.jpg" alt="Fascinating Frontiers" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Fascinating Frontiers</div>
                         <div class="cross-network-card-tagline">Journey to the stars with today's discoveries.</div>
@@ -563,8 +563,8 @@
                 
                 
                 
-                <a href="planetterrian.html" class="cross-network-card">
-                    <img src="assets/covers/planetterrian-daily.jpg" alt="Planetterrian Daily" loading="lazy">
+                <a href="../planetterrian.html" class="cross-network-card">
+                    <img src="../assets/covers/planetterrian-daily.jpg" alt="Planetterrian Daily" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Planetterrian Daily</div>
                         <div class="cross-network-card-tagline">Science, longevity, and the frontier of human health.</div>
@@ -573,8 +573,8 @@
                 
                 
                 
-                <a href="env-intel.html" class="cross-network-card">
-                    <img src="assets/covers/environmental-intelligence.jpg" alt="Environmental Intelligence" loading="lazy">
+                <a href="../env-intel.html" class="cross-network-card">
+                    <img src="../assets/covers/environmental-intelligence.jpg" alt="Environmental Intelligence" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Environmental Intelligence</div>
                         <div class="cross-network-card-tagline">Environmental regulatory and compliance briefing.</div>
@@ -583,8 +583,8 @@
                 
                 
                 
-                <a href="models-agents.html" class="cross-network-card">
-                    <img src="assets/covers/models-agents.jpg" alt="Models & Agents" loading="lazy">
+                <a href="../models-agents.html" class="cross-network-card">
+                    <img src="../assets/covers/models-agents.jpg" alt="Models & Agents" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Models & Agents</div>
                         <div class="cross-network-card-tagline">Daily AI models, agents, and practical developments.</div>
@@ -593,8 +593,8 @@
                 
                 
                 
-                <a href="models-agents-beginners.html" class="cross-network-card">
-                    <img src="assets/covers/models-agents-beginners.jpg" alt="Models & Agents for Beginners" loading="lazy">
+                <a href="../models-agents-beginners.html" class="cross-network-card">
+                    <img src="../assets/covers/models-agents-beginners.jpg" alt="Models & Agents for Beginners" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Models & Agents for Beginners</div>
                         <div class="cross-network-card-tagline">AI explained simply — for beginners and teens.</div>
@@ -603,8 +603,8 @@
                 
                 
                 
-                <a href="ru/finansy-prosto.html" class="cross-network-card">
-                    <img src="assets/covers/finansy-prosto.jpg" alt="Финансы Просто" loading="lazy">
+                <a href="../ru/finansy-prosto.html" class="cross-network-card">
+                    <img src="../assets/covers/finansy-prosto.jpg" alt="Финансы Просто" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">Финансы Просто</div>
                         <div class="cross-network-card-tagline">Finances Made Simple.</div>
@@ -630,47 +630,47 @@
                 <div class="nn-footer-col">
                     <h4>Shows</h4>
                     
-                    <a href="tesla.html">Tesla Shorts Time</a>
+                    <a href="../tesla.html">Tesla Shorts Time</a>
                     
-                    <a href="omni-view.html">Omni View</a>
+                    <a href="../omni-view.html">Omni View</a>
                     
-                    <a href="fascinating_frontiers.html">Fascinating Frontiers</a>
+                    <a href="../fascinating_frontiers.html">Fascinating Frontiers</a>
                     
-                    <a href="planetterrian.html">Planetterrian Daily</a>
+                    <a href="../planetterrian.html">Planetterrian Daily</a>
                     
-                    <a href="env-intel.html">Environmental Intelligence</a>
+                    <a href="../env-intel.html">Environmental Intelligence</a>
                     
-                    <a href="models-agents.html">Models & Agents</a>
+                    <a href="../models-agents.html">Models & Agents</a>
                     
-                    <a href="models-agents-beginners.html">Models & Agents for Beginners</a>
+                    <a href="../models-agents-beginners.html">Models & Agents for Beginners</a>
                     
-                    <a href="ru/finansy-prosto.html">Финансы Просто</a>
+                    <a href="../ru/finansy-prosto.html">Финансы Просто</a>
                     
-                    <a href="ru/privet-russian.html">Привет, Русский!</a>
+                    <a href="../ru/privet-russian.html">Привет, Русский!</a>
                     
                 </div>
                 <div class="nn-footer-col">
                     <h4>Listen</h4>
                     <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939" target="_blank" rel="noopener">Apple Podcasts</a>
-                    <a href="network.rss">Network RSS</a>
+                    <a href="../network.rss">Network RSS</a>
                     
-                    <a href="podcast.rss">Tesla Shorts Time RSS</a>
+                    <a href="../podcast.rss">Tesla Shorts Time RSS</a>
                     
-                    <a href="omni_view_podcast.rss">Omni View RSS</a>
+                    <a href="../omni_view_podcast.rss">Omni View RSS</a>
                     
-                    <a href="fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
+                    <a href="../fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
                     
-                    <a href="planetterrian_podcast.rss">Planetterrian Daily RSS</a>
+                    <a href="../planetterrian_podcast.rss">Planetterrian Daily RSS</a>
                     
-                    <a href="env_intel_podcast.rss">Environmental Intelligence RSS</a>
+                    <a href="../env_intel_podcast.rss">Environmental Intelligence RSS</a>
                     
-                    <a href="models_agents_podcast.rss">Models & Agents RSS</a>
+                    <a href="../models_agents_podcast.rss">Models & Agents RSS</a>
                     
-                    <a href="models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
+                    <a href="../models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
                     
-                    <a href="finansy_prosto_podcast.rss">Финансы Просто RSS</a>
+                    <a href="../finansy_prosto_podcast.rss">Финансы Просто RSS</a>
                     
-                    <a href="privet_russian_podcast.rss">Привет, Русский! RSS</a>
+                    <a href="../privet_russian_podcast.rss">Привет, Русский! RSS</a>
                     
                 </div>
                 <div class="nn-footer-col">
@@ -683,7 +683,7 @@
             </div>
             <div class="nn-footer-bottom">
                 <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
-                <a href="index.html">nerranetwork.com</a>
+                <a href="../index.html">nerranetwork.com</a>
             </div>
         </div>
     </footer>
@@ -691,9 +691,9 @@
     
     
     <script>
-        const JSON_URL = 'digests/privet_russian/summaries_privet_russian.json';
+        const JSON_URL = '../digests/privet_russian/summaries_privet_russian.json';
         const JSON_FORMAT = 'wrapped';
-        const RSS_URL = 'privet_russian_podcast.rss';
+        const RSS_URL = '../privet_russian_podcast.rss';
         const SHOW_NAME = "\u041f\u0440\u0438\u0432\u0435\u0442, \u0420\u0443\u0441\u0441\u043a\u0438\u0439!";
 
         // --- Helpers ---

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -25,7 +25,7 @@
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%237C5CFF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/></svg>">
 
     <!-- Shared CSS -->
-    <link rel="stylesheet" href="styles/main.css">
+    <link rel="stylesheet" href="{{ path_prefix }}styles/main.css">
 
     {% block head_extra %}{% endblock %}
 
@@ -37,7 +37,7 @@
     <!-- Navigation -->
     <nav class="nn-nav">
         <div class="nn-nav-inner">
-            <a href="index.html" class="nn-nav-logo">
+            <a href="{{ path_prefix }}index.html" class="nn-nav-logo">
                 <span class="gradient-text">Nerra</span> Network
             </a>
 
@@ -49,15 +49,15 @@
                     </button>
                     <div class="nn-nav-dropdown-menu">
                         {% for s in all_shows %}
-                        <a href="{{ s.show_page }}">
-                            <img src="{{ s.podcast_image }}" alt="" loading="lazy">
+                        <a href="{{ path_prefix }}{{ s.show_page }}">
+                            <img src="{{ path_prefix }}{{ s.podcast_image }}" alt="" loading="lazy">
                             {{ s.name }}
                         </a>
                         {% endfor %}
                     </div>
                 </li>
                 {% block nav_links %}
-                <li><a href="index.html">Home</a></li>
+                <li><a href="{{ path_prefix }}index.html">Home</a></li>
                 {% endblock %}
                 <li><a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener">GitHub</a></li>
             </ul>
@@ -69,14 +69,14 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         {% block mobile_nav_links %}
-        <a href="index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
+        <a href="{{ path_prefix }}index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
         {% endblock %}
         <a href="https://github.com/patricknovak/Tesla-shorts-time" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">GitHub</a>
         <div class="nn-mobile-shows">
             <div class="nn-mobile-shows-title">All Shows</div>
             {% for s in all_shows %}
-            <a href="{{ s.show_page }}" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
-                <img src="{{ s.podcast_image }}" alt="" loading="lazy">
+            <a href="{{ path_prefix }}{{ s.show_page }}" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open')">
+                <img src="{{ path_prefix }}{{ s.podcast_image }}" alt="" loading="lazy">
                 {{ s.name }}
             </a>
             {% endfor %}
@@ -96,15 +96,15 @@
                 <div class="nn-footer-col">
                     <h4>Shows</h4>
                     {% for s in all_shows %}
-                    <a href="{{ s.show_page }}">{{ s.name }}</a>
+                    <a href="{{ path_prefix }}{{ s.show_page }}">{{ s.name }}</a>
                     {% endfor %}
                 </div>
                 <div class="nn-footer-col">
                     <h4>Listen</h4>
                     <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939" target="_blank" rel="noopener">Apple Podcasts</a>
-                    <a href="network.rss">Network RSS</a>
+                    <a href="{{ path_prefix }}network.rss">Network RSS</a>
                     {% for s in all_shows %}
-                    <a href="{{ s.rss_file }}">{{ s.name }} RSS</a>
+                    <a href="{{ path_prefix }}{{ s.rss_file }}">{{ s.name }} RSS</a>
                     {% endfor %}
                 </div>
                 <div class="nn-footer-col">
@@ -117,7 +117,7 @@
             </div>
             <div class="nn-footer-bottom">
                 <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
-                <a href="index.html">nerranetwork.com</a>
+                <a href="{{ path_prefix }}index.html">nerranetwork.com</a>
             </div>
         </div>
     </footer>

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -19,7 +19,7 @@
   "name": {{ show_name | tojson }},
   "description": {{ meta_description | tojson }},
   "url": {{ canonical_url | tojson }},
-  "webFeed": "{{ rss_file }}"{% if podcast_image_url %},
+  "webFeed": "{{ path_prefix }}{{ rss_file }}"{% if podcast_image_url %},
   "image": "{{ podcast_image_url }}"{% endif %}{% if apple_podcasts_url %},
   "sameAs": [{{ apple_podcasts_url | tojson }}]{% endif %}
 }
@@ -27,14 +27,14 @@
 {% endblock %}
 
 {% block nav_links %}
-<li><a href="{{ summaries_page }}">Summaries</a></li>
-<li><a href="{{ rss_file }}">RSS</a></li>
+<li><a href="{{ path_prefix }}{{ summaries_page }}">Summaries</a></li>
+<li><a href="{{ path_prefix }}{{ rss_file }}">RSS</a></li>
 {% if x_account %}<li><a href="https://x.com/{{ x_account }}" target="_blank" rel="noopener">@{{ x_account }}</a></li>{% endif %}
 {% endblock %}
 
 {% block mobile_nav_links %}
-<a href="{{ show_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
-<a href="{{ summaries_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
+<a href="{{ path_prefix }}{{ show_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
+<a href="{{ path_prefix }}{{ summaries_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
 <a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
 <a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
 <a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
@@ -46,7 +46,7 @@
     <section class="show-hero">
         <div class="show-hero-bg"></div>
         <div class="show-hero-inner">
-            <img src="{{ podcast_image_url }}" alt="{{ show_name }}" class="show-hero-art"
+            <img src="{{ path_prefix }}{{ podcast_image_url }}" alt="{{ show_name }}" class="show-hero-art"
                  onerror="this.style.display='none'">
             <div class="show-hero-info">
                 <h1>{{ show_name }}</h1>
@@ -61,11 +61,11 @@
                 {% endif %}
                 <div class="show-hero-actions">
                     <a href="#episodes" class="nn-btn nn-btn-primary">Listen Now</a>
-                    <a href="{{ summaries_page }}" class="nn-btn">View Summaries</a>
+                    <a href="{{ path_prefix }}{{ summaries_page }}" class="nn-btn">View Summaries</a>
                     {% if apple_podcasts_url %}
                     <a href="{{ apple_podcasts_url }}" class="nn-btn" target="_blank" rel="noopener">Apple Podcasts</a>
                     {% endif %}
-                    <a href="{{ rss_file }}" class="nn-btn">RSS Feed</a>
+                    <a href="{{ path_prefix }}{{ rss_file }}" class="nn-btn">RSS Feed</a>
                     {% if x_account %}
                     <a href="https://x.com/{{ x_account }}" class="nn-btn" target="_blank" rel="noopener">@{{ x_account }}</a>
                     {% endif %}
@@ -102,7 +102,7 @@
             </div>
             <div id="episodes-grid" class="episodes-grid"></div>
             <div style="text-align:center;margin-top:var(--sp-6);">
-                <a href="{{ summaries_page }}" class="nn-btn">View All Episodes</a>
+                <a href="{{ path_prefix }}{{ summaries_page }}" class="nn-btn">View All Episodes</a>
             </div>
         </div>
     </section>
@@ -222,8 +222,8 @@
         <div class="container" style="max-width:700px;">
             <div class="glass-card" style="padding:var(--sp-6);border-color:color-mix(in srgb, var(--show-color) 30%, var(--nn-border));">
                 <div style="font-family:var(--font-ui);font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;color:var(--show-color);margin-bottom:var(--sp-3);">Recommended for you</div>
-                <a href="{{ related_show.show_page }}" style="display:flex;align-items:center;gap:var(--sp-4);text-decoration:none;">
-                    <img src="{{ related_show.podcast_image }}" alt="{{ related_show.name }}" style="width:72px;height:72px;border-radius:12px;object-fit:cover;flex-shrink:0;" loading="lazy">
+                <a href="{{ path_prefix }}{{ related_show.show_page }}" style="display:flex;align-items:center;gap:var(--sp-4);text-decoration:none;">
+                    <img src="{{ path_prefix }}{{ related_show.podcast_image }}" alt="{{ related_show.name }}" style="width:72px;height:72px;border-radius:12px;object-fit:cover;flex-shrink:0;" loading="lazy">
                     <div>
                         <div style="font-family:var(--font-heading);font-weight:600;color:var(--nn-white);font-size:1.05rem;margin-bottom:var(--sp-1);">{{ related_show.name }}</div>
                         <div style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);line-height:1.5;">{{ related_show.reason }}</div>
@@ -244,8 +244,8 @@
             <div class="cross-network-grid">
                 {% for s in all_shows %}
                 {% if s.slug != show_slug %}
-                <a href="{{ s.show_page }}" class="cross-network-card">
-                    <img src="{{ s.podcast_image }}" alt="{{ s.name }}" loading="lazy">
+                <a href="{{ path_prefix }}{{ s.show_page }}" class="cross-network-card">
+                    <img src="{{ path_prefix }}{{ s.podcast_image }}" alt="{{ s.name }}" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">{{ s.name }}</div>
                         <div class="cross-network-card-tagline">{{ s.tagline }}</div>
@@ -263,9 +263,9 @@
     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     {% endif %}
     <script>
-        const JSON_URL = '{{ json_path }}';
+        const JSON_URL = '{{ path_prefix }}{{ json_path }}';
         const JSON_FORMAT = '{{ json_format }}';
-        const RSS_URL = '{{ rss_file }}';
+        const RSS_URL = '{{ path_prefix }}{{ rss_file }}';
         const SHOW_NAME = {{ show_name | tojson }};
 
         // --- Helpers ---

--- a/templates/summaries_page.html.j2
+++ b/templates/summaries_page.html.j2
@@ -1,16 +1,16 @@
 {% extends "base.html.j2" %}
 
 {% block nav_links %}
-<li><a href="{{ show_page }}">{{ show_name }}</a></li>
-<li><a href="{{ summaries_page }}">Summaries</a></li>
-<li><a href="{{ rss_file }}">RSS</a></li>
+<li><a href="{{ path_prefix }}{{ show_page }}">{{ show_name }}</a></li>
+<li><a href="{{ path_prefix }}{{ summaries_page }}">Summaries</a></li>
+<li><a href="{{ path_prefix }}{{ rss_file }}">RSS</a></li>
 {% if x_account %}<li><a href="https://x.com/{{ x_account }}" target="_blank" rel="noopener">@{{ x_account }}</a></li>{% endif %}
 {% endblock %}
 
 {% block mobile_nav_links %}
-<a href="{{ show_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ show_name }}</a>
-<a href="{{ summaries_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
-<a href="{{ rss_file }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">RSS</a>
+<a href="{{ path_prefix }}{{ show_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ show_name }}</a>
+<a href="{{ path_prefix }}{{ summaries_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
+<a href="{{ path_prefix }}{{ rss_file }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">RSS</a>
 {% if x_account %}
 <a href="https://x.com/{{ x_account }}" target="_blank" rel="noopener" onclick="document.getElementById('mobileMenu').classList.remove('open')">@{{ x_account }}</a>
 {% endif %}
@@ -78,8 +78,8 @@
             <div class="cross-network-grid">
                 {% for s in all_shows %}
                 {% if s.slug != slug %}
-                <a href="{{ s.summaries_page }}" class="cross-network-card">
-                    <img src="{{ s.podcast_image }}" alt="{{ s.name }}" loading="lazy">
+                <a href="{{ path_prefix }}{{ s.summaries_page }}" class="cross-network-card">
+                    <img src="{{ path_prefix }}{{ s.podcast_image }}" alt="{{ s.name }}" loading="lazy">
                     <div class="cross-network-card-info">
                         <div class="cross-network-card-name">{{ s.name }}</div>
                         <div class="cross-network-card-tagline">{{ s.tagline }}</div>
@@ -94,7 +94,7 @@
 
 {% block scripts %}
     <script>
-        const JSON_URL = '{{ json_path }}';
+        const JSON_URL = '{{ path_prefix }}{{ json_path }}';
         const JSON_FORMAT = '{{ json_format | default("wrapped") }}';
         const SHOW_NAME = {{ show_name | tojson }};
 


### PR DESCRIPTION
Pages in ru/ used relative paths (styles/main.css, index.html, etc.) that resolved incorrectly from the subdirectory. Added path_prefix computation to generate_html.py that produces "../" for subdirectory pages and "" for root-level pages, then applied {{ path_prefix }} to all relative URLs in base.html.j2, show_page.html.j2, and summaries_page.html.j2.

https://claude.ai/code/session_01SoZV9YikuTpoBv1KFJJQzw