### PR TITLE
Add uploaded YouTube videos to their show's podcast playlist

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -222,6 +222,7 @@ class YouTubeConfig:
     short_duration_seconds: float = 55.0
     tags: List[str] = field(default_factory=list)
     synthetic_disclosure: str = ""
+    podcast_playlist_id: Optional[str] = None
 
 
 @dataclass

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
@@ -203,7 +204,7 @@ def upload_video(
     thumbnail_path: Optional[Path] = None,
     contains_synthetic_media: bool = True,
     made_for_kids: bool = False,
-) -> str:
+) -> "UploadResult":
     """Upload a single video and (optionally) its custom thumbnail.
 
     Parameters
@@ -230,8 +231,10 @@ def upload_video(
 
     Returns
     -------
-    str
-        The canonical watch URL (``https://www.youtube.com/watch?v=…``).
+    UploadResult
+        Bundle of ``video_id`` and the canonical ``watch_url``
+        (``https://www.youtube.com/watch?v=…``). Callers that only
+        want the URL should use ``result.watch_url``.
     """
     if not video_path.exists():
         raise FileNotFoundError(f"video not found: {video_path}")
@@ -295,4 +298,61 @@ def upload_video(
         except Exception as exc:  # pragma: no cover - thumbnail is best-effort
             logger.warning("Thumbnail upload failed (non-fatal): %s", exc)
 
-    return watch_url
+    return UploadResult(video_id=video_id, watch_url=watch_url)
+
+
+@dataclass
+class UploadResult:
+    """Return value of :func:`upload_video`.
+
+    Exposes both the bare ``video_id`` (needed for follow-up API calls
+    like ``playlistItems.insert``) and the canonical ``watch_url`` that
+    ends up in RSS feeds and X posts.
+    """
+    video_id: str
+    watch_url: str
+
+
+def add_video_to_playlist(
+    *,
+    credentials,
+    video_id: str,
+    playlist_id: str,
+) -> bool:
+    """Append a video to a playlist via the YouTube Data API.
+
+    Returns ``True`` on success, ``False`` on any 4xx (we don't own
+    the playlist, video is private and not viewable, etc.) or 5xx
+    (which we don't retry — playlist membership is best-effort, not
+    the upload itself).
+
+    Costs 50 quota units per call.
+    """
+    from googleapiclient.discovery import build
+    from googleapiclient.errors import HttpError
+
+    youtube = build(
+        "youtube", "v3", credentials=credentials, cache_discovery=False,
+    )
+    body = {
+        "snippet": {
+            "playlistId": playlist_id,
+            "resourceId": {
+                "kind": "youtube#video",
+                "videoId": video_id,
+            },
+        },
+    }
+    try:
+        youtube.playlistItems().insert(part="snippet", body=body).execute()
+    except HttpError as exc:
+        status = getattr(getattr(exc, "resp", None), "status", "?")
+        logger.warning(
+            "Failed to add video %s to playlist %s (HTTP %s): %s",
+            video_id, playlist_id, status, exc,
+        )
+        return False
+    logger.info(
+        "added video %s to playlist %s", video_id, playlist_id,
+    )
+    return True

--- a/run_show.py
+++ b/run_show.py
@@ -2360,6 +2360,7 @@ def _publish_youtube(
     )
     from engine.visual_assets import fetch_scene_images
     from engine.youtube import (
+        add_video_to_playlist,
         get_channel_credentials_from_env,
         upload_video,
     )
@@ -2441,7 +2442,7 @@ def _publish_youtube(
                 chapters_path=chapters_path if chapters_path.exists() else None,
                 photo_attribution=pexels_attribution,
             )
-            long_url = upload_video(
+            upload = upload_video(
                 long_video_path,
                 credentials=credentials,
                 title=meta["title"],
@@ -2452,7 +2453,21 @@ def _publish_youtube(
                 privacy_status=config.youtube.privacy_status,
                 thumbnail_path=thumbnail_path,
             )
+            long_url = upload.watch_url
             result["long_url"] = long_url
+            playlist_id = (
+                getattr(config.youtube, "podcast_playlist_id", None) or ""
+            ).strip()
+            if not playlist_id:
+                logger.info(
+                    "Podcast playlist ID empty — skipping playlist add."
+                )
+            else:
+                add_video_to_playlist(
+                    credentials=credentials,
+                    video_id=upload.video_id,
+                    playlist_id=playlist_id,
+                )
         except Exception as exc:
             logger.exception("YouTube long-form publish failed: %s", exc)
 
@@ -2478,7 +2493,7 @@ def _publish_youtube(
                 hook=hook,
                 long_form_url=long_url,
             )
-            short_url = upload_video(
+            short_upload = upload_video(
                 short_video_path,
                 credentials=credentials,
                 title=meta["title"],
@@ -2489,7 +2504,20 @@ def _publish_youtube(
                 privacy_status=config.youtube.privacy_status,
                 thumbnail_path=thumbnail_path,
             )
-            result["short_url"] = short_url
+            result["short_url"] = short_upload.watch_url
+            playlist_id = (
+                getattr(config.youtube, "podcast_playlist_id", None) or ""
+            ).strip()
+            if not playlist_id:
+                logger.info(
+                    "Podcast playlist ID empty — skipping playlist add."
+                )
+            else:
+                add_video_to_playlist(
+                    credentials=credentials,
+                    video_id=short_upload.video_id,
+                    playlist_id=playlist_id,
+                )
         except Exception as exc:
             logger.exception("YouTube Shorts publish failed: %s", exc)
 

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -327,7 +327,7 @@ def test_upload_video_invokes_api_and_returns_watch_url(monkeypatch, tmp_path):
                         fake_discovery)
     monkeypatch.setitem(sys.modules, "googleapiclient.http", fake_http)
 
-    url = youtube.upload_video(
+    result = youtube.upload_video(
         video_path,
         credentials=object(),  # not used by the fake
         title="Test",
@@ -337,12 +337,128 @@ def test_upload_video_invokes_api_and_returns_watch_url(monkeypatch, tmp_path):
         default_language="en",
         privacy_status="public",
     )
-    assert url == "https://www.youtube.com/watch?v=abc123"
+    assert isinstance(result, youtube.UploadResult)
+    assert result.video_id == "abc123"
+    assert result.watch_url == "https://www.youtube.com/watch?v=abc123"
 
     body = captured["insert_kwargs"]["body"]
     assert body["status"]["containsSyntheticMedia"] is True
     assert body["snippet"]["title"] == "Test"
     assert captured["insert_kwargs"]["part"] == "snippet,status"
+
+
+def test_upload_result_has_video_id_and_watch_url():
+    result = youtube.UploadResult(
+        video_id="abc123",
+        watch_url="https://www.youtube.com/watch?v=abc123",
+    )
+    assert result.video_id == "abc123"
+    assert result.watch_url == "https://www.youtube.com/watch?v=abc123"
+
+
+def _patch_googleapiclient(monkeypatch, fake_youtube, http_error_cls=None):
+    """Install a fake googleapiclient module tree for the duration of a test."""
+    import sys
+
+    fake_googleapiclient = type(sys)("googleapiclient")
+    fake_discovery = type(sys)("googleapiclient.discovery")
+    fake_http = type(sys)("googleapiclient.http")
+    fake_errors = type(sys)("googleapiclient.errors")
+    fake_discovery.build = lambda *a, **kw: fake_youtube
+    fake_http.MediaFileUpload = lambda *a, **kw: None
+
+    if http_error_cls is None:
+        class HttpError(Exception):
+            def __init__(self, status=400, message="error"):
+                super().__init__(message)
+                self.resp = SimpleNamespace(status=status)
+        http_error_cls = HttpError
+    fake_errors.HttpError = http_error_cls
+
+    fake_googleapiclient.discovery = fake_discovery
+    fake_googleapiclient.http = fake_http
+    fake_googleapiclient.errors = fake_errors
+    monkeypatch.setitem(sys.modules, "googleapiclient", fake_googleapiclient)
+    monkeypatch.setitem(sys.modules, "googleapiclient.discovery", fake_discovery)
+    monkeypatch.setitem(sys.modules, "googleapiclient.http", fake_http)
+    monkeypatch.setitem(sys.modules, "googleapiclient.errors", fake_errors)
+    return http_error_cls
+
+
+def test_add_video_to_playlist_calls_playlistitems_insert(monkeypatch):
+    captured = {}
+
+    class _FakeRequest:
+        def execute(self):
+            captured["executed"] = True
+            return {"id": "playlistitem123"}
+
+    class _FakePlaylistItems:
+        def insert(self, **kwargs):
+            captured["insert_kwargs"] = kwargs
+            return _FakeRequest()
+
+    class _FakeYouTube:
+        def playlistItems(self):
+            return _FakePlaylistItems()
+
+    _patch_googleapiclient(monkeypatch, _FakeYouTube())
+
+    ok = youtube.add_video_to_playlist(
+        credentials=object(),
+        video_id="abc123",
+        playlist_id="PLRHMnzNNXPYCRrcYpPwAzjaRXqzKRUl23",
+    )
+    assert ok is True
+    assert captured["executed"] is True
+    assert captured["insert_kwargs"]["part"] == "snippet"
+    body = captured["insert_kwargs"]["body"]
+    assert body["snippet"]["playlistId"] == (
+        "PLRHMnzNNXPYCRrcYpPwAzjaRXqzKRUl23"
+    )
+    assert body["snippet"]["resourceId"] == {
+        "kind": "youtube#video",
+        "videoId": "abc123",
+    }
+
+
+def test_add_video_to_playlist_returns_false_on_http_error(monkeypatch, caplog):
+    class HttpError(Exception):
+        def __init__(self, status=403, message="forbidden"):
+            super().__init__(message)
+            self.resp = SimpleNamespace(status=status)
+
+    http_error_cls = _patch_googleapiclient(
+        monkeypatch, fake_youtube=None, http_error_cls=HttpError,
+    )
+
+    class _FakeRequest:
+        def execute(self):
+            raise http_error_cls(status=403, message="forbidden")
+
+    class _FakePlaylistItems:
+        def insert(self, **kwargs):
+            return _FakeRequest()
+
+    class _FakeYouTube:
+        def playlistItems(self):
+            return _FakePlaylistItems()
+
+    # Re-patch build to return the youtube fake now that classes exist.
+    import sys
+    sys.modules["googleapiclient.discovery"].build = (
+        lambda *a, **kw: _FakeYouTube()
+    )
+
+    with caplog.at_level("WARNING", logger="engine.youtube"):
+        ok = youtube.add_video_to_playlist(
+            credentials=object(),
+            video_id="abc123",
+            playlist_id="PL_bad",
+        )
+    assert ok is False
+    assert any("403" in rec.message or "Failed" in rec.message
+               for rec in caplog.records)
 
 
 def test_upload_video_requires_existing_file(tmp_path):


### PR DESCRIPTION
## Summary
- After each successful upload, append the video to `config.youtube.podcast_playlist_id` via `playlistItems.insert` (50 quota units/call). Runs once for the long-form video and once for the Shorts.
- `upload_video` now returns a small `UploadResult` dataclass exposing both `video_id` (needed for the playlist insert) and `watch_url` (used everywhere else). Both call sites in `run_show.py:_publish_youtube` were updated.
- New `engine.youtube.add_video_to_playlist` is intentionally best-effort: any `HttpError` (4xx/5xx) is logged as a `WARNING` and the run continues — the upload itself already succeeded, so failing the run because we couldn't add to a playlist would be silly. No retries.
- Empty / missing `podcast_playlist_id` logs `Podcast playlist ID empty — skipping playlist add.` and skips. Useful breadcrumb for any new show added without running `create_youtube_playlists.py`.
- Added `podcast_playlist_id: Optional[str] = None` to the `YouTubeConfig` dataclass so the YAML field is no longer dead.

## Quota note
Each episode now costs 1600 (long upload) + 1600 (short upload) + 100 (thumbnails ×2) + 100 (playlist inserts ×2) = 3,400 units. Per the brief, do NOT enable more shows on this PR — phase-1 set (`tesla`, `fascinating_frontiers`, `models_agents`) only. The 10k/day quota extension is a separate follow-up.

## Test plan
- [x] `pytest tests/test_youtube.py` — 4 new/updated tests pass:
  - `test_upload_video_invokes_api_and_returns_watch_url` — now asserts `UploadResult.video_id` + `watch_url`
  - `test_upload_result_has_video_id_and_watch_url`
  - `test_add_video_to_playlist_calls_playlistitems_insert`
  - `test_add_video_to_playlist_returns_false_on_http_error`
  - (Two pre-existing failures in `test_build_oauth_credentials_*` are environmental — missing `_cffi_backend` for `cryptography` — and reproduce on `main` unchanged.)
- [ ] Manually re-trigger the `tesla` workflow and confirm:
  - Logs include `added video <id> to playlist PLRHMnzNNXPYCRrcYpPwAzjaRXqzKRUl23` twice (long + short)
  - The new videos appear in https://www.youtube.com/playlist?list=PLRHMnzNNXPYCRrcYpPwAzjaRXqzKRUl23

## Out of scope
- Backfilling existing episodes into playlists (separate one-time script).
- Auto-removing privacy-deleted videos from playlists.
- Per-show `youtube.add_to_playlist: bool` flag (only ship if quota turns out to be tight).

https://claude.ai/code/session_01KiwVZd18FK8fZBdDDjP3Q2

---
_Generated by [Claude Code](https://claude.ai/code/session_01KiwVZd18FK8fZBdDDjP3Q2)_