### PR TITLE
Make hero show cards square, larger, rounded, and clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,47 +381,36 @@
             <p class="network-hero-tagline">Feed your curiosity. Not your anxiety.</p>
             <p class="hero-subtitle">10 ad-free shows covering Tesla, world news, space, science, AI, investing, and more. Produced daily in Vancouver.</p>
             <div class="hero-show-orbit">
-                
-                <div class="orbit-card" style="--i: 0;">
+                <a href="models-agents.html" class="orbit-card" style="--i: 0;">
                     <img src="assets/covers/models-agents.jpg" alt="Models & Agents" loading="eager" />
-                </div>
-                
-                <div class="orbit-card" style="--i: 1;">
+                </a>
+                <a href="planetterrian.html" class="orbit-card" style="--i: 1;">
                     <img src="assets/covers/planetterrian-daily.jpg" alt="Planetterrian Daily" loading="eager" />
-                </div>
-                
-                <div class="orbit-card" style="--i: 2;">
+                </a>
+                <a href="omni-view.html" class="orbit-card" style="--i: 2;">
                     <img src="assets/covers/omni-view.jpg" alt="Omni View" loading="eager" />
-                </div>
-                
-                <div class="orbit-card" style="--i: 3;">
+                </a>
+                <a href="models-agents-beginners.html" class="orbit-card" style="--i: 3;">
                     <img src="assets/covers/models-agents-beginners.jpg" alt="Models & Agents for Beginners" loading="eager" />
-                </div>
-                
-                <div class="orbit-card" style="--i: 4;">
+                </a>
+                <a href="fascinating_frontiers.html" class="orbit-card" style="--i: 4;">
                     <img src="assets/covers/fascinating-frontiers.jpg" alt="Fascinating Frontiers" loading="eager" />
-                </div>
-                
-                <div class="orbit-card" style="--i: 5;">
+                </a>
+                <a href="modern-investing.html" class="orbit-card" style="--i: 5;">
                     <img src="assets/covers/modern-investing.jpg" alt="Modern Investing Techniques" loading="eager" />
-                </div>
-                
-                <div class="orbit-card" style="--i: 6;">
+                </a>
+                <a href="tesla.html" class="orbit-card" style="--i: 6;">
                     <img src="assets/covers/tesla-shorts-time.jpg" alt="Tesla Shorts Time" loading="eager" />
-                </div>
-                
-                <div class="orbit-card" style="--i: 7;">
+                </a>
+                <a href="env-intel.html" class="orbit-card" style="--i: 7;">
                     <img src="assets/covers/environmental-intelligence.jpg" alt="Environmental Intelligence" loading="eager" />
-                </div>
-                
-                <div class="orbit-card" style="--i: 8;">
+                </a>
+                <a href="ru/finansy-prosto.html" class="orbit-card" style="--i: 8;">
                     <img src="assets/covers/finansy-prosto.jpg" alt="Финансы Просто" loading="eager" />
-                </div>
-                
-                <div class="orbit-card" style="--i: 9;">
+                </a>
+                <a href="ru/privet-russian.html" class="orbit-card" style="--i: 9;">
                     <img src="assets/covers/privet-russian.jpg" alt="Привет, Русский!" loading="eager" />
-                </div>
-                
+                </a>
             </div>
             <div class="hero-cta-row">
                 <a href="#shows" class="nn-btn nn-btn-primary nn-btn-lg hero-cta-primary" style="--show-color:#7C5CFF;">Explore Shows</a>

--- a/styles/main.css
+++ b/styles/main.css
@@ -938,9 +938,10 @@ button { font-family: var(--font-ui); cursor: pointer; }
 }
 
 .orbit-card {
-  width: 76px;
-  height: 76px;
-  border-radius: 18%;
+  display: block;
+  width: 96px;
+  height: 96px;
+  border-radius: 16px;
   overflow: hidden;
   box-shadow:
     0 4px 20px rgba(0, 0, 0, 0.35),
@@ -949,6 +950,9 @@ button { font-family: var(--font-ui); cursor: pointer; }
   animation-delay: calc(var(--i) * -0.4s);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   cursor: pointer;
+  aspect-ratio: 1 / 1;
+  text-decoration: none;
+  flex-shrink: 0;
 }
 
 .orbit-card:hover {
@@ -973,12 +977,12 @@ button { font-family: var(--font-ui); cursor: pointer; }
 }
 
 @media (min-width: 640px) {
-  .orbit-card { width: 96px; height: 96px; }
+  .orbit-card { width: 110px; height: 110px; }
   .hero-show-orbit { gap: 20px; }
 }
 
 @media (min-width: 1024px) {
-  .orbit-card { width: 115px; height: 115px; }
+  .orbit-card { width: 120px; height: 120px; }
   .hero-show-orbit { gap: 22px; flex-wrap: nowrap; }
 }
 

--- a/templates/network_page.html.j2
+++ b/templates/network_page.html.j2
@@ -66,15 +66,16 @@
             <p class="hero-subtitle">{{ all_shows | length }} ad-free shows covering Tesla, world news, space, science, AI, investing, and more. Produced daily in Vancouver.</p>
             <div class="hero-show-orbit">
                 {% for s in all_shows %}
-                <div class="orbit-card" style="--i: {{ loop.index0 }};">
-                    <img src="{{ s.podcast_image }}" alt="{{ s.name }}" loading="eager" />
-                </div>
+                <a href="{{ path_prefix }}{{ s.show_page }}" class="orbit-card" style="--i: {{ loop.index0 }};">
+                    <img src="{{ path_prefix }}{{ s.podcast_image }}" alt="{{ s.name }}" loading="eager" />
+                </a>
                 {% endfor %}
             </div>
             <div class="hero-cta-row">
                 <a href="#shows" class="nn-btn nn-btn-primary nn-btn-lg hero-cta-primary" style="--show-color:#7C5CFF;">Explore Shows</a>
+                <a href="{{ path_prefix }}player.html" class="nn-btn nn-btn-lg">Open Player</a>
                 <a href="#subscribe" class="nn-btn nn-btn-lg">Subscribe Free</a>
-                <a href="blog/index.html" class="nn-btn nn-btn-lg">Read Blog</a>
+                <a href="{{ path_prefix }}blog/index.html" class="nn-btn nn-btn-lg">Read Blog</a>
             </div>
         </div>
     </section>


### PR DESCRIPTION
- Orbit cards now link to each show's page (div -> a tags)
- Increased card size: 96px base, 110px at 640px+, 120px at 1024px+
- Fixed border-radius to 16px (was 18% which made them look oblong)
- Added aspect-ratio: 1/1 to enforce square shape
- Updated network_page.html.j2 template to match (linked cards + "Open Player" CTA button)

https://claude.ai/code/session_01LmUHbSFDKdrxVpwK73WHox