### PR TITLE
Add curated x_accounts to the 7 shows that were missing X content

### DIFF
--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -78,6 +78,26 @@ web_search_queries:
   - "environmental science breakthrough"
   - "clean energy news Canada"
 
+x_accounts:
+  - handle: environmentca
+    label: Environment and Climate Change Canada
+    max_posts: 4
+  - handle: TheNarwhalCA
+    label: The Narwhal (Canadian env journalism)
+    max_posts: 4
+  - handle: TheTyee
+    label: The Tyee (BC investigative)
+    max_posts: 3
+  - handle: DavidSuzukiFDN
+    label: David Suzuki Foundation
+    max_posts: 3
+  - handle: PembinaInst
+    label: Pembina Institute (energy/climate)
+    max_posts: 3
+  - handle: BCGovNews
+    label: BC Government News
+    max_posts: 3
+
 keywords:
   - contaminated sites
   - remediation

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -63,6 +63,29 @@ web_search_queries:
   - "astronomy discovery news"
   - "rocket launch news today"
 
+x_accounts:
+  - handle: NASA
+    label: NASA
+    max_posts: 4
+  - handle: SpaceX
+    label: SpaceX
+    max_posts: 4
+  - handle: esa
+    label: European Space Agency
+    max_posts: 3
+  - handle: SciGuySpace
+    label: Eric Berger (Ars Technica space)
+    max_posts: 3
+  - handle: planet4589
+    label: Jonathan McDowell (orbital launch tracker)
+    max_posts: 3
+  - handle: Erdayastronaut
+    label: Tim Dodd (Everyday Astronaut)
+    max_posts: 3
+  - handle: NASAWebb
+    label: NASA Webb Telescope
+    max_posts: 3
+
 min_articles_skip: 4
 
 keywords:

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -66,6 +66,29 @@ web_search_queries:
   - "AI agent framework news"
   - "OpenAI Anthropic Google AI news"
 
+x_accounts:
+  - handle: sama
+    label: Sam Altman (OpenAI)
+    max_posts: 4
+  - handle: karpathy
+    label: Andrej Karpathy
+    max_posts: 4
+  - handle: AnthropicAI
+    label: Anthropic
+    max_posts: 4
+  - handle: OpenAI
+    label: OpenAI
+    max_posts: 4
+  - handle: DarioAmodei
+    label: Dario Amodei (Anthropic)
+    max_posts: 3
+  - handle: demishassabis
+    label: Demis Hassabis (DeepMind)
+    max_posts: 3
+  - handle: simonw
+    label: Simon Willison (AI builder)
+    max_posts: 3
+
 min_articles_skip: 4
 
 keywords:

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -51,6 +51,26 @@ web_search_queries:
   - "ChatGPT update news"
   - "AI tools new features today"
 
+x_accounts:
+  - handle: emollick
+    label: Ethan Mollick (One Useful Thing)
+    max_posts: 4
+  - handle: OpenAI
+    label: OpenAI
+    max_posts: 3
+  - handle: AnthropicAI
+    label: Anthropic
+    max_posts: 3
+  - handle: LinusEkenstam
+    label: Linus Ekenstam (daily AI tools)
+    max_posts: 3
+  - handle: MKBHD
+    label: Marques Brownlee (consumer tech)
+    max_posts: 3
+  - handle: GoogleAI
+    label: Google AI
+    max_posts: 3
+
 keywords:
   # Core AI concepts (beginner-accessible)
   - ai model

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -69,6 +69,26 @@ web_search_queries:
   - "world news geopolitics today"
   - "economy markets news today"
 
+x_accounts:
+  - handle: Reuters
+    label: Reuters
+    max_posts: 4
+  - handle: AP
+    label: Associated Press
+    max_posts: 4
+  - handle: BBCBreaking
+    label: BBC Breaking News
+    max_posts: 3
+  - handle: TheEconomist
+    label: The Economist
+    max_posts: 3
+  - handle: AxiosNews
+    label: Axios
+    max_posts: 3
+  - handle: SemaforNews
+    label: Semafor
+    max_posts: 3
+
 min_articles_skip: 4
 
 keywords:

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -66,6 +66,29 @@ web_search_queries:
   - "microbiome sleep circadian research"
   - "genetics epigenetics stem cell research breakthrough"
 
