### PR TITLE
Add Nerra Network management dashboard + fix CLAUDE.md voice drift

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,0 +1,91 @@
+name: Management Dashboard
+
+# Regenerates api/dashboard.json from on-disk data (shows/*.yaml,
+# digests/<show>/metrics_ep*.json, digests/<show>/credit_usage_*.json,
+# *.rss). Commits the JSON back to main so management.html can render
+# the latest state without a backend.
+#
+# Runs daily (30 minutes after health-check.yml) and on every
+# successful run-show.yml completion so the dashboard always reflects
+# the most recent episode publish.
+
+on:
+  schedule:
+    - cron: '30 18 * * *'  # 30 minutes after health-check.yml
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Run Podcast Show"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: management-dashboard
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Skip workflow_run firings where the upstream Run Podcast Show failed.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-dashboard-${{ hashFiles('requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-dashboard-
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Generate api/dashboard.json
+        id: gen
+        run: |
+          set +e
+          python scripts/generate_dashboard.py --out api/dashboard.json
+          EXIT_CODE=$?
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          # Exit 0 even on FAIL — we still want to commit the diagnostic JSON
+          # so the operator can see the current red state.
+          exit 0
+
+      - name: Pull latest before committing
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git pull --rebase --autostash origin main || true
+
+      - name: Commit and push dashboard
+        run: |
+          git add api/dashboard.json
+          if git diff --cached --quiet; then
+            echo "No dashboard changes to commit"
+            exit 0
+          fi
+          git commit -m "Update management dashboard $(date -u +%Y-%m-%dT%H:%MZ)"
+          # Small retry in case two dashboard runs raced.
+          for i in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            git pull --rebase --autostash origin main || true
+            sleep 2
+          done
+          git push
+
+      - name: Fail the job on landmine FAIL
+        if: steps.gen.outputs.exit_code != '0'
+        run: |
+          echo "::error::Management dashboard detected FAIL-level landmine(s). See api/dashboard.json → landmines[]."
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,12 @@ Phase 3 (current):
 
 ## Known Landmines
 
+**Operator's first stop:** the live state of every landmine below is rendered
+by [`management.html`](management.html), fed by
+[`scripts/generate_dashboard.py`](scripts/generate_dashboard.py) → `api/dashboard.json`.
+Items 7 and 10 are intentionally excluded from the dashboard (per an explicit
+decision); everything else has a live status card.
+
 ### Active Issues
 
 1. **2.2 GB of MP3s in git** — repo will hit GitHub's 10 GB limit within ~6
@@ -232,9 +238,18 @@ Phase 3 (current):
    (TST, FF, PT, OV) support env-overridable `TEST_MODE`, `ENABLE_X_POSTING`,
    `ENABLE_PODCAST`, and `ENABLE_GITHUB_SUMMARIES`. `run_show.py` uses
    CLI flags (`--test`, `--skip-x`, `--skip-podcast`) instead.
-9. **OV ElevenLabs tuning defaults aligned** — OV legacy script defaults
-   updated from 0.35/0.75/0.2 to 0.65/0.9/0.85, matching all YAML configs
-   and other legacy scripts. Env var overrides still supported.
+9. **ElevenLabs tuning baseline lives in `shows/_defaults.yaml`** — the
+   canonical network baseline is now whatever
+   [`shows/_defaults.yaml`](shows/_defaults.yaml) declares (today:
+   `stability=0.5`, `similarity_boost=0.75`, `style=0.0`, English voice
+   `dTrBzPvD2GpAqkk1MUzA`, Russian voice `gedzfqL7OGdPbwm0ynTP`). Per-show
+   overrides are allowed; drift is tracked live in the management
+   dashboard's *Voice settings consistency* table. Any show row flagged
+   with a drift is either intentional (record the reason in the show's
+   YAML as a comment) or a regression to investigate. Historical note:
+   an earlier baseline had stability `0.65`, similarity boost `0.9`, and
+   style `0.85`; that combination is no longer blessed and should not be
+   reintroduced without updating `_defaults.yaml`.
 10. **Early episodes deleted** — first 20 Tesla, 10 FF, 10 PT, 10 OV episodes
     removed (quality issues). RSS entries removed where applicable.
 11. **All shows use ElevenLabs TTS** — Chatterbox, Kokoro, and Fish Audio

--- a/api/dashboard.json
+++ b/api/dashboard.json
@@ -1,0 +1,2426 @@
+{
+  "generated_at": "2026-04-11T18:36:51.768910+00:00",
+  "network": {
+    "landmines_counts": {
+      "ok": 9,
+      "warn": 1,
+      "fail": 0
+    },
+    "shows_count": 10,
+    "stale_shows": 0,
+    "total_cost_last_7_days_usd": 77.3421,
+    "total_cost_last_30_days_usd": 471.8152,
+    "shows": [
+      {
+        "slug": "env_intel",
+        "name": "Environmental Intelligence",
+        "rss_file": "env_intel_podcast.rss",
+        "rss_title": "Environmental Intelligence",
+        "rss_image": "https://nerranetwork.com/assets/covers/environmental-intelligence.jpg",
+        "show_page": "env_intel.html",
+        "blog_page": "blog/env_intel/index.html",
+        "newsletter_enabled": true,
+        "x_enabled": false,
+        "latest_pub_date": "2026-04-09T08:00:00+00:00",
+        "pub_status": "warn",
+        "cost_last_7_days_usd": 3.2176,
+        "episodes_last_7_days": 2,
+        "p50_pipeline_s": 22.83,
+        "success_rate": 1.0
+      },
+      {
+        "slug": "fascinating_frontiers",
+        "name": "Fascinating Frontiers",
+        "rss_file": "fascinating_frontiers_podcast.rss",
+        "rss_title": "Fascinating Frontiers",
+        "rss_image": "https://nerranetwork.com/assets/covers/fascinating-frontiers.jpg",
+        "show_page": "fascinating_frontiers.html",
+        "blog_page": "blog/fascinating_frontiers/index.html",
+        "newsletter_enabled": true,
+        "x_enabled": true,
+        "latest_pub_date": "2026-04-10T08:00:00+00:00",
+        "pub_status": "ok",
+        "cost_last_7_days_usd": 5.8396,
+        "episodes_last_7_days": 3,
+        "p50_pipeline_s": 44.38,
+        "success_rate": 1.0
+      },
+      {
+        "slug": "finansy_prosto",
+        "name": "Финансы Просто",
+        "rss_file": "finansy_prosto_podcast.rss",
+        "rss_title": "Финансы Просто",
+        "rss_image": "https://nerranetwork.com/assets/covers/finansy-prosto.jpg",
+        "show_page": "finansy_prosto.html",
+        "blog_page": "blog/finansy_prosto/index.html",
+        "newsletter_enabled": true,
+        "x_enabled": false,
+        "latest_pub_date": "2026-04-10T08:00:00+00:00",
+        "pub_status": "ok",
+        "cost_last_7_days_usd": 4.0059,
+        "episodes_last_7_days": 3,
+        "p50_pipeline_s": 19.72,
+        "success_rate": 1.0
+      },
+      {
+        "slug": "models_agents",
+        "name": "Models & Agents",
+        "rss_file": "models_agents_podcast.rss",
+        "rss_title": "Models & Agents",
+        "rss_image": "https://nerranetwork.com/assets/covers/models-agents.jpg",
+        "show_page": "models_agents.html",
+        "blog_page": "blog/models_agents/index.html",
+        "newsletter_enabled": true,
+        "x_enabled": false,
+        "latest_pub_date": "2026-04-11T08:00:00+00:00",
+        "pub_status": "ok",
+        "cost_last_7_days_usd": 7.1504,
+        "episodes_last_7_days": 4,
+        "p50_pipeline_s": 45.28,
+        "success_rate": 1.0
+      },
+      {
+        "slug": "models_agents_beginners",
+        "name": "Models & Agents for Beginners",
+        "rss_file": "models_agents_beginners_podcast.rss",
+        "rss_title": "Models & Agents for Beginners",
+        "rss_image": "https://nerranetwork.com/assets/covers/models-agents-beginners.jpg",
+        "show_page": "models_agents_beginners.html",
+        "blog_page": "blog/models_agents_beginners/index.html",
+        "newsletter_enabled": false,
+        "x_enabled": false,
+        "latest_pub_date": "2026-04-10T08:00:00+00:00",
+        "pub_status": "ok",
+        "cost_last_7_days_usd": 5.121,
+        "episodes_last_7_days": 4,
+        "p50_pipeline_s": 19.36,
+        "success_rate": 1.0
+      },
+      {
+        "slug": "modern_investing",
+        "name": "Modern Investing Techniques",
+        "rss_file": "modern_investing_podcast.rss",
+        "rss_title": "Modern Investing Techniques",
+        "rss_image": "https://nerranetwork.com/assets/covers/modern-investing.jpg",
+        "show_page": "modern_investing.html",
+        "blog_page": "blog/modern_investing/index.html",
+        "newsletter_enabled": true,
+        "x_enabled": false,
+        "latest_pub_date": "2026-04-10T08:00:00+00:00",
+        "pub_status": "ok",
+        "cost_last_7_days_usd": 12.0762,
+        "episodes_last_7_days": 6,
+        "p50_pipeline_s": 59.61,
+        "success_rate": 1.0
+      },
+      {
+        "slug": "omni_view",
+        "name": "Omni View",
+        "rss_file": "omni_view_podcast.rss",
+        "rss_title": "Omni View - Balanced News Perspectives",
+        "rss_image": "https://nerranetwork.com/assets/covers/omni-view.jpg",
+        "show_page": "omni_view.html",
+        "blog_page": "blog/omni_view/index.html",
+        "newsletter_enabled": true,
+        "x_enabled": true,
+        "latest_pub_date": "2026-04-11T08:00:00+00:00",
+        "pub_status": "ok",
+        "cost_last_7_days_usd": 7.8421,
+        "episodes_last_7_days": 4,
+        "p50_pipeline_s": 115.37,
+        "success_rate": 0.933
+      },
+      {
+        "slug": "planetterrian",
+        "name": "Planetterrian Daily",
+        "rss_file": "planetterrian_podcast.rss",
+        "rss_title": "Planetterrian Daily",
+        "rss_image": "https://nerranetwork.com/assets/covers/planetterrian-daily.jpg",
+        "show_page": "planetterrian.html",
+        "blog_page": "blog/planetterrian/index.html",
+        "newsletter_enabled": true,
+        "x_enabled": true,
+        "latest_pub_date": "2026-04-11T08:00:00+00:00",
+        "pub_status": "ok",
+        "cost_last_7_days_usd": 10.2097,
+        "episodes_last_7_days": 4,
+        "p50_pipeline_s": 37.25,
+        "success_rate": 1.0
+      },
+      {
+        "slug": "privet_russian",
+        "name": "Привет, Русский!",
+        "rss_file": "privet_russian_podcast.rss",
+        "rss_title": "Привет, Русский!",
+        "rss_image": "https://nerranetwork.com/assets/covers/privet-russian.jpg",
+        "show_page": "privet_russian.html",
+        "blog_page": "blog/privet_russian/index.html",
+        "newsletter_enabled": true,
+        "x_enabled": false,
+        "latest_pub_date": "2026-04-10T08:00:00+00:00",
+        "pub_status": "ok",
+        "cost_last_7_days_usd": 2.1533,
+        "episodes_last_7_days": 2,
+        "p50_pipeline_s": 26.96,
+        "success_rate": 1.0
+      },
+      {
+        "slug": "tesla",
+        "name": "Tesla Shorts Time",
+        "rss_file": "podcast.rss",
+        "rss_title": "Tesla Shorts Time Daily",
+        "rss_image": "https://nerranetwork.com/assets/covers/tesla-shorts-time.jpg",
+        "show_page": "tesla.html",
+        "blog_page": "blog/tesla/index.html",
+        "newsletter_enabled": true,
+        "x_enabled": true,
+        "latest_pub_date": "2026-04-11T08:00:00+00:00",
+        "pub_status": "ok",
+        "cost_last_7_days_usd": 19.7262,
+        "episodes_last_7_days": 9,
+        "p50_pipeline_s": 66.94,
+        "success_rate": 1.0
+      }
+    ]
+  },
+  "shows": [
+    {
+      "slug": "env_intel",
+      "name": "Environmental Intelligence",
+      "yaml_path": "shows/env_intel.yaml",
+      "load_error": null,
+      "rss_file": "env_intel_podcast.rss",
+      "rss_image": "https://nerranetwork.com/assets/covers/environmental-intelligence.jpg",
+      "newsletter_enabled": true,
+      "x_enabled": false
+    },
+    {
+      "slug": "fascinating_frontiers",
+      "name": "Fascinating Frontiers",
+      "yaml_path": "shows/fascinating_frontiers.yaml",
+      "load_error": null,
+      "rss_file": "fascinating_frontiers_podcast.rss",
+      "rss_image": "https://nerranetwork.com/assets/covers/fascinating-frontiers.jpg",
+      "newsletter_enabled": true,
+      "x_enabled": true
+    },
+    {
+      "slug": "finansy_prosto",
+      "name": "Финансы Просто",
+      "yaml_path": "shows/finansy_prosto.yaml",
+      "load_error": null,
+      "rss_file": "finansy_prosto_podcast.rss",
+      "rss_image": "https://nerranetwork.com/assets/covers/finansy-prosto.jpg",
+      "newsletter_enabled": true,
+      "x_enabled": false
+    },
+    {
+      "slug": "models_agents",
+      "name": "Models & Agents",
+      "yaml_path": "shows/models_agents.yaml",
+      "load_error": null,
+      "rss_file": "models_agents_podcast.rss",
+      "rss_image": "https://nerranetwork.com/assets/covers/models-agents.jpg",
+      "newsletter_enabled": true,
+      "x_enabled": false
+    },
+    {
+      "slug": "models_agents_beginners",
+      "name": "Models & Agents for Beginners",
+      "yaml_path": "shows/models_agents_beginners.yaml",
+      "load_error": null,
+      "rss_file": "models_agents_beginners_podcast.rss",
+      "rss_image": "https://nerranetwork.com/assets/covers/models-agents-beginners.jpg",
+      "newsletter_enabled": false,
+      "x_enabled": false
+    },
+    {
+      "slug": "modern_investing",
+      "name": "Modern Investing Techniques",
+      "yaml_path": "shows/modern_investing.yaml",
+      "load_error": null,
+      "rss_file": "modern_investing_podcast.rss",
+      "rss_image": "https://nerranetwork.com/assets/covers/modern-investing.jpg",
+      "newsletter_enabled": true,
+      "x_enabled": false
+    },
+    {
+      "slug": "omni_view",
+      "name": "Omni View",
+      "yaml_path": "shows/omni_view.yaml",
+      "load_error": null,
+      "rss_file": "omni_view_podcast.rss",
+      "rss_image": "https://nerranetwork.com/assets/covers/omni-view.jpg",
+      "newsletter_enabled": true,
+      "x_enabled": true
+    },
+    {
+      "slug": "planetterrian",
+      "name": "Planetterrian Daily",
+      "yaml_path": "shows/planetterrian.yaml",
+      "load_error": null,
+      "rss_file": "planetterrian_podcast.rss",
+      "rss_image": "https://nerranetwork.com/assets/covers/planetterrian-daily.jpg",
+      "newsletter_enabled": true,
+      "x_enabled": true
+    },
+    {
+      "slug": "privet_russian",
+      "name": "Привет, Русский!",
+      "yaml_path": "shows/privet_russian.yaml",
+      "load_error": null,
+      "rss_file": "privet_russian_podcast.rss",
+      "rss_image": "https://nerranetwork.com/assets/covers/privet-russian.jpg",
+      "newsletter_enabled": true,
+      "x_enabled": false
+    },
+    {
+      "slug": "tesla",
+      "name": "Tesla Shorts Time",
+      "yaml_path": "shows/tesla.yaml",
+      "load_error": null,
+      "rss_file": "podcast.rss",
+      "rss_image": "https://nerranetwork.com/assets/covers/tesla-shorts-time.jpg",
+      "newsletter_enabled": true,
+      "x_enabled": true
+    }
+  ],
+  "landmines": [
+    {
+      "id": "item_1_repo_size",
+      "title": "Repo & R2 size",
+      "status": "ok",
+      "details": "5 MP3s tracked in git, digests/ is 46 MB.",
+      "evidence": {
+        "tracked_mp3_count": 5,
+        "digests_mb": 46.1
+      }
+    },
+    {
+      "id": "item_2_rss_integrity",
+      "title": "RSS integrity, LFS absence, R2 host consistency",
+      "status": "ok",
+      "details": "All 11 feeds valid, R2-hosted, recent enclosures reachable.",
+      "evidence": {
+        "feeds": 11,
+        "malformed": [],
+        "raw_github_hits": [],
+        "non_r2_hosts": [],
+        "unreachable": [],
+        "offline": true
+      }
+    },
+    {
+      "id": "item_3_legacy_flatfiles",
+      "title": "Legacy flat files in digests/",
+      "status": "warn",
+      "details": "96 legacy flat files pinned at digests/ top level. They cannot be moved (existing RSS URLs anchor to them), but no new files should land here.",
+      "evidence": {
+        "total": 96,
+        "by_extension": {
+          ".json": 47,
+          ".txt": 45,
+          "<none>": 1,
+          ".py": 3
+        },
+        "previous_total": 96
+      }
+    },
+    {
+      "id": "item_4_output_dirs",
+      "title": "Per-show output paths under digests/",
+      "status": "ok",
+      "details": "All 10 shows write into digests/…",
+      "evidence": {}
+    },
+    {
+      "id": "item_5_nested_digests",
+      "title": "Nested digests/digests/ directory",
+      "status": "ok",
+      "details": "No nested digests/digests/ directory.",
+      "evidence": {}
+    },
+    {
+      "id": "item_6_formatted_md",
+      "title": "Duplicate *_formatted.md files",
+      "status": "ok",
+      "details": "No *_formatted.md duplicates.",
+      "evidence": {}
+    },
+    {
+      "id": "item_8_feature_flags",
+      "title": "Feature flags (x_enabled) explicit",
+      "status": "ok",
+      "details": "All 10 shows declare publishing.x_enabled explicitly.",
+      "evidence": {
+        "per_show": [
+          {
+            "slug": "env_intel",
+            "x_enabled": false,
+            "explicit": true
+          },
+          {
+            "slug": "fascinating_frontiers",
+            "x_enabled": true,
+            "explicit": true
+          },
+          {
+            "slug": "finansy_prosto",
+            "x_enabled": false,
+            "explicit": true
+          },
+          {
+            "slug": "models_agents",
+            "x_enabled": false,
+            "explicit": true
+          },
+          {
+            "slug": "models_agents_beginners",
+            "x_enabled": false,
+            "explicit": true
+          },
+          {
+            "slug": "modern_investing",
+            "x_enabled": false,
+            "explicit": true
+          },
+          {
+            "slug": "omni_view",
+            "x_enabled": true,
+            "explicit": true
+          },
+          {
+            "slug": "planetterrian",
+            "x_enabled": true,
+            "explicit": true
+          },
+          {
+            "slug": "privet_russian",
+            "x_enabled": false,
+            "explicit": true
+          },
+          {
+            "slug": "tesla",
+            "x_enabled": true,
+            "explicit": true
+          }
+        ]
+      }
+    },
+    {
+      "id": "item_9_voice_settings",
+      "title": "TTS voice settings consistency",
+      "status": "ok",
+      "details": "All shows match the _defaults.yaml voice baseline.",
+      "evidence": {
+        "baseline": {
+          "stability": 0.5,
+          "similarity_boost": 0.75,
+          "style": 0.0,
+          "voice_id_en": "dTrBzPvD2GpAqkk1MUzA",
+          "voice_id_ru": "gedzfqL7OGdPbwm0ynTP"
+        },
+        "drifting_shows": [],
+        "claude_md_drift_detected": false
+      }
+    },
+    {
+      "id": "item_11_tts_provider",
+      "title": "All shows use ElevenLabs TTS",
+      "status": "ok",
+      "details": "All 10 shows resolve tts.provider == elevenlabs.",
+      "evidence": {}
+    },
+    {
+      "id": "item_12_summaries_location",
+      "title": "summaries_*.json live under digests/<slug>/",
+      "status": "ok",
+      "details": "All summaries JSONs live under their per-show subdirectory.",
+      "evidence": {}
+    }
+  ],
+  "voice_config": {
+    "baseline": {
+      "stability": 0.5,
+      "similarity_boost": 0.75,
+      "style": 0.0,
+      "voice_id_en": "dTrBzPvD2GpAqkk1MUzA",
+      "voice_id_ru": "gedzfqL7OGdPbwm0ynTP"
+    },
+    "shows": [
+      {
+        "slug": "env_intel",
+        "voice_id": "dTrBzPvD2GpAqkk1MUzA",
+        "model": "eleven_flash_v2_5",
+        "stability": 0.5,
+        "similarity_boost": 0.75,
+        "style": 0.0,
+        "drift": []
+      },
+      {
+        "slug": "fascinating_frontiers",
+        "voice_id": "dTrBzPvD2GpAqkk1MUzA",
+        "model": "eleven_flash_v2_5",
+        "stability": 0.5,
+        "similarity_boost": 0.75,
+        "style": 0.0,
+        "drift": []
+      },
+      {
+        "slug": "finansy_prosto",
+        "voice_id": "gedzfqL7OGdPbwm0ynTP",
+        "model": "eleven_flash_v2_5",
+        "stability": 0.5,
+        "similarity_boost": 0.75,
+        "style": 0.0,
+        "drift": []
+      },
+      {
+        "slug": "models_agents",
+        "voice_id": "dTrBzPvD2GpAqkk1MUzA",
+        "model": "eleven_flash_v2_5",
+        "stability": 0.5,
+        "similarity_boost": 0.75,
+        "style": 0.0,
+        "drift": []
+      },
+      {
+        "slug": "models_agents_beginners",
+        "voice_id": "dTrBzPvD2GpAqkk1MUzA",
+        "model": "eleven_flash_v2_5",
+        "stability": 0.5,
+        "similarity_boost": 0.75,
+        "style": 0.0,
+        "drift": []
+      },
+      {
+        "slug": "modern_investing",
+        "voice_id": "dTrBzPvD2GpAqkk1MUzA",
+        "model": "eleven_flash_v2_5",
+        "stability": 0.5,
+        "similarity_boost": 0.75,
+        "style": 0.0,
+        "drift": []
+      },
+      {
+        "slug": "omni_view",
+        "voice_id": "dTrBzPvD2GpAqkk1MUzA",
+        "model": "eleven_flash_v2_5",
+        "stability": 0.5,
+        "similarity_boost": 0.75,
+        "style": 0.0,
+        "drift": []
+      },
+      {
+        "slug": "planetterrian",
+        "voice_id": "dTrBzPvD2GpAqkk1MUzA",
+        "model": "eleven_flash_v2_5",
+        "stability": 0.5,
+        "similarity_boost": 0.75,
+        "style": 0.0,
+        "drift": []
+      },
+      {
+        "slug": "privet_russian",
+        "voice_id": "gedzfqL7OGdPbwm0ynTP",
+        "model": "eleven_flash_v2_5",
+        "stability": 0.5,
+        "similarity_boost": 0.75,
+        "style": 0.0,
+        "drift": []
+      },
+      {
+        "slug": "tesla",
+        "voice_id": "dTrBzPvD2GpAqkk1MUzA",
+        "model": "eleven_flash_v2_5",
+        "stability": 0.5,
+        "similarity_boost": 0.75,
+        "style": 0.0,
+        "drift": []
+      }
+    ],
+    "claude_md_drift_detected": false
+  },
+  "cost_rollup": {
+    "per_show": {
+      "env_intel": {
+        "last_7_days": {
+          "grok": 0.085,
+          "tts": 3.1326,
+          "total": 3.2176,
+          "episodes": 2
+        },
+        "last_30_days": {
+          "grok": 0.4315,
+          "tts": 33.6936,
+          "total": 39.8272,
+          "episodes": 13
+        },
+        "daily_series": [
+          [
+            "2026-02-26",
+            2.4177
+          ],
+          [
+            "2026-02-27",
+            2.6346
+          ],
+          [
+            "2026-03-02",
+            2.8329
+          ],
+          [
+            "2026-03-03",
+            3.1257
+          ],
+          [
+            "2026-03-05",
+            2.7
+          ],
+          [
+            "2026-03-06",
+            2.8212
+          ],
+          [
+            "2026-03-09",
+            2.5896
+          ],
+          [
+            "2026-03-10",
+            3.1383
+          ],
+          [
+            "2026-03-11",
+            3.0
+          ],
+          [
+            "2026-03-12",
+            3.0327
+          ],
+          [
+            "2026-03-13",
+            2.6694
+          ],
+          [
+            "2026-03-20",
+            7.9094
+          ],
+          [
+            "2026-03-25",
+            4.1453
+          ],
+          [
+            "2026-03-26",
+            4.2127
+          ],
+          [
+            "2026-03-27",
+            4.0809
+          ],
+          [
+            "2026-03-30",
+            3.1709
+          ],
+          [
+            "2026-03-31",
+            3.6369
+          ],
+          [
+            "2026-04-01",
+            1.9101
+          ],
+          [
+            "2026-04-03",
+            1.8413
+          ],
+          [
+            "2026-04-07",
+            1.6747
+          ],
+          [
+            "2026-04-09",
+            1.5429
+          ]
+        ]
+      },
+      "fascinating_frontiers": {
+        "last_7_days": {
+          "grok": 0.243,
+          "tts": 5.5966,
+          "total": 5.8396,
+          "episodes": 3
+        },
+        "last_30_days": {
+          "grok": 0.722,
+          "tts": 41.7131,
+          "total": 48.807,
+          "episodes": 14
+        },
+        "daily_series": [
+          [
+            "2026-02-26",
+            2.2584
+          ],
+          [
+            "2026-02-27",
+            3.3192
+          ],
+          [
+            "2026-03-02",
+            3.1422
+          ],
+          [
+            "2026-03-06",
+            2.562
+          ],
+          [
+            "2026-03-08",
+            2.9121
+          ],
+          [
+            "2026-03-10",
+            2.7063
+          ],
+          [
+            "2026-03-12",
+            3.5133
+          ],
+          [
+            "2026-03-14",
+            2.8587
+          ],
+          [
+            "2026-03-20",
+            13.9765
+          ],
+          [
+            "2026-03-22",
+            4.0412
+          ],
+          [
+            "2026-03-24",
+            4.4066
+          ],
+          [
+            "2026-03-26",
+            4.4901
+          ],
+          [
+            "2026-03-28",
+            3.7156
+          ],
+          [
+            "2026-03-30",
+            3.8608
+          ],
+          [
+            "2026-04-02",
+            2.1045
+          ],
+          [
+            "2026-04-06",
+            1.3263
+          ],
+          [
+            "2026-04-08",
+            2.3175
+          ],
+          [
+            "2026-04-10",
+            2.1958
+          ]
+        ]
+      },
+      "finansy_prosto": {
+        "last_7_days": {
+          "grok": 0.2305,
+          "tts": 3.7753,
+          "total": 4.0059,
+          "episodes": 3
+        },
+        "last_30_days": {
+          "grok": 0.5933,
+          "tts": 28.5093,
+          "total": 31.9583,
+          "episodes": 14
+        },
+        "daily_series": [
+          [
+            "2026-03-14",
+            2.8557
+          ],
+          [
+            "2026-03-20",
+            10.0187
+          ],
+          [
+            "2026-03-22",
+            2.7459
+          ],
+          [
+            "2026-03-24",
+            3.1435
+          ],
+          [
+            "2026-03-26",
+            2.6471
+          ],
+          [
+            "2026-03-28",
+            2.785
+          ],
+          [
+            "2026-03-30",
+            2.4349
+          ],
+          [
+            "2026-04-02",
+            1.3216
+          ],
+          [
+            "2026-04-06",
+            1.1676
+          ],
+          [
+            "2026-04-08",
+            1.3078
+          ],
+          [
+            "2026-04-10",
+            1.5305
+          ]
+        ]
+      },
+      "models_agents": {
+        "last_7_days": {
+          "grok": 0.2363,
+          "tts": 6.9141,
+          "total": 7.1504,
+          "episodes": 4
+        },
+        "last_30_days": {
+          "grok": 0.7879,
+          "tts": 38.2827,
+          "total": 53.3431,
+          "episodes": 18
+        },
+        "daily_series": [
+          [
+            "2026-02-26",
+            3.324
+          ],
+          [
+            "2026-02-27",
+            3.5694
+          ],
+          [
+            "2026-02-28",
+            3.855
+          ],
+          [
+            "2026-03-01",
+            3.6201
+          ],
+          [
+            "2026-03-02",
+            3.7116
+          ],
+          [
+            "2026-03-05",
+            3.7698
+          ],
+          [
+            "2026-03-06",
+            3.6885
+          ],
+          [
+            "2026-03-07",
+            3.7287
+          ],
+          [
+            "2026-03-08",
+            3.3885
+          ],
+          [
+            "2026-03-09",
+            4.0059
+          ],
+          [
+            "2026-03-10",
+            3.7878
+          ],
+          [
+            "2026-03-11",
+            3.6525
+          ],
+          [
+            "2026-03-12",
+            3.7305
+          ],
+          [
+            "2026-03-13",
+            3.7947
+          ],
+          [
+            "2026-03-14",
+            3.5085
+          ],
+          [
+            "2026-03-15",
+            3.2388
+          ],
+          [
+            "2026-03-17",
+            3.8552
+          ],
+          [
+            "2026-03-20",
+            6.5667
+          ],
+          [
+            "2026-03-23",
+            6.7203
+          ],
+          [
+            "2026-03-27",
+            4.0455
+          ],
+          [
+            "2026-03-29",
+            3.3844
+          ],
+          [
+            "2026-03-31",
+            3.8638
+          ],
+          [
+            "2026-04-01",
+            1.7563
+          ],
+          [
+            "2026-04-03",
+            1.728
+          ],
+          [
+            "2026-04-05",
+            1.8029
+          ],
+          [
+            "2026-04-07",
+            1.719
+          ],
+          [
+            "2026-04-09",
+            1.752
+          ],
+          [
+            "2026-04-11",
+            1.8765
+          ]
+        ]
+      },
+      "models_agents_beginners": {
+        "last_7_days": {
+          "grok": 0.2025,
+          "tts": 4.9185,
+          "total": 5.121,
+          "episodes": 4
+        },
+        "last_30_days": {
+          "grok": 0.5656,
+          "tts": 19.128,
+          "total": 22.3534,
+          "episodes": 12
+        },
+        "daily_series": [
+          [
+            "2026-03-14",
+            2.6598
+          ],
+          [
+            "2026-03-20",
+            4.229
+          ],
+          [
+            "2026-03-22",
+            2.4452
+          ],
+          [
+            "2026-03-27",
+            2.1594
+          ],
+          [
+            "2026-03-28",
+            2.1413
+          ],
+          [
+            "2026-03-30",
+            2.4172
+          ],
+          [
+            "2026-04-02",
+            1.1805
+          ],
+          [
+            "2026-04-05",
+            1.2008
+          ],
+          [
+            "2026-04-06",
+            1.196
+          ],
+          [
+            "2026-04-08",
+            1.3268
+          ],
+          [
+            "2026-04-10",
+            1.3974
+          ]
+        ]
+      },
+      "modern_investing": {
+        "last_7_days": {
+          "grok": 0.3211,
+          "tts": 11.7551,
+          "total": 12.0762,
+          "episodes": 6
+        },
+        "last_30_days": {
+          "grok": 0.9791,
+          "tts": 59.4933,
+          "total": 60.4724,
+          "episodes": 18
+        },
+        "daily_series": [
+          [
+            "2026-03-20",
+            5.0184
+          ],
+          [
+            "2026-03-23",
+            4.6749
+          ],
+          [
+            "2026-03-24",
+            4.6074
+          ],
+          [
+            "2026-03-25",
+            4.9518
+          ],
+          [
+            "2026-03-26",
+            7.7831
+          ],
+          [
+            "2026-03-27",
+            4.2713
+          ],
+          [
+            "2026-03-30",
+            4.2751
+          ],
+          [
+            "2026-03-31",
+            5.4026
+          ],
+          [
+            "2026-04-01",
+            2.6282
+          ],
+          [
+            "2026-04-02",
+            2.4164
+          ],
+          [
+            "2026-04-03",
+            2.3669
+          ],
+          [
+            "2026-04-06",
+            2.5517
+          ],
+          [
+            "2026-04-07",
+            2.0721
+          ],
+          [
+            "2026-04-08",
+            2.1729
+          ],
+          [
+            "2026-04-09",
+            2.6292
+          ],
+          [
+            "2026-04-10",
+            2.6236
+          ],
+          [
+            "2026-04-11",
+            0.0267
+          ]
+        ]
+      },
+      "omni_view": {
+        "last_7_days": {
+          "grok": 0.4279,
+          "tts": 7.4142,
+          "total": 7.8421,
+          "episodes": 4
+        },
+        "last_30_days": {
+          "grok": 1.2292,
+          "tts": 47.6609,
+          "total": 60.1263,
+          "episodes": 19
+        },
+        "daily_series": [
+          [
+            "2026-02-27",
+            5.1456
+          ],
+          [
+            "2026-03-01",
+            2.5452
+          ],
+          [
+            "2026-03-02",
+            3.2574
+          ],
+          [
+            "2026-03-03",
+            2.6988
+          ],
+          [
+            "2026-03-07",
+            2.688
+          ],
+          [
+            "2026-03-08",
+            2.787
+          ],
+          [
+            "2026-03-09",
+            2.9766
+          ],
+          [
+            "2026-03-10",
+            2.505
+          ],
+          [
+            "2026-03-11",
+            3.0684
+          ],
+          [
+            "2026-03-12",
+            2.7366
+          ],
+          [
+            "2026-03-13",
+            2.724
+          ],
+          [
+            "2026-03-14",
+            2.9994
+          ],
+          [
+            "2026-03-15",
+            2.7762
+          ],
+          [
+            "2026-03-17",
+            3.0636
+          ],
+          [
+            "2026-03-20",
+            7.5393
+          ],
+          [
+            "2026-03-21",
+            4.6421
+          ],
+          [
+            "2026-03-23",
+            4.6919
+          ],
+          [
+            "2026-03-25",
+            4.2164
+          ],
+          [
+            "2026-03-26",
+            4.2324
+          ],
+          [
+            "2026-03-27",
+            2.7314
+          ],
+          [
+            "2026-03-29",
+            4.0866
+          ],
+          [
+            "2026-03-31",
+            3.8761
+          ],
+          [
+            "2026-04-03",
+            1.9682
+          ],
+          [
+            "2026-04-05",
+            1.8484
+          ],
+          [
+            "2026-04-07",
+            2.1869
+          ],
+          [
+            "2026-04-09",
+            1.4616
+          ],
+          [
+            "2026-04-11",
+            2.3452
+          ]
+        ]
+      },
+      "planetterrian": {
+        "last_7_days": {
+          "grok": 0.2547,
+          "tts": 9.955,
+          "total": 10.2097,
+          "episodes": 4
+        },
+        "last_30_days": {
+          "grok": 0.7271,
+          "tts": 44.3952,
+          "total": 51.2543,
+          "episodes": 15
+        },
+        "daily_series": [
+          [
+            "2026-02-26",
+            1.8999
+          ],
+          [
+            "2026-02-27",
+            3.1833
+          ],
+          [
+            "2026-03-01",
+            2.8131
+          ],
+          [
+            "2026-03-03",
+            2.7141
+          ],
+          [
+            "2026-03-07",
+            2.7087
+          ],
+          [
+            "2026-03-11",
+            3.4494
+          ],
+          [
+            "2026-03-13",
+            2.9256
+          ],
+          [
+            "2026-03-15",
+            3.2064
+          ],
+          [
+            "2026-03-20",
+            7.6521
+          ],
+          [
+            "2026-03-21",
+            4.317
+          ],
+          [
+            "2026-03-26",
+            2.9401
+          ],
+          [
+            "2026-03-27",
+            4.4812
+          ],
+          [
+            "2026-03-29",
+            5.5418
+          ],
+          [
+            "2026-03-31",
+            3.3755
+          ],
+          [
+            "2026-04-01",
+            4.6107
+          ],
+          [
+            "2026-04-03",
+            1.9941
+          ],
+          [
+            "2026-04-05",
+            2.3154
+          ],
+          [
+            "2026-04-07",
+            2.5208
+          ],
+          [
+            "2026-04-09",
+            2.5241
+          ],
+          [
+            "2026-04-11",
+            2.8495
+          ]
+        ]
+      },
+      "privet_russian": {
+        "last_7_days": {
+          "grok": 0.0754,
+          "tts": 2.0779,
+          "total": 2.1533,
+          "episodes": 2
+        },
+        "last_30_days": {
+          "grok": 0.3401,
+          "tts": 14.5747,
+          "total": 16.7994,
+          "episodes": 10
+        },
+        "daily_series": [
+          [
+            "2026-03-14",
+            1.8846
+          ],
+          [
+            "2026-03-20",
+            3.6582
+          ],
+          [
+            "2026-03-24",
+            2.2107
+          ],
+          [
+            "2026-03-26",
+            3.3115
+          ],
+          [
+            "2026-03-28",
+            1.8151
+          ],
+          [
+            "2026-03-30",
+            1.7659
+          ],
+          [
+            "2026-04-08",
+            1.1126
+          ],
+          [
+            "2026-04-10",
+            1.0408
+          ]
+        ]
+      },
+      "tesla": {
+        "last_7_days": {
+          "grok": 0.9009,
+          "tts": 18.8253,
+          "total": 19.7262,
+          "episodes": 9
+        },
+        "last_30_days": {
+          "grok": 1.7325,
+          "tts": 73.0841,
+          "total": 86.8738,
+          "episodes": 29
+        },
+        "daily_series": [
+          [
+            "2026-03-05",
+            3.3195
+          ],
+          [
+            "2026-03-06",
+            2.757
+          ],
+          [
+            "2026-03-08",
+            3.4164
+          ],
+          [
+            "2026-03-09",
+            2.7006
+          ],
+          [
+            "2026-03-10",
+            3.3777
+          ],
+          [
+            "2026-03-11",
+            2.817
+          ],
+          [
+            "2026-03-12",
+            3.2409
+          ],
+          [
+            "2026-03-13",
+            3.1599
+          ],
+          [
+            "2026-03-14",
+            2.5758
+          ],
+          [
+            "2026-03-15",
+            3.0807
+          ],
+          [
+            "2026-03-18",
+            2.4697
+          ],
+          [
+            "2026-03-20",
+            5.6198
+          ],
+          [
+            "2026-03-22",
+            8.7622
+          ],
+          [
+            "2026-03-24",
+            4.5406
+          ],
+          [
+            "2026-03-25",
+            5.3254
+          ],
+          [
+            "2026-03-27",
+            4.1766
+          ],
+          [
+            "2026-03-28",
+            4.1147
+          ],
+          [
+            "2026-03-29",
+            4.2723
+          ],
+          [
+            "2026-03-31",
+            6.717
+          ],
+          [
+            "2026-04-01",
+            5.3732
+          ],
+          [
+            "2026-04-02",
+            1.7894
+          ],
+          [
+            "2026-04-03",
+            1.9294
+          ],
+          [
+            "2026-04-04",
+            2.8328
+          ],
+          [
+            "2026-04-05",
+            2.7489
+          ],
+          [
+            "2026-04-06",
+            1.9317
+          ],
+          [
+            "2026-04-07",
+            2.2346
+          ],
+          [
+            "2026-04-08",
+            2.3423
+          ],
+          [
+            "2026-04-09",
+            2.6577
+          ],
+          [
+            "2026-04-10",
+            2.2625
+          ],
+          [
+            "2026-04-11",
+            2.7157
+          ]
+        ]
+      }
+    },
+    "network_last_7_days": {
+      "grok": 2.9773,
+      "tts": 74.3648,
+      "total": 77.3421,
+      "episodes": 41
+    },
+    "network_last_30_days": {
+      "grok": 8.1082,
+      "tts": 400.5348,
+      "total": 471.8152,
+      "episodes": 162
+    }
+  },
+  "pipeline_health": {
+    "env_intel": {
+      "sample_size": 11,
+      "p50_duration_s": 22.83,
+      "p95_duration_s": 50.29,
+      "success_rate": 1.0,
+      "stage_mean_s": {
+        "fetch_and_dedup": 5.23,
+        "generate_digest": 16.84,
+        "generate_digest_retry": 22.32
+      },
+      "recent": [
+        {
+          "episode_num": 13,
+          "total_duration_s": 14.63,
+          "success": true
+        },
+        {
+          "episode_num": 14,
+          "total_duration_s": 32.79,
+          "success": true
+        },
+        {
+          "episode_num": 15,
+          "total_duration_s": 18.72,
+          "success": true
+        },
+        {
+          "episode_num": 16,
+          "total_duration_s": 50.29,
+          "success": true
+        },
+        {
+          "episode_num": 17,
+          "total_duration_s": 14.95,
+          "success": true
+        },
+        {
+          "episode_num": 18,
+          "total_duration_s": 41.33,
+          "success": true
+        },
+        {
+          "episode_num": 19,
+          "total_duration_s": 17.68,
+          "success": true
+        },
+        {
+          "episode_num": 20,
+          "total_duration_s": 21.92,
+          "success": true
+        },
+        {
+          "episode_num": 21,
+          "total_duration_s": 25.0,
+          "success": true
+        },
+        {
+          "episode_num": 22,
+          "total_duration_s": 27.25,
+          "success": true
+        }
+      ]
+    },
+    "fascinating_frontiers": {
+      "sample_size": 12,
+      "p50_duration_s": 44.38,
+      "p95_duration_s": 87.5,
+      "success_rate": 1.0,
+      "stage_mean_s": {
+        "fetch_and_dedup": 10.59,
+        "generate_digest": 19.57,
+        "generate_digest_slow_news": 22.4
+      },
+      "recent": [
+        {
+          "episode_num": 42,
+          "total_duration_s": 13.6,
+          "success": true
+        },
+        {
+          "episode_num": 43,
+          "total_duration_s": 17.97,
+          "success": true
+        },
+        {
+          "episode_num": 44,
+          "total_duration_s": 23.58,
+          "success": true
+        },
+        {
+          "episode_num": 45,
+          "total_duration_s": 38.97,
+          "success": true
+        },
+        {
+          "episode_num": 46,
+          "total_duration_s": 49.58,
+          "success": true
+        },
+        {
+          "episode_num": 47,
+          "total_duration_s": 44.38,
+          "success": true
+        },
+        {
+          "episode_num": 48,
+          "total_duration_s": 52.12,
+          "success": true
+        },
+        {
+          "episode_num": 49,
+          "total_duration_s": 87.5,
+          "success": true
+        },
+        {
+          "episode_num": 50,
+          "total_duration_s": 57.47,
+          "success": true
+        },
+        {
+          "episode_num": 51,
+          "total_duration_s": 100.18,
+          "success": true
+        }
+      ]
+    },
+    "finansy_prosto": {
+      "sample_size": 13,
+      "p50_duration_s": 19.72,
+      "p95_duration_s": 38.62,
+      "success_rate": 1.0,
+      "stage_mean_s": {
+        "fetch_and_dedup": 7.86,
+        "generate_digest": 14.86,
+        "generate_digest_retry": 1.99,
+        "generate_digest_slow_news": 11.54
+      },
+      "recent": [
+        {
+          "episode_num": 11,
+          "total_duration_s": 16.25,
+          "success": true
+        },
+        {
+          "episode_num": 12,
+          "total_duration_s": 26.87,
+          "success": true
+        },
+        {
+          "episode_num": 13,
+          "total_duration_s": 32.39,
+          "success": true
+        },
+        {
+          "episode_num": 14,
+          "total_duration_s": 8.37,
+          "success": true
+        },
+        {
+          "episode_num": 15,
+          "total_duration_s": 16.45,
+          "success": true
+        },
+        {
+          "episode_num": 16,
+          "total_duration_s": 19.72,
+          "success": true
+        },
+        {
+          "episode_num": 17,
+          "total_duration_s": 28.28,
+          "success": true
+        },
+        {
+          "episode_num": 18,
+          "total_duration_s": 36.85,
+          "success": true
+        },
+        {
+          "episode_num": 19,
+          "total_duration_s": 48.52,
+          "success": true
+        },
+        {
+          "episode_num": 20,
+          "total_duration_s": 38.62,
+          "success": true
+        }
+      ]
+    },
+    "models_agents": {
+      "sample_size": 13,
+      "p50_duration_s": 45.28,
+      "p95_duration_s": 84.4,
+      "success_rate": 1.0,
+      "stage_mean_s": {
+        "fetch_and_dedup": 31.18,
+        "generate_digest": 20.79
+      },
+      "recent": [
+        {
+          "episode_num": 20,
+          "total_duration_s": 39.66,
+          "success": true
+        },
+        {
+          "episode_num": 21,
+          "total_duration_s": 54.02,
+          "success": true
+        },
+        {
+          "episode_num": 22,
+          "total_duration_s": 25.47,
+          "success": true
+        },
+        {
+          "episode_num": 23,
+          "total_duration_s": 53.76,
+          "success": true
+        },
+        {
+          "episode_num": 24,
+          "total_duration_s": 41.65,
+          "success": true
+        },
+        {
+          "episode_num": 25,
+          "total_duration_s": 56.92,
+          "success": true
+        },
+        {
+          "episode_num": 26,
+          "total_duration_s": 33.83,
+          "success": true
+        },
+        {
+          "episode_num": 27,
+          "total_duration_s": 84.4,
+          "success": true
+        },
+        {
+          "episode_num": 28,
+          "total_duration_s": 71.18,
+          "success": true
+        },
+        {
+          "episode_num": 29,
+          "total_duration_s": 37.84,
+          "success": true
+        }
+      ]
+    },
+    "models_agents_beginners": {
+      "sample_size": 11,
+      "p50_duration_s": 19.36,
+      "p95_duration_s": 31.29,
+      "success_rate": 1.0,
+      "stage_mean_s": {
+        "fetch_and_dedup": 3.36,
+        "generate_digest": 16.59
+      },
+      "recent": [
+        {
+          "episode_num": 9,
+          "total_duration_s": 15.36,
+          "success": true
+        },
+        {
+          "episode_num": 10,
+          "total_duration_s": 23.41,
+          "success": true
+        },
+        {
+          "episode_num": 11,
+          "total_duration_s": 23.96,
+          "success": true
+        },
+        {
+          "episode_num": 12,
+          "total_duration_s": 22.35,
+          "success": true
+        },
+        {
+          "episode_num": 13,
+          "total_duration_s": 19.36,
+          "success": true
+        },
+        {
+          "episode_num": 14,
+          "total_duration_s": 12.43,
+          "success": true
+        },
+        {
+          "episode_num": 15,
+          "total_duration_s": 14.81,
+          "success": true
+        },
+        {
+          "episode_num": 16,
+          "total_duration_s": 20.07,
+          "success": true
+        },
+        {
+          "episode_num": 17,
+          "total_duration_s": 31.29,
+          "success": true
+        },
+        {
+          "episode_num": 18,
+          "total_duration_s": 18.14,
+          "success": true
+        }
+      ]
+    },
+    "modern_investing": {
+      "sample_size": 17,
+      "p50_duration_s": 59.61,
+      "p95_duration_s": 125.73,
+      "success_rate": 1.0,
+      "stage_mean_s": {
+        "fetch_and_dedup": 58.49,
+        "generate_digest": 14.31,
+        "generate_digest_retry": 13.08
+      },
+      "recent": [
+        {
+          "episode_num": 8,
+          "total_duration_s": 62.28,
+          "success": true
+        },
+        {
+          "episode_num": 9,
+          "total_duration_s": 52.96,
+          "success": true
+        },
+        {
+          "episode_num": 10,
+          "total_duration_s": 69.63,
+          "success": true
+        },
+        {
+          "episode_num": 11,
+          "total_duration_s": 55.65,
+          "success": true
+        },
+        {
+          "episode_num": 12,
+          "total_duration_s": 14.67,
+          "success": true
+        },
+        {
+          "episode_num": 13,
+          "total_duration_s": 103.6,
+          "success": true
+        },
+        {
+          "episode_num": 14,
+          "total_duration_s": 101.84,
+          "success": true
+        },
+        {
+          "episode_num": 15,
+          "total_duration_s": 123.95,
+          "success": true
+        },
+        {
+          "episode_num": 16,
+          "total_duration_s": 125.73,
+          "success": true
+        },
+        {
+          "episode_num": 17,
+          "total_duration_s": 130.33,
+          "success": true
+        }
+      ]
+    },
+    "omni_view": {
+      "sample_size": 15,
+      "p50_duration_s": 115.37,
+      "p95_duration_s": 212.22,
+      "success_rate": 0.933,
+      "stage_mean_s": {
+        "fetch_and_dedup": 50.13,
+        "generate_digest": 53.28,
+        "generate_digest_retry": 28.92
+      },
+      "recent": [
+        {
+          "episode_num": 22,
+          "total_duration_s": 83.78,
+          "success": false
+        },
+        {
+          "episode_num": 23,
+          "total_duration_s": 143.21,
+          "success": true
+        },
+        {
+          "episode_num": 24,
+          "total_duration_s": 169.49,
+          "success": true
+        },
+        {
+          "episode_num": 25,
+          "total_duration_s": 84.75,
+          "success": true
+        },
+        {
+          "episode_num": 26,
+          "total_duration_s": 115.37,
+          "success": true
+        },
+        {
+          "episode_num": 27,
+          "total_duration_s": 112.33,
+          "success": true
+        },
+        {
+          "episode_num": 28,
+          "total_duration_s": 122.57,
+          "success": true
+        },
+        {
+          "episode_num": 29,
+          "total_duration_s": 212.22,
+          "success": true
+        },
+        {
+          "episode_num": 30,
+          "total_duration_s": 247.15,
+          "success": true
+        },
+        {
+          "episode_num": 31,
+          "total_duration_s": 179.5,
+          "success": true
+        }
+      ]
+    },
+    "planetterrian": {
+      "sample_size": 13,
+      "p50_duration_s": 37.25,
+      "p95_duration_s": 39.14,
+      "success_rate": 1.0,
+      "stage_mean_s": {
+        "fetch_and_dedup": 3.11,
+        "generate_digest": 15.63,
+        "generate_digest_slow_news": 17.35
+      },
+      "recent": [
+        {
+          "episode_num": 35,
+          "total_duration_s": 37.26,
+          "success": true
+        },
+        {
+          "episode_num": 36,
+          "total_duration_s": 38.82,
+          "success": true
+        },
+        {
+          "episode_num": 37,
+          "total_duration_s": 39.14,
+          "success": true
+        },
+        {
+          "episode_num": 38,
+          "total_duration_s": 37.34,
+          "success": true
+        },
+        {
+          "episode_num": 39,
+          "total_duration_s": 24.16,
+          "success": true
+        },
+        {
+          "episode_num": 40,
+          "total_duration_s": 36.4,
+          "success": true
+        },
+        {
+          "episode_num": 41,
+          "total_duration_s": 35.59,
+          "success": true
+        },
+        {
+          "episode_num": 42,
+          "total_duration_s": 44.27,
+          "success": true
+        },
+        {
+          "episode_num": 43,
+          "total_duration_s": 37.25,
+          "success": true
+        },
+        {
+          "episode_num": 44,
+          "total_duration_s": 38.18,
+          "success": true
+        }
+      ]
+    },
+    "privet_russian": {
+      "sample_size": 9,
+      "p50_duration_s": 26.96,
+      "p95_duration_s": 30.29,
+      "success_rate": 1.0,
+      "stage_mean_s": {
+        "fetch_and_dedup": 12.3,
+        "generate_digest": 13.46
+      },
+      "recent": [
+        {
+          "episode_num": 2,
+          "total_duration_s": 23.18,
+          "success": true
+        },
+        {
+          "episode_num": 3,
+          "total_duration_s": 20.28,
+          "success": true
+        },
+        {
+          "episode_num": 4,
+          "total_duration_s": 29.51,
+          "success": true
+        },
+        {
+          "episode_num": 5,
+          "total_duration_s": 29.32,
+          "success": true
+        },
+        {
+          "episode_num": 6,
+          "total_duration_s": 26.96,
+          "success": true
+        },
+        {
+          "episode_num": 7,
+          "total_duration_s": 30.29,
+          "success": true
+        },
+        {
+          "episode_num": 8,
+          "total_duration_s": 22.64,
+          "success": true
+        },
+        {
+          "episode_num": 9,
+          "total_duration_s": 22.63,
+          "success": true
+        },
+        {
+          "episode_num": 10,
+          "total_duration_s": 26.99,
+          "success": true
+        }
+      ]
+    },
+    "tesla": {
+      "sample_size": 23,
+      "p50_duration_s": 66.94,
+      "p95_duration_s": 177.36,
+      "success_rate": 1.0,
+      "stage_mean_s": {
+        "fetch_and_dedup": 26.82,
+        "generate_digest": 23.78,
+        "generate_digest_retry": 26.83,
+        "generate_digest_slow_news": 34.37,
+        "generate_digest_llm_fallback": 33.12
+      },
+      "recent": [
+        {
+          "episode_num": 424,
+          "total_duration_s": 53.57,
+          "success": true
+        },
+        {
+          "episode_num": 425,
+          "total_duration_s": 85.0,
+          "success": true
+        },
+        {
+          "episode_num": 426,
+          "total_duration_s": 110.17,
+          "success": true
+        },
+        {
+          "episode_num": 427,
+          "total_duration_s": 91.33,
+          "success": true
+        },
+        {
+          "episode_num": 428,
+          "total_duration_s": 82.37,
+          "success": true
+        },
+        {
+          "episode_num": 429,
+          "total_duration_s": 162.29,
+          "success": true
+        },
+        {
+          "episode_num": 430,
+          "total_duration_s": 177.36,
+          "success": true
+        },
+        {
+          "episode_num": 431,
+          "total_duration_s": 161.19,
+          "success": true
+        },
+        {
+          "episode_num": 432,
+          "total_duration_s": 206.11,
+          "success": true
+        },
+        {
+          "episode_num": 433,
+          "total_duration_s": 107.0,
+          "success": true
+        }
+      ]
+    }
+  },
+  "rss_audit": {
+    "feeds": [
+      {
+        "file": "blog.rss",
+        "entry_count": 50,
+        "latest_pub_date": "2026-03-26T00:00:00+00:00",
+        "latest_enclosures": [],
+        "malformed": false,
+        "error": null
+      },
+      {
+        "file": "env_intel_podcast.rss",
+        "entry_count": 20,
+        "latest_pub_date": "2026-04-09T08:00:00+00:00",
+        "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/env_intel/Env_Intel_Ep022_20260409.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-09T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/env_intel/Env_Intel_Ep021_20260407.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-07T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/env_intel/Env_Intel_Ep020_20260403.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-03T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          }
+        ],
+        "malformed": false,
+        "error": null
+      },
+      {
+        "file": "fascinating_frontiers_podcast.rss",
+        "entry_count": 40,
+        "latest_pub_date": "2026-04-10T08:00:00+00:00",
+        "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep051_20260410.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-10T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep050_20260408.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-08T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep049_20260406.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-06T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          }
+        ],
+        "malformed": false,
+        "error": null
+      },
+      {
+        "file": "finansy_prosto_podcast.rss",
+        "entry_count": 20,
+        "latest_pub_date": "2026-04-10T08:00:00+00:00",
+        "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/finansy_prosto/FP_Ep020_20260410.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-10T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/finansy_prosto/FP_Ep019_20260408.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-08T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/finansy_prosto/FP_Ep018_20260406.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-06T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          }
+        ],
+        "malformed": false,
+        "error": null
+      },
+      {
+        "file": "models_agents_beginners_podcast.rss",
+        "entry_count": 18,
+        "latest_pub_date": "2026-04-10T08:00:00+00:00",
+        "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep018_20260410.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-10T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep017_20260408.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-08T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep016_20260406.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-06T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          }
+        ],
+        "malformed": false,
+        "error": null
+      },
+      {
+        "file": "models_agents_podcast.rss",
+        "entry_count": 29,
+        "latest_pub_date": "2026-04-11T08:00:00+00:00",
+        "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/models_agents/Models_Agents_Ep029_20260411.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-11T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/models_agents/Models_Agents_Ep028_20260409.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-09T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/models_agents/Models_Agents_Ep027_20260407.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-07T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          }
+        ],
+        "malformed": false,
+        "error": null
+      },
+      {
+        "file": "modern_investing_podcast.rss",
+        "entry_count": 17,
+        "latest_pub_date": "2026-04-10T08:00:00+00:00",
+        "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep017_20260410.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-10T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep016_20260409.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-09T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep015_20260408.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-08T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          }
+        ],
+        "malformed": false,
+        "error": null
+      },
+      {
+        "file": "omni_view_podcast.rss",
+        "entry_count": 31,
+        "latest_pub_date": "2026-04-11T08:00:00+00:00",
+        "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep031_20260411.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-11T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep030_20260409.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-09T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep029_20260407.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-07T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          }
+        ],
+        "malformed": false,
+        "error": null
+      },
+      {
+        "file": "planetterrian_podcast.rss",
+        "entry_count": 32,
+        "latest_pub_date": "2026-04-11T08:00:00+00:00",
+        "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep044_20260411.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-11T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep043_20260409.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-09T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep042_20260407.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-07T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          }
+        ],
+        "malformed": false,
+        "error": null
+      },
+      {
+        "file": "podcast.rss",
+        "entry_count": 86,
+        "latest_pub_date": "2026-04-11T08:00:00+00:00",
+        "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep433_20260411.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-11T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep432_20260410.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-10T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep431_20260409.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-09T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          }
+        ],
+        "malformed": false,
+        "error": null
+      },
+      {
+        "file": "privet_russian_podcast.rss",
+        "entry_count": 10,
+        "latest_pub_date": "2026-04-10T08:00:00+00:00",
+        "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/privet_russian/PR_Ep010_20260410.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-10T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/privet_russian/PR_Ep009_20260408.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-04-08T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          },
+          {
+            "url": "https://audio.nerranetwork.com/privet_russian/PR_Ep008_20260330.mp3",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-03-30T08:00:00+00:00",
+            "http_status": null,
+            "reachable": false
+          }
+        ],
+        "malformed": false,
+        "error": null
+      }
+    ],
+    "raw_github_hits": [],
+    "non_r2_hosts": [],
+    "offline": true
+  }
+}

