### PR TITLE
Add burned-in captions + Pexels slideshow to YouTube long-form

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -293,6 +293,10 @@ jobs:
           YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
           YOUTUBE_REFRESH_TOKEN_EN: ${{ secrets.YOUTUBE_REFRESH_TOKEN_EN }}
           YOUTUBE_REFRESH_TOKEN_RU: ${{ secrets.YOUTUBE_REFRESH_TOKEN_RU }}
+          # Pexels: backs the long-form video slideshow (royalty-free
+          # photos keyed off each show's keywords). Missing → falls back
+          # to single-cover Ken Burns. Free tier covers our usage.
+          PEXELS_API_KEY: ${{ secrets.PEXELS_API_KEY }}
           PIPELINE_TIMEOUT_SECONDS: '2400'
 
       - name: Validate output

--- a/engine/captions.py
+++ b/engine/captions.py
@@ -1,0 +1,166 @@
+"""Convert faster-whisper transcript JSON into SRT subtitles.
+
+Used by the YouTube long-form pipeline to burn the spoken dialogue
+into the video as on-screen captions. We already produce the
+transcript JSON post-TTS for Podcasting 2.0 ``<podcast:transcript>``
+RSS support, so generating SRT is just a format conversion.
+
+Transcript JSON shape (faster-whisper output)::
+
+    {
+      "language": "en",
+      "duration": 397.28,
+      "segments": [
+        {"start": 0.0, "end": 1.46, "text": "...", "words": [...]},
+        ...
+      ]
+    }
+
+We only need ``segments[]`` — the per-word timing is finer-grained
+than YouTube viewers can usefully read, and segment-level captions
+match how YouTube's own auto-captions are paced (~5–10 s per cue).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _format_srt_timestamp(seconds: float) -> str:
+    """Format seconds as ``HH:MM:SS,mmm`` per the SRT spec."""
+    if seconds < 0:
+        seconds = 0.0
+    total_ms = int(round(seconds * 1000))
+    hours, rem_ms = divmod(total_ms, 3_600_000)
+    minutes, rem_ms = divmod(rem_ms, 60_000)
+    secs, ms = divmod(rem_ms, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d},{ms:03d}"
+
+
+def _wrap_caption_line(text: str, max_chars: int = 42) -> str:
+    """Greedy word-wrap so each caption stays at ≤2 lines.
+
+    SRT renders blank lines as cue terminators, so we use ``\\n``
+    between lines within a single cue. 42 chars per line at ~30pt
+    sits inside a 1920-wide frame with margins.
+    """
+    text = " ".join(text.split())
+    if len(text) <= max_chars:
+        return text
+    words = text.split()
+    lines: List[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if len(candidate) <= max_chars or not current:
+            current = candidate
+        else:
+            lines.append(current)
+            current = word
+            if len(lines) >= 2:
+                # Trailing words go in the second line — let it overflow
+                # rather than truncate; the caption renderer can clip
+                # gracefully but a missing word reads as a transcription
+                # error.
+                rest = [current] + [w for w in words[words.index(word) + 1:]]
+                lines[-1] = " ".join(rest)
+                return "\n".join(lines)
+    if current:
+        lines.append(current)
+    return "\n".join(lines)
+
+
+def transcript_to_srt(transcript_path: Path, srt_path: Path,
+                      *, min_segment_duration: float = 0.4) -> Path:
+    """Convert a faster-whisper transcript JSON into SRT subtitles.
+
+    Parameters
+    ----------
+    transcript_path:
+        Path to the JSON written by ``engine.transcripts``.
+    srt_path:
+        Where to write the ``.srt``.
+    min_segment_duration:
+        Skip cues shorter than this many seconds. Whisper sometimes
+        emits sub-100ms artifacts for breath/punctuation that flicker
+        on screen.
+
+    Returns
+    -------
+    Path
+        ``srt_path`` on success.
+    """
+    if not transcript_path.exists():
+        raise FileNotFoundError(f"transcript not found: {transcript_path}")
+
+    data = json.loads(transcript_path.read_text(encoding="utf-8"))
+    segments = data.get("segments") or []
+    if not isinstance(segments, list):
+        raise ValueError(
+            f"transcript JSON {transcript_path} has no 'segments' list"
+        )
+
+    srt_path.parent.mkdir(parents=True, exist_ok=True)
+    cues: List[str] = []
+    cue_index = 1
+    for seg in segments:
+        if not isinstance(seg, dict):
+            continue
+        start = seg.get("start")
+        end = seg.get("end")
+        text = (seg.get("text") or "").strip()
+        if start is None or end is None or not text:
+            continue
+        try:
+            start_f = float(start)
+            end_f = float(end)
+        except (TypeError, ValueError):
+            continue
+        if end_f - start_f < min_segment_duration:
+            continue
+        wrapped = _wrap_caption_line(text)
+        cues.append(
+            f"{cue_index}\n"
+            f"{_format_srt_timestamp(start_f)} --> "
+            f"{_format_srt_timestamp(end_f)}\n"
+            f"{wrapped}\n"
+        )
+        cue_index += 1
+
+    if not cues:
+        logger.warning(
+            "Transcript %s produced no usable cues — caption file will be empty",
+            transcript_path,
+        )
+
+    # SRT files use \n line breaks but cues are separated by a blank line.
+    srt_path.write_text("\n".join(cues), encoding="utf-8")
+    logger.info("Wrote %d caption cues → %s", len(cues), srt_path.name)
+    return srt_path
+
+
+def find_transcript_for_episode(digests_dir: Path,
+                                episode_prefix: str,
+                                episode_num: int,
+                                date_str: str) -> Optional[Path]:
+    """Locate the transcript JSON written by the TTS stage.
+
+    The pipeline writes
+    ``digests/<slug>/<prefix>_Ep{NNN}_{YYYYMMDD}_transcript.json``;
+    this helper builds the path and returns it if the file exists,
+    or ``None`` if it doesn't (caller decides whether to skip
+    captions or fail).
+    """
+    candidate = digests_dir / (
+        f"{episode_prefix}_Ep{episode_num:03d}_{date_str}_transcript.json"
+    )
+    if candidate.exists():
+        return candidate
+    logger.info("No transcript JSON at %s — captions will be skipped",
+                candidate)
+    return None

--- a/engine/video.py
+++ b/engine/video.py
@@ -1,35 +1,29 @@
 """Video assembly helpers for the YouTube publishing pipeline.
 
-Two builders share one visual recipe so every show looks like part of
-the same network without per-show artwork. The recipe:
+Two builders share one visual recipe so every show looks like part
+of the same network without per-show artwork:
 
-  - **Background**: the show cover image, scaled-and-cropped to fill
-    the frame; long-form gets a slow Ken Burns zoom (1.00 → 1.08 over
-    the audio), Shorts stay static (55s of zoom looks frenetic on
-    mobile).
-  - **Tint band**: 25% black overlay sits underneath the visualization
-    so it reads against any cover.
-  - **Visualization**: ``showcqt`` (constant-Q transform) burned in —
-    the colorful music-bar look you see on Lofi Girl / Spotify Canvas.
-    Inherently dynamic frame-by-frame, audio-reactive, and works for
-    speech and music alike.
-  - **Brand pill**: a small ``Nerra Network · AI-narrated`` pill PNG
-    (rendered once with Pillow per work-dir, then reused) overlaid
-    top-left on long-form / top-right on Shorts.
+  - **Background**: either the show cover (single Ken Burns image) or
+    a pre-rendered slideshow MP4 of Pexels photos cycling every ~12 s.
+    Slideshow uses :mod:`engine.visual_assets`; without
+    ``PEXELS_API_KEY`` we silently fall back to the static cover.
+  - **Tint band**: 25% black overlay underneath the visualization so
+    it reads against any cover.
+  - **Visualization**: ``showcqt`` (constant-Q transform) — the
+    colorful music-bar look. Audio-reactive, frame-by-frame motion.
+  - **Brand pill**: ``Nerra Network · AI-narrated`` PNG (rendered
+    once with Pillow). Top-left long-form, top-right Shorts.
   - **First-seconds burn-in**: long-form fades in/out a centered
-    "AI-narrated content · Editorial by Nerra Network" line for the
-    first 4s. Shorts (when given a hook headline) burn the headline
-    for the first 3s so the scrolling viewer sees the topic before
-    deciding to stay.
+    AI-disclosure line for the first 4 s. Shorts (with a hook) burn
+    the headline for the first 3 s.
+  - **Captions** (long-form only): when a transcript SRT is supplied,
+    ffmpeg's ``subtitles`` filter burns synchronized captions in a
+    semi-transparent band sitting just above the spectrum.
 
 The encoder profile uses ``-g 60 -keyint_min 60 -sc_threshold 0
