### PR TITLE
Cross-post YouTube URL into RSS, blog, X teaser, and closing script

### DIFF
--- a/engine/blog.py
+++ b/engine/blog.py
@@ -517,6 +517,8 @@ def generate_blog_post_html(
     prev_post: Optional[dict] = None,
     next_post: Optional[dict] = None,
     related_posts: Optional[list] = None,
+    youtube_url: str = "",
+    youtube_short_url: str = "",
 ) -> str:
     """Generate a complete blog post HTML page from digest markdown.
 
@@ -613,6 +615,10 @@ def generate_blog_post_html(
         "related_posts": related_posts or [],
         "newsletter_tag": show_config["name"],
         "page_lang": "ru" if show_slug in ("finansy_prosto", "privet_russian") else "en",
+        # YouTube cross-posting — when present, the template renders a
+        # "Watch on YouTube" button next to the existing podcast/summaries CTAs.
+        "youtube_url": youtube_url or metadata.get("youtube_url", ""),
+        "youtube_short_url": youtube_short_url or metadata.get("youtube_short_url", ""),
     }
 
     return template.render(**context)

--- a/engine/intros.py
+++ b/engine/intros.py
@@ -634,6 +634,7 @@ def build_closing_block(
     today_str: str,
     date: datetime.date | None = None,
     extra_context: dict[str, Any] | None = None,
+    youtube_channel_handle: str = "",
 ) -> str:
     """Build a dynamic, day-varying closing block for the given show.
 
@@ -649,6 +650,11 @@ def build_closing_block(
         ``datetime.date`` for deterministic selection.
     extra_context:
         Optional dict with show-specific vars (e.g. Tesla stock price/change).
+    youtube_channel_handle:
+        Optional ``@handle`` of the show's YouTube channel (e.g.
+        ``"@NerraNetwork"``). When set, a brief callout sentence is
+        appended to the closing so the spoken script mentions where
+        listeners can watch the video version.
 
     Returns
     -------
