### PR TITLE
Fix weekly-newsletter workflow: install full requirements.txt

### DIFF
--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -46,7 +46,7 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies
-        run: pip install pyyaml requests
+        run: pip install -r requirements.txt
 
       - name: Run weekly newsletters
         env:


### PR DESCRIPTION
The workflow only installed pyyaml and requests, but the newsletter script imports engine.generator which requires tenacity. Switching to `pip install -r requirements.txt` so all engine dependencies are available.

https://claude.ai/code/session_01XakHcahNY9Bh9n9rrYh7N7