### PR TITLE
Fix missed episode scheduling by adding skip markers

### DIFF
--- a/review_episodes.py
+++ b/review_episodes.py
@@ -238,6 +238,22 @@ def _should_run_on(schedule: str, target_date: datetime.date) -> bool:
     return True  # unknown schedule → assume should run
 
 
+def _read_skip_marker(output_dir: str, target_date: datetime.date) -> Optional[dict]:
+    """Read a skip marker file if one exists for the given date.
+
+    Skip markers are written by ``run_show.py`` when the pipeline exits early
+    (exit code 2) due to insufficient articles, duplicate content, etc.
+    """
+    marker_path = PROJECT_ROOT / output_dir / f".skip_{target_date.strftime('%Y%m%d')}.json"
+    if not marker_path.exists():
+        return None
+    try:
+        return json.loads(marker_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to read skip marker %s: %s", marker_path, exc)
+        return None
+
+
 def check_missed_episodes(
     target_date: datetime.date,
     found_episodes: List[EpisodeReview],
@@ -245,7 +261,10 @@ def check_missed_episodes(
 ) -> List[Issue]:
     """Detect shows that were scheduled to produce an episode but didn't.
 
-    Returns a list of Issue objects for missing episodes.
+    Returns a list of Issue objects for missing episodes.  If the pipeline
+    intentionally skipped an episode (and left a skip marker file), the issue
+    is reported as a *warning* instead of *critical* so the daily review can
+    distinguish genuine failures from expected skips.
     """
     found_slugs = {ep.show_slug for ep in found_episodes}
     missed: List[Issue] = []
@@ -258,19 +277,38 @@ def check_missed_episodes(
             continue
         if slug in found_slugs:
             continue
-        missed.append(Issue(
-            show=slug,
-            episode=0,
-            severity="critical",
-            title=f"Missed episode: {info['name']}",
-            detail=(
-                f"{info['name']} was scheduled to produce an episode on "
-                f"{target_date.isoformat()} (schedule: {schedule}) but no output "
-                f"files were found in {info['output_dir']}/. The pipeline may have "
-                f"failed, been skipped due to insufficient articles, or the workflow "
-                f"did not trigger."
-            ),
-        ))
+
+        # Check for a skip marker — pipeline ran but intentionally skipped
+        marker = _read_skip_marker(info["output_dir"], target_date)
+        if marker:
+            reason = marker.get("reason", "unknown")
+            detail = marker.get("detail", "No detail provided.")
+            missed.append(Issue(
+                show=slug,
+                episode=0,
+                severity="warning",
+                title=f"Skipped episode: {info['name']} ({reason})",
+                detail=(
+                    f"{info['name']} was scheduled on "
+                    f"{target_date.isoformat()} (schedule: {schedule}) but the "
+                    f"pipeline intentionally skipped this episode. "
+                    f"Reason: {detail}"
+                ),
+            ))
+        else:
+            missed.append(Issue(
+                show=slug,
+                episode=0,
+                severity="critical",
+                title=f"Missed episode: {info['name']}",
+                detail=(
+                    f"{info['name']} was scheduled to produce an episode on "
+                    f"{target_date.isoformat()} (schedule: {schedule}) but no output "
+                    f"files were found in {info['output_dir']}/ and no skip marker "
+                    f"was present. The pipeline may have failed or the workflow did "
+                    f"not trigger."
+                ),
+            ))
 
     return missed
 
@@ -1137,9 +1175,10 @@ def create_github_issue(
     else:
         title = f"Daily Review {target_date}: {len(warnings)} warning(s) across {n_shows} show(s)"
 
-    # Separate missed-episode issues from per-episode issues
+    # Separate missed/skipped episode issues from per-episode issues
     _missed = [i for i in all_issues if i.episode == 0 and "Missed episode" in i.title]
-    _missed_shows = {i.show for i in _missed}
+    _skipped = [i for i in all_issues if i.episode == 0 and "Skipped episode" in i.title]
+    _missed_shows = {i.show for i in _missed} | {i.show for i in _skipped}
 
     # Build issue body
     body_lines = [
@@ -1148,6 +1187,8 @@ def create_github_issue(
     ]
     if _missed:
         body_lines.append(f"**Missed episodes:** {len(_missed)} show(s) failed to produce output")
+    if _skipped:
+        body_lines.append(f"**Skipped episodes:** {len(_skipped)} show(s) intentionally skipped")
     body_lines.append(
         f"**Issues found:** {len(critical)} critical, {len(warnings)} warning(s), {len(infos)} info\n"
     )
@@ -1159,6 +1200,17 @@ def create_github_issue(
             "These shows were scheduled to produce an episode today but no output was found:\n"
         )
         for issue in _missed:
+            show_name = SHOW_REGISTRY.get(issue.show, {}).get("name", issue.show)
+            body_lines.append(f"- **{show_name}** (`{issue.show}`): {issue.detail}")
+        body_lines.append("")
+
+    # Skipped episodes section
+    if _skipped:
+        body_lines.append("### Skipped Episodes\n")
+        body_lines.append(
+            "These shows ran but intentionally skipped episode production:\n"
+        )
+        for issue in _skipped:
             show_name = SHOW_REGISTRY.get(issue.show, {}).get("name", issue.show)
             body_lines.append(f"- **{show_name}** (`{issue.show}`): {issue.detail}")
         body_lines.append("")
@@ -1285,18 +1337,21 @@ def format_for_claude(
 
     critical = [(ep, i) for ep, i in all_issues if i.severity == "critical"]
     warnings = [(ep, i) for ep, i in all_issues if i.severity == "warning"]
+    _missed_critical = [i for i in missed_issues if i.severity == "critical"]
+    _missed_warnings = [i for i in missed_issues if i.severity == "warning"]
 
     lines = [
         f"Fix the following issues found by the daily episode review for {target_date}.",
-        f"There are {len(critical) + len(missed_issues)} critical and {len(warnings)} warning-level issues.",
+        f"There are {len(critical) + len(_missed_critical)} critical and "
+        f"{len(warnings) + len(_missed_warnings)} warning-level issues.",
         "",
     ]
 
-    # Missed episodes section
-    if missed_issues:
+    # Missed episodes section (genuine failures — no skip marker)
+    if _missed_critical:
         lines.append("## Missed Episodes")
         lines.append("")
-        for issue in missed_issues:
+        for issue in _missed_critical:
             show_name = SHOW_REGISTRY.get(issue.show, {}).get("name", issue.show)
             lines.append(f"- **[CRITICAL] {show_name}** — {issue.detail}")
         lines.append("")
@@ -1305,6 +1360,15 @@ def format_for_claude(
             "why they failed. Check GitHub Actions run history, RSS feed health, "
             "and news source availability."
         )
+        lines.append("")
+
+    # Skipped episodes section (intentional skips — skip marker present)
+    if _missed_warnings:
+        lines.append("## Skipped Episodes")
+        lines.append("")
+        for issue in _missed_warnings:
+            show_name = SHOW_REGISTRY.get(issue.show, {}).get("name", issue.show)
+            lines.append(f"- **[WARNING] {show_name}** — {issue.detail}")
         lines.append("")
 
     # Group by issue type for efficient fixing
@@ -1388,7 +1452,10 @@ def run_review(
     missed_issues = check_missed_episodes(target_date, episodes, show_filter)
     if missed_issues:
         for issue in missed_issues:
-            logger.error("[CRITICAL] %s: %s", issue.title, issue.detail)
+            if issue.severity == "critical":
+                logger.error("[CRITICAL] %s: %s", issue.title, issue.detail)
+            else:
+                logger.warning("[%s] %s: %s", issue.severity.upper(), issue.title, issue.detail)
 
     if not episodes and not missed_issues:
         logger.info("No episodes found for %s (and none expected)", target_date.isoformat())
@@ -1426,8 +1493,8 @@ def run_review(
         logger.info("Skipping AI review (no GROK_API_KEY)")
 
     # Report
-    total_critical = len(missed_issues)  # missed episodes are critical
-    total_warnings = 0
+    total_critical = sum(1 for i in missed_issues if i.severity == "critical")
+    total_warnings = sum(1 for i in missed_issues if i.severity == "warning")
     for ep in episodes:
         n_crit = sum(1 for i in ep.issues if i.severity == "critical")
         n_warn = sum(1 for i in ep.issues if i.severity == "warning")
@@ -1469,10 +1536,15 @@ def run_review(
             logger.info("No actionable issues — skipping GitHub issue creation")
 
     # Summary
-    logger.info(
-        "=== Review complete: %d episode(s), %d missed, %d critical, %d warning(s) ===",
-        len(episodes), len(missed_issues), total_critical, total_warnings,
-    )
+    n_missed = sum(1 for i in missed_issues if i.severity == "critical")
+    n_skipped = sum(1 for i in missed_issues if i.severity == "warning")
+    parts = [f"{len(episodes)} episode(s)"]
+    if n_missed:
+        parts.append(f"{n_missed} missed")
+    if n_skipped:
+        parts.append(f"{n_skipped} skipped")
+    parts.extend([f"{total_critical} critical", f"{total_warnings} warning(s)"])
+    logger.info("=== Review complete: %s ===", ", ".join(parts))
 
     if total_critical > 0:
         return 1

--- a/run_show.py
+++ b/run_show.py
@@ -327,6 +327,30 @@ def run(args: argparse.Namespace) -> None:
     today_str = today.strftime("%B %d, %Y")
     digests_dir = PROJECT_ROOT / config.episode.output_dir
 
+    def _skip_episode(reason: str, detail: str) -> None:
+        """Write a skip marker file and exit with code 2.
+
+        The marker lets the daily review script distinguish intentional skips
+        (insufficient articles, duplicate content, etc.) from genuine pipeline
+        failures or missed workflow triggers.
+        """
+        marker_path = digests_dir / f".skip_{today.strftime('%Y%m%d')}.json"
+        marker_path.parent.mkdir(parents=True, exist_ok=True)
+        marker_data = {
+            "date": today.isoformat(),
+            "show": config.slug,
+            "show_name": config.name,
+            "reason": reason,
+            "detail": detail,
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        }
+        try:
+            marker_path.write_text(json.dumps(marker_data, indent=2))
+            logger.info("Skip marker written: %s (%s)", marker_path.name, reason)
+        except OSError as exc:
+            logger.warning("Failed to write skip marker: %s", exc)
+        sys.exit(2)
+
     # Initialize pipeline metrics
     from engine.metrics import PipelineMetrics
     metrics = PipelineMetrics(show_slug=config.slug, episode_num=0)  # Updated after ep num known
@@ -506,7 +530,7 @@ def run(args: argparse.Namespace) -> None:
 
     if not articles:
         logger.warning("No articles found even after expanded search. Skipping episode.")
-        sys.exit(2)
+        _skip_episode("no_articles", "No articles found even after expanded search.")
 
     # Skip episode if digest would be too thin — or activate slow news mode
     skip_threshold = getattr(config, "min_articles_skip", 3) or 3
@@ -557,7 +581,10 @@ def run(args: argparse.Namespace) -> None:
                 "Only %d article(s) found — below minimum threshold (%d) for a quality episode. Skipping.",
                 len(articles), skip_threshold,
             )
-            sys.exit(2)
+            _skip_episode(
+                "insufficient_articles",
+                f"Only {len(articles)} article(s) found — below minimum threshold ({skip_threshold}).",
+            )
 
     # 5b2. Thin content detection — article count is above skip threshold but
     #      below the quality threshold (min_articles).  Activate slow news mode
@@ -785,7 +812,10 @@ def run(args: argparse.Namespace) -> None:
                 "aborting episode to prevent recycled content from reaching audio: %s",
                 len(_critical_dup_issues), "; ".join(_critical_dup_issues),
             )
-            sys.exit(2)
+            _skip_episode(
+                "duplicate_content",
+                f"Digest has {len(_critical_dup_issues)} near-verbatim (>=80%) intra-episode duplicate(s).",
+            )
         if not _val_passed:
             # Check for critical missing sections (non-optional)
             _missing = [
@@ -882,7 +912,11 @@ def run(args: argparse.Namespace) -> None:
                             len(_item_count_issues), _digest_char_count,
                             "; ".join(_item_count_issues),
                         )
-                        sys.exit(2)
+                        _skip_episode(
+                            "thin_episode",
+                            f"Digest has {len(_item_count_issues)} item-count shortfall(s) "
+                            f"and is short ({_digest_char_count} chars).",
+                        )
                     else:
                         # Long enough to be real content — likely a formatting
                         # mismatch rather than missing content.
@@ -950,7 +984,10 @@ def run(args: argparse.Namespace) -> None:
                                 )
                         except LLMRefusalError as e:
                             logger.error("Slow news fallback digest refused: %s", e)
-                            sys.exit(2)
+                            _skip_episode(
+                                "llm_refusal",
+                                f"Slow news fallback digest refused by LLM: {e}",
+                            )
                         except Exception as e:
                             logger.error("Slow news fallback digest failed: %s", e)
                             sys.exit(1)
@@ -977,7 +1014,11 @@ def run(args: argparse.Namespace) -> None:
                             "stories to publish.",
                             len(_repeat_issues),
                         )
-                        sys.exit(2)
+                        _skip_episode(
+                            "cross_episode_repeats",
+                            f"Digest has {len(_repeat_issues)} cross-episode repeat(s) — "
+                            "too many recycled stories.",
+                        )
 
                 logger.warning(
                     "Digest validation found %d issue(s) — continuing (non-blocking)",
@@ -1514,7 +1555,10 @@ def run(args: argparse.Namespace) -> None:
                     audio_duration, _min_audio,
                 )
                 final_mp3.unlink(missing_ok=True)
-                sys.exit(2)
+                _skip_episode(
+                    "audio_too_short",
+                    f"Audio too short ({audio_duration:.0f}s < {_min_audio}s minimum).",
+                )
 
             # 10a. Generate chapter data (timestamps + JSON)
             if episode_chapters and audio_duration > 0:

--- a/tests/test_skip_markers.py
+++ b/tests/test_skip_markers.py
@@ -1,0 +1,262 @@
+"""Tests for skip marker logic in run_show.py and review_episodes.py."""
+
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+
+import pytest
+
+from review_episodes import (
+    Issue,
+    EpisodeReview,
+    SHOW_REGISTRY,
+    _read_skip_marker,
+    _should_run_on,
+    check_missed_episodes,
+)
+
+
+# ---------------------------------------------------------------------------
+# _should_run_on
+# ---------------------------------------------------------------------------
+
+
+class TestShouldRunOn:
+    def test_daily_always(self):
+        assert _should_run_on("daily", datetime.date(2026, 4, 13)) is True
+        assert _should_run_on("daily", datetime.date(2026, 4, 14)) is True
+
+    def test_odd_day(self):
+        assert _should_run_on("odd", datetime.date(2026, 4, 13)) is True  # day=13
+        assert _should_run_on("odd", datetime.date(2026, 4, 14)) is False  # day=14
+
+    def test_even_day(self):
+        assert _should_run_on("even", datetime.date(2026, 4, 14)) is True  # day=14
+        assert _should_run_on("even", datetime.date(2026, 4, 13)) is False  # day=13
+
+    def test_weekday(self):
+        # 2026-04-13 is Monday
+        assert _should_run_on("weekday", datetime.date(2026, 4, 13)) is True
+        # 2026-04-12 is Sunday
+        assert _should_run_on("weekday", datetime.date(2026, 4, 12)) is False
+
+    def test_odd_weekday(self):
+        # 2026-04-13: day=13 (odd), Monday (weekday) → True
+        assert _should_run_on("odd_weekday", datetime.date(2026, 4, 13)) is True
+        # 2026-04-14: day=14 (even), Tuesday → False
+        assert _should_run_on("odd_weekday", datetime.date(2026, 4, 14)) is False
+        # 2026-04-11: day=11 (odd), Saturday → False
+        assert _should_run_on("odd_weekday", datetime.date(2026, 4, 11)) is False
+
+
+# ---------------------------------------------------------------------------
+# _read_skip_marker
+# ---------------------------------------------------------------------------
+
+
+class TestReadSkipMarker:
+    def test_reads_valid_marker(self, tmp_path):
+        marker_data = {
+            "date": "2026-04-13",
+            "show": "tesla",
+            "show_name": "Tesla Shorts Time",
+            "reason": "insufficient_articles",
+            "detail": "Only 2 articles found.",
+        }
+        marker_file = tmp_path / ".skip_20260413.json"
+        marker_file.write_text(json.dumps(marker_data))
+
+        # _read_skip_marker expects output_dir relative to PROJECT_ROOT,
+        # so we monkeypatch PROJECT_ROOT for testing
+        import review_episodes
+        orig = review_episodes.PROJECT_ROOT
+        try:
+            review_episodes.PROJECT_ROOT = tmp_path.parent
+            result = _read_skip_marker(tmp_path.name, datetime.date(2026, 4, 13))
+        finally:
+            review_episodes.PROJECT_ROOT = orig
+
+        assert result is not None
+        assert result["reason"] == "insufficient_articles"
+        assert result["show"] == "tesla"
+
+    def test_returns_none_when_missing(self, tmp_path):
+        import review_episodes
+        orig = review_episodes.PROJECT_ROOT
+        try:
+            review_episodes.PROJECT_ROOT = tmp_path.parent
+            result = _read_skip_marker(tmp_path.name, datetime.date(2026, 4, 13))
+        finally:
+            review_episodes.PROJECT_ROOT = orig
+
+        assert result is None
+
+    def test_returns_none_on_invalid_json(self, tmp_path):
+        marker_file = tmp_path / ".skip_20260413.json"
+        marker_file.write_text("not valid json{{{")
+
+        import review_episodes
+        orig = review_episodes.PROJECT_ROOT
+        try:
+            review_episodes.PROJECT_ROOT = tmp_path.parent
+            result = _read_skip_marker(tmp_path.name, datetime.date(2026, 4, 13))
+        finally:
+            review_episodes.PROJECT_ROOT = orig
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# check_missed_episodes — with and without skip markers
+# ---------------------------------------------------------------------------
+
+
+class TestCheckMissedEpisodes:
+    def test_no_missed_when_episode_exists(self):
+        """A show with output should not be flagged."""
+        target = datetime.date(2026, 4, 13)
+        found = [
+            EpisodeReview(
+                show_slug="tesla",
+                show_name="Tesla Shorts Time",
+                episode_num=435,
+                date="2026-04-13",
+            )
+        ]
+        issues = check_missed_episodes(target, found, show_filter="tesla")
+        assert len(issues) == 0
+
+    def test_critical_when_no_output_and_no_marker(self, tmp_path):
+        """A missed show with no skip marker → critical."""
+        target = datetime.date(2026, 4, 13)
+        found: list[EpisodeReview] = []
+
+        # Point to tmp_path so no marker file exists
+        import review_episodes
+        orig = review_episodes.PROJECT_ROOT
+        orig_registry = review_episodes.SHOW_REGISTRY.copy()
+        try:
+            review_episodes.PROJECT_ROOT = tmp_path
+            # Create a minimal test registry
+            review_episodes.SHOW_REGISTRY = {
+                "tesla": {
+                    "name": "Tesla Shorts Time",
+                    "output_dir": "digests/tesla_shorts_time",
+                    "prefix": "Tesla_Shorts_Time_Pod",
+                    "schedule": "daily",
+                    "min_digest_chars": 3000,
+                    "max_digest_chars": 20000,
+                    "min_tts_words": 2200,
+                    "min_audio_s": 300,
+                    "max_audio_s": 1800,
+                    "required_sections": [],
+                },
+            }
+            issues = check_missed_episodes(target, found, show_filter="tesla")
+        finally:
+            review_episodes.PROJECT_ROOT = orig
+            review_episodes.SHOW_REGISTRY = orig_registry
+
+        assert len(issues) == 1
+        assert issues[0].severity == "critical"
+        assert "Missed episode" in issues[0].title
+
+    def test_warning_when_skip_marker_exists(self, tmp_path):
+        """A skipped show with a marker → warning (not critical)."""
+        target = datetime.date(2026, 4, 13)
+        found: list[EpisodeReview] = []
+
+        # Create the output dir with a skip marker
+        output_dir = tmp_path / "digests" / "tesla_shorts_time"
+        output_dir.mkdir(parents=True)
+        marker = {
+            "date": "2026-04-13",
+            "show": "tesla",
+            "show_name": "Tesla Shorts Time",
+            "reason": "insufficient_articles",
+            "detail": "Only 2 articles found — below minimum threshold (6).",
+        }
+        (output_dir / ".skip_20260413.json").write_text(json.dumps(marker))
+
+        import review_episodes
+        orig = review_episodes.PROJECT_ROOT
+        orig_registry = review_episodes.SHOW_REGISTRY.copy()
+        try:
+            review_episodes.PROJECT_ROOT = tmp_path
+            review_episodes.SHOW_REGISTRY = {
+                "tesla": {
+                    "name": "Tesla Shorts Time",
+                    "output_dir": "digests/tesla_shorts_time",
+                    "prefix": "Tesla_Shorts_Time_Pod",
+                    "schedule": "daily",
+                    "min_digest_chars": 3000,
+                    "max_digest_chars": 20000,
+                    "min_tts_words": 2200,
+                    "min_audio_s": 300,
+                    "max_audio_s": 1800,
+                    "required_sections": [],
+                },
+            }
+            issues = check_missed_episodes(target, found, show_filter="tesla")
+        finally:
+            review_episodes.PROJECT_ROOT = orig
+            review_episodes.SHOW_REGISTRY = orig_registry
+
+        assert len(issues) == 1
+        assert issues[0].severity == "warning"
+        assert "Skipped episode" in issues[0].title
+        assert "insufficient_articles" in issues[0].title
+        assert "intentionally skipped" in issues[0].detail
+
+    def test_skip_marker_reason_in_detail(self, tmp_path):
+        """Skip marker detail text should appear in the issue detail."""
+        target = datetime.date(2026, 4, 13)
+        found: list[EpisodeReview] = []
+
+        output_dir = tmp_path / "digests" / "tesla_shorts_time"
+        output_dir.mkdir(parents=True)
+        marker = {
+            "date": "2026-04-13",
+            "show": "tesla",
+            "show_name": "Tesla Shorts Time",
+            "reason": "audio_too_short",
+            "detail": "Audio too short (180s < 300s minimum).",
+        }
+        (output_dir / ".skip_20260413.json").write_text(json.dumps(marker))
+
+        import review_episodes
+        orig = review_episodes.PROJECT_ROOT
+        orig_registry = review_episodes.SHOW_REGISTRY.copy()
+        try:
+            review_episodes.PROJECT_ROOT = tmp_path
+            review_episodes.SHOW_REGISTRY = {
+                "tesla": {
+                    "name": "Tesla Shorts Time",
+                    "output_dir": "digests/tesla_shorts_time",
+                    "prefix": "Tesla_Shorts_Time_Pod",
+                    "schedule": "daily",
+                    "min_digest_chars": 3000,
+                    "max_digest_chars": 20000,
+                    "min_tts_words": 2200,
+                    "min_audio_s": 300,
+                    "max_audio_s": 1800,
+                    "required_sections": [],
+                },
+            }
+            issues = check_missed_episodes(target, found, show_filter="tesla")
+        finally:
+            review_episodes.PROJECT_ROOT = orig
+            review_episodes.SHOW_REGISTRY = orig_registry
+
+        assert len(issues) == 1
+        assert "Audio too short" in issues[0].detail
+
+    def test_not_scheduled_not_flagged(self):
+        """A show not scheduled for the target date should not be flagged."""
+        # Day 14 is even — omni_view (odd schedule) should not be flagged
+        target = datetime.date(2026, 4, 14)
+        found: list[EpisodeReview] = []
+        issues = check_missed_episodes(target, found, show_filter="omni_view")
+        assert len(issues) == 0


### PR DESCRIPTION
When run_show.py skips an episode (exit code 2) due to insufficient articles, duplicate content, etc., it now writes a .skip_YYYYMMDD.json marker file to the output directory. The review script reads these markers and reports intentional skips as warnings instead of critical missed-episode alerts, so operators can distinguish genuine failures from expected skips.

https://claude.ai/code/session_01SJkK1j4zvCKCFLvxgkk6cV