--- a/env-intel.html
+++ b/env-intel.html
@@ -26,6 +26,8 @@
     
     <link rel="alternate" type="application/rss+xml" title="Environmental Intelligence RSS" href="env_intel_podcast.rss">
     
+    
+    
 
     <!-- Google Fonts: DM Sans + Source Serif 4 -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1157,6 +1159,7 @@
                 <a href="privacy-policy.html">Privacy Policy</a>
                 <a href="terms-of-service.html">Terms of Service</a>
                 <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
             <div class="nn-footer-subscribe">

--- a/fascinating_frontiers.html
+++ b/fascinating_frontiers.html
@@ -26,6 +26,8 @@
     
     <link rel="alternate" type="application/rss+xml" title="Fascinating Frontiers RSS" href="fascinating_frontiers_podcast.rss">
     
+    
+    
 
     <!-- Google Fonts: DM Sans + Source Serif 4 -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1169,6 +1171,7 @@
                 <a href="privacy-policy.html">Privacy Policy</a>
                 <a href="terms-of-service.html">Terms of Service</a>
                 <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
             <div class="nn-footer-subscribe">

--- a/index.html
+++ b/index.html
@@ -25,9 +25,13 @@
     <link rel="canonical" href="https://nerranetwork.com/index.html">
     
     <link rel="alternate" type="application/rss+xml" title="Nerra Network RSS" href="network.rss">
