### PR TITLE
Fix latest episodes template to handle ascending RSS feeds

### DIFF
--- a/index.html
+++ b/index.html
@@ -674,10 +674,46 @@
             
             <div class="latest-scroll-card glass-card">
                 <div class="episode-card-show" style="background:#E31937;">Tesla Shorts Time</div>
-                <div class="episode-card-title">Ep 417: [Slow News Edition] Tesla makes Fortune’s 2026 Most Innovative Companies list thanks to the Cybercab as production begins this year.</div>
-                <div class="episode-card-date">Fri, Mar 27, 2026</div>
+                <div class="episode-card-title">Ep 418: A Tesla on FSD Supervised avoided a potential collision with a school bus that nearly ran a red light, with the viral video showing the system braking sharply to protect its occupants.</div>
+                <div class="episode-card-date">Sat, Mar 28, 2026</div>
                 
-                <audio controls preload="none" src="https://audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep417_20260327.mp3" aria-label="Tesla Shorts Time episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                <audio controls preload="none" src="https://audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep418_20260328.mp3" aria-label="Tesla Shorts Time episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#7C5CFF;">Fascinating Frontiers</div>
+                <div class="episode-card-title">Ep 46: [Slow News Edition] Mars-like exoplanets orbiting M-dwarfs could lose their atmospheres in just millions of years.</div>
+                <div class="episode-card-date">Sat, Mar 28, 2026</div>
+                
+                <audio controls preload="none" src="https://audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep046_20260328.mp3" aria-label="Fascinating Frontiers episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#F59E0B;">Models & Agents for Beginners</div>
+                <div class="episode-card-title">Ep 12: Meta built an AI that can predict how your brain will react to pictures, music, and speech — better than reading one real person's brain scan.</div>
+                <div class="episode-card-date">Sat, Mar 28, 2026</div>
+                
+                <audio controls preload="none" src="https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep012_20260328.mp3" aria-label="Models & Agents for Beginners episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#EC4899;">Финансы Просто</div>
+                <div class="episode-card-title">Ep 15: [Slow News Edition]</div>
+                <div class="episode-card-date">Sat, Mar 28, 2026</div>
+                
+                <audio controls preload="none" src="https://audio.nerranetwork.com/finansy_prosto/FP_Ep015_20260328.mp3" aria-label="Финансы Просто episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#6366F1;">Привет, Русский!</div>
+                <div class="episode-card-title">Привет, Русский! - Episode 7 - March 28, 2026</div>
+                <div class="episode-card-date">Sat, Mar 28, 2026</div>
+                
+                <audio controls preload="none" src="https://audio.nerranetwork.com/privet_russian/PR_Ep007_20260328.mp3" aria-label="Привет, Русский! episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
                 
             </div>
             
@@ -718,47 +754,11 @@
             </div>
             
             <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#F59E0B;">Models & Agents for Beginners</div>
-                <div class="episode-card-title">Ep 11: Anthropic just confirmed their leaked model is a huge leap in AI reasoning — and it happened because of a simple security slip-up.</div>
-                <div class="episode-card-date">Fri, Mar 27, 2026</div>
-                
-                <audio controls preload="none" src="https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep011_20260327.mp3" aria-label="Models & Agents for Beginners episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
                 <div class="episode-card-show" style="background:#059669;">Modern Investing Techniques</div>
                 <div class="episode-card-title">Ep 7: Oil prices climb as Trump notes Iran allowed 10 tankers through the Strait of Hormuz, creating fresh energy-sector volatility.</div>
                 <div class="episode-card-date">Fri, Mar 27, 2026</div>
                 
                 <audio controls preload="none" src="https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep007_20260327.mp3" aria-label="Modern Investing Techniques episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#7C5CFF;">Fascinating Frontiers</div>
