### PR TITLE
Public uploads, prominent show link, real CC track, MAB swap

### DIFF
--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -211,14 +211,23 @@ def build_long_form_metadata(
 
     chapters_block = _format_chapter_block(_read_chapters(chapters_path))
 
+    # Order matters: YouTube only shows the first ~150 chars above the
+    # "Show more" fold on mobile, so the subscribe link goes right
+    # after the hook so it's always visible. Body/chapters/credits
+    # follow.
+    show_label = rss_title or getattr(config, "name", "this show")
+    subscribe_line = (
+        f"🎧 Subscribe to {show_label} on the Nerra Network: {utm_link}"
+    )
+
     pieces: List[str] = []
     if hook:
         pieces.append(hook.strip())
+    pieces.append(subscribe_line)
     if body:
         pieces.append(body)
     if chapters_block:
         pieces.append("Chapters:\n" + chapters_block)
-    pieces.append(f"Listen on the podcast feed: {utm_link}")
     if audio_url:
         pieces.append(f"Direct audio: {audio_url}")
     if photo_attribution:

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -356,3 +356,98 @@ def add_video_to_playlist(
         "added video %s to playlist %s", video_id, playlist_id,
     )
     return True
+
+
+def upload_caption_track(
+    *,
+    credentials,
+    video_id: str,
+    srt_path: Path,
+    language: str = "en",
+    name: str = "English",
+    is_draft: bool = False,
+) -> bool:
+    """Upload a caption track (SRT) to a YouTube video via ``captions.insert``.
+
+    This is on top of the burned-in captions we render into the video
+    pixels — uploading a real caption track lets YouTube:
+
+      - Show the CC button so viewers can toggle captions
+      - Auto-translate to other languages
+      - Surface the captions in YouTube search
+      - Serve them to screen readers / accessibility tools
+
+    Costs **400 quota units** per call.
+
+    Parameters
+    ----------
+    credentials:
+        Refreshable :class:`Credentials` (same one used for upload).
+    video_id:
+        The video ID returned by :func:`upload_video`.
+    srt_path:
+        Path to the SRT subtitle file to upload (output of
+        :func:`engine.captions.transcript_to_srt`).
+    language:
+        BCP-47 language code (``"en"``, ``"ru"``, etc.). Must match
+        what the captions actually contain.
+    name:
+        Human-readable track name shown in YouTube's CC menu (e.g.
+        ``"English"``, ``"Русский"``).
+    is_draft:
+        ``True`` keeps the track as a draft (operator must publish in
+        Studio); ``False`` (default) publishes immediately.
+
+    Returns
+    -------
+    bool
+        ``True`` on success; ``False`` if the SRT is missing or the
+        API call fails (logged, never raised — caption upload is
+        best-effort and must not crash a run).
+    """
+    if not srt_path or not srt_path.exists():
+        logger.info("No SRT file at %s — skipping caption track upload",
+                    srt_path)
+        return False
+    if not video_id:
+        logger.warning("No video ID — skipping caption track upload")
+        return False
+
+    from googleapiclient.discovery import build
+    from googleapiclient.errors import HttpError
+    from googleapiclient.http import MediaFileUpload
+
+    youtube = build(
+        "youtube", "v3", credentials=credentials, cache_discovery=False,
+    )
+    body = {
+        "snippet": {
+            "videoId": video_id,
+            "language": language,
+            "name": name,
+            "isDraft": is_draft,
+        },
+    }
+    media = MediaFileUpload(
+        str(srt_path),
+        mimetype="application/octet-stream",
+        resumable=False,
+    )
+    try:
+        youtube.captions().insert(
+            part="snippet", body=body, media_body=media,
+        ).execute()
+    except HttpError as exc:
+        status = getattr(getattr(exc, "resp", None), "status", "?")
+        logger.warning(
+            "Failed to upload caption track for %s (HTTP %s): %s",
+            video_id, status, exc,
+        )
+        return False
+    except Exception as exc:  # noqa: BLE001 — never crash the run
+        logger.warning(
+            "Caption track upload errored for %s: %s", video_id, exc,
+        )
+        return False
+    logger.info("Uploaded %s caption track for %s", language, video_id)
+    return True

--- a/run_show.py
+++ b/run_show.py
@@ -2468,6 +2468,23 @@ def _publish_youtube(
                     video_id=upload.video_id,
                     playlist_id=playlist_id,
                 )
+            # Upload the SRT as a real caption track. This is on top of
+            # the burned-in captions — gives YouTube the CC button +
+            # auto-translation + accessibility search. Best-effort:
+            # failures are logged and the run continues.
+            if srt_path and srt_path.exists():
+                from engine.youtube import upload_caption_track
+                lang_code = (config.youtube.default_language or "en").lower()
+                track_name = "English" if lang_code == "en" else (
+                    "Русский" if lang_code == "ru" else lang_code.upper()
+                )
+                upload_caption_track(
+                    credentials=credentials,
+                    video_id=upload.video_id,
+                    srt_path=srt_path,
+                    language=lang_code,
+                    name=track_name,
+                )
         except Exception as exc:
             logger.exception("YouTube long-form publish failed: %s", exc)
 

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -216,7 +216,7 @@ youtube:
   channel: en
   category_id: 28               # Science & Tech
   default_language: en
-  privacy_status: unlisted
+  privacy_status: public        # Phase-1 validated; uploads are public
   tags:
     - space
     - astronomy

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -232,11 +232,11 @@ newsletter:
 
 youtube:
   podcast_playlist_id: PLRHMnzNNXPYAUq0HBfZahYXJaEaknuTGg
-  enabled: true                 # Phase-1 rollout show
+  enabled: false                # Phase 2 (swapped out for models_agents_beginners)
   channel: en
   category_id: 28               # Science & Tech
   default_language: en
-  privacy_status: unlisted
+  privacy_status: public
   tags:
     - ai
     - llm

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -203,10 +203,11 @@ slow_news:
 
 youtube:
   podcast_playlist_id: PLRHMnzNNXPYBFcirj6Ivq6PxZealY8fAp
-  enabled: false                # Phase 2 — flip after quota raise
+  enabled: true                 # Phase-1 rollout show (replaces models_agents)
   channel: en
   category_id: 27               # Education (beginner / teen-focused)
   default_language: en
+  privacy_status: public
   tags:
     - ai for beginners
     - learn ai

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -217,7 +217,7 @@ youtube:
   channel: en
   category_id: 28               # Science & Tech (algorithm performs better than 2/Autos here)
   default_language: en
-  privacy_status: unlisted      # Flip to "public" after first successful upload
+  privacy_status: public        # Phase-1 validated; uploads are public
   tags:
     - tesla
     - tsla

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -471,3 +471,181 @@ def test_upload_video_requires_existing_file(tmp_path):
             tags=[],
             category_id=28,
         )
