### PR TITLE
Tighten env_intel and models_agents digest prompts to prevent repetition

### DIFF
--- a/shows/prompts/env_intel_digest.txt
+++ b/shows/prompts/env_intel_digest.txt
@@ -98,7 +98,7 @@ Source: [EXACT URL]
 
 **HOOK:** [One factual sentence that captures the single most important development for Canadian environmental professionals today. Under 120 characters. Specific and actionable. No URLs, no dates, no emoji.]
 
-**Executive Summary:** 2-3 sentences. Lead with the single most actionable development. Be specific — name the regulation, the threshold, the deadline, the jurisdiction (province or federal). End with one sentence on what professionals should watch this week.
+**Executive Summary:** 2-3 sentences that give a LANDSCAPE view of the day — reference 2-3 DIFFERENT developments from across the briefing (not just the Lead Story). Do NOT restate the Lead Story's regulatory context or implications here; that happens in the Lead Story section. The Exec Summary should read like a table of contents, not a preview of the lead. End with one sentence on what professionals should watch this week.
 
 ━━━━━━━━━━━━━━━━━━━━
 ### Lead Story
@@ -108,6 +108,8 @@ The most significant development for Canadian environmental professionals today.
 - Sentence 4: Direct implications for practitioners — what does this mean for current projects, assessments, or compliance programs
 - Sentence 5-6: What to watch — next steps, consultation deadlines, implementation timelines
 Source: [EXACT URL FROM PRE-FETCHED — no modifications]
+
+**ANTI-DUPLICATION RULE:** The Lead Story must NOT repeat the exact sentences or phrases used in the Executive Summary. The Exec Summary gives the headline; the Lead Story gives the full details. If the Exec Summary already said "the claim engages Alberta EPEA, federal Fisheries Act, and Species at Risk Act", the Lead Story must describe those regulatory engagements with DIFFERENT wording, or move that detail to a sentence the Exec Summary did not cover.
 
 ━━━━━━━━━━━━━━━━━━━━
 ### Regulatory & Policy Watch

--- a/shows/prompts/models_agents_digest.txt
+++ b/shows/prompts/models_agents_digest.txt
@@ -67,6 +67,8 @@ The most significant AI development today. 4-6 sentences:
 - Sentence 5-6: What to watch — upcoming releases, expected developments, things to try
 Source: [EXACT URL FROM PRE-FETCHED — no modifications]
 
+**ONE-SECTION RULE:** The Top Story's URL must NOT reappear in Model Updates, Agent & Tool Developments, or Practical & Community. Each URL/story appears in EXACTLY ONE section. If the most significant development is an agent/tool, pick the NEXT-most-significant different item to lead Agent & Tool Developments — do not list the Top Story there as well.
+
 ━━━━━━━━━━━━━━━━━━━━
 ### Model Updates
 2-4 items tracking new model releases, updates, benchmarks, or capability changes. For each:
@@ -93,6 +95,8 @@ Source: [EXACT URL]
 An engineering teardown of ONE AI concept, architecture, or technique. This section uses YOUR OWN knowledge of ML systems, distributed computing, and AI engineering — not just today's articles — to reveal how something ACTUALLY works beneath the marketing.
 
 **TOPIC SELECTION:** Choose the technology where the gap between public perception and engineering reality is WIDEST. Prioritize: (1) techniques that sound like magic but have elegant engineering explanations, (2) concepts where the press release hides important tradeoffs, (3) architectural decisions that seem obvious but have counterintuitive reasons.
+
+**TOPIC DISTINCTNESS — MUST NOT be the same topic as today's Top Story.** If the Top Story is about compiler-backed agents, Under the Hood must pick a different technology (e.g., a retrieval technique, an inference optimisation, an architectural tradeoff). A listener should hear TWO separate technical stories, not the same story told twice with different framing. Reusing the Top Story's subject here is forbidden even if it is the most interesting topic of the day.
 
 **TOPIC FRESHNESS — MUST choose a DIFFERENT topic than recent episodes:**
 {recent_deep_dive_topics}


### PR DESCRIPTION
Daily review for 2026-04-09 flagged two critical "Repetitive" issues:

- env_intel Ep022: Executive Summary and Lead Story both described the Piikani Nation selenium story with nearly verbatim sentences (the "claim engages Alberta EPEA, federal Fisheries Act, and Species at Risk Act" phrase appeared in both).

- models_agents Ep028: The compiler-as-a-service Reddit post was listed as the Top Story, repeated as an item in Agent & Tool Developments, and then deep-dived again in Under the Hood — three passes at the same story in one episode.

Root cause in both cases is the digest prompt: env_intel's Exec Summary was instructed to "Lead with the single most actionable development", which inevitably echoed the Lead Story; models_agents had no rule preventing the same URL from appearing in multiple sections or Under the Hood picking the same topic as the Top Story.

Fixes:
- env_intel_digest.txt: Exec Summary must now give a landscape view referencing 2-3 different developments, not preview the Lead Story. Added an explicit anti-duplication rule for the Lead Story sentences.
- models_agents_digest.txt: Added a one-section rule (each URL appears in exactly one section) and a topic-distinctness rule (Under the Hood must not cover the same topic as the Top Story).

Episodes Ep022 and Ep028 are left in their RSS feeds — the repetition is noticeable but the episodes still deliver valid content, and removal would create listener-visible gaps without fixing the underlying cause. The prompt changes prevent recurrence.

https://claude.ai/code/session_01WN7fo2mcvm9HXZGxe7EfCD