-                <div class="episode-card-title">Ep 45: [Slow News Edition] Hubble has caught a tiny comet slowing its spin and then reversing direction entirely.</div>
-                <div class="episode-card-date">Thu, Mar 26, 2026</div>
-                
-                <audio controls preload="none" src="https://audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep045_20260326.mp3" aria-label="Fascinating Frontiers episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#EC4899;">Финансы Просто</div>
-                <div class="episode-card-title">Финансы Просто - Episode 14 - March 26, 2026</div>
-                <div class="episode-card-date">Thu, Mar 26, 2026</div>
-                
-                <audio controls preload="none" src="https://audio.nerranetwork.com/finansy_prosto/FP_Ep014_20260326.mp3" aria-label="Финансы Просто episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#6366F1;">Привет, Русский!</div>
-                <div class="episode-card-title">Привет, Русский! - Episode 5 - March 26, 2026</div>
-                <div class="episode-card-date">Thu, Mar 26, 2026</div>
-                
-                <audio controls preload="none" src="https://audio.nerranetwork.com/privet_russian/PR_Ep005_20260326.mp3" aria-label="Привет, Русский! episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
                 
             </div>
             
@@ -819,6 +819,66 @@
             </div>
             <div class="blog-idx-grid" style="max-width:900px;margin:0 auto;padding-bottom:var(--sp-8)">
                 
+                <a href="blog/tesla/ep418.html"
+                   class="blog-idx-card"
+                   style="--card-show-color: #E31937">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #E31937 15%, transparent);color:#E31937">Tesla Shorts Time</span>
+                        <span class="blog-idx-date">March 28, 2026</span>
+                        <span class="blog-idx-ep">Ep 418</span>
+                        <span class="blog-idx-reading">6 min</span>
+                    </div>
+                    <h2>Tesla Shorts Time</h2>
+                    
+                    <p>A Tesla on FSD Supervised avoided a potential collision with a school bus that nearly ran a red light, with the viral video showing the syst&hellip;</p>
+                    
+                    <span class="blog-idx-read-more" style="color:#E31937">Read article &rarr;</span>
+                </a>
+                
+                <a href="blog/models_agents_beginners/ep012.html"
+                   class="blog-idx-card"
+                   style="--card-show-color: #F59E0B">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #F59E0B 15%, transparent);color:#F59E0B">Models & Agents for Beginners</span>
+                        <span class="blog-idx-date">March 28, 2026</span>
+                        <span class="blog-idx-ep">Ep 12</span>
+                        <span class="blog-idx-reading">6 min</span>
+                    </div>
+                    <h2>Models & Agents for Beginners</h2>
+                    
+                    <p>Meta built an AI that can predict how your brain will react to pictures, music, and speech — better than reading one real person's brain sca&hellip;</p>
+                    
+                    <span class="blog-idx-read-more" style="color:#F59E0B">Read article &rarr;</span>
+                </a>
+                
+                <a href="blog/finansy_prosto/ep015.html"
+                   class="blog-idx-card"
+                   style="--card-show-color: #EC4899">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #EC4899 15%, transparent);color:#EC4899">Финансы Просто</span>
+                        <span class="blog-idx-date">March 28, 2026</span>
+                        <span class="blog-idx-ep">Ep 15</span>
+                        <span class="blog-idx-reading">5 min</span>
+                    </div>
+                    <h2>Финансы Просто</h2>
+                    
+                    <span class="blog-idx-read-more" style="color:#EC4899">Read article &rarr;</span>
+                </a>
+                
+                <a href="blog/privet_russian/ep007.html"
+                   class="blog-idx-card"
+                   style="--card-show-color: #6366F1">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #6366F1 15%, transparent);color:#6366F1">Привет, Русский!</span>
+                        <span class="blog-idx-date">March 28, 2026</span>
+                        <span class="blog-idx-ep">Ep 7</span>
+                        <span class="blog-idx-reading">4 min</span>
+                    </div>
+                    <h2>Привет, Русский!</h2>
+                    
+                    <span class="blog-idx-read-more" style="color:#6366F1">Read article &rarr;</span>
+                </a>
+                
                 <a href="blog/tesla/ep417.html"
                    class="blog-idx-card"
                    style="--card-show-color: #E31937">
@@ -849,70 +909,6 @@
                     <p>Trump extends deadline for Iran to reopen Strait of Hormuz to April 6, pausing strikes on energy sites as oil markets fluctuate.</p>
                     
                     <span class="blog-idx-read-more" style="color:#0B6FD6">Read article &rarr;</span>
