### PR TITLE
Post-model-upgrade pipeline improvements: reliability and quality

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -59,6 +59,7 @@ class TTSConfig:
     style: float = 0.85
     use_speaker_boost: bool = True
     max_chars: int = 5000
+    language_code: str = ""  # ISO 639-1 code (e.g. "ru" for Russian); improves eleven_v3 pronunciation
     # Kokoro-specific (ignored when provider != kokoro)
     kokoro_voice: str = "am_adam"
     kokoro_speed: float = 1.0

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -36,6 +36,12 @@ class LLMRefusalError(RuntimeError):
     """
 
 
+# Fallback model used when the primary model refuses to generate content
+# after educational prompt retry.  A different model often has different
+# refusal thresholds and can succeed where the primary model won't.
+_LLM_FALLBACK_MODEL = "grok-4"
+
+
 # ---------------------------------------------------------------------------
 # Prompt template loading
 # ---------------------------------------------------------------------------
@@ -381,11 +387,32 @@ def _validate_llm_output(
         from collections import Counter
         bigrams = [" ".join(words[i:i+2]).lower() for i in range(len(words) - 1)]
         bigram_counts = Counter(bigrams)
+        # Common phrases that naturally repeat in news digests and podcast scripts
+        _COMMON_BIGRAMS = {
+            # Articles / prepositions
+            "the the", "of the", "in the", "to the", "and the", "on the",
+            "for the", "is the", "is a", "it's a", "this is", "with the",
+            "at the", "by the", "from the", "that the", "has been",
+            # Host attribution patterns (e.g. "patrick: the", "host: this")
+            "patrick: the", "patrick: this", "patrick: it", "patrick: a",
+            "patrick: so", "patrick: now", "patrick: and", "patrick: but",
+            "**host:** the", "**host:** this", "**host:** it", "**host:** a",
+            # Section separators / formatting
+            "━━━━━━━━━━ ###", "━━━━━━━━━━━━━━━━━━━━ ###",
+            # Article reference patterns
+            "according to", "going to", "we're going",
+        }
+        # Podcast scripts are longer and naturally have more repeated phrases
+        _rep_threshold = 5 if stage == "podcast_script" else 4
         for phrase, count in bigram_counts.most_common(5):
             # Skip common phrases
-            if phrase in ("the the", "of the", "in the", "to the", "and the", "on the", "for the", "is the"):
+            if phrase in _COMMON_BIGRAMS:
                 continue
-            if count >= 4:
+            # Skip phrases that are mostly stopwords or very short tokens
+            tokens = phrase.split()
+            if all(len(t) <= 3 for t in tokens):
+                continue
+            if count >= _rep_threshold:
                 _suspicious_count += 1
                 logger.warning(
                     "LLM %s for '%s' has suspicious repetition: '%s' appears %d times (possible hallucination)",
@@ -822,8 +849,44 @@ def generate_digest(
 
             logger.info("Retry 2 (educational) digest generated (%d chars, %s tokens)",
                         len(text), meta3.get("usage", {}).get("total_tokens", "?"))
-            # Validate — if even the educational fallback refuses, let it propagate
-            _rep_count = _validate_llm_output(text, stage="digest", show_name=config.name)
+            # Validate — if even the educational fallback refuses, try a
+            # different model before giving up.
+            try:
+                _rep_count = _validate_llm_output(text, stage="digest", show_name=config.name)
+            except LLMRefusalError:
+                if config.llm.model == _LLM_FALLBACK_MODEL:
+                    raise  # Already using fallback model — nothing left to try
+                # --- Retry 3: fallback model with educational prompt ---
+                logger.warning(
+                    "LLM refused even educational fallback for '%s' — "
+                    "trying fallback model '%s' ...",
+                    config.name, _LLM_FALLBACK_MODEL,
+                )
+                text, meta4 = _call_grok(
+                    edu_prompt,
+                    model=_LLM_FALLBACK_MODEL,
+                    system_prompt=system_prompt,
+                    temperature=config.llm.podcast_temperature,
+                    max_tokens=config.llm.max_tokens,
+                )
+                if tracker and "usage" in meta4:
+                    try:
+                        from engine.tracking import record_llm_usage
+                        record_llm_usage(
+                            tracker,
+                            "x_thread_generation_retry_fallback_model",
+                            meta4["usage"].get("prompt_tokens", 0),
+                            meta4["usage"].get("completion_tokens", 0),
+                            model=_LLM_FALLBACK_MODEL,
+                        )
+                    except Exception as e:
+                        logger.warning("Failed to record fallback model LLM usage: %s", e)
+                logger.info(
+                    "Retry 3 (fallback model) digest generated (%d chars, %s tokens)",
+                    len(text), meta4.get("usage", {}).get("total_tokens", "?"),
+                )
+                # Validate — if fallback model also refuses, let it propagate
+                _rep_count = _validate_llm_output(text, stage="digest", show_name=config.name)
 
     # If the digest has severe repetition (3+ distinct phrases appearing 4+
     # times), retry once with lower temperature to reduce hallucination.
@@ -1030,10 +1093,85 @@ def generate_podcast_script(
 
     min_words = getattr(config.llm, "min_podcast_words", 1500)
 
-    # Validate the podcast script is usable
-    _rep_count = _validate_llm_output(text, stage="podcast_script",
-                                      show_name=config.name,
-                                      min_podcast_words=min_words)
+    # Use podcast-specific tokens for retries too
+    podcast_tokens_for_retry = podcast_tokens
+
+    # Validate the podcast script — recover from refusals with retries
+    try:
+        _rep_count = _validate_llm_output(text, stage="podcast_script",
+                                          show_name=config.name,
+                                          min_podcast_words=min_words)
+    except LLMRefusalError:
+        # --- Retry 1: lower temperature + simplified prompt (just digest) ---
+        logger.warning(
+            "LLM refused to generate podcast script for '%s' — "
+            "retrying with lower temperature (attempt 1/2) ...",
+            config.name,
+        )
+        digest_text = template_vars.get("digest", "")
+        simple_prompt = (
+            f"You are the host of {config.name}. Read the following digest and "
+            f"convert it into a natural, conversational podcast script. "
+            f"Speak directly to the listener. Cover every story.\n\n"
+            f"DIGEST:\n{digest_text}"
+        )
+        lower_temp = max(0.3, config.llm.podcast_temperature * 0.6)
+        text, meta_r1 = _call_grok(
+            simple_prompt,
+            model=config.llm.model,
+            system_prompt=system_prompt,
+            temperature=lower_temp,
+            max_tokens=podcast_tokens_for_retry,
+        )
+        if tracker and "usage" in meta_r1:
+            try:
+                from engine.tracking import record_llm_usage
+                record_llm_usage(
+                    tracker, "podcast_script_refusal_retry",
+                    meta_r1["usage"].get("prompt_tokens", 0),
+                    meta_r1["usage"].get("completion_tokens", 0),
+                    model=config.llm.model,
+                )
+            except Exception:
+                pass
+        logger.info("Podcast refusal retry 1 generated (%d chars)", len(text))
+
+        try:
+            _rep_count = _validate_llm_output(text, stage="podcast_script",
+                                              show_name=config.name,
+                                              min_podcast_words=min_words)
+        except LLMRefusalError:
+            # --- Retry 2: fallback model ---
+            if config.llm.model == _LLM_FALLBACK_MODEL:
+                raise
+            logger.warning(
+                "LLM refused podcast script again for '%s' — "
+                "trying fallback model '%s' ...",
+                config.name, _LLM_FALLBACK_MODEL,
+            )
+            text, meta_r2 = _call_grok(
+                simple_prompt,
+                model=_LLM_FALLBACK_MODEL,
+                system_prompt=system_prompt,
+                temperature=lower_temp,
+                max_tokens=podcast_tokens_for_retry,
+            )
+            if tracker and "usage" in meta_r2:
+                try:
+                    from engine.tracking import record_llm_usage
+                    record_llm_usage(
+                        tracker, "podcast_script_refusal_fallback_model",
+                        meta_r2["usage"].get("prompt_tokens", 0),
+                        meta_r2["usage"].get("completion_tokens", 0),
+                        model=_LLM_FALLBACK_MODEL,
+                    )
+                except Exception:
+                    pass
+            logger.info("Podcast refusal retry 2 (fallback model) generated (%d chars)", len(text))
+            # If fallback model also refuses, let it propagate
+            _rep_count = _validate_llm_output(text, stage="podcast_script",
+                                              show_name=config.name,
+                                              min_podcast_words=min_words)
 
     # Retry once if podcast script is too short for target duration
     word_count = len(text.split())

--- a/engine/tts.py
+++ b/engine/tts.py
@@ -230,6 +230,7 @@ def speak_chunk(
     similarity_boost: float = 0.9,
     style: float = 0.85,
     use_speaker_boost: bool = True,
+    language_code: str = "",
     timeout: int = 120,
     previous_text: str = "",
     next_text: str = "",
@@ -271,6 +272,10 @@ def speak_chunk(
             "use_speaker_boost": use_speaker_boost,
         },
     }
+    # ElevenLabs eleven_v3 uses language_code for optimal pronunciation
+    # in non-English content (ISO 639-1, e.g. "ru", "es").
+    if language_code:
+        payload["language_code"] = language_code
     # ElevenLabs uses previous/next_text to condition prosody at chunk
     # boundaries, reducing audible transitions between chunks.
     if previous_text:
@@ -333,6 +338,7 @@ def speak(
     similarity_boost: float = 0.9,
     style: float = 0.85,
     use_speaker_boost: bool = True,
+    language_code: str = "",
     timeout: int = 120,
     append_exclamation: bool = False,
 ) -> None:
@@ -353,6 +359,7 @@ def speak(
         similarity_boost=similarity_boost,
         style=style,
         use_speaker_boost=use_speaker_boost,
+        language_code=language_code,
         timeout=timeout,
     )
 
@@ -510,6 +517,7 @@ def synthesize(
     stability: float = 0.65,
     similarity_boost: float = 0.9,
     style: float = 0.85,
+    language_code: str = "",
     timeout: int = 120,
     append_exclamation: bool = False,
 ) -> Path:
@@ -529,6 +537,7 @@ def synthesize(
         stability=stability,
         similarity_boost=similarity_boost,
         style=style,
+        language_code=language_code,
         timeout=timeout,
         append_exclamation=append_exclamation,
     )
@@ -547,6 +556,7 @@ def synthesize_sections(
     stability: float = 0.65,
     similarity_boost: float = 0.9,
     style: float = 0.85,
+    language_code: str = "",
     timeout: int = 120,
 ) -> List[Path]:
     """Synthesize multiple script sections into individual audio files.
