### PR TITLE
Add Wealthsimple referral, redesign landing page, fix json_format

### DIFF
--- a/generate_html.py
+++ b/generate_html.py
@@ -125,6 +125,7 @@ NETWORK_SHOWS = {
         "referral": {
             "url": "https://ts.la/patrick84289",
             "heading": "Buy a Tesla & Get Free Stuff",
+            "cta": "Order a Tesla with Free FSD Trial",
             "intro": "Use our referral link when ordering your new Tesla and you'll receive free benefits at no extra cost. It's Tesla's way of rewarding customers who spread the word.",
             "buyer_benefits": [
                 "3 months of Full Self-Driving (Supervised) free — a $297 value",
@@ -903,7 +904,7 @@ NETWORK_SHOWS = {
         "show_page": "modern-investing.html",
         "summaries_page": "modern-investing-summaries.html",
         "json_path": "digests/modern_investing/summaries_modern_investing.json",
-        "json_format": "wrapped",
+        "json_format": "array",
         "rss_file": "modern_investing_podcast.rss",
         "podcast_image": "assets/covers/modern-investing.jpg",
         "x_account": None,
@@ -970,6 +971,25 @@ NETWORK_SHOWS = {
             {"name": "Seeking Alpha", "url": "https://seekingalpha.com", "desc": "Deep stock analysis, quant ratings, earnings transcripts, and dividend data", "badge": "Free tier"},
             {"name": "Portfolio Visualizer", "url": "https://www.portfoliovisualizer.com", "desc": "Backtest portfolios, optimize asset allocation, and analyze historical factor returns", "badge": "Free tier"},
         ],
+        "referral": {
+            "url": "https://wealthsimple.com/invite/U5JROW",
+            "heading": "Start Investing with Wealthsimple",
+            "cta": "Get Started with Wealthsimple",
+            "intro": "New to investing? Wealthsimple is Canada's most popular investing platform with commission-free trading, automatic contributions, and tax-advantaged accounts. Sign up with our referral link and start building your portfolio today.",
+            "buyer_benefits": [
+                "Commission-free trading on stocks, ETFs, and crypto",
+                "Tax-advantaged accounts — TFSA, RRSP, and FHSA supported",
+                "Fractional shares — start investing with as little as $1",
+                "Automatic contributions and smart savings features",
+            ],
+            "how_to_steps": [
+                "Click our referral link below to visit Wealthsimple",
+                "Create your free account in minutes",
+                "Open a TFSA, RRSP, or personal investing account",
+                "Fund your account and start investing commission-free",
+            ],
+            "fine_print": "Wealthsimple referral benefits are subject to Wealthsimple's current terms and may change. This podcast is not financial advice — always do your own research before investing.",
+        },
         "faq": [
             {"q": "Are the trades real?", "a": "No — all Practice Investment picks are simulated. We track them as if we invested $1,000 per trade using real market open/close prices, but no actual money is involved. This is purely educational. The podcast is not financial advice. Always do your own research before investing real money."},
             {"q": "What is a TFSA?", "a": "A Tax-Free Savings Account is a Canadian registered account where all investment gains — dividends, interest, and capital gains — are completely tax-free. In 2026, the annual contribution limit is $7,000, with cumulative room of $102,000 if you've been eligible since 2009. It's the most powerful wealth-building tool for most Canadians because you never pay tax on withdrawals."},
@@ -1161,8 +1181,8 @@ def generate_network_page(*, dry_run=False):
 
     context = {
         "path_prefix": "",
-        "page_title": "Nerra Network | 9 Daily Shows",
-        "meta_description": "Nerra Network — Nine daily podcasts keeping you informed. Tesla, world news, space, science, environment, AI, Russian finance, and language learning. Independent, daily, free.",
+        "page_title": "Nerra Network | 10 Daily Shows",
+        "meta_description": "Nerra Network — Ten daily podcasts keeping you informed. Tesla, world news, space, science, environment, AI, modern investing, Russian finance, and language learning. Independent, daily, free.",
         "meta_keywords": "podcast network, daily podcasts, Nerra Network, Tesla, space, science, AI, environment",
         "theme_color": "#7C5CFF",
         "og_image": None,  # No single show image represents the network

--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Nerra Network — Nine daily podcasts keeping you informed. Tesla, world news, space, science, environment, AI, Russian finance, and language learning. Independent, daily, free.">
+    <meta name="description" content="Nerra Network — Ten daily podcasts keeping you informed. Tesla, world news, space, science, environment, AI, modern investing, Russian finance, and language learning. Independent, daily, free.">
     <meta name="keywords" content="podcast network, daily podcasts, Nerra Network, Tesla, space, science, AI, environment">
-    <title>Nerra Network | 9 Daily Shows</title>
+    <title>Nerra Network | 10 Daily Shows</title>
     <meta name="theme-color" content="#7C5CFF">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="Nerra Network | 9 Daily Shows">
-    <meta property="og:description" content="Nerra Network — Nine daily podcasts keeping you informed. Tesla, world news, space, science, environment, AI, Russian finance, and language learning. Independent, daily, free.">
+    <meta property="og:title" content="Nerra Network | 10 Daily Shows">
+    <meta property="og:description" content="Nerra Network — Ten daily podcasts keeping you informed. Tesla, world news, space, science, environment, AI, modern investing, Russian finance, and language learning. Independent, daily, free.">
     <meta property="og:type" content="website">
     
 
@@ -175,37 +175,92 @@
     <!-- Hero -->
     <section class="network-hero">
         <div class="network-hero-bg">
-            <div class="network-hero-nodes">
-                <svg viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
-                    <!-- Network graph lines -->
-                    <line x1="200" y1="200" x2="600" y2="400" stroke="#7C5CFF" stroke-width="1" opacity="0.3"/>
-                    <line x1="1000" y1="200" x2="600" y2="400" stroke="#00D4FF" stroke-width="1" opacity="0.3"/>
-                    <line x1="150" y1="500" x2="600" y2="400" stroke="#7C5CFF" stroke-width="1" opacity="0.2"/>
-                    <line x1="1050" y1="550" x2="600" y2="400" stroke="#00D4FF" stroke-width="1" opacity="0.2"/>
-                    <line x1="400" y1="700" x2="600" y2="400" stroke="#7C5CFF" stroke-width="1" opacity="0.25"/>
-                    <line x1="800" y1="700" x2="600" y2="400" stroke="#00D4FF" stroke-width="1" opacity="0.25"/>
-                    <line x1="200" y1="200" x2="1000" y2="200" stroke="#7C5CFF" stroke-width="0.5" opacity="0.15"/>
-                    <line x1="150" y1="500" x2="1050" y2="550" stroke="#00D4FF" stroke-width="0.5" opacity="0.15"/>
-                    <line x1="200" y1="200" x2="150" y2="500" stroke="#7C5CFF" stroke-width="0.5" opacity="0.15"/>
-                    <line x1="1000" y1="200" x2="1050" y2="550" stroke="#00D4FF" stroke-width="0.5" opacity="0.15"/>
-                    <line x1="400" y1="700" x2="800" y2="700" stroke="#7C5CFF" stroke-width="0.5" opacity="0.12"/>
-                    <!-- Nodes -->
-                    <circle cx="600" cy="400" r="6" fill="#7C5CFF" opacity="0.6"/>
-                    <circle cx="200" cy="200" r="4" fill="#00D4FF" opacity="0.4"/>
-                    <circle cx="1000" cy="200" r="4" fill="#00D4FF" opacity="0.4"/>
-                    <circle cx="150" cy="500" r="4" fill="#00D4FF" opacity="0.4"/>
-                    <circle cx="1050" cy="550" r="4" fill="#00D4FF" opacity="0.4"/>
-                    <circle cx="400" cy="700" r="3" fill="#7C5CFF" opacity="0.3"/>
-                    <circle cx="800" cy="700" r="3" fill="#7C5CFF" opacity="0.3"/>
-                </svg>
-            </div>
+            <!-- Animated gradient orbs -->
+            <div class="hero-orb hero-orb-1"></div>
+            <div class="hero-orb hero-orb-2"></div>
+            <div class="hero-orb hero-orb-3"></div>
+            <!-- Grid overlay -->
+            <div class="hero-grid"></div>
         </div>
         <div class="network-hero-content">
+            <div class="hero-badge">Independent Podcast Network</div>
             <h1><span class="gradient-text">Nerra</span> Network</h1>
             <p class="network-hero-tagline">Feed your curiosity. Not your anxiety.</p>
-            <div style="display:flex;gap:var(--sp-3);justify-content:center;flex-wrap:wrap;">
-                <a href="#shows" class="nn-btn nn-btn-primary" style="--show-color:#7C5CFF;">Explore Shows</a>
-                <a href="#subscribe" class="nn-btn">Subscribe</a>
+            <p class="hero-subtitle">10 ad-free shows covering Tesla, world news, space, science, AI, investing, and more. Produced daily in Vancouver.</p>
+            <div class="hero-cta-row">
+                <a href="#shows" class="nn-btn nn-btn-primary nn-btn-lg" style="--show-color:#7C5CFF;">Explore Shows</a>
+                <a href="#subscribe" class="nn-btn nn-btn-lg">Subscribe Free</a>
+            </div>
+        </div>
+        <!-- Floating show art -->
+        <div class="hero-show-orbit">
+            
+            <div class="hero-orbit-item" style="--orbit-i:0;--orbit-total:10;">
+                <img src="assets/covers/tesla-shorts-time.jpg" alt="Tesla Shorts Time" loading="eager">
+            </div>
+            
+            <div class="hero-orbit-item" style="--orbit-i:1;--orbit-total:10;">
+                <img src="assets/covers/omni-view.jpg" alt="Omni View" loading="eager">
+            </div>
+            
+            <div class="hero-orbit-item" style="--orbit-i:2;--orbit-total:10;">
+                <img src="assets/covers/fascinating-frontiers.jpg" alt="Fascinating Frontiers" loading="eager">
+            </div>
+            
+            <div class="hero-orbit-item" style="--orbit-i:3;--orbit-total:10;">
+                <img src="assets/covers/planetterrian-daily.jpg" alt="Planetterrian Daily" loading="eager">
+            </div>
+            
+            <div class="hero-orbit-item" style="--orbit-i:4;--orbit-total:10;">
+                <img src="assets/covers/environmental-intelligence.jpg" alt="Environmental Intelligence" loading="eager">
+            </div>
+            
+            <div class="hero-orbit-item" style="--orbit-i:5;--orbit-total:10;">
+                <img src="assets/covers/models-agents.jpg" alt="Models & Agents" loading="eager">
+            </div>
+            
+            <div class="hero-orbit-item" style="--orbit-i:6;--orbit-total:10;">
+                <img src="assets/covers/models-agents-beginners.jpg" alt="Models & Agents for Beginners" loading="eager">
+            </div>
+            
+            <div class="hero-orbit-item" style="--orbit-i:7;--orbit-total:10;">
+                <img src="assets/covers/finansy-prosto.jpg" alt="Финансы Просто" loading="eager">
+            </div>
+            
+            <div class="hero-orbit-item" style="--orbit-i:8;--orbit-total:10;">
+                <img src="assets/covers/privet-russian.jpg" alt="Привет, Русский!" loading="eager">
+            </div>
+            
+            <div class="hero-orbit-item" style="--orbit-i:9;--orbit-total:10;">
+                <img src="assets/covers/modern-investing.jpg" alt="Modern Investing Techniques" loading="eager">
+            </div>
+            
+        </div>
+    </section>
+
+    <!-- Stats Bar -->
+    <section class="stats-bar">
+        <div class="container">
+            <div class="stats-row">
+                <div class="stat-item">
+                    <div class="stat-number">10</div>
+                    <div class="stat-label">Shows</div>
+                </div>
+                <div class="stat-divider"></div>
+                <div class="stat-item">
+                    <div class="stat-number">9</div>
+                    <div class="stat-label">Topics</div>
+                </div>
+                <div class="stat-divider"></div>
+                <div class="stat-item">
+                    <div class="stat-number">2</div>
+                    <div class="stat-label">Languages</div>
+                </div>
+                <div class="stat-divider"></div>
+                <div class="stat-item">
+                    <div class="stat-number">0</div>
+                    <div class="stat-label">Ads</div>
+                </div>
             </div>
         </div>
     </section>
@@ -214,8 +269,9 @@
     <section id="shows" class="nn-section">
         <div class="container">
             <div class="nn-section-header">
-                <h2>Our Shows</h2>
-                <p>Ad-free daily and weekly shows on the ideas shaping tomorrow.</p>
+                <div class="section-label">Our Shows</div>
+                <h2>Daily intelligence on the topics that matter</h2>
+                <p>Every show is ad-free, independently produced, and published daily. Pick one or subscribe to all.</p>
             </div>
             <div class="show-showcase">
                 
@@ -397,12 +453,12 @@
     <section id="latest" class="nn-section" style="background:var(--nn-bg-alt);">
         <div class="container">
             <div class="nn-section-header">
+                <div class="section-label">Fresh Episodes</div>
                 <h2>Latest Across the Network</h2>
-                <p>The most recent episodes from all seven shows.</p>
+                <p>The most recent episodes from all shows.</p>
             </div>
         </div>
         <div class="latest-scroll-row" id="latestEpisodes">
-            <!-- Populated by JS from network.rss -->
             <div class="latest-scroll-card glass-card nn-skeleton" style="height:180px;"></div>
             <div class="latest-scroll-card glass-card nn-skeleton" style="height:180px;"></div>
             <div class="latest-scroll-card glass-card nn-skeleton" style="height:180px;"></div>
@@ -412,14 +468,57 @@
         </div>
     </section>
 
-    <!-- About the Network -->
+    <!-- Why Nerra -->
     <section class="nn-section">
         <div class="container">
             <div class="nn-section-header">
+                <div class="section-label">Why Nerra</div>
+                <h2>Built different</h2>
+            </div>
+            <div class="features-grid">
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#9889;</div>
+                    <h3>AI-Enhanced Research</h3>
+                    <p>Every episode is backed by real-time news analysis across dozens of sources, curated and verified by a human host.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#127911;</div>
+                    <h3>Zero Ads. Zero Sponsors.</h3>
+                    <p>No ad reads, no sponsor segments, no paywalls. Just pure content, every single day. Free forever.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#127758;</div>
+                    <h3>Multi-Perspective Coverage</h3>
+                    <p>We pull from diverse sources to present balanced, nuanced takes — not echo chambers or clickbait.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#128197;</div>
+                    <h3>Daily Consistency</h3>
+                    <p>New episodes every day (or weekday), rain or shine. Build a daily learning habit you can rely on.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#127463;&#127464;</div>
+                    <h3>Made in Canada</h3>
+                    <p>Independently produced in Vancouver by Patrick. No corporate backing, no editorial interference.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#128266;</div>
+                    <h3>Multilingual</h3>
+                    <p>Shows in English and Russian, with more languages planned. Knowledge shouldn't have a language barrier.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- About the Network -->
+    <section class="nn-section" style="background:var(--nn-bg-alt);">
+        <div class="container">
+            <div class="nn-section-header">
+                <div class="section-label">About</div>
                 <h2>About Nerra Network</h2>
             </div>
             <div class="about-section-text">
-                <p><strong>Ad-free daily and weekly shows on the ideas shaping tomorrow.</strong></p>
+                <p><strong>10 ad-free shows on the ideas shaping tomorrow.</strong></p>
                 <p>Nerra Network is an independent podcast network covering Tesla, balanced world news, space and astronomy, science and longevity, environmental intelligence, AI, financial literacy, language learning, and modern investing. All produced in Vancouver, Canada by Patrick.</p>
                 <p>Our mission: stimulating conversation, supporting positive developments that benefit all, and providing unbiased coverage with varying perspectives.</p>
             </div>
@@ -427,9 +526,10 @@
     </section>
 
     <!-- Subscribe -->
-    <section id="subscribe" class="nn-section" style="background:var(--nn-bg-alt);border-top:1px solid var(--nn-border);">
+    <section id="subscribe" class="nn-section" style="border-top:1px solid var(--nn-border);">
         <div class="container">
             <div class="nn-section-header">
+                <div class="section-label">Listen Anywhere</div>
                 <h2>Subscribe Everywhere</h2>
                 <p>All shows are available via RSS. Pick your favorite podcast app and never miss an episode.</p>
             </div>

--- a/modern-investing-summaries.html
+++ b/modern-investing-summaries.html
@@ -421,7 +421,7 @@
     
     <script>
         const JSON_URL = 'digests/modern_investing/summaries_modern_investing.json';
-        const JSON_FORMAT = 'wrapped';
+        const JSON_FORMAT = 'array';
         const SHOW_NAME = "Modern Investing Techniques";
 
         document.addEventListener('DOMContentLoaded', function() {

--- a/modern-investing.html
+++ b/modern-investing.html
@@ -451,6 +451,58 @@
 
     <!-- Referral -->
     
+    <section id="referral" class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:800px;">
+            <div class="referral-card glass-card" style="padding:var(--sp-8);border-color:color-mix(in srgb, var(--show-color) 35%, var(--nn-border));">
+                <div style="text-align:center;margin-bottom:var(--sp-6);">
+                    <div style="font-size:2.2rem;margin-bottom:var(--sp-2);">&#9889;</div>
+                    <h2 style="font-family:var(--font-heading);font-size:1.5rem;font-weight:700;color:var(--nn-white);margin-bottom:var(--sp-3);">Start Investing with Wealthsimple</h2>
+                    <p style="color:var(--nn-text-muted);font-size:0.95rem;line-height:1.7;max-width:600px;margin:0 auto;">New to investing? Wealthsimple is Canada's most popular investing platform with commission-free trading, automatic contributions, and tax-advantaged accounts. Sign up with our referral link and start building your portfolio today.</p>
+                </div>
+
+                <div style="display:grid;grid-template-columns:repeat(auto-fit, minmax(280px, 1fr));gap:var(--sp-6);margin-bottom:var(--sp-6);">
+                    <div>
+                        <h3 style="font-family:var(--font-heading);font-size:1rem;font-weight:600;color:var(--show-color);margin-bottom:var(--sp-3);">Vehicle Benefits</h3>
+                        <ul style="list-style:none;padding:0;margin:0;">
+                            
+                            <li style="font-family:var(--font-ui);font-size:0.9rem;color:var(--nn-text-muted);line-height:1.6;padding:var(--sp-1) 0;padding-left:1.4em;position:relative;"><span style="position:absolute;left:0;color:var(--show-color);">&#10003;</span>Commission-free trading on stocks, ETFs, and crypto</li>
+                            
+                            <li style="font-family:var(--font-ui);font-size:0.9rem;color:var(--nn-text-muted);line-height:1.6;padding:var(--sp-1) 0;padding-left:1.4em;position:relative;"><span style="position:absolute;left:0;color:var(--show-color);">&#10003;</span>Tax-advantaged accounts — TFSA, RRSP, and FHSA supported</li>
+                            
+                            <li style="font-family:var(--font-ui);font-size:0.9rem;color:var(--nn-text-muted);line-height:1.6;padding:var(--sp-1) 0;padding-left:1.4em;position:relative;"><span style="position:absolute;left:0;color:var(--show-color);">&#10003;</span>Fractional shares — start investing with as little as $1</li>
+                            
+                            <li style="font-family:var(--font-ui);font-size:0.9rem;color:var(--nn-text-muted);line-height:1.6;padding:var(--sp-1) 0;padding-left:1.4em;position:relative;"><span style="position:absolute;left:0;color:var(--show-color);">&#10003;</span>Automatic contributions and smart savings features</li>
+                            
+                        </ul>
+                    </div>
+                    
+                </div>
+
+                
+                <div style="background:var(--nn-surface);border-radius:12px;padding:var(--sp-5);margin-bottom:var(--sp-6);">
+                    <h3 style="font-family:var(--font-heading);font-size:1rem;font-weight:600;color:var(--nn-white);margin-bottom:var(--sp-3);">How to Use the Referral Link</h3>
+                    <ol style="padding-left:1.4em;margin:0;">
+                        
+                        <li style="font-family:var(--font-ui);font-size:0.9rem;color:var(--nn-text-muted);line-height:1.6;padding:var(--sp-1) 0;">Click our referral link below to visit Wealthsimple</li>
+                        
+                        <li style="font-family:var(--font-ui);font-size:0.9rem;color:var(--nn-text-muted);line-height:1.6;padding:var(--sp-1) 0;">Create your free account in minutes</li>
+                        
+                        <li style="font-family:var(--font-ui);font-size:0.9rem;color:var(--nn-text-muted);line-height:1.6;padding:var(--sp-1) 0;">Open a TFSA, RRSP, or personal investing account</li>
+                        
+                        <li style="font-family:var(--font-ui);font-size:0.9rem;color:var(--nn-text-muted);line-height:1.6;padding:var(--sp-1) 0;">Fund your account and start investing commission-free</li>
+                        
+                    </ol>
+                </div>
+                
+
+                <div style="text-align:center;">
+                    <a href="https://wealthsimple.com/invite/U5JROW" class="nn-btn nn-btn-primary" target="_blank" rel="noopener" style="font-size:1rem;padding:var(--sp-3) var(--sp-8);">Get Started with Wealthsimple</a>
+                    <div style="margin-top:var(--sp-3);font-family:var(--font-ui);font-size:0.78rem;color:var(--nn-text-muted);max-width:500px;margin-left:auto;margin-right:auto;">Wealthsimple referral benefits are subject to Wealthsimple's current terms and may change. This podcast is not financial advice — always do your own research before investing.</div>
+                </div>
+            </div>
+        </div>
+    </section>
+    
 
     <!-- Key Concepts / FAQ -->
     
@@ -692,7 +744,7 @@
     
     <script>
         const JSON_URL = 'digests/modern_investing/summaries_modern_investing.json';
-        const JSON_FORMAT = 'wrapped';
+        const JSON_FORMAT = 'array';
         const RSS_URL = 'modern_investing_podcast.rss';
         const SHOW_NAME = "Modern Investing Techniques";
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -774,11 +774,11 @@ button { font-family: var(--font-ui); cursor: pointer; }
 
 /* ---------- Network Hero ---------- */
 .network-hero {
-  min-height: 80vh;
+  min-height: 100vh;
   display: flex; flex-direction: column;
   justify-content: center; align-items: center;
   text-align: center;
-  padding: calc(var(--nav-height) + var(--sp-16)) var(--sp-6) var(--sp-16);
+  padding: calc(var(--nav-height) + var(--sp-20)) var(--sp-6) var(--sp-16);
   position: relative;
   overflow: hidden;
 }
@@ -787,46 +787,229 @@ button { font-family: var(--font-ui); cursor: pointer; }
   background: var(--nn-bg);
   z-index: 0;
 }
-.network-hero-bg::before {
-  content: '';
-  position: absolute; inset: 0;
-  background:
-    radial-gradient(ellipse 50% 40% at 30% 30%, rgba(124, 92, 255, 0.12), transparent),
-    radial-gradient(ellipse 50% 40% at 70% 70%, rgba(0, 212, 255, 0.08), transparent);
-  animation: heroShift 12s ease-in-out infinite alternate;
-}
-@keyframes heroShift {
-  0%   { opacity: 0.7; transform: scale(1); }
-  50%  { opacity: 1;   transform: scale(1.05); }
-  100% { opacity: 0.8; transform: scale(0.98); }
-}
-/* SVG network lines background */
-.network-hero-nodes {
-  position: absolute; inset: 0;
-  overflow: hidden;
-  opacity: 0.15;
-}
-.network-hero-nodes svg {
+
+/* Animated gradient orbs */
+.hero-orb {
   position: absolute;
-  width: 100%; height: 100%;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.4;
+  will-change: transform;
 }
+.hero-orb-1 {
+  width: 600px; height: 600px;
+  background: radial-gradient(circle, rgba(124, 92, 255, 0.35), transparent 70%);
+  top: -10%; left: -5%;
+  animation: orbFloat1 16s ease-in-out infinite;
+}
+.hero-orb-2 {
+  width: 500px; height: 500px;
+  background: radial-gradient(circle, rgba(0, 212, 255, 0.25), transparent 70%);
+  bottom: -5%; right: -5%;
+  animation: orbFloat2 20s ease-in-out infinite;
+}
+.hero-orb-3 {
+  width: 400px; height: 400px;
+  background: radial-gradient(circle, rgba(124, 92, 255, 0.2), transparent 70%);
+  top: 40%; left: 50%;
+  transform: translateX(-50%);
+  animation: orbFloat3 14s ease-in-out infinite;
+}
+@keyframes orbFloat1 {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(80px, 40px) scale(1.1); }
+  66% { transform: translate(-40px, 80px) scale(0.95); }
+}
+@keyframes orbFloat2 {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(-60px, -40px) scale(1.05); }
+  66% { transform: translate(40px, -60px) scale(0.9); }
+}
+@keyframes orbFloat3 {
+  0%, 100% { transform: translateX(-50%) scale(1); opacity: 0.3; }
+  50% { transform: translateX(-50%) scale(1.2); opacity: 0.5; }
+}
+
+/* Subtle dot grid overlay */
+.hero-grid {
+  position: absolute; inset: 0;
+  background-image: radial-gradient(rgba(255,255,255,0.04) 1px, transparent 1px);
+  background-size: 40px 40px;
+  z-index: 1;
+}
+
 .network-hero-content {
-  position: relative; z-index: 1;
-  max-width: 720px;
+  position: relative; z-index: 2;
+  max-width: 780px;
 }
+
+/* Hero badge */
+.hero-badge {
+  display: inline-block;
+  font-family: var(--font-ui);
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--nn-cyan);
+  background: rgba(0, 212, 255, 0.08);
+  border: 1px solid rgba(0, 212, 255, 0.2);
+  padding: var(--sp-2) var(--sp-4);
+  border-radius: 100px;
+  margin-bottom: var(--sp-6);
+}
+
 .network-hero h1 {
   font-family: var(--font-heading);
-  font-size: clamp(3rem, 6vw, 5rem);
+  font-size: clamp(3.5rem, 7vw, 6rem);
   font-weight: 700;
   margin-bottom: var(--sp-4);
-  line-height: 1.1;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
 }
 .network-hero-tagline {
+  font-family: var(--font-heading);
+  font-size: clamp(1.2rem, 2.5vw, 1.6rem);
+  font-weight: 600;
+  color: var(--nn-text);
+  margin-bottom: var(--sp-4);
+}
+.hero-subtitle {
   font-family: var(--font-ui);
-  font-size: clamp(1.1rem, 2vw, 1.4rem);
-  font-weight: 500;
+  font-size: clamp(0.95rem, 1.5vw, 1.1rem);
+  font-weight: 400;
   color: var(--nn-text-muted);
-  margin-bottom: var(--sp-8);
+  max-width: 560px;
+  margin: 0 auto var(--sp-8);
+  line-height: 1.6;
+}
+.hero-cta-row {
+  display: flex; gap: var(--sp-4);
+  justify-content: center; flex-wrap: wrap;
+}
+.nn-btn-lg {
+  padding: var(--sp-4) var(--sp-8);
+  font-size: 1rem;
+  border-radius: 12px;
+}
+
+/* Floating show art orbit */
+.hero-show-orbit {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+.hero-orbit-item {
+  position: absolute;
+  --angle: calc(var(--orbit-i) * (360deg / var(--orbit-total)));
+  width: 64px; height: 64px;
+  border-radius: 14px;
+  overflow: hidden;
+  opacity: 0.15;
+  animation: orbitDrift 30s ease-in-out infinite;
+  animation-delay: calc(var(--orbit-i) * -3s);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+}
+.hero-orbit-item:nth-child(1) { top: 12%; left: 8%; }
+.hero-orbit-item:nth-child(2) { top: 8%; right: 12%; }
+.hero-orbit-item:nth-child(3) { top: 35%; left: 3%; }
+.hero-orbit-item:nth-child(4) { top: 30%; right: 5%; }
+.hero-orbit-item:nth-child(5) { bottom: 25%; left: 6%; }
+.hero-orbit-item:nth-child(6) { bottom: 20%; right: 8%; }
+.hero-orbit-item:nth-child(7) { bottom: 8%; left: 15%; }
+.hero-orbit-item:nth-child(8) { bottom: 12%; right: 18%; }
+.hero-orbit-item:nth-child(9) { top: 55%; left: 10%; }
+.hero-orbit-item:nth-child(10) { top: 60%; right: 6%; }
+.hero-orbit-item img {
+  width: 100%; height: 100%; object-fit: cover;
+}
+@keyframes orbitDrift {
+  0%, 100% { transform: translateY(0) rotate(0deg); opacity: 0.15; }
+  25% { transform: translateY(-12px) rotate(2deg); opacity: 0.25; }
+  50% { transform: translateY(0) rotate(0deg); opacity: 0.15; }
+  75% { transform: translateY(8px) rotate(-2deg); opacity: 0.2; }
+}
+
+/* ---------- Stats Bar ---------- */
+.stats-bar {
+  background: var(--nn-bg-alt);
+  border-top: 1px solid var(--nn-border);
+  border-bottom: 1px solid var(--nn-border);
+  padding: var(--sp-8) 0;
+}
+.stats-row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--sp-10);
+  flex-wrap: wrap;
+}
+.stat-item { text-align: center; }
+.stat-number {
+  font-family: var(--font-heading);
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  background: var(--nn-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  line-height: 1.2;
+}
+.stat-label {
+  font-family: var(--font-ui);
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--nn-text-muted);
+  margin-top: var(--sp-1);
+}
+.stat-divider {
+  width: 1px;
+  height: 40px;
+  background: var(--nn-border);
+}
+
+/* ---------- Section Label ---------- */
+.section-label {
+  display: inline-block;
+  font-family: var(--font-ui);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--nn-purple);
+  margin-bottom: var(--sp-3);
+}
+
+/* ---------- Features Grid ---------- */
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--sp-6);
+}
+.feature-card {
+  padding: var(--sp-8);
+  text-align: center;
+}
+.feature-icon {
+  font-size: 2rem;
+  margin-bottom: var(--sp-4);
+  line-height: 1;
+}
+.feature-card h3 {
+  font-family: var(--font-heading);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--nn-white);
+  margin-bottom: var(--sp-3);
+}
+.feature-card p {
+  font-family: var(--font-ui);
+  font-size: 0.9rem;
+  color: var(--nn-text-muted);
+  line-height: 1.6;
 }
 
 /* Show Showcase 2x3 grid */
