### PR TITLE
Fix YouTube long-form playback + add dynamic visuals

### DIFF
--- a/engine/video.py
+++ b/engine/video.py
@@ -1,21 +1,35 @@
 """Video assembly helpers for the YouTube publishing pipeline.
 
-Provides ffmpeg-based builders for two video formats produced from each
-podcast episode:
+Two builders share one visual recipe so every show looks like part of
+the same network without per-show artwork. The recipe:
 
-  - :func:`build_long_form_video`  — 1920x1080 (16:9) horizontal MP4
-    with the show cover as a still background and an animated audio
-    waveform overlay running for the full duration of the episode audio.
-  - :func:`build_short_video`     — 1080x1920 (9:16) vertical MP4 with
-    a clipped portion of the audio (default 55s, well under the 60s
-    YouTube Shorts limit) and the cover scaled-and-cropped to fill.
+  - **Background**: the show cover image, scaled-and-cropped to fill
+    the frame; long-form gets a slow Ken Burns zoom (1.00 → 1.08 over
+    the audio), Shorts stay static (55s of zoom looks frenetic on
+    mobile).
+  - **Tint band**: 25% black overlay sits underneath the visualization
+    so it reads against any cover.
+  - **Visualization**: ``showcqt`` (constant-Q transform) burned in —
+    the colorful music-bar look you see on Lofi Girl / Spotify Canvas.
+    Inherently dynamic frame-by-frame, audio-reactive, and works for
+    speech and music alike.
+  - **Brand pill**: a small ``Nerra Network · AI-narrated`` pill PNG
+    (rendered once with Pillow per work-dir, then reused) overlaid
+    top-left on long-form / top-right on Shorts.
+  - **First-seconds burn-in**: long-form fades in/out a centered
+    "AI-narrated content · Editorial by Nerra Network" line for the
+    first 4s. Shorts (when given a hook headline) burn the headline
+    for the first 3s so the scrolling viewer sees the topic before
+    deciding to stay.
 
-Both functions share the same encoding profile (libx264 + AAC, faststart)
-so uploads are immediately playable on YouTube without a re-mux pass.
+The encoder profile uses ``-g 60 -keyint_min 60 -sc_threshold 0
+-force_key_frames`` to force a keyframe every 2s. Without this, x264
+sees redundant input frames and produces a single keyframe at t=0,
+which made YouTube's transcoder reject the long-form rendition.
 
-The command builders are kept as module-level pure functions so they
-can be inspected by ``tests/test_video_commands.py`` without invoking
-ffmpeg.
+The command builders are pure functions (no subprocess) so unit tests
+in ``tests/test_video_commands.py`` can inspect them without a real
+ffmpeg install.
 """
 
 from __future__ import annotations
@@ -23,7 +37,7 @@ from __future__ import annotations
 import logging
 import subprocess
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -32,9 +46,14 @@ logger = logging.getLogger(__name__)
 # Encoding profile
 # ---------------------------------------------------------------------------
 
