### PR TITLE
Fresh > Long: fix episode failures, repetition, and quality issues

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -176,6 +176,14 @@ class SlowNewsConfig:
     max_segments: int = 2           # Max evergreen segments per slow-news episode
     cooldown_days: int = 30         # Don't reuse a segment within this window
     selection_mode: str = "round_robin"  # "round_robin" or "random"
+    repeat_trigger_threshold: int = 3  # Cross-episode repeats that trigger slow news
+
+
+@dataclass
+class ContentFreshnessConfig:
+    """Per-show article freshness filter overrides."""
+    lookback_days: int = 0          # 0 = use pipeline default (1 or 3 based on episode count)
+    similarity_threshold: float = 0.0  # 0.0 = use pipeline default
 
 
 @dataclass
@@ -202,6 +210,7 @@ class ShowConfig:
     chapters: ChaptersConfig = field(default_factory=ChaptersConfig)
     content_tracking: ContentTrackingConfig = field(default_factory=ContentTrackingConfig)
     slow_news: SlowNewsConfig = field(default_factory=SlowNewsConfig)
+    content_freshness: ContentFreshnessConfig = field(default_factory=ContentFreshnessConfig)
 
 
 # ---------------------------------------------------------------------------
@@ -340,6 +349,7 @@ def load_config(yaml_path: str | Path) -> ShowConfig:
         chapters=_build_chapters(data.get("chapters")),
         content_tracking=_build_nested(ContentTrackingConfig, data.get("content_tracking")),
         slow_news=_build_nested(SlowNewsConfig, data.get("slow_news")),
+        content_freshness=_build_nested(ContentFreshnessConfig, data.get("content_freshness")),
     )
     logger.info("Loaded config for '%s' from %s", config.name, path)
     return config

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -1343,23 +1343,25 @@ def generate_podcast_script(
                                               show_name=config.name,
                                               min_podcast_words=min_words)
 
-    # Retry once if podcast script is too short for target duration
+    # Retry once if podcast script is catastrophically short (< 50% of
+    # target).  Above that, accept the shorter script — fresh content
+    # matters more than hitting a word count.
     word_count = len(text.split())