--force_key_frames`` to force a keyframe every 2s. Without this, x264
-sees redundant input frames and produces a single keyframe at t=0,
-which made YouTube's transcoder reject the long-form rendition.
-
-The command builders are pure functions (no subprocess) so unit tests
-in ``tests/test_video_commands.py`` can inspect them without a real
-ffmpeg install.
+-force_key_frames`` to force a keyframe every 2 s; without this,
+x264 produced a single IDR at t=0 and YouTube's transcoder rejected
+the rendition with "video can't play".
 """
 
 from __future__ import annotations
@@ -37,7 +31,7 @@ from __future__ import annotations
 import logging
 import subprocess
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -46,14 +40,6 @@ logger = logging.getLogger(__name__)
 # Encoding profile
 # ---------------------------------------------------------------------------
 
-# libx264 + yuv420p + faststart is what YouTube wants for instant
-# playback (moov atom before mdat). The keyframe args below are what
-# fixes the original "video can't play" bug — without them, x264 sees
-# the looped cover input as one big static scene and emits a single
-# IDR at t=0, producing an MP4 the YouTube transcoder either rejects
-# or serves as un-seekable. Forcing a keyframe every 2s is cheap (the
-# zoompan + showcqt motion gives x264 actual change to compress) and
-# matches what handbrake/Handbrake-Web defaults use for streaming.
 _VIDEO_ENCODE: List[str] = [
     "-c:v", "libx264",
     "-pix_fmt", "yuv420p",
@@ -79,9 +65,6 @@ _AUDIO_ENCODE: List[str] = [
 # Font + drawtext helpers
 # ---------------------------------------------------------------------------
 
-# DejaVu ships on Ubuntu / GitHub Actions runners and includes glyphs
-# for the en-dot, em-dash, and Cyrillic so it works for English and
-# Russian shows alike.
 _FONT_CANDIDATES = (
     "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
     "/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf",
@@ -91,14 +74,7 @@ _FONT_CANDIDATES = (
 
 
 def _find_font() -> str:
-    """Return the path of an installed bold sans-serif font.
-
-    Falls through a list of common platform paths. If none exist we
-    return the first candidate anyway — ffmpeg will fail loudly with
-    ``Cannot find a valid font for the specified font`` and the caller
-    sees the error in logs (better than silently rendering with no
-    glyphs).
-    """
+    """Return the path of an installed bold sans-serif font."""
     for candidate in _FONT_CANDIDATES:
         if Path(candidate).exists():
             return candidate
@@ -106,13 +82,7 @@ def _find_font() -> str:
 
 
 def _drawtext_escape(value: str) -> str:
-    """Escape a string for ffmpeg's ``drawtext text=...`` value.
-
-    drawtext uses ``:`` to separate options and ``\\`` / ``'`` /
-    ``%`` as metacharacters inside the text value. This minimal escape
-    is what ffmpeg's documented examples use — robust enough for
-    arbitrary news-headline content.
-    """
+    """Escape a string for ffmpeg ``drawtext text=`` value."""
     return (
         value.replace("\\", "\\\\")
              .replace(":", r"\:")
@@ -121,14 +91,24 @@ def _drawtext_escape(value: str) -> str:
     )
 
 
+def _subtitles_path_escape(p: str) -> str:
+    """Escape a path for use inside the ffmpeg ``subtitles`` filter.
+
+    ``subtitles`` uses ``:`` as its option separator, so any colons
+    in the path (notably the C: drive on Windows or any odd Linux
+    paths) need backslash escaping. Single quotes are wrapped at the
+    surrounding ``'…'`` so we escape those too.
+    """
+    return (
+        p.replace("\\", "/")
+         .replace(":", r"\:")
+         .replace("'", r"\'")
+    )
+
+
 def _wrap_caption(text: str, max_chars_per_line: int = 22,
                   max_lines: int = 3) -> str:
-    """Greedy word-wrap for a Shorts caption, capped at *max_lines*.
-
-    drawtext supports ``\\n`` literal in the text value to break lines,
-    so we just join with that. Truncates with an ellipsis if the
-    message exceeds the line cap.
-    """
+    """Greedy word-wrap for a Shorts caption, capped at *max_lines*."""
     if not text:
         return ""
     words = text.split()
@@ -146,7 +126,6 @@ def _wrap_caption(text: str, max_chars_per_line: int = 22,
     if current and len(lines) < max_lines:
         lines.append(current)
     if len(lines) >= max_lines and len(" ".join(lines).split()) < len(words):
-        # Truncated mid-sentence — add ellipsis to the last line.
         last = lines[-1]
         if not last.endswith("..."):
             lines[-1] = (last[: max_chars_per_line - 3].rstrip() + "...") \
@@ -163,12 +142,7 @@ _BRAND_PILL_TEXT = "Nerra Network · AI-narrated"
 
 def _make_brand_pill(output_path: Path,
                      *, width: int = 320, height: int = 60) -> Path:
-    """Render the network brand pill as an RGBA PNG.
-
-    Idempotent: if *output_path* already exists, returns it without
-    re-rendering. Output is a transparent-background PNG with a
-    rounded-rect 50% black backdrop and the brand text centered.
-    """
+    """Render the network brand pill as an RGBA PNG. Idempotent."""
     if output_path.exists():
         return output_path
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -178,7 +152,6 @@ def _make_brand_pill(output_path: Path,
     img = Image.new("RGBA", (width, height), (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
 
-    # Rounded rectangle backdrop, 50% black.
     radius = height // 2
     draw.rounded_rectangle(
         [(0, 0), (width - 1, height - 1)],
@@ -186,7 +159,6 @@ def _make_brand_pill(output_path: Path,
         fill=(0, 0, 0, 140),
     )
 
-    # Text — pick the largest font size that fits horizontally.
     font_path = _find_font()
     font = None
     for size in range(22, 12, -1):
@@ -213,44 +185,153 @@ def _make_brand_pill(output_path: Path,
 
 
 # ---------------------------------------------------------------------------
-# Filter graphs
+# Slideshow renderer (stage 1)
 # ---------------------------------------------------------------------------
 
-def _long_form_filter_graph(width: int = 1920, height: int = 1080,
+# Each photo holds for ~12 s — long enough to read the spectrum + caption
+# but short enough that the long-form keeps moving. Slideshow loops in
+# stage 2 so we don't need to scale the photo count to audio length.
+_SCENE_DURATION_SECONDS = 12.0
+
+
+def _slideshow_filter_graph(scene_count: int, *,
+                            scene_duration: float = _SCENE_DURATION_SECONDS,
+                            width: int = 1920, height: int = 1080,
                             fps: int = 30) -> str:
-    """filter_complex graph for the 1920x1080 long-form build.
+    """Build the filter_complex for a Ken Burns slideshow with hard cuts.
 
-    Inputs (assumed by ``_long_form_cmd``):
-
-      ``[0:v]``  show cover, looped at ``fps``
-      ``[1:a]``  episode audio
-      ``[2:v]``  brand pill PNG, looped
-
-    Outputs ``[v]`` for video mapping.
+    Each scene gets a 1.00 → 1.12 zoom over its window. Hard cuts
+    between scenes (no crossfade) — the spectrum + brand pill + caption
+    motion in stage 2 hides any visual jump.
     """
-    # Visualization band sits along the bottom 25% of the frame.
-    viz_h = height // 4
-    viz_y = height - viz_h
-    # Slow Ken Burns: 0.000004/frame → 1.08 cap reaches at ~6000 frames
-    # (200s @30fps), then clamps. Subtle on shorter episodes, satisfying
-    # on hour-long ones.
-    zoom_expr = "min(zoom+0.000004,1.08)"
-    # Pre-scale before zoompan so we don't zoom into pixelated source —
-    # 1.15× the target dims is enough headroom for the 1.08 zoom cap.
     pre_w = int(width * 1.15)
     pre_h = int(height * 1.15)
+    zoom_expr = "min(zoom+0.0006,1.12)"
+    frames_per_scene = int(scene_duration * fps)
 
-    disclosure = _drawtext_escape("AI-narrated content · Editorial by Nerra Network")
+    chains: List[str] = []
+    for i in range(scene_count):
+        chains.append(
+            f"[{i}:v]"
+            f"scale={pre_w}:{pre_h}:force_original_aspect_ratio=increase,"
+            f"crop={pre_w}:{pre_h},setsar=1,"
+            f"zoompan=z='{zoom_expr}':d={frames_per_scene}"
+            f":s={width}x{height}:fps={fps},"
+            f"trim=duration={scene_duration:.2f},setpts=PTS-STARTPTS"
+            f"[s{i}]"
+        )
+    concat_in = "".join(f"[s{i}]" for i in range(scene_count))
+    chains.append(f"{concat_in}concat=n={scene_count}:v=1:a=0[v]")
+    return ";".join(chains)
+
+
+def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
+                   *, scene_duration: float = _SCENE_DURATION_SECONDS,
+                   fps: int = 30) -> List[str]:
+    """ffmpeg command for stage 1 (slideshow render)."""
+    inputs: List[str] = []
+    for path in scene_paths:
+        inputs.extend([
+            "-loop", "1",
+            "-framerate", str(fps),
+            "-t", f"{scene_duration + 0.5:.2f}",
+            "-i", str(path),
+        ])
+    return [
+        "ffmpeg", "-y", "-threads", "0",
+        *inputs,
+        "-filter_complex",
+        _slideshow_filter_graph(len(scene_paths),
+                                scene_duration=scene_duration, fps=fps),
+        "-map", "[v]",
+        "-r", str(fps),
+        *_VIDEO_ENCODE,
+        "-an",
+        "-movflags", "+faststart",
+        str(output),
+    ]
+
+
+def _render_slideshow(scene_paths: Sequence[Path], output: Path,
+                      *, fps: int = 30) -> Path:
+    """Render the stage-1 slideshow MP4. Idempotent (skips if output exists)."""
+    if output.exists():
+        return output
+    cmd = _slideshow_cmd(scene_paths, output, fps=fps)
+    logger.info("Rendering slideshow (%d scenes) → %s",
+                len(scene_paths), output.name)
+    subprocess.run(cmd, check=True, capture_output=True)
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Long-form filter graph (stage 2)
+# ---------------------------------------------------------------------------
+
+# Force-style for the burn-in subtitles. ASS color format is &HAABBGGRR
+# (alpha is "100 minus opacity" — 0 is opaque, 255 is transparent).
+# BorderStyle=3 = opaque box behind the text. MarginV=350 lifts the
+# subtitle baseline above the spectrum band.
+_SUBTITLES_FORCE_STYLE = (
+    "FontName=DejaVu Sans,"
+    "FontSize=22,"
+    "PrimaryColour=&H00FFFFFF,"
+    "OutlineColour=&H00000000,"
+    "BackColour=&HA0000000,"
+    "BorderStyle=3,"
+    "Outline=4,"
+    "Shadow=0,"
+    "Alignment=2,"
+    "MarginV=320"
+)
+
+
+def _long_form_filter_graph(*, width: int = 1920, height: int = 1080,
+                            fps: int = 30,
+                            bg_is_video: bool = False,
+                            subtitles_path: Optional[str] = None) -> str:
+    """filter_complex for stage 2.
+
+    Inputs:
+      ``[0:v]`` — background. Either looped cover image (Ken Burns
+      applied here) or pre-rendered slideshow MP4 (zoom already
+      baked in; we just scale to fill).
+      ``[1:a]`` — episode audio.
+      ``[2:v]`` — brand pill PNG, looped.
+    """
+    viz_h = height // 4
+    viz_y = height - viz_h
+
+    if bg_is_video:
+        # Slideshow MP4 already has motion + zoom; just normalize to
+        # the target frame and fps.
+        bg_chain = (
+            f"[0:v]scale={width}:{height}:force_original_aspect_ratio=increase,"
+            f"crop={width}:{height},setsar=1,format=yuv420p[bg]"
+        )
+    else:
+        pre_w = int(width * 1.15)
+        pre_h = int(height * 1.15)
+        zoom_expr = "min(zoom+0.000004,1.08)"
+        bg_chain = (
+            f"[0:v]"
+            f"scale={pre_w}:{pre_h}:force_original_aspect_ratio=increase,"
+            f"crop={pre_w}:{pre_h},setsar=1,"
+            f"zoompan=z='{zoom_expr}':d=1:s={width}x{height}:fps={fps}"
+            f"[bg]"
+        )
+
+    disclosure = _drawtext_escape(
+        "AI-narrated content · Editorial by Nerra Network"
+    )
     font_path = _drawtext_escape(_find_font())
 
