### PR TITLE
Fix MIT show page not displaying Episode 1 and harden episode loading

### DIFF
--- a/digests/modern_investing/summaries_modern_investing.json
+++ b/digests/modern_investing/summaries_modern_investing.json
@@ -1,1 +1,4 @@
-[]
+{
+  "podcast": "modern_investing",
+  "summaries": []
+}

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -510,6 +510,10 @@ def save_summary_to_github_pages(
                 fcntl.flock(f.fileno(), fcntl.LOCK_EX)
                 try:
                     data = json.load(f)
+                    # Handle malformed files (e.g. bare array instead of wrapped object)
+                    if not isinstance(data, dict) or "summaries" not in data:
+                        existing = data if isinstance(data, list) else []
+                        data = {"podcast": podcast_name, "summaries": existing}
                     data["summaries"].insert(0, entry)
                     data["summaries"] = data["summaries"][:max_summaries]
                     f.seek(0)

--- a/env-intel.html
+++ b/env-intel.html
@@ -795,7 +795,7 @@
         }
 
         function renderEpisodes(episodes) {
-            if (!episodes || !episodes.length) { showNoEpisodes(); return; }
+            if (!episodes || !episodes.length) { loadFromRSS(); return; }
             episodes.sort((a, b) => new Date(b.date) - new Date(a.date));
             const latest = episodes[0];
             document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';

--- a/fascinating_frontiers.html
+++ b/fascinating_frontiers.html
@@ -807,7 +807,7 @@
         }
 
         function renderEpisodes(episodes) {
-            if (!episodes || !episodes.length) { showNoEpisodes(); return; }
+            if (!episodes || !episodes.length) { loadFromRSS(); return; }
             episodes.sort((a, b) => new Date(b.date) - new Date(a.date));
             const latest = episodes[0];
             document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';

--- a/models-agents-beginners.html
+++ b/models-agents-beginners.html
@@ -773,7 +773,7 @@
         }
 
         function renderEpisodes(episodes) {
-            if (!episodes || !episodes.length) { showNoEpisodes(); return; }
+            if (!episodes || !episodes.length) { loadFromRSS(); return; }
             episodes.sort((a, b) => new Date(b.date) - new Date(a.date));
             const latest = episodes[0];
             document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';

--- a/models-agents.html
+++ b/models-agents.html
@@ -803,7 +803,7 @@
         }
 
         function renderEpisodes(episodes) {
-            if (!episodes || !episodes.length) { showNoEpisodes(); return; }
+            if (!episodes || !episodes.length) { loadFromRSS(); return; }
             episodes.sort((a, b) => new Date(b.date) - new Date(a.date));
             const latest = episodes[0];
             document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';

--- a/modern-investing.html
+++ b/modern-investing.html
@@ -788,7 +788,7 @@
         }
 
         function renderEpisodes(episodes) {
-            if (!episodes || !episodes.length) { showNoEpisodes(); return; }
+            if (!episodes || !episodes.length) { loadFromRSS(); return; }
             episodes.sort((a, b) => new Date(b.date) - new Date(a.date));
             const latest = episodes[0];
             document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';

--- a/omni-view.html
+++ b/omni-view.html
@@ -820,7 +820,7 @@
         }
 
         function renderEpisodes(episodes) {
-            if (!episodes || !episodes.length) { showNoEpisodes(); return; }
+            if (!episodes || !episodes.length) { loadFromRSS(); return; }
             episodes.sort((a, b) => new Date(b.date) - new Date(a.date));
             const latest = episodes[0];
             document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';

--- a/planetterrian.html
+++ b/planetterrian.html
@@ -795,7 +795,7 @@
         }
 
         function renderEpisodes(episodes) {
-            if (!episodes || !episodes.length) { showNoEpisodes(); return; }
+            if (!episodes || !episodes.length) { loadFromRSS(); return; }
             episodes.sort((a, b) => new Date(b.date) - new Date(a.date));
             const latest = episodes[0];
             document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';

--- a/ru/finansy-prosto.html
+++ b/ru/finansy-prosto.html
@@ -767,7 +767,7 @@
         }
 
         function renderEpisodes(episodes) {
-            if (!episodes || !episodes.length) { showNoEpisodes(); return; }
+            if (!episodes || !episodes.length) { loadFromRSS(); return; }
             episodes.sort((a, b) => new Date(b.date) - new Date(a.date));
             const latest = episodes[0];
             document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';

--- a/ru/privet-russian.html
+++ b/ru/privet-russian.html
@@ -761,7 +761,7 @@
         }
 
         function renderEpisodes(episodes) {
-            if (!episodes || !episodes.length) { showNoEpisodes(); return; }
+            if (!episodes || !episodes.length) { loadFromRSS(); return; }
             episodes.sort((a, b) => new Date(b.date) - new Date(a.date));
             const latest = episodes[0];
             document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';

--- a/tesla.html
+++ b/tesla.html
@@ -880,7 +880,7 @@
         }
 
         function renderEpisodes(episodes) {
-            if (!episodes || !episodes.length) { showNoEpisodes(); return; }
+            if (!episodes || !episodes.length) { loadFromRSS(); return; }
             episodes.sort((a, b) => new Date(b.date) - new Date(a.date));
             const latest = episodes[0];
             document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';


### PR DESCRIPTION
Three bugs formed a chain preventing the MIT show page from showing Episode 1:

1. summaries_modern_investing.json contained [] (bare array) instead of the expected {"podcast": ..., "summaries": []} wrapped format. This caused save_summary_to_github_pages() to crash with TypeError on data["summaries"], silently preventing Episode 1 from being written to the JSON.

2. engine/publisher.py save_summary_to_github_pages() now handles malformed JSON files (bare arrays, missing keys) by resetting to proper wrapped format instead of crashing silently.

3. All 10 show HTML pages had a fallback gap: when JSON loaded successfully but contained no episodes, they showed "No episodes available yet" instead of falling back to RSS. Now renderEpisodes() calls loadFromRSS() when the JSON has no episodes, ensuring the RSS feed (which was correct) is used as a fallback data source.

https://claude.ai/code/session_01AX3a2twSemxQS5vevCrEAx