-    if word_count < min_words:
+    _retry_threshold = max(600, int(min_words * 0.5))
+    if word_count < _retry_threshold:
         logger.warning(
-            "Podcast script for '%s' is short (%d words, minimum %d). "
-            "Retrying with explicit expansion instructions ...",
-            config.name, word_count, min_words,
+            "Podcast script for '%s' is very short (%d words, retry threshold %d). "
+            "Retrying with expansion instructions ...",
+            config.name, word_count, _retry_threshold,
         )
         retry_prompt = (
             f"The script you just wrote is only {word_count} words. "
-            f"The target is {min_words}\u2013{int(min_words * 1.3)} words "
-            f"({min_words // 150}\u2013{int(min_words * 1.3) // 150} minutes of audio). "
-            f"Please rewrite it with significantly more depth:\n"
-            f"- Expand each story to 6\u20138 sentences (not 3\u20134)\n"
-            f"- Add more context, background, and your take on each story\n"
-            f"- Include natural transitions between stories\n"
-            f"- Do NOT add new stories \u2014 just deepen the existing ones\n\n"
+            f"Please rewrite it with more substance:\n"
+            f"- Add one missing element per story only if useful: a brief "
+            f"listener takeaway, a transition, or a one-sentence why-it-matters\n"
+            f"- Do NOT pad existing stories with filler or repeat content\n"
+            f"- Do NOT add new stories \u2014 just deepen the existing ones\n"
+            f"- Better to stay short than to repeat yourself\n\n"
             f"Here is your short script to expand:\n\n{text}"
         )
         text2, meta2 = _call_grok(

--- a/engine/slow_news.py
+++ b/engine/slow_news.py
@@ -215,9 +215,11 @@ def build_slow_news_prompt_context(
     parts.append("=" * 60)
     parts.append("")
     parts.append(
-        "You MUST produce a full-length, high-quality episode using the format "
-        "below. Do NOT shorten the episode, do NOT mention that news is slow or "
-        "lighter than usual, and do NOT apologize or comment on the number of "
+        "Produce a high-quality episode using the format below. If a section's "
+        "available material is genuinely thin, write fewer items rather than "
+        "padding with filler or repeating content. A shorter, fresh episode is "
+        "better than a longer repetitive one. Do NOT mention that news is slow "
+        "or lighter than usual, and do NOT apologize or comment on the number of "
         "stories. Treat this as a completely normal episode."
     )
     parts.append("")

--- a/run_show.py
+++ b/run_show.py
@@ -935,7 +935,8 @@ def run(args: argparse.Namespace) -> None:
                     if "cross-episode repeat" in i.lower()
                 ]
                 metrics.record("cross_episode_repeats", len(_repeat_issues))
-                if len(_repeat_issues) >= 3:
+                _repeat_threshold = getattr(config.slow_news, "repeat_trigger_threshold", 3) or 3
+                if len(_repeat_issues) >= _repeat_threshold:
                     # If slow news mode is available, fall back to it instead
                     # of skipping entirely — the repeat articles are stale but
                     # evergreen segments can fill the episode.
@@ -1274,21 +1275,28 @@ def run(args: argparse.Namespace) -> None:
             sys.exit(1)
         logger.info("Podcast script generation took %.1fs", time.monotonic() - t0)
 
-        # 8b. Minimum podcast script length gate — catch LLM garbage before
-        #     spending TTS credits on a worthless episode.  Short-but-coherent
-        #     scripts are fine; only abort on clear garbage.  Per-show config
-        #     (min_podcast_words) takes precedence over the 1000-word default
-        #     to accommodate shorter shows like language-learning podcasts.
-        _MIN_SCRIPT_WORDS = getattr(config.llm, "min_podcast_words", 1000) or 1000
+        # 8b. Podcast script length check — two-tier gate.
+        #     Hard floor (true garbage): abort only when clearly broken.
+        #     Soft floor (below target): warn but continue — a shorter fresh
+        #     episode is better than no episode.
+        _TARGET_WORDS = getattr(config.llm, "min_podcast_words", 1000) or 1000
+        _HARD_FLOOR = max(600, int(_TARGET_WORDS * 0.4))
         _script_word_count = len(podcast_script.split())
-        if _script_word_count < _MIN_SCRIPT_WORDS:
+        if _script_word_count < _HARD_FLOOR:
             logger.error(
-                "Podcast script is too short (%d words, minimum %d) — LLM "
-                "likely returned garbage. Aborting episode.",
-                _script_word_count, _MIN_SCRIPT_WORDS,
+                "Podcast script is clearly broken (%d words, hard floor %d) — "
+                "aborting episode.",
+                _script_word_count, _HARD_FLOOR,
             )
             save_usage(tracker, digests_dir)
             sys.exit(1)
+        elif _script_word_count < _TARGET_WORDS:
+            logger.warning(
+                "Podcast script below target (%d words, target %d) — "
+                "continuing with shorter episode (fresh > long).",
+                _script_word_count, _TARGET_WORDS,
+            )
+            metrics.record("script_below_target", True)
 
         # 8c. Pre-TTS duration estimate — skip obviously doomed episodes before
         #     burning TTS credits.  ~150 words/minute for podcast speech.
@@ -1870,9 +1878,11 @@ def _fetch_with_expansion(
         # Reduce dedup lookback for young shows (< 10 episodes) to avoid
         # over-filtering when the content tracker has very few episodes.
         ep_count = len(content_tracker.data.get("episodes", []))
-        lookback_days = 1 if ep_count < 10 else 3
+        _cf = getattr(config, "content_freshness", None)
+        lookback_days = (_cf and _cf.lookback_days) or (1 if ep_count < 10 else 3)
+        _cf_sim = (_cf and _cf.similarity_threshold) or sim_threshold
         articles = content_tracker.filter_recent_articles(
-            articles, similarity_threshold=sim_threshold, days=lookback_days,
+            articles, similarity_threshold=_cf_sim, days=lookback_days,
         )
         logger.info(
             "After dedup (sim=%.2f): %d articles remain",

--- a/shows/prompts/env_intel_digest.txt
+++ b/shows/prompts/env_intel_digest.txt
@@ -121,6 +121,8 @@ The following stories were covered in recent episodes. Prioritize genuinely NEW 
 
 **ANTI-DUPLICATION RULE:** The Lead Story must NOT repeat the exact sentences or phrases used in the Executive Summary. The Exec Summary gives the headline; the Lead Story gives the full details. If the Exec Summary already said "the claim engages Alberta EPEA, federal Fisheries Act, and Species at Risk Act", the Lead Story must describe those regulatory engagements with DIFFERENT wording, or move that detail to a sentence the Exec Summary did not cover.
 
+**JURISDICTION/REGULATION UNIQUENESS:** Each specific regulation citation (e.g. "Alberta EPEA", "CCME PFAS guideline", "Ontario O. Reg. 153/04") may anchor at most ONE paragraph block across the entire digest. If multiple stories touch the same regulation, combine them into one block or pick the strongest one. Do NOT write separate paragraphs that reference the same 3+ regulation names.
+
 ━━━━━━━━━━━━━━━━━━━━
 ### Regulatory & Policy Watch
 2-4 items tracking regulation changes, proposed amendments, enforcement actions, court decisions, or government consultations from any Canadian jurisdiction. For each:

--- a/shows/prompts/fascinating_frontiers_digest.txt
+++ b/shows/prompts/fascinating_frontiers_digest.txt
@@ -32,8 +32,8 @@ If fewer than 5 quality articles are available today:
 
 ━━━━━━━━━━━━━━━━━━━━
 ### Top 15 Space & Astronomy Stories
-1. **Title (<= 12 words): DD Month YYYY • Source Name**
-   2 sentences max. Sentence 1: what happened (specific + concrete). Sentence 2: why it's significant — what it tells us, what comes next, or what it enables.
+1. **Title (<= 12 words) — Source Name**
+   2 sentences max. Sentence 1: what happened (specific + concrete). Sentence 2: why it's significant — what it tells us, what comes next, or what it enables. Do NOT include a date in any item heading; the digest header already provides the date.
    Source: [EXACT URL FROM PRE-FETCHED—no mods]
 2. [Repeat format for 3-15; if <15 items, stop at available count, add a blank line after each item]
 

--- a/shows/prompts/modern_investing_podcast.txt
+++ b/shows/prompts/modern_investing_podcast.txt
@@ -140,7 +140,8 @@ Deliver with energy — this is the reason investors should keep listening. Then
 
 7. [Trade Review — 60-90 seconds] (skip for Episode 1)
 - Report last week's completed hold honestly: "we simulated buying [X] at Monday's open..."
-- Give the weekly P&L and running total
+- Give the weekly P&L (entry price, exit price, dollar/percentage move)
+- DO NOT mention the running portfolio total, win rate, or YTD performance here — those belong to Portfolio Performance only
 - Analyse what happened over the week: did the thesis play out? What moved the stock?
 - Extract the lesson: "what this teaches us about [specific analytical technique]"
 - If it was a loss, be direct: "this didn't work, and here's what I'd adjust next time"
@@ -157,8 +158,10 @@ Deliver with energy — this is the reason investors should keep listening. Then
 - Keep energy up — these are interesting tidbits, not deep analysis
 
 10. [Portfolio Performance — 30-45 seconds]
+- This is the ONLY segment that reports running portfolio stats (win rate, YTD %, alpha vs NASDAQ)
 - Running total of all simulated trades
 - Win rate and average return per trade
+- DO NOT repeat any specific trade narrative or P&L from Trade Review — just the cumulative numbers
 - Brief commentary: "our AI analysis is learning from [pattern] and adjusting..."
 - Frame it as a learning journey, not a track record to follow
 
@@ -181,6 +184,7 @@ Use this exact closing (do not rewrite it):
 
 CONTENT REPETITION (STRICT):
 - Each source article should appear in AT MOST one segment. Do NOT discuss the same story in both Strategy Spotlight and Quick Hits, or in both Tools & Techniques and Quick Hits.
+- PORTFOLIO STATS UNIQUENESS: Running totals, win rate, YTD performance, and alpha numbers (e.g. -0.02%, -3.75% vs NASDAQ) MUST appear in exactly ONE segment (Portfolio Performance). Repeating these in Trade Review, Strategy Spotlight, or anywhere else is a critical failure.
 - If the briefing has too few unique stories, reduce Quick Hits to 2 items rather than repeating stories from earlier segments.
 - Use the EXACT segment order above (1-12). Do NOT rearrange segments. Market Pulse always comes before Strategy Spotlight, which always comes before Practice Investment, etc.
 

--- a/shows/prompts/planetterrian_digest.txt
+++ b/shows/prompts/planetterrian_digest.txt
@@ -32,8 +32,8 @@ If fewer than 5 quality articles are available today:
 
 ━━━━━━━━━━━━━━━━━━━━
 ### Top 15 Science & Health Discoveries
-1. **Title (<= 12 words): DD Month YYYY • Source Name**
-   2 sentences max. Sentence 1: what happened (specific + concrete). Sentence 2: why it's significant — practical implications, what it enables, or what comes next.
+1. **Title (<= 12 words) — Source Name**
+   2 sentences max. Sentence 1: what happened (specific + concrete). Sentence 2: why it's significant — practical implications, what it enables, or what comes next. Do NOT include a date in any item heading; the digest header already provides the date.
    Source: [EXACT URL FROM PRE-FETCHED—no mods]
 2. [Repeat format for 3-15; if <15 items, stop at available count, add a blank line after each item]
 

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -176,6 +176,11 @@ slow_news:
   library_file: shows/segments/tesla.json
   max_segments: 2
   cooldown_days: 30
+  repeat_trigger_threshold: 5
+
+content_freshness:
+  lookback_days: 2
+  similarity_threshold: 0.72
 
 newsletter:
   enabled: true


### PR DESCRIPTION
User guidance: "It's OK if we don't have as many new stories and they don't necessarily need to be a set length, just great fresh content for listeners such that they keep listening and enjoying the shows."

Fix 1 — Soften word-count gate (fixes Planetterrian Apr 17 failure):
- run_show.py: Two-tier check replaces single hard-fail. Hard floor at max(600, target*0.4) catches true garbage; soft floor warns but continues for slightly-short episodes (1869-word Planetterrian will now ship instead of aborting)

Fix 2 — Loosen retry-for-length (reduces filler padding):
- engine/generator.py: Only retry when < 50% of target (was 100%). Retry instruction changed from "expand to 6-8 sentences and add context" to "add one missing element only if useful; better to stay short than to repeat yourself"

Fix 3 — Remove date hallucination from PT/FF digests:
- planetterrian_digest.txt, fascinating_frontiers_digest.txt: Remove "DD Month YYYY" from per-item format. Date already in digest header; per-item dates caused "17 Apr 2026 •" to repeat 12 times

Fix 4 — Soften slow-news prompt to allow shorter episodes:
- engine/slow_news.py: Replace "You MUST produce a full-length episode, Do NOT shorten" with "If a section's material is thin, write fewer items rather than padding. A shorter, fresh episode is better than a longer repetitive one."

Fix 5 — Per-show slow-news trigger threshold (Tesla fix):
- engine/config.py: Add repeat_trigger_threshold to SlowNewsConfig (default 3, preserves existing behavior for all shows)
- run_show.py: Read threshold from config instead of hardcoded 3
- shows/tesla.yaml: Set to 5 (Tesla's 14 sources + multiple outlets covering the same story = 10 repeats was triggering slow news daily)

Fix 6 — Per-show content freshness filter (Tesla fix):
- engine/config.py: New ContentFreshnessConfig dataclass with lookback_days and similarity_threshold (defaults use pipeline logic)
- run_show.py: Use per-show overrides when set
- shows/tesla.yaml: lookback_days=2, similarity_threshold=0.72 to prevent overly aggressive pre-filtering of genuinely new Tesla angles

Fix 8 — Modern Investing prompt restructure:
- modern_investing_podcast.txt: Trade Review segment now explicitly prohibited from mentioning running totals/win rate/YTD (those belong to Portfolio Performance only). Added PORTFOLIO STATS UNIQUENESS rule.

Fix 9 — env_intel jurisdiction uniqueness rule:
- env_intel_digest.txt: Added rule that each regulation citation may anchor at most ONE paragraph block across the entire digest.

All 1010 tests pass.

https://claude.ai/code/session_01XakHcahNY9Bh9n9rrYh7N7