+
+
+# ---------------------------------------------------------------------------
+# Description ordering — subscribe link must sit above the fold
+# ---------------------------------------------------------------------------
+
+def test_long_form_description_subscribe_link_appears_before_body():
+    """Subscribe link should be right after the hook, before the digest
+    body — so it's visible above YouTube's "Show more" fold."""
+    config = _make_config()
+    meta = vm.build_long_form_metadata(
+        config,
+        episode_num=42,
+        today_str="2026-04-26",
+        hook="Robotaxi expands to Vancouver",
+        digest_text="Tesla announced robotaxi expansion today, with...",
+        audio_url="https://audio.nerranetwork.com/tesla/ep042.mp3",
+    )
+    desc = meta["description"]
+    hook_idx = desc.find("Robotaxi expands to Vancouver")
+    subscribe_idx = desc.find("Subscribe to")
+    body_idx = desc.find("Tesla announced robotaxi expansion")
+    assert hook_idx >= 0 and subscribe_idx >= 0 and body_idx >= 0
+    assert hook_idx < subscribe_idx < body_idx, (
+        "Order must be: hook → subscribe → body"
+    )
+
+
+def test_long_form_description_subscribe_uses_show_name():
+    config = _make_config(rss_title="Tesla Shorts Time Daily")
+    meta = vm.build_long_form_metadata(
+        config,
+        episode_num=1,
+        today_str="2026-04-26",
+        hook="A hook",
+        digest_text="Body",
+        audio_url="",
+    )
+    assert "Subscribe to Tesla Shorts Time Daily" in meta["description"]
+    assert "🎧" in meta["description"]
+
+
+# ---------------------------------------------------------------------------
+# Caption track upload
+# ---------------------------------------------------------------------------
+
+def test_upload_caption_track_skips_when_srt_missing(tmp_path):
+    from engine.youtube import upload_caption_track
+    assert upload_caption_track(
+        credentials=object(),
+        video_id="abc",
+        srt_path=tmp_path / "missing.srt",
+        language="en",
+    ) is False
+
+
+def test_upload_caption_track_skips_when_video_id_empty(tmp_path):
+    from engine.youtube import upload_caption_track
+    srt = tmp_path / "captions.srt"
+    srt.write_text("1\n00:00:00,000 --> 00:00:02,000\nHi\n", encoding="utf-8")
+    assert upload_caption_track(
+        credentials=object(),
+        video_id="",
+        srt_path=srt,
+        language="en",
+    ) is False
+
+
+def test_upload_caption_track_calls_api_with_correct_body(monkeypatch, tmp_path):
+    """Happy-path: correct snippet shape (videoId, language, name,
+    isDraft) and a media body, returns True."""
+    from engine import youtube as yt_module
+
+    srt = tmp_path / "ep001.srt"
+    srt.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n",
+                   encoding="utf-8")
+
+    captured = {}
+
+    class _FakeRequest:
+        def execute(self):
+            captured["executed"] = True
+            return {"id": "cap123"}
+
+    class _FakeCaptions:
+        def insert(self, **kwargs):
+            captured["insert_kwargs"] = kwargs
+            return _FakeRequest()
+
+    class _FakeYouTube:
+        def captions(self):
+            return _FakeCaptions()
+
+    class _FakeMediaFileUpload:
+        def __init__(self, *args, **kwargs):
+            captured["media_args"] = (args, kwargs)
+
+    import sys
+    fake_googleapiclient = type(sys)("googleapiclient")
+    fake_discovery = type(sys)("googleapiclient.discovery")
+    fake_http = type(sys)("googleapiclient.http")
+    fake_errors = type(sys)("googleapiclient.errors")
+    fake_errors.HttpError = type("HttpError", (Exception,), {})
+    fake_discovery.build = lambda *a, **kw: _FakeYouTube()
+    fake_http.MediaFileUpload = _FakeMediaFileUpload
+    fake_googleapiclient.discovery = fake_discovery
+    fake_googleapiclient.http = fake_http
+    fake_googleapiclient.errors = fake_errors
+    monkeypatch.setitem(sys.modules, "googleapiclient", fake_googleapiclient)
+    monkeypatch.setitem(sys.modules, "googleapiclient.discovery",
+                        fake_discovery)
+    monkeypatch.setitem(sys.modules, "googleapiclient.http", fake_http)
+    monkeypatch.setitem(sys.modules, "googleapiclient.errors", fake_errors)
+
+    result = yt_module.upload_caption_track(
+        credentials=object(),
+        video_id="vid42",
+        srt_path=srt,
+        language="en",
+        name="English",
+    )
+    assert result is True
+    body = captured["insert_kwargs"]["body"]
+    assert body["snippet"]["videoId"] == "vid42"
+    assert body["snippet"]["language"] == "en"
+    assert body["snippet"]["name"] == "English"
+    assert body["snippet"]["isDraft"] is False
+    assert captured["insert_kwargs"]["part"] == "snippet"
+
+
+def test_upload_caption_track_returns_false_on_api_error(monkeypatch, tmp_path):
+    """Failures must not raise — caption upload is best-effort."""
+    from engine import youtube as yt_module
+
+    srt = tmp_path / "ep001.srt"
+    srt.write_text("1\n00:00:00,000 --> 00:00:02,000\nHi\n", encoding="utf-8")
+
+    class _FakeHttpError(Exception):
+        pass
+
+    class _FakeRequest:
+        def execute(self):
+            err = _FakeHttpError("boom")
+            err.resp = type("R", (), {"status": 403})()
+            raise err
+
+    class _FakeCaptions:
+        def insert(self, **kwargs):
+            return _FakeRequest()
+
+    class _FakeYouTube:
+        def captions(self):
+            return _FakeCaptions()
+
+    import sys
+    fake_googleapiclient = type(sys)("googleapiclient")
+    fake_discovery = type(sys)("googleapiclient.discovery")
+    fake_http = type(sys)("googleapiclient.http")
+    fake_errors = type(sys)("googleapiclient.errors")
+    fake_errors.HttpError = _FakeHttpError
+    fake_discovery.build = lambda *a, **kw: _FakeYouTube()
+    fake_http.MediaFileUpload = lambda *a, **kw: None
+    fake_googleapiclient.discovery = fake_discovery
+    fake_googleapiclient.http = fake_http
+    fake_googleapiclient.errors = fake_errors
+    monkeypatch.setitem(sys.modules, "googleapiclient", fake_googleapiclient)
+    monkeypatch.setitem(sys.modules, "googleapiclient.discovery",
+                        fake_discovery)
+    monkeypatch.setitem(sys.modules, "googleapiclient.http", fake_http)
+    monkeypatch.setitem(sys.modules, "googleapiclient.errors", fake_errors)
+
+    result = yt_module.upload_caption_track(
+        credentials=object(),
+        video_id="vid42",
+        srt_path=srt,
+        language="en",
+    )
+    assert result is False