+x_accounts:
+  - handle: EricTopol
+    label: Dr. Eric Topol (medicine + AI)
+    max_posts: 4
+  - handle: PeterAttiaMD
+    label: Dr. Peter Attia (longevity)
+    max_posts: 3
+  - handle: hubermanlab
+    label: Andrew Huberman (neuroscience)
+    max_posts: 3
+  - handle: davidasinclair
+    label: Dr. David Sinclair (aging biology)
+    max_posts: 3
+  - handle: foundmyfitness
+    label: Rhonda Patrick (nutrition science)
+    max_posts: 3
+  - handle: edyong209
+    label: Ed Yong (science journalist)
+    max_posts: 3
+  - handle: MartyMakary
+    label: Dr. Marty Makary (public health)
+    max_posts: 3
+
 min_articles_skip: 2
 
 keywords:

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -61,6 +61,20 @@ web_search_queries:
   - "Russian culture traditions news"
   - "fun world news vocabulary themes"
 
+x_accounts:
+  - handle: meduzaproject
+    label: Meduza (Russian news in English)
+    max_posts: 3
+  - handle: MoscowTimes
+    label: The Moscow Times
+    max_posts: 3
+  - handle: russianpod101
+    label: RussianPod101 (language learning)
+    max_posts: 3
+  - handle: rferl
+    label: Radio Free Europe / Radio Liberty
+    max_posts: 3
+
 min_articles_skip: 1
 
 keywords:


### PR DESCRIPTION
## Summary

Tesla, Modern Investing, and Финансы Просто already pull per-show X content via xAI search; this propagates that pattern to the other 7 shows so every episode has the same shot at surfacing breaking voices and primary-source commentary alongside the RSS articles.

## Per-show curation

5–7 handles each, max 3–4 posts/handle so the xAI search budget stays bounded:

| Show | Handles |
|------|---------|
| **Omni View** (balanced news, cross-spectrum) | `Reuters`, `AP`, `BBCBreaking`, `TheEconomist`, `AxiosNews`, `SemaforNews` |
| **Fascinating Frontiers** (space + astronomy) | `NASA`, `SpaceX`, `esa`, `SciGuySpace` (Eric Berger), `planet4589` (Jonathan McDowell — orbital launch tracker), `Erdayastronaut` (Tim Dodd), `NASAWebb` |
| **Planetterrian** (longevity + neuroscience + nutrition) | `EricTopol`, `PeterAttiaMD`, `hubermanlab`, `davidasinclair`, `foundmyfitness` (Rhonda Patrick), `edyong209`, `MartyMakary` |
| **Env Intel** (Canadian environmental regulatory) | `environmentca` (ECCC), `TheNarwhalCA`, `TheTyee`, `DavidSuzukiFDN`, `PembinaInst`, `BCGovNews` |
| **Models & Agents** (frontier AI for builders) | `sama`, `karpathy`, `AnthropicAI`, `OpenAI`, `DarioAmodei`, `demishassabis`, `simonw` |
| **Models & Agents for Beginners** (accessible AI for newcomers/teens) | `emollick`, `OpenAI`, `AnthropicAI`, `LinusEkenstam`, `MKBHD`, `GoogleAI` |
| **Привет, Русский!** (bilingual Russian language learning) | `meduzaproject`, `MoscowTimes`, `russianpod101`, `rferl` (smaller list — show is more vocabulary-themed than news-driven) |

## Test plan

- [x] `python -c "from engine.config import load_config; ..."` — all 7 YAMLs parse, x_accounts list lengths match expected (4–7 handles each)
- [x] Full `pytest` suite — 1,197 passed, 3 skipped, no regressions
- [x] `ruff check engine/ run_show.py tests/ --select=E9,F63,F7,F82` — clean
- [ ] **Operator (manual)**: trigger one show from each category (e.g. `fascinating_frontiers`, `planetterrian`, `models_agents_beginners`) from the Actions UI; spot-check the digest's "From X" section to confirm relevant handles surfaced quote-worthy posts.

If any handle returns nothing useful after a few runs, swap it in the YAML — the only cost of a bad handle is wasted xAI search calls (still cheap), not a pipeline failure.

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_