-    return (
-        f"[0:v]"
-        f"scale={pre_w}:{pre_h}:force_original_aspect_ratio=increase,"
-        f"crop={pre_w}:{pre_h},setsar=1,"
-        f"zoompan=z='{zoom_expr}':d=1:s={width}x{height}:fps={fps}"
-        f"[bg];"
-        f"[bg]drawbox=x=0:y={viz_y}:w={width}:h={viz_h}:color=black@0.25:t=fill[bg2];"
-        f"[1:a]showcqt=s={width}x{viz_h}:fps={fps}:basefreq=30:endfreq=18000:axis=0[viz];"
+    graph = (
+        f"{bg_chain};"
+        f"[bg]drawbox=x=0:y={viz_y}:w={width}:h={viz_h}"
+        f":color=black@0.25:t=fill[bg2];"
+        f"[1:a]showcqt=s={width}x{viz_h}:fps={fps}"
+        f":basefreq=30:endfreq=18000:axis=0[viz];"
         f"[bg2][viz]overlay=x=0:y={viz_y}:format=auto[bgviz];"
         f"[2:v]format=rgba[brand];"
         f"[bgviz][brand]overlay=x=24:y=24[branded];"
@@ -261,27 +342,25 @@ def _long_form_filter_graph(width: int = 1920, height: int = 1080,
         f"box=1:boxcolor=black@0.55:boxborderw=18:"
         f"enable='between(t,0,4)':"
         f"alpha='if(lt(t,3),1,if(lt(t,4),1-(t-3),0))'"
-        f"[v]"
+        f"[disclosed]"
     )
+
+    if subtitles_path:
+        escaped = _subtitles_path_escape(subtitles_path)
+        graph += (
+            f";[disclosed]subtitles='{escaped}'"
+            f":force_style='{_SUBTITLES_FORCE_STYLE}'[v]"
+        )
+    else:
+        graph += ";[disclosed]null[v]"
+    return graph
 
 
 def _short_form_filter_graph(width: int = 1080, height: int = 1920,
                              fps: int = 30,
                              hook: Optional[str] = None) -> str:
-    """filter_complex graph for the 1080x1920 Shorts build.
-
-    Inputs (assumed by ``_short_form_cmd``):
-
-      ``[0:v]``  show cover, looped at ``fps``
-      ``[1:a]``  audio (already clipped via input-side ``-ss``/``-t``)
-      ``[2:v]``  brand pill PNG, looped
-
-    Outputs ``[v]`` for video mapping.
-
-    When *hook* is provided, the headline is wrapped, escaped, and
-    burned in as a centered caption for the first 3s.
-    """
-    viz_h = height // 4 + 40  # 520 — slightly taller band reads better in vertical
+    """filter_complex for the 1080x1920 Shorts build."""
+    viz_h = height // 4 + 40
     viz_y = (height // 2) - (viz_h // 2)
     font_path = _drawtext_escape(_find_font())
 
@@ -289,8 +368,10 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
         f"[0:v]"
         f"scale={width}:{height}:force_original_aspect_ratio=increase,"
         f"crop={width}:{height},setsar=1,format=yuv420p[bg];"
-        f"[bg]drawbox=x=0:y={viz_y}:w={width}:h={viz_h}:color=black@0.25:t=fill[bg2];"
-        f"[1:a]showcqt=s={width}x{viz_h}:fps={fps}:basefreq=30:endfreq=18000:axis=0[viz];"
+        f"[bg]drawbox=x=0:y={viz_y}:w={width}:h={viz_h}"
+        f":color=black@0.25:t=fill[bg2];"
+        f"[1:a]showcqt=s={width}x{viz_h}:fps={fps}"
+        f":basefreq=30:endfreq=18000:axis=0[viz];"
         f"[bg2][viz]overlay=x=0:y={viz_y}:format=auto[bgviz];"
         f"[2:v]format=rgba[brand];"
         f"[bgviz][brand]overlay=x=W-w-24:y=24[branded]"
@@ -314,18 +395,36 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
 
 
 # ---------------------------------------------------------------------------
-# Command builders
+# Long-form command builder (stage 2)
 # ---------------------------------------------------------------------------
 
-def _long_form_cmd(audio_in: str, cover_in: str, brand_in: str,
-                   output: str, *, fps: int = 30) -> List[str]:
-    """Full ffmpeg command for the 1920x1080 long-form build."""
+def _long_form_cmd(audio_in: str, bg_in: str, brand_in: str,
+                   output: str, *,
+                   fps: int = 30,
+                   bg_is_video: bool = False,
+                   subtitles_path: Optional[str] = None) -> List[str]:
+    """Full ffmpeg command for stage 2.
+
+    When *bg_is_video* is True, *bg_in* is a pre-rendered slideshow
+    MP4; we ``-stream_loop -1`` it so it loops to match the audio
+    length, and we don't apply ``-loop 1 -framerate``.
+    """
+    if bg_is_video:
+        bg_input = ["-stream_loop", "-1", "-i", bg_in]
+    else:
+        bg_input = ["-loop", "1", "-framerate", str(fps), "-i", bg_in]
+
     return [
         "ffmpeg", "-y", "-threads", "0",
-        "-loop", "1", "-framerate", str(fps), "-i", cover_in,
+        *bg_input,
         "-i", audio_in,
         "-loop", "1", "-framerate", str(fps), "-i", brand_in,
-        "-filter_complex", _long_form_filter_graph(1920, 1080, fps),
+        "-filter_complex",
+        _long_form_filter_graph(
+            fps=fps,
+            bg_is_video=bg_is_video,
+            subtitles_path=subtitles_path,
+        ),
         "-map", "[v]", "-map", "1:a",
         *_VIDEO_ENCODE,
         "-r", str(fps),
@@ -342,13 +441,7 @@ def _short_form_cmd(audio_in: str, cover_in: str, brand_in: str,
                     duration: float = 55.0,
                     fps: int = 30,
                     hook: Optional[str] = None) -> List[str]:
-    """Full ffmpeg command for the 1080x1920 Shorts build.
-
-    The audio input is clipped via ``-ss`` (input-side seek) before the
-    decoder so we only decode the slice we keep. ``-t`` is applied to
-    the audio input as well so ``-shortest`` truncates the looped cover
-    to match.
-    """
+    """ffmpeg command for the 1080x1920 Shorts build."""
     return [
         "ffmpeg", "-y", "-threads", "0",
         "-loop", "1", "-framerate", str(fps), "-i", cover_in,
@@ -356,7 +449,8 @@ def _short_form_cmd(audio_in: str, cover_in: str, brand_in: str,
         "-t", f"{duration:.2f}",
         "-i", audio_in,
         "-loop", "1", "-framerate", str(fps), "-i", brand_in,
-        "-filter_complex", _short_form_filter_graph(1080, 1920, fps, hook),
+        "-filter_complex",
+        _short_form_filter_graph(1080, 1920, fps, hook),
         "-map", "[v]", "-map", "1:a",
         *_VIDEO_ENCODE,
         "-r", str(fps),
@@ -371,25 +465,37 @@ def _short_form_cmd(audio_in: str, cover_in: str, brand_in: str,
 # Public API
 # ---------------------------------------------------------------------------
 
-def build_long_form_video(audio_path: Path, cover_path: Path,
-                          output_path: Path, *, fps: int = 30) -> Path:
+def build_long_form_video(
+    audio_path: Path,
+    cover_path: Path,
+    output_path: Path,
+    *,
+    fps: int = 30,
+    scene_paths: Optional[Sequence[Path]] = None,
+    subtitles_path: Optional[Path] = None,
+) -> Path:
     """Render a 1920x1080 long-form podcast video.
-
-    The brand pill PNG is generated once per work directory
-    (``output_path.parent / _brand_pill.png``) and reused on
-    subsequent calls.
 
     Parameters
     ----------
     audio_path:
-        Path to the final mixed episode MP3.
+        Final mixed episode MP3.
     cover_path:
-        Path to the show's static cover image (under ``assets/covers/``).
+        Show cover image. Used as the background when ``scene_paths``
+        is empty / unset (single-image Ken Burns), or as the fallback
+        if slideshow rendering fails.
     output_path:
-        Where to write the MP4. Parent dir must exist.
+        Where to write the final MP4.
     fps:
-        Frame rate for both the still video stream and the
-        visualization animation. 30 is the standard YouTube target.
+        Frame rate.
+    scene_paths:
+        Optional list of slideshow images. ``len ≥ 2`` triggers the
+        two-stage pipeline (slideshow MP4 first, then composite). A
+        single-element list (or ``None``) uses the single-cover path.
+    subtitles_path:
+        Optional path to an SRT file. When provided, ``ffmpeg``'s
+        ``subtitles`` filter burns the cues onto the video using a
+        styled box just above the spectrum band.
 
     Returns
     -------
@@ -401,12 +507,33 @@ def build_long_form_video(audio_path: Path, cover_path: Path,
     if not cover_path.exists():
         raise FileNotFoundError(f"cover not found: {cover_path}")
 
-    brand_path = output_path.parent / "_brand_pill.png"
+    work_dir = output_path.parent
+    brand_path = work_dir / "_brand_pill.png"
     _make_brand_pill(brand_path)
 
-    cmd = _long_form_cmd(str(audio_path), str(cover_path),
-                         str(brand_path), str(output_path), fps=fps)
-    logger.info("Building long-form video → %s", output_path.name)
+    bg_path: Path = cover_path
+    bg_is_video = False
+    if scene_paths and len(scene_paths) >= 2:
+        slideshow_path = work_dir / f"{output_path.stem}_slides.mp4"
+        try:
+            _render_slideshow(scene_paths, slideshow_path, fps=fps)
+            bg_path = slideshow_path
+            bg_is_video = True
+        except subprocess.CalledProcessError as exc:
+            logger.warning(
+                "Slideshow render failed (%s) — falling back to single cover",
+                exc,
+            )
+
+    cmd = _long_form_cmd(
+        str(audio_path), str(bg_path), str(brand_path),
+        str(output_path),
+        fps=fps,
+        bg_is_video=bg_is_video,
+        subtitles_path=str(subtitles_path) if subtitles_path else None,
+    )
+    logger.info("Building long-form video → %s (slideshow=%s, captions=%s)",
+                output_path.name, bg_is_video, bool(subtitles_path))
     subprocess.run(cmd, check=True, capture_output=True)
     return output_path
 
@@ -417,38 +544,7 @@ def build_short_video(audio_path: Path, cover_path: Path,
                       duration: float = 55.0,
                       fps: int = 30,
                       hook: Optional[str] = None) -> Path:
-    """Render a 1080x1920 vertical YouTube Shorts video.
-
-    Parameters
-    ----------
-    audio_path:
-        Source audio (usually the same final mixed episode MP3 used
-        for long-form). Only the slice from *start_offset* to
-        *start_offset + duration* is included.
-    cover_path:
-        Path to the show's cover image (filled, then cropped to vertical).
-    output_path:
-        Where to write the MP4.
-    start_offset:
-        Seconds into the audio where the Short should start. Pass
-        ``audio.intro_duration + audio.voice_intro_delay`` so the clip
-        skips music intro and starts on voice.
-    duration:
-        Length of the short clip in seconds. **Must stay below 60** so
-        YouTube classifies the upload as a Short.
-    fps:
-        Frame rate; same caveats as the long-form builder.
-    hook:
-        Optional one-line headline. When provided, it's wrapped and
-        burned in as a centered caption for the first 3s — gives the
-        scrolling Shorts viewer a topic preview before they decide to
-        stay.
-
-    Returns
-    -------
-    Path
-        ``output_path`` on success.
-    """
+    """Render a 1080x1920 vertical YouTube Shorts video."""
     if duration >= 60:
         raise ValueError(
             f"Shorts duration must stay below 60s; got {duration}"

--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -170,8 +170,16 @@ def build_long_form_metadata(
     digest_text: str,
     audio_url: str,
     chapters_path: Optional[Path] = None,
+    photo_attribution: Optional[List[str]] = None,
 ) -> Dict:
     """Assemble the YouTube metadata payload for a long-form upload.
+
+    Parameters
+    ----------
+    photo_attribution:
+        Optional list of one-line photographer credits (e.g. from the
+        Pexels slideshow). When non-empty, a "Photos:" block is
+        appended to the description above the AI disclosure footer.
 
     Returns
     -------
@@ -213,6 +221,10 @@ def build_long_form_metadata(
     pieces.append(f"Listen on the podcast feed: {utm_link}")
     if audio_url:
         pieces.append(f"Direct audio: {audio_url}")
+    if photo_attribution:
+        cleaned = [line.strip() for line in photo_attribution if line.strip()]
+        if cleaned:
+            pieces.append("Photos via Pexels:\n" + "\n".join(cleaned))
     disclosure = (config.youtube.synthetic_disclosure or "").strip()
     if disclosure:
         pieces.append(disclosure)

--- a/engine/visual_assets.py
+++ b/engine/visual_assets.py
@@ -1,0 +1,368 @@
+"""Pexels-backed scene-image fetcher for the YouTube long-form pipeline.
+
+Replaces the static-cover background with a slideshow of royalty-free
+photos relevant to the show's topic. The keyword set comes straight
+from each show's YAML ``keywords:`` list, so the operator never has
+to curate per-show artwork — TST gets Tesla / EV photos, Fascinating
+Frontiers gets space photos, Финансы Просто gets finance photos,
+etc.
+
+Why Pexels:
+
+  - Free tier covers 200 req/hour, 20k/month. We use ≤ 10 req/day
+    across all shows. Way under the cap.
+  - All photos are royalty-free with no attribution legally required
+    (Pexels License). We add credits in the video description anyway
+    because it's polite and signals to YouTube we sourced legitimately.
+  - Their search returns recent, varied photos for common topics.
+
+If ``PEXELS_API_KEY`` isn't set, or the API call fails, the function
+falls back to the show's static cover image — the long-form pipeline
+keeps working, just less visually varied.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Scene:
+    """One scene image plus its attribution metadata."""
+    path: Path
+    photographer: str = ""
+    photographer_url: str = ""
+    pexels_url: str = ""
+
+    def attribution_line(self) -> str:
+        """One-line credit suitable for the video description."""
+        if not self.photographer:
+            return ""
+        if self.photographer_url:
+            return f"Photo by {self.photographer} ({self.photographer_url})"
+        return f"Photo by {self.photographer}"
+
+
+@dataclass
+class SceneSet:
+    """Collection of scenes for one episode + cache metadata."""
+    scenes: List[Scene] = field(default_factory=list)
+    is_fallback: bool = False  # True when we returned the cover only
+
+    def __len__(self) -> int:
+        return len(self.scenes)
+
+    def paths(self) -> List[Path]:
+        return [s.path for s in self.scenes]
+
+    def attribution_lines(self) -> List[str]:
+        seen: set = set()
+        out: List[str] = []
+        for scene in self.scenes:
+            line = scene.attribution_line()
+            if line and line not in seen:
+                seen.add(line)
+                out.append(line)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Pexels client
+# ---------------------------------------------------------------------------
+
+PEXELS_SEARCH_URL = "https://api.pexels.com/v1/search"
+DEFAULT_PHOTO_COUNT = 8
+DEFAULT_KEYWORDS_PER_QUERY = 5
+
+
+@retry(
+    retry=retry_if_exception_type((requests.RequestException, requests.Timeout)),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=2, min=2, max=15),
+    reraise=True,
+)
+def _pexels_search(query: str, *, api_key: str,
+                   per_page: int = 3) -> dict:
+    """Run one Pexels search request. Retries transient network errors."""
+    response = requests.get(
+        PEXELS_SEARCH_URL,
+        params={
+            "query": query,
+            "per_page": per_page,
+            "orientation": "landscape",
+            "size": "large",
+        },
+        headers={"Authorization": api_key},
+        timeout=15,
+    )
+    response.raise_for_status()
+    return response.json() or {}
+
+
+def _download_image(url: str, dest: Path) -> Optional[Path]:
+    """Download a single image. Returns None if the download fails."""
+    try:
+        with requests.get(url, stream=True, timeout=30) as r:
+            r.raise_for_status()
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with open(dest, "wb") as f:
+                for chunk in r.iter_content(chunk_size=64 * 1024):
+                    if chunk:
+                        f.write(chunk)
+        return dest
+    except (requests.RequestException, OSError) as exc:
+        logger.warning("Failed to download %s: %s", url, exc)
+        return None
+
+
+def _select_keywords(keywords: List[str],
+                     limit: int = DEFAULT_KEYWORDS_PER_QUERY) -> List[str]:
+    """Pick the *limit* most useful keywords for image search.
+
+    Single-word, lowercase, deduped. Skips boilerplate tokens that
+    are technical jargon ('hw4', 'lfp', 'fsd' etc. — Pexels gets
+    nothing useful for those).
+    """
+    # Skip technical SKUs / acronyms that return junk on Pexels.
+    skip_too_short = {
+        "ai", "hw", "lfp", "ev", "fsd", "tsla", "hw4", "hw5",
+        "ai5", "ipo", "etf", "gic", "tfsa", "rrsp",
+    }
+    seen: set = set()
+    out: List[str] = []
+    for kw in keywords:
+        if not isinstance(kw, str):
+            continue
+        clean = kw.strip().lower()
+        if not clean or clean in seen or clean in skip_too_short:
+            continue
+        # Skip obvious technical SKUs / acronyms (only digits or 2-3 char tokens).
+        if clean.isdigit() or (len(clean) <= 3 and clean.isalpha() and clean.isupper()):
+            continue
+        seen.add(clean)
+        out.append(clean)
+        if len(out) >= limit:
+            break
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+def _cache_dir(work_dir: Path, episode_num: int) -> Path:
+    return work_dir / f"scenes_ep{episode_num:03d}"
+
+
+def _manifest_path(cache_dir: Path) -> Path:
+    return cache_dir / "manifest.json"
+
+
+def _load_cached_scenes(cache_dir: Path) -> Optional[SceneSet]:
+    """Return a cached SceneSet if every file referenced still exists."""
+    manifest = _manifest_path(cache_dir)
+    if not manifest.exists():
+        return None
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    scenes: List[Scene] = []
+    for entry in data.get("scenes", []):
+        path = Path(entry.get("path", ""))
+        if not path.exists():
+            return None  # cache invalid; refetch
+        scenes.append(Scene(
+            path=path,
+            photographer=entry.get("photographer", ""),
+            photographer_url=entry.get("photographer_url", ""),
+            pexels_url=entry.get("pexels_url", ""),
+        ))
+    if not scenes:
+        return None
+    return SceneSet(scenes=scenes, is_fallback=bool(data.get("is_fallback")))
+
+
+def _save_manifest(cache_dir: Path, scene_set: SceneSet) -> None:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "is_fallback": scene_set.is_fallback,
+        "scenes": [
+            {
+                "path": str(s.path),
+                "photographer": s.photographer,
+                "photographer_url": s.photographer_url,
+                "pexels_url": s.pexels_url,
+            }
+            for s in scene_set.scenes
+        ],
+    }
+    _manifest_path(cache_dir).write_text(
+        json.dumps(payload, indent=2), encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def fetch_scene_images(
+    *,
+    work_dir: Path,
+    episode_num: int,
+    keywords: List[str],
+    fallback_cover: Path,
+    api_key: Optional[str] = None,
+    target_count: int = DEFAULT_PHOTO_COUNT,
+) -> SceneSet:
+    """Fetch a slideshow of royalty-free photos for the episode.
+
+    Parameters
+    ----------
+    work_dir:
+        Per-episode YouTube work directory (typically
+        ``digests/<slug>/youtube_tmp``). Cache lives at
+        ``work_dir/scenes_ep<NNN>/``.
+    episode_num:
+        Episode number — keys the cache so reruns don't re-fetch.
+    keywords:
+        Show YAML's ``keywords:`` list. We pick the most useful 5,
+        query each, and dedupe results.
+    fallback_cover:
+        Path to the show's cover JPG. Used as the only scene if
+        Pexels is disabled / unavailable / returns nothing.
+    api_key:
+        Pexels API key. Defaults to ``PEXELS_API_KEY`` env var. When
+        empty, we return a fallback ``SceneSet`` containing only
+        ``fallback_cover``.
+    target_count:
+        Target number of distinct photos. Stops querying once we
+        have at least this many.
+
+    Returns
+    -------
+    SceneSet
+        Always non-empty (worst case: just the cover).
+    """
+    if api_key is None:
+        api_key = os.getenv("PEXELS_API_KEY", "").strip()
+
+    cache_dir = _cache_dir(work_dir, episode_num)
+    cached = _load_cached_scenes(cache_dir)
+    if cached is not None:
+        logger.info("Using cached scene set from %s (%d photos)",
+                    cache_dir, len(cached))
+        return cached
+
+    if not api_key:
+        logger.info("PEXELS_API_KEY not set — using show cover as the "
+                    "single scene")
+        scene_set = SceneSet(
+            scenes=[Scene(path=fallback_cover)],
+            is_fallback=True,
+        )
+        _save_manifest(cache_dir, scene_set)
+        return scene_set
+
+    if not fallback_cover.exists():
+        # The cover is required as a last-resort fallback; if the file
+        # is missing the caller has bigger problems and shouldn't have
+        # called us.
+        raise FileNotFoundError(f"fallback_cover missing: {fallback_cover}")
+
+    selected = _select_keywords(keywords)
+    if not selected:
+        logger.info("No usable keywords for slideshow — using cover")
+        scene_set = SceneSet(scenes=[Scene(path=fallback_cover)],
+                             is_fallback=True)
+        _save_manifest(cache_dir, scene_set)
+        return scene_set
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    scenes: List[Scene] = []
+    seen_pexels_ids: set = set()
+
+    for query in selected:
+        if len(scenes) >= target_count:
+            break
+        try:
+            payload = _pexels_search(query, api_key=api_key, per_page=3)
+        except requests.HTTPError as exc:
+            status = getattr(exc.response, "status_code", "?")
+            logger.warning("Pexels search '%s' failed (HTTP %s)", query, status)
+            continue
+        except Exception as exc:  # noqa: BLE001 — we want to never crash here
+            logger.warning("Pexels search '%s' errored: %s", query, exc)
+            continue
+
+        for photo in payload.get("photos", []) or []:
+            if len(scenes) >= target_count:
+                break
+            photo_id = photo.get("id")
+            if not photo_id or photo_id in seen_pexels_ids:
+                continue
+            src = photo.get("src") or {}
+            image_url = src.get("large2x") or src.get("large") or src.get("original")
+            if not image_url:
+                continue
+            ext = Path(image_url.split("?")[0]).suffix or ".jpg"
+            # Filename keys by photo id so cache hits across keywords work.
+            filename = f"pexels_{photo_id}{ext}"
+            dest = cache_dir / filename
+            if not dest.exists():
+                downloaded = _download_image(image_url, dest)
+                if downloaded is None:
+                    continue
+            scenes.append(Scene(
+                path=dest,
+                photographer=str(photo.get("photographer", "")).strip(),
+                photographer_url=str(photo.get("photographer_url", "")).strip(),
+                pexels_url=str(photo.get("url", "")).strip(),
+            ))
+            seen_pexels_ids.add(photo_id)
+
+    if not scenes:
+        logger.info("Pexels returned no usable photos — using cover")
+        scene_set = SceneSet(scenes=[Scene(path=fallback_cover)],
+                             is_fallback=True)
+    else:
+        scene_set = SceneSet(scenes=scenes, is_fallback=False)
+        logger.info(
+            "Built %d-photo slideshow for ep%d (queries: %s)",
+            len(scenes), episode_num, ", ".join(selected),
+        )
+
+    _save_manifest(cache_dir, scene_set)
+    return scene_set
+
+
+def keyword_cache_key(keywords: List[str]) -> str:
+    """Stable hash of the keyword list. Used for cache invalidation.
+
+    Currently informational — the per-episode cache key already
+    keys on the episode number, but if a show's keywords change
+    mid-episode we want manual invalidation to be a single delete.
+    """
+    return hashlib.sha1(
+        ",".join(sorted(k.lower() for k in keywords)).encode("utf-8"),
+    ).hexdigest()[:8]

--- a/run_show.py
+++ b/run_show.py
@@ -2348,12 +2348,17 @@ def _publish_youtube(
         )
         return result
 
+    from engine.captions import (
+        find_transcript_for_episode,
+        transcript_to_srt,
+    )
     from engine.publisher import generate_episode_thumbnail
     from engine.video import build_long_form_video, build_short_video
     from engine.video_metadata import (
         build_long_form_metadata,
         build_short_metadata,
     )
+    from engine.visual_assets import fetch_scene_images
     from engine.youtube import (
         get_channel_credentials_from_env,
         upload_video,
@@ -2388,11 +2393,44 @@ def _publish_youtube(
         logger.warning("Thumbnail generation failed: %s", exc)
         thumbnail_path = None  # type: ignore[assignment]
 
+    # ---- Build captions SRT (optional — falls back to no captions) ----
+    srt_path = None
+    transcript_path = find_transcript_for_episode(
+        digests_dir, config.episode.prefix, episode_num, f"{today:%Y%m%d}",
+    )
+    if transcript_path is not None:
+        try:
+            srt_candidate = work_dir / f"{base_name}.srt"
+            transcript_to_srt(transcript_path, srt_candidate)
+            srt_path = srt_candidate
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.warning("Caption generation failed: %s", exc)
+
+    # ---- Resolve scene slideshow (Pexels-backed; falls back to cover) ----
+    scene_paths = [cover_path]
+    pexels_attribution: list = []
+    try:
+        scene_set = fetch_scene_images(
+            work_dir=work_dir,
+            episode_num=episode_num,
+            keywords=list(getattr(config, "keywords", []) or []),
+            fallback_cover=cover_path,
+        )
+        if not scene_set.is_fallback and len(scene_set) >= 2:
+            scene_paths = scene_set.paths()
+            pexels_attribution = scene_set.attribution_lines()
+    except Exception as exc:  # pragma: no cover — best-effort
+        logger.warning("Scene fetch failed (using cover only): %s", exc)
+
     # ---- Long-form ----
     long_url = ""
     if config.youtube.publish_long_form:
         try:
-            build_long_form_video(final_mp3, cover_path, long_video_path)
+            build_long_form_video(
+                final_mp3, cover_path, long_video_path,
+                scene_paths=scene_paths if len(scene_paths) >= 2 else None,
+                subtitles_path=srt_path,
+            )
             meta = build_long_form_metadata(
                 config,
                 episode_num=episode_num,
@@ -2401,6 +2439,7 @@ def _publish_youtube(
                 digest_text=digest_text,
                 audio_url=audio_url,
                 chapters_path=chapters_path if chapters_path.exists() else None,
+                photo_attribution=pexels_attribution,
             )
             long_url = upload_video(
                 long_video_path,

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -1,0 +1,121 @@
+"""Tests for the transcript-JSON → SRT converter used by the YouTube
+caption burn-in pipeline."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from engine.captions import (
+    _format_srt_timestamp,
+    _wrap_caption_line,
+    find_transcript_for_episode,
+    transcript_to_srt,
+)
+
+
+def test_srt_timestamp_format():
+    assert _format_srt_timestamp(0.0) == "00:00:00,000"
+    assert _format_srt_timestamp(1.5) == "00:00:01,500"
+    assert _format_srt_timestamp(75.123) == "00:01:15,123"
+    assert _format_srt_timestamp(3725.999) == "01:02:05,999"
+    # Negatives clamp to zero rather than emitting "-00:..." which
+    # libass refuses to parse.
+    assert _format_srt_timestamp(-1.0) == "00:00:00,000"
+
+
+def test_wrap_caption_line_short_text_unchanged():
+    assert _wrap_caption_line("Short caption.") == "Short caption."
+
+
+def test_wrap_caption_line_breaks_at_word_boundary():
+    out = _wrap_caption_line(
+        "This is a fairly long caption that needs wrapping",
+        max_chars=20,
+    )
+    lines = out.split("\n")
+    assert len(lines) >= 2
+    # No line should split a word in the middle.
+    for line in lines:
+        assert " " in line or len(line) <= 20
+
+
+def test_transcript_to_srt_basic(tmp_path: Path):
+    transcript = {
+        "language": "en",
+        "duration": 30.0,
+        "segments": [
+            {"start": 0.0, "end": 2.5, "text": "Hello world"},
+            {"start": 3.0, "end": 6.5, "text": "This is a test caption"},
+            # Sub-min-duration cue should be filtered out.
+            {"start": 7.0, "end": 7.05, "text": "blip"},
+            {"start": 8.0, "end": 11.0, "text": "Final cue"},
+        ],
+    }
+    transcript_path = tmp_path / "ep_transcript.json"
+    transcript_path.write_text(json.dumps(transcript), encoding="utf-8")
+
+    srt_path = tmp_path / "ep.srt"
+    result = transcript_to_srt(transcript_path, srt_path)
+
+    assert result == srt_path
+    content = srt_path.read_text(encoding="utf-8")
+
+    # Three usable cues (the sub-min-duration one was dropped).
+    assert content.count(" --> ") == 3
+    assert "Hello world" in content
+    assert "Final cue" in content
+    assert "blip" not in content
+    # Cues are 1-indexed.
+    assert content.startswith("1\n")
+
+
+def test_transcript_to_srt_skips_blank_text(tmp_path: Path):
+    transcript = {
+        "segments": [
+            {"start": 0.0, "end": 2.0, "text": ""},
+            {"start": 2.5, "end": 4.0, "text": "   "},
+            {"start": 5.0, "end": 8.0, "text": "Real caption"},
+        ],
+    }
+    transcript_path = tmp_path / "t.json"
+    transcript_path.write_text(json.dumps(transcript), encoding="utf-8")
+    srt_path = tmp_path / "t.srt"
+    transcript_to_srt(transcript_path, srt_path)
+    content = srt_path.read_text(encoding="utf-8")
+    assert content.count(" --> ") == 1
+    assert "Real caption" in content
+
+
+def test_transcript_to_srt_handles_unicode(tmp_path: Path):
+    """Russian transcripts must round-trip through UTF-8 unchanged."""
+    transcript = {
+        "language": "ru",
+        "segments": [
+            {"start": 0.0, "end": 2.0, "text": "Привет, Русский!"},
+        ],
+    }
+    transcript_path = tmp_path / "ru.json"
+    transcript_path.write_text(json.dumps(transcript, ensure_ascii=False),
+                               encoding="utf-8")
+    srt_path = tmp_path / "ru.srt"
+    transcript_to_srt(transcript_path, srt_path)
+    assert "Привет, Русский!" in srt_path.read_text(encoding="utf-8")
+
+
+def test_transcript_to_srt_missing_file_raises(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        transcript_to_srt(tmp_path / "missing.json", tmp_path / "out.srt")
+
+
+def test_find_transcript_for_episode(tmp_path: Path):
+    digests = tmp_path / "digests"
+    digests.mkdir()
+    target = digests / "TST_Ep042_20260427_transcript.json"
+    target.write_text("{}", encoding="utf-8")
+
+    found = find_transcript_for_episode(digests, "TST", 42, "20260427")
+    assert found == target
+
+    missing = find_transcript_for_episode(digests, "TST", 99, "20260427")
+    assert missing is None

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -17,6 +17,7 @@ import pytest
 
 from engine.video import (
     _AUDIO_ENCODE,
+    _SUBTITLES_FORCE_STYLE,
     _VIDEO_ENCODE,
     _drawtext_escape,
     _long_form_cmd,
@@ -24,6 +25,9 @@ from engine.video import (
     _make_brand_pill,
     _short_form_cmd,
     _short_form_filter_graph,
+    _slideshow_cmd,
+    _slideshow_filter_graph,
+    _subtitles_path_escape,
     _wrap_caption,
     build_long_form_video,
     build_short_video,
@@ -330,3 +334,218 @@ def test_wrap_caption_short_text_unchanged():
 
 def test_wrap_caption_empty_returns_empty():
     assert _wrap_caption("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Slideshow (stage 1) — multi-scene Ken Burns + concat
+# ---------------------------------------------------------------------------
+
+def test_slideshow_filter_graph_has_per_scene_chains():
+    graph = _slideshow_filter_graph(scene_count=4)
+    # One zoompan chain per scene, then a final concat.
+    assert graph.count("zoompan") == 4
+    assert graph.count("[s0]") >= 1
+    assert graph.count("[s3]") >= 1
+    assert "concat=n=4:v=1:a=0[v]" in graph
+    assert graph.endswith("[v]")
+
+
+def test_slideshow_filter_graph_zoom_per_scene():
+    """Slideshow zoom is faster than the single-image Ken Burns
+    (each scene is only ~12s)."""
+    graph = _slideshow_filter_graph(scene_count=2)
+    assert "min(zoom+0.0006,1.12)" in graph
+
+
+def test_slideshow_cmd_has_one_input_per_scene(tmp_path):
+    paths = [tmp_path / f"scene{i}.jpg" for i in range(3)]
+    out = tmp_path / "slides.mp4"
+    cmd = _slideshow_cmd(paths, out)
+
+    # Three -i flags (one per scene), three -loop flags.
+    assert cmd.count("-i") == 3
+    assert cmd.count("-loop") == 3
+    # No audio in slideshow output.
+    assert "-an" in cmd
+    # Encoding profile applies (keyframe args present).
+    for token in _VIDEO_ENCODE:
+        assert token in cmd
+    assert cmd[-1] == str(out)
+
+
+# ---------------------------------------------------------------------------
+# Long-form filter graph — slideshow (bg_is_video) variant
+# ---------------------------------------------------------------------------
+
+def test_long_form_filter_graph_video_bg_skips_zoompan():
+    """When the background is already a slideshow video, we skip
+    zoompan in stage 2 (the zoom is baked into the slideshow itself)."""
+    graph = _long_form_filter_graph(bg_is_video=True)
+    assert "zoompan" not in graph
+    # Showcqt + brand + disclosure still composite on top.
+    assert "showcqt" in graph
+    assert "[2:v]" in graph and "format=rgba" in graph
+    assert "drawtext" in graph
+    assert graph.endswith("[v]")
+
+
+def test_long_form_filter_graph_image_bg_uses_zoompan():
+    graph = _long_form_filter_graph(bg_is_video=False)
+    assert "zoompan" in graph
+
+
+# ---------------------------------------------------------------------------
+# Long-form filter graph — subtitles burn-in
+# ---------------------------------------------------------------------------
+
+def test_long_form_filter_graph_with_subtitles_appends_filter():
+    graph = _long_form_filter_graph(subtitles_path="/tmp/captions.srt")
+    assert "subtitles=" in graph
+    # ASS force-style is appended.
+    assert "force_style=" in graph
+    assert "Alignment=2" in graph
+    assert "MarginV=320" in graph
+    # Disclosure chain is followed by the subtitles stage.
+    assert "[disclosed]" in graph
+    assert graph.endswith("[v]")
+
+
+def test_long_form_filter_graph_no_subtitles_uses_null_passthrough():
+    graph = _long_form_filter_graph(subtitles_path=None)
+    assert "subtitles=" not in graph
+    # null filter renames [disclosed] → [v] without re-encoding the alpha.
+    assert "[disclosed]null[v]" in graph
+
+
+def test_subtitles_path_escape_handles_metacharacters():
+    # Colons are option separators inside the subtitles filter.
+    assert _subtitles_path_escape("/tmp/with:colon/file.srt") == \
+        r"/tmp/with\:colon/file.srt"
+    # Backslashes get normalised to forward slashes (Windows safety).
+    assert _subtitles_path_escape("C:\\Users\\caps.srt") == \
+        r"C\:/Users/caps.srt"
+
+
+def test_subtitles_force_style_has_required_fields():
+    """Sanity check on the ASS force-style string."""
+    assert "FontName=DejaVu Sans" in _SUBTITLES_FORCE_STYLE
+    assert "Alignment=2" in _SUBTITLES_FORCE_STYLE
+    # MarginV pushes the baseline above the spectrum band.
+    assert "MarginV=320" in _SUBTITLES_FORCE_STYLE
+    # BorderStyle=3 = opaque box behind text (better readability than outline).
+    assert "BorderStyle=3" in _SUBTITLES_FORCE_STYLE
+
+
+# ---------------------------------------------------------------------------
+# Long-form command — slideshow + subtitles wiring
+# ---------------------------------------------------------------------------
+
+def test_long_form_cmd_video_bg_uses_stream_loop():
+    """When bg is the pre-rendered slideshow MP4, we ``-stream_loop -1``
+    it so it loops to match audio length, and we drop ``-loop 1
+    -framerate``."""
+    cmd = _long_form_cmd(
+        "voice.mp3", "slides.mp4", "brand.png", "out.mp4",
+        bg_is_video=True,
+    )
+    assert "-stream_loop" in cmd
+    assert cmd[cmd.index("-stream_loop") + 1] == "-1"
+    # Cover-style -loop / -framerate only on the brand input now (1 each).
+    assert cmd.count("-loop") == 1
+    # Three -i still: bg, audio, brand.
+    assert cmd.count("-i") == 3
+
+
+def test_long_form_cmd_threads_subtitles_path():
+    cmd = _long_form_cmd(
+        "voice.mp3", "cover.jpg", "brand.png", "out.mp4",
+        subtitles_path="/work/captions.srt",
+    )
+    graph = cmd[cmd.index("-filter_complex") + 1]
+    assert "subtitles=" in graph
+    assert "captions.srt" in graph
+
+
+def test_build_long_form_video_falls_back_to_cover_with_one_scene(tmp_path,
+                                                                  monkeypatch):
+    """Single-scene list should NOT trigger the two-stage slideshow
+    pipeline (one photo isn't a slideshow)."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    out = tmp_path / "out.mp4"
+
+    captured_cmds = []
+    monkeypatch.setattr(
+        "engine.video.subprocess.run",
+        lambda cmd, **kw: (captured_cmds.append(list(cmd)),
+                           type("R", (), {"returncode": 0})())[1],
+    )
+    build_long_form_video(audio, cover, out, scene_paths=[cover])
+    # Only one ffmpeg invocation (no slideshow stage).
+    assert len(captured_cmds) == 1
+    # The single command's filter graph contains zoompan (image bg).
+    graph = captured_cmds[0][captured_cmds[0].index("-filter_complex") + 1]
+    assert "zoompan" in graph
+
+
+def test_build_long_form_video_renders_slideshow_for_multi_scene(tmp_path,
+                                                                 monkeypatch):
+    """Multi-scene list triggers a stage-1 slideshow render before
+    the final composite."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    scenes = []
+    for i in range(3):
+        s = tmp_path / f"scene{i}.jpg"
+        s.write_bytes(b"\xFF\xD8")
+        scenes.append(s)
+    out = tmp_path / "out.mp4"
+
+    captured_cmds = []
+
+    def fake_run(cmd, **kw):
+        captured_cmds.append(list(cmd))
+
+        # Stage 1 writes the slideshow MP4; touch it so stage 2 sees it.
+        for i, arg in enumerate(cmd):
+            if arg == "-an":
+                # Slideshow command — last arg is output path.
+                Path(cmd[-1]).write_bytes(b"\x00")
+                break
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    build_long_form_video(audio, cover, out, scene_paths=scenes)
+
+    # Two ffmpeg invocations: stage-1 slideshow, stage-2 composite.
+    assert len(captured_cmds) == 2
+    # Stage 1 has 3 inputs (one per scene), no audio output.
+    assert "-an" in captured_cmds[0]
+    assert captured_cmds[0].count("-i") == 3
+    # Stage 2 uses -stream_loop on the slideshow MP4.
+    assert "-stream_loop" in captured_cmds[1]
+
+
+def test_build_long_form_video_threads_subtitles(tmp_path, monkeypatch):
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    srt = tmp_path / "captions.srt"
+    srt.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n", encoding="utf-8")
+    out = tmp_path / "out.mp4"
+
+    captured = {}
+    monkeypatch.setattr(
+        "engine.video.subprocess.run",
+        lambda cmd, **kw: (captured.update(cmd=list(cmd)),
+                           type("R", (), {"returncode": 0})())[1],
+    )
+    build_long_form_video(audio, cover, out, subtitles_path=srt)
+    graph = captured["cmd"][captured["cmd"].index("-filter_complex") + 1]
+    assert "subtitles=" in graph
+    assert "captions.srt" in graph

--- a/tests/test_visual_assets.py
+++ b/tests/test_visual_assets.py
@@ -1,0 +1,312 @@
+"""Tests for the Pexels-backed scene-image fetcher.
+
+The HTTP layer is mocked end-to-end so the suite never hits the
+network. We verify keyword selection, fallback behaviour, cache
+hits, and the attribution metadata that ends up in the YouTube
+description.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from engine import visual_assets
+
+
+# ---------------------------------------------------------------------------
+# Keyword selection
+# ---------------------------------------------------------------------------
+
+def test_select_keywords_dedupes_and_lowercases():
+    out = visual_assets._select_keywords(
+        ["Tesla", "TESLA", "Model 3", "model 3", "FSD"],
+        limit=5,
+    )
+    # FSD (3-letter all-caps) is filtered as a SKU/acronym.
+    assert "tesla" in out
+    assert "model 3" in out
+    assert "fsd" not in out  # in skip_too_short list
+    assert len(out) == set(out).__len__()  # no duplicates
+
+
+def test_select_keywords_respects_limit():
+    out = visual_assets._select_keywords(
+        ["a-1-very-long-keyword", "b-1", "c-1", "d-1", "e-1", "f-1"],
+        limit=3,
+    )
+    assert len(out) == 3
+
+
+def test_select_keywords_skips_pure_digits():
+    out = visual_assets._select_keywords(["4680", "tesla", "100"])
+    assert "4680" not in out
+    assert "100" not in out
+    assert "tesla" in out
+
+
+# ---------------------------------------------------------------------------
+# Fallback paths
+# ---------------------------------------------------------------------------
+
+def test_fetch_falls_back_to_cover_when_no_api_key(tmp_path: Path):
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")  # JPEG magic bytes
+    work = tmp_path / "youtube_tmp"
+
+    result = visual_assets.fetch_scene_images(
+        work_dir=work,
+        episode_num=42,
+        keywords=["tesla", "ev"],
+        fallback_cover=cover,
+        api_key="",
+    )
+
+    assert result.is_fallback is True
+    assert len(result) == 1
+    assert result.scenes[0].path == cover
+    assert result.attribution_lines() == []
+
+
+def test_fetch_returns_cached_set_on_second_call(tmp_path: Path):
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    work = tmp_path / "youtube_tmp"
+
+    first = visual_assets.fetch_scene_images(
+        work_dir=work, episode_num=1,
+        keywords=["tesla"], fallback_cover=cover, api_key="",
+    )
+    # Manifest written.
+    manifest = work / "scenes_ep001" / "manifest.json"
+    assert manifest.exists()
+
+    # Second call must NOT call the API (api_key stays empty so an API
+    # call would do nothing useful anyway, but we want to see cache hit).
+    second = visual_assets.fetch_scene_images(
+        work_dir=work, episode_num=1,
+        keywords=["tesla"], fallback_cover=cover, api_key="some-key",
+    )
+    assert second.is_fallback == first.is_fallback
+    assert second.paths() == first.paths()
+
+
+# ---------------------------------------------------------------------------
+# Pexels API plumbing (mocked)
+# ---------------------------------------------------------------------------
+
+def _fake_pexels_response(photo_ids):
+    """Build a Pexels-shaped JSON response for a search."""
+    photos = []
+    for pid in photo_ids:
+        photos.append({
+            "id": pid,
+            "url": f"https://pexels.com/photo/{pid}",
+            "photographer": f"Photographer {pid}",
+            "photographer_url": f"https://pexels.com/@{pid}",
+            "src": {
+                "large2x": f"https://images.pexels.com/photo{pid}_large2x.jpg",
+                "large": f"https://images.pexels.com/photo{pid}_large.jpg",
+            },
+        })
+    return {"photos": photos}
+
+
+def test_fetch_with_api_key_downloads_photos(tmp_path: Path, monkeypatch):
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    work = tmp_path / "youtube_tmp"
+
+    queries_seen = []
+
+    def fake_search(query, *, api_key, per_page=3):
+        queries_seen.append(query)
+        # Return 2 unique photo IDs per query so we can exercise dedupe.
+        return _fake_pexels_response([
+            f"{query}_1", f"{query}_2",
+        ])
+
+    downloads_seen = []
+
+    def fake_download(url, dest):
+        downloads_seen.append((url, dest))
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"\xFF\xD8")
+        return dest
+
+    monkeypatch.setattr(visual_assets, "_pexels_search", fake_search)
+    monkeypatch.setattr(visual_assets, "_download_image", fake_download)
+
+    result = visual_assets.fetch_scene_images(
+        work_dir=work,
+        episode_num=7,
+        keywords=["tesla", "cybertruck", "model 3", "robotaxi", "supercharger"],
+        fallback_cover=cover,
+        api_key="fake-key",
+        target_count=6,
+    )
+
+    assert result.is_fallback is False
+    assert len(result) == 6
+    # Each scene has the photographer credit.
+    attributions = result.attribution_lines()
+    assert all("Photographer" in line for line in attributions)
+    assert len(attributions) == 6
+    # We stopped querying once we hit target_count.
+    assert len(queries_seen) <= 5
+
+
+def test_fetch_dedupes_repeated_photo_ids(tmp_path: Path, monkeypatch):
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    work = tmp_path / "youtube_tmp"
+
+    def fake_search(query, *, api_key, per_page=3):
+        # Every query returns the same photo id 99 — should dedupe.
+        return _fake_pexels_response([99])
+
+    monkeypatch.setattr(visual_assets, "_pexels_search", fake_search)
+    monkeypatch.setattr(
+        visual_assets, "_download_image",
+        lambda url, dest: (dest.parent.mkdir(parents=True, exist_ok=True),
+                           dest.write_bytes(b"\xFF\xD8"), dest)[2],
+    )
+
+    result = visual_assets.fetch_scene_images(
+        work_dir=work, episode_num=8,
+        keywords=["tesla", "cybertruck", "model 3"],
+        fallback_cover=cover,
+        api_key="fake-key",
+        target_count=5,
+    )
+
+    # Only one unique photo, even though three queries returned it.
+    assert len(result) == 1
+    # Falls into the "got at least one photo, not fallback" branch.
+    assert result.is_fallback is False
+
+
+def test_fetch_falls_back_when_search_returns_nothing(tmp_path: Path, monkeypatch):
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    work = tmp_path / "youtube_tmp"
+
+    monkeypatch.setattr(
+        visual_assets, "_pexels_search",
+        lambda query, *, api_key, per_page=3: {"photos": []},
+    )
+
+    result = visual_assets.fetch_scene_images(
+        work_dir=work, episode_num=9,
+        keywords=["nonsense-no-results"],
+        fallback_cover=cover, api_key="fake-key",
+    )
+
+    assert result.is_fallback is True
+    assert len(result) == 1
+    assert result.scenes[0].path == cover
+
+
+def test_fetch_falls_back_when_search_raises(tmp_path: Path, monkeypatch):
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    work = tmp_path / "youtube_tmp"
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("Pexels is down")
+
+    monkeypatch.setattr(visual_assets, "_pexels_search", boom)
+
+    result = visual_assets.fetch_scene_images(
+        work_dir=work, episode_num=10,
+        keywords=["tesla"], fallback_cover=cover, api_key="fake-key",
+    )
+
+    # Should still cache + return a fallback set, not raise.
+    assert result.is_fallback is True
+    assert len(result) == 1
+
+
+def test_fallback_cover_must_exist(tmp_path: Path):
+    work = tmp_path / "youtube_tmp"
+    with pytest.raises(FileNotFoundError, match="fallback_cover"):
+        visual_assets.fetch_scene_images(
+            work_dir=work, episode_num=1,
+            keywords=["tesla"],
+            fallback_cover=tmp_path / "missing.jpg",
+            api_key="fake-key",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Manifest / cache
+# ---------------------------------------------------------------------------
+
+def test_manifest_contains_attribution(tmp_path: Path, monkeypatch):
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    work = tmp_path / "youtube_tmp"
+
+    monkeypatch.setattr(
+        visual_assets, "_pexels_search",
+        lambda q, *, api_key, per_page=3: _fake_pexels_response([42]),
+    )
+    monkeypatch.setattr(
+        visual_assets, "_download_image",
+        lambda url, dest: (dest.parent.mkdir(parents=True, exist_ok=True),
+                           dest.write_bytes(b"\xFF\xD8"), dest)[2],
+    )
+
+    visual_assets.fetch_scene_images(
+        work_dir=work, episode_num=11,
+        keywords=["tesla"], fallback_cover=cover, api_key="fake-key",
+    )
+
+    manifest = work / "scenes_ep011" / "manifest.json"
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    assert data["is_fallback"] is False
+    assert len(data["scenes"]) == 1
+    assert data["scenes"][0]["photographer"] == "Photographer 42"
+    assert "https://pexels.com/photo/42" == data["scenes"][0]["pexels_url"]
+
+
+def test_manifest_invalidates_on_missing_image(tmp_path: Path, monkeypatch):
+    """If a cached image file is deleted, manifest is treated as invalid
+    and we refetch."""
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    work = tmp_path / "youtube_tmp"
+
+    monkeypatch.setattr(
+        visual_assets, "_pexels_search",
+        lambda q, *, api_key, per_page=3: _fake_pexels_response([55]),
+    )
+    monkeypatch.setattr(
+        visual_assets, "_download_image",
+        lambda url, dest: (dest.parent.mkdir(parents=True, exist_ok=True),
+                           dest.write_bytes(b"\xFF\xD8"), dest)[2],
+    )
+
+    first = visual_assets.fetch_scene_images(
+        work_dir=work, episode_num=12,
+        keywords=["tesla"], fallback_cover=cover, api_key="fake-key",
+    )
+    # Delete the cached image — cache should now be invalid.
+    first.scenes[0].path.unlink()
+
+    fetch_calls = []
+
+    def tracking_download(url, dest):
+        fetch_calls.append(dest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"\xFF\xD8")
+        return dest
+
+    monkeypatch.setattr(visual_assets, "_download_image", tracking_download)
+    visual_assets.fetch_scene_images(
+        work_dir=work, episode_num=12,
+        keywords=["tesla"], fallback_cover=cover, api_key="fake-key",
+    )
+    # We re-downloaded.
+    assert len(fetch_calls) == 1


### PR DESCRIPTION
## Summary

Two features that turn the long-form from "static cover with spectrum bars" into something a viewer would actually watch through.

### 1. Burned-in transcript captions

We already produce per-episode transcript JSON via faster-whisper for the Podcasting 2.0 RSS `<podcast:transcript>` tag, so this is just JSON→SRT + one extra ffmpeg `subtitles` filter stage.

- Cues sit in a semi-transparent box just above the spectrum band (`Alignment=2, MarginV=320, BorderStyle=3`) — readable without fighting the visualization.
- Sub-100ms artifacts filtered out (whisper sometimes emits these for breath/punctuation and they flicker on screen).
- Russian transcripts work too (UTF-8 round-trip + DejaVu Sans has Cyrillic glyphs).
- Falls back to no-captions silently if transcript JSON is missing.

### 2. Pexels-backed photo slideshow

Each show's `keywords:` list (already in YAML) drives Pexels search queries. We pull 6–8 royalty-free landscape photos per episode and pre-render a stage-1 slideshow MP4 (each scene 12s, hard cuts + Ken Burns per scene). Stage 2 then `-stream_loop`'s the slideshow to match audio length and overlays the existing tint/spectrum/brand/disclosure/captions on top.

- Photographer credits get appended to the description as `Photos via Pexels: …` above the AI disclosure footer.
- Cached per-episode in `digests/<slug>/youtube_tmp/scenes_ep<NNN>/` with a manifest — re-runs don't re-fetch.
- Falls back to single-cover Ken Burns if `PEXELS_API_KEY` is unset, the API errors, returns nothing, or no usable keywords are available.
- Free tier (200 req/hr, 20k/month) easily covers 10 daily shows × ~5 queries each.

### What it looks like for TST

For Tesla Shorts Time, slideshow keywords filter to `tesla, model 3, model y, model x, cybertruck, robotaxi, supercharger, gigafactory, …`. Pexels returns photos of Teslas / Superchargers / generic EV imagery. Each holds for 12s with a slow 1.00→1.12 zoom, then hard-cuts to the next photo. Spectrum bars pulse along the bottom in the colorful `showcqt` palette. Captions read along with the narration in a clean black box. Brand pill stays in the top-left; AI-disclosure overlay fades out at t=4s.

### Architecture

| File | Purpose |
|------|---------|
| `engine/captions.py` | Transcript JSON → SRT, with min-duration filter and word-boundary line wrapping |
| `engine/visual_assets.py` | Pexels client + per-episode cache + manifest with attribution metadata + graceful fallback |
| `engine/video.py` | New `_slideshow_cmd` stage-1 builder; `bg_is_video` branch in long-form filter graph; `subtitles` filter stage; `build_long_form_video` accepts `scene_paths` + `subtitles_path` kwargs |
| `engine/video_metadata.py` | `build_long_form_metadata` accepts `photo_attribution` kwarg |
| `run_show.py` | `_publish_youtube` resolves transcript + fetches scene set + threads both into the builder |
| `.github/workflows/run-show.yml` | Exposes `PEXELS_API_KEY` runtime env |

### Out of scope

- **Shorts captions**: the 55s hook caption is enough; a full transcript track would visually overload mobile.
- **Shorts slideshow**: cover stays static so the hook caption + spectrum stays the focus.
- **AI image gen**: cost + brand consistency + YouTube's 2026 "AI slop" policy crackdown.
- **Stock video clips**: 10× render time for marginal additional engagement.

## Test plan

- [x] `pytest tests/test_video_commands.py tests/test_captions.py tests/test_visual_assets.py tests/test_youtube.py` — 74 pass
- [x] Full `pytest` suite — 1,174 passed, 3 skipped, no regressions
- [x] `ruff check engine/ run_show.py tests/ --select=E9,F63,F7,F82` — clean
- [ ] **Operator (manual)**: add `PEXELS_API_KEY` to GitHub secrets (free signup at pexels.com/api). Without it, the pipeline falls back to single-cover Ken Burns.
- [ ] **Operator (manual)**: trigger `tesla` workflow from Actions UI; verify on YouTube that long-form has slideshow cuts + readable captions, plays through cleanly.

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_