### PR DESCRIPTION
## Summary

Four polish fixes after watching the first uploads land in Studio.

### 1. Public uploads
Phase-1 YAMLs were still pinned at `privacy_status: unlisted` from the original safety setup. Flipped:
- `shows/tesla.yaml` → `public`
- `shows/fascinating_frontiers.yaml` → `public`

Network default in `_defaults.yaml` has been `public` for a while; this brings the per-show overrides in line.

### 2. Phase-1 roster swap
- `shows/models_agents.yaml` → `enabled: false`
- `shows/models_agents_beginners.yaml` → `enabled: true` (with `privacy_status: public`)

Phase-1 is now: **Tesla Shorts Time + Fascinating Frontiers + Models & Agents for Beginners**.

### 3. Prominent subscribe link in long-form description
Subscribe link now sits **right after the hook**, before the digest body:

```
Tesla just unveiled a Virtual Queue for Superchargers.

🎧 Subscribe to Tesla Shorts Time Daily on the Nerra Network: https://nerranetwork.com/tesla.html?utm_source=youtube&utm_medium=video&utm_campaign=ep452

[digest body…]

Chapters:
0:00 Introduction
…
```

YouTube only shows the first ~150 chars above the "Show more" fold on mobile, so this is the placement that's actually visible. Format includes both the show name and the Nerra Network branding so viewers know what they're subscribing to without clicking.