@@ -596,6 +606,7 @@ def synthesize_sections(
             stability=stability,
             similarity_boost=similarity_boost,
             style=style,
+            language_code=language_code,
             timeout=timeout,
         )
         section_files.append(section_path)

--- a/engine/validation.py
+++ b/engine/validation.py
@@ -185,16 +185,25 @@ def check_cross_episode_repeats(
     recent_headlines: List[str],
     section_patterns: Dict[str, str],
     threshold: float = 0.65,
-) -> List[str]:
-    """Check for stories that repeat from recent episodes."""
+) -> Tuple[List[str], List[str]]:
+    """Check for stories that repeat from recent episodes.
+
+    Returns
+    -------
+    Tuple of (warning_issues, exact_duplicate_headlines).
+    - warning_issues: list of warning strings for near-duplicates (>= threshold)
+    - exact_duplicate_headlines: list of headline texts that matched at 100%
+      similarity (should be stripped from digest before podcast generation)
+    """
     if not recent_headlines:
-        return []
+        return [], []
 
     issues = []
+    exact_duplicates: List[str] = []
     # Extract today's headlines
     headlines_pattern = section_patterns.get("headlines", "")
     if not headlines_pattern:
-        return []
+        return [], []
 
     today_items = _extract_items_from_section(digest_text, headlines_pattern)
 