@@ -661,18 +667,40 @@ def build_closing_block(
     personality = _SHOW_PERSONALITIES.get(show_slug)
     if not personality:
         logger.warning("No closing personality for show '%s' — using generic.", show_slug)
-        return (
+        base = (
             f"Patrick: That's the show for today. Thanks for listening, "
             f"and I'll see you tomorrow."
         )
+        return _maybe_append_youtube_cta(base, youtube_channel_handle)
 
     host = personality["host"]
     closing_pool = personality.get("closings", [])
     if not closing_pool:
-        return f"{host}: Thanks for listening. See you tomorrow."
+        return _maybe_append_youtube_cta(
+            f"{host}: Thanks for listening. See you tomorrow.",
+            youtube_channel_handle,
+        )
 
     closing = _pick(closing_pool, show_slug, date, salt="closing")
-    return f"{host}: {closing}"
+    return _maybe_append_youtube_cta(f"{host}: {closing}",
+                                     youtube_channel_handle)
+
+
+def _maybe_append_youtube_cta(closing: str, handle: str) -> str:
+    """Append a brief "watch on YouTube" callout when a handle is set.
+
+    Idempotent — won't duplicate the line if it's already present.
+    """
+    handle = (handle or "").strip()
+    if not handle:
+        return closing
+    if "youtube" in closing.lower() or handle.lower() in closing.lower():
+        return closing
+    cta = (
+        f" And if you'd rather watch than listen, find us on YouTube at "
+        f"{handle} — link's in the show notes."
+    )
+    return closing + cta
 
 
 def get_show_host(show_slug: str) -> str:

--- a/run_show.py
+++ b/run_show.py
@@ -1286,21 +1286,34 @@ def run(args: argparse.Namespace) -> None:
         # the detailed first-episode introduction based on {episode_num}.
         from engine.intros import build_intro_line, build_closing_block, get_show_host
         host = getattr(config.publishing, "host_name", None) or get_show_host(args.show)
+        # Pick the YouTube channel handle so the closing line can mention
+        # the right channel. Empty string means "don't mention YouTube"
+        # (e.g. shows where YouTube publishing isn't enabled yet).
+        _yt_handle = ""
+        if getattr(config, "youtube", None) and config.youtube.enabled:
+            _yt_handle = (
+                "@NerraRU" if config.youtube.channel == "ru" else "@NerraNetwork"
+            )
         if episode_num == 1:
             pod_vars.setdefault(
                 "intro_line",
                 f"{host}: Welcome to the very first episode of {config.name}! "
                 f"Today is {today_str}. {effective_hook}",
             )
-            pod_vars.setdefault(
-                "closing_block",
+            _ep1_close = (
                 f"{host}: That wraps up our very first episode of {config.name}! "
                 f"If you enjoyed this, please subscribe on Apple Podcasts, Spotify, "
                 f"or wherever you listen — and a rating or review really helps new "
                 f"listeners find us. "
                 f"I'm {host} in Vancouver. Thanks for joining me on this journey, "
-                f"and I'll see you tomorrow for episode two.",
+                f"and I'll see you tomorrow for episode two."
             )
+            if _yt_handle:
+                _ep1_close += (
+                    f" And if you'd rather watch than listen, find us on YouTube "
+                    f"at {_yt_handle} — link's in the show notes."
+                )
+            pod_vars.setdefault("closing_block", _ep1_close)
         else:
             pod_vars.setdefault(
                 "intro_line",
@@ -1320,6 +1333,7 @@ def run(args: argparse.Namespace) -> None:
                     today_str=today_str,
                     date=today,
                     extra_context=extra_context,
+                    youtube_channel_handle=_yt_handle,
                 ),
             )
         pod_vars.setdefault("tone_hint", "natural and conversational")
@@ -1675,6 +1689,39 @@ def run(args: argparse.Namespace) -> None:
         rss_audio_url = apply_op3_prefix(rss_audio_url, config.analytics.prefix_url)
         logger.info("OP3 prefixed URL: %s", rss_audio_url)
 
+    # 10d. Build & upload YouTube videos (long-form + Shorts) BEFORE the
+    # RSS / blog / X stages, so the YouTube URL can land in the
+    # episode description, blog post, and X teaser.
+    _t_yt = time.monotonic()
+    chapters_path_for_yt = digests_dir / f"chapters_ep{episode_num:03d}.json"
+    youtube_urls = _publish_youtube(
+        config,
+        episode_num=episode_num,
+        today=today,
+        today_str=today_str,
+        hook=hook or "",
+        digest_text=x_thread,
+        final_mp3=final_mp3,
+        audio_url=r2_audio_url or "",
+        chapters_path=chapters_path_for_yt,
+        digests_dir=digests_dir,
+        args=args,
+    )
+    youtube_long_url = youtube_urls.get("long_url", "")
+    youtube_short_url = youtube_urls.get("short_url", "")
+    if youtube_long_url:
+        extra_context["youtube_url"] = youtube_long_url
+    if youtube_short_url:
+        extra_context["youtube_short_url"] = youtube_short_url
+    if youtube_urls:
+        try:
+            metrics.record(
+                "youtube_publish_duration_s",
+                round(time.monotonic() - _t_yt, 2),
+            )
+        except Exception:
+            pass
+
     # 11. Update RSS feed
     _t_rss = time.monotonic()
     if final_mp3 and final_mp3.exists():
@@ -1694,6 +1741,11 @@ def run(args: argparse.Namespace) -> None:
         else:
             episode_desc = x_thread
         episode_desc = episode_desc.rstrip() + "\n\n" + _AI_DISCLOSURE_RSS
+        # If the episode landed on YouTube, surface the watch link in
+        # the RSS description so listeners on every podcast app can
+        # click through to the video version.
+        if youtube_long_url:
+            episode_desc += f"\n\n🎬 Watch on YouTube: {youtube_long_url}"
 
         # If no R2 URL but analytics is enabled, build URL and prefix it
         feed_audio_url = rss_audio_url
@@ -1791,7 +1843,11 @@ def run(args: argparse.Namespace) -> None:
             _blog_env = _get_jinja_env()
             _blog_meta = extract_blog_metadata(x_thread, config.slug, digest_md.name if digest_md else "", file_path=digest_md)
             _blog_meta["episode_num"] = episode_num
-            _blog_html = generate_blog_post_html(x_thread, _blog_meta, _NS[config.slug], _blog_env)
+            _blog_html = generate_blog_post_html(
+                x_thread, _blog_meta, _NS[config.slug], _blog_env,
+                youtube_url=youtube_long_url,
+                youtube_short_url=youtube_short_url,
+            )
             _blog_dir = PROJECT_ROOT / "blog" / config.slug
             _blog_dir.mkdir(parents=True, exist_ok=True)
             _blog_path = _blog_dir / f"ep{episode_num:03d}.html"
@@ -1819,35 +1875,6 @@ def run(args: argparse.Namespace) -> None:
             logger.info("Newsletter sent: %s", email_id)
         else:
             logger.info("Newsletter skipped or failed.")
-
-    # 12c. Build & upload YouTube videos (long-form + Shorts)
-    _t_yt = time.monotonic()
-    chapters_path_for_yt = digests_dir / f"chapters_ep{episode_num:03d}.json"
-    youtube_urls = _publish_youtube(
-        config,
-        episode_num=episode_num,
-        today=today,
-        today_str=today_str,
-        hook=hook or "",
-        digest_text=x_thread,
-        final_mp3=final_mp3,
-        audio_url=audio_url,
-        chapters_path=chapters_path_for_yt,
-        digests_dir=digests_dir,
-        args=args,
-    )
-    if youtube_urls.get("long_url"):
-        extra_context["youtube_url"] = youtube_urls["long_url"]
-    if youtube_urls.get("short_url"):
-        extra_context["youtube_short_url"] = youtube_urls["short_url"]
-    if youtube_urls:
-        try:
-            metrics.record(
-                "youtube_publish_duration_s",
-                round(time.monotonic() - _t_yt, 2),
-            )
-        except Exception:
-            pass
 
     # 13. Post to X
     _t_x = time.monotonic()
@@ -2550,12 +2577,31 @@ def _publish_youtube(
     return result
 
 
+def _append_youtube_line(teaser: str, extra_context: dict) -> str:
+    """Append a "Watch on YouTube" line to the teaser when a URL is available.
+
+    Idempotent — never duplicates the line if the teaser already
+    references the URL (e.g. when a YAML ``x_teaser_template`` already
+    embedded ``{youtube_url}``).
+    """
+    yt_url = (extra_context.get("youtube_url") or "").strip()
+    if not yt_url:
+        return teaser
+    if yt_url in teaser:
+        return teaser
+    return f"{teaser}\n🎬 Watch on YouTube: {yt_url}"
+
+
 def _build_teaser(config, episode_num: int, today_str: str, extra_context: dict) -> str:
     """Build a short X teaser post for the episode.
 
     If the YAML config has ``x_teaser_template``, it's used as a format string
     with ``{episode_num}``, ``{today_str}``, and any extra_context keys.  Otherwise,
     falls back to the per-show hardcoded templates below.
+
+    A "🎬 Watch on YouTube: <url>" line is appended when
+    ``extra_context["youtube_url"]`` is set (set by the pipeline after
+    a successful long-form upload).
     """
     # Use YAML template if configured
     template = getattr(config.publishing, "x_teaser_template", "")
@@ -2563,7 +2609,8 @@ def _build_teaser(config, episode_num: int, today_str: str, extra_context: dict)
         fmt_vars = {"episode_num": episode_num, "today_str": today_str, "show_name": config.name}
         fmt_vars.update(extra_context)
         try:
-            return template.format(**fmt_vars)
+            return _append_youtube_line(template.format(**fmt_vars),
+                                        extra_context)
         except (KeyError, IndexError):
             logger.warning("x_teaser_template format failed, falling back to hardcoded")
 
@@ -2572,30 +2619,32 @@ def _build_teaser(config, episode_num: int, today_str: str, extra_context: dict)
         price_str = ""
         if "price" in extra_context:
             price_str = f" | TSLA ${extra_context['price']}"
-        return (
+        teaser = (
             f"🚀⚡ Tesla Shorts Time Daily — {today_str}{price_str}\n\n"
             f"Episode {episode_num} is live!\n"
             f"🎧 Listen & read: https://nerranetwork.com/tesla-summaries.html"
         )
     elif slug == "omni_view":
-        return (
+        teaser = (
             f"📰⚖️ Omni View — {today_str}\n\n"
             f"Episode {episode_num}: Balanced news perspectives.\n"
             f"🎧 Read & listen: https://nerranetwork.com/omni-view-summaries.html"
         )
     elif slug == "fascinating_frontiers":
-        return (
+        teaser = (
             f"🚀🌌 Fascinating Frontiers — {today_str}\n\n"
             f"Episode {episode_num}: Space & astronomy news.\n"
             f"🎧 Read & listen: https://nerranetwork.com/fascinating-frontiers-summaries.html"
         )
     elif slug == "planetterrian":
-        return (
+        teaser = (
             f"🌍🧬 Planetterrian Daily — {today_str}\n\n"
             f"Episode {episode_num}: Science, longevity & health.\n"
             f"🎧 Read & listen: https://nerranetwork.com/planetterrian-summaries.html"
         )
-    return f"{config.name} Episode {episode_num} — {today_str}"
+    else:
+        teaser = f"{config.name} Episode {episode_num} — {today_str}"
+    return _append_youtube_line(teaser, extra_context)
 
 
 

--- a/templates/blog_post.html.j2
+++ b/templates/blog_post.html.j2
@@ -584,6 +584,12 @@
                     View summaries
                 </a>
                 {% endif %}
+                {% if youtube_url %}
+                <a href="{{ youtube_url }}" class="blog-listen-cta" rel="noopener" target="_blank">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2"/></svg>
+                    Watch on YouTube
+                </a>
+                {% endif %}
             </div>
         </div>
     </header>

--- a/tests/test_intros.py
+++ b/tests/test_intros.py
@@ -253,3 +253,49 @@ def test_all_shows_produce_closings(show_slug):
     )
     assert len(closing) > 20
     assert ":" in closing
+
+
+# ---------------------------------------------------------------------------
+# YouTube channel CTA in closing block
+# ---------------------------------------------------------------------------
+
+def test_closing_block_appends_youtube_cta_when_handle_set():
+    closing = build_closing_block(
+        "tesla",
+        episode_num=42,
+        today_str="April 30, 2026",
+        youtube_channel_handle="@NerraNetwork",
+    )
+    assert "@NerraNetwork" in closing
+    assert "YouTube" in closing
+    assert "show notes" in closing
+
+
+def test_closing_block_omits_youtube_cta_without_handle():
+    closing = build_closing_block(
+        "tesla",
+        episode_num=42,
+        today_str="April 30, 2026",
+    )
+    assert "@NerraNetwork" not in closing
+    assert "YouTube" not in closing
+
+
+def test_closing_block_youtube_cta_idempotent():
+    """If the closing already mentions YouTube (e.g. handcrafted in
+    show personality), the helper should not duplicate the line."""
+    from engine.intros import _maybe_append_youtube_cta
+    closing = "Patrick: That's it. Watch us on YouTube tomorrow."
+    out = _maybe_append_youtube_cta(closing, "@NerraNetwork")
+    # No duplicate "YouTube" sentence appended.
+    assert out == closing
+
+
+def test_closing_block_supports_russian_handle():
+    closing = build_closing_block(
+        "finansy_prosto",
+        episode_num=1,
+        today_str="30 апреля 2026",
+        youtube_channel_handle="@NerraRU",
+    )
+    assert "@NerraRU" in closing

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -649,3 +649,38 @@ def test_upload_caption_track_returns_false_on_api_error(monkeypatch, tmp_path):
         language="en",
     )
     assert result is False
+
+
+# ---------------------------------------------------------------------------
+# X teaser — "Watch on YouTube" line gets appended when URL is set
+# ---------------------------------------------------------------------------
+
+def test_append_youtube_line_adds_url_when_set():
+    """``_append_youtube_line`` should append a "Watch on YouTube" line
+    when ``extra_context["youtube_url"]`` is non-empty."""
+    from run_show import _append_youtube_line
+    base = "🚀 Tesla Shorts Time — April 30, 2026\n🎧 Listen here."
+    out = _append_youtube_line(base, {"youtube_url": "https://www.youtube.com/watch?v=abc123"})
+    assert "🎬 Watch on YouTube" in out
+    assert "https://www.youtube.com/watch?v=abc123" in out
+
+
+def test_append_youtube_line_noop_when_empty():
+    from run_show import _append_youtube_line
+    base = "Tesla Shorts Time — Episode 1"
+    out = _append_youtube_line(base, {})
+    assert out == base
+    out = _append_youtube_line(base, {"youtube_url": ""})
+    assert out == base
+
+
+def test_append_youtube_line_idempotent():
+    """If the URL already appears in the teaser (e.g. via a YAML
+    template), don't append a duplicate line."""
+    from run_show import _append_youtube_line
+    base = "Episode 1\nWatch: https://www.youtube.com/watch?v=abc"
+    out = _append_youtube_line(
+        base, {"youtube_url": "https://www.youtube.com/watch?v=abc"},
+    )
+    # No second occurrence appended.
+    assert out.count("https://www.youtube.com/watch?v=abc") == 1


### PR DESCRIPTION
## Summary

Currently the YouTube URL only lives on YouTube. This PR pushes it into the four other places listeners and readers actually look — items 1–4 from the cross-posting proposal.

### 1. RSS episode description

`🎬 Watch on YouTube: <url>` appended to the per-episode `<description>` / `<itunes:summary>`. Apple, Spotify, Overcast, Pocket Casts all render description text with clickable links — biggest cross-posting reach for the smallest change.

### 2. Per-show website blog page

`templates/blog_post.html.j2` now renders a **"Watch on YouTube"** button next to the existing "Listen to podcast" / "View summaries" CTAs. Plumbed via new `generate_blog_post_html(youtube_url=, youtube_short_url=)` kwargs.

### 3. X teaser

`_build_teaser` appends `🎬 Watch on YouTube: <url>` when `extra_context["youtube_url"]` is set. Idempotent — won't duplicate if a YAML `x_teaser_template` already embedded `{youtube_url}`.

### 4. Spoken closing line

`build_closing_block` grows a `youtube_channel_handle` kwarg. When set, the dynamic per-show closing tacks on:

> "And if you'd rather watch than listen, find us on YouTube at @NerraNetwork — link's in the show notes."

`run_show.py` picks `@NerraNetwork` or `@NerraRU` based on `config.youtube.channel`, only when `youtube.enabled` is true. The handle becomes part of the spoken script the TTS narrator reads, so listeners hear about the YouTube channel every episode.

## Pipeline ordering change

`_publish_youtube` now runs **before** RSS update / blog generation / X posting (it was after). YouTube upload takes ~2–5 min, so RSS publishes 2–5 min later than before, but the URL is available to populate everywhere downstream.

## Out of scope

Item 5 from the proposal — Podcasting 2.0 `<podcast:alternateEnclosure>` RSS tag. Apple Podcasts doesn't support that field yet, so deferred.

## Test plan

- [x] `pytest tests/test_intros.py tests/test_youtube.py tests/test_video_commands.py` — 115 pass
- [x] Full `pytest` suite — 1,190 passed, 3 skipped, no regressions
- [x] `ruff check engine/ run_show.py tests/ --select=E9,F63,F7,F82` — clean
- [ ] **Operator (manual)**: trigger one phase-1 show; confirm:
  - RSS episode description (in any podcast app) ends with the YouTube URL
  - `nerranetwork.com/blog/<show>/ep<N>.html` shows a "Watch on YouTube" button in the meta bar
  - X post includes the YouTube URL line
  - Audio script reads the closing CTA mentioning `@NerraNetwork`

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_