### 4. Real CC track upload
After the long-form upload, we now upload the same SRT we already burn into the video as a real YouTube caption track via `captions.insert` (400 quota units).

- **Burned-in captions** stay (visual consistency, always-on, can't be disabled)
- **CC track** adds: YouTube's CC button, auto-translation to other languages, search indexing of dialogue, screen-reader/accessibility support

Best-effort: failures are logged and the run continues. The default audio/caption language follows `youtube.default_language` so RU shows get a Russian track named "Русский".

## Operator note: Podcasts tab still empty

The Podcasts tab is empty in Studio because the **"Set as podcast"** toggle hasn't been flipped on the playlists yet. That toggle is not exposed in the YouTube Data API — it has to be clicked once per playlist in Studio:

> Content → Playlists → click "Tesla Shorts Time Daily" → Settings (gear icon) → "Set as podcast" → On

Repeat for each of the 8 English playlists on Nerra Network and 2 RU playlists on Nerra RU. Until that's done, videos appear in the Playlists tab (which `playlistItems.insert` populates) but won't show up under the Podcasts tab or in YouTube Music's Podcasts section.

## Test plan

- [x] `pytest tests/test_youtube.py` — 28/28 pass
- [x] Full `pytest` suite — 1,183 passed, 3 skipped, no regressions
- [x] `ruff check engine/ run_show.py tests/ --select=E9,F63,F7,F82` — clean
- [ ] **Operator (manual)**: flip "Set as podcast" on each playlist in Studio
- [ ] **Operator (manual)**: trigger one phase-1 show and verify in Studio:
  - Visibility = Public
  - Description's first line: hook → second line: 🎧 Subscribe to … link
  - Edit video → Subtitles tab shows an "English" track listed
  - CC button appears on the player

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_