-                </a>
-                
-                <a href="blog/models_agents/ep021.html"
-                   class="blog-idx-card"
-                   style="--card-show-color: #8B5CF6">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #8B5CF6 15%, transparent);color:#8B5CF6">Models & Agents</span>
-                        <span class="blog-idx-date">March 27, 2026</span>
-                        <span class="blog-idx-ep">Ep 21</span>
-                        <span class="blog-idx-reading">5 min</span>
-                    </div>
-                    <h2>Models & Agents</h2>
-                    
-                    <p>New arXiv papers expose critical flaws in how we evaluate depression-detection models, LLM pruning, and verbalized confidence.</p>
-                    
-                    <span class="blog-idx-read-more" style="color:#8B5CF6">Read article &rarr;</span>
-                </a>
-                
-                <a href="blog/modern_investing/ep007.html"
-                   class="blog-idx-card"
-                   style="--card-show-color: #059669">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #059669 15%, transparent);color:#059669">Modern Investing Techniques</span>
-                        <span class="blog-idx-date">March 27, 2026</span>
-                        <span class="blog-idx-ep">Ep 7</span>
-                        <span class="blog-idx-reading">5 min</span>
-                    </div>
-                    <h2>Modern Investing Techniques</h2>
-                    
-                    <p>Oil prices climb as Trump notes Iran allowed 10 tankers through the Strait of Hormuz, creating fresh energy-sector volatility.</p>
-                    
-                    <span class="blog-idx-read-more" style="color:#059669">Read article &rarr;</span>
-                </a>
-                
-                <a href="blog/omni_view/ep023.html"
-                   class="blog-idx-card"
-                   style="--card-show-color: #0B6FD6">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #0B6FD6 15%, transparent);color:#0B6FD6">Omni View</span>
-                        <span class="blog-idx-date">March 26, 2026</span>
-                        <span class="blog-idx-ep">Ep 23</span>
-                        <span class="blog-idx-reading">16 min</span>
-                    </div>
-                    <h2>Omni View</h2>
-                    
-                    <p>Iran has rejected President Trump’s proposed peace plan as a pretext for invasion, while Israel claims it killed Iran’s naval chief amid esc&hellip;</p>
-                    
-                    <span class="blog-idx-read-more" style="color:#0B6FD6">Read article &rarr;</span>
-                </a>
-                
-                <a href="blog/planetterrian/ep035.html"
-                   class="blog-idx-card"
-                   style="--card-show-color: #018DB1">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #018DB1 15%, transparent);color:#018DB1">Planetterrian Daily</span>
-                        <span class="blog-idx-date">March 26, 2026</span>
-                        <span class="blog-idx-ep">Ep 35</span>
-                        <span class="blog-idx-reading">5 min</span>
-                    </div>
-                    <h2>Planetterrian Daily</h2>
-                    
-                    <p>Light-activated nanoparticles trigger copper overload to kill cancer cells 100 times more effectively than existing chemotherapy.</p>
-                    
-                    <span class="blog-idx-read-more" style="color:#018DB1">Read article &rarr;</span>
                 </a>
                 
             </div>


### PR DESCRIPTION
## Summary

- **Merge conflicts resolved**: Accepted main's server-side rendering approach for latest episodes (iterates all RSS items by pubDate in `generate_html.py`) — this correctly handles both ascending and descending RSS feeds without needing client-side JS.
- **Regenerated `index.html`** with today's (March 28) episodes and blog posts.

## Context

The earlier JS-based fix (PR #145) was overwritten each time `generate_html.py` re-ran. Meanwhile, a separate session (commit `13728ea`) replaced the JS with server-side Jinja2 rendering that correctly finds the newest episode. This PR merges main's approach and regenerates the homepage.

## Test plan
- [ ] Verify homepage shows March 28 episodes after merge
- [ ] Verify "Latest from the Blog" section renders
- [ ] All 979 tests pass

https://claude.ai/code/session_01JLuRiWUsxPpMmMSXtTcUC8