### PR TITLE
Fix 6 high-severity silent failures in RSS + newsletter pipeline

### DIFF
--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -206,12 +206,16 @@ def send_newsletter(
             "Newsletter created: id=%s status=%s tags=%s recipients=%s",
             email_id, status, tags, recipient_count,
         )
-        if result.get("num_recipients", 1) == 0:
-            logger.warning(
+        # Zero recipients when tag filters are set is a misconfiguration —
+        # the email was accepted but nobody received it. Surface this as a
+        # failure so the caller can alert/retry rather than logging "sent".
+        if tags and result.get("num_recipients", 1) == 0:
+            logger.error(
                 "Newsletter %s was created but has 0 recipients — "
-                "check that subscriber tags match: %s",
+                "tag filter %s matched no subscribers. Treating as failure.",
                 email_id, tags,
             )
+            return None
         return email_id
     else:
         logger.error(

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -256,6 +256,19 @@ def update_rss_feed(
                     if ep_data.get("guid"):
                         existing_episodes.append(ep_data)
         except Exception as exc:
+            # If the file looks like a real RSS with episodes but won't parse,
+            # refuse to proceed — silently writing a fresh feed would drop all
+            # historical episodes from subscribers' players.
+            try:
+                raw = rss_path.read_bytes()
+            except OSError:
+                raw = b""
+            if b"<item" in raw or b"itunes:episode" in raw or b"<enclosure" in raw:
+                raise RuntimeError(
+                    f"Refusing to overwrite unparseable RSS with episode "
+                    f"content ({rss_path}): {exc}. Manual review required "
+                    f"to avoid wiping subscriber history."
+                ) from exc
             logger.warning("Could not parse existing RSS feed: %s", exc)
 
     # --- Deduplicate by episode number ------------------------------------
@@ -267,6 +280,11 @@ def update_rss_feed(
             match = re.search(r"ep(\d+)", guid)
             if match:
                 ep_num_str = match.group(1)
+                # Persist the derived number so _add_existing_entry_to_feed
+                # re-emits <itunes:episode> on rewrite. Without this, a feed
+                # imported without the tag would silently lose it on every
+                # write, causing get_next_episode_number to reuse numbers.
+                ep_data["itunes_episode"] = ep_num_str
         if ep_num_str:
             try:
                 num = int(ep_num_str)
@@ -406,8 +424,76 @@ def update_rss_feed(
             pass
         raise
 
+    # Post-write validation: confirm Podcasting 2.0 tags we just injected
+    # survived round-trip. Silent drops here degrade chapter/transcript
+    # support on Apple/Overcast/Pocket Casts with no external signal.
+    _validate_injected_tags(
+        rss_path,
+        new_guid,
+        chapters_url=chapters_url,
+        transcript_url=transcript_url,
+        expect_locked=True,
+    )
+
     logger.info("RSS feed updated: %s", rss_path)
     return rss_path
+
+
+def _validate_injected_tags(
+    rss_path: Path,
+    new_guid: str,
+    *,
+    chapters_url: str,
+    transcript_url: str,
+    expect_locked: bool,
+) -> None:
+    """Parse the final RSS and log ERROR if expected Podcasting 2.0 tags are missing."""
+    PODCAST_NS = "https://podcastindex.org/namespace/1.0"
+    try:
+        tree = ET.parse(str(rss_path))
+        root = tree.getroot()
+        channel = root.find("channel")
+        if channel is None:
+            logger.error("RSS validation: <channel> missing in %s", rss_path)
+            return
+
+        if expect_locked and channel.find(f"{{{PODCAST_NS}}}locked") is None:
+            logger.error(
+                "RSS validation: <podcast:locked> missing after injection "
+                "(%s). Feed imports are not protected.", rss_path,
+            )
+
+        if chapters_url or transcript_url:
+            target_item = None
+            for item in channel.findall("item"):
+                guid_el = item.find("guid")
+                if (
+                    guid_el is not None
+                    and guid_el.text
+                    and guid_el.text.strip() == new_guid
+                ):
+                    target_item = item
+                    break
+            if target_item is None:
+                logger.error(
+                    "RSS validation: new episode <item guid=%s> not found in %s",
+                    new_guid, rss_path,
+                )
+                return
+            if chapters_url and target_item.find(f"{{{PODCAST_NS}}}chapters") is None:
+                logger.error(
+                    "RSS validation: <podcast:chapters> missing for %s after "
+                    "injection — chapter markers will not appear in players.",
+                    new_guid,
+                )
+            if transcript_url and target_item.find(f"{{{PODCAST_NS}}}transcript") is None:
+                logger.error(
+                    "RSS validation: <podcast:transcript> missing for %s after "
+                    "injection — transcript links will not appear in players.",
+                    new_guid,
+                )
+    except Exception as exc:
+        logger.error("RSS validation pass failed for %s: %s", rss_path, exc)
 
 
 def _inject_podcast_locked_tag(rss_path: Path, owner_email: str) -> None:
@@ -449,7 +535,7 @@ def _inject_podcast_locked_tag(rss_path: Path, owner_email: str) -> None:
         logger.info("Injected <podcast:locked> tag")
 
     except Exception as exc:
-        logger.warning("Failed to inject <podcast:locked> tag: %s", exc)
+        logger.error("Failed to inject <podcast:locked> tag: %s", exc)
 
 
 def _inject_chapters_tag(rss_path: Path, guid: str, chapters_url: str) -> None:
@@ -495,7 +581,7 @@ def _inject_chapters_tag(rss_path: Path, guid: str, chapters_url: str) -> None:
         logger.info("Injected <podcast:chapters> for %s", guid)
 
     except Exception as exc:
-        logger.warning("Failed to inject <podcast:chapters> tag: %s", exc)
+        logger.error("Failed to inject <podcast:chapters> tag: %s", exc)
 
 
 def _inject_transcript_tag(rss_path: Path, guid: str, transcript_url: str) -> None:
@@ -535,7 +621,7 @@ def _inject_transcript_tag(rss_path: Path, guid: str, transcript_url: str) -> No
         logger.info("Injected <podcast:transcript> for %s", guid)
 
     except Exception as exc:
-        logger.warning("Failed to inject <podcast:transcript> tag: %s", exc)
+        logger.error("Failed to inject <podcast:transcript> tag: %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -567,9 +653,35 @@ def get_next_episode_number(
                     if ep_el is not None and ep_el.text:
                         try:
                             max_episode = max(max_episode, int(ep_el.text))
+                            continue
                         except ValueError:
                             pass
+                    # Fallback: derive from GUID (e.g. "tesla-ep042-20260419-...").
+                    # Without this, a feed entry missing <itunes:episode> is
+                    # invisible to numbering and will be silently overwritten
+                    # by the next run.
+                    guid_el = item.find("guid")
+                    if guid_el is not None and guid_el.text:
+                        match = re.search(r"ep(\d+)", guid_el.text)
+                        if match:
+                            try:
+                                max_episode = max(max_episode, int(match.group(1)))
+                            except ValueError:
+                                pass
         except Exception as exc:
+            # Refuse to restart numbering when an RSS with real episode
+            # content won't parse — doing so would overwrite Ep 1's audio
+            # in R2 and dupe GUIDs for every subscriber.
+            try:
+                raw = rss_path.read_bytes()
+            except OSError:
+                raw = b""
+            if b"<item" in raw or b"itunes:episode" in raw:
+                raise RuntimeError(
+                    f"Refusing to compute next episode number from "
+                    f"unparseable RSS with episode content ({rss_path}): "
+                    f"{exc}. Manual review required."
+                ) from exc
             logger.warning("Could not parse RSS feed for episode number: %s", exc)
 
     # Scan MP3 filenames

--- a/run_show.py
+++ b/run_show.py
@@ -451,6 +451,7 @@ def run(args: argparse.Namespace) -> None:
 
     articles = []
     x_posts = []
+    rss_fetch_failed = False
     with metrics.stage("fetch_and_dedup"):
         with ThreadPoolExecutor(max_workers=3) as executor:
             hook_future = executor.submit(_run_hook)
@@ -471,12 +472,24 @@ def run(args: argparse.Namespace) -> None:
             except Exception as exc:
                 logger.error("RSS fetch failed: %s", exc)
                 articles = []
+                # Distinguish a structural fetch failure from a genuine
+                # slow-news day. Without this flag, slow_news mode would
+                # happily ship an evergreen-only episode when feeds are
+                # actually broken, masking the outage from operators.
+                rss_fetch_failed = True
 
             try:
                 x_posts = x_fetch_future.result(timeout=120)
             except Exception as exc:
                 logger.warning("X account fetch failed: %s — continuing with RSS only", exc)
                 x_posts = []
+
+    if rss_fetch_failed and not articles and not x_posts:
+        _skip_episode(
+            "rss_fetch_failed",
+            "RSS fetch raised and no fallback content available. "
+            "Refusing to ship evergreen filler on a fetch outage.",
+        )
 
     # Merge X posts into articles, deduplicating against existing RSS articles
     if x_posts:

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -252,6 +252,32 @@ class TestSendNewsletter(unittest.TestCase):
         self.assertEqual(result, "unknown")
 
     @patch("engine.newsletter.requests.post")
+    def test_zero_recipients_with_tags_returns_none(self, mock_post):
+        """Buttondown can accept the email and send to 0 subscribers when
+        tag filters match nobody. That's a misconfiguration, not success."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 201
+        mock_resp.json.return_value = {"id": "eid", "num_recipients": 0}
+        mock_post.return_value = mock_resp
+
+        result = send_newsletter(
+            "Subj", "Body", api_key="key", tags=["ghost-tag"],
+        )
+        self.assertIsNone(result)
+
+    @patch("engine.newsletter.requests.post")
+    def test_zero_recipients_without_tags_still_succeeds(self, mock_post):
+        """No tag filter means the zero count likely reflects API response
+        shape, not a misconfiguration — don't fail the call."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 201
+        mock_resp.json.return_value = {"id": "eid", "num_recipients": 0}
+        mock_post.return_value = mock_resp
+
+        result = send_newsletter("Subj", "Body", api_key="key")
+        self.assertEqual(result, "eid")
+
+    @patch("engine.newsletter.requests.post")
     def test_default_status_is_about_to_send(self, mock_post):
         mock_resp = MagicMock()
         mock_resp.status_code = 201

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -161,6 +161,33 @@ class TestGetNextEpisodeNumber:
         result = get_next_episode_number(rss_path, tmp_path)
         assert result == 1
 
+    def test_unparseable_rss_with_episodes_raises(self, tmp_path):
+        """Truncated/corrupt RSS with episode content must refuse to restart
+        numbering — silently returning 1 would overwrite Ep 1's MP3 in R2."""
+        rss_path = tmp_path / "podcast.rss"
+        rss_path.write_text(
+            "<?xml version='1.0'?><rss><channel>"
+            "<item><itunes:episode>42</itunes:episode>"
+            # truncated — no closing tags
+        )
+        with pytest.raises(RuntimeError, match="Refusing"):
+            get_next_episode_number(rss_path, tmp_path)
+
+    def test_episode_number_falls_back_to_guid(self, tmp_path):
+        """When <itunes:episode> is missing, derive from GUID suffix so
+        numbering never silently restarts."""
+        rss_path = tmp_path / "podcast.rss"
+        rss_path.write_text("""<?xml version='1.0' encoding='UTF-8'?>
+        <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+          <channel>
+            <item>
+              <guid>tesla-ep050-20260419-120000000000</guid>
+            </item>
+          </channel>
+        </rss>""")
+        result = get_next_episode_number(rss_path, tmp_path)
+        assert result == 51
+
     def test_episode_numbers_from_filename_regex(self, tmp_path):
         rss_path = tmp_path / "podcast.rss"
         (tmp_path / "Show_Ep100_20260101.mp3").touch()
@@ -387,6 +414,57 @@ class TestUpdateRssFeed:
         item = tree.getroot().find("channel").findall("item")[0]
         ns = "{http://www.itunes.com/dtds/podcast-1.0.dtd}"
         assert item.find(f"{ns}duration").text == "01:01:01"
+
+    def test_refuses_to_overwrite_unparseable_rss_with_episodes(self, tmp_path):
+        """Corrupt RSS with real episode content must not be silently
+        overwritten — doing so drops every historical episode from
+        subscribers' feeds."""
+        rss_path = tmp_path / "podcast.rss"
+        rss_path.write_text(
+            "<?xml version='1.0'?><rss><channel>"
+            "<item><enclosure url='https://audio.nerranetwork.com/ep001.mp3'/>"
+            # truncated
+        )
+        mp3 = _make_mp3(tmp_path)
+        with pytest.raises(RuntimeError, match="Refusing"):
+            update_rss_feed(
+                rss_path, 2, "Ep 2", "Desc",
+                datetime.date(2026, 1, 2), "ep002.mp3", 300.0, mp3,
+                channel_title="Test", format_duration_func=_fmt_dur,
+            )
+
+    def test_preserves_itunes_episode_derived_from_guid(self, tmp_path):
+        """An existing entry missing <itunes:episode> must have it re-emitted
+        (derived from GUID) on rewrite, so next-number lookup stays stable."""
+        rss_path = tmp_path / "podcast.rss"
+        rss_path.write_text("""<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Test</title>
+    <description>d</description>
+    <link>http://x</link>
+    <item>
+      <title>Old Ep</title>
+      <guid>tesla-ep007-20260101-120000</guid>
+      <enclosure url="http://x/old.mp3" type="audio/mpeg" length="1"/>
+    </item>
+  </channel>
+</rss>""")
+        mp3 = _make_mp3(tmp_path)
+        update_rss_feed(
+            rss_path, 8, "New Ep", "Desc",
+            datetime.date(2026, 1, 2), "ep008.mp3", 300.0, mp3,
+            channel_title="Test", format_duration_func=_fmt_dur,
+        )
+        ns = "{http://www.itunes.com/dtds/podcast-1.0.dtd}"
+        items = ET.parse(str(rss_path)).getroot().find("channel").findall("item")
+        nums = sorted(
+            int(it.find(f"{ns}episode").text)
+            for it in items
+            if it.find(f"{ns}episode") is not None and it.find(f"{ns}episode").text
+        )
+        # Both the re-emitted old episode (derived as 7) and the new 8 must appear.
+        assert nums == [7, 8]
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Fixes six high-severity silent-failure modes surfaced in the full-codebase ultrareview. Every one of them could let a run exit green while subscribers saw a broken episode (or no episode at all).

- **RSS parse failure no longer wipes subscriber history.** If the existing feed contains `<item>` / `itunes:episode` / `<enclosure>` bytes but won't parse, `update_rss_feed` and `get_next_episode_number` now raise instead of silently proceeding with an empty episode list.
- **Episode numbering is stable under missing `<itunes:episode>` tags.** `get_next_episode_number` falls back to GUID regex; `update_rss_feed`'s dedup loop persists the derived number so it's re-emitted on the next rewrite.
- **RSS fetch outages no longer ship evergreen filler.** `run_show.py` now flags a structural fetch failure (`rss_fetch_failed`) separately from a genuine slow-news day, and skips with a clear marker when the fetch itself raised and no fallback content exists.
- **Zero-recipient newsletters are treated as failures when a tag filter is set** — a misconfigured Buttondown tag filter (matches no subscribers) now returns `None` instead of logging "sent".
- **Podcasting 2.0 tag-injection failures are loud.** The three injectors log at ERROR, and `update_rss_feed` runs a post-write validation pass that re-parses the final RSS to confirm `<podcast:chapters>`, `<podcast:transcript>`, and `<podcast:locked>` survived — logs ERROR if any are missing.

## Files

- `engine/publisher.py` — RSS parse guard, episode-number GUID fallback, validation pass, ERROR escalation on injectors
- `engine/newsletter.py` — zero-recipient failure path
- `run_show.py` — `rss_fetch_failed` flag + early skip
- `tests/test_publisher.py` — 3 new tests covering the new guards
- `tests/test_newsletter.py` — 2 new tests for the zero-recipient paths

## Test plan

- [x] `pytest tests/test_publisher.py tests/test_newsletter.py` — 153 passed
- [x] Full suite: `pytest` — 1204 passed, 3 skipped
- [ ] Verify next production run succeeds end-to-end and shows the new validation-pass log lines at INFO/ERROR as expected
- [ ] Confirm an intentionally corrupted RSS file triggers the RuntimeError (manual spot-check) before next cron window

## Out of scope (tracked for follow-up PRs)

From the ultrareview punch list, explicitly *not* addressed here so this stays reviewable:
- `post_to_x` / `notify_directories` silent-failure rework (separate behavioral change)
- X-enabled-but-missing-credentials exit-code change
- ElevenLabs model-fallback dashboard signal
- Workflow bash-interpolation hardening (5 workflows)
- CLAUDE.md documentation drift cleanup (resolved-item wording, stale template voice settings, Fish Audio/Chatterbox orphans, broken `daily-podcast.yml` refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
