### PR TITLE
Fix weekly newsletter not delivering emails

### DIFF
--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -24,10 +24,10 @@ on:
           - modern_investing
           - privet_russian
       dry_run:
-        description: 'Generate but do not send'
+        description: 'Generate but do not send (default: false — will send!)'
         required: false
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: write

--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -180,11 +180,13 @@ def send_newsletter(
         "subject": subject,
         "body": body,
         "status": status,
-        "filters": {
-            "filters": [{"field": "tag", "operator": "includes", "value": t} for t in tags] if tags else [],
-            "groups": [],
-        },
     }
+
+    if tags:
+        data["filters"] = {
+            "filters": [{"field": "tag", "operator": "is", "value": t} for t in tags],
+            "groups": [],
+        }
 
     resp = requests.post(
         f"{BUTTONDOWN_API_BASE}/emails",
@@ -199,10 +201,23 @@ def send_newsletter(
     if resp.status_code in (200, 201):
         result = resp.json()
         email_id = result.get("id", "unknown")
-        logger.info("Newsletter sent: %s (status=%s, tags=%s)", email_id, status, tags)
+        recipient_count = result.get("secondary_id", result.get("num_recipients", "?"))
+        logger.info(
+            "Newsletter created: id=%s status=%s tags=%s recipients=%s",
+            email_id, status, tags, recipient_count,
+        )
+        if result.get("num_recipients", 1) == 0:
+            logger.warning(
+                "Newsletter %s was created but has 0 recipients — "
+                "check that subscriber tags match: %s",
+                email_id, tags,
+            )
         return email_id
     else:
-        logger.error("Newsletter send failed: %s %s", resp.status_code, resp.text[:200])
+        logger.error(
+            "Newsletter send failed: %s %s",
+            resp.status_code, resp.text[:500],
+        )
         return None
 
 


### PR DESCRIPTION
Three issues preventing newsletter delivery:

1. workflow_dispatch dry_run defaulted to true, so every manual dispatch ran in dry-run mode and skipped sending. Changed default to false with a clear description label warning it will send.

2. Buttondown API filter operator was "includes" which is not a valid Buttondown filter operator. Changed to "is" which correctly targets subscribers who have the specified tag. Also removed the filters dict from the payload when no tags are specified (sends to all subscribers).

3. No visibility into delivery success: the API returns 200/201 even when zero subscribers match the tag filter. Added response logging that surfaces the recipient count and warns when it's zero so tag mismatches are immediately visible in the workflow logs.

https://claude.ai/code/session_01XakHcahNY9Bh9n9rrYh7N7