### PR TITLE
Add automated YouTube long-form + Shorts publishing

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -286,6 +286,13 @@ jobs:
           R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          # YouTube OAuth — refresh tokens are minted once via
+          # scripts/youtube_oauth_bootstrap.py, then stored as secrets.
+          # Missing values cause the YouTube stage to skip cleanly.
+          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+          YOUTUBE_REFRESH_TOKEN_EN: ${{ secrets.YOUTUBE_REFRESH_TOKEN_EN }}
+          YOUTUBE_REFRESH_TOKEN_RU: ${{ secrets.YOUTUBE_REFRESH_TOKEN_RU }}
           PIPELINE_TIMEOUT_SECONDS: '2400'
 
       - name: Validate output

--- a/docs/youtube_setup.md
+++ b/docs/youtube_setup.md
@@ -1,0 +1,146 @@
+# YouTube Publishing — Setup & Operator Runbook
+
+The pipeline can publish each episode as a long-form 1920x1080 video and
+a 1080x1920 Shorts teaser, automatically disclosed as AI-narrated and
+monetization-eligible. This document covers the one-time setup work an
+operator (you) does outside the repo: GCP project, OAuth, channels,
+quota.
+
+For day-to-day code locations see:
+
+- `engine/video.py` — ffmpeg long-form + Shorts builders
+- `engine/youtube.py` — Google API upload wrapper
+- `engine/video_metadata.py` — title / description / tag construction
+- `run_show.py` — `_publish_youtube()` stage runs after RSS, before X
+
+## Channel topology
+
+We use two channels:
+
+| Channel | Audience | Shows | Refresh-token secret |
+|---------|----------|-------|----------------------|
+| English Nerra Network | Default | tesla, omni_view, fascinating_frontiers, planetterrian, env_intel, models_agents, models_agents_beginners, modern_investing | `YOUTUBE_REFRESH_TOKEN_EN` |
+| Russian Nerra Network | Russian-speaking | finansy_prosto, privet_russian | `YOUTUBE_REFRESH_TOKEN_RU` |
+
+Per-show YAMLs select the channel via `youtube.channel: en` or
+`youtube.channel: ru`. The channel handle and display names are
+configured in YouTube Studio — the code only needs the OAuth refresh
+token belonging to that channel's account.
+
+## One-time GCP + OAuth setup
+
+1. **Create a Google Cloud project** at <https://console.cloud.google.com/>.
+   Name it something like `nerra-network-youtube`.
+2. **Enable the YouTube Data API v3** under `APIs & Services → Library`.
+3. **Configure the OAuth consent screen** (`APIs & Services → OAuth consent screen`):
+   - User type: External.
+   - Add yourself as a test user (until the screen is verified, only test users can authorize).
+   - Scopes: `youtube.upload`, `youtube`.
+4. **Create OAuth credentials** (`APIs & Services → Credentials → Create Credentials → OAuth client ID`):
+   - Application type: **Desktop app**.
+   - Download the JSON file. Keep it local — never commit it.
+5. **Mint refresh tokens** (one per channel) by running the bootstrap
+   script locally:
+
+   ```bash
+   python scripts/youtube_oauth_bootstrap.py ~/Downloads/client_secrets.json
+   ```
+
+   The script opens a browser. Sign into the Google account that owns
+   the **English channel** first, then re-run for the **Russian channel**.
+   Each run prints the refresh token; paste it into the matching GitHub
+   secret:
+
+   - English run → `YOUTUBE_REFRESH_TOKEN_EN`
+   - Russian run → `YOUTUBE_REFRESH_TOKEN_RU`
+
+   The script also prints `YOUTUBE_CLIENT_ID` and `YOUTUBE_CLIENT_SECRET`
+   — set those once (they're shared across both channels).
+
+## GitHub secrets
+
+The pipeline reads four secrets:
+
+| Secret | Source |
+|--------|--------|
+| `YOUTUBE_CLIENT_ID` | OAuth client JSON |
+| `YOUTUBE_CLIENT_SECRET` | OAuth client JSON |
+| `YOUTUBE_REFRESH_TOKEN_EN` | Bootstrap script (English channel) |
+| `YOUTUBE_REFRESH_TOKEN_RU` | Bootstrap script (Russian channel) |
+
+If any are missing, the YouTube stage logs a "credentials missing" notice
+and skips the upload — the rest of the pipeline (audio, RSS, X, etc.)
+continues unaffected.
+
+## Quota — the operational gotcha
+
+The default Google Cloud quota is **10,000 units/day** per project.
+Each `videos.insert` costs **1,600 units**, so the default lets you
+upload roughly six videos per day. With 10 shows × (long-form + Shorts)
+that's 32,000 units — over budget by a factor of three.
+
+Two paths forward:
+
+1. **Phased rollout** (default in this repo): only `tesla`,
+   `fascinating_frontiers`, and `models_agents` have `youtube.enabled:
+   true` to start. That's 3 × (1,600 + 1,600) = **9,600 units/day** —
+   right under the cap.
+2. **Quota extension request** (file on day 1): in Cloud Console →
+   `APIs & Services → YouTube Data API v3 → Quotas`, request an increase
+   to ~50,000 units/day. Justify with:
+   - Original editorial pipeline (we're not aggregating other creators).
+   - Compliance with `containsSyntheticMedia` disclosure on every upload.
+   - 10 daily shows × 2 video formats × OAuth-authenticated uploads.
+
+   Reviews typically take 1–2 weeks. Once granted, flip `youtube.enabled`
+   to `true` on the remaining shows.
+
+## AI disclosure
+
+Every upload sets `status.containsSyntheticMedia=True` via the API. This
+is the field YouTube introduced in October 2024 specifically for AI/A&S
+disclosure; setting it via the API renders the same "Altered or
+synthetic content" label the Studio UI applies and is required for
+monetization-eligible AI audio uploads.
+
+In addition, every video description ends with a plain-language
+disclosure (defined in `shows/_defaults.yaml` under
+`youtube.synthetic_disclosure`):
+
+> AI Disclosure: This podcast is curated by Patrick but uses
+> AI-generated voice synthesis (ElevenLabs) for the narration. …
+
+Do not remove or weaken this. Both layers (API flag + description text)
+are needed to stay inside YouTube's monetization policy.
+
+## YouTube Analytics vs. Google Analytics
+
+YouTube Studio has its own analytics dashboard and **does not** stream
+data into GA4. What the pipeline does instead: every video description
+links to `nerranetwork.com/<show>.html` with
+`?utm_source=youtube&utm_medium=video&utm_campaign=ep<N>` so when a
+viewer clicks through, GA4 on `nerranetwork.com` attributes the traffic
+to YouTube. Shorts use `utm_medium=shorts` to separate the two
+funnels.
+
+If you want a periodic dump of YouTube Analytics into GA4, that's a
+separate manual integration (third-party connector) — out of scope here.
+
+## Validation steps for the first uploads
+
+1. Set `youtube.privacy_status: unlisted` in `shows/tesla.yaml` (already
+   the default for phase-1 shows in this repo).
+2. Run locally:
+
+   ```bash
+   python run_show.py tesla --skip-x --skip-newsletter
+   ```
+
+3. In YouTube Studio, open the new video and confirm:
+   - Title, description, chapters, tags rendered correctly.
+   - Custom thumbnail rendered (1280x720, hook visible).
+   - Under `Details → Altered content`: "Altered or synthetic content"
+     label is visible.
+   - Privacy is "Unlisted".
+4. Flip `youtube.privacy_status: public` in the YAML, re-run.
+5. Once two or three episodes have landed cleanly, repeat for the Shorts.

--- a/engine/config.py
+++ b/engine/config.py
@@ -204,6 +204,27 @@ class ContentFreshnessConfig:
 
 
 @dataclass
+class YouTubeConfig:
+    """Per-show YouTube publishing configuration.
+
+    Network-wide defaults live in ``shows/_defaults.yaml`` under
+    ``youtube:``; show YAMLs override individual fields. The synthesized
+    voice means every upload sets ``status.containsSyntheticMedia=True``
+    (the API field YouTube introduced in October 2024 for AI disclosure).
+    """
+    enabled: bool = False
+    channel: str = "en"                    # "en" or "ru" — picks refresh token
+    category_id: int = 28                  # 28 = Science & Tech (sane default)
+    default_language: str = "en"
+    privacy_status: str = "public"         # "public" | "unlisted" | "private"
+    publish_long_form: bool = True
+    publish_shorts: bool = True
+    short_duration_seconds: float = 55.0
+    tags: List[str] = field(default_factory=list)
+    synthetic_disclosure: str = ""
+
+
+@dataclass
 class ShowConfig:
     name: str = ""
     slug: str = ""
@@ -228,6 +249,7 @@ class ShowConfig:
     content_tracking: ContentTrackingConfig = field(default_factory=ContentTrackingConfig)
     slow_news: SlowNewsConfig = field(default_factory=SlowNewsConfig)
     content_freshness: ContentFreshnessConfig = field(default_factory=ContentFreshnessConfig)
+    youtube: YouTubeConfig = field(default_factory=YouTubeConfig)
 
 
 # ---------------------------------------------------------------------------
@@ -367,6 +389,7 @@ def load_config(yaml_path: str | Path) -> ShowConfig:
         content_tracking=_build_nested(ContentTrackingConfig, data.get("content_tracking")),
         slow_news=_build_nested(SlowNewsConfig, data.get("slow_news")),
         content_freshness=_build_nested(ContentFreshnessConfig, data.get("content_freshness")),
+        youtube=_build_nested(YouTubeConfig, data.get("youtube")),
     )
     logger.info("Loaded config for '%s' from %s", config.name, path)
     return config

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -875,24 +875,150 @@ def notify_directories(rss_url: str, show_name: str = "Podcast") -> dict:
 # Episode thumbnail
 # ---------------------------------------------------------------------------
 
+_FONT_CANDIDATES = (
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf",
+    "/Library/Fonts/Arial Bold.ttf",
+    "/System/Library/Fonts/Helvetica.ttc",
+    "C:\\Windows\\Fonts\\arialbd.ttf",
+)
+
+
+def _load_font(size: int):
+    """Return a usable bold sans-serif font at the requested size.
+
+    Tries DejaVu Sans Bold (shipped on Ubuntu / GitHub Actions runners
+    by default) first, then falls back through common platform-specific
+    paths, then PIL's default bitmap font.
+    """
+    from PIL import ImageFont
+
+    for candidate in _FONT_CANDIDATES:
+        if Path(candidate).exists():
+            try:
+                return ImageFont.truetype(candidate, size)
+            except (IOError, OSError):
+                continue
+    return ImageFont.load_default()
+
+
+def _wrap_text(text: str, font, max_width: int) -> list:
+    """Greedy word-wrap that respects the rendered pixel width."""
+    if not text:
+        return []
+    words = text.split()
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        bbox = font.getbbox(candidate)
+        width = bbox[2] - bbox[0]
+        if width <= max_width or not current:
+            current = candidate
+        else:
+            lines.append(current)
+            current = word
+    if current:
+        lines.append(current)
+    return lines
+
+
 def generate_episode_thumbnail(
     base_image_path: Path,
     episode_num: int,
     date_str: str,
     output_path: Path,
+    *,
+    hook: str = "",
+    show_name: str = "",
+    size: tuple = (1280, 720),
 ) -> Path:
-    """Generate a simple episode thumbnail by overlaying text on a base image."""
-    from PIL import Image, ImageDraw, ImageFont
+    """Render an episode thumbnail by overlaying text on the show cover.
 
-    img = Image.open(base_image_path)
+    Output is a JPEG at YouTube's recommended 1280x720 thumbnail spec by
+    default. The cover is scaled-and-cropped to fill the frame, darkened
+    for legibility, then overlaid with the show name (top-left), the
+    headline ``hook`` (large, centred), and an "Ep N — date" footer.
+
+    Parameters
+    ----------
+    base_image_path:
+        Source cover image (e.g. ``assets/covers/<show>.jpg``).
+    episode_num:
+        Episode number for the footer line.
+    date_str:
+        Pre-formatted date string for the footer line.
+    output_path:
+        Output file path. Suffix ``.jpg``/``.jpeg`` writes JPEG (what
+        YouTube prefers); anything else writes PNG.
+    hook:
+        Optional one-line headline. Wrapped to fit and rendered as the
+        dominant text. When empty, only the show name + footer appear.
+    show_name:
+        Optional small label rendered top-left.
+    size:
+        Output ``(width, height)`` in pixels.
+    """
+    from PIL import Image, ImageDraw, ImageEnhance
+
+    width, height = size
+    img = Image.open(base_image_path).convert("RGB")
+
+    # Scale-and-crop the cover to fill the output frame (no letterboxing).
+    src_ratio = img.width / img.height
+    dst_ratio = width / height
+    if src_ratio > dst_ratio:
+        new_h = height
+        new_w = int(round(height * src_ratio))
+    else:
+        new_w = width
+        new_h = int(round(width / src_ratio))
+    img = img.resize((new_w, new_h), Image.LANCZOS)
+    left = (new_w - width) // 2
+    top = (new_h - height) // 2
+    img = img.crop((left, top, left + width, top + height))
+
+    # Darken so white text reads cleanly.
+    img = ImageEnhance.Brightness(img).enhance(0.55)
+
     draw = ImageDraw.Draw(img)
-    try:
-        font = ImageFont.truetype("arial.ttf", 48)
-    except IOError:
-        font = ImageFont.load_default()
-    draw.text((50, 50), f"Episode {episode_num}", font=font, fill=(255, 255, 255))
-    draw.text((50, 100), date_str, font=font, fill=(255, 255, 255))
-    img.save(output_path, "PNG")
+    margin = max(32, width // 32)
+
+    if show_name:
+        label_font = _load_font(max(28, width // 32))
+        draw.text((margin, margin), show_name, font=label_font,
+                  fill=(255, 255, 255))
+
+    if hook:
+        clean_hook = hook.strip()
+        if len(clean_hook) > 120:
+            clean_hook = clean_hook[:117].rstrip() + "..."
+        hook_font = _load_font(max(56, width // 14))
+        max_text_width = width - 2 * margin
+        lines = _wrap_text(clean_hook, hook_font, max_text_width)
+        ascent_descent = hook_font.getbbox("Ay")
+        line_h = (ascent_descent[3] - ascent_descent[1]) + 12
+        block_h = line_h * len(lines)
+        y = (height - block_h) // 2
+        for line in lines:
+            bbox = hook_font.getbbox(line)
+            line_w = bbox[2] - bbox[0]
+            x = (width - line_w) // 2
+            draw.text((x, y), line, font=hook_font, fill=(255, 255, 255))
+            y += line_h
+
+    footer_font = _load_font(max(28, width // 32))
+    footer = f"Ep {episode_num} — {date_str}" if date_str else f"Ep {episode_num}"
+    footer_bbox = footer_font.getbbox(footer)
+    footer_h = footer_bbox[3] - footer_bbox[1]
+    draw.text((margin, height - margin - footer_h), footer,
+              font=footer_font, fill=(255, 255, 255))
+
+    suffix = output_path.suffix.lower()
+    if suffix in (".jpg", ".jpeg"):
+        img.save(output_path, "JPEG", quality=88, optimize=True)
+    else:
+        img.save(output_path, "PNG")
     return output_path
 
 

--- a/engine/video.py
+++ b/engine/video.py
@@ -1,0 +1,244 @@
+"""Video assembly helpers for the YouTube publishing pipeline.
+
+Provides ffmpeg-based builders for two video formats produced from each
+podcast episode:
+
+  - :func:`build_long_form_video`  — 1920x1080 (16:9) horizontal MP4
+    with the show cover as a still background and an animated audio
+    waveform overlay running for the full duration of the episode audio.
+  - :func:`build_short_video`     — 1080x1920 (9:16) vertical MP4 with
+    a clipped portion of the audio (default 55s, well under the 60s
+    YouTube Shorts limit) and the cover scaled-and-cropped to fill.
+
+Both functions share the same encoding profile (libx264 + AAC, faststart)
+so uploads are immediately playable on YouTube without a re-mux pass.
+
+The command builders are kept as module-level pure functions so they
+can be inspected by ``tests/test_video_commands.py`` without invoking
+ffmpeg.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Encoding profile
+# ---------------------------------------------------------------------------
+
+# Shared video/audio encoder args. libx264 + yuv420p + faststart is the
+# combination YouTube requires for instant playback (the moov atom must
+# sit before mdat or the upload triggers a re-process pass).
+_VIDEO_ENCODE: List[str] = [
+    "-c:v", "libx264",
+    "-pix_fmt", "yuv420p",
+    "-preset", "medium",
+    "-crf", "22",
+    "-profile:v", "high",
+    "-level", "4.1",
+]
+
+_AUDIO_ENCODE: List[str] = [
+    "-c:a", "aac",
+    "-b:a", "192k",
+    "-ar", "44100",
+    "-ac", "2",
+]
+
+
+# ---------------------------------------------------------------------------
+# Filter graph builders
+# ---------------------------------------------------------------------------
+
+def _long_form_filter_graph(width: int = 1920, height: int = 1080,
+                            fps: int = 30) -> str:
+    """Build the filter_complex graph for a horizontal long-form video.
+
+    The graph composites three layers:
+
+      1. The cover image, scaled to *cover* the 1920x1080 frame (no
+         letterboxing) and given a fixed SAR so YouTube doesn't re-encode.
+      2. A semi-transparent animated waveform spanning the full width,
+         180 px tall, anchored 60 px above the bottom edge.
+      3. The original audio passed through unchanged.
+
+    Returns
+    -------
+    str
+        The filter_complex string with three named outputs: ``[bg]``,
+        ``[wave]``, ``[v]``.
+    """
+    return (
+        f"[0:v]scale={width}:{height}:force_original_aspect_ratio=increase,"
+        f"crop={width}:{height},setsar=1,format=yuv420p[bg];"
+        f"[1:a]showwaves=s={width}x180:mode=cline:colors=0xFFFFFF:rate={fps},"
+        f"format=yuva420p,colorchannelmixer=aa=0.7[wave];"
+        f"[bg][wave]overlay=x=0:y=H-h-60:format=auto[v]"
+    )
+
+
+def _short_form_filter_graph(width: int = 1080, height: int = 1920,
+                             fps: int = 30) -> str:
+    """Build the filter_complex graph for a 9:16 vertical Shorts video.
+
+    Scale-and-crop the cover to fill the vertical frame (square covers
+    end up centred), drop a 1080x300 waveform overlay at the vertical
+    midpoint, and pass audio through.
+    """
+    wave_y = (height // 2) - 150  # 300/2 = 150 → centred vertically
+    return (
+        f"[0:v]scale={width}:{height}:force_original_aspect_ratio=increase,"
+        f"crop={width}:{height},setsar=1,format=yuv420p[bg];"
+        f"[1:a]showwaves=s={width}x300:mode=cline:colors=0xFFFFFF:rate={fps},"
+        f"format=yuva420p,colorchannelmixer=aa=0.7[wave];"
+        f"[bg][wave]overlay=x=0:y={wave_y}:format=auto[v]"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Command builders
+# ---------------------------------------------------------------------------
+
+def _long_form_cmd(audio_in: str, cover_in: str, output: str,
+                   *, fps: int = 30) -> List[str]:
+    """Full ffmpeg command for the long-form 1920x1080 build."""
+    return [
+        "ffmpeg", "-y", "-threads", "0",
+        "-loop", "1", "-framerate", str(fps), "-i", cover_in,
+        "-i", audio_in,
+        "-filter_complex", _long_form_filter_graph(1920, 1080, fps),
+        "-map", "[v]", "-map", "1:a",
+        *_VIDEO_ENCODE,
+        "-r", str(fps),
+        *_AUDIO_ENCODE,
+        "-shortest",
+        "-movflags", "+faststart",
+        output,
+    ]
+
+
+def _short_form_cmd(audio_in: str, cover_in: str, output: str,
+                    *, start_offset: float = 0.0,
+                    duration: float = 55.0,
+                    fps: int = 30) -> List[str]:
+    """Full ffmpeg command for the 1080x1920 Shorts build.
+
+    The audio input is clipped via ``-ss`` (input-side seek) before the
+    decoder so we only decode the slice we keep. ``-t`` is applied to
+    the audio input as well so ``-shortest`` truncates the looped cover
+    to match.
+    """
+    return [
+        "ffmpeg", "-y", "-threads", "0",
+        "-loop", "1", "-framerate", str(fps), "-i", cover_in,
+        "-ss", f"{start_offset:.2f}",
+        "-t", f"{duration:.2f}",
+        "-i", audio_in,
+        "-filter_complex", _short_form_filter_graph(1080, 1920, fps),
+        "-map", "[v]", "-map", "1:a",
+        *_VIDEO_ENCODE,
+        "-r", str(fps),
+        *_AUDIO_ENCODE,
+        "-shortest",
+        "-movflags", "+faststart",
+        output,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def build_long_form_video(audio_path: Path, cover_path: Path,
+                          output_path: Path, *, fps: int = 30) -> Path:
+    """Render a 1920x1080 long-form podcast video.
+
+    Parameters
+    ----------
+    audio_path:
+        Path to the final mixed episode MP3 (output of
+        :func:`engine.audio.mix_with_music`).
+    cover_path:
+        Path to the show's static cover image (typically the JPG under
+        ``assets/covers/``). Anything ffmpeg can decode works.
+    output_path:
+        Where to write the MP4. Parent dir must exist.
+    fps:
+        Frame rate for both the still video stream and the waveform
+        animation. 30 is the standard YouTube target; lower values
+        produce smaller files but choppier waveforms.
+
+    Returns
+    -------
+    Path
+        ``output_path`` on success.
+    """
+    if not audio_path.exists():
+        raise FileNotFoundError(f"audio not found: {audio_path}")
+    if not cover_path.exists():
+        raise FileNotFoundError(f"cover not found: {cover_path}")
+
+    cmd = _long_form_cmd(str(audio_path), str(cover_path),
+                         str(output_path), fps=fps)
+    logger.info("Building long-form video → %s", output_path.name)
+    subprocess.run(cmd, check=True, capture_output=True)
+    return output_path
+
+
+def build_short_video(audio_path: Path, cover_path: Path,
+                      output_path: Path, *,
+                      start_offset: float = 0.0,
+                      duration: float = 55.0,
+                      fps: int = 30) -> Path:
+    """Render a 1080x1920 vertical YouTube Shorts video.
+
+    Parameters
+    ----------
+    audio_path:
+        Path to the source audio (usually the same final mixed episode
+        MP3 used for long-form). Only the slice from *start_offset* to
+        *start_offset + duration* is included.
+    cover_path:
+        Path to the show's cover image (filled, then cropped to vertical).
+    output_path:
+        Where to write the MP4.
+    start_offset:
+        Seconds into the audio where the Short should start. Set to
+        ``audio.intro_duration + audio.voice_intro_delay`` so we skip
+        the music intro and start on voice.
+    duration:
+        Length of the short clip in seconds. **Must stay below 60** so
+        YouTube classifies the upload as a Short.
+    fps:
+        Frame rate; same caveats as the long-form builder.
+
+    Returns
+    -------
+    Path
+        ``output_path`` on success.
+    """
+    if duration >= 60:
+        raise ValueError(
+            f"Shorts duration must stay below 60s; got {duration}"
+        )
+    if not audio_path.exists():
+        raise FileNotFoundError(f"audio not found: {audio_path}")
+    if not cover_path.exists():
+        raise FileNotFoundError(f"cover not found: {cover_path}")
+
+    cmd = _short_form_cmd(str(audio_path), str(cover_path),
+                          str(output_path),
+                          start_offset=start_offset,
+                          duration=duration, fps=fps)
+    logger.info(
+        "Building Shorts video (%.1fs from %.1fs) → %s",
+        duration, start_offset, output_path.name,
+    )
+    subprocess.run(cmd, check=True, capture_output=True)
+    return output_path

--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -1,0 +1,290 @@
+"""Build YouTube title / description / tag payloads from existing show data.
+
+Mirrors the role :func:`run_show._build_teaser` plays for X — same data
+sources (digest, hook, episode number, chapters), different output. Pure
+functions so the unit tests don't need a network or a populated repo.
+
+YouTube enforces three hard limits we respect:
+
+  - Title: 100 characters (we truncate with an ellipsis).
+  - Description: 5000 characters (we trim trailing chunks if needed).
+  - Combined tag length: 500 characters when joined with commas (we
+    drop tags from the tail until we fit).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+YOUTUBE_TITLE_MAX = 100
+YOUTUBE_DESC_MAX = 5000
+YOUTUBE_TAG_TOTAL_MAX = 500
+
+
+# ---------------------------------------------------------------------------
+# Markdown stripping (matches the spirit of publisher.format_digest_for_x)
+# ---------------------------------------------------------------------------
+
+def _strip_markdown(text: str) -> str:
+    """Strip the markdown that shows up in our digests.
+
+    Keeps URLs as bare text, removes header markers, bold/italic, and
+    inline code fences.
+    """
+    if not text:
+        return ""
+    # Strip code fences first so their contents aren't mis-parsed.
+    text = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    # Headers
+    text = re.sub(r"^#+\s+", "", text, flags=re.MULTILINE)
+    # Bold + italic
+    text = re.sub(r"\*\*(.*?)\*\*", r"\1", text)
+    text = re.sub(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"\1", text)
+    text = re.sub(r"__(.*?)__", r"\1", text)
+    # Inline code
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    # Markdown links → plain URL
+    text = re.sub(r"\[([^\]]+)\]\((https?://[^\)]+)\)", r"\1: \2", text)
+    return text
+
+
+def _truncate(text: str, max_len: int) -> str:
+    """Trim *text* to ``max_len`` characters with an ellipsis if shortened."""
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+# ---------------------------------------------------------------------------
+# Chapter formatting
+# ---------------------------------------------------------------------------
+
+def _format_chapter_timestamp(seconds: float) -> str:
+    """``H:MM:SS`` for hour-long content, ``MM:SS`` otherwise.
+
+    YouTube requires the **first** chapter to start at ``0:00`` for the
+    description-driven chapter feature to activate.
+    """
+    seconds = max(0, int(seconds))
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}:{m:02d}:{s:02d}"
+    return f"{m}:{s:02d}"
+
+
+def _read_chapters(chapters_path: Optional[Path]) -> List[Dict]:
+    """Load a ``chapters_ep*.json`` file. Returns an empty list on error."""
+    if not chapters_path or not chapters_path.exists():
+        return []
+    try:
+        data = json.loads(chapters_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.warning("Could not read chapters file %s: %s", chapters_path, exc)
+        return []
+    chapters = data.get("chapters") if isinstance(data, dict) else data
+    if not isinstance(chapters, list):
+        return []
+    return chapters
+
+
+def _format_chapter_block(chapters: List[Dict]) -> str:
+    """Render chapters as the YouTube-compatible ``0:00 Title`` block.
+
+    Returns an empty string when the chapter list is missing, has fewer
+    than 2 entries, or doesn't start at 0 — YouTube silently ignores
+    chapter blocks that don't meet those rules, so there's no point
+    rendering one.
+    """
+    if not chapters or len(chapters) < 2:
+        return ""
+
+    rendered: List[str] = []
+    for ch in chapters:
+        if not isinstance(ch, dict):
+            continue
+        title = (ch.get("title") or "").strip()
+        start = ch.get("startTime", ch.get("start_time", ch.get("start")))
+        if start is None or not title:
+            continue
+        try:
+            start_f = float(start)
+        except (TypeError, ValueError):
+            continue
+        rendered.append(f"{_format_chapter_timestamp(start_f)} {title}")
+
+    # YouTube requires the first stamp to be 0:00.
+    if not rendered or not rendered[0].startswith("0:00"):
+        return ""
+    return "\n".join(rendered)
+
+
+# ---------------------------------------------------------------------------
+# Tag handling
+# ---------------------------------------------------------------------------
+
+def _build_tags(
+    extra: List[str],
+    keywords: List[str],
+    *,
+    network_tags: List[str],
+    max_tags: int = 30,
+) -> List[str]:
+    """Build a deduped list of tags that fits inside YouTube's 500-char cap."""
+    seen = set()
+    ordered: List[str] = []
+    for tag in list(extra) + list(network_tags) + list(keywords):
+        if not tag:
+            continue
+        clean = str(tag).strip().lower()
+        if not clean or clean in seen:
+            continue
+        seen.add(clean)
+        ordered.append(clean)
+        if len(ordered) >= max_tags:
+            break
+
+    # Trim from the tail while the comma-joined length exceeds the cap.
+    while ordered and len(",".join(ordered)) > YOUTUBE_TAG_TOTAL_MAX:
+        ordered.pop()
+    return ordered
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def build_long_form_metadata(
+    config,
+    *,
+    episode_num: int,
+    today_str: str,
+    hook: str,
+    digest_text: str,
+    audio_url: str,
+    chapters_path: Optional[Path] = None,
+) -> Dict:
+    """Assemble the YouTube metadata payload for a long-form upload.
+
+    Returns
+    -------
+    dict
+        ``{"title": str, "description": str, "tags": List[str],
+        "category_id": int, "default_language": str}``
+    """
+    rss_title = (
+        getattr(config.publishing, "rss_title", "")
+        or getattr(config, "name", "")
+    )
+    title_seed = f"{rss_title} — Ep {episode_num}: {hook}" if hook else (
+        f"{rss_title} — Ep {episode_num} — {today_str}"
+    )
+    title = _truncate(title_seed.strip(), YOUTUBE_TITLE_MAX)
+
+    base_url = getattr(config.publishing, "base_url",
+                       "https://nerranetwork.com").rstrip("/")
+    rss_link = getattr(config.publishing, "rss_link", "") or base_url
+    utm_link = (
+        f"{rss_link}{'&' if '?' in rss_link else '?'}"
+        f"utm_source=youtube&utm_medium=video&utm_campaign=ep{episode_num}"
+    )
+
+    # First few paragraphs of the digest become the description body.
+    body_source = _strip_markdown(digest_text or "")
+    paragraphs = [p.strip() for p in body_source.split("\n\n") if p.strip()]
+    body = "\n\n".join(paragraphs[:4]).strip()
+
+    chapters_block = _format_chapter_block(_read_chapters(chapters_path))
+
+    pieces: List[str] = []
+    if hook:
+        pieces.append(hook.strip())
+    if body:
+        pieces.append(body)
+    if chapters_block:
+        pieces.append("Chapters:\n" + chapters_block)
+    pieces.append(f"Listen on the podcast feed: {utm_link}")
+    if audio_url:
+        pieces.append(f"Direct audio: {audio_url}")
+    disclosure = (config.youtube.synthetic_disclosure or "").strip()
+    if disclosure:
+        pieces.append(disclosure)
+
+    description = _truncate("\n\n".join(pieces).strip(), YOUTUBE_DESC_MAX)
+
+    tags = _build_tags(
+        list(config.youtube.tags or []),
+        list(getattr(config, "keywords", []) or []),
+        network_tags=[],  # already merged into youtube.tags via _defaults.yaml
+    )
+
+    return {
+        "title": title,
+        "description": description,
+        "tags": tags,
+        "category_id": int(config.youtube.category_id or 28),
+        "default_language": (config.youtube.default_language or "en").lower(),
+    }
+
+
+def build_short_metadata(
+    config,
+    *,
+    episode_num: int,
+    today_str: str,
+    hook: str,
+    long_form_url: str = "",
+) -> Dict:
+    """Assemble the YouTube metadata payload for a Shorts upload.
+
+    Title gets ``#Shorts`` appended (the most reliable way to get the
+    auto-classifier to treat the upload as a Short). The description is
+    deliberately brief so the disclosure footer remains visible above
+    the "Show more" fold on mobile.
+    """
+    rss_title = (
+        getattr(config.publishing, "rss_title", "")
+        or getattr(config, "name", "")
+    )
+    headline = hook.strip() if hook else f"Ep {episode_num} highlight"
+    title_seed = f"{headline} | {rss_title} #Shorts"
+    title = _truncate(title_seed.strip(), YOUTUBE_TITLE_MAX)
+
+    pieces: List[str] = [headline]
+    if long_form_url:
+        pieces.append(f"Full episode: {long_form_url}")
+    base_url = getattr(config.publishing, "base_url",
+                       "https://nerranetwork.com").rstrip("/")
+    rss_link = getattr(config.publishing, "rss_link", "") or base_url
+    utm_link = (
+        f"{rss_link}{'&' if '?' in rss_link else '?'}"
+        f"utm_source=youtube&utm_medium=shorts&utm_campaign=ep{episode_num}"
+    )
+    pieces.append(f"Subscribe to the podcast: {utm_link}")
+    disclosure = (config.youtube.synthetic_disclosure or "").strip()
+    if disclosure:
+        pieces.append(disclosure)
+    pieces.append("#Shorts #podcast")
+
+    description = _truncate("\n\n".join(pieces).strip(), YOUTUBE_DESC_MAX)
+
+    tags = _build_tags(
+        list(config.youtube.tags or []) + ["shorts", "podcast clip"],
+        list(getattr(config, "keywords", []) or []),
+        network_tags=[],
+    )
+
+    return {
+        "title": title,
+        "description": description,
+        "tags": tags,
+        "category_id": int(config.youtube.category_id or 28),
+        "default_language": (config.youtube.default_language or "en").lower(),
+    }

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -1,0 +1,298 @@
+"""YouTube publishing wrapper for the podcast pipeline.
+
+Provides:
+
+  - :func:`upload_video` — resumable video upload + thumbnail set in one
+    call. Mirrors the ``post_to_x()`` style: explicit credentials in,
+    watch URL out.
+  - :func:`build_oauth_credentials` — turn a long-lived refresh token
+    into a usable :class:`google.oauth2.credentials.Credentials`. Used
+    in production (CI) where we cannot run a browser flow.
+  - :func:`get_channel_credentials_from_env` — convenience wrapper that
+    reads the four ``YOUTUBE_*`` env vars used by the workflow.
+
+Every upload sets ``status.containsSyntheticMedia=True`` because all
+Nerra Network episodes use ElevenLabs voice synthesis. This is the API
+field YouTube introduced in October 2024 for AI/A&S disclosure; setting
+it via the API renders the same "Altered or synthetic content" label
+the Studio UI applies, and is required for monetization-eligible AI
+audio uploads.
+
+Quotas
+------
+``videos.insert`` costs **1,600 quota units** per upload. The default
+project quota is 10,000 units/day. ``thumbnails.set`` adds another
+50 units. Plan accordingly — see ``docs/youtube_setup.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import List, Optional
+
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# OAuth scopes required for upload + thumbnail set + channel read.
+YOUTUBE_SCOPES = [
+    "https://www.googleapis.com/auth/youtube.upload",
+    "https://www.googleapis.com/auth/youtube",
+]
+
+# Google's OAuth token endpoint. Held as a constant rather than an env
+# var so misconfigured deployments fail loudly at import time, not
+# halfway through a run.
+GOOGLE_TOKEN_URI = "https://oauth2.googleapis.com/token"
+
+
+# ---------------------------------------------------------------------------
+# Credential helpers
+# ---------------------------------------------------------------------------
+
+def build_oauth_credentials(
+    *,
+    client_id: str,
+    client_secret: str,
+    refresh_token: str,
+):
+    """Return a refreshable :class:`Credentials` for the YouTube API.
+
+    The refresh token is what we mint **once** via the bootstrap script
+    (``scripts/youtube_oauth_bootstrap.py``) and store as a GitHub
+    secret. Google's library automatically swaps it for a short-lived
+    access token on every API call.
+    """
+    from google.oauth2.credentials import Credentials
+
+    if not client_id or not client_secret:
+        raise ValueError(
+            "YouTube OAuth client_id/client_secret are required"
+        )
+    if not refresh_token:
+        raise ValueError("YouTube OAuth refresh_token is required")
+
+    return Credentials(
+        token=None,
+        refresh_token=refresh_token,
+        token_uri=GOOGLE_TOKEN_URI,
+        client_id=client_id,
+        client_secret=client_secret,
+        scopes=YOUTUBE_SCOPES,
+    )
+
+
+def get_channel_credentials_from_env(channel: str = "en"):
+    """Read the four ``YOUTUBE_*`` env vars and return Credentials.
+
+    *channel* picks which refresh token to load: ``"en"`` →
+    ``YOUTUBE_REFRESH_TOKEN_EN``, ``"ru"`` →
+    ``YOUTUBE_REFRESH_TOKEN_RU``. Returns ``None`` (not an exception)
+    if any value is missing — the caller decides whether to skip the
+    upload or fail the run.
+    """
+    client_id = os.getenv("YOUTUBE_CLIENT_ID", "").strip()
+    client_secret = os.getenv("YOUTUBE_CLIENT_SECRET", "").strip()
+    suffix = "RU" if channel.lower() == "ru" else "EN"
+    refresh_token = os.getenv(f"YOUTUBE_REFRESH_TOKEN_{suffix}", "").strip()
+
+    if not all([client_id, client_secret, refresh_token]):
+        logger.info(
+            "YouTube credentials not fully set for channel=%s — skipping",
+            channel,
+        )
+        return None
+
+    return build_oauth_credentials(
+        client_id=client_id,
+        client_secret=client_secret,
+        refresh_token=refresh_token,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Upload
+# ---------------------------------------------------------------------------
+
+# Errors that warrant a retry. Pulled in lazily inside
+# ``_should_retry_http`` so the module imports cleanly even when the
+# google libraries are missing (e.g. in pure-unit-test environments).
+def _is_retryable_http_error(exc: BaseException) -> bool:
+    try:
+        from googleapiclient.errors import HttpError
+    except ImportError:  # pragma: no cover
+        return False
+    if not isinstance(exc, HttpError):
+        return False
+    status = getattr(getattr(exc, "resp", None), "status", 0)
+    return status in (429, 500, 502, 503, 504)
+
+
+def _build_video_body(
+    *,
+    title: str,
+    description: str,
+    tags: List[str],
+    category_id: int,
+    default_language: str,
+    privacy_status: str,
+    contains_synthetic_media: bool,
+    made_for_kids: bool,
+) -> dict:
+    """Construct the request body for ``youtube.videos().insert()``."""
+    return {
+        "snippet": {
+            "title": title,
+            "description": description,
+            "tags": tags,
+            "categoryId": str(category_id),
+            "defaultLanguage": default_language,
+            "defaultAudioLanguage": default_language,
+        },
+        "status": {
+            "privacyStatus": privacy_status,
+            "selfDeclaredMadeForKids": made_for_kids,
+            "containsSyntheticMedia": contains_synthetic_media,
+            # Skip YouTube's gradual rollout to subscribers' homepages
+            # (we have RSS + X for that). False = publish to subs feed.
+            "publishToSubscriptions": True,
+        },
+    }
+
+
+@retry(
+    retry=retry_if_exception_type(Exception) & retry_if_exception_type(Exception),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=2, min=4, max=30),
+    reraise=True,
+)
+def _execute_resumable_upload(insert_request) -> dict:
+    """Drive the chunked upload loop until the API returns a video resource.
+
+    Tenacity wraps the whole call so a hard 5xx during chunk transfer
+    gets retried from scratch with backoff. ``next_chunk`` itself does
+    not retry — it returns ``(status, response)`` per chunk.
+    """
+    response = None
+    while response is None:
+        status, response = insert_request.next_chunk()
+        if status:
+            logger.info("YouTube upload progress: %d%%",
+                        int(status.progress() * 100))
+    return response
+
+
+def upload_video(
+    video_path: Path,
+    *,
+    credentials,
+    title: str,
+    description: str,
+    tags: List[str],
+    category_id: int,
+    default_language: str = "en",
+    privacy_status: str = "public",
+    thumbnail_path: Optional[Path] = None,
+    contains_synthetic_media: bool = True,
+    made_for_kids: bool = False,
+) -> str:
+    """Upload a single video and (optionally) its custom thumbnail.
+
+    Parameters
+    ----------
+    video_path:
+        Local MP4 to upload.
+    credentials:
+        Refreshable :class:`google.oauth2.credentials.Credentials` —
+        usually from :func:`get_channel_credentials_from_env`.
+    title, description, tags, category_id, default_language:
+        Snippet metadata. ``description`` may include the YouTube
+        chapter block; YouTube parses it automatically when the format
+        is right (first stamp ``0:00``, ≥ 2 stamps).
+    privacy_status:
+        ``"public"`` | ``"unlisted"`` | ``"private"``.
+    thumbnail_path:
+        Optional 1280x720 JPEG/PNG. Skipped silently when ``None``.
+    contains_synthetic_media:
+        Sets ``status.containsSyntheticMedia``. Defaults to ``True``
+        because every Nerra Network episode uses synthesized voice.
+    made_for_kids:
+        ``status.selfDeclaredMadeForKids``. Default ``False``; flip per
+        show in the YAML if a show is targeted at < 13.
+
+    Returns
+    -------
+    str
+        The canonical watch URL (``https://www.youtube.com/watch?v=…``).
+    """
+    if not video_path.exists():
+        raise FileNotFoundError(f"video not found: {video_path}")
+
+    # Lazy imports so ``import engine.youtube`` works in environments
+    # where the google libs aren't installed (e.g. fresh CI before
+    # ``pip install -r requirements.txt``).
+    from googleapiclient.discovery import build
+    from googleapiclient.http import MediaFileUpload
+
+    youtube = build("youtube", "v3", credentials=credentials,
+                    cache_discovery=False)
+
+    body = _build_video_body(
+        title=title,
+        description=description,
+        tags=tags,
+        category_id=category_id,
+        default_language=default_language,
+        privacy_status=privacy_status,
+        contains_synthetic_media=contains_synthetic_media,
+        made_for_kids=made_for_kids,
+    )
+
+    media = MediaFileUpload(
+        str(video_path),
+        mimetype="video/mp4",
+        chunksize=8 * 1024 * 1024,
+        resumable=True,
+    )
+
+    logger.info(
+        "Uploading to YouTube: %s (%.1f MiB, privacy=%s, AI-disclosed)",
+        video_path.name,
+        video_path.stat().st_size / (1024 * 1024),
+        privacy_status,
+    )
+
+    insert_request = youtube.videos().insert(
+        part="snippet,status",
+        body=body,
+        media_body=media,
+    )
+
+    response = _execute_resumable_upload(insert_request)
+    video_id = response.get("id")
+    if not video_id:
+        raise RuntimeError(
+            f"YouTube upload returned no video id: {response!r}"
+        )
+    watch_url = f"https://www.youtube.com/watch?v={video_id}"
+    logger.info("Uploaded: %s", watch_url)
+
+    if thumbnail_path and thumbnail_path.exists():
+        try:
+            youtube.thumbnails().set(
+                videoId=video_id,
+                media_body=str(thumbnail_path),
+            ).execute()
+            logger.info("Thumbnail set for %s", video_id)
+        except Exception as exc:  # pragma: no cover - thumbnail is best-effort
+            logger.warning("Thumbnail upload failed (non-fatal): %s", exc)
+
+    return watch_url

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,7 @@ pyyaml>=6.0
 jinja2>=3.1.0
 boto3>=1.28.0
 faster-whisper>=1.0.0
+google-api-python-client>=2.120.0
+google-auth>=2.28.0
+google-auth-oauthlib>=1.2.0
+google-auth-httplib2>=0.2.0

--- a/run_show.py
+++ b/run_show.py
@@ -2332,7 +2332,7 @@ def _publish_youtube(
 
     # Resolve cover image. We fall back to whatever the show used in the
     # RSS <itunes:image> tag if a local file isn't obvious from the slug.
-    cover_path: Optional[Path] = None
+    cover_path = None
     cover_candidates = [
         PROJECT_ROOT / "assets" / "covers" / f"{config.slug.replace('_', '-')}.jpg",
         PROJECT_ROOT / "assets" / "covers" / f"{config.slug}.jpg",

--- a/run_show.py
+++ b/run_show.py
@@ -128,6 +128,8 @@ def parse_args() -> argparse.Namespace:
                         help="Skip TTS, audio mixing, and RSS update")
     parser.add_argument("--skip-newsletter", action="store_true",
                         help="Skip newsletter sending")
+    parser.add_argument("--skip-youtube", action="store_true",
+                        help="Skip YouTube video build + upload")
     return parser.parse_args()
 
 
@@ -1818,6 +1820,35 @@ def run(args: argparse.Namespace) -> None:
         else:
             logger.info("Newsletter skipped or failed.")
 
+    # 12c. Build & upload YouTube videos (long-form + Shorts)
+    _t_yt = time.monotonic()
+    chapters_path_for_yt = digests_dir / f"chapters_ep{episode_num:03d}.json"
+    youtube_urls = _publish_youtube(
+        config,
+        episode_num=episode_num,
+        today=today,
+        today_str=today_str,
+        hook=hook or "",
+        digest_text=x_thread,
+        final_mp3=final_mp3,
+        audio_url=audio_url,
+        chapters_path=chapters_path_for_yt,
+        digests_dir=digests_dir,
+        args=args,
+    )
+    if youtube_urls.get("long_url"):
+        extra_context["youtube_url"] = youtube_urls["long_url"]
+    if youtube_urls.get("short_url"):
+        extra_context["youtube_short_url"] = youtube_urls["short_url"]
+    if youtube_urls:
+        try:
+            metrics.record(
+                "youtube_publish_duration_s",
+                round(time.monotonic() - _t_yt, 2),
+            )
+        except Exception:
+            pass
+
     # 13. Post to X
     _t_x = time.monotonic()
     if config.publishing.x_enabled and not args.skip_x:
@@ -2264,6 +2295,174 @@ def _break_long_paragraphs(text: str, max_chars: int = 400) -> str:
             out_paragraphs.append(" ".join(chunk))
 
     return "\n\n".join(out_paragraphs)
+
+
+def _publish_youtube(
+    config,
+    *,
+    episode_num: int,
+    today: "datetime.date",
+    today_str: str,
+    hook: str,
+    digest_text: str,
+    final_mp3: "Path",
+    audio_url: str,
+    chapters_path: "Path",
+    digests_dir: "Path",
+    args,
+) -> dict:
+    """Render long-form + Shorts video assets and upload them to YouTube.
+
+    Returns a ``{"long_url": ..., "short_url": ...}`` dict with whichever
+    URLs succeeded; missing keys mean that variant was disabled or
+    failed (failures are logged, not raised — this stage must never
+    crash a run).
+    """
+    result: dict = {}
+
+    if getattr(args, "skip_youtube", False):
+        logger.info("YouTube publishing skipped (--skip-youtube).")
+        return result
+    if not getattr(config, "youtube", None) or not config.youtube.enabled:
+        logger.info("YouTube publishing disabled in config.")
+        return result
+    if not final_mp3 or not final_mp3.exists():
+        logger.info("YouTube publishing skipped — no final mp3.")
+        return result
+
+    # Resolve cover image. We fall back to whatever the show used in the
+    # RSS <itunes:image> tag if a local file isn't obvious from the slug.
+    cover_path: Optional[Path] = None
+    cover_candidates = [
+        PROJECT_ROOT / "assets" / "covers" / f"{config.slug.replace('_', '-')}.jpg",
+        PROJECT_ROOT / "assets" / "covers" / f"{config.slug}.jpg",
+    ]
+    for candidate in cover_candidates:
+        if candidate.exists():
+            cover_path = candidate
+            break
+    if cover_path is None:
+        logger.warning(
+            "YouTube: no cover art under assets/covers/ for slug=%s — skipping.",
+            config.slug,
+        )
+        return result
+
+    from engine.publisher import generate_episode_thumbnail
+    from engine.video import build_long_form_video, build_short_video
+    from engine.video_metadata import (
+        build_long_form_metadata,
+        build_short_metadata,
+    )
+    from engine.youtube import (
+        get_channel_credentials_from_env,
+        upload_video,
+    )
+
+    credentials = get_channel_credentials_from_env(config.youtube.channel)
+    if credentials is None:
+        logger.warning(
+            "YouTube credentials missing for channel=%s — skipping upload.",
+            config.youtube.channel,
+        )
+        return result
+
+    work_dir = digests_dir / "youtube_tmp"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    base_name = final_mp3.stem  # e.g. Tesla_Shorts_Time_Pod_Ep042_20260425
+    long_video_path = work_dir / f"{base_name}.mp4"
+    short_video_path = work_dir / f"{base_name}_short.mp4"
+    thumbnail_path = work_dir / f"{base_name}_thumb.jpg"
+
+    # Thumbnail is shared between long-form and Shorts.
+    try:
+        generate_episode_thumbnail(
+            cover_path,
+            episode_num=episode_num,
+            date_str=today_str,
+            output_path=thumbnail_path,
+            hook=hook,
+            show_name=config.publishing.rss_title or config.name,
+        )
+    except Exception as exc:  # pragma: no cover - thumbnail rendering best-effort
+        logger.warning("Thumbnail generation failed: %s", exc)
+        thumbnail_path = None  # type: ignore[assignment]
+
+    # ---- Long-form ----
+    long_url = ""
+    if config.youtube.publish_long_form:
+        try:
+            build_long_form_video(final_mp3, cover_path, long_video_path)
+            meta = build_long_form_metadata(
+                config,
+                episode_num=episode_num,
+                today_str=today_str,
+                hook=hook,
+                digest_text=digest_text,
+                audio_url=audio_url,
+                chapters_path=chapters_path if chapters_path.exists() else None,
+            )
+            long_url = upload_video(
+                long_video_path,
+                credentials=credentials,
+                title=meta["title"],
+                description=meta["description"],
+                tags=meta["tags"],
+                category_id=meta["category_id"],
+                default_language=meta["default_language"],
+                privacy_status=config.youtube.privacy_status,
+                thumbnail_path=thumbnail_path,
+            )
+            result["long_url"] = long_url
+        except Exception as exc:
+            logger.exception("YouTube long-form publish failed: %s", exc)
+
+    # ---- Shorts ----
+    if config.youtube.publish_shorts:
+        try:
+            short_offset = float(
+                getattr(config.audio, "intro_duration", 0.0) or 0.0
+            ) + float(
+                getattr(config.audio, "voice_intro_delay", 0.0) or 0.0
+            )
+            duration = float(config.youtube.short_duration_seconds or 55.0)
+            build_short_video(
+                final_mp3, cover_path, short_video_path,
+                start_offset=short_offset,
+                duration=duration,
+            )
+            meta = build_short_metadata(
+                config,
+                episode_num=episode_num,
+                today_str=today_str,
+                hook=hook,
+                long_form_url=long_url,
+            )
+            short_url = upload_video(
+                short_video_path,
+                credentials=credentials,
+                title=meta["title"],
+                description=meta["description"],
+                tags=meta["tags"],
+                category_id=meta["category_id"],
+                default_language=meta["default_language"],
+                privacy_status=config.youtube.privacy_status,
+                thumbnail_path=thumbnail_path,
+            )
+            result["short_url"] = short_url
+        except Exception as exc:
+            logger.exception("YouTube Shorts publish failed: %s", exc)
+
+    # Best-effort cleanup of the rendered MP4s (large files; YouTube has
+    # the canonical copy now). Thumbnail kept on disk for debugging.
+    for video_file in (long_video_path, short_video_path):
+        try:
+            if video_file.exists():
+                video_file.unlink()
+        except OSError:
+            pass
+
+    return result
 
 
 def _build_teaser(config, episode_num: int, today_str: str, extra_context: dict) -> str:

--- a/scripts/youtube_oauth_bootstrap.py
+++ b/scripts/youtube_oauth_bootstrap.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""One-time OAuth refresh-token bootstrap for the YouTube publishing pipeline.
+
+Run **locally** (not in CI) — this script opens a browser, walks the
+Google OAuth consent flow, and prints the resulting refresh token. Paste
+the token into the appropriate GitHub Secret:
+
+  - English channel  → ``YOUTUBE_REFRESH_TOKEN_EN``
+  - Russian channel  → ``YOUTUBE_REFRESH_TOKEN_RU``
+
+You'll also need to create a Google Cloud project, enable the YouTube
+Data API v3, and download an OAuth 2.0 "Desktop app" client_secrets JSON.
+See ``docs/youtube_setup.md`` for the full sequence.
+
+Usage::
+
+    python scripts/youtube_oauth_bootstrap.py path/to/client_secrets.json
+
+The token is granted ``youtube.upload`` + ``youtube`` scopes (the second
+is needed for ``thumbnails.set`` and channel reads). Run once per
+channel, signing into the matching Google account each time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+SCOPES = [
+    "https://www.googleapis.com/auth/youtube.upload",
+    "https://www.googleapis.com/auth/youtube",
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "client_secrets",
+        type=Path,
+        help="Path to the OAuth 2.0 client secrets JSON downloaded from "
+             "Google Cloud Console (Desktop application credential type).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=0,
+        help="Port for the local OAuth callback server (0 = pick automatically).",
+    )
+    args = parser.parse_args()
+
+    if not args.client_secrets.exists():
+        print(f"client_secrets not found: {args.client_secrets}",
+              file=sys.stderr)
+        return 1
+
+    try:
+        from google_auth_oauthlib.flow import InstalledAppFlow
+    except ImportError:
+        print(
+            "google-auth-oauthlib is not installed. Run "
+            "`pip install google-auth-oauthlib` and try again.",
+            file=sys.stderr,
+        )
+        return 1
+
+    flow = InstalledAppFlow.from_client_secrets_file(
+        str(args.client_secrets), SCOPES,
+    )
+    print(
+        "Opening browser for consent. Sign in with the Google account "
+        "that owns the target YouTube channel."
+    )
+    creds = flow.run_local_server(port=args.port, prompt="consent",
+                                  access_type="offline")
+
+    if not creds.refresh_token:
+        print(
+            "ERROR: Google did not return a refresh token. This usually "
+            "means the consent screen was not shown (e.g. you've already "
+            "authorized this client). Revoke access at "
+            "https://myaccount.google.com/permissions and re-run.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print()
+    print("=" * 68)
+    print("SUCCESS — paste the value below into the matching GitHub secret")
+    print("(YOUTUBE_REFRESH_TOKEN_EN or YOUTUBE_REFRESH_TOKEN_RU):")
+    print("=" * 68)
+    print(creds.refresh_token)
+    print("=" * 68)
+    print()
+    print("Also set these once (same for both channels):")
+    print(f"  YOUTUBE_CLIENT_ID     = {creds.client_id}")
+    print(f"  YOUTUBE_CLIENT_SECRET = {creds.client_secret}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -89,3 +89,37 @@ chapters:
 content_tracking:
   enabled: true
   max_days: 14
+
+youtube:
+  # Off by default — flip per-show in the show YAML once an OAuth refresh
+  # token is provisioned for that channel.
+  enabled: false
+  # "en" = upload to the English Nerra Network channel using
+  # YOUTUBE_REFRESH_TOKEN_EN. "ru" = Russian channel
+  # using YOUTUBE_REFRESH_TOKEN_RU.
+  channel: en
+  # YouTube category ID (24=Entertainment, 25=News, 27=Education,
+  # 28=Science & Tech). Override per-show when a more specific bucket fits.
+  category_id: 28
+  default_language: en
+  # "public" once we've validated a few uploads via "unlisted".
+  privacy_status: public
+  # Per-episode rendering toggles.
+  publish_long_form: true
+  publish_shorts: true
+  # Shorts clip pulled from the voice track only (skips music intro);
+  # keep < 60s so YouTube treats it as a Short.
+  short_duration_seconds: 55
+  # Network-wide tags appended to per-show tags.
+  tags:
+    - nerra network
+    - podcast
+    - ai podcast
+  # Disclosure footer appended to every video description. The API also
+  # sets status.containsSyntheticMedia=True on every upload, which is the
+  # field YouTube uses to render the "Altered or synthetic content" label.
+  synthetic_disclosure: |
+    AI Disclosure: This podcast is curated by Patrick but uses AI-generated
+    voice synthesis (ElevenLabs) for the narration. Editorial selection,
+    summaries, and analysis are written from primary sources by
+    Nerra Network. Learn more: https://nerranetwork.com/about

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -244,3 +244,15 @@ newsletter:
   status: about_to_send
   tag: "Environmental Intelligence"
 
+youtube:
+  enabled: false                # Phase 2 — flip after quota raise
+  channel: en
+  category_id: 28               # Science & Tech
+  default_language: en
+  tags:
+    - environment
+    - canada environment
+    - environmental compliance
+    - climate
+    - sustainability
+

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -210,3 +210,17 @@ content_freshness:
   lookback_days: 2
   similarity_threshold: 0.72
 
+youtube:
+  enabled: true                 # Phase-1 rollout show
+  channel: en
+  category_id: 28               # Science & Tech
+  default_language: en
+  privacy_status: unlisted
+  tags:
+    - space
+    - astronomy
+    - nasa
+    - spacex
+    - science podcast
+    - space news
+

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -247,3 +247,15 @@ slow_news:
   library_file: shows/segments/finansy_prosto.json
   max_segments: 2
   cooldown_days: 30
+
+youtube:
+  enabled: false                # Phase 2 — flip after quota raise + RU channel set up
+  channel: ru
+  category_id: 25               # News & Politics
+  default_language: ru
+  tags:
+    - финансы
+    - инвестиции
+    - канада
+    - финансовая грамотность
+    - сбережения

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -230,3 +230,18 @@ newsletter:
   status: about_to_send
   tag: "Models & Agents"
 
+youtube:
+  enabled: true                 # Phase-1 rollout show
+  channel: en
+  category_id: 28               # Science & Tech
+  default_language: en
+  privacy_status: unlisted
+  tags:
+    - ai
+    - llm
+    - artificial intelligence
+    - ai agents
+    - openai
+    - anthropic
+    - ai podcast
+

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -200,3 +200,15 @@ slow_news:
   library_file: shows/segments/models_agents_beginners.json
   max_segments: 2
   cooldown_days: 30
+
+youtube:
+  enabled: false                # Phase 2 — flip after quota raise
+  channel: en
+  category_id: 27               # Education (beginner / teen-focused)
+  default_language: en
+  tags:
+    - ai for beginners
+    - learn ai
+    - ai for teens
+    - ai explained
+    - ai education

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -231,3 +231,15 @@ slow_news:
   library_file: shows/segments/modern_investing.json
   max_segments: 2
   cooldown_days: 30
+
+youtube:
+  enabled: false                # Phase 2 — flip after quota raise
+  channel: en
+  category_id: 25               # News & Politics (markets/business)
+  default_language: en
+  tags:
+    - investing
+    - canadian investing
+    - us markets
+    - stocks
+    - investing podcast

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -206,3 +206,13 @@ slow_news:
   max_segments: 2
   cooldown_days: 30
 
+youtube:
+  enabled: false                # Phase 2 — flip after quota raise
+  channel: en
+  category_id: 25               # News & Politics
+  default_language: en
+  tags:
+    - news
+    - balanced news
+    - news podcast
+

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -242,3 +242,15 @@ slow_news:
   max_segments: 2
   cooldown_days: 30
 
+youtube:
+  enabled: false                # Phase 2 — flip after quota raise
+  channel: en
+  category_id: 28               # Science & Tech
+  default_language: en
+  tags:
+    - science
+    - longevity
+    - health
+    - neuroscience
+    - science podcast
+

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -183,3 +183,15 @@ slow_news:
   library_file: shows/segments/privet_russian.json
   max_segments: 2
   cooldown_days: 30
+
+youtube:
+  enabled: false                # Phase 2 — flip after quota raise + RU channel set up
+  channel: ru
+  category_id: 27               # Education (language learning)
+  default_language: ru
+  tags:
+    - learn russian
+    - russian for beginners
+    - russian language
+    - russian podcast
+    - bilingual russian

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -211,3 +211,17 @@ newsletter:
   status: about_to_send
   tag: "Tesla Shorts Time"
 
+youtube:
+  enabled: true                 # Phase-1 rollout show
+  channel: en
+  category_id: 28               # Science & Tech (algorithm performs better than 2/Autos here)
+  default_language: en
+  privacy_status: unlisted      # Flip to "public" after first successful upload
+  tags:
+    - tesla
+    - tsla
+    - electric vehicle
+    - ev news
+    - fsd
+    - tesla podcast
+

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1,0 +1,162 @@
+"""Tests that pin down the EXACT ffmpeg commands :mod:`engine.video` emits.
+
+We don't actually run ffmpeg — we just verify the command lists. Same
+pattern as :mod:`tests.test_audio_commands`. These act as a regression
+fence: any future tweak to the long-form or Shorts video pipeline will
+trip these tests, forcing the change to be intentional.
+"""
+
+import pytest
+
+from engine.video import (
+    _AUDIO_ENCODE,
+    _VIDEO_ENCODE,
+    _long_form_cmd,
+    _long_form_filter_graph,
+    _short_form_cmd,
+    _short_form_filter_graph,
+    build_long_form_video,
+    build_short_video,
+)
+
+
+# ---------------------------------------------------------------------------
+# Filter graph shape
+# ---------------------------------------------------------------------------
+
+def test_long_form_filter_graph_default_resolution():
+    graph = _long_form_filter_graph()
+    assert "scale=1920:1080" in graph
+    assert "showwaves=s=1920x180" in graph
+    assert "[bg]" in graph and "[wave]" in graph and "[v]" in graph
+    # waveform overlay sits 60px above the bottom edge
+    assert "y=H-h-60" in graph
+
+
+def test_short_form_filter_graph_default_resolution():
+    graph = _short_form_filter_graph()
+    assert "scale=1080:1920" in graph
+    assert "showwaves=s=1080x300" in graph
+    # 1920/2 - 150 = 810 — waveform centered vertically
+    assert "y=810" in graph
+
+
+# ---------------------------------------------------------------------------
+# Long-form command shape
+# ---------------------------------------------------------------------------
+
+def test_long_form_cmd_structure():
+    cmd = _long_form_cmd("voice.mp3", "cover.jpg", "out.mp4")
+
+    # Two inputs: looped cover image, then audio.
+    assert cmd[:2] == ["ffmpeg", "-y"]
+    assert "-loop" in cmd and cmd[cmd.index("-loop") + 1] == "1"
+    # Two -i flags for the two inputs
+    assert cmd.count("-i") == 2
+    # Filter graph is supplied via -filter_complex
+    fc_idx = cmd.index("-filter_complex")
+    graph = cmd[fc_idx + 1]
+    assert "[bg][wave]overlay" in graph
+    # Map the composited video and the second input's audio
+    assert "-map" in cmd
+    map_indices = [i for i, x in enumerate(cmd) if x == "-map"]
+    map_values = [cmd[i + 1] for i in map_indices]
+    assert "[v]" in map_values
+    assert "1:a" in map_values
+    # Encoding profile + faststart + shortest are present
+    for token in ("-shortest", "-movflags", "+faststart"):
+        assert token in cmd
+    for token in _VIDEO_ENCODE:
+        assert token in cmd
+    for token in _AUDIO_ENCODE:
+        assert token in cmd
+    assert cmd[-1] == "out.mp4"
+
+
+def test_long_form_cmd_respects_fps():
+    cmd = _long_form_cmd("voice.mp3", "cover.jpg", "out.mp4", fps=24)
+    # -framerate is set on the looped image input *before* -i
+    assert cmd[cmd.index("-framerate") + 1] == "24"
+    # -r controls the output frame rate
+    assert cmd[cmd.index("-r") + 1] == "24"
+    # Filter graph picks up the same fps for the waveform animation
+    graph = cmd[cmd.index("-filter_complex") + 1]
+    assert "rate=24" in graph
+
+
+# ---------------------------------------------------------------------------
+# Shorts command shape
+# ---------------------------------------------------------------------------
+
+def test_short_form_cmd_clips_audio():
+    cmd = _short_form_cmd(
+        "voice.mp3", "cover.jpg", "short.mp4",
+        start_offset=15.0, duration=55.0,
+    )
+    # -ss / -t are applied to the audio input (they appear AFTER the
+    # cover input's -i but BEFORE the audio input's -i).
+    ss_idx = cmd.index("-ss")
+    t_idx = cmd.index("-t")
+    assert cmd[ss_idx + 1] == "15.00"
+    assert cmd[t_idx + 1] == "55.00"
+    # Two -i flags: cover then audio.
+    i_indices = [i for i, x in enumerate(cmd) if x == "-i"]
+    assert len(i_indices) == 2
+    # Audio input must come after -ss/-t.
+    assert i_indices[1] > t_idx
+    # Filter graph references the vertical Shorts geometry.
+    graph = cmd[cmd.index("-filter_complex") + 1]
+    assert "scale=1080:1920" in graph
+    assert "showwaves=s=1080x300" in graph
+    assert cmd[-1] == "short.mp4"
+
+
+def test_short_form_rejects_60s_duration(tmp_path):
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\x00")
+    out = tmp_path / "short.mp4"
+    with pytest.raises(ValueError, match="below 60s"):
+        build_short_video(audio, cover, out, duration=60.0)
+
+
+def test_short_form_accepts_under_60s(tmp_path, monkeypatch):
+    """Shorts under 60s should pass validation; we don't actually run ffmpeg."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\x00")
+    out = tmp_path / "short.mp4"
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+
+        class _R:
+            returncode = 0
+        return _R()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    build_short_video(audio, cover, out, duration=55.0, start_offset=10.0)
+    assert captured["cmd"][0] == "ffmpeg"
+    assert "55.00" in captured["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# Public API guards
+# ---------------------------------------------------------------------------
+
+def test_build_long_form_video_requires_audio(tmp_path):
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\x00")
+    with pytest.raises(FileNotFoundError, match="audio not found"):
+        build_long_form_video(tmp_path / "missing.mp3", cover, tmp_path / "out.mp4")
+
+
+def test_build_long_form_video_requires_cover(tmp_path):
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    with pytest.raises(FileNotFoundError, match="cover not found"):
+        build_long_form_video(audio, tmp_path / "missing.jpg", tmp_path / "out.mp4")

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -1,0 +1,357 @@
+"""Tests for the YouTube uploader and metadata builders.
+
+These tests use mocks for the Google API client so the suite never
+touches the network. They verify three things:
+
+  1. The video metadata builders honour YouTube's hard limits (title
+     100 chars, description 5000, tag total 500) and produce well-formed
+     chapter blocks.
+  2. The upload request body always sets
+     ``status.containsSyntheticMedia=True`` (the AI disclosure flag).
+  3. Credential plumbing — ``get_channel_credentials_from_env`` returns
+     ``None`` cleanly when secrets are missing instead of raising.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from engine import youtube
+from engine import video_metadata as vm
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(**overrides):
+    """Build a stand-in for ShowConfig with the fields the metadata
+    builders touch. Avoids depending on the real dataclass + YAML loader."""
+    publishing = SimpleNamespace(
+        rss_title=overrides.get("rss_title", "Tesla Shorts Time Daily"),
+        base_url=overrides.get("base_url", "https://nerranetwork.com"),
+        rss_link=overrides.get(
+            "rss_link", "https://nerranetwork.com/tesla.html"
+        ),
+    )
+    youtube_cfg = SimpleNamespace(
+        tags=overrides.get("tags", ["tesla", "ev"]),
+        category_id=overrides.get("category_id", 28),
+        default_language=overrides.get("default_language", "en"),
+        synthetic_disclosure=overrides.get(
+            "synthetic_disclosure", "AI Disclosure: synthesized voice."
+        ),
+        enabled=True,
+        channel="en",
+    )
+    return SimpleNamespace(
+        name=overrides.get("name", "Tesla Shorts Time"),
+        publishing=publishing,
+        youtube=youtube_cfg,
+        keywords=overrides.get(
+            "keywords", ["model 3", "fsd", "robotaxi", "tsla"]
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Markdown stripping
+# ---------------------------------------------------------------------------
+
+def test_strip_markdown_removes_headers_bold_and_links():
+    raw = (
+        "# Big news\n"
+        "**Tesla** delivers on Q3.\n"
+        "Read [the announcement](https://example.com/post).\n"
+    )
+    out = vm._strip_markdown(raw)
+    assert "**" not in out
+    assert "#" not in out.split("\n")[0]
+    assert "https://example.com/post" in out
+
+
+def test_strip_markdown_drops_code_fences():
+    raw = "```python\nprint(1)\n```\n\nAfter."
+    out = vm._strip_markdown(raw)
+    assert "print" not in out
+    assert "After." in out
+
+
+# ---------------------------------------------------------------------------
+# Chapter formatting
+# ---------------------------------------------------------------------------
+
+def test_format_chapter_timestamp_under_an_hour():
+    assert vm._format_chapter_timestamp(0) == "0:00"
+    assert vm._format_chapter_timestamp(75) == "1:15"
+    assert vm._format_chapter_timestamp(3599) == "59:59"
+
+
+def test_format_chapter_timestamp_over_an_hour():
+    assert vm._format_chapter_timestamp(3600) == "1:00:00"
+    assert vm._format_chapter_timestamp(3725) == "1:02:05"
+
+
+def test_chapter_block_requires_zero_start():
+    chapters = [
+        {"title": "Intro", "startTime": 30},  # YouTube ignores blocks not starting at 0
+        {"title": "Main", "startTime": 120},
+    ]
+    assert vm._format_chapter_block(chapters) == ""
+
+
+def test_chapter_block_renders_when_starts_at_zero():
+    chapters = [
+        {"title": "Intro", "startTime": 0},
+        {"title": "Top Stories", "startTime": 30},
+        {"title": "Closing", "startTime": 600},
+    ]
+    block = vm._format_chapter_block(chapters)
+    lines = block.split("\n")
+    assert lines[0] == "0:00 Intro"
+    assert lines[1] == "0:30 Top Stories"
+    assert lines[2] == "10:00 Closing"
+
+
+def test_chapter_block_handles_short_lists():
+    assert vm._format_chapter_block([]) == ""
+    assert vm._format_chapter_block([{"title": "Solo", "startTime": 0}]) == ""
+
+
+# ---------------------------------------------------------------------------
+# Tag handling
+# ---------------------------------------------------------------------------
+
+def test_build_tags_dedupes_and_lowercases():
+    tags = vm._build_tags(
+        extra=["Tesla", "TESLA", " Model 3 "],
+        keywords=["model 3", "FSD"],
+        network_tags=[],
+    )
+    assert tags == ["tesla", "model 3", "fsd"]
+
+
+def test_build_tags_respects_500_char_cap():
+    long_extras = [f"tag-{i:03d}-padded-out" for i in range(50)]
+    tags = vm._build_tags(extra=long_extras, keywords=[], network_tags=[])
+    assert len(",".join(tags)) <= vm.YOUTUBE_TAG_TOTAL_MAX
+
+
+# ---------------------------------------------------------------------------
+# Metadata builders
+# ---------------------------------------------------------------------------
+
+def test_build_long_form_metadata_truncates_title_to_100_chars():
+    config = _make_config(rss_title="X" * 80)
+    meta = vm.build_long_form_metadata(
+        config,
+        episode_num=1,
+        today_str="2026-04-26",
+        hook="Y" * 80,
+        digest_text="A short digest body.",
+        audio_url="https://audio.nerranetwork.com/tesla/ep001.mp3",
+    )
+    assert len(meta["title"]) <= vm.YOUTUBE_TITLE_MAX
+    assert meta["title"].endswith("...")
+
+
+def test_build_long_form_metadata_includes_disclosure_and_utm():
+    config = _make_config()
+    meta = vm.build_long_form_metadata(
+        config,
+        episode_num=42,
+        today_str="2026-04-26",
+        hook="Robotaxi expands to Vancouver",
+        digest_text="Tesla announced robotaxi expansion today...",
+        audio_url="https://audio.nerranetwork.com/tesla/ep042.mp3",
+    )
+    assert "AI Disclosure" in meta["description"]
+    assert "utm_source=youtube" in meta["description"]
+    assert "utm_medium=video" in meta["description"]
+    assert "utm_campaign=ep42" in meta["description"]
+    assert meta["category_id"] == 28
+    assert meta["default_language"] == "en"
+
+
+def test_build_long_form_metadata_chapter_block_appears(tmp_path):
+    chapters_path = tmp_path / "chapters_ep042.json"
+    chapters_path.write_text(
+        '{"chapters": ['
+        '{"title": "Intro", "startTime": 0},'
+        '{"title": "Top Stories", "startTime": 45}'
+        ']}', encoding="utf-8",
+    )
+    config = _make_config()
+    meta = vm.build_long_form_metadata(
+        config,
+        episode_num=42,
+        today_str="2026-04-26",
+        hook="Big news",
+        digest_text="Body text.",
+        audio_url="https://example.com/ep.mp3",
+        chapters_path=chapters_path,
+    )
+    assert "Chapters:" in meta["description"]
+    assert "0:00 Intro" in meta["description"]
+    assert "0:45 Top Stories" in meta["description"]
+
+
+def test_build_short_metadata_uses_shorts_hashtag():
+    config = _make_config()
+    meta = vm.build_short_metadata(
+        config,
+        episode_num=42,
+        today_str="2026-04-26",
+        hook="Robotaxi expands",
+        long_form_url="https://www.youtube.com/watch?v=abc",
+    )
+    assert "#Shorts" in meta["title"]
+    assert "https://www.youtube.com/watch?v=abc" in meta["description"]
+    assert "utm_medium=shorts" in meta["description"]
+    assert "AI Disclosure" in meta["description"]
+    # Tags should include the shorts marker.
+    assert "shorts" in meta["tags"]
+
+
+# ---------------------------------------------------------------------------
+# YouTube API plumbing
+# ---------------------------------------------------------------------------
+
+def test_build_video_body_sets_synthetic_media_flag():
+    body = youtube._build_video_body(
+        title="Ep 1",
+        description="hello",
+        tags=["t"],
+        category_id=28,
+        default_language="en",
+        privacy_status="public",
+        contains_synthetic_media=True,
+        made_for_kids=False,
+    )
+    assert body["status"]["containsSyntheticMedia"] is True
+    assert body["status"]["selfDeclaredMadeForKids"] is False
+    assert body["status"]["privacyStatus"] == "public"
+    assert body["snippet"]["title"] == "Ep 1"
+    assert body["snippet"]["categoryId"] == "28"
+    assert body["snippet"]["defaultLanguage"] == "en"
+
+
+def test_build_oauth_credentials_validates_inputs():
+    with pytest.raises(ValueError, match="client_id"):
+        youtube.build_oauth_credentials(
+            client_id="", client_secret="x", refresh_token="y",
+        )
+    with pytest.raises(ValueError, match="refresh_token"):
+        youtube.build_oauth_credentials(
+            client_id="x", client_secret="y", refresh_token="",
+        )
+
+
+def test_get_channel_credentials_from_env_returns_none_when_missing(monkeypatch):
+    for var in (
+        "YOUTUBE_CLIENT_ID",
+        "YOUTUBE_CLIENT_SECRET",
+        "YOUTUBE_REFRESH_TOKEN_EN",
+        "YOUTUBE_REFRESH_TOKEN_RU",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    assert youtube.get_channel_credentials_from_env("en") is None
+    assert youtube.get_channel_credentials_from_env("ru") is None
+
+
+def test_get_channel_credentials_from_env_picks_correct_token(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_CLIENT_ID", "id")
+    monkeypatch.setenv("YOUTUBE_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("YOUTUBE_REFRESH_TOKEN_EN", "rt-en")
+    monkeypatch.setenv("YOUTUBE_REFRESH_TOKEN_RU", "rt-ru")
+    creds_en = youtube.get_channel_credentials_from_env("en")
+    creds_ru = youtube.get_channel_credentials_from_env("ru")
+    assert creds_en is not None and creds_en.refresh_token == "rt-en"
+    assert creds_ru is not None and creds_ru.refresh_token == "rt-ru"
+
+
+def test_upload_video_invokes_api_and_returns_watch_url(monkeypatch, tmp_path):
+    """End-to-end test of upload_video with a fully mocked Google client.
+
+    We assert the request body shape (containsSyntheticMedia=True) and
+    the watch URL is constructed from the returned video id.
+    """
+    video_path = tmp_path / "ep001.mp4"
+    video_path.write_bytes(b"\x00" * 1024)
+
+    captured = {}
+
+    class _FakeRequest:
+        def __init__(self, response):
+            self._response = response
+
+        def next_chunk(self):
+            return None, self._response
+
+        def execute(self):
+            return self._response
+
+    class _FakeVideos:
+        def insert(self, **kwargs):
+            captured["insert_kwargs"] = kwargs
+            return _FakeRequest({"id": "abc123"})
+
+    class _FakeThumbnails:
+        def set(self, **kwargs):
+            captured["thumb_kwargs"] = kwargs
+            return _FakeRequest({})
+
+    class _FakeYouTube:
+        def videos(self):
+            return _FakeVideos()
+
+        def thumbnails(self):
+            return _FakeThumbnails()
+
+    class _FakeMediaFileUpload:
+        def __init__(self, *args, **kwargs):
+            captured["media_args"] = (args, kwargs)
+
+    # Patch the lazy imports inside upload_video.
+    import sys
+    fake_googleapiclient = type(sys)("googleapiclient")
+    fake_discovery = type(sys)("googleapiclient.discovery")
+    fake_http = type(sys)("googleapiclient.http")
+    fake_discovery.build = lambda *a, **kw: _FakeYouTube()
+    fake_http.MediaFileUpload = _FakeMediaFileUpload
+    fake_googleapiclient.discovery = fake_discovery
+    fake_googleapiclient.http = fake_http
+    monkeypatch.setitem(sys.modules, "googleapiclient", fake_googleapiclient)
+    monkeypatch.setitem(sys.modules, "googleapiclient.discovery",
+                        fake_discovery)
+    monkeypatch.setitem(sys.modules, "googleapiclient.http", fake_http)
+
+    url = youtube.upload_video(
+        video_path,
+        credentials=object(),  # not used by the fake
+        title="Test",
+        description="desc",
+        tags=["t"],
+        category_id=28,
+        default_language="en",
+        privacy_status="public",
+    )
+    assert url == "https://www.youtube.com/watch?v=abc123"
+
+    body = captured["insert_kwargs"]["body"]
+    assert body["status"]["containsSyntheticMedia"] is True
+    assert body["snippet"]["title"] == "Test"
+    assert captured["insert_kwargs"]["part"] == "snippet,status"
+
+
+def test_upload_video_requires_existing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        youtube.upload_video(
+            tmp_path / "missing.mp4",
+            credentials=object(),
+            title="t",
+            description="d",
+            tags=[],
+            category_id=28,
+        )


### PR DESCRIPTION
## Summary

New per-episode pipeline stage that renders and uploads two YouTube videos for every podcast episode:

- **Long-form** — 1920x1080 MP4 with show cover + animated `showwaves` waveform overlay, full episode audio.
- **Shorts** — 1080x1920 MP4, ~55s clipped from voice (skips music intro), `#Shorts` in title.
- **Per-episode thumbnail** — 1280x720 with show cover + episode # + extracted hook headline. Activates the previously-dead `engine.publisher.generate_episode_thumbnail`.

Every upload sets `status.containsSyntheticMedia=True` (the YouTube Data API field for AI/synthetic-content disclosure introduced Oct 2024) **and** appends the disclosure footer from `shows/_defaults.yaml` to the description. Both layers together are needed for monetization eligibility on synthesized-voice content.

## Architecture

- **Channels**: Two-channel topology — English Nerra Network + Russian — selected per-show via `youtube.channel: en|ru`. Two refresh tokens (`YOUTUBE_REFRESH_TOKEN_EN`, `YOUTUBE_REFRESH_TOKEN_RU`).
- **Pipeline hook**: `_publish_youtube()` runs after RSS update / newsletter and before X posting (`run_show.py`). Failures are logged, never raised — same pattern as the newsletter stage.
- **Quota**: Default Google Cloud quota = 10,000 units/day. Each `videos.insert` = 1,600 units. Phase-1 ships with `youtube.enabled: true` only on `tesla`, `fascinating_frontiers`, `models_agents` (3 shows × 2 formats × 1,600 = 9,600 units/day, just under the cap). Other shows ship with metadata wired up but `enabled: false`. Operator runbook (`docs/youtube_setup.md`) covers the quota-extension workflow.
- **GA attribution**: Description links to `nerranetwork.com` carry `?utm_source=youtube&utm_medium=video|shorts&utm_campaign=ep<N>` so click-throughs land in GA4 attributed to YouTube.

## New modules

- `engine/video.py` — ffmpeg builders (`build_long_form_video`, `build_short_video`) with libx264 + AAC + faststart for instant playback.
- `engine/video_metadata.py` — title / description / tag construction; honours YouTube's 100/5000/500-char limits; renders `0:00 Intro`-style chapter blocks from existing `chapters_ep*.json`.
- `engine/youtube.py` — OAuth credential plumbing + resumable upload via `MediaFileUpload`, with retry on 5xx/429.
- `scripts/youtube_oauth_bootstrap.py` — one-time local helper to mint refresh tokens.
- `docs/youtube_setup.md` — operator runbook (GCP project, OAuth consent, quota, validation).

## Per-show YAML

New `youtube:` block at the network level (`shows/_defaults.yaml`) and per-show overrides in all 10 show YAMLs. `engine/config.py` now has a `YouTubeConfig` dataclass merged into `ShowConfig`.

## CI

`.github/workflows/run-show.yml` exports four new secrets to the runtime env (same pattern as the R2 keys): `YOUTUBE_CLIENT_ID`, `YOUTUBE_CLIENT_SECRET`, `YOUTUBE_REFRESH_TOKEN_EN`, `YOUTUBE_REFRESH_TOKEN_RU`. Missing values cause the YouTube stage to skip cleanly.

## Test plan

- [x] `pytest tests/test_video_commands.py tests/test_youtube.py` — 28/28 passing
- [x] Full `pytest` suite — 1128 passed, 3 skipped (env-gated), no regressions
- [x] Smoke-test: `engine.config.load_config('shows/tesla.yaml').youtube` reflects the new block
- [x] Smoke-test: `run_show.py` parses + imports cleanly with the new `_publish_youtube()` helper
- [ ] **Operator (manual)**: file YouTube API quota extension request in Google Cloud Console
- [ ] **Operator (manual)**: run `scripts/youtube_oauth_bootstrap.py` once per channel, paste tokens into GitHub secrets
- [ ] **Operator (manual)**: trigger `tesla` with `youtube.privacy_status: unlisted` (current default), confirm video appears in Studio with the AI-disclosure label, then flip to `public`

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_