### PR TITLE
Apply long-form's slideshow + Ken Burns recipe to YouTube Shorts

### DIFF
--- a/engine/video.py
+++ b/engine/video.py
@@ -188,10 +188,13 @@ def _make_brand_pill(output_path: Path,
 # Slideshow renderer (stage 1)
 # ---------------------------------------------------------------------------
 
-# Each photo holds for ~12 s — long enough to read the spectrum + caption
-# but short enough that the long-form keeps moving. Slideshow loops in
-# stage 2 so we don't need to scale the photo count to audio length.
+# Each photo holds for ~12 s on long-form — long enough to read the
+# spectrum + caption but short enough that the video keeps moving.
+# Shorts use a faster pace (~7 s/scene) so a 55 s clip sees ~8 scene
+# changes; static photos for 12 s on a phone scroll feel like
+# nothing's happening.
 _SCENE_DURATION_SECONDS = 12.0
+_SHORT_SCENE_DURATION_SECONDS = 7.0
 
 
 def _slideshow_filter_graph(scene_count: int, *,
@@ -227,8 +230,13 @@ def _slideshow_filter_graph(scene_count: int, *,
 
 def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
                    *, scene_duration: float = _SCENE_DURATION_SECONDS,
+                   width: int = 1920, height: int = 1080,
                    fps: int = 30) -> List[str]:
-    """ffmpeg command for stage 1 (slideshow render)."""
+    """ffmpeg command for stage 1 (slideshow render).
+
+    *width* and *height* default to 1920x1080 for the long-form path;
+    pass 1080x1920 for the vertical Shorts variant.
+    """
     inputs: List[str] = []
     for path in scene_paths:
         inputs.extend([
@@ -242,7 +250,8 @@ def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
         *inputs,
         "-filter_complex",
         _slideshow_filter_graph(len(scene_paths),
-                                scene_duration=scene_duration, fps=fps),
+                                scene_duration=scene_duration,
+                                width=width, height=height, fps=fps),
         "-map", "[v]",
         "-r", str(fps),
         *_VIDEO_ENCODE,
@@ -253,13 +262,17 @@ def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
 
 
 def _render_slideshow(scene_paths: Sequence[Path], output: Path,
-                      *, fps: int = 30) -> Path:
+                      *, scene_duration: float = _SCENE_DURATION_SECONDS,
+                      width: int = 1920, height: int = 1080,
+                      fps: int = 30) -> Path:
     """Render the stage-1 slideshow MP4. Idempotent (skips if output exists)."""
     if output.exists():
         return output
-    cmd = _slideshow_cmd(scene_paths, output, fps=fps)
-    logger.info("Rendering slideshow (%d scenes) → %s",
-                len(scene_paths), output.name)
+    cmd = _slideshow_cmd(scene_paths, output,
+                         scene_duration=scene_duration,
+                         width=width, height=height, fps=fps)
+    logger.info("Rendering slideshow (%d scenes, %dx%d) → %s",
+                len(scene_paths), width, height, output.name)
     subprocess.run(cmd, check=True, capture_output=True)
     return output
 
@@ -358,16 +371,37 @@ def _long_form_filter_graph(*, width: int = 1920, height: int = 1080,
 
 def _short_form_filter_graph(width: int = 1080, height: int = 1920,
                              fps: int = 30,
-                             hook: Optional[str] = None) -> str:
-    """filter_complex for the 1080x1920 Shorts build."""
+                             hook: Optional[str] = None,
+                             bg_is_video: bool = False) -> str:
+    """filter_complex for the 1080x1920 Shorts build.
+
+    Inputs:
+      ``[0:v]`` — background. Either looped cover image (static) or
+      pre-rendered vertical slideshow MP4 (motion baked in; we just
+      scale to fill).
+      ``[1:a]`` — episode audio (clipped to ~55 s by input-side
+      ``-ss``/``-t`` upstream).
+      ``[2:v]`` — brand pill PNG, looped.
+    """
     viz_h = height // 4 + 40
     viz_y = (height // 2) - (viz_h // 2)
     font_path = _drawtext_escape(_find_font())
 
+    if bg_is_video:
+        bg_chain = (
+            f"[0:v]"
+            f"scale={width}:{height}:force_original_aspect_ratio=increase,"
+            f"crop={width}:{height},setsar=1,format=yuv420p[bg]"
+        )
+    else:
+        bg_chain = (
+            f"[0:v]"
+            f"scale={width}:{height}:force_original_aspect_ratio=increase,"
+            f"crop={width}:{height},setsar=1,format=yuv420p[bg]"
+        )
+
     base = (
-        f"[0:v]"
-        f"scale={width}:{height}:force_original_aspect_ratio=increase,"
-        f"crop={width}:{height},setsar=1,format=yuv420p[bg];"
+        f"{bg_chain};"
         f"[bg]drawbox=x=0:y={viz_y}:w={width}:h={viz_h}"
         f":color=black@0.25:t=fill[bg2];"
         f"[1:a]showcqt=s={width}x{viz_h}:fps={fps}"
@@ -435,22 +469,35 @@ def _long_form_cmd(audio_in: str, bg_in: str, brand_in: str,
     ]
 
 
-def _short_form_cmd(audio_in: str, cover_in: str, brand_in: str,
+def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
                     output: str, *,
                     start_offset: float = 0.0,
                     duration: float = 55.0,
                     fps: int = 30,
-                    hook: Optional[str] = None) -> List[str]:
-    """ffmpeg command for the 1080x1920 Shorts build."""
+                    hook: Optional[str] = None,
+                    bg_is_video: bool = False) -> List[str]:
+    """ffmpeg command for the 1080x1920 Shorts build.
+
+    When *bg_is_video* is True, *bg_in* is a pre-rendered vertical
+    slideshow MP4; we ``-stream_loop -1`` it so it loops to match the
+    Shorts clip length, and we drop the ``-loop 1 -framerate``
+    image-input flags.
+    """
+    if bg_is_video:
+        bg_input = ["-stream_loop", "-1", "-i", bg_in]
+    else:
+        bg_input = ["-loop", "1", "-framerate", str(fps), "-i", bg_in]
+
     return [
         "ffmpeg", "-y", "-threads", "0",
-        "-loop", "1", "-framerate", str(fps), "-i", cover_in,
+        *bg_input,
         "-ss", f"{start_offset:.2f}",
         "-t", f"{duration:.2f}",
         "-i", audio_in,
         "-loop", "1", "-framerate", str(fps), "-i", brand_in,
         "-filter_complex",
-        _short_form_filter_graph(1080, 1920, fps, hook),
+        _short_form_filter_graph(1080, 1920, fps, hook,
+                                 bg_is_video=bg_is_video),
         "-map", "[v]", "-map", "1:a",
         *_VIDEO_ENCODE,
         "-r", str(fps),
@@ -543,8 +590,29 @@ def build_short_video(audio_path: Path, cover_path: Path,
                       start_offset: float = 0.0,
                       duration: float = 55.0,
                       fps: int = 30,
-                      hook: Optional[str] = None) -> Path:
-    """Render a 1080x1920 vertical YouTube Shorts video."""
+                      hook: Optional[str] = None,
+                      scene_paths: Optional[Sequence[Path]] = None) -> Path:
+    """Render a 1080x1920 vertical YouTube Shorts video.
+
+    Parameters
+    ----------
+    audio_path:
+        Source audio. Only the slice from *start_offset* to
+        *start_offset + duration* is included.
+    cover_path:
+        Show cover image — used as the static background when
+        ``scene_paths`` is empty/unset, or as the fallback if the
+        slideshow render fails.
+    output_path:
+        Where to write the MP4.
+    start_offset, duration, fps, hook:
+        See module docstring.
+    scene_paths:
+        Optional list of slideshow images. ``len ≥ 2`` triggers the
+        two-stage pipeline (vertical slideshow MP4 first, then
+        composite). A single-element list (or ``None``) keeps the
+        existing static-cover path.
+    """
     if duration >= 60:
         raise ValueError(
             f"Shorts duration must stay below 60s; got {duration}"
@@ -554,14 +622,34 @@ def build_short_video(audio_path: Path, cover_path: Path,
     if not cover_path.exists():
         raise FileNotFoundError(f"cover not found: {cover_path}")
 
-    brand_path = output_path.parent / "_brand_pill.png"
+    work_dir = output_path.parent
+    brand_path = work_dir / "_brand_pill.png"
     _make_brand_pill(brand_path)
 
+    bg_path: Path = cover_path
+    bg_is_video = False
+    if scene_paths and len(scene_paths) >= 2:
+        slideshow_path = work_dir / f"{output_path.stem}_short_slides.mp4"
+        try:
+            _render_slideshow(
+                scene_paths, slideshow_path,
+                scene_duration=_SHORT_SCENE_DURATION_SECONDS,
+                width=1080, height=1920, fps=fps,
+            )
+            bg_path = slideshow_path
+            bg_is_video = True
+        except subprocess.CalledProcessError as exc:
+            logger.warning(
+                "Shorts slideshow render failed (%s) — falling back to cover",
+                exc,
+            )
+
     cmd = _short_form_cmd(
-        str(audio_path), str(cover_path), str(brand_path),
+        str(audio_path), str(bg_path), str(brand_path),
         str(output_path),
         start_offset=start_offset,
         duration=duration, fps=fps, hook=hook,
+        bg_is_video=bg_is_video,
     )
     logger.info(
         "Building Shorts video (%.1fs from %.1fs) → %s",

--- a/run_show.py
+++ b/run_show.py
@@ -2502,6 +2502,7 @@ def _publish_youtube(
                 start_offset=short_offset,
                 duration=duration,
                 hook=hook or None,
+                scene_paths=scene_paths if len(scene_paths) >= 2 else None,
             )
             meta = build_short_metadata(
                 config,

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -549,3 +549,136 @@ def test_build_long_form_video_threads_subtitles(tmp_path, monkeypatch):
     graph = captured["cmd"][captured["cmd"].index("-filter_complex") + 1]
     assert "subtitles=" in graph
     assert "captions.srt" in graph
+
+
+# ---------------------------------------------------------------------------
+# Shorts slideshow — vertical version of the long-form slideshow
+# ---------------------------------------------------------------------------
+
+def test_slideshow_filter_graph_supports_vertical_dimensions():
+    """The slideshow generator should respect width/height kwargs so
+    the same code path produces both 1920x1080 and 1080x1920 output."""
+    graph = _slideshow_filter_graph(
+        scene_count=3, width=1080, height=1920,
+    )
+    assert "1080:1920" in graph or "s=1080x1920" in graph
+    # Per-scene zoompan still drives motion.
+    assert graph.count("zoompan") == 3
+    assert "concat=n=3:v=1:a=0[v]" in graph
+
+
+def test_slideshow_cmd_accepts_width_height(tmp_path):
+    paths = [tmp_path / f"scene{i}.jpg" for i in range(3)]
+    out = tmp_path / "vertical_slides.mp4"
+    cmd = _slideshow_cmd(paths, out, width=1080, height=1920,
+                         scene_duration=7.0)
+    assert cmd.count("-i") == 3
+    assert "-an" in cmd
+    graph = cmd[cmd.index("-filter_complex") + 1]
+    assert "s=1080x1920" in graph or "1080:1920" in graph
+    assert cmd[-1] == str(out)
+
+
+def test_short_form_filter_graph_with_video_bg_skips_loop_setup():
+    """When the Shorts background is the slideshow MP4, the bg chain
+    should still produce [bg] but the caller doesn't need a zoompan
+    (motion's already in the slideshow)."""
+    graph = _short_form_filter_graph(bg_is_video=True)
+    assert "showcqt" in graph
+    assert "scale=1080:1920" in graph
+    # Brand pill + tint + spectrum still composite.
+    assert "drawbox" in graph and "color=black@0.25" in graph
+    assert graph.endswith("[v]")
+
+
+def test_short_form_cmd_uses_stream_loop_for_video_bg():
+    """When bg is the pre-rendered vertical slideshow MP4, we use
+    -stream_loop -1 instead of -loop 1 -framerate."""
+    cmd = _short_form_cmd(
+        "voice.mp3", "vertical_slides.mp4", "brand.png", "short.mp4",
+        start_offset=10.0, duration=55.0, bg_is_video=True,
+    )
+    assert "-stream_loop" in cmd
+    assert cmd[cmd.index("-stream_loop") + 1] == "-1"
+    # -loop only on the brand input now (1 occurrence, not 2).
+    assert cmd.count("-loop") == 1
+    # Three -i still: bg, audio, brand.
+    assert cmd.count("-i") == 3
+
+
+def test_short_form_cmd_image_bg_unchanged():
+    """When bg is a still image (default path), the existing -loop 1
+    -framerate flags still apply."""
+    cmd = _short_form_cmd(
+        "voice.mp3", "cover.jpg", "brand.png", "short.mp4",
+        start_offset=10.0, duration=55.0,
+    )
+    assert "-stream_loop" not in cmd
+    # Two looped image inputs (cover + brand pill).
+    assert cmd.count("-loop") == 2
+
+
+def test_build_short_video_falls_back_to_cover_with_one_scene(tmp_path,
+                                                              monkeypatch):
+    """Single-scene list should NOT trigger the two-stage Shorts
+    pipeline (one photo isn't a slideshow)."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    out = tmp_path / "short.mp4"
+
+    captured_cmds = []
+    monkeypatch.setattr(
+        "engine.video.subprocess.run",
+        lambda cmd, **kw: (captured_cmds.append(list(cmd)),
+                           type("R", (), {"returncode": 0})())[1],
+    )
+    build_short_video(audio, cover, out, duration=55.0,
+                      scene_paths=[cover])
+    # Only one ffmpeg invocation (no slideshow stage).
+    assert len(captured_cmds) == 1
+    # And no -stream_loop on the bg.
+    assert "-stream_loop" not in captured_cmds[0]
+
+
+def test_build_short_video_renders_vertical_slideshow_for_multi_scene(tmp_path,
+                                                                       monkeypatch):
+    """Multi-scene list triggers a stage-1 vertical slideshow render
+    before the final composite."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    scenes = []
+    for i in range(3):
+        s = tmp_path / f"scene{i}.jpg"
+        s.write_bytes(b"\xFF\xD8")
+        scenes.append(s)
+    out = tmp_path / "short.mp4"
+
+    captured_cmds = []
+
+    def fake_run(cmd, **kw):
+        captured_cmds.append(list(cmd))
+        # Stage 1 writes the slideshow MP4; touch it so stage 2 sees it.
+        if "-an" in cmd:
+            from pathlib import Path as _P
+            _P(cmd[-1]).write_bytes(b"\x00")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    build_short_video(audio, cover, out, duration=55.0,
+                      scene_paths=scenes)
+
+    # Two ffmpeg invocations: stage-1 vertical slideshow, stage-2 composite.
+    assert len(captured_cmds) == 2
+    # Stage 1: 3 inputs, no audio output, vertical resolution in graph.
+    assert "-an" in captured_cmds[0]
+    assert captured_cmds[0].count("-i") == 3
+    stage1_graph = captured_cmds[0][
+        captured_cmds[0].index("-filter_complex") + 1
+    ]
+    assert "s=1080x1920" in stage1_graph or "1080:1920" in stage1_graph
+    # Stage 2 uses -stream_loop on the slideshow MP4.
+    assert "-stream_loop" in captured_cmds[1]


### PR DESCRIPTION
## Summary

Shorts were visually static — same cover image for the full 55s, just with a spectrum band in the middle. This brings them up to the same visual recipe as the long-form: Pexels photos cut between each other with Ken Burns zoom on each, looped to match the clip length, with spectrum / brand pill / hook caption overlaid on top.

## Pacing tuned per format

- **Long-form**: 12s per scene (existing — long enough to read captions on a 9-minute episode)
- **Shorts**: 7s per scene (new — 55s clip sees ~8 cuts; static photos for 12s each on a phone scroll feel like nothing's happening)

## Architecture

Same two-stage pipeline as the long-form:

1. **Stage 1** renders `<base>_short_slides.mp4` (vertical 1080x1920 slideshow with hard cuts + Ken Burns per scene, no audio).
2. **Stage 2** composites spectrum + brand pill + hook caption over the slideshow, looping with `-stream_loop -1` to match the clipped audio.

The slideshow generator (`_slideshow_filter_graph`, `_slideshow_cmd`, `_render_slideshow`) gains `width` / `height` kwargs so the same code path produces both 1920x1080 and 1080x1920 output.

`build_short_video` gains a `scene_paths` kwarg (default `None` preserves existing behaviour). `run_show.py:_publish_youtube` passes the same scene set the long-form already uses, so Shorts and long-form share photos within an episode for visual continuity.

Single-scene fallback (no Pexels key, API errored, no usable keywords) keeps the existing static-cover path — same code, same look, no regressions.

## Files

| File | Change |
|------|--------|
| `engine/video.py` | `_slideshow_cmd` / `_render_slideshow` accept width/height; `_short_form_filter_graph` + `_short_form_cmd` gain `bg_is_video` branch; `build_short_video` accepts `scene_paths` and pre-renders vertical slideshow when len ≥ 2 |
| `run_show.py` | `_publish_youtube` passes `scene_paths` into `build_short_video` |
| `tests/test_video_commands.py` | 7 new test cases covering vertical filter graph, `-stream_loop` branch, slideshow command with width/height kwargs, two-stage Shorts pipeline |

## Test plan

- [x] `pytest tests/test_video_commands.py` — 42/42 pass
- [x] Full `pytest` suite — 1,190 passed, 3 skipped, no regressions
- [x] `ruff check engine/ run_show.py tests/ --select=E9,F63,F7,F82` — clean
- [ ] **Operator (manual)**: trigger `tesla` from Actions UI; on the next Shorts upload, confirm photos cut every ~7s + Ken Burns is visible + hook caption shows for first 3s.

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_