### PR TITLE
Fix MIT show page not displaying episodes: wrong JSON field names and…

### DIFF
--- a/digests/modern_investing/summaries_modern_investing.json
+++ b/digests/modern_investing/summaries_modern_investing.json
@@ -1,10 +1,23 @@
-[
-  {
-    "date": "2026-03-17",
-    "datetime": "2026-03-17T08:00:00.000000",
-    "title": "Ep 1: Modern Investing Techniques — Premiere Episode",
-    "content": "Welcome to Modern Investing Techniques — your daily AI-powered market intelligence podcast. In this premiere episode, we cover the latest market movements, introduce our Practice Investment tracking system, and break down strategies for Canadian and US investors using TFSA, RRSP, and FHSA accounts.",
-    "audio_file": "https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep001_20260317.mp3",
-    "episode_number": 1
-  }
-]
+{
+  "podcast": "modern_investing",
+  "summaries": [
+    {
+      "date": "2026-03-19",
+      "datetime": "2026-03-19T14:18:24.000000",
+      "content": "Modern Investing Techniques - Episode 2 - March 19, 2026",
+      "episode_num": 2,
+      "episode_title": "Modern Investing Techniques - Episode 2 - March 19, 2026",
+      "audio_url": "https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep002_20260319.mp3",
+      "rss_url": "https://nerranetwork.com/modern_investing_podcast.rss"
+    },
+    {
+      "date": "2026-03-17",
+      "datetime": "2026-03-17T08:00:00.000000",
+      "content": "Welcome to Modern Investing Techniques \u2014 your daily AI-powered market intelligence podcast. In this premiere episode, we cover the latest market movements, introduce our Practice Investment tracking system, and break down strategies for Canadian and US investors using TFSA, RRSP, and FHSA accounts.",
+      "episode_num": 1,
+      "episode_title": "Ep 1: Modern Investing Techniques \u2014 Premiere Episode",
+      "audio_url": "https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep001_20260317.mp3",
+      "rss_url": "https://nerranetwork.com/modern_investing_podcast.rss"
+    }
+  ]
+}

--- a/env-intel-summaries.html
+++ b/env-intel-summaries.html
@@ -423,7 +423,7 @@
     
     <script>
         const JSON_URL = 'digests/env_intel/summaries_env_intel.json';
-        const JSON_FORMAT = 'array';
+        const JSON_FORMAT = 'wrapped';
         const SHOW_NAME = "Environmental Intelligence";
 
         document.addEventListener('DOMContentLoaded', function() {

--- a/env-intel.html
+++ b/env-intel.html
@@ -751,7 +751,7 @@
     
     <script>
         const JSON_URL = 'digests/env_intel/summaries_env_intel.json';
-        const JSON_FORMAT = 'array';
+        const JSON_FORMAT = 'wrapped';
         const RSS_URL = 'env_intel_podcast.rss';
         const SHOW_NAME = "Environmental Intelligence";
 

--- a/modern-investing-summaries.html
+++ b/modern-investing-summaries.html
@@ -421,7 +421,7 @@
     
     <script>
         const JSON_URL = 'digests/modern_investing/summaries_modern_investing.json';
-        const JSON_FORMAT = 'array';
+        const JSON_FORMAT = 'wrapped';
         const SHOW_NAME = "Modern Investing Techniques";
 
         document.addEventListener('DOMContentLoaded', function() {

--- a/modern-investing.html
+++ b/modern-investing.html
@@ -744,7 +744,7 @@
     
     <script>
         const JSON_URL = 'digests/modern_investing/summaries_modern_investing.json';
-        const JSON_FORMAT = 'array';
+        const JSON_FORMAT = 'wrapped';
         const RSS_URL = 'modern_investing_podcast.rss';
         const SHOW_NAME = "Modern Investing Techniques";
 


### PR DESCRIPTION
… structure

The summaries_modern_investing.json was manually created with wrong field names (audio_file/title/episode_number instead of audio_url/episode_title/episode_num) and as a raw array instead of the standard { podcast, summaries } wrapper. This caused two failures:
1. Audio player showed "Error" because HTML looks for audio_url but JSON had audio_file
2. Pipeline's save_summary_to_github_pages() crashed silently trying data["summaries"] on a list, so Ep 2 was never appended to the JSON

Also fix JSON_FORMAT from 'array' to 'wrapped' in MIT and env-intel HTML files to match the standard pipeline output format.

https://claude.ai/code/session_01NYswHbcwjseFLzph1QqXaF