@@ -913,6 +1096,16 @@ button { font-family: var(--font-ui); cursor: pointer; }
     gap: var(--sp-4);
   }
 
+  .features-grid {
+    grid-template-columns: 1fr;
+    gap: var(--sp-4);
+  }
+
+  .hero-show-orbit { display: none; }
+
+  .stats-row { gap: var(--sp-6); }
+  .stat-divider { display: none; }
+
   .nn-footer-grid {
     grid-template-columns: 1fr;
     gap: var(--sp-6);
@@ -949,6 +1142,12 @@ button { font-family: var(--font-ui); cursor: pointer; }
   .show-showcase {
     grid-template-columns: repeat(2, 1fr);
   }
+
+  .features-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .hero-show-orbit { display: none; }
 
   .nn-footer-grid {
     grid-template-columns: repeat(2, 1fr);

--- a/templates/network_page.html.j2
+++ b/templates/network_page.html.j2
@@ -14,37 +14,56 @@
     <!-- Hero -->
     <section class="network-hero">
         <div class="network-hero-bg">
-            <div class="network-hero-nodes">
-                <svg viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
-                    <!-- Network graph lines -->
-                    <line x1="200" y1="200" x2="600" y2="400" stroke="#7C5CFF" stroke-width="1" opacity="0.3"/>
-                    <line x1="1000" y1="200" x2="600" y2="400" stroke="#00D4FF" stroke-width="1" opacity="0.3"/>
-                    <line x1="150" y1="500" x2="600" y2="400" stroke="#7C5CFF" stroke-width="1" opacity="0.2"/>
-                    <line x1="1050" y1="550" x2="600" y2="400" stroke="#00D4FF" stroke-width="1" opacity="0.2"/>
-                    <line x1="400" y1="700" x2="600" y2="400" stroke="#7C5CFF" stroke-width="1" opacity="0.25"/>
-                    <line x1="800" y1="700" x2="600" y2="400" stroke="#00D4FF" stroke-width="1" opacity="0.25"/>
-                    <line x1="200" y1="200" x2="1000" y2="200" stroke="#7C5CFF" stroke-width="0.5" opacity="0.15"/>
-                    <line x1="150" y1="500" x2="1050" y2="550" stroke="#00D4FF" stroke-width="0.5" opacity="0.15"/>
-                    <line x1="200" y1="200" x2="150" y2="500" stroke="#7C5CFF" stroke-width="0.5" opacity="0.15"/>
-                    <line x1="1000" y1="200" x2="1050" y2="550" stroke="#00D4FF" stroke-width="0.5" opacity="0.15"/>
-                    <line x1="400" y1="700" x2="800" y2="700" stroke="#7C5CFF" stroke-width="0.5" opacity="0.12"/>
-                    <!-- Nodes -->
-                    <circle cx="600" cy="400" r="6" fill="#7C5CFF" opacity="0.6"/>
-                    <circle cx="200" cy="200" r="4" fill="#00D4FF" opacity="0.4"/>
-                    <circle cx="1000" cy="200" r="4" fill="#00D4FF" opacity="0.4"/>
-                    <circle cx="150" cy="500" r="4" fill="#00D4FF" opacity="0.4"/>
-                    <circle cx="1050" cy="550" r="4" fill="#00D4FF" opacity="0.4"/>
-                    <circle cx="400" cy="700" r="3" fill="#7C5CFF" opacity="0.3"/>
-                    <circle cx="800" cy="700" r="3" fill="#7C5CFF" opacity="0.3"/>
-                </svg>
-            </div>
+            <!-- Animated gradient orbs -->
+            <div class="hero-orb hero-orb-1"></div>
+            <div class="hero-orb hero-orb-2"></div>
+            <div class="hero-orb hero-orb-3"></div>
+            <!-- Grid overlay -->
+            <div class="hero-grid"></div>
         </div>
         <div class="network-hero-content">
+            <div class="hero-badge">Independent Podcast Network</div>
             <h1><span class="gradient-text">Nerra</span> Network</h1>
             <p class="network-hero-tagline">Feed your curiosity. Not your anxiety.</p>
-            <div style="display:flex;gap:var(--sp-3);justify-content:center;flex-wrap:wrap;">
-                <a href="#shows" class="nn-btn nn-btn-primary" style="--show-color:#7C5CFF;">Explore Shows</a>
-                <a href="#subscribe" class="nn-btn">Subscribe</a>
+            <p class="hero-subtitle">{{ all_shows | length }} ad-free shows covering Tesla, world news, space, science, AI, investing, and more. Produced daily in Vancouver.</p>
+            <div class="hero-cta-row">
+                <a href="#shows" class="nn-btn nn-btn-primary nn-btn-lg" style="--show-color:#7C5CFF;">Explore Shows</a>
+                <a href="#subscribe" class="nn-btn nn-btn-lg">Subscribe Free</a>
+            </div>
+        </div>
+        <!-- Floating show art -->
+        <div class="hero-show-orbit">
+            {% for s in all_shows %}
+            <div class="hero-orbit-item" style="--orbit-i:{{ loop.index0 }};--orbit-total:{{ all_shows | length }};">
+                <img src="{{ s.podcast_image }}" alt="{{ s.name }}" loading="eager">
+            </div>
+            {% endfor %}
+        </div>
+    </section>
+
+    <!-- Stats Bar -->
+    <section class="stats-bar">
+        <div class="container">
+            <div class="stats-row">
+                <div class="stat-item">
+                    <div class="stat-number">{{ all_shows | length }}</div>
+                    <div class="stat-label">Shows</div>
+                </div>
+                <div class="stat-divider"></div>
+                <div class="stat-item">
+                    <div class="stat-number">9</div>
+                    <div class="stat-label">Topics</div>
+                </div>
+                <div class="stat-divider"></div>
+                <div class="stat-item">
+                    <div class="stat-number">2</div>
+                    <div class="stat-label">Languages</div>
+                </div>
+                <div class="stat-divider"></div>
+                <div class="stat-item">
+                    <div class="stat-number">0</div>
+                    <div class="stat-label">Ads</div>
+                </div>
             </div>
         </div>
     </section>
@@ -53,8 +72,9 @@
     <section id="shows" class="nn-section">
         <div class="container">
             <div class="nn-section-header">
-                <h2>Our Shows</h2>
-                <p>Ad-free daily and weekly shows on the ideas shaping tomorrow.</p>
+                <div class="section-label">Our Shows</div>
+                <h2>Daily intelligence on the topics that matter</h2>
+                <p>Every show is ad-free, independently produced, and published daily. Pick one or subscribe to all.</p>
             </div>
             <div class="show-showcase">
                 {% for s in all_shows %}
@@ -83,12 +103,12 @@
     <section id="latest" class="nn-section" style="background:var(--nn-bg-alt);">
         <div class="container">
             <div class="nn-section-header">
+                <div class="section-label">Fresh Episodes</div>
                 <h2>Latest Across the Network</h2>
-                <p>The most recent episodes from all seven shows.</p>
+                <p>The most recent episodes from all shows.</p>
             </div>
         </div>
         <div class="latest-scroll-row" id="latestEpisodes">
-            <!-- Populated by JS from network.rss -->
             <div class="latest-scroll-card glass-card nn-skeleton" style="height:180px;"></div>
             <div class="latest-scroll-card glass-card nn-skeleton" style="height:180px;"></div>
             <div class="latest-scroll-card glass-card nn-skeleton" style="height:180px;"></div>
@@ -98,14 +118,57 @@
         </div>
     </section>
 
-    <!-- About the Network -->
+    <!-- Why Nerra -->
     <section class="nn-section">
         <div class="container">
             <div class="nn-section-header">
+                <div class="section-label">Why Nerra</div>
+                <h2>Built different</h2>
+            </div>
+            <div class="features-grid">
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#9889;</div>
+                    <h3>AI-Enhanced Research</h3>
+                    <p>Every episode is backed by real-time news analysis across dozens of sources, curated and verified by a human host.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#127911;</div>
+                    <h3>Zero Ads. Zero Sponsors.</h3>
+                    <p>No ad reads, no sponsor segments, no paywalls. Just pure content, every single day. Free forever.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#127758;</div>
+                    <h3>Multi-Perspective Coverage</h3>
+                    <p>We pull from diverse sources to present balanced, nuanced takes — not echo chambers or clickbait.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#128197;</div>
+                    <h3>Daily Consistency</h3>
+                    <p>New episodes every day (or weekday), rain or shine. Build a daily learning habit you can rely on.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#127463;&#127464;</div>
+                    <h3>Made in Canada</h3>
+                    <p>Independently produced in Vancouver by Patrick. No corporate backing, no editorial interference.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#128266;</div>
+                    <h3>Multilingual</h3>
+                    <p>Shows in English and Russian, with more languages planned. Knowledge shouldn't have a language barrier.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- About the Network -->
+    <section class="nn-section" style="background:var(--nn-bg-alt);">
+        <div class="container">
+            <div class="nn-section-header">
+                <div class="section-label">About</div>
                 <h2>About Nerra Network</h2>
             </div>
             <div class="about-section-text">
-                <p><strong>Ad-free daily and weekly shows on the ideas shaping tomorrow.</strong></p>
+                <p><strong>{{ all_shows | length }} ad-free shows on the ideas shaping tomorrow.</strong></p>
                 <p>Nerra Network is an independent podcast network covering Tesla, balanced world news, space and astronomy, science and longevity, environmental intelligence, AI, financial literacy, language learning, and modern investing. All produced in Vancouver, Canada by Patrick.</p>
                 <p>Our mission: stimulating conversation, supporting positive developments that benefit all, and providing unbiased coverage with varying perspectives.</p>
             </div>
@@ -113,9 +176,10 @@
     </section>
 
     <!-- Subscribe -->
-    <section id="subscribe" class="nn-section" style="background:var(--nn-bg-alt);border-top:1px solid var(--nn-border);">
+    <section id="subscribe" class="nn-section" style="border-top:1px solid var(--nn-border);">
         <div class="container">
             <div class="nn-section-header">
+                <div class="section-label">Listen Anywhere</div>
                 <h2>Subscribe Everywhere</h2>
                 <p>All shows are available via RSS. Pick your favorite podcast app and never miss an episode.</p>
             </div>

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -229,7 +229,7 @@
                 {% endif %}
 
                 <div style="text-align:center;">
-                    <a href="{{ referral.url }}" class="nn-btn nn-btn-primary" target="_blank" rel="noopener" style="font-size:1rem;padding:var(--sp-3) var(--sp-8);">Order a Tesla with Free FSD Trial</a>
+                    <a href="{{ referral.url }}" class="nn-btn nn-btn-primary" target="_blank" rel="noopener" style="font-size:1rem;padding:var(--sp-3) var(--sp-8);">{{ referral.cta | default('Get Started') }}</a>
                     <div style="margin-top:var(--sp-3);font-family:var(--font-ui);font-size:0.78rem;color:var(--nn-text-muted);max-width:500px;margin-left:auto;margin-right:auto;">{{ referral.fine_print }}</div>
                 </div>
             </div>


### PR DESCRIPTION
- Add Wealthsimple referral section to Modern Investing show page (https://wealthsimple.com/invite/U5JROW)
- Fix json_format from "wrapped" to "array" to match summaries file
- Redesign Nerra Network landing page:
  - Animated gradient orbs replacing static SVG network graph
  - Floating show art orbit around hero
  - Stats bar (10 shows, 9 topics, 2 languages, 0 ads)
  - "Why Nerra" features grid (6 feature cards)
  - Section labels, larger hero typography, dot grid overlay
- Make referral CTA button text configurable via "cta" field
- Update page title/meta to reflect 10 shows
- Regenerate all 21 HTML pages

https://claude.ai/code/session_01ARcEfFEq2LuZvhVnAs7xjF