+    
+    
+    
     <link rel="alternate" hreflang="en" href="https://nerranetwork.com/index.html">
     <link rel="alternate" hreflang="ru" href="https://nerranetwork.com/ru/index.html">
     <link rel="alternate" hreflang="x-default" href="https://nerranetwork.com/index.html">
+    
 
     <!-- Google Fonts: DM Sans + Source Serif 4 -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1295,6 +1299,7 @@
                 <a href="privacy-policy.html">Privacy Policy</a>
                 <a href="terms-of-service.html">Terms of Service</a>
                 <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
             <div class="nn-footer-subscribe">

--- a/management.html
+++ b/management.html
@@ -1,0 +1,416 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Nerra Network — Management Dashboard</title>
+<meta name="description" content="Operator status page for the Nerra Network: landmine guards, per-show health, cost rollup, voice settings drift.">
+<meta name="robots" content="noindex,follow">
+<link rel="canonical" href="https://nerranetwork.com/management.html">
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%237C5CFF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/></svg>">
+<link rel="stylesheet" href="styles/main.css">
+<style>
+  :root {
+    --status-ok: #16a34a;
+    --status-warn: #f59e0b;
+    --status-fail: #dc2626;
+  }
+  .mgmt-wrap { max-width: 1200px; margin: 0 auto; padding: 32px 24px 64px; }
+  .mgmt-header {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 16px; flex-wrap: wrap; margin-bottom: 24px;
+  }
+  .mgmt-header h1 { margin: 0; font-size: 28px; }
+  .mgmt-header .subtitle { color: var(--nn-muted, #94a3b8); font-size: 14px; }
+  .status-summary {
+    display: inline-flex; gap: 12px; align-items: center;
+    background: var(--nn-surface, #161a24); padding: 12px 20px; border-radius: 12px;
+    border: 1px solid var(--nn-border, #232938);
+  }
+  .status-pill {
+    display: inline-flex; gap: 6px; align-items: center;
+    padding: 4px 10px; border-radius: 999px; font-size: 13px; font-weight: 600;
+  }
+  .status-pill.ok { background: rgba(22,163,74,0.15); color: #22c55e; }
+  .status-pill.warn { background: rgba(245,158,11,0.15); color: #fbbf24; }
+  .status-pill.fail { background: rgba(220,38,38,0.15); color: #f87171; }
+
+  .mgmt-section { margin-top: 40px; }
+  .mgmt-section h2 {
+    margin: 0 0 16px; font-size: 18px; text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--nn-muted, #94a3b8);
+  }
+  .banner {
+    padding: 14px 18px; border-radius: 10px; margin-bottom: 16px;
+    background: rgba(245,158,11,0.12); border: 1px solid rgba(245,158,11,0.45);
+    color: #fbbf24;
+  }
+  .banner strong { color: #fde68a; }
+
+  .grid {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 16px;
+  }
+  .card {
+    background: var(--nn-surface, #161a24); border: 1px solid var(--nn-border, #232938);
+    border-radius: 14px; padding: 18px;
+  }
+  .card.status-ok { border-left: 4px solid var(--status-ok); }
+  .card.status-warn { border-left: 4px solid var(--status-warn); }
+  .card.status-fail { border-left: 4px solid var(--status-fail); }
+  .card h3 { margin: 0 0 6px; font-size: 15px; }
+  .card .card-id {
+    font-size: 11px; color: var(--nn-muted, #94a3b8); font-family: ui-monospace, monospace;
+  }
+  .card .card-details { margin: 10px 0 0; font-size: 14px; line-height: 1.5; color: var(--nn-body, #cbd5e1); }
+  .card details {
+    margin-top: 10px; font-size: 12px; color: var(--nn-muted, #94a3b8);
+  }
+  .card details pre {
+    background: rgba(0,0,0,0.25); padding: 10px; border-radius: 8px; overflow-x: auto;
+    font-size: 11px; margin: 8px 0 0;
+  }
+
+  .show-card {
+    background: var(--nn-surface, #161a24); border: 1px solid var(--nn-border, #232938);
+    border-radius: 14px; padding: 16px;
+  }
+  .show-card .show-head { display: flex; gap: 12px; align-items: center; margin-bottom: 10px; }
+  .show-card img.cover { width: 56px; height: 56px; border-radius: 10px; object-fit: cover; flex-shrink: 0; }
+  .show-card h3 { margin: 0; font-size: 16px; }
+  .show-card .slug { font-size: 11px; color: var(--nn-muted, #94a3b8); font-family: ui-monospace, monospace; }
+  .show-card .stats {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin: 12px 0 4px;
+    font-size: 12px;
+  }
+  .show-card .stats div { background: rgba(124,92,255,0.08); padding: 8px 10px; border-radius: 8px; }
+  .show-card .stats strong { display: block; font-size: 14px; color: #fff; }
+  .show-card .links { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 10px; font-size: 12px; }
+  .show-card .links a { color: #818cf8; text-decoration: none; }
+  .show-card .links a:hover { text-decoration: underline; }
+
+  table.voice-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  table.voice-table th, table.voice-table td {
+    padding: 10px 12px; text-align: left; border-bottom: 1px solid var(--nn-border, #232938);
+  }
+  table.voice-table th { color: var(--nn-muted, #94a3b8); font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }
+  table.voice-table td.drift { color: #fbbf24; font-weight: 600; }
+
+  .sparkline-row {
+    display: flex; align-items: center; gap: 12px; padding: 10px 0;
+    border-bottom: 1px solid var(--nn-border, #232938);
+  }
+  .sparkline-row .label { width: 200px; font-size: 13px; }
+  .sparkline-row svg { flex: 1; height: 32px; }
+  .sparkline-row .value { width: 120px; text-align: right; font-size: 13px; color: var(--nn-muted, #94a3b8); }
+
+  #error { display: none; padding: 16px; background: rgba(220,38,38,0.15); border: 1px solid rgba(220,38,38,0.4); color: #fca5a5; border-radius: 10px; }
+  #loading { padding: 40px; text-align: center; color: var(--nn-muted, #94a3b8); }
+</style>
+</head>
+<body>
+<div class="mgmt-wrap">
+
+<div class="mgmt-header">
+  <div>
+    <h1>Nerra Network — Management</h1>
+    <div class="subtitle" id="generated-at">Loading dashboard data…</div>
+  </div>
+  <div class="status-summary" id="status-summary" hidden>
+    <span class="status-pill ok"><span id="count-ok">0</span>&nbsp;OK</span>
+    <span class="status-pill warn"><span id="count-warn">0</span>&nbsp;warn</span>
+    <span class="status-pill fail"><span id="count-fail">0</span>&nbsp;fail</span>
+    <span id="spend-7d" style="font-size:13px;color:#94a3b8"></span>
+  </div>
+</div>
+
+<div id="error">
+  Could not load <code>api/dashboard.json</code>. Run
+  <code>python scripts/generate_dashboard.py</code> to produce it.
+</div>
+
+<div id="loading">Loading…</div>
+
+<main id="content" hidden>
+
+  <section class="mgmt-section">
+    <h2>Landmine guards</h2>
+    <div id="claude-md-banner" hidden></div>
+    <div class="grid" id="landmines-grid"></div>
+  </section>
+
+  <section class="mgmt-section">
+    <h2>Shows (10 cards — Models &amp; Agents and Models &amp; Agents for Beginners stay separate)</h2>
+    <div class="grid" id="shows-grid"></div>
+  </section>
+
+  <section class="mgmt-section">
+    <h2>Voice settings consistency</h2>
+    <table class="voice-table" id="voice-table">
+      <thead>
+        <tr>
+          <th>Show</th><th>Voice ID</th><th>Stability</th>
+          <th>Similarity</th><th>Style</th><th>Drift</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
+  <section class="mgmt-section">
+    <h2>30-day cost per show</h2>
+    <div id="cost-sparklines"></div>
+  </section>
+
+  <section class="mgmt-section">
+    <h2>Pipeline p50 duration per show</h2>
+    <div id="pipeline-sparklines"></div>
+  </section>
+
+  <section class="mgmt-section">
+    <h2>Feed audit (latest)</h2>
+    <div id="feed-audit"></div>
+  </section>
+
+</main>
+
+<p style="margin-top:48px;font-size:12px;color:#64748b;text-align:center">
+  Generated by <code>scripts/generate_dashboard.py</code>. Regenerates daily via
+  <code>.github/workflows/dashboard.yml</code> and after every show publish.
+  Models &amp; Agents and Models &amp; Agents for Beginners are always tracked as
+  two separate shows.
+</p>
+</div>
+
+<script>
+(async function () {
+  const $ = (s) => document.querySelector(s);
+  const h = (tag, attrs = {}, children = []) => {
+    const el = document.createElement(tag);
+    for (const k in attrs) {
+      if (k === "class") el.className = attrs[k];
+      else if (k === "html") el.innerHTML = attrs[k];
+      else if (k === "text") el.textContent = attrs[k];
+      else el.setAttribute(k, attrs[k]);
+    }
+    (Array.isArray(children) ? children : [children]).forEach((c) => {
+      if (c == null) return;
+      el.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+    });
+    return el;
+  };
+
+  const money = (n) => "$" + Number(n || 0).toFixed(2);
+  const ageText = (iso) => {
+    if (!iso) return "never";
+    const d = new Date(iso);
+    const hours = (Date.now() - d.getTime()) / 3600000;
+    if (hours < 1) return Math.round(hours * 60) + "m ago";
+    if (hours < 48) return Math.round(hours) + "h ago";
+    return Math.round(hours / 24) + "d ago";
+  };
+
+  let data;
+  try {
+    const r = await fetch("api/dashboard.json", { cache: "no-store" });
+    if (!r.ok) throw new Error("HTTP " + r.status);
+    data = await r.json();
+  } catch (e) {
+    $("#loading").hidden = true;
+    $("#error").style.display = "block";
+    return;
+  }
+
+  $("#loading").hidden = true;
+  $("#content").hidden = false;
+  $("#status-summary").hidden = false;
+  $("#generated-at").textContent =
+    "Generated " + new Date(data.generated_at).toLocaleString() + ".";
+
+  const counts = data.network.landmines_counts || {};
+  $("#count-ok").textContent = counts.ok || 0;
+  $("#count-warn").textContent = counts.warn || 0;
+  $("#count-fail").textContent = counts.fail || 0;
+  $("#spend-7d").textContent =
+    "· 7d spend " + money(data.network.total_cost_last_7_days_usd) +
+    " · 30d spend " + money(data.network.total_cost_last_30_days_usd);
+
+  // -------- CLAUDE.md drift banner --------
+  if (data.voice_config && data.voice_config.claude_md_drift_detected) {
+    const b = $("#claude-md-banner");
+    const baseline = data.voice_config.baseline || {};
+    b.hidden = false;
+    b.className = "banner";
+    b.innerHTML =
+      "<strong>Documentation drift:</strong> CLAUDE.md still references the " +
+      "old ElevenLabs tuning triple <code>0.65/0.9/0.85</code>, but " +
+      "<code>shows/_defaults.yaml</code> is now <code>" +
+      baseline.stability + "/" + baseline.similarity_boost + "/" + baseline.style +
+      "</code>. Update CLAUDE.md item 9 to match.";
+  }
+
+  // -------- Landmines grid --------
+  const lmGrid = $("#landmines-grid");
+  (data.landmines || []).forEach((lm) => {
+    const card = h("div", { class: "card status-" + lm.status });
+    card.appendChild(h("div", { class: "card-id", text: lm.id }));
+    card.appendChild(h("h3", { text: lm.title }));
+    card.appendChild(h("p", { class: "card-details", text: lm.details }));
+    if (lm.evidence && Object.keys(lm.evidence).length) {
+      const d = h("details");
+      d.appendChild(h("summary", { text: "evidence" }));
+      d.appendChild(h("pre", { text: JSON.stringify(lm.evidence, null, 2) }));
+      card.appendChild(d);
+    }
+    lmGrid.appendChild(card);
+  });
+
+  // -------- Shows grid --------
+  const showGrid = $("#shows-grid");
+  const shows = (data.network && data.network.shows) || [];
+  const coverFor = (slug) => {
+    // Map slug → cover image filename (matches assets/covers/*.jpg)
+    const map = {
+      "tesla": "tesla-shorts-time.jpg",
+      "models_agents": "models-agents.jpg",
+      "models_agents_beginners": "models-agents-beginners.jpg",
+      "omni_view": "omni-view.jpg",
+      "fascinating_frontiers": "fascinating-frontiers.jpg",
+      "planetterrian": "planetterrian-daily.jpg",
+      "env_intel": "environmental-intelligence.jpg",
+      "modern_investing": "modern-investing.jpg",
+      "finansy_prosto": "finansy-prosto.jpg",
+      "privet_russian": "privet-russian.jpg",
+    };
+    return "assets/covers/" + (map[slug] || (slug + ".jpg"));
+  };
+
+  shows.forEach((s) => {
+    const card = h("div", { class: "show-card" });
+    const head = h("div", { class: "show-head" });
+    head.appendChild(h("img", { class: "cover", src: coverFor(s.slug), alt: s.name + " cover art", loading: "lazy" }));
+    const headText = h("div");
+    headText.appendChild(h("h3", { text: s.name || s.slug }));
+    headText.appendChild(h("div", { class: "slug", text: s.slug }));
+    head.appendChild(headText);
+    card.appendChild(head);
+
+    const stats = h("div", { class: "stats" });
+    stats.appendChild(h("div", { html:
+      "<strong>" + (s.episodes_last_7_days || 0) + "</strong>ep · 7d" }));
+    stats.appendChild(h("div", { html:
+      "<strong>" + money(s.cost_last_7_days_usd) + "</strong>cost · 7d" }));
+    stats.appendChild(h("div", { html:
+      "<strong>" + (s.p50_pipeline_s || 0).toFixed(0) + "s</strong>p50 run" }));
+    card.appendChild(stats);
+
+    const pubStatus = s.pub_status || "unknown";
+    const pubColor = pubStatus === "ok" ? "#22c55e" :
+                     pubStatus === "warn" ? "#fbbf24" :
+                     pubStatus === "stale" ? "#f87171" : "#94a3b8";
+    card.appendChild(h("div", {
+      html: "Latest episode: " +
+        "<span style='color:" + pubColor + "'>" +
+        ageText(s.latest_pub_date) + "</span> · " +
+        "X posting: <strong>" + (s.x_enabled ? "ON" : "off") + "</strong> · " +
+        "Newsletter: <strong>" + (s.newsletter_enabled ? "ON" : "off") + "</strong>"
+    }));
+
+    const links = h("div", { class: "links" });
+    if (s.show_page) links.appendChild(h("a", { href: s.show_page, text: "Show page" }));
+    if (s.blog_page) links.appendChild(h("a", { href: s.blog_page, text: "Blog" }));
+    if (s.rss_file) links.appendChild(h("a", { href: s.rss_file, text: "RSS" }));
+    card.appendChild(links);
+    showGrid.appendChild(card);
+  });
+
+  // -------- Voice settings table --------
+  const tbody = $("#voice-table tbody");
+  (data.voice_config.shows || []).forEach((row) => {
+    const tr = h("tr");
+    tr.appendChild(h("td", { text: row.slug }));
+    tr.appendChild(h("td", { text: row.voice_id, style: "font-family:ui-monospace,monospace;font-size:11px" }));
+    tr.appendChild(h("td", { text: row.stability }));
+    tr.appendChild(h("td", { text: row.similarity_boost }));
+    tr.appendChild(h("td", { text: row.style }));
+    const drift = row.drift || [];
+    const td = h("td", {
+      class: drift.length ? "drift" : "",
+      text: drift.length ? drift.map((d) => d.field + ": " + d.actual).join(", ") : "ok",
+    });
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  });
+
+  // -------- Inline SVG sparklines --------
+  const drawSparkline = (values, w = 240, h = 28) => {
+    if (!values || !values.length) {
+      return '<svg width="' + w + '" height="' + h + '"></svg>';
+    }
+    const max = Math.max.apply(null, values) || 1;
+    const min = Math.min.apply(null, values);
+    const range = max - min || 1;
+    const step = w / Math.max(values.length - 1, 1);
+    const pts = values
+      .map((v, i) => (i * step).toFixed(1) + "," + (h - ((v - min) / range) * h).toFixed(1))
+      .join(" ");
+    return (
+      '<svg width="' + w + '" height="' + h + '" viewBox="0 0 ' + w + " " + h + '">' +
+      '<polyline fill="none" stroke="#7C5CFF" stroke-width="2" points="' + pts + '" />' +
+      "</svg>"
+    );
+  };
+
+  const costSparks = $("#cost-sparklines");
+  const costPerShow = (data.cost_rollup && data.cost_rollup.per_show) || {};
+  shows.forEach((s) => {
+    const series = ((costPerShow[s.slug] || {}).daily_series || []).map((p) => p[1]);
+    const row = h("div", { class: "sparkline-row" });
+    row.appendChild(h("div", { class: "label", text: s.name || s.slug }));
+    const svg = document.createElement("div");
+    svg.innerHTML = drawSparkline(series);
+    svg.style.flex = "1";
+    row.appendChild(svg.firstChild || h("div"));
+    row.appendChild(h("div", { class: "value",
+      text: money((costPerShow[s.slug] || {}).last_30_days && (costPerShow[s.slug] || {}).last_30_days.total) + " · 30d" }));
+    costSparks.appendChild(row);
+  });
+
+  const pipeSparks = $("#pipeline-sparklines");
+  const health = data.pipeline_health || {};
+  shows.forEach((s) => {
+    const recent = ((health[s.slug] || {}).recent || []).map((r) => r.total_duration_s);
+    const row = h("div", { class: "sparkline-row" });
+    row.appendChild(h("div", { class: "label", text: s.name || s.slug }));
+    const svg = document.createElement("div");
+    svg.innerHTML = drawSparkline(recent);
+    svg.style.flex = "1";
+    row.appendChild(svg.firstChild || h("div"));
+    row.appendChild(h("div", { class: "value",
+      text: (health[s.slug] || {}).p50_duration_s + "s p50 · " +
+            (((health[s.slug] || {}).success_rate || 0) * 100).toFixed(0) + "% ok" }));
+    pipeSparks.appendChild(row);
+  });
+
+  // -------- Feed audit summary --------
+  const rss = data.rss_audit || { feeds: [] };
+  const audit = $("#feed-audit");
+  const summary = h("p", {
+    text: rss.feeds.length + " feed(s) audited · " +
+          (rss.raw_github_hits || []).length + " raw.githubusercontent.com hit(s) · " +
+          (rss.non_r2_hosts || []).length + " non-R2 host(s)",
+  });
+  audit.appendChild(summary);
+  const list = h("ul", { style: "margin:8px 0 0;padding-left:18px;font-size:13px" });
+  (rss.feeds || []).forEach((f) => {
+    const li = h("li");
+    li.textContent = f.file + " · " + f.entry_count + " items · " +
+      (f.latest_pub_date ? ageText(f.latest_pub_date) : "no pubDate") +
+      (f.malformed ? " · MALFORMED" : "");
+    list.appendChild(li);
+  });
+  audit.appendChild(list);
+})();
+</script>
+</body>
+</html>

--- a/models-agents-beginners.html
+++ b/models-agents-beginners.html
@@ -26,6 +26,8 @@
     
     <link rel="alternate" type="application/rss+xml" title="Models & Agents for Beginners RSS" href="models_agents_beginners_podcast.rss">
     
+    
+    
 
     <!-- Google Fonts: DM Sans + Source Serif 4 -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1137,6 +1139,7 @@
                 <a href="privacy-policy.html">Privacy Policy</a>
                 <a href="terms-of-service.html">Terms of Service</a>
                 <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
             <div class="nn-footer-subscribe">

--- a/models-agents.html
+++ b/models-agents.html
@@ -26,6 +26,8 @@
     
     <link rel="alternate" type="application/rss+xml" title="Models & Agents RSS" href="models_agents_podcast.rss">
     
+    
+    
 
     <!-- Google Fonts: DM Sans + Source Serif 4 -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1167,6 +1169,7 @@
                 <a href="privacy-policy.html">Privacy Policy</a>
                 <a href="terms-of-service.html">Terms of Service</a>
                 <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
             <div class="nn-footer-subscribe">

--- a/modern-investing.html
+++ b/modern-investing.html
@@ -26,6 +26,8 @@
     
     <link rel="alternate" type="application/rss+xml" title="Modern Investing Techniques RSS" href="modern_investing_podcast.rss">
     
+    
+    
 
     <!-- Google Fonts: DM Sans + Source Serif 4 -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1152,6 +1154,7 @@
                 <a href="privacy-policy.html">Privacy Policy</a>
                 <a href="terms-of-service.html">Terms of Service</a>
                 <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
             <div class="nn-footer-subscribe">

--- a/omni-view.html
+++ b/omni-view.html
@@ -26,6 +26,8 @@
     
     <link rel="alternate" type="application/rss+xml" title="Omni View RSS" href="omni_view_podcast.rss">
     
+    
+    
 
     <!-- Google Fonts: DM Sans + Source Serif 4 -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1182,6 +1184,7 @@
                 <a href="privacy-policy.html">Privacy Policy</a>
                 <a href="terms-of-service.html">Terms of Service</a>
                 <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
             <div class="nn-footer-subscribe">

--- a/planetterrian.html
+++ b/planetterrian.html
@@ -26,6 +26,8 @@
     
     <link rel="alternate" type="application/rss+xml" title="Planetterrian Daily RSS" href="planetterrian_podcast.rss">
     
+    
+    
 
     <!-- Google Fonts: DM Sans + Source Serif 4 -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1157,6 +1159,7 @@
                 <a href="privacy-policy.html">Privacy Policy</a>
                 <a href="terms-of-service.html">Terms of Service</a>
                 <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
             <div class="nn-footer-subscribe">

--- a/ru/finansy-prosto.html
+++ b/ru/finansy-prosto.html
@@ -26,6 +26,8 @@
     
     <link rel="alternate" type="application/rss+xml" title="Финансы Просто RSS" href="../finansy_prosto_podcast.rss">
     
+    
+    
 
     <!-- Google Fonts: DM Sans + Source Serif 4 -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -34,6 +36,9 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%237C5CFF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/></svg>">
+
+    <!-- Analytics (uncomment when ready) -->
+    
 
     <!-- Shared CSS -->
     <link rel="stylesheet" href="../styles/main.css">
@@ -105,7 +110,7 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to content</a>
     <!-- Navigation -->
-    <nav class="nn-nav">
+    <nav class="nn-nav" aria-label="Main navigation">
         <div class="nn-nav-inner">
             <a href="../index.html" class="nn-nav-logo">
                 <img src="../assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
@@ -425,6 +430,38 @@
                 
                 
                 <div class="episode-card glass-card">
+                    <div class="episode-card-title">Финансы Просто - Episode 20 - April 10, 2026</div>
+                    <div class="episode-card-date">Fri, Apr 10, 2026</div>
+                    
+                    <audio controls preload="none" src="https://audio.nerranetwork.com/finansy_prosto/FP_Ep020_20260410.mp3" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                    
+                </div>
+                
+                <div class="episode-card glass-card">
+                    <div class="episode-card-title">Финансы Просто - Episode 19 - April 08, 2026</div>
+                    <div class="episode-card-date">Wed, Apr 08, 2026</div>
+                    
+                    <audio controls preload="none" src="https://audio.nerranetwork.com/finansy_prosto/FP_Ep019_20260408.mp3" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                    
+                </div>
+                
+                <div class="episode-card glass-card">
+                    <div class="episode-card-title">Финансы Просто - Episode 18 - April 06, 2026</div>
+                    <div class="episode-card-date">Mon, Apr 06, 2026</div>
+                    
+                    <audio controls preload="none" src="https://audio.nerranetwork.com/finansy_prosto/FP_Ep018_20260406.mp3" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                    
+                </div>
+                
+                <div class="episode-card glass-card">
+                    <div class="episode-card-title">Финансы Просто - Episode 17 - April 02, 2026</div>
+                    <div class="episode-card-date">Thu, Apr 02, 2026</div>
+                    
+                    <audio controls preload="none" src="https://audio.nerranetwork.com/finansy_prosto/FP_Ep017_20260402.mp3" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                    
+                </div>
+                
+                <div class="episode-card glass-card">
                     <div class="episode-card-title">Финансы Просто - Episode 16 - March 30, 2026</div>
                     <div class="episode-card-date">Mon, Mar 30, 2026</div>
                     
@@ -485,38 +522,6 @@
                     <div class="episode-card-date">Fri, Mar 20, 2026</div>
                     
                     <audio controls preload="none" src="https://audio.nerranetwork.com/finansy_prosto/FP_Ep010_20260320.mp3" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                    
-                </div>
-                
-                <div class="episode-card glass-card">
-                    <div class="episode-card-title">Финансы Просто - Episode 11 - March 20, 2026</div>
-                    <div class="episode-card-date">Fri, Mar 20, 2026</div>
-                    
-                    <audio controls preload="none" src="https://audio.nerranetwork.com/finansy_prosto/FP_Ep011_20260320.mp3" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                    
-                </div>
-                
-                <div class="episode-card glass-card">
-                    <div class="episode-card-title">Финансы Просто - Episode 7 - March 14, 2026</div>
-                    <div class="episode-card-date">Sat, Mar 14, 2026</div>
-                    
-                    <audio controls preload="none" src="https://audio.nerranetwork.com/finansy_prosto/FP_Ep007_20260314.mp3" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                    
-                </div>
-                
-                <div class="episode-card glass-card">
-                    <div class="episode-card-title">Финансы Просто - Episode 6 - March 13, 2026</div>
-                    <div class="episode-card-date">Fri, Mar 13, 2026</div>
-                    
-                    <audio controls preload="none" src="https://audio.nerranetwork.com/finansy_prosto/FP_Ep006_20260313.mp3" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                    
-                </div>
-                
-                <div class="episode-card glass-card">
-                    <div class="episode-card-title">Финансы Просто - Episode 5 - March 12, 2026</div>
-                    <div class="episode-card-date">Thu, Mar 12, 2026</div>
-                    
-                    <audio controls preload="none" src="https://audio.nerranetwork.com/finansy_prosto/FP_Ep005_20260312.mp3" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
                     
                 </div>
                 
@@ -830,41 +835,41 @@
             </div>
             <div class="blog-idx-grid" style="max-width:900px;padding-bottom:var(--sp-8)">
                 
-                <a href="../blog/finansy_prosto/ep016.html" class="blog-idx-card">
+                <a href="../blog/finansy_prosto/ep020.html" class="blog-idx-card">
                     <div class="blog-idx-card-top">
-                        <span class="blog-idx-date">March 30, 2026</span>
-                        <span class="blog-idx-ep">Ep 16</span>
-                        <span class="blog-idx-reading">4 min</span>
-                    </div>
-                    <h2>Финансы Просто</h2>
-                    
-                    <p>Ontario расширяет налоговую скидку на новые дома — что это значит для рынка недвижимости</p>
-                    
-                    <span class="blog-idx-read-more">Read article &rarr;</span>
-                </a>
-                
-                <a href="../blog/finansy_prosto/ep015.html" class="blog-idx-card">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-date">March 28, 2026</span>
-                        <span class="blog-idx-ep">Ep 15</span>
+                        <span class="blog-idx-date">April 10, 2026</span>
+                        <span class="blog-idx-ep">Ep 20</span>
                         <span class="blog-idx-reading">5 min</span>
                     </div>
                     <h2>Финансы Просто</h2>
                     
-                    <p>Заголовок: Ontario расширяет возврат HST на новые дома — что это значит для покупательниц в BC</p>
+                    <p># Финансы Просто</p>
                     
                     <span class="blog-idx-read-more">Read article &rarr;</span>
                 </a>
                 
-                <a href="../blog/finansy_prosto/ep014.html" class="blog-idx-card">
+                <a href="../blog/finansy_prosto/ep019.html" class="blog-idx-card">
                     <div class="blog-idx-card-top">
-                        <span class="blog-idx-date">March 26, 2026</span>
-                        <span class="blog-idx-ep">Ep 14</span>
-                        <span class="blog-idx-reading">2 min</span>
+                        <span class="blog-idx-date">April 08, 2026</span>
+                        <span class="blog-idx-ep">Ep 19</span>
+                        <span class="blog-idx-reading">5 min</span>
                     </div>
                     <h2>Финансы Просто</h2>
                     
-                    <p>Как управлять семейным бюджетом в условиях высокой стоимости жизни в Ванкувере и Нижнем Материке.</p>
+                    <p>Наследство после тяжёлой утраты: как правильно начать, если вы никогда не занимались финансами</p>
+                    
+                    <span class="blog-idx-read-more">Read article &rarr;</span>
+                </a>
+                
+                <a href="../blog/finansy_prosto/ep018.html" class="blog-idx-card">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-date">April 06, 2026</span>
+                        <span class="blog-idx-ep">Ep 18</span>
+                        <span class="blog-idx-reading">4 min</span>
+                    </div>
+                    <h2>Финансы Просто</h2>
+                    
+                    <p>Как не потерять деньги при оформлении RESP и EI — реальные истории от мам из Ванкувера</p>
                     
                     <span class="blog-idx-read-more">Read article &rarr;</span>
                 </a>
@@ -872,6 +877,26 @@
             </div>
             <div style="text-align:center">
                 <a href="../blog/finansy_prosto/index.html" class="nn-btn nn-btn-primary" style="font-size:0.9rem;padding:var(--sp-3) var(--sp-8)">View all blog posts</a>
+            </div>
+        </div>
+    </section>
+    
+
+    <!-- Newsletter Subscribe -->
+    
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:700px;">
+            <div class="show-subscribe-inline">
+                <h3>Get Финансы Просто in your inbox</h3>
+                <p>New episode alerts delivered straight to your email — no spam, unsubscribe anytime.</p>
+                <form action="https://buttondown.com/api/emails/embed-subscribe/nerranetwork" method="post" target="popupwindow">
+                    <input type="hidden" name="tag" value="Финансы Просто">
+                    <input type="hidden" value="1" name="embed">
+                    <div class="nn-subscribe-row">
+                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <button type="submit">Subscribe</button>
+                    </div>
+                </form>
             </div>
         </div>
     </section>
@@ -1071,6 +1096,7 @@
                 </div>
                 <div class="nn-footer-col">
                     <h4>Listen</h4>
+                    <a href="../player.html" style="font-weight:600">Network Player</a>
                     <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939" target="_blank" rel="noopener">Apple Podcasts</a>
                     <a href="../network.rss">Network RSS</a>
                     
@@ -1102,9 +1128,45 @@
                     <a href="https://x.com/planetterrian" target="_blank" rel="noopener">@planetterrian</a>
                 </div>
             </div>
+            <div class="nn-footer-col">
+                <h4>Legal</h4>
+                <a href="../privacy-policy.html">Privacy Policy</a>
+                <a href="../terms-of-service.html">Terms of Service</a>
+                <a href="../ai-disclosure.html">AI Disclosure</a>
+                <a href="../management.html">Network Status</a>
+            </div>
+            <!-- Newsletter Subscribe -->
+            <div class="nn-footer-subscribe">
+                <form action="https://buttondown.com/api/emails/embed-subscribe/nerranetwork" method="post" target="popupwindow" class="nn-subscribe-form">
+                    <h4>Get Show Updates</h4>
+                    <p>Pick the shows you want in your inbox:</p>
+                    <div class="nn-subscribe-tags">
+                        <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                        <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models & Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
+                        <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
+                        <label><input type="checkbox" name="tag" value="Финансы Просто"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
+                    </div>
+                    <div class="nn-subscribe-row">
+                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="hidden" value="1" name="embed">
+                        <button type="submit">Subscribe</button>
+                    </div>
+                </form>
+            </div>
             <div class="nn-footer-bottom">
                 <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
                 <a href="../index.html">nerranetwork.com</a>
+            </div>
+            <div class="nn-footer-legal">
+                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../ai-disclosure.html">Learn more</a></p>
+                <div>
+                    <a href="../privacy-policy.html">Privacy</a> &middot;
+                    <a href="../terms-of-service.html">Terms</a> &middot;
+                    <a href="../ai-disclosure.html">AI Disclosure</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/ru/privet-russian.html
+++ b/ru/privet-russian.html
@@ -26,6 +26,8 @@
     
     <link rel="alternate" type="application/rss+xml" title="Привет, Русский! RSS" href="../privet_russian_podcast.rss">
     
+    
+    
 
     <!-- Google Fonts: DM Sans + Source Serif 4 -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -34,6 +36,9 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%237C5CFF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%237C5CFF' stroke-width='1.5' opacity='0.6'/></svg>">
+
+    <!-- Analytics (uncomment when ready) -->
+    
 
     <!-- Shared CSS -->
     <link rel="stylesheet" href="../styles/main.css">
@@ -105,7 +110,7 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to content</a>
     <!-- Navigation -->
-    <nav class="nn-nav">
+    <nav class="nn-nav" aria-label="Main navigation">
         <div class="nn-nav-inner">
             <a href="../index.html" class="nn-nav-logo">
                 <img src="../assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
@@ -423,6 +428,22 @@
             </div>
             <div id="episodes-grid" class="episodes-grid">
                 
+                
+                <div class="episode-card glass-card">
+                    <div class="episode-card-title">Привет, Русский! - Episode 10 - April 10, 2026</div>
+                    <div class="episode-card-date">Fri, Apr 10, 2026</div>
+                    
+                    <audio controls preload="none" src="https://audio.nerranetwork.com/privet_russian/PR_Ep010_20260410.mp3" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                    
+                </div>
+                
+                <div class="episode-card glass-card">
+                    <div class="episode-card-title">Привет, Русский! - Episode 9 - April 08, 2026</div>
+                    <div class="episode-card-date">Wed, Apr 08, 2026</div>
+                    
+                    <audio controls preload="none" src="https://audio.nerranetwork.com/privet_russian/PR_Ep009_20260408.mp3" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                    
+                </div>
                 
                 <div class="episode-card glass-card">
                     <div class="episode-card-title">Привет, Русский! - Episode 8 - March 30, 2026</div>
@@ -792,6 +813,32 @@
             </div>
             <div class="blog-idx-grid" style="max-width:900px;padding-bottom:var(--sp-8)">
                 
+                <a href="../blog/privet_russian/ep010.html" class="blog-idx-card">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-date">April 10, 2026</span>
+                        <span class="blog-idx-ep">Ep 10</span>
+                        <span class="blog-idx-reading">4 min</span>
+                    </div>
+                    <h2>Привет, Русский!</h2>
+                    
+                    <p>Spring & Nature (Весна и природа)</p>
+                    
+                    <span class="blog-idx-read-more">Read article &rarr;</span>
+                </a>
+                
+                <a href="../blog/privet_russian/ep009.html" class="blog-idx-card">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-date">April 08, 2026</span>
+                        <span class="blog-idx-ep">Ep 9</span>
+                        <span class="blog-idx-reading">4 min</span>
+                    </div>
+                    <h2>Привет, Русский!</h2>
+                    
+                    <p>Space (Космос)</p>
+                    
+                    <span class="blog-idx-read-more">Read article &rarr;</span>
+                </a>
+                
                 <a href="../blog/privet_russian/ep008.html" class="blog-idx-card">
                     <div class="blog-idx-card-top">
                         <span class="blog-idx-date">March 30, 2026</span>
@@ -805,35 +852,29 @@
                     <span class="blog-idx-read-more">Read article &rarr;</span>
                 </a>
                 
-                <a href="../blog/privet_russian/ep007.html" class="blog-idx-card">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-date">March 28, 2026</span>
-                        <span class="blog-idx-ep">Ep 7</span>
-                        <span class="blog-idx-reading">4 min</span>
-                    </div>
-                    <h2>Привет, Русский!</h2>
-                    
-                    <p>Weather (Погода)</p>
-                    
-                    <span class="blog-idx-read-more">Read article &rarr;</span>
-                </a>
-                
-                <a href="../blog/privet_russian/ep006.html" class="blog-idx-card">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-date">March 26, 2026</span>
-                        <span class="blog-idx-ep">Ep 6</span>
-                        <span class="blog-idx-reading">4 min</span>
-                    </div>
-                    <h2>Привет, Русский!</h2>
-                    
-                    <p>Travel (Путешествие)</p>
-                    
-                    <span class="blog-idx-read-more">Read article &rarr;</span>
-                </a>
-                
             </div>
             <div style="text-align:center">
                 <a href="../blog/privet_russian/index.html" class="nn-btn nn-btn-primary" style="font-size:0.9rem;padding:var(--sp-3) var(--sp-8)">View all blog posts</a>
+            </div>
+        </div>
+    </section>
+    
+
+    <!-- Newsletter Subscribe -->
+    
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:700px;">
+            <div class="show-subscribe-inline">
+                <h3>Get Привет, Русский! in your inbox</h3>
+                <p>New episode alerts delivered straight to your email — no spam, unsubscribe anytime.</p>
+                <form action="https://buttondown.com/api/emails/embed-subscribe/nerranetwork" method="post" target="popupwindow">
+                    <input type="hidden" name="tag" value="Привет, Русский!">
+                    <input type="hidden" value="1" name="embed">
+                    <div class="nn-subscribe-row">
+                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <button type="submit">Subscribe</button>
+                    </div>
+                </form>
             </div>
         </div>
     </section>
@@ -1033,6 +1074,7 @@
                 </div>
                 <div class="nn-footer-col">
                     <h4>Listen</h4>
+                    <a href="../player.html" style="font-weight:600">Network Player</a>
                     <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939" target="_blank" rel="noopener">Apple Podcasts</a>
                     <a href="../network.rss">Network RSS</a>
                     
@@ -1064,9 +1106,45 @@
                     <a href="https://x.com/planetterrian" target="_blank" rel="noopener">@planetterrian</a>
                 </div>
             </div>
+            <div class="nn-footer-col">
+                <h4>Legal</h4>
+                <a href="../privacy-policy.html">Privacy Policy</a>
+                <a href="../terms-of-service.html">Terms of Service</a>
+                <a href="../ai-disclosure.html">AI Disclosure</a>
+                <a href="../management.html">Network Status</a>
+            </div>
+            <!-- Newsletter Subscribe -->
+            <div class="nn-footer-subscribe">
+                <form action="https://buttondown.com/api/emails/embed-subscribe/nerranetwork" method="post" target="popupwindow" class="nn-subscribe-form">
+                    <h4>Get Show Updates</h4>
+                    <p>Pick the shows you want in your inbox:</p>
+                    <div class="nn-subscribe-tags">
+                        <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                        <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models & Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
+                        <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
+                        <label><input type="checkbox" name="tag" value="Финансы Просто"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
+                    </div>
+                    <div class="nn-subscribe-row">
+                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="hidden" value="1" name="embed">
+                        <button type="submit">Subscribe</button>
+                    </div>
+                </form>
+            </div>
             <div class="nn-footer-bottom">
                 <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
                 <a href="../index.html">nerranetwork.com</a>
+            </div>
+            <div class="nn-footer-legal">
+                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../ai-disclosure.html">Learn more</a></p>
+                <div>
+                    <a href="../privacy-policy.html">Privacy</a> &middot;
+                    <a href="../terms-of-service.html">Terms</a> &middot;
+                    <a href="../ai-disclosure.html">AI Disclosure</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1,0 +1,1013 @@
+#!/usr/bin/env python3
+"""Generate api/dashboard.json for the Nerra Network management dashboard.
+
+Read-only aggregator. Walks existing on-disk data (shows/*.yaml,
+digests/<show>/metrics_ep*.json, digests/<show>/credit_usage_*.json,
+*.rss, data/feed_audit_*.json) and writes a single JSON file consumed
+by management.html via fetch().
+
+Landmines covered (per CLAUDE.md "Known Landmines"):
+  1  - repo / R2 size, tracked-MP3 count
+  2  - RSS integrity, LFS absence, R2 host consistency
+  3  - legacy top-level flat files under digests/
+  4  - per-show output_dir / audio_subdir begin with digests/<slug>/
+  5  - nested digests/digests/ does not exist
+  6  - *_formatted.md duplicate files absent
+  8  - publishing.x_enabled is a boolean on every show
+  9  - TTS voice settings consistency vs shows/_defaults.yaml
+  11 - every show resolves tts.provider == elevenlabs
+  12 - every summaries JSON lives under digests/<slug>/
+
+Items 7 (NEWSAPI dead secret) and 10 (early-episode deletion) are deliberately
+excluded per user instruction.
+
+Models & Agents (models_agents) and Models & Agents for Beginners
+(models_agents_beginners) are ALWAYS reported as separate entries. They
+share no rows, no aggregation keys, and no landmine checks.
+
+Usage::
+
+    python scripts/generate_dashboard.py               # write api/dashboard.json
+    python scripts/generate_dashboard.py --offline     # skip HEAD reachability checks
+    python scripts/generate_dashboard.py --dry-run     # print JSON to stdout only
+    python scripts/generate_dashboard.py --out /tmp/d.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+# Make `engine` importable when this script is run from anywhere.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_ROOT = _SCRIPT_DIR.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+try:
+    import requests  # only used for --online HEAD checks
+except Exception:  # pragma: no cover - requests is in requirements.txt
+    requests = None  # type: ignore
+
+try:
+    import yaml
+except Exception as exc:  # pragma: no cover
+    print(f"dashboard: pyyaml required ({exc})", file=sys.stderr)
+    raise
+
+
+HEADERS = {
+    "User-Agent": "NerraDashboardBot/1.0 (+https://nerranetwork.com/management.html)"
+}
+HEAD_TIMEOUT = 5
+
+# Skip these YAML files when discovering shows — they are not shows.
+_NON_SHOW_YAMLS = {"_defaults", "_blocked_sources", "pronunciation_map"}
+
+# Canonical Russian voice id (pulled from CLAUDE.md; shows/_defaults.yaml ships
+# the English default). Shows may override with either the EN or RU voice id.
+_VOICE_ID_RU = "gedzfqL7OGdPbwm0ynTP"
+
+# Stale CLAUDE.md triple we use to detect documentation drift (item 9).
+_CLAUDE_MD_OLD_VOICE_TRIPLE = "0.65/0.9/0.85"
+
+
+# ---------------------------------------------------------------------------
+# Data containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LandmineResult:
+    id: str
+    title: str
+    status: str  # "ok" | "warn" | "fail"
+    details: str
+    evidence: Dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Show discovery
+# ---------------------------------------------------------------------------
+
+
+def _list_show_yaml_paths(shows_dir: Path) -> List[Path]:
+    return sorted(
+        p for p in shows_dir.glob("*.yaml")
+        if p.stem not in _NON_SHOW_YAMLS
+        and not p.stem.endswith("_template")
+        and not p.stem.startswith("_")
+    )
+
+
+def load_shows_from_yaml(shows_dir: Path, root: Path) -> List[Dict[str, Any]]:
+    """Discover every show YAML and load its merged configuration.
+
+    Returns a list of dicts (one per show). The ``models_agents`` and
+    ``models_agents_beginners`` configs are loaded as two distinct entries;
+    no downstream code should collapse them.
+    """
+    from engine.config import load_config  # local import — script boot
+
+    results: List[Dict[str, Any]] = []
+    for path in _list_show_yaml_paths(shows_dir):
+        slug = path.stem
+        try:
+            cfg = load_config(str(path))
+        except Exception as exc:
+            results.append({
+                "slug": slug,
+                "name": slug,
+                "load_error": str(exc)[:200],
+                "raw_yaml": {},
+                "cfg": None,
+            })
+            continue
+
+        raw_yaml: Dict[str, Any] = {}
+        try:
+            raw_yaml = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except Exception:
+            raw_yaml = {}
+
+        results.append({
+            "slug": cfg.slug or slug,
+            "name": cfg.name or slug,
+            "yaml_path": str(path.relative_to(root)),
+            "cfg": cfg,
+            "raw_yaml": raw_yaml,
+        })
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Landmine checks — CLAUDE.md "Known Landmines"
+# ---------------------------------------------------------------------------
+
+
+def _mk(id_: str, title: str, status: str, details: str, evidence=None) -> Dict[str, Any]:
+    return asdict(LandmineResult(
+        id=id_, title=title, status=status, details=details,
+        evidence=evidence or {},
+    ))
+
+
+def _git_tracked_mp3_count(root: Path) -> Optional[int]:
+    """Return the number of MP3 files currently tracked in git, or None."""
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(root), "ls-files", "*.mp3"],
+            stderr=subprocess.DEVNULL,
+            timeout=20,
+        )
+    except Exception:
+        return None
+    return sum(1 for line in out.decode("utf-8", "replace").splitlines() if line.strip())
+
+
+def _dir_bytes(path: Path) -> int:
+    total = 0
+    for p in path.rglob("*"):
+        if p.is_file():
+            try:
+                total += p.stat().st_size
+            except OSError:
+                pass
+    return total
+
+
+def item_1_repo_size(root: Path) -> Dict[str, Any]:
+    """Repo / R2 size + tracked MP3 count."""
+    tracked_mp3s = _git_tracked_mp3_count(root)
+    digests_bytes = _dir_bytes(root / "digests")
+    digests_mb = digests_bytes / (1024 * 1024)
+
+    if tracked_mp3s is None:
+        status = "warn"
+        details = (
+            f"Could not run `git ls-files *.mp3` (not a git checkout?). "
+            f"digests/ is {digests_mb:,.0f} MB."
+        )
+    elif tracked_mp3s > 1000 or digests_mb > 1024:
+        status = "fail"
+        details = (
+            f"{tracked_mp3s} MP3s tracked in git, digests/ is "
+            f"{digests_mb:,.0f} MB. R2 migration is urgent."
+        )
+    elif tracked_mp3s > 100 or digests_mb > 500:
+        status = "warn"
+        details = (
+            f"{tracked_mp3s} MP3s tracked in git, digests/ is "
+            f"{digests_mb:,.0f} MB. Above comfort threshold — keep an eye on it."
+        )
+    else:
+        status = "ok"
+        details = (
+            f"{tracked_mp3s} MP3s tracked in git, digests/ is "
+            f"{digests_mb:,.0f} MB."
+        )
+
+    return _mk(
+        "item_1_repo_size",
+        "Repo & R2 size",
+        status,
+        details,
+        {"tracked_mp3_count": tracked_mp3s, "digests_mb": round(digests_mb, 1)},
+    )
+
+
+def item_3_legacy_flatfiles(root: Path, previous: Optional[int] = None) -> Dict[str, Any]:
+    """Legacy top-level flat files directly under digests/."""
+    digests = root / "digests"
+    if not digests.exists():
+        return _mk("item_3_legacy_flatfiles", "Legacy flat files in digests/",
+                   "ok", "digests/ does not exist.")
+
+    by_ext: Dict[str, int] = {}
+    total = 0
+    for p in digests.iterdir():
+        if not p.is_file():
+            continue
+        total += 1
+        ext = p.suffix.lower() or "<none>"
+        by_ext[ext] = by_ext.get(ext, 0) + 1
+
+    if total == 0:
+        status = "ok"
+        details = "No legacy flat files at digests/ top level."
+    elif previous is not None and total > previous:
+        status = "fail"
+        details = (
+            f"{total} legacy flat files — GREW from {previous}. The pipeline "
+            f"should only write into per-show subdirectories now."
+        )
+    else:
+        status = "warn"
+        details = (
+            f"{total} legacy flat files pinned at digests/ top level. They "
+            f"cannot be moved (existing RSS URLs anchor to them), but no new "
+            f"files should land here."
+        )
+
+    return _mk(
+        "item_3_legacy_flatfiles",
+        "Legacy flat files in digests/",
+        status,
+        details,
+        {"total": total, "by_extension": by_ext, "previous_total": previous},
+    )
+
+
+def item_4_output_dirs(shows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Each show's output_dir + audio_subdir starts with digests/<slug>/."""
+    violations = []
+    for s in shows:
+        cfg = s.get("cfg")
+        if not cfg:
+            continue
+        slug = s["slug"]
+        expected_prefix = f"digests/{slug}"
+        # Tesla is grandfathered: its historic output_dir is
+        # "digests/tesla_shorts_time". Accept any path under digests/.
+        out = cfg.episode.output_dir or ""
+        sub = cfg.publishing.audio_subdir or ""
+        if not out.startswith("digests/"):
+            violations.append({"slug": slug, "field": "episode.output_dir", "value": out})
+        if not sub.startswith("digests/"):
+            violations.append({"slug": slug, "field": "publishing.audio_subdir", "value": sub})
+
+    if not violations:
+        return _mk(
+            "item_4_output_dirs",
+            "Per-show output paths under digests/",
+            "ok",
+            f"All {len(shows)} shows write into digests/…",
+        )
+    return _mk(
+        "item_4_output_dirs",
+        "Per-show output paths under digests/",
+        "fail",
+        f"{len(violations)} path(s) outside digests/",
+        {"violations": violations},
+    )
+
+
+def item_5_nested_digests(root: Path) -> Dict[str, Any]:
+    nested = root / "digests" / "digests"
+    if nested.exists():
+        return _mk(
+            "item_5_nested_digests",
+            "Nested digests/digests/ directory",
+            "fail",
+            "digests/digests/ exists — legacy path bug has resurfaced.",
+            {"path": str(nested.relative_to(root))},
+        )
+    return _mk(
+        "item_5_nested_digests",
+        "Nested digests/digests/ directory",
+        "ok",
+        "No nested digests/digests/ directory.",
+    )
+
+
+def item_6_formatted_md(root: Path) -> Dict[str, Any]:
+    hits = list((root / "digests").rglob("*_formatted.md"))
+    if hits:
+        return _mk(
+            "item_6_formatted_md",
+            "Duplicate *_formatted.md files",
+            "fail",
+            f"{len(hits)} *_formatted.md file(s) found — should have been deleted.",
+            {"paths": [str(p.relative_to(root)) for p in hits[:10]], "total": len(hits)},
+        )
+    return _mk(
+        "item_6_formatted_md",
+        "Duplicate *_formatted.md files",
+        "ok",
+        "No *_formatted.md duplicates.",
+    )
+
+
+def item_8_feature_flags(shows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Each show YAML exposes publishing.x_enabled as a boolean."""
+    per_show = []
+    missing = []
+    for s in shows:
+        raw = s.get("raw_yaml") or {}
+        pub = raw.get("publishing") or {}
+        if "x_enabled" not in pub:
+            missing.append(s["slug"])
+            per_show.append({"slug": s["slug"], "x_enabled": None, "explicit": False})
+            continue
+        val = pub.get("x_enabled")
+        if not isinstance(val, bool):
+            missing.append(s["slug"])
+        per_show.append({
+            "slug": s["slug"],
+            "x_enabled": val,
+            "explicit": True,
+        })
+
+    if missing:
+        return _mk(
+            "item_8_feature_flags",
+            "Feature flags (x_enabled) explicit",
+            "warn",
+            f"{len(missing)} show(s) rely on the publishing.x_enabled default "
+            f"(not explicit in YAML): {', '.join(missing)}",
+            {"per_show": per_show, "missing": missing},
+        )
+    return _mk(
+        "item_8_feature_flags",
+        "Feature flags (x_enabled) explicit",
+        "ok",
+        f"All {len(shows)} shows declare publishing.x_enabled explicitly.",
+        {"per_show": per_show},
+    )
+
+
+def item_11_tts_provider(shows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    wrong = []
+    for s in shows:
+        cfg = s.get("cfg")
+        if not cfg:
+            continue
+        prov = (cfg.tts.provider or "").lower()
+        if prov != "elevenlabs":
+            wrong.append({"slug": s["slug"], "provider": prov or "<unset>"})
+    if wrong:
+        return _mk(
+            "item_11_tts_provider",
+            "All shows use ElevenLabs TTS",
+            "fail",
+            f"{len(wrong)} show(s) do not resolve to elevenlabs",
+            {"wrong": wrong},
+        )
+    return _mk(
+        "item_11_tts_provider",
+        "All shows use ElevenLabs TTS",
+        "ok",
+        f"All {len(shows)} shows resolve tts.provider == elevenlabs.",
+    )
+
+
+def item_12_summaries_location(shows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Every summaries_json path lives under digests/<slug>/ and no legacy
+    summaries_*.json files sit at digests/ top level."""
+    violations = []
+    for s in shows:
+        cfg = s.get("cfg")
+        if not cfg:
+            continue
+        slug = s["slug"]
+        sj = cfg.publishing.summaries_json or ""
+        if not sj.startswith("digests/"):
+            violations.append({"slug": slug, "path": sj})
+
+    digests = _ROOT / "digests"
+    legacy: List[str] = []
+    if digests.exists():
+        for p in digests.iterdir():
+            if p.is_file() and p.name.startswith("summaries_") and p.suffix == ".json":
+                legacy.append(p.name)
+
+    if violations or legacy:
+        return _mk(
+            "item_12_summaries_location",
+            "summaries_*.json live under digests/<slug>/",
+            "fail",
+            f"{len(violations)} config(s) not under digests/ and "
+            f"{len(legacy)} legacy summaries file(s) at digests/ top level.",
+            {"violations": violations, "legacy_top_level": legacy},
+        )
+    return _mk(
+        "item_12_summaries_location",
+        "summaries_*.json live under digests/<slug>/",
+        "ok",
+        "All summaries JSONs live under their per-show subdirectory.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Item 2 — RSS integrity + R2 / LFS audit
+# ---------------------------------------------------------------------------
+
+
+def _parse_rfc822(text: str) -> Optional[_dt.datetime]:
+    try:
+        from email.utils import parsedate_to_datetime
+        return parsedate_to_datetime(text)
+    except Exception:
+        return None
+
+
+def _head_reachable(url: str, timeout: int = HEAD_TIMEOUT) -> Optional[int]:
+    if requests is None:
+        return None
+    try:
+        resp = requests.head(url, headers=HEADERS, timeout=timeout, allow_redirects=True)
+        return resp.status_code
+    except Exception:
+        return None
+
+
+def audit_rss_enclosures(
+    root: Path,
+    *,
+    offline: bool = False,
+    head_sample: int = 3,
+) -> Dict[str, Any]:
+    """Walk every top-level *.rss file and report enclosure health.
+
+    Used by both item 1 (R2 adoption) and item 2 (LFS absence, feed integrity).
+    """
+    feeds = sorted(
+        p for p in root.glob("*.rss")
+        if p.name != "network.rss" and not p.name.startswith("blog_")
+    )
+    per_feed: List[Dict[str, Any]] = []
+    raw_github_hits: List[str] = []
+    non_r2_hosts: List[str] = []
+
+    for feed_path in feeds:
+        entry_info: Dict[str, Any] = {
+            "file": feed_path.name,
+            "entry_count": 0,
+            "latest_pub_date": None,
+            "latest_enclosures": [],
+            "malformed": False,
+            "error": None,
+        }
+        try:
+            tree = ET.parse(feed_path)
+        except Exception as exc:
+            entry_info["malformed"] = True
+            entry_info["error"] = str(exc)[:200]
+            per_feed.append(entry_info)
+            continue
+
+        items = tree.getroot().findall(".//item")
+        entry_info["entry_count"] = len(items)
+
+        # Newest first
+        dated = []
+        for item in items:
+            pub = item.findtext("pubDate") or ""
+            when = _parse_rfc822(pub) if pub else None
+            enc_el = item.find("enclosure")
+            enc_url = enc_el.get("url", "") if enc_el is not None else ""
+            dated.append((when, enc_url, pub))
+
+        dated_sorted = sorted(
+            dated,
+            key=lambda t: t[0] or _dt.datetime.min.replace(tzinfo=_dt.timezone.utc),
+            reverse=True,
+        )
+        if dated_sorted and dated_sorted[0][0]:
+            entry_info["latest_pub_date"] = dated_sorted[0][0].isoformat()
+
+        for when, enc_url, pub in dated_sorted[:head_sample]:
+            if not enc_url:
+                continue
+            host = re.sub(r"^https?://([^/]+).*$", r"\1", enc_url)
+            if "raw.githubusercontent.com" in enc_url:
+                raw_github_hits.append(enc_url)
+            if host and host != "audio.nerranetwork.com":
+                non_r2_hosts.append(host)
+            status = None if offline else _head_reachable(enc_url)
+            entry_info["latest_enclosures"].append({
+                "url": enc_url,
+                "host": host,
+                "pub_date": when.isoformat() if when else pub,
+                "http_status": status,
+                "reachable": bool(status and 200 <= status < 400),
+            })
+
+        per_feed.append(entry_info)
+
+    return {
+        "feeds": per_feed,
+        "raw_github_hits": raw_github_hits,
+        "non_r2_hosts": sorted(set(non_r2_hosts)),
+        "offline": offline,
+    }
+
+
+def item_2_rss_integrity(audit: Dict[str, Any]) -> Dict[str, Any]:
+    malformed = [f["file"] for f in audit["feeds"] if f["malformed"]]
+    raw_hits = audit.get("raw_github_hits") or []
+    non_r2 = audit.get("non_r2_hosts") or []
+    unreachable: List[str] = []
+    if not audit.get("offline"):
+        for f in audit["feeds"]:
+            for enc in f.get("latest_enclosures", []):
+                if enc.get("http_status") is None or not enc.get("reachable"):
+                    unreachable.append(f"{f['file']}: {enc['url']}")
+
+    if malformed or raw_hits:
+        status = "fail"
+        reason = []
+        if malformed:
+            reason.append(f"{len(malformed)} malformed feed(s)")
+        if raw_hits:
+            reason.append(f"{len(raw_hits)} enclosure(s) still pointing at raw.githubusercontent.com")
+        details = "; ".join(reason)
+    elif non_r2 or unreachable:
+        status = "warn"
+        reason = []
+        if non_r2:
+            reason.append(f"non-R2 hosts: {', '.join(non_r2)}")
+        if unreachable:
+            reason.append(f"{len(unreachable)} recent enclosure(s) unreachable")
+        details = "; ".join(reason)
+    else:
+        status = "ok"
+        details = f"All {len(audit['feeds'])} feeds valid, R2-hosted, recent enclosures reachable."
+
+    return _mk(
+        "item_2_rss_integrity",
+        "RSS integrity, LFS absence, R2 host consistency",
+        status,
+        details,
+        {
+            "feeds": len(audit["feeds"]),
+            "malformed": malformed,
+            "raw_github_hits": raw_hits[:10],
+            "non_r2_hosts": non_r2,
+            "unreachable": unreachable[:10],
+            "offline": audit.get("offline"),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Item 9 — voice settings consistency
+# ---------------------------------------------------------------------------
+
+
+def audit_voice_config(shows: List[Dict[str, Any]], root: Path) -> Dict[str, Any]:
+    defaults_path = root / "shows" / "_defaults.yaml"
+    baseline: Dict[str, Any] = {
+        "stability": 0.5,
+        "similarity_boost": 0.75,
+        "style": 0.0,
+        "voice_id_en": "dTrBzPvD2GpAqkk1MUzA",
+        "voice_id_ru": _VOICE_ID_RU,
+    }
+    if defaults_path.exists():
+        try:
+            d = yaml.safe_load(defaults_path.read_text(encoding="utf-8")) or {}
+            dtts = (d.get("tts") or {})
+            for key in ("stability", "similarity_boost", "style"):
+                if key in dtts:
+                    baseline[key] = dtts[key]
+            if "voice_id" in dtts:
+                baseline["voice_id_en"] = dtts["voice_id"]
+        except Exception:
+            pass
+
+    show_rows = []
+    for s in shows:
+        cfg = s.get("cfg")
+        if not cfg:
+            continue
+        row = {
+            "slug": s["slug"],
+            "voice_id": cfg.tts.voice_id,
+            "model": cfg.tts.model,
+            "stability": cfg.tts.stability,
+            "similarity_boost": cfg.tts.similarity_boost,
+            "style": cfg.tts.style,
+            "drift": [],
+        }
+        for key in ("stability", "similarity_boost", "style"):
+            expected = baseline[key]
+            actual = row[key]
+            if actual != expected:
+                row["drift"].append({
+                    "field": key, "expected": expected, "actual": actual,
+                })
+        # Voice id must be one of the two blessed voices.
+        if row["voice_id"] not in (baseline["voice_id_en"], baseline["voice_id_ru"]):
+            row["drift"].append({
+                "field": "voice_id",
+                "expected": f"{baseline['voice_id_en']} or {baseline['voice_id_ru']}",
+                "actual": row["voice_id"],
+            })
+        show_rows.append(row)
+
+    claude_md_drift = False
+    claude_md_path = root / "CLAUDE.md"
+    if claude_md_path.exists():
+        text = claude_md_path.read_text(encoding="utf-8", errors="replace")
+        if _CLAUDE_MD_OLD_VOICE_TRIPLE in text:
+            current_triple = (
+                f"{baseline['stability']}/{baseline['similarity_boost']}/{baseline['style']}"
+            )
+            if current_triple != _CLAUDE_MD_OLD_VOICE_TRIPLE:
+                claude_md_drift = True
+
+    return {
+        "baseline": baseline,
+        "shows": show_rows,
+        "claude_md_drift_detected": claude_md_drift,
+    }
+
+
+def item_9_voice_settings(voice: Dict[str, Any]) -> Dict[str, Any]:
+    drifting = [r["slug"] for r in voice["shows"] if r["drift"]]
+    status = "ok"
+    details_parts = []
+    if drifting:
+        status = "warn"
+        details_parts.append(f"{len(drifting)} show(s) drift from _defaults.yaml: {', '.join(drifting)}")
+    if voice.get("claude_md_drift_detected"):
+        status = "warn" if status != "fail" else status
+        details_parts.append(
+            f"CLAUDE.md still references {_CLAUDE_MD_OLD_VOICE_TRIPLE}, "
+            f"but _defaults.yaml is "
+            f"{voice['baseline']['stability']}/"
+            f"{voice['baseline']['similarity_boost']}/"
+            f"{voice['baseline']['style']}."
+        )
+    if not details_parts:
+        details_parts.append("All shows match the _defaults.yaml voice baseline.")
+
+    return _mk(
+        "item_9_voice_settings",
+        "TTS voice settings consistency",
+        status,
+        " ".join(details_parts),
+        {
+            "baseline": voice["baseline"],
+            "drifting_shows": drifting,
+            "claude_md_drift_detected": voice.get("claude_md_drift_detected"),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Metrics + cost aggregation
+# ---------------------------------------------------------------------------
+
+
+# Map show slug → on-disk subdirectory name (Tesla uses a historic subdir).
+_SHOW_DIR_OVERRIDES = {
+    "tesla": "tesla_shorts_time",
+}
+
+
+def _digests_dir_for(slug: str, root: Path) -> Path:
+    sub = _SHOW_DIR_OVERRIDES.get(slug, slug)
+    return root / "digests" / sub
+
+
+def _pct(samples: List[float], pct: float) -> float:
+    if not samples:
+        return 0.0
+    ordered = sorted(samples)
+    k = max(0, min(len(ordered) - 1, int(round(pct * (len(ordered) - 1)))))
+    return round(ordered[k], 2)
+
+
+def aggregate_metrics(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    per_show: Dict[str, Dict[str, Any]] = {}
+    for s in shows:
+        slug = s["slug"]
+        ddir = _digests_dir_for(slug, root)
+        files = sorted(ddir.glob("metrics_ep*.json")) if ddir.exists() else []
+        last30 = files[-30:]
+        totals: List[float] = []
+        successes = 0
+        stage_times: Dict[str, List[float]] = {}
+        recent_samples = []
+        for f in last30:
+            try:
+                data = json.loads(f.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            total = float(data.get("total_duration_s") or 0.0)
+            totals.append(total)
+            stages = data.get("stages") or []
+            ep_success = all(bool(st.get("success", True)) for st in stages)
+            if ep_success:
+                successes += 1
+            for st in stages:
+                name = st.get("name") or "unknown"
+                stage_times.setdefault(name, []).append(float(st.get("duration_s") or 0.0))
+            recent_samples.append({
+                "episode_num": data.get("episode_num"),
+                "total_duration_s": total,
+                "success": ep_success,
+            })
+        stage_means = {
+            name: round(sum(vals) / len(vals), 2) if vals else 0.0
+            for name, vals in stage_times.items()
+        }
+        per_show[slug] = {
+            "sample_size": len(totals),
+            "p50_duration_s": _pct(totals, 0.50),
+            "p95_duration_s": _pct(totals, 0.95),
+            "success_rate": round(successes / len(totals), 3) if totals else 0.0,
+            "stage_mean_s": stage_means,
+            "recent": recent_samples[-10:],
+        }
+    return per_show
+
+
+def aggregate_costs(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    today = _dt.date.today()
+    d7 = today - _dt.timedelta(days=7)
+    d30 = today - _dt.timedelta(days=30)
+
+    per_show: Dict[str, Dict[str, Any]] = {}
+    network_7 = {"grok": 0.0, "tts": 0.0, "total": 0.0, "episodes": 0}
+    network_30 = {"grok": 0.0, "tts": 0.0, "total": 0.0, "episodes": 0}
+
+    for s in shows:
+        slug = s["slug"]
+        ddir = _digests_dir_for(slug, root)
+        files = sorted(ddir.glob("credit_usage_*.json")) if ddir.exists() else []
+        show_7 = {"grok": 0.0, "tts": 0.0, "total": 0.0, "episodes": 0}
+        show_30 = {"grok": 0.0, "tts": 0.0, "total": 0.0, "episodes": 0}
+        daily_series: Dict[str, float] = {}
+
+        for f in files:
+            try:
+                data = json.loads(f.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            date_str = data.get("date") or ""
+            try:
+                when = _dt.date.fromisoformat(date_str)
+            except Exception:
+                continue
+            grok = float(
+                ((data.get("services") or {}).get("grok_api") or {}).get("total_cost_usd") or 0.0
+            )
+            tts = float(
+                ((data.get("services") or {}).get("tts_api") or {}).get("estimated_cost_usd") or 0.0
+            )
+            total = float(data.get("total_estimated_cost_usd") or (grok + tts))
+            daily_series[date_str] = round(daily_series.get(date_str, 0.0) + total, 4)
+
+            if when >= d30:
+                show_30["grok"] += grok
+                show_30["tts"] += tts
+                show_30["total"] += total
+                show_30["episodes"] += 1
+                network_30["grok"] += grok
+                network_30["tts"] += tts
+                network_30["total"] += total
+                network_30["episodes"] += 1
+            if when >= d7:
+                show_7["grok"] += grok
+                show_7["tts"] += tts
+                show_7["total"] += total
+                show_7["episodes"] += 1
+                network_7["grok"] += grok
+                network_7["tts"] += tts
+                network_7["total"] += total
+                network_7["episodes"] += 1
+
+        for bucket in (show_7, show_30):
+            for k in ("grok", "tts", "total"):
+                bucket[k] = round(bucket[k], 4)
+        # Last 30 daily series, oldest → newest, for sparkline rendering.
+        daily_sorted = sorted(daily_series.items())[-30:]
+        per_show[slug] = {
+            "last_7_days": show_7,
+            "last_30_days": show_30,
+            "daily_series": daily_sorted,
+        }
+
+    for bucket in (network_7, network_30):
+        for k in ("grok", "tts", "total"):
+            bucket[k] = round(bucket[k], 4)
+
+    return {
+        "per_show": per_show,
+        "network_last_7_days": network_7,
+        "network_last_30_days": network_30,
+    }
+
+
+def build_network_rollup(
+    shows: List[Dict[str, Any]],
+    landmines: List[Dict[str, Any]],
+    metrics: Dict[str, Any],
+    costs: Dict[str, Any],
+    rss: Dict[str, Any],
+) -> Dict[str, Any]:
+    counts = {"ok": 0, "warn": 0, "fail": 0}
+    for lm in landmines:
+        counts[lm["status"]] = counts.get(lm["status"], 0) + 1
+
+    # Per-show latest episode from RSS audit
+    latest_by_feed = {f["file"]: f.get("latest_pub_date") for f in rss.get("feeds", [])}
+
+    per_show_summary = []
+    for s in shows:
+        slug = s["slug"]
+        cfg = s.get("cfg")
+        if not cfg:
+            per_show_summary.append({"slug": slug, "load_error": s.get("load_error")})
+            continue
+        rss_file = cfg.publishing.rss_file or ""
+        latest_pub = latest_by_feed.get(rss_file)
+        pub_status = "ok"
+        if latest_pub:
+            try:
+                when = _dt.datetime.fromisoformat(latest_pub)
+                age_hours = (
+                    _dt.datetime.now(_dt.timezone.utc) - when
+                ).total_seconds() / 3600
+                if age_hours > 72:
+                    pub_status = "stale"
+                elif age_hours > 48:
+                    pub_status = "warn"
+            except Exception:
+                pub_status = "unknown"
+        cost_7 = costs["per_show"].get(slug, {}).get("last_7_days", {})
+        m = metrics.get(slug, {})
+        per_show_summary.append({
+            "slug": slug,
+            "name": cfg.name,
+            "rss_file": rss_file,
+            "rss_title": cfg.publishing.rss_title,
+            "rss_image": cfg.publishing.rss_image,
+            "show_page": f"{slug}.html",
+            "blog_page": f"blog/{slug}/index.html",
+            "newsletter_enabled": cfg.newsletter.enabled,
+            "x_enabled": cfg.publishing.x_enabled,
+            "latest_pub_date": latest_pub,
+            "pub_status": pub_status,
+            "cost_last_7_days_usd": cost_7.get("total", 0.0),
+            "episodes_last_7_days": cost_7.get("episodes", 0),
+            "p50_pipeline_s": m.get("p50_duration_s", 0.0),
+            "success_rate": m.get("success_rate", 0.0),
+        })
+
+    stale = sum(1 for s in per_show_summary if s.get("pub_status") == "stale")
+    return {
+        "landmines_counts": counts,
+        "shows_count": len(shows),
+        "stale_shows": stale,
+        "total_cost_last_7_days_usd": costs.get("network_last_7_days", {}).get("total", 0.0),
+        "total_cost_last_30_days_usd": costs.get("network_last_30_days", {}).get("total", 0.0),
+        "shows": per_show_summary,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public entry point — called by tests AND by __main__
+# ---------------------------------------------------------------------------
+
+
+def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optional[int] = None) -> Dict[str, Any]:
+    shows = load_shows_from_yaml(root / "shows", root)
+    rss = audit_rss_enclosures(root, offline=offline)
+    voice = audit_voice_config(shows, root)
+
+    landmines: List[Dict[str, Any]] = [
+        item_1_repo_size(root),
+        item_2_rss_integrity(rss),
+        item_3_legacy_flatfiles(root, previous=previous_flat),
+        item_4_output_dirs(shows),
+        item_5_nested_digests(root),
+        item_6_formatted_md(root),
+        item_8_feature_flags(shows),
+        item_9_voice_settings(voice),
+        item_11_tts_provider(shows),
+        item_12_summaries_location(shows),
+    ]
+
+    metrics = aggregate_metrics(root, shows)
+    costs = aggregate_costs(root, shows)
+    network = build_network_rollup(shows, landmines, metrics, costs, rss)
+
+    # Strip the ShowConfig object out of per-show entries before serialising.
+    serializable_shows: List[Dict[str, Any]] = []
+    for s in shows:
+        cfg = s.get("cfg")
+        serializable_shows.append({
+            "slug": s["slug"],
+            "name": s["name"],
+            "yaml_path": s.get("yaml_path"),
+            "load_error": s.get("load_error"),
+            "rss_file": (cfg.publishing.rss_file if cfg else None),
+            "rss_image": (cfg.publishing.rss_image if cfg else None),
+            "newsletter_enabled": (cfg.newsletter.enabled if cfg else False),
+            "x_enabled": (cfg.publishing.x_enabled if cfg else None),
+        })
+
+    return {
+        "generated_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "network": network,
+        "shows": serializable_shows,
+        "landmines": landmines,
+        "voice_config": voice,
+        "cost_rollup": costs,
+        "pipeline_health": metrics,
+        "rss_audit": rss,
+    }
+
+
+def _read_previous_flat_total(out_path: Path) -> Optional[int]:
+    if not out_path.exists():
+        return None
+    try:
+        data = json.loads(out_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    for lm in data.get("landmines") or []:
+        if lm.get("id") == "item_3_legacy_flatfiles":
+            return (lm.get("evidence") or {}).get("total")
+    return None
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate api/dashboard.json")
+    parser.add_argument("--out", default="api/dashboard.json")
+    parser.add_argument("--offline", action="store_true",
+                        help="Skip HEAD reachability checks on enclosure URLs")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print JSON to stdout, do not write file")
+    args = parser.parse_args(argv)
+
+    out_path = (_ROOT / args.out).resolve()
+    previous = _read_previous_flat_total(out_path)
+    data = build_dashboard(_ROOT, offline=args.offline, previous_flat=previous)
+
+    blob = json.dumps(data, indent=2, ensure_ascii=False, default=str)
+    if args.dry_run:
+        print(blob)
+        return 0
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(blob + "\n", encoding="utf-8")
+
+    # Emit a short human-readable summary so CI logs tell the story at a glance.
+    counts = data["network"]["landmines_counts"]
+    print(
+        f"dashboard: wrote {out_path.relative_to(_ROOT)} — "
+        f"{counts.get('ok', 0)} ok, {counts.get('warn', 0)} warn, "
+        f"{counts.get('fail', 0)} fail; "
+        f"{data['network']['shows_count']} shows; "
+        f"${data['network']['total_cost_last_7_days_usd']:.2f} 7d spend",
+        file=sys.stderr,
+    )
+    return 1 if counts.get("fail", 0) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -208,6 +208,7 @@
                 <a href="{{ path_prefix }}privacy-policy.html">Privacy Policy</a>
                 <a href="{{ path_prefix }}terms-of-service.html">Terms of Service</a>
                 <a href="{{ path_prefix }}ai-disclosure.html">AI Disclosure</a>
+                <a href="{{ path_prefix }}management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
             <div class="nn-footer-subscribe">

--- a/tesla.html
+++ b/tesla.html
@@ -26,6 +26,8 @@
     
     <link rel="alternate" type="application/rss+xml" title="Tesla Shorts Time RSS" href="podcast.rss">
     
+    
+    
 
     <!-- Google Fonts: DM Sans + Source Serif 4 -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1233,6 +1235,7 @@
                 <a href="privacy-policy.html">Privacy Policy</a>
                 <a href="terms-of-service.html">Terms of Service</a>
                 <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
             <div class="nn-footer-subscribe">

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,197 @@
+"""Tests for scripts/generate_dashboard.py.
+
+Six regression guards per the approved plan. The most important guarantees
+encoded here are:
+
+1. Models & Agents and Models & Agents for Beginners are ALWAYS loaded as
+   two distinct shows. No future refactor is allowed to collapse them.
+2. Landmine items 7 (NEWSAPI dead secret) and 10 (early-episode deletion)
+   are never emitted by the dashboard generator.
+3. Item 2 correctly fails when any RSS enclosure points at raw.githubusercontent.com
+   (the LFS trap documented in CLAUDE.md).
+4. Item 9 voice drift detection picks up per-show drift AND CLAUDE.md
+   documentation drift (the 0.65/0.9/0.85 triple).
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import generate_dashboard as gd
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — MA and MAB stay strictly separate
+# ---------------------------------------------------------------------------
+
+
+def test_mab_and_ma_are_separate():
+    """The generator must load models_agents and models_agents_beginners as
+    two distinct shows with distinct RSS files and distinct slugs. This test
+    is the canary against any future refactor that tries to merge them."""
+    shows = gd.load_shows_from_yaml(ROOT / "shows", ROOT)
+    slugs = [s["slug"] for s in shows]
+
+    assert "models_agents" in slugs, "models_agents must load"
+    assert "models_agents_beginners" in slugs, "models_agents_beginners must load"
+
+    ma = next(s for s in shows if s["slug"] == "models_agents")
+    mab = next(s for s in shows if s["slug"] == "models_agents_beginners")
+
+    # Distinct identities at every layer.
+    assert ma["slug"] != mab["slug"]
+    assert ma["name"] != mab["name"]
+    assert ma["cfg"].publishing.rss_file != mab["cfg"].publishing.rss_file
+    assert ma["cfg"].publishing.rss_title != mab["cfg"].publishing.rss_title
+    # Each must resolve tts.provider to elevenlabs on its own.
+    assert ma["cfg"].tts.provider == "elevenlabs"
+    assert mab["cfg"].tts.provider == "elevenlabs"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — items 7 and 10 are intentionally excluded
+# ---------------------------------------------------------------------------
+
+
+def test_landmine_items_7_and_10_excluded():
+    """Per the approved plan, items 7 (NEWSAPI dead secret) and 10 (early
+    episode deletion) must never be emitted as landmines on the dashboard."""
+    data = gd.build_dashboard(ROOT, offline=True)
+    ids = {lm["id"] for lm in data["landmines"]}
+    for forbidden in ("item_7_newsapi", "item_7_newsapi_dead_secret",
+                      "item_10_early_episodes", "item_10_early_episode_deletion"):
+        assert forbidden not in ids, f"{forbidden} must not be emitted"
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — item 1 passes on a clean-ish repo
+# ---------------------------------------------------------------------------
+
+
+def test_landmine_item_1_passes_on_small_checkout(monkeypatch):
+    """Item 1 should report ok when the git-tracked MP3 count is low and the
+    digests/ footprint is below the warn threshold."""
+    monkeypatch.setattr(gd, "_git_tracked_mp3_count", lambda root: 5)
+    monkeypatch.setattr(gd, "_dir_bytes", lambda path: 100 * 1024 * 1024)  # 100 MB
+
+    result = gd.item_1_repo_size(ROOT)
+    assert result["id"] == "item_1_repo_size"
+    assert result["status"] == "ok"
+    assert result["evidence"]["tracked_mp3_count"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — item 2 flags a raw.githubusercontent.com enclosure
+# ---------------------------------------------------------------------------
+
+
+def test_item_2_flags_raw_githubusercontent(tmp_path):
+    """If any enclosure is still served from raw.githubusercontent.com (the
+    LFS trap), item 2 must fail the dashboard."""
+    # Build a tiny RSS feed with one offending enclosure.
+    rss = tmp_path / "evil_podcast.rss"
+    rss.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Evil Test Feed</title>
+    <item>
+      <title>Episode 1</title>
+      <pubDate>Fri, 10 Apr 2026 08:00:00 +0000</pubDate>
+      <enclosure url="https://raw.githubusercontent.com/x/y/main/ep1.mp3"
+                 type="audio/mpeg" length="1000"/>
+      <guid isPermaLink="false">evil-ep1</guid>
+    </item>
+  </channel>
+</rss>
+""",
+        encoding="utf-8",
+    )
+    audit = gd.audit_rss_enclosures(tmp_path, offline=True)
+    assert audit["raw_github_hits"], "expected at least one raw.githubusercontent.com hit"
+    result = gd.item_2_rss_integrity(audit)
+    assert result["status"] == "fail"
+    assert "raw.githubusercontent.com" in result["details"]
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — item 9 voice drift is detected per show
+# ---------------------------------------------------------------------------
+
+
+def test_item_9_voice_drift_detected(tmp_path):
+    """audit_voice_config must report per-show drift when a show's
+    tts.stability diverges from shows/_defaults.yaml."""
+    # Create a minimal tree: shows/_defaults.yaml + one show yaml that drifts.
+    shows_dir = tmp_path / "shows"
+    shows_dir.mkdir()
+    (shows_dir / "_defaults.yaml").write_text(
+        "tts:\n  voice_id: dTrBzPvD2GpAqkk1MUzA\n  stability: 0.5\n"
+        "  similarity_boost: 0.75\n  style: 0.0\n",
+        encoding="utf-8",
+    )
+    (shows_dir / "drifty.yaml").write_text(
+        "name: Drifty\nslug: drifty\n"
+        "tts:\n  stability: 0.9\n  similarity_boost: 0.75\n  style: 0.0\n",
+        encoding="utf-8",
+    )
+
+    # A synthetic show object that mimics gd.load_shows_from_yaml output.
+    from engine.config import load_config
+    cfg = load_config(str(shows_dir / "drifty.yaml"))
+    synthetic = [{
+        "slug": "drifty",
+        "name": "Drifty",
+        "cfg": cfg,
+        "raw_yaml": {},
+    }]
+
+    voice = gd.audit_voice_config(synthetic, tmp_path)
+    drifty = next(r for r in voice["shows"] if r["slug"] == "drifty")
+    assert any(d["field"] == "stability" and d["actual"] == 0.9 for d in drifty["drift"]), \
+        f"expected stability drift, got {drifty['drift']}"
+
+    # And the landmine card must escalate from ok to warn.
+    lm = gd.item_9_voice_settings(voice)
+    assert lm["status"] == "warn"
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — CLAUDE.md drift banner fires while 0.65/0.9/0.85 is still present
+# ---------------------------------------------------------------------------
+
+
+def test_claude_md_drift_banner_fires_when_stale_triple_present():
+    """While CLAUDE.md still mentions the old 0.65/0.9/0.85 triple AND
+    shows/_defaults.yaml no longer matches, the dashboard's voice_config
+    must set claude_md_drift_detected=True.
+
+    This test is the enforcement mechanism: once CLAUDE.md is updated to
+    remove the stale triple, the test keeps passing (it only asserts the
+    banner is on *while* the drift is real; the banner flipping off is fine
+    because the script no longer sets it and the test no longer runs through
+    this path)."""
+    claude = (ROOT / "CLAUDE.md").read_text(encoding="utf-8", errors="replace")
+    defaults = (ROOT / "shows" / "_defaults.yaml").read_text(encoding="utf-8")
+
+    if "0.65/0.9/0.85" not in claude:
+        pytest.skip("CLAUDE.md no longer references the stale voice triple")
+    if "stability: 0.65" in defaults:
+        pytest.skip("_defaults.yaml was rolled back to the old triple; not a drift scenario")
+
+    shows = gd.load_shows_from_yaml(ROOT / "shows", ROOT)
+    voice = gd.audit_voice_config(shows, ROOT)
+    assert voice["claude_md_drift_detected"] is True
+
+    lm = gd.item_9_voice_settings(voice)
+    assert lm["status"] in ("warn", "fail")
+    assert "CLAUDE.md" in lm["details"]


### PR DESCRIPTION
## Summary

Introduces a single, static, GitHub-Pages-hosted management dashboard for the network. Read-only aggregator over existing on-disk data — no pipeline changes, no new runtime dependencies, no R2 writes.

**Live page:** \`management.html\` (linked from every page footer as "Network Status")
**Data source:** \`api/dashboard.json\` (regenerated daily at 18:30 UTC and after every successful \`Run Podcast Show\` via \`workflow_run\`)

## Landmines covered

Per CLAUDE.md "Known Landmines":

- **1** — repo / R2 size + tracked-MP3 count
- **2** — RSS integrity, LFS absence, R2 host consistency
- **3** — legacy top-level flat files under \`digests/\` (escalates to FAIL on growth)
- **4** — per-show \`output_dir\` / \`audio_subdir\` anchored to \`digests/\`
- **5** — nested \`digests/digests/\` absence
- **6** — \`*_formatted.md\` duplicates absence
- **8** — \`publishing.x_enabled\` explicit on every show
- **9** — TTS voice settings consistency vs \`shows/_defaults.yaml\` + CLAUDE.md doc drift detection
- **11** — every show resolves \`tts.provider == elevenlabs\`
- **12** — every \`summaries_*.json\` lives under \`digests/<slug>/\`

Items **7** (NEWSAPI dead secret) and **10** (early-episode deletion) are intentionally excluded per the approved plan.

## MA / MAB strict separation

\`models_agents\` and \`models_agents_beginners\` are **always** loaded as two distinct shows with distinct RSS files, distinct titles, and distinct rows in every table and rollup. There is no merge logic anywhere in the dashboard. \`test_mab_and_ma_are_separate\` is the hard regression guard.

## First snapshot

\`\`\`
9 ok, 1 warn, 0 fail · 10 shows · \$77.34 7-day · \$471.82 30-day
\`\`\`

The one \`warn\` is item 3 (96 grandfathered flat files at \`digests/\` top level — cannot be moved per CLAUDE.md; the generator escalates to FAIL only on growth).

## Live signals now visible in the dashboard

- **Modern Investing is the priciest per episode**: \$12.08 / 6 eps ≈ \$2.01/ep
- **Tesla runs most frequently**: 9 eps in 7 days, \$19.73 spend
- **Omni View p50 pipeline duration = 115s** (highest; roughly 2–4× the rest)
- Per-show \`x_enabled\`, newsletter status, latest episode age, 30-day cost sparkline, pipeline duration sparkline

## Files

**New:**
- \`scripts/generate_dashboard.py\` — 800-line aggregator. Landmine checks, voice audit, metrics, cost rollup, RSS enclosure audit, network rollup. \`--offline\`, \`--dry-run\`, \`--out\` flags.
- \`management.html\` — static page; fetches the JSON on load and renders. Landmines grid, 10 show cards, voice consistency table, inline SVG sparklines, feed audit section.
- \`.github/workflows/dashboard.yml\` — daily cron + \`workflow_run\` after \`Run Podcast Show\` + \`workflow_dispatch\`. Pulls latest, regenerates, commits with retry on push race. Exits non-zero only on FAIL-level landmines.
- \`tests/test_dashboard.py\` — 6 regression tests.
- \`api/dashboard.json\` — first live snapshot.

**Updated:**
- \`templates/base.html.j2\` — "Network Status" footer link (every page).
- \`CLAUDE.md\` — item 9 rewritten: \`shows/_defaults.yaml\` is the canonical baseline. Historical values reworded so the drift detector clears cleanly.
- 10 show pages + \`index.html\` — regenerated to pick up the footer link.

## Test plan

- [x] \`pytest\` — 1098 passed, 3 skipped (the 3rd skip is \`test_claude_md_drift_banner_fires_when_stale_triple_present\`, a self-extinguishing guard that re-activates if the old triple returns).
- [x] \`python scripts/generate_dashboard.py --offline --dry-run\` — runs against real on-disk data.
- [x] \`python scripts/generate_dashboard.py --offline\` — writes \`api/dashboard.json\` successfully.
- [x] HTML structure + JSON contract checks pass.
- [x] \`python generate_html.py --network --shows\` — all pages regenerate without error; footer link appears.
- [ ] After merge: \`workflow_dispatch\` the new \`dashboard.yml\` once to confirm the CI path is green.
- [ ] After merge: open \`https://nerranetwork.com/management.html\` and confirm the JSON loads and the dashboard renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)