-# Shared video/audio encoder args. libx264 + yuv420p + faststart is the
-# combination YouTube requires for instant playback (the moov atom must
-# sit before mdat or the upload triggers a re-process pass).
+# libx264 + yuv420p + faststart is what YouTube wants for instant
+# playback (moov atom before mdat). The keyframe args below are what
+# fixes the original "video can't play" bug — without them, x264 sees
+# the looped cover input as one big static scene and emits a single
+# IDR at t=0, producing an MP4 the YouTube transcoder either rejects
+# or serves as un-seekable. Forcing a keyframe every 2s is cheap (the
+# zoompan + showcqt motion gives x264 actual change to compress) and
+# matches what handbrake/Handbrake-Web defaults use for streaming.
 _VIDEO_ENCODE: List[str] = [
     "-c:v", "libx264",
     "-pix_fmt", "yuv420p",
@@ -42,6 +61,10 @@ _VIDEO_ENCODE: List[str] = [
     "-crf", "22",
     "-profile:v", "high",
     "-level", "4.1",
+    "-g", "60",
+    "-keyint_min", "60",
+    "-sc_threshold", "0",
+    "-force_key_frames", "expr:gte(t,n_forced*2)",
 ]
 
 _AUDIO_ENCODE: List[str] = [
@@ -53,65 +76,255 @@ _AUDIO_ENCODE: List[str] = [
 
 
 # ---------------------------------------------------------------------------
-# Filter graph builders
+# Font + drawtext helpers
+# ---------------------------------------------------------------------------
+
+# DejaVu ships on Ubuntu / GitHub Actions runners and includes glyphs
+# for the en-dot, em-dash, and Cyrillic so it works for English and
+# Russian shows alike.
+_FONT_CANDIDATES = (
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf",
+    "/Library/Fonts/Arial Bold.ttf",
+    "/System/Library/Fonts/Helvetica.ttc",
+)
+
+
+def _find_font() -> str:
+    """Return the path of an installed bold sans-serif font.
+
+    Falls through a list of common platform paths. If none exist we
+    return the first candidate anyway — ffmpeg will fail loudly with
+    ``Cannot find a valid font for the specified font`` and the caller
+    sees the error in logs (better than silently rendering with no
+    glyphs).
+    """
+    for candidate in _FONT_CANDIDATES:
+        if Path(candidate).exists():
+            return candidate
+    return _FONT_CANDIDATES[0]
+
+
+def _drawtext_escape(value: str) -> str:
+    """Escape a string for ffmpeg's ``drawtext text=...`` value.
+
+    drawtext uses ``:`` to separate options and ``\\`` / ``'`` /
+    ``%`` as metacharacters inside the text value. This minimal escape
+    is what ffmpeg's documented examples use — robust enough for
+    arbitrary news-headline content.
+    """
+    return (
+        value.replace("\\", "\\\\")
+             .replace(":", r"\:")
+             .replace("'", r"\'")
+             .replace("%", r"\%")
+    )
+
+
+def _wrap_caption(text: str, max_chars_per_line: int = 22,
+                  max_lines: int = 3) -> str:
+    """Greedy word-wrap for a Shorts caption, capped at *max_lines*.
+
+    drawtext supports ``\\n`` literal in the text value to break lines,
+    so we just join with that. Truncates with an ellipsis if the
+    message exceeds the line cap.
+    """
+    if not text:
+        return ""
+    words = text.split()
+    lines: List[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if len(candidate) <= max_chars_per_line or not current:
+            current = candidate
+        else:
+            lines.append(current)
+            current = word
+            if len(lines) >= max_lines:
+                break
+    if current and len(lines) < max_lines:
+        lines.append(current)
+    if len(lines) >= max_lines and len(" ".join(lines).split()) < len(words):
+        # Truncated mid-sentence — add ellipsis to the last line.
+        last = lines[-1]
+        if not last.endswith("..."):
+            lines[-1] = (last[: max_chars_per_line - 3].rstrip() + "...") \
+                if len(last) > max_chars_per_line - 3 else last + "..."
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Brand pill PNG
+# ---------------------------------------------------------------------------
+
+_BRAND_PILL_TEXT = "Nerra Network · AI-narrated"
+
+
+def _make_brand_pill(output_path: Path,
+                     *, width: int = 320, height: int = 60) -> Path:
+    """Render the network brand pill as an RGBA PNG.
+
+    Idempotent: if *output_path* already exists, returns it without
+    re-rendering. Output is a transparent-background PNG with a
+    rounded-rect 50% black backdrop and the brand text centered.
+    """
+    if output_path.exists():
+        return output_path
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    from PIL import Image, ImageDraw, ImageFont
+
+    img = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    # Rounded rectangle backdrop, 50% black.
+    radius = height // 2
+    draw.rounded_rectangle(
+        [(0, 0), (width - 1, height - 1)],
+        radius=radius,
+        fill=(0, 0, 0, 140),
+    )
+
+    # Text — pick the largest font size that fits horizontally.
+    font_path = _find_font()
+    font = None
+    for size in range(22, 12, -1):
+        try:
+            candidate = ImageFont.truetype(font_path, size)
+        except (IOError, OSError):
+            continue
+        bbox = candidate.getbbox(_BRAND_PILL_TEXT)
+        if bbox[2] - bbox[0] <= width - 32:
+            font = candidate
+            break
+    if font is None:
+        font = ImageFont.load_default()
+
+    bbox = font.getbbox(_BRAND_PILL_TEXT)
+    text_w = bbox[2] - bbox[0]
+    text_h = bbox[3] - bbox[1]
+    x = (width - text_w) // 2 - bbox[0]
+    y = (height - text_h) // 2 - bbox[1]
+    draw.text((x, y), _BRAND_PILL_TEXT, font=font, fill=(255, 255, 255, 235))
+
+    img.save(output_path, "PNG")
+    return output_path
+
+
+# ---------------------------------------------------------------------------
+# Filter graphs
 # ---------------------------------------------------------------------------
 
 def _long_form_filter_graph(width: int = 1920, height: int = 1080,
                             fps: int = 30) -> str:
-    """Build the filter_complex graph for a horizontal long-form video.
+    """filter_complex graph for the 1920x1080 long-form build.
 
-    The graph composites three layers:
+    Inputs (assumed by ``_long_form_cmd``):
 
-      1. The cover image, scaled to *cover* the 1920x1080 frame (no
-         letterboxing) and given a fixed SAR so YouTube doesn't re-encode.
-      2. A semi-transparent animated waveform spanning the full width,
-         180 px tall, anchored 60 px above the bottom edge.
-      3. The original audio passed through unchanged.
+      ``[0:v]``  show cover, looped at ``fps``
+      ``[1:a]``  episode audio
+      ``[2:v]``  brand pill PNG, looped
 
-    Returns
-    -------
-    str
-        The filter_complex string with three named outputs: ``[bg]``,
-        ``[wave]``, ``[v]``.
+    Outputs ``[v]`` for video mapping.
     """
+    # Visualization band sits along the bottom 25% of the frame.
+    viz_h = height // 4
+    viz_y = height - viz_h
+    # Slow Ken Burns: 0.000004/frame → 1.08 cap reaches at ~6000 frames
+    # (200s @30fps), then clamps. Subtle on shorter episodes, satisfying
+    # on hour-long ones.
+    zoom_expr = "min(zoom+0.000004,1.08)"
+    # Pre-scale before zoompan so we don't zoom into pixelated source —
+    # 1.15× the target dims is enough headroom for the 1.08 zoom cap.
+    pre_w = int(width * 1.15)
+    pre_h = int(height * 1.15)
+
+    disclosure = _drawtext_escape("AI-narrated content · Editorial by Nerra Network")
+    font_path = _drawtext_escape(_find_font())
+
     return (
-        f"[0:v]scale={width}:{height}:force_original_aspect_ratio=increase,"
-        f"crop={width}:{height},setsar=1,format=yuv420p[bg];"
-        f"[1:a]showwaves=s={width}x180:mode=cline:colors=0xFFFFFF:rate={fps},"
-        f"format=yuva420p,colorchannelmixer=aa=0.7[wave];"
-        f"[bg][wave]overlay=x=0:y=H-h-60:format=auto[v]"
+        f"[0:v]"
+        f"scale={pre_w}:{pre_h}:force_original_aspect_ratio=increase,"
+        f"crop={pre_w}:{pre_h},setsar=1,"
+        f"zoompan=z='{zoom_expr}':d=1:s={width}x{height}:fps={fps}"
+        f"[bg];"
+        f"[bg]drawbox=x=0:y={viz_y}:w={width}:h={viz_h}:color=black@0.25:t=fill[bg2];"
+        f"[1:a]showcqt=s={width}x{viz_h}:fps={fps}:basefreq=30:endfreq=18000:axis=0[viz];"
+        f"[bg2][viz]overlay=x=0:y={viz_y}:format=auto[bgviz];"
+        f"[2:v]format=rgba[brand];"
+        f"[bgviz][brand]overlay=x=24:y=24[branded];"
+        f"[branded]drawtext=fontfile='{font_path}':"
+        f"text='{disclosure}':"
+        f"fontsize=44:fontcolor=white:"
+        f"x=(w-text_w)/2:y=(h-text_h)/2:"
+        f"box=1:boxcolor=black@0.55:boxborderw=18:"
+        f"enable='between(t,0,4)':"
+        f"alpha='if(lt(t,3),1,if(lt(t,4),1-(t-3),0))'"
+        f"[v]"
     )
 
 
 def _short_form_filter_graph(width: int = 1080, height: int = 1920,
-                             fps: int = 30) -> str:
-    """Build the filter_complex graph for a 9:16 vertical Shorts video.
+                             fps: int = 30,
+                             hook: Optional[str] = None) -> str:
+    """filter_complex graph for the 1080x1920 Shorts build.
 
-    Scale-and-crop the cover to fill the vertical frame (square covers
-    end up centred), drop a 1080x300 waveform overlay at the vertical
-    midpoint, and pass audio through.
+    Inputs (assumed by ``_short_form_cmd``):
+
+      ``[0:v]``  show cover, looped at ``fps``
+      ``[1:a]``  audio (already clipped via input-side ``-ss``/``-t``)
+      ``[2:v]``  brand pill PNG, looped
+
+    Outputs ``[v]`` for video mapping.
+
+    When *hook* is provided, the headline is wrapped, escaped, and
+    burned in as a centered caption for the first 3s.
     """
-    wave_y = (height // 2) - 150  # 300/2 = 150 → centred vertically
-    return (
-        f"[0:v]scale={width}:{height}:force_original_aspect_ratio=increase,"
+    viz_h = height // 4 + 40  # 520 — slightly taller band reads better in vertical
+    viz_y = (height // 2) - (viz_h // 2)
+    font_path = _drawtext_escape(_find_font())
+
+    base = (
+        f"[0:v]"
+        f"scale={width}:{height}:force_original_aspect_ratio=increase,"
         f"crop={width}:{height},setsar=1,format=yuv420p[bg];"
-        f"[1:a]showwaves=s={width}x300:mode=cline:colors=0xFFFFFF:rate={fps},"
-        f"format=yuva420p,colorchannelmixer=aa=0.7[wave];"
-        f"[bg][wave]overlay=x=0:y={wave_y}:format=auto[v]"
+        f"[bg]drawbox=x=0:y={viz_y}:w={width}:h={viz_h}:color=black@0.25:t=fill[bg2];"
+        f"[1:a]showcqt=s={width}x{viz_h}:fps={fps}:basefreq=30:endfreq=18000:axis=0[viz];"
+        f"[bg2][viz]overlay=x=0:y={viz_y}:format=auto[bgviz];"
+        f"[2:v]format=rgba[brand];"
+        f"[bgviz][brand]overlay=x=W-w-24:y=24[branded]"
     )
+
+    if hook:
+        wrapped = _wrap_caption(hook)
+        escaped = _drawtext_escape(wrapped)
+        caption = (
+            f";[branded]drawtext=fontfile='{font_path}':"
+            f"text='{escaped}':"
+            f"fontsize=64:fontcolor=white:"
+            f"x=(w-text_w)/2:y=240:"
+            f"box=1:boxcolor=black@0.6:boxborderw=24:"
+            f"line_spacing=14:"
+            f"enable='between(t,0,3)'"
+            f"[v]"
+        )
+        return base + caption
+    return base + ";[branded]null[v]"
 
 
 # ---------------------------------------------------------------------------
 # Command builders
 # ---------------------------------------------------------------------------
 
-def _long_form_cmd(audio_in: str, cover_in: str, output: str,
-                   *, fps: int = 30) -> List[str]:
-    """Full ffmpeg command for the long-form 1920x1080 build."""
+def _long_form_cmd(audio_in: str, cover_in: str, brand_in: str,
+                   output: str, *, fps: int = 30) -> List[str]:
+    """Full ffmpeg command for the 1920x1080 long-form build."""
     return [
         "ffmpeg", "-y", "-threads", "0",
         "-loop", "1", "-framerate", str(fps), "-i", cover_in,
         "-i", audio_in,
+        "-loop", "1", "-framerate", str(fps), "-i", brand_in,
         "-filter_complex", _long_form_filter_graph(1920, 1080, fps),
         "-map", "[v]", "-map", "1:a",
         *_VIDEO_ENCODE,
@@ -123,10 +336,12 @@ def _long_form_cmd(audio_in: str, cover_in: str, output: str,
     ]
 
 
-def _short_form_cmd(audio_in: str, cover_in: str, output: str,
-                    *, start_offset: float = 0.0,
+def _short_form_cmd(audio_in: str, cover_in: str, brand_in: str,
+                    output: str, *,
+                    start_offset: float = 0.0,
                     duration: float = 55.0,
-                    fps: int = 30) -> List[str]:
+                    fps: int = 30,
+                    hook: Optional[str] = None) -> List[str]:
     """Full ffmpeg command for the 1080x1920 Shorts build.
 
     The audio input is clipped via ``-ss`` (input-side seek) before the
@@ -140,7 +355,8 @@ def _short_form_cmd(audio_in: str, cover_in: str, output: str,
         "-ss", f"{start_offset:.2f}",
         "-t", f"{duration:.2f}",
         "-i", audio_in,
-        "-filter_complex", _short_form_filter_graph(1080, 1920, fps),
+        "-loop", "1", "-framerate", str(fps), "-i", brand_in,
+        "-filter_complex", _short_form_filter_graph(1080, 1920, fps, hook),
         "-map", "[v]", "-map", "1:a",
         *_VIDEO_ENCODE,
         "-r", str(fps),
@@ -159,20 +375,21 @@ def build_long_form_video(audio_path: Path, cover_path: Path,
                           output_path: Path, *, fps: int = 30) -> Path:
     """Render a 1920x1080 long-form podcast video.
 
+    The brand pill PNG is generated once per work directory
+    (``output_path.parent / _brand_pill.png``) and reused on
+    subsequent calls.
+
     Parameters
     ----------
     audio_path:
-        Path to the final mixed episode MP3 (output of
-        :func:`engine.audio.mix_with_music`).
+        Path to the final mixed episode MP3.
     cover_path:
-        Path to the show's static cover image (typically the JPG under
-        ``assets/covers/``). Anything ffmpeg can decode works.
+        Path to the show's static cover image (under ``assets/covers/``).
     output_path:
         Where to write the MP4. Parent dir must exist.
     fps:
-        Frame rate for both the still video stream and the waveform
-        animation. 30 is the standard YouTube target; lower values
-        produce smaller files but choppier waveforms.
+        Frame rate for both the still video stream and the
+        visualization animation. 30 is the standard YouTube target.
 
     Returns
     -------
@@ -184,8 +401,11 @@ def build_long_form_video(audio_path: Path, cover_path: Path,
     if not cover_path.exists():
         raise FileNotFoundError(f"cover not found: {cover_path}")
 
+    brand_path = output_path.parent / "_brand_pill.png"
+    _make_brand_pill(brand_path)
+
     cmd = _long_form_cmd(str(audio_path), str(cover_path),
-                         str(output_path), fps=fps)
+                         str(brand_path), str(output_path), fps=fps)
     logger.info("Building long-form video → %s", output_path.name)
     subprocess.run(cmd, check=True, capture_output=True)
     return output_path
@@ -195,28 +415,34 @@ def build_short_video(audio_path: Path, cover_path: Path,
                       output_path: Path, *,
                       start_offset: float = 0.0,
                       duration: float = 55.0,
-                      fps: int = 30) -> Path:
+                      fps: int = 30,
+                      hook: Optional[str] = None) -> Path:
     """Render a 1080x1920 vertical YouTube Shorts video.
 
     Parameters
     ----------
     audio_path:
-        Path to the source audio (usually the same final mixed episode
-        MP3 used for long-form). Only the slice from *start_offset* to
+        Source audio (usually the same final mixed episode MP3 used
+        for long-form). Only the slice from *start_offset* to
         *start_offset + duration* is included.
     cover_path:
         Path to the show's cover image (filled, then cropped to vertical).
     output_path:
         Where to write the MP4.
     start_offset:
-        Seconds into the audio where the Short should start. Set to
-        ``audio.intro_duration + audio.voice_intro_delay`` so we skip
-        the music intro and start on voice.
+        Seconds into the audio where the Short should start. Pass
+        ``audio.intro_duration + audio.voice_intro_delay`` so the clip
+        skips music intro and starts on voice.
     duration:
         Length of the short clip in seconds. **Must stay below 60** so
         YouTube classifies the upload as a Short.
     fps:
         Frame rate; same caveats as the long-form builder.
+    hook:
+        Optional one-line headline. When provided, it's wrapped and
+        burned in as a centered caption for the first 3s — gives the
+        scrolling Shorts viewer a topic preview before they decide to
+        stay.
 
     Returns
     -------
@@ -232,10 +458,15 @@ def build_short_video(audio_path: Path, cover_path: Path,
     if not cover_path.exists():
         raise FileNotFoundError(f"cover not found: {cover_path}")
 
-    cmd = _short_form_cmd(str(audio_path), str(cover_path),
-                          str(output_path),
-                          start_offset=start_offset,
-                          duration=duration, fps=fps)
+    brand_path = output_path.parent / "_brand_pill.png"
+    _make_brand_pill(brand_path)
+
+    cmd = _short_form_cmd(
+        str(audio_path), str(cover_path), str(brand_path),
+        str(output_path),
+        start_offset=start_offset,
+        duration=duration, fps=fps, hook=hook,
+    )
     logger.info(
         "Building Shorts video (%.1fs from %.1fs) → %s",
         duration, start_offset, output_path.name,

--- a/run_show.py
+++ b/run_show.py
@@ -2430,6 +2430,7 @@ def _publish_youtube(
                 final_mp3, cover_path, short_video_path,
                 start_offset=short_offset,
                 duration=duration,
+                hook=hook or None,
             )
             meta = build_short_metadata(
                 config,

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -2,43 +2,117 @@
 
 We don't actually run ffmpeg — we just verify the command lists. Same
 pattern as :mod:`tests.test_audio_commands`. These act as a regression
-fence: any future tweak to the long-form or Shorts video pipeline will
-trip these tests, forcing the change to be intentional.
+fence: any future tweak to the long-form or Shorts video pipeline
+will trip these tests, forcing the change to be intentional.
+
+The tests also pin the keyframe-spacing args (``-g``, ``-keyint_min``,
+``-sc_threshold``, ``-force_key_frames``) — without those, the
+long-form MP4 has only one keyframe at t=0 and YouTube's transcoder
+serves an unplayable rendition.
 """
+
+from pathlib import Path
 
 import pytest
 
 from engine.video import (
     _AUDIO_ENCODE,
     _VIDEO_ENCODE,
+    _drawtext_escape,
     _long_form_cmd,
     _long_form_filter_graph,
+    _make_brand_pill,
     _short_form_cmd,
     _short_form_filter_graph,
+    _wrap_caption,
     build_long_form_video,
     build_short_video,
 )
 
 
 # ---------------------------------------------------------------------------
-# Filter graph shape
+# Encoder profile — keyframe args are the playback fix
 # ---------------------------------------------------------------------------
 
-def test_long_form_filter_graph_default_resolution():
+def test_video_encode_profile_includes_keyframe_args():
+    """``-g``, ``-keyint_min``, ``-sc_threshold`` and
+    ``-force_key_frames`` must all be present.
+
+    Without these, x264 sees the looped cover as one big static
+    scene, emits a single IDR at t=0, and YouTube's transcoder
+    rejects the rendition with "video can't play".
+    """
+    assert "-g" in _VIDEO_ENCODE
+    assert _VIDEO_ENCODE[_VIDEO_ENCODE.index("-g") + 1] == "60"
+    assert "-keyint_min" in _VIDEO_ENCODE
+    assert _VIDEO_ENCODE[_VIDEO_ENCODE.index("-keyint_min") + 1] == "60"
+    assert "-sc_threshold" in _VIDEO_ENCODE
+    assert _VIDEO_ENCODE[_VIDEO_ENCODE.index("-sc_threshold") + 1] == "0"
+    assert "-force_key_frames" in _VIDEO_ENCODE
+    fkf_value = _VIDEO_ENCODE[_VIDEO_ENCODE.index("-force_key_frames") + 1]
+    assert "expr:gte(t,n_forced*2)" in fkf_value
+
+
+# ---------------------------------------------------------------------------
+# Long-form filter graph — zoompan + showcqt + brand + disclosure
+# ---------------------------------------------------------------------------
+
+def test_long_form_filter_graph_uses_zoompan_and_showcqt():
     graph = _long_form_filter_graph()
-    assert "scale=1920:1080" in graph
-    assert "showwaves=s=1920x180" in graph
-    assert "[bg]" in graph and "[wave]" in graph and "[v]" in graph
-    # waveform overlay sits 60px above the bottom edge
-    assert "y=H-h-60" in graph
+    # Ken Burns zoom on the cover.
+    assert "zoompan" in graph
+    # Audio-reactive visualization (replaces the static-image
+    # showwaves of the original implementation).
+    assert "showcqt" in graph
+    # Brand pill is overlaid (third input).
+    assert "[2:v]" in graph and "format=rgba" in graph
+    # 25%-black tint band sits underneath the visualization.
+    assert "drawbox" in graph and "color=black@0.25" in graph
+    # First-4s AI-disclosure burn-in.
+    assert "drawtext" in graph
+    assert r"enable='between(t,0,4)'" in graph
+    assert "AI-narrated content" in graph
+    # Final output label is [v].
+    assert graph.endswith("[v]")
 
 
-def test_short_form_filter_graph_default_resolution():
+def test_long_form_filter_graph_respects_fps():
+    graph = _long_form_filter_graph(fps=24)
+    # Both the visualization and zoompan honour the requested fps.
+    assert "fps=24" in graph
+
+
+# ---------------------------------------------------------------------------
+# Short-form filter graph
+# ---------------------------------------------------------------------------
+
+def test_short_form_filter_graph_uses_showcqt_and_vertical_dims():
     graph = _short_form_filter_graph()
+    assert "showcqt" in graph
     assert "scale=1080:1920" in graph
-    assert "showwaves=s=1080x300" in graph
-    # 1920/2 - 150 = 810 — waveform centered vertically
-    assert "y=810" in graph
+    # Brand pill is anchored top-right (W-w-24).
+    assert "x=W-w-24:y=24" in graph
+    assert graph.endswith("[v]")
+
+
+def test_short_form_filter_graph_with_hook_burns_caption():
+    graph = _short_form_filter_graph(
+        hook="Tesla just unveiled a Virtual Queue for Superchargers."
+    )
+    assert "drawtext" in graph
+    # Hook caption shows for the first 3s only.
+    assert r"enable='between(t,0,3)'" in graph
+    # Some text from the hook appears (escaped) in the graph.
+    assert "Tesla" in graph
+    assert graph.endswith("[v]")
+
+
+def test_short_form_filter_graph_without_hook_omits_caption():
+    graph = _short_form_filter_graph(hook=None)
+    # No first-3s caption when hook isn't provided.
+    assert "between(t,0,3)" not in graph
+    # But the brand pill + visualization still produce the [v] output.
+    assert graph.endswith("[v]")
 
 
 # ---------------------------------------------------------------------------
@@ -46,24 +120,24 @@ def test_short_form_filter_graph_default_resolution():
 # ---------------------------------------------------------------------------
 
 def test_long_form_cmd_structure():
-    cmd = _long_form_cmd("voice.mp3", "cover.jpg", "out.mp4")
+    cmd = _long_form_cmd("voice.mp3", "cover.jpg", "brand.png", "out.mp4")
 
-    # Two inputs: looped cover image, then audio.
+    # Three inputs: cover (looped), audio, brand pill (looped).
     assert cmd[:2] == ["ffmpeg", "-y"]
-    assert "-loop" in cmd and cmd[cmd.index("-loop") + 1] == "1"
-    # Two -i flags for the two inputs
-    assert cmd.count("-i") == 2
-    # Filter graph is supplied via -filter_complex
+    assert cmd.count("-loop") == 2  # cover + brand
+    assert cmd.count("-i") == 3
+    # filter_complex contains all the new filters.
     fc_idx = cmd.index("-filter_complex")
     graph = cmd[fc_idx + 1]
-    assert "[bg][wave]overlay" in graph
-    # Map the composited video and the second input's audio
-    assert "-map" in cmd
+    assert "zoompan" in graph
+    assert "showcqt" in graph
+    assert "[bgviz][brand]overlay" in graph
+    # Map composited video and audio.
     map_indices = [i for i, x in enumerate(cmd) if x == "-map"]
     map_values = [cmd[i + 1] for i in map_indices]
     assert "[v]" in map_values
     assert "1:a" in map_values
-    # Encoding profile + faststart + shortest are present
+    # Encoding + container args present.
     for token in ("-shortest", "-movflags", "+faststart"):
         assert token in cmd
     for token in _VIDEO_ENCODE:
@@ -74,14 +148,15 @@ def test_long_form_cmd_structure():
 
 
 def test_long_form_cmd_respects_fps():
-    cmd = _long_form_cmd("voice.mp3", "cover.jpg", "out.mp4", fps=24)
-    # -framerate is set on the looped image input *before* -i
-    assert cmd[cmd.index("-framerate") + 1] == "24"
-    # -r controls the output frame rate
+    cmd = _long_form_cmd("voice.mp3", "cover.jpg", "brand.png",
+                         "out.mp4", fps=24)
+    # -framerate is set on each looped image input *before* its -i.
+    framerate_indices = [i for i, x in enumerate(cmd) if x == "-framerate"]
+    assert len(framerate_indices) == 2
+    for idx in framerate_indices:
+        assert cmd[idx + 1] == "24"
+    # -r controls the output frame rate.
     assert cmd[cmd.index("-r") + 1] == "24"
-    # Filter graph picks up the same fps for the waveform animation
-    graph = cmd[cmd.index("-filter_complex") + 1]
-    assert "rate=24" in graph
 
 
 # ---------------------------------------------------------------------------
@@ -90,25 +165,38 @@ def test_long_form_cmd_respects_fps():
 
 def test_short_form_cmd_clips_audio():
     cmd = _short_form_cmd(
-        "voice.mp3", "cover.jpg", "short.mp4",
+        "voice.mp3", "cover.jpg", "brand.png", "short.mp4",
         start_offset=15.0, duration=55.0,
     )
-    # -ss / -t are applied to the audio input (they appear AFTER the
-    # cover input's -i but BEFORE the audio input's -i).
+    # -ss / -t are applied to the audio input (between cover -i and audio -i).
     ss_idx = cmd.index("-ss")
     t_idx = cmd.index("-t")
     assert cmd[ss_idx + 1] == "15.00"
     assert cmd[t_idx + 1] == "55.00"
-    # Two -i flags: cover then audio.
+    # Three -i flags: cover, audio, brand.
     i_indices = [i for i, x in enumerate(cmd) if x == "-i"]
-    assert len(i_indices) == 2
+    assert len(i_indices) == 3
     # Audio input must come after -ss/-t.
     assert i_indices[1] > t_idx
-    # Filter graph references the vertical Shorts geometry.
+    # Two looped image inputs (cover + brand pill); audio is not looped.
+    assert cmd.count("-loop") == 2
+    # Filter graph references vertical Shorts geometry.
     graph = cmd[cmd.index("-filter_complex") + 1]
     assert "scale=1080:1920" in graph
-    assert "showwaves=s=1080x300" in graph
+    assert "showcqt" in graph
     assert cmd[-1] == "short.mp4"
+
+
+def test_short_form_cmd_threads_hook_into_filter_graph():
+    cmd = _short_form_cmd(
+        "voice.mp3", "cover.jpg", "brand.png", "short.mp4",
+        start_offset=10.0, duration=55.0,
+        hook="A short headline",
+    )
+    graph = cmd[cmd.index("-filter_complex") + 1]
+    assert "drawtext" in graph
+    assert "A short headline" in graph
+    assert r"enable='between(t,0,3)'" in graph
 
 
 def test_short_form_rejects_60s_duration(tmp_path):
@@ -122,7 +210,8 @@ def test_short_form_rejects_60s_duration(tmp_path):
 
 
 def test_short_form_accepts_under_60s(tmp_path, monkeypatch):
-    """Shorts under 60s should pass validation; we don't actually run ffmpeg."""
+    """Shorts under 60s pass validation. We don't run ffmpeg — we
+    capture the command and assert its shape."""
     audio = tmp_path / "voice.mp3"
     audio.write_bytes(b"\x00")
     cover = tmp_path / "cover.jpg"
@@ -139,9 +228,13 @@ def test_short_form_accepts_under_60s(tmp_path, monkeypatch):
         return _R()
 
     monkeypatch.setattr("engine.video.subprocess.run", fake_run)
-    build_short_video(audio, cover, out, duration=55.0, start_offset=10.0)
+    build_short_video(audio, cover, out, duration=55.0,
+                      start_offset=10.0, hook="Test headline")
     assert captured["cmd"][0] == "ffmpeg"
     assert "55.00" in captured["cmd"]
+    # Brand pill PNG should have been generated alongside the output.
+    brand_pill = out.parent / "_brand_pill.png"
+    assert brand_pill.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -152,11 +245,88 @@ def test_build_long_form_video_requires_audio(tmp_path):
     cover = tmp_path / "cover.jpg"
     cover.write_bytes(b"\x00")
     with pytest.raises(FileNotFoundError, match="audio not found"):
-        build_long_form_video(tmp_path / "missing.mp3", cover, tmp_path / "out.mp4")
+        build_long_form_video(tmp_path / "missing.mp3", cover,
+                              tmp_path / "out.mp4")
 
 
 def test_build_long_form_video_requires_cover(tmp_path):
     audio = tmp_path / "voice.mp3"
     audio.write_bytes(b"\x00")
     with pytest.raises(FileNotFoundError, match="cover not found"):
-        build_long_form_video(audio, tmp_path / "missing.jpg", tmp_path / "out.mp4")
+        build_long_form_video(audio, tmp_path / "missing.jpg",
+                              tmp_path / "out.mp4")
+
+
+# ---------------------------------------------------------------------------
+# Brand pill PNG generation
+# ---------------------------------------------------------------------------
+
+def test_make_brand_pill_creates_png(tmp_path):
+    target = tmp_path / "_brand_pill.png"
+    assert not target.exists()
+    result = _make_brand_pill(target)
+    assert result == target
+    assert target.exists()
+    # Sanity: PNG signature is 8 bytes \x89PNG\r\n\x1a\n.
+    with open(target, "rb") as f:
+        assert f.read(8) == b"\x89PNG\r\n\x1a\n"
+
+
+def test_make_brand_pill_is_idempotent(tmp_path):
+    """Second call should reuse the cached file (not rewrite it)."""
+    target = tmp_path / "_brand_pill.png"
+    _make_brand_pill(target)
+    first_mtime = target.stat().st_mtime_ns
+    # Touch a marker so we'd notice if Pillow re-wrote.
+    second = _make_brand_pill(target)
+    assert second == target
+    assert target.stat().st_mtime_ns == first_mtime
+
+
+def test_build_long_form_video_generates_brand_pill(tmp_path, monkeypatch):
+    """``build_long_form_video`` should generate the brand pill on
+    first call so the ffmpeg command can reference it."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\x00")
+    out = tmp_path / "out.mp4"
+
+    monkeypatch.setattr("engine.video.subprocess.run",
+                        lambda cmd, **kwargs: type("R", (), {"returncode": 0})())
+    build_long_form_video(audio, cover, out)
+    assert (out.parent / "_brand_pill.png").exists()
+
+
+# ---------------------------------------------------------------------------
+# drawtext escaping
+# ---------------------------------------------------------------------------
+
+def test_drawtext_escape_handles_metacharacters():
+    # Colons are option separators; backslashes, single quotes, and
+    # percent signs are drawtext metachars.
+    assert _drawtext_escape("It's 5:30 PM (50% off)") == \
+        r"It\'s 5\:30 PM (50\% off)"
+    assert _drawtext_escape("path\\to") == "path\\\\to"
+
+
+# ---------------------------------------------------------------------------
+# Caption wrapping for Shorts
+# ---------------------------------------------------------------------------
+
+def test_wrap_caption_breaks_long_text():
+    out = _wrap_caption(
+        "Tesla just unveiled a Virtual Queue for Superchargers.",
+        max_chars_per_line=22,
+    )
+    lines = out.split("\n")
+    assert all(len(line) <= 26 for line in lines)  # small slack for greedy wrap
+    assert len(lines) <= 3
+
+
+def test_wrap_caption_short_text_unchanged():
+    assert _wrap_caption("Short headline.") == "Short headline."
+
+
+def test_wrap_caption_empty_returns_empty():
+    assert _wrap_caption("") == ""


### PR DESCRIPTION
## Summary

The first end-to-end YouTube run (Tesla ep452) uploaded successfully but YouTube served the long-form with "video can't play". Shorts played fine. Root cause: x264 saw the looped static cover as one big static scene and emitted a single IDR at t=0 for the whole 9-minute video — YouTube's transcoder either rejected the rendition or produced a stream the HTML5 player couldn't seek into. The Shorts file (55s) was short enough that the t=0 keyframe stayed in the initial buffer, so it played fine.

## Fix

Force a keyframe every 2s via `-g 60 -keyint_min 60 -sc_threshold 0 -force_key_frames "expr:gte(t,n_forced*2)"` applied to both formats. Belt-and-suspenders so the encoder can't elide IDRs even if rate control wants to.

## Visual upgrade (one recipe, all 10 shows)

While rebuilding the pipeline, replaced the static-cover + `showwaves` approach with one that has actual motion:

- **Cover** gets a slow Ken Burns zoom (1.00 → 1.08 over the audio) via `zoompan` on long-form. Shorts stay static — 55s of zoom on mobile is jarring.
- **`showcqt`** (constant-Q transform) replaces `showwaves` — the colorful music-bar visualization you see on Lofi Girl / Spotify Canvas. Sits in a 25%-black tint band so it reads against any cover.
- **Brand pill PNG** rendered once per work-dir with Pillow (cached + idempotent). Says "Nerra Network · AI-narrated", top-left on long-form, top-right on Shorts.
- **Long-form** fades a centered "AI-narrated content · Editorial by Nerra Network" line for the first 4s as a UX hint. The persistent disclosure stays in the description footer + `containsSyntheticMedia` API flag.
- **Shorts** burn the hook headline as a centered caption for the first 3s when one is provided — gives the scrolling viewer a topic preview.

`build_short_video` gains an optional `hook` kwarg (default `None` preserves existing behaviour). `run_show.py:_publish_youtube` threads the existing `hook` variable through.

## Acceptance criteria

1. ✅ `pytest tests/test_video_commands.py` — 21/21 pass
2. ⏭️ Local ffmpeg verification skipped (ffmpeg not installed in dev env)
3. ⏭️ Hook caption + spectrum visible — verified by tests asserting `drawtext` + `showcqt` in filter graphs; visual check happens on the next manual workflow trigger
4. ⏳ Tesla long-form plays back fully on YouTube — to be verified by next manual workflow trigger
5. ⏳ Same recipe works for `fascinating_frontiers` — verifiable via that show's next workflow run

## Test plan

- [x] `pytest tests/test_video_commands.py tests/test_youtube.py` — 40 pass
- [x] Full `pytest` suite — 1,140 passed, 3 skipped, no regressions
- [x] `ruff check engine/ run_show.py tests/test_video_commands.py --select=E9,F63,F7,F82` — clean
- [ ] **Operator (manual)**: trigger `tesla` workflow from Actions UI, confirm new long-form plays through on YouTube without "video can't play". Same for `fascinating_frontiers`.

## Out of scope

- Custom thumbnail upload (the 403 is a YouTube account-gating issue, not our code)
- Per-show visualization customization
- Subtitle/transcript burn-in beyond the first 3-4s hint
- Audio-reactive cover transforms (`showcqt` already provides the audio-reactive visual)

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_