@@ -207,14 +216,21 @@ def check_cross_episode_repeats(
             if not r:
                 continue
             sim = calculate_similarity(norm_item, r)
-            if sim >= threshold:
+            if sim >= 1.0:
+                exact_duplicates.append(item)
+                issues.append(
+                    f"BLOCKING cross-episode repeat: '{item[:60]}...' is identical "
+                    f"to recent story (similarity 100%)"
+                )
+                break
+            elif sim >= threshold:
                 issues.append(
                     f"Cross-episode repeat: '{item[:60]}...' similar to recent story "
                     f"(similarity {sim:.0%})"
                 )
                 break
 
-    return issues
+    return issues, exact_duplicates
 
 
 def validate_digest(
@@ -222,8 +238,8 @@ def validate_digest(
     config: ValidationConfig,
     section_patterns: Optional[Dict[str, str]] = None,
     recent_headlines: Optional[List[str]] = None,
-) -> Tuple[bool, List[str]]:
-    """Master validation function. Returns (passed, issues).
+) -> Tuple[bool, List[str], List[str]]:
+    """Master validation function. Returns (passed, issues, exact_duplicates).
 
     Args:
         digest_text: The generated digest text to validate.
@@ -232,13 +248,16 @@ def validate_digest(
         recent_headlines: Headlines from recent episodes for cross-day check.
 
     Returns:
-        Tuple of (passed: bool, issues: list[str]).
+        Tuple of (passed: bool, issues: list[str], exact_duplicates: list[str]).
         passed is True if no issues were found.
+        exact_duplicates contains headlines that matched at 100% similarity
+        to recent episodes — callers should strip these before podcast generation.
     """
     if not digest_text:
-        return False, ["Empty digest text"]
+        return False, ["Empty digest text"], []
 
     issues: List[str] = []
+    exact_duplicates: List[str] = []
     patterns = section_patterns or {}
 
     # 1. Section overlap check
@@ -265,7 +284,7 @@ def validate_digest(
 
     # 5. Cross-episode repeats
     if recent_headlines and patterns:
-        repeat_issues = check_cross_episode_repeats(
+        repeat_issues, exact_duplicates = check_cross_episode_repeats(
             digest_text, recent_headlines, patterns, config.cross_episode_threshold
         )
         issues.extend(repeat_issues)
@@ -277,7 +296,7 @@ def validate_digest(
     else:
         logger.info("Digest validation passed — no issues found")
 
-    return (len(issues) == 0, issues)
+    return (len(issues) == 0, issues, exact_duplicates)
 
 
 # ---------------------------------------------------------------------------

--- a/run_show.py
+++ b/run_show.py
@@ -382,11 +382,34 @@ def run(args: argparse.Namespace) -> None:
                 logger.warning("X account fetch failed: %s — continuing with RSS only", exc)
                 x_posts = []
 
-    # Merge X posts into articles
+    # Merge X posts into articles, deduplicating against existing RSS articles
     if x_posts:
         logger.info("Merging %d X posts from %d account(s) into %d RSS articles",
                      len(x_posts), len(config.x_accounts), len(articles))
-        articles.extend(x_posts)
+        from engine.utils import calculate_similarity
+        _X_DEDUP_THRESHOLD = 0.65
+        filtered_x = []
+        for xp in x_posts:
+            xp_title = (xp.get("title") or xp.get("summary") or "")[:200]
+            if not xp_title:
+                filtered_x.append(xp)
+                continue
+            is_dup = False
+            for art in articles:
+                art_title = (art.get("title") or art.get("summary") or "")[:200]
+                if art_title and calculate_similarity(xp_title, art_title) >= _X_DEDUP_THRESHOLD:
+                    logger.info("X post deduped against RSS article (%.0f%%): '%s'",
+                                calculate_similarity(xp_title, art_title) * 100,
+                                xp_title[:80])
+                    is_dup = True
+                    break
+            if not is_dup:
+                filtered_x.append(xp)
+        skipped = len(x_posts) - len(filtered_x)
+        if skipped:
+            logger.info("Cross-dedup filtered %d X post(s) that overlapped with RSS articles", skipped)
+        articles.extend(filtered_x)
+        x_posts = filtered_x  # Update for accurate count below
     logger.info("After fetch + dedup: %d articles (incl. %d X posts)", len(articles), len(x_posts))
     metrics.record("article_count", len(articles))
 
@@ -543,10 +566,11 @@ def run(args: argparse.Namespace) -> None:
     #      explicit instruction to include them.
     from engine.validation import validate_digest as _validate_digest, SHOW_VALIDATION_CONFIGS
     _val_factory = SHOW_VALIDATION_CONFIGS.get(config.slug)
+    _exact_dups: list = []  # Populated by validate_digest for 100% cross-episode matches
     if _val_factory:
         _val_config = _val_factory()
         _recent = content_tracker.get_recent_headlines(days=7)
-        _val_passed, _val_issues = _validate_digest(
+        _val_passed, _val_issues, _exact_dups = _validate_digest(
             x_thread, _val_config,
             section_patterns=section_patterns,
             recent_headlines=_recent,
@@ -581,7 +605,7 @@ def run(args: argparse.Namespace) -> None:
                             prompt_suffix=_retry_suffix,
                         )
                     # Re-validate
-                    _val2_passed, _val2_issues = _validate_digest(
+                    _val2_passed, _val2_issues, _exact_dups2 = _validate_digest(
                         x_thread_retry, _val_config,
                         section_patterns=section_patterns,
                         recent_headlines=_recent,
@@ -601,12 +625,14 @@ def run(args: argparse.Namespace) -> None:
                             len(x_thread), len(x_thread_retry),
                         )
                         x_thread = x_thread_retry
+                        _exact_dups = _exact_dups2
                     elif len(_missing2) < len(_missing):
                         logger.info(
                             "Digest retry improved: %d → %d missing sections",
                             len(_missing), len(_missing2),
                         )
                         x_thread = x_thread_retry
+                        _exact_dups = _exact_dups2
                     elif len(x_thread_retry) > len(x_thread):
                         # Same missing sections but retry is longer — prefer
                         # the longer output (less likely to be garbage).
@@ -615,6 +641,7 @@ def run(args: argparse.Namespace) -> None:
                             len(x_thread), len(x_thread_retry),
                         )
                         x_thread = x_thread_retry
+                        _exact_dups = _exact_dups2
                     else:
                         logger.warning("Digest retry did not improve — keeping original")
                 except LLMRefusalError:
@@ -898,6 +925,28 @@ def run(args: argparse.Namespace) -> None:
         # sometimes echoes these through to the script, and TTS reads them
         # aloud.  This is defense-in-depth alongside the prompt instructions.
         clean_digest = _clean_digest_for_podcast(x_thread)
+
+        # Strip exact cross-episode duplicates from the digest so they don't
+        # make it into the podcast script.  _exact_dups is populated by
+        # validate_digest when a headline matches a recent episode at 100%.
+        if _val_factory and _exact_dups:
+            for dup_headline in _exact_dups:
+                if dup_headline in clean_digest:
+                    # Remove the paragraph containing the duplicate headline
+                    import re as _re
+                    # Try to remove the full bold-headline block
+                    _dup_escaped = _re.escape(dup_headline)
+                    _pattern = _re.compile(
+                        r'\n[^\n]*\*\*' + _dup_escaped + r'\*\*[^\n]*(?:\n(?![#\n━*])[^\n]*)*',
+                        _re.IGNORECASE,
+                    )
+                    clean_digest_new = _pattern.sub('', clean_digest)
+                    if clean_digest_new != clean_digest:
+                        logger.info(
+                            "Stripped 100%% duplicate headline from podcast digest: '%s'",
+                            dup_headline[:60],
+                        )
+                        clean_digest = clean_digest_new
 
         effective_hook = hook or f"Here's what's making news in the {config.name} world today."
 
@@ -1196,6 +1245,7 @@ def run(args: argparse.Namespace) -> None:
                             stability=config.tts.stability,
                             similarity_boost=config.tts.similarity_boost,
                             style=config.tts.style,
+                            language_code=config.tts.language_code,
                         )
 
                     generate_transition_sting(sting_path)

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -130,6 +130,7 @@ llm:
 
 tts:
   voice_id: gedzfqL7OGdPbwm0ynTP
+  language_code: ru
   stability: 0.65
   similarity_boost: 0.9
   style: 0.85

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -95,6 +95,7 @@ llm:
 
 tts:
   voice_id: gedzfqL7OGdPbwm0ynTP
+  language_code: ru
   stability: 0.65
   similarity_boost: 0.9
   style: 0.85

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -198,7 +198,7 @@ class TestWithinEpisodeDuplicates:
 class TestCrossEpisodeRepeats:
     def test_detects_repeat(self):
         recent = ["Tesla Cybertruck Production Ramps Up Significantly"]
-        issues = check_cross_episode_repeats(
+        issues, exact_dups = check_cross_episode_repeats(
             SAMPLE_DIGEST,
             recent,
             TST_SECTION_PATTERNS,
@@ -208,32 +208,34 @@ class TestCrossEpisodeRepeats:
 
     def test_no_repeats_with_different_headlines(self):
         recent = ["SpaceX Launches New Satellite"]
-        issues = check_cross_episode_repeats(
+        issues, exact_dups = check_cross_episode_repeats(
             SAMPLE_DIGEST,
             recent,
             TST_SECTION_PATTERNS,
             threshold=0.65,
         )
         assert len(issues) == 0
+        assert len(exact_dups) == 0
 
 
 class TestValidateDigest:
     def test_clean_digest_passes(self):
         config = ValidationConfig()
-        passed, issues = validate_digest(SAMPLE_DIGEST, config)
+        passed, issues, exact_dups = validate_digest(SAMPLE_DIGEST, config)
         assert passed is True
         assert len(issues) == 0
+        assert len(exact_dups) == 0
 
     def test_empty_digest_fails(self):
         config = ValidationConfig()
-        passed, issues = validate_digest("", config)
+        passed, issues, exact_dups = validate_digest("", config)
         assert passed is False
 
     def test_with_section_pairs(self):
         config = ValidationConfig(
             section_pairs=[("headlines", "takeover_headlines")],
         )
-        passed, issues = validate_digest(
+        passed, issues, exact_dups = validate_digest(
             SAMPLE_DIGEST, config, section_patterns=TST_SECTION_PATTERNS
         )
         assert passed is True


### PR DESCRIPTION
Six improvements to leverage the grok-4.20 and eleven_v3 model upgrades:

1. Russian TTS language_code: Pass language_code=ru to ElevenLabs eleven_v3 for Finansy Prosto and Privet Russian, improving pronunciation accuracy.

2. LLM model fallback for digest refusals: After the educational prompt retry fails, try once more with grok-4 fallback model before raising LLMRefusalError. Different models have different refusal thresholds.

3. Podcast script refusal recovery: Add refusal retry chain to podcast script generation (previously only digest had recovery). Uses simplified prompt at lower temperature, then fallback model.

4. Repetition detection false positives: Expand common-phrase exclusion list (host attribution, separators, stopwords). Raise threshold from 4 to 5 occurrences for podcast scripts which are naturally longer.

5. X post cross-dedup against RSS: When merging X posts into articles, check similarity against existing RSS articles and skip duplicates above 0.65 threshold.

6. Blocking cross-episode 100% repeats: validate_digest now returns exact duplicate headlines separately. These are stripped from the digest before podcast script generation to prevent recycled content.

https://claude.ai/code/session_01HTVom53SHEcC8GS1T8CAQM