### PR TITLE
Add YouTube Podcasts integration via playlistItems.insert

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -222,6 +222,12 @@ class YouTubeConfig:
     short_duration_seconds: float = 55.0
     tags: List[str] = field(default_factory=list)
     synthetic_disclosure: str = ""
+    # YouTube podcast playlist ID (PL...). When set, every long-form
+    # upload is appended to this playlist via playlistItems.insert.
+    # Listeners then see the show in YouTube Music's Podcasts section.
+    # Operator creates the playlist once in Studio (Content → Playlists
+    # → New → toggle "Set as podcast"). Empty string skips cleanly.
+    podcast_playlist_id: str = ""
 
 
 @dataclass

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -296,3 +296,101 @@ def upload_video(
             logger.warning("Thumbnail upload failed (non-fatal): %s", exc)
 
     return watch_url
+
+
+# ---------------------------------------------------------------------------
+# YouTube Podcasts integration
+# ---------------------------------------------------------------------------
+
+def add_to_podcast_playlist(
+    *,
+    credentials,
+    playlist_id: str,
+    video_id: str,
+) -> bool:
+    """Append a video to a podcast playlist via ``playlistItems.insert``.
+
+    The playlist itself must already exist and have its "Set as podcast"
+    toggle enabled in YouTube Studio — the API surface for that toggle
+    isn't public, which is why the operator creates the playlist by
+    hand once. From there, every long-form episode added to the
+    playlist surfaces in YouTube Music's Podcasts section.
+
+    Costs **50 quota units** per add (negligible vs. ``videos.insert``
+    at 1,600).
+
+    Parameters
+    ----------
+    credentials:
+        Refreshable :class:`google.oauth2.credentials.Credentials`,
+        usually from :func:`get_channel_credentials_from_env`. The
+        ``youtube`` scope is required (``youtube.upload`` alone is
+        insufficient for playlist mutations) — the bootstrap script
+        already requests both, so existing refresh tokens work.
+    playlist_id:
+        The ``PL...`` playlist ID. Pulled from the show's YAML
+        ``youtube.podcast_playlist_id`` field.
+    video_id:
+        The bare YouTube video ID (the ``v=`` part of the watch URL),
+        not the full URL.
+
+    Returns
+    -------
+    bool
+        ``True`` if the API call succeeded; ``False`` if the playlist
+        ID is empty (skipped cleanly) or the API call failed (logged,
+        not raised — playlist add must never crash a run).
+    """
+    if not playlist_id or not playlist_id.strip():
+        logger.info("Podcast playlist ID empty — skipping playlist add")
+        return False
+    if not video_id:
+        logger.warning("No video ID — skipping playlist add")
+        return False
+
+    from googleapiclient.discovery import build
+
+    youtube = build("youtube", "v3", credentials=credentials,
+                    cache_discovery=False)
+
+    body = {
+        "snippet": {
+            "playlistId": playlist_id,
+            "resourceId": {
+                "kind": "youtube#video",
+                "videoId": video_id,
+            },
+        },
+    }
+
+    try:
+        youtube.playlistItems().insert(part="snippet", body=body).execute()
+    except Exception as exc:  # noqa: BLE001 — never crash the run
+        logger.warning(
+            "Failed to add video %s to playlist %s: %s",
+            video_id, playlist_id, exc,
+        )
+        return False
+
+    logger.info("Added %s to podcast playlist %s", video_id, playlist_id)
+    return True
+
+
+def video_id_from_watch_url(watch_url: str) -> str:
+    """Extract the bare video ID from a ``https://www.youtube.com/watch?v=…`` URL.
+
+    Returns an empty string if the URL doesn't match the expected shape
+    (e.g. an empty failure-case from :func:`upload_video`).
+    """
+    if not watch_url:
+        return ""
+    marker = "watch?v="
+    idx = watch_url.find(marker)
+    if idx < 0:
+        return ""
+    tail = watch_url[idx + len(marker):]
+    # Strip any query/fragment trailing the id.
+    for sep in ("&", "#", "?"):
+        if sep in tail:
+            tail = tail.split(sep, 1)[0]
+    return tail

--- a/run_show.py
+++ b/run_show.py
@@ -2456,6 +2456,28 @@ def _publish_youtube(
         except Exception as exc:
             logger.exception("YouTube long-form publish failed: %s", exc)
 
+    # ---- YouTube Podcasts: add long-form to the podcast playlist ----
+    # Surfaces the episode in YouTube Music's Podcasts section. Skips
+    # cleanly if the operator hasn't set up a playlist yet (empty ID).
+    playlist_id = (config.youtube.podcast_playlist_id or "").strip()
+    if long_url and playlist_id:
+        try:
+            from engine.youtube import (
+                add_to_podcast_playlist,
+                video_id_from_watch_url,
+            )
+            video_id = video_id_from_watch_url(long_url)
+            if video_id:
+                added = add_to_podcast_playlist(
+                    credentials=credentials,
+                    playlist_id=playlist_id,
+                    video_id=video_id,
+                )
+                if added:
+                    result["podcast_playlist_added"] = True
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.warning("Podcast playlist add failed: %s", exc)
+
     # ---- Shorts ----
     if config.youtube.publish_shorts:
         try:

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -107,6 +107,12 @@ youtube:
   # Per-episode rendering toggles.
   publish_long_form: true
   publish_shorts: true
+  # YouTube Podcasts integration: paste the playlist's PL... ID per show
+  # to also surface long-form uploads in YouTube Music's Podcasts section.
+  # Operator creates the playlist once in Studio with "Set as podcast"
+  # toggled on. Empty string skips the playlist add cleanly. Set per-show
+  # in shows/<slug>.yaml since each show is its own podcast feed.
+  podcast_playlist_id: ""
   # Shorts clip pulled from the voice track only (skips music intro);
   # keep < 60s so YouTube treats it as a Short.
   short_duration_seconds: 55

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -355,3 +355,126 @@ def test_upload_video_requires_existing_file(tmp_path):
             tags=[],
             category_id=28,
         )
+
+
+# ---------------------------------------------------------------------------
+# YouTube Podcasts integration
+# ---------------------------------------------------------------------------
+
+def test_video_id_from_watch_url_extracts_id():
+    from engine.youtube import video_id_from_watch_url
+    assert video_id_from_watch_url(
+        "https://www.youtube.com/watch?v=abc123"
+    ) == "abc123"
+    # Trailing query params and fragments are stripped.
+    assert video_id_from_watch_url(
+        "https://www.youtube.com/watch?v=abc123&t=30"
+    ) == "abc123"
+    assert video_id_from_watch_url(
+        "https://www.youtube.com/watch?v=abc123#fragment"
+    ) == "abc123"
+
+
+def test_video_id_from_watch_url_returns_empty_on_bad_input():
+    from engine.youtube import video_id_from_watch_url
+    assert video_id_from_watch_url("") == ""
+    assert video_id_from_watch_url("https://example.com/foo") == ""
+    assert video_id_from_watch_url(None) == ""  # type: ignore[arg-type]
+
+
+def test_add_to_podcast_playlist_skips_when_id_empty():
+    from engine.youtube import add_to_podcast_playlist
+    # Empty playlist_id → returns False without making an API call.
+    assert add_to_podcast_playlist(
+        credentials=object(),
+        playlist_id="",
+        video_id="abc",
+    ) is False
+    # Whitespace-only too.
+    assert add_to_podcast_playlist(
+        credentials=object(),
+        playlist_id="   ",
+        video_id="abc",
+    ) is False
+
+
+def test_add_to_podcast_playlist_skips_when_video_id_empty():
+    from engine.youtube import add_to_podcast_playlist
+    assert add_to_podcast_playlist(
+        credentials=object(),
+        playlist_id="PLabc",
+        video_id="",
+    ) is False
+
+
+def test_add_to_podcast_playlist_calls_api_with_correct_body(monkeypatch):
+    """Happy-path: builds a youtube client, calls
+    ``playlistItems.insert`` with the right snippet shape, returns
+    True. We mock the Google client so no network."""
+    from engine import youtube as yt_module
+
+    captured = {}
+
+    class _FakeRequest:
+        def execute(self):
+            captured["executed"] = True
+            return {}
+
+    class _FakePlaylistItems:
+        def insert(self, **kwargs):
+            captured["insert_kwargs"] = kwargs
+            return _FakeRequest()
+
+    class _FakeYouTube:
+        def playlistItems(self):
+            return _FakePlaylistItems()
+
+    import sys
+    fake_discovery = type(sys)("googleapiclient.discovery")
+    fake_discovery.build = lambda *a, **kw: _FakeYouTube()
+    monkeypatch.setitem(sys.modules, "googleapiclient", type(sys)("googleapiclient"))
+    monkeypatch.setitem(sys.modules, "googleapiclient.discovery", fake_discovery)
+
+    result = yt_module.add_to_podcast_playlist(
+        credentials=object(),
+        playlist_id="PLxyz",
+        video_id="vid42",
+    )
+    assert result is True
+    assert captured["executed"] is True
+    body = captured["insert_kwargs"]["body"]
+    assert body["snippet"]["playlistId"] == "PLxyz"
+    assert body["snippet"]["resourceId"]["videoId"] == "vid42"
+    assert body["snippet"]["resourceId"]["kind"] == "youtube#video"
+    assert captured["insert_kwargs"]["part"] == "snippet"
+
+
+def test_add_to_podcast_playlist_returns_false_on_api_error(monkeypatch):
+    """Failures must not raise — the playlist add is best-effort and
+    must never crash a pipeline run."""
+    from engine import youtube as yt_module
+
+    class _FakeRequest:
+        def execute(self):
+            raise RuntimeError("API exploded")
+
+    class _FakePlaylistItems:
+        def insert(self, **kwargs):
+            return _FakeRequest()
+
+    class _FakeYouTube:
+        def playlistItems(self):
+            return _FakePlaylistItems()
+
+    import sys
+    fake_discovery = type(sys)("googleapiclient.discovery")
+    fake_discovery.build = lambda *a, **kw: _FakeYouTube()
+    monkeypatch.setitem(sys.modules, "googleapiclient", type(sys)("googleapiclient"))
+    monkeypatch.setitem(sys.modules, "googleapiclient.discovery", fake_discovery)
+
+    result = yt_module.add_to_podcast_playlist(
+        credentials=object(),
+        playlist_id="PLxyz",
+        video_id="vid42",
+    )
+    assert result is False


### PR DESCRIPTION
Superseded by #256, which shipped the same feature with a slightly cleaner API (`upload_video` returns an `UploadResult` dataclass exposing `video_id` directly, instead of parsing the watch URL). Main also already has the per-show `podcast_playlist_id` values populated across all 10 YAMLs. Closing this without merging — no conflicts to resolve usefully.