### PR TITLE
Move content quality detection earlier in pipeline

### DIFF
--- a/engine/generator.py
+++ b/engine/generator.py
@@ -315,7 +315,7 @@ def _detect_story_duplication(text: str, show_name: str) -> int:
     # Cap at 2 — story-level duplication is a softer signal than
     # bigram-level hallucination.  The prompt-level anti-repetition
     # instruction is the primary fix; this detector is a safety net.
-    return min(dup_count, 2)
+    return min(dup_count, 3)
 
 
 def _validate_llm_output(
@@ -446,6 +446,30 @@ def _validate_llm_output(
                     stage, show_name, phrase, count,
                 )
 
+    # Also scan for 3-word phrases (trigrams) — catches patterns like
+    # "the question worth" that slip through bigram detection.
+    if len(words) > 50:
+        trigrams = [" ".join(words[i:i+3]).lower() for i in range(len(words) - 2)]
+        trigram_counts = Counter(trigrams)
+        _COMMON_TRIGRAMS = {
+            "of the the", "in the the", "one of the", "some of the",
+            "a lot of", "going to be", "it's going to",
+            "according to the", "is going to", "we're going to",
+            "repeat after me.", "repeat after me,", "repeat after me:",
+        }
+        for phrase, count in trigram_counts.most_common(5):
+            if phrase in _COMMON_TRIGRAMS:
+                continue
+            tokens = phrase.split()
+            if all(len(t) <= 3 for t in tokens):
+                continue
+            if count >= _rep_threshold:
+                _suspicious_count += 1
+                logger.warning(
+                    "LLM %s for '%s' has suspicious trigram repetition: '%s' appears %d times",
+                    stage, show_name, phrase, count,
+                )
+
     # Warn if podcast script is too short to fill target duration
     if stage == "podcast_script":
         word_count = len(text.split())
@@ -460,7 +484,7 @@ def _validate_llm_output(
     # Detect story-level duplication — same news story retold in different
     # sections of the podcast script (e.g. school bus story told at lines
     # 7-13 and again at lines 31-35 with different framing).
-    if stage == "podcast_script":
+    if stage in ("digest", "podcast_script"):
         _suspicious_count += _detect_story_duplication(text, show_name)
 
     return _suspicious_count

--- a/engine/validation.py
+++ b/engine/validation.py
@@ -326,6 +326,15 @@ def tst_validation_config() -> ValidationConfig:
                 ),
                 min_items=1,
             ),
+            SectionRule(
+                name="First Principles",
+                pattern=(
+                    r"(?:### Tesla First Principles|🧠\s*Tesla First Principles)"
+                    r"(.*?)"
+                    r"(?=━━|### Daily Challenge|💪|$)"
+                ),
+                min_items=1,
+            ),
         ],
         forbidden_patterns=[
             # Stock price in podcast script (not digest — only for POD_PROMPT output)


### PR DESCRIPTION
Fix 4 issues caught by post-run review that should have been caught before TTS/publication:

1. Add "First Principles" SectionRule to Tesla validation config so missing section triggers in-pipeline retry (was only checked post-hoc)
2. Raise story duplication cap from 2 to 3 to actually trigger the retry threshold (>=3) when 3+ duplicate pairs are found
3. Add trigram (3-word phrase) repetition detection alongside existing bigram detection — catches patterns like "the question worth" (8x)
4. Run story duplication detection on digest text too, not just podcast scripts — catches duplication at the source before it propagates

https://claude.ai/code/session_01HTVom53SHEcC8GS1T8CAQM