### PR TITLE
Newsletter unblock + reliability fixes from review

### DIFF
--- a/.github/workflows/buttondown-tag-subscriber.yml
+++ b/.github/workflows/buttondown-tag-subscriber.yml
@@ -1,0 +1,94 @@
+name: Tag Buttondown Subscriber
+
+# Manual one-off workflow to add (or remove) a Nerra Network subscriber's
+# per-show tags in Buttondown. Necessary because the public website
+# signup form historically didn't tag subscribers per show — newsletters
+# filter by tag, so untagged subscribers receive nothing.
+#
+# Trigger from the Actions UI: pick the show(s), pass an email, run.
+# The actual subscriber CRUD lives in scripts/buttondown_tag_subscriber.py.
+
+on:
+  workflow_dispatch:
+    inputs:
+      email:
+        description: 'Subscriber email address'
+        required: true
+        type: string
+      mode:
+        description: 'What to do'
+        required: true
+        type: choice
+        options:
+          - 'add-all'        # tag for every Nerra Network show
+          - 'add-shows'      # tag for the comma-separated shows in `shows`
+          - 'remove-shows'   # untag for the comma-separated shows in `shows`
+          - 'list'           # print the subscriber's current tags
+        default: 'add-all'
+      shows:
+        description: 'Comma-separated show slugs (used by add-shows / remove-shows)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install requests pyyaml
+
+      - name: Apply tag change
+        env:
+          BUTTONDOWN_API_KEY: ${{ secrets.BUTTONDOWN_API_KEY }}
+        run: |
+          set -e
+          MODE='${{ github.event.inputs.mode }}'
+          EMAIL='${{ github.event.inputs.email }}'
+          SHOWS='${{ github.event.inputs.shows }}'
+          ARGS=()
+          case "$MODE" in
+            add-all)
+              ARGS+=(--all)
+              ;;
+            add-shows)
+              if [ -z "$SHOWS" ]; then
+                echo "::error::add-shows requires the 'shows' input"
+                exit 2
+              fi
+              IFS=',' read -ra _slugs <<< "$SHOWS"
+              for s in "${_slugs[@]}"; do
+                ARGS+=(--show "$(echo "$s" | xargs)")
+              done
+              ;;
+            remove-shows)
+              if [ -z "$SHOWS" ]; then
+                echo "::error::remove-shows requires the 'shows' input"
+                exit 2
+              fi
+              IFS=',' read -ra _slugs <<< "$SHOWS"
+              for s in "${_slugs[@]}"; do
+                ARGS+=(--show "$(echo "$s" | xargs)")
+              done
+              ARGS+=(--remove)
+              ;;
+            list)
+              ARGS+=(--list)
+              ;;
+            *)
+              echo "::error::Unknown mode: $MODE"
+              exit 2
+              ;;
+          esac
+          python scripts/buttondown_tag_subscriber.py "$EMAIL" "${ARGS[@]}"

--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -3,8 +3,11 @@ name: Run Podcast Show
 on:
   schedule:
     # All shows scheduled to finish before 7 AM Eastern (~11 UTC EDT / 12 UTC EST).
-    # Pipeline takes up to 45 min, so all triggers fire by 9:30 UTC.
-    # Staggered by 30 min to spread GitHub Actions load.
+    # Pipeline takes up to 45 min, so triggers must be staggered by at
+    # least that much — Tesla previously sat at 9:30 UTC and could
+    # collide with Modern Investing's 9:00 UTC weekday slot. Tesla now
+    # fires at 10:00 UTC daily (60-min gap after MI), still well
+    # ahead of the 11/12 UTC Eastern cutoff.
     #
     # Привет, Русский!: Even days at 5:00 UTC
     - cron: '0 5 2-31/2 * *'
@@ -24,8 +27,9 @@ on:
     - cron: '30 8 2-31/2 * *'
     # Modern Investing Techniques: Weekdays at 9:00 UTC (before US market open)
     - cron: '0 9 * * 1-5'
-    # Tesla Shorts Time: Daily at 9:30 UTC — last to get freshest news
-    - cron: '30 9 * * *'
+    # Tesla Shorts Time: Daily at 10:00 UTC — last to get freshest news,
+    # 60-min gap after Modern Investing avoids Grok API contention.
+    - cron: '0 10 * * *'
 
   workflow_dispatch:
     inputs:
@@ -108,7 +112,7 @@ jobs:
                   "0 8 2-31/2 * *":   ("models_agents_beginners", "even"),
                   "30 8 2-31/2 * *":  ("finansy_prosto",          "even"),
                   "0 9 * * 1-5":      ("modern_investing",        "weekday"),
-                  "30 9 * * *":       ("tesla",                    None),
+                  "0 10 * * *":       ("tesla",                    None),
               }
 
               shows = []

--- a/engine/captions.py
+++ b/engine/captions.py
@@ -139,7 +139,16 @@ def transcript_to_srt(transcript_path: Path, srt_path: Path,
         )
 
     # SRT files use \n line breaks but cues are separated by a blank line.
-    srt_path.write_text("\n".join(cues), encoding="utf-8")
+    try:
+        srt_path.write_text("\n".join(cues), encoding="utf-8")
+    except OSError as exc:
+        # Disk full / permission denied / read-only mount — caller
+        # should know and decide whether to skip burned-in captions.
+        logger.error(
+            "Failed to write SRT to %s (%s): %s",
+            srt_path, type(exc).__name__, exc,
+        )
+        raise
     logger.info("Wrote %d caption cues → %s", len(cues), srt_path.name)
     return srt_path
 

--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -117,7 +117,15 @@ def _md_inline(text: str) -> str:
 
 
 def validate_api_key(api_key: str) -> bool:
-    """Test if the Buttondown API key is valid by calling GET /v1/emails."""
+    """Test if the Buttondown API key is valid by calling GET /v1/emails.
+
+    Returns ``True`` only on a clean ``200``. ``401``/``403`` mean the
+    key is bad. Other status codes (``429``, ``5xx``, network errors)
+    return ``False`` too — the caller can't safely proceed when
+    Buttondown's reachability is unknown, and the previous behavior
+    (returning ``True`` on any non-401) created false confidence
+    that pre-flight passed when the service was down.
+    """
     try:
         resp = requests.get(
             f"{BUTTONDOWN_API_BASE}/emails",
@@ -125,22 +133,37 @@ def validate_api_key(api_key: str) -> bool:
             timeout=10,
             params={"limit": 1},
         )
-        if resp.status_code == 401:
-            logger.error("Buttondown API key is INVALID or EXPIRED (401 Unauthorized)")
-            return False
-        if resp.status_code == 200:
-            logger.info("Buttondown API key validated successfully")
-            return True
-        logger.warning("Buttondown API key check returned status %d", resp.status_code)
-        return True
     except Exception as e:
         logger.error("Buttondown API key validation failed: %s", e)
         return False
+
+    if resp.status_code == 200:
+        logger.info("Buttondown API key validated successfully")
+        return True
+    if resp.status_code in (401, 403):
+        logger.error(
+            "Buttondown API key is INVALID or EXPIRED (HTTP %d)",
+            resp.status_code,
+        )
+        return False
+    # 429 / 5xx / anything else — we can't confirm the key is good and
+    # we shouldn't claim it is. Surface as a soft failure so the
+    # newsletter stage skips this run cleanly rather than queuing a
+    # send against a potentially-unhealthy Buttondown.
+    logger.warning(
+        "Buttondown API key check returned HTTP %d — treating as "
+        "transient unavailability (validation failed).",
+        resp.status_code,
+    )
+    return False
 
 
 # ---------------------------------------------------------------------------
 # Send
 # ---------------------------------------------------------------------------
+
+
+_VALID_STATUSES = {"about_to_send", "draft", "scheduled"}
 
 
 def send_newsletter(
@@ -175,6 +198,14 @@ def send_newsletter(
     """
     # Strip newlines from subject to prevent email header injection
     subject = subject.replace("\r", "").replace("\n", " ").strip()
+
+    if status not in _VALID_STATUSES:
+        logger.error(
+            "Newsletter status %r is invalid — must be one of %s. "
+            "Refusing to send to avoid wasting an API call on a 400.",
+            status, sorted(_VALID_STATUSES),
+        )
+        return None
 
     data = {
         "subject": subject,

--- a/engine/storage.py
+++ b/engine/storage.py
@@ -94,7 +94,10 @@ def upload_episode(
 
     Reads R2 credentials from environment variables named in the config.
     Returns the public URL on success, or ``None`` if storage is not
-    configured or credentials are missing.
+    configured, credentials are missing, **or the upload failed for any
+    reason** (timeouts, bad credentials, network errors, etc.).
+    Failures are logged with the boto3 exception class so the operator
+    can tell a credential issue from a transient network blip.
 
     Parameters
     ----------
@@ -117,12 +120,25 @@ def upload_episode(
 
     remote_key = f"{config.slug}/{local_path.name}"
 
-    return upload_to_r2(
-        local_path,
-        remote_key,
-        bucket=storage.bucket,
-        endpoint_url=endpoint,
-        access_key=access_key,
-        secret_key=secret_key,
-        public_base_url=storage.public_base_url,
-    )
+    try:
+        return upload_to_r2(
+            local_path,
+            remote_key,
+            bucket=storage.bucket,
+            endpoint_url=endpoint,
+            access_key=access_key,
+            secret_key=secret_key,
+            public_base_url=storage.public_base_url,
+        )
+    except Exception as exc:  # noqa: BLE001 — we want every failure mode
+        # boto3 surfaces these via botocore.exceptions; importing them
+        # eagerly would force a hard dependency at module-import time
+        # even when storage isn't configured. Catching the broad class
+        # and logging the type name keeps the behavior contract simple
+        # ("returns None on any failure") while preserving diagnostic
+        # detail for the operator.
+        logger.error(
+            "R2 upload failed (%s): %s",
+            type(exc).__name__, exc,
+        )
+        return None

--- a/run_show.py
+++ b/run_show.py
@@ -250,6 +250,39 @@ def _preflight_checks(config, *, dry_run: bool = False) -> None:
             if env_name and not os.environ.get(env_name):
                 logger.warning("R2 env var %s (%s) is empty — upload may fail", env_name, env_attr)
 
+    # YouTube preflight — when publishing is enabled, surface common
+    # misconfigurations as warnings (not fatal — YouTube is non-blocking
+    # for the rest of the pipeline).
+    yt_cfg = getattr(config, "youtube", None)
+    if yt_cfg and getattr(yt_cfg, "enabled", False):
+        playlist_id = (
+            getattr(yt_cfg, "podcast_playlist_id", "") or ""
+        ).strip()
+        if not playlist_id:
+            logger.warning(
+                "YouTube enabled for %s but youtube.podcast_playlist_id "
+                "is empty — episodes won't appear in the show's "
+                "Podcast playlist on YouTube Music. Set the PL... ID "
+                "in shows/%s.yaml after creating the playlist in Studio.",
+                config.slug, config.slug,
+            )
+        privacy = (getattr(yt_cfg, "privacy_status", "public") or "").strip()
+        if privacy not in ("public", "unlisted", "private"):
+            issues.append(
+                f"youtube.privacy_status={privacy!r} is invalid — "
+                "must be public, unlisted, or private."
+            )
+
+    # Newsletter preflight — when enabled, validate the status enum
+    # before we hit Buttondown with a guaranteed-400 request.
+    if config.newsletter.enabled:
+        nl_status = (getattr(config.newsletter, "status", "") or "").strip()
+        if nl_status and nl_status not in {"about_to_send", "draft", "scheduled"}:
+            issues.append(
+                f"newsletter.status={nl_status!r} is invalid — "
+                "must be about_to_send, draft, or scheduled."
+            )
+
     # Cost circuit breaker: skip episode if 7-day spend exceeds the show's
     # max_weekly_cost_usd (reads the previously committed dashboard JSON).
     max_cost = getattr(config, "max_weekly_cost_usd", 0.0) or 0.0
@@ -1713,14 +1746,22 @@ def run(args: argparse.Namespace) -> None:
         extra_context["youtube_url"] = youtube_long_url
     if youtube_short_url:
         extra_context["youtube_short_url"] = youtube_short_url
-    if youtube_urls:
-        try:
-            metrics.record(
-                "youtube_publish_duration_s",
-                round(time.monotonic() - _t_yt, 2),
-            )
-        except Exception:
-            pass
+    # Record YouTube publishing outcomes so the dashboard can graph
+    # upload success rate per show. We always record these (even on
+    # skip/fail) so the dashboard sees zeros instead of missing data.
+    try:
+        metrics.record(
+            "youtube_publish_duration_s",
+            round(time.monotonic() - _t_yt, 2),
+        )
+        metrics.record("youtube_long_form_uploaded", bool(youtube_long_url))
+        metrics.record("youtube_short_uploaded", bool(youtube_short_url))
+        metrics.record(
+            "youtube_enabled",
+            bool(getattr(config.youtube, "enabled", False)),
+        )
+    except Exception:
+        pass
 
     # 11. Update RSS feed
     _t_rss = time.monotonic()
@@ -1870,11 +1911,45 @@ def run(args: argparse.Namespace) -> None:
     if config.newsletter.enabled and not args.skip_newsletter:
         from engine.newsletter import send_show_newsletter
 
-        email_id = send_show_newsletter(x_thread, config, episode_num, today_str, hook=hook)
+        try:
+            email_id = send_show_newsletter(
+                x_thread, config, episode_num, today_str, hook=hook,
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            email_id = None
+            logger.exception("Newsletter send raised: %s", exc)
+
         if email_id:
             logger.info("Newsletter sent: %s", email_id)
         else:
-            logger.info("Newsletter skipped or failed.")
+            # send_show_newsletter returns None for several distinct
+            # reasons. Help the operator diagnose by surfacing which
+            # one applied on this run.
+            tag = (
+                getattr(config.newsletter, "tag", "") or ""
+            ).strip()
+            api_key_env = getattr(
+                config.newsletter, "api_key_env", "BUTTONDOWN_API_KEY",
+            )
+            if not os.getenv(api_key_env, "").strip():
+                logger.warning(
+                    "Newsletter not sent: %s env var is empty. "
+                    "Add the secret in GitHub Actions to enable "
+                    "newsletters.", api_key_env,
+                )
+            elif tag:
+                logger.warning(
+                    "Newsletter not sent: tag filter %r matched zero "
+                    "Buttondown subscribers, OR Buttondown rejected "
+                    "the send. Check Buttondown subscriber tags + "
+                    "the previous log lines from engine.newsletter.",
+                    tag,
+                )
+            else:
+                logger.warning(
+                    "Newsletter not sent: see preceding "
+                    "engine.newsletter log lines for the API response.",
+                )
 
     # 13. Post to X
     _t_x = time.monotonic()

--- a/scripts/buttondown_tag_subscriber.py
+++ b/scripts/buttondown_tag_subscriber.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Tag (or untag) a Buttondown subscriber across all Nerra Network show tags.
+
+Used to:
+
+  - Bootstrap Patrick's own subscription so newsletters reach his inbox
+    even though the website signup form didn't tag him.
+  - Add an existing subscriber to a new show's mailing list without
+    asking them to re-subscribe.
+  - Audit which shows a subscriber is on, by passing ``--list``.
+
+Reads ``BUTTONDOWN_API_KEY`` from the environment. Tag values come from
+each show's ``newsletter.tag`` in ``shows/<slug>.yaml``.
+
+Usage::
+
+    # Tag the user across all 10 shows
+    python scripts/buttondown_tag_subscriber.py user@example.com --all
+
+    # Tag for specific shows
+    python scripts/buttondown_tag_subscriber.py user@example.com \\
+        --show tesla --show fascinating_frontiers
+
+    # Print what tags they have today
+    python scripts/buttondown_tag_subscriber.py user@example.com --list
+
+    # Remove the user from a show's mailing list
+    python scripts/buttondown_tag_subscriber.py user@example.com \\
+        --show tesla --remove
+
+The Buttondown API key needs ``subscribers:read`` and
+``subscribers:write`` permissions (the default API key has both).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+import requests
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SHOWS_DIR = PROJECT_ROOT / "shows"
+BUTTONDOWN_API_BASE = "https://api.buttondown.email/v1"
+
+
+def _load_show_tags() -> Dict[str, str]:
+    """Return ``{slug: tag}`` for every show that has a newsletter tag."""
+    tags: Dict[str, str] = {}
+    for yaml_path in sorted(SHOWS_DIR.glob("*.yaml")):
+        if yaml_path.stem.startswith("_") or yaml_path.stem == "pronunciation_map":
+            continue
+        try:
+            data = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError:
+            continue
+        nl = data.get("newsletter") or {}
+        tag = (nl.get("tag") or "").strip()
+        if tag:
+            tags[yaml_path.stem] = tag
+    return tags
+
+
+def _get_subscriber(email: str, api_key: str) -> Optional[dict]:
+    """Look up a subscriber by email. Returns the JSON record or None."""
+    resp = requests.get(
+        f"{BUTTONDOWN_API_BASE}/subscribers",
+        headers={"Authorization": f"Token {api_key}"},
+        params={"email": email},
+        timeout=15,
+    )
+    resp.raise_for_status()
+    payload = resp.json() or {}
+    results = payload.get("results") or []
+    if not results:
+        return None
+    return results[0]
+
+
+def _create_subscriber(email: str, tags: List[str], api_key: str) -> dict:
+    """Create a new subscriber with the given tags."""
+    resp = requests.post(
+        f"{BUTTONDOWN_API_BASE}/subscribers",
+        headers={
+            "Authorization": f"Token {api_key}",
+            "Content-Type": "application/json",
+        },
+        json={"email": email, "tags": tags, "type": "regular"},
+        timeout=15,
+    )
+    if resp.status_code not in (200, 201):
+        raise RuntimeError(
+            f"Failed to create subscriber {email}: HTTP {resp.status_code} {resp.text[:300]}"
+        )
+    return resp.json() or {}
+
+
+def _patch_subscriber_tags(sub_id: str, tags: List[str], api_key: str) -> dict:
+    """Replace a subscriber's tag list."""
+    resp = requests.patch(
+        f"{BUTTONDOWN_API_BASE}/subscribers/{sub_id}",
+        headers={
+            "Authorization": f"Token {api_key}",
+            "Content-Type": "application/json",
+        },
+        json={"tags": tags},
+        timeout=15,
+    )
+    if resp.status_code not in (200, 201):
+        raise RuntimeError(
+            f"Failed to update subscriber {sub_id}: HTTP {resp.status_code} {resp.text[:300]}"
+        )
+    return resp.json() or {}
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("email", help="Subscriber email address")
+    parser.add_argument(
+        "--show",
+        action="append",
+        default=[],
+        help="Show slug to tag (can pass multiple). Conflicts with --all.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Tag the subscriber for every Nerra Network show.",
+    )
+    parser.add_argument(
+        "--remove",
+        action="store_true",
+        help="Remove the listed shows' tags instead of adding them.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Print the subscriber's current tags and exit.",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("BUTTONDOWN_API_KEY", "").strip(),
+        help="Buttondown API key (defaults to BUTTONDOWN_API_KEY env var).",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.api_key:
+        print("Error: BUTTONDOWN_API_KEY is not set.", file=sys.stderr)
+        return 2
+
+    show_tags = _load_show_tags()
+
+    # Resolve which tags the operator wants to mutate.
+    if args.list:
+        target_tags: Set[str] = set()
+    elif args.all:
+        target_tags = set(show_tags.values())
+    elif args.show:
+        unknown = [s for s in args.show if s not in show_tags]
+        if unknown:
+            print(f"Unknown show slug(s): {unknown}", file=sys.stderr)
+            print(f"Known: {sorted(show_tags)}", file=sys.stderr)
+            return 2
+        target_tags = {show_tags[s] for s in args.show}
+    else:
+        print("Error: pass --all, --show <slug> (one or more), or --list.",
+              file=sys.stderr)
+        return 2
+
+    sub = _get_subscriber(args.email, args.api_key)
+    if args.list:
+        if sub is None:
+            print(f"{args.email} is not a subscriber.")
+        else:
+            existing = sub.get("tags") or []
+            print(f"{args.email} (id={sub.get('id')}, type={sub.get('type')})")
+            print(f"  tags: {sorted(existing) if existing else '(none)'}")
+        return 0
+
+    if sub is None:
+        if args.remove:
+            print(f"{args.email} is not a subscriber — nothing to remove.")
+            return 0
+        # Create with the requested tags.
+        new_tags = sorted(target_tags)
+        created = _create_subscriber(args.email, new_tags, args.api_key)
+        print(f"Created subscriber {args.email} (id={created.get('id')}) "
+              f"with tags: {new_tags}")
+        return 0
+
+    existing = set(sub.get("tags") or [])
+    if args.remove:
+        new = existing - target_tags
+        action = "Removed"
+    else:
+        new = existing | target_tags
+        action = "Added"
+    if new == existing:
+        print(f"No-op: {args.email} already has the requested tags "
+              f"({sorted(existing)}).")
+        return 0
+
+    _patch_subscriber_tags(sub.get("id"), sorted(new), args.api_key)
+    delta = sorted(target_tags & (new - existing) if action == "Added"
+                   else target_tags & (existing - new))
+    print(f"{action} tag(s) {delta} on {args.email}. "
+          f"Now tagged for {len(new)} show(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -438,6 +438,53 @@ def item_12_summaries_location(shows: List[Dict[str, Any]]) -> Dict[str, Any]:
     )
 
 
+def item_13_youtube_health(shows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Every YouTube-enabled show has a non-empty podcast_playlist_id.
+
+    Without a playlist ID, episodes upload but never appear in YouTube
+    Music's Podcasts section for that show — silent reach loss.
+    """
+    enabled = []
+    missing = []
+    for s in shows:
+        cfg = s.get("cfg")
+        if not cfg:
+            continue
+        yt = getattr(cfg, "youtube", None)
+        if not yt or not getattr(yt, "enabled", False):
+            continue
+        slug = s["slug"]
+        enabled.append(slug)
+        playlist = (getattr(yt, "podcast_playlist_id", "") or "").strip()
+        if not playlist:
+            missing.append(slug)
+
+    if not enabled:
+        return _mk(
+            "item_13_youtube_health",
+            "YouTube-enabled shows have podcast playlists",
+            "ok",
+            "No shows have youtube.enabled — nothing to validate.",
+        )
+    if missing:
+        return _mk(
+            "item_13_youtube_health",
+            "YouTube-enabled shows have podcast playlists",
+            "fail",
+            f"{len(missing)} of {len(enabled)} YouTube-enabled "
+            f"show(s) missing podcast_playlist_id: "
+            f"{', '.join(missing)}.",
+            {"missing": missing, "enabled": enabled},
+        )
+    return _mk(
+        "item_13_youtube_health",
+        "YouTube-enabled shows have podcast playlists",
+        "ok",
+        f"All {len(enabled)} YouTube-enabled show(s) have a podcast "
+        f"playlist ID configured.",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Item 2 — RSS integrity + R2 / LFS audit
 # ---------------------------------------------------------------------------
@@ -731,6 +778,15 @@ def aggregate_metrics(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]
         successes = 0
         stage_times: Dict[str, List[float]] = {}
         recent_samples = []
+        # YouTube publishing health: count how many of the last 30
+        # episodes successfully uploaded long-form / shorts. Episodes
+        # where the show was YouTube-disabled are excluded from the
+        # denominator so we don't dilute the success rate.
+        yt_long_attempts = 0
+        yt_long_uploaded = 0
+        yt_short_attempts = 0
+        yt_short_uploaded = 0
+        yt_enabled_recent = False
         for f in last30:
             try:
                 data = json.loads(f.read_text(encoding="utf-8"))
@@ -745,10 +801,21 @@ def aggregate_metrics(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]
             for st in stages:
                 name = st.get("name") or "unknown"
                 stage_times.setdefault(name, []).append(float(st.get("duration_s") or 0.0))
+            counters = data.get("counters") or {}
+            if counters.get("youtube_enabled"):
+                yt_enabled_recent = True
+                yt_long_attempts += 1
+                yt_short_attempts += 1
+                if counters.get("youtube_long_form_uploaded"):
+                    yt_long_uploaded += 1
+                if counters.get("youtube_short_uploaded"):
+                    yt_short_uploaded += 1
             recent_samples.append({
                 "episode_num": data.get("episode_num"),
                 "total_duration_s": total,
                 "success": ep_success,
+                "youtube_long_url": bool(counters.get("youtube_long_form_uploaded")),
+                "youtube_short_url": bool(counters.get("youtube_short_uploaded")),
             })
         stage_means = {
             name: round(sum(vals) / len(vals), 2) if vals else 0.0
@@ -761,6 +828,21 @@ def aggregate_metrics(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]
             "success_rate": round(successes / len(totals), 3) if totals else 0.0,
             "stage_mean_s": stage_means,
             "recent": recent_samples[-10:],
+            "youtube": {
+                "enabled_in_recent": yt_enabled_recent,
+                "long_form_attempts": yt_long_attempts,
+                "long_form_uploaded": yt_long_uploaded,
+                "long_form_success_rate": (
+                    round(yt_long_uploaded / yt_long_attempts, 3)
+                    if yt_long_attempts else 0.0
+                ),
+                "shorts_attempts": yt_short_attempts,
+                "shorts_uploaded": yt_short_uploaded,
+                "shorts_success_rate": (
+                    round(yt_short_uploaded / yt_short_attempts, 3)
+                    if yt_short_attempts else 0.0
+                ),
+            },
         }
     return per_show
 
@@ -1092,6 +1174,7 @@ def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optiona
         item_9_voice_settings(voice),
         item_11_tts_provider(shows),
         item_12_summaries_location(shows),
+        item_13_youtube_health(shows),
     ]
 
     metrics = aggregate_metrics(root, shows)

--- a/templates/network_page.html.j2
+++ b/templates/network_page.html.j2
@@ -452,11 +452,25 @@
             </div>
             <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow"
                   class="nn-subscribe-form" style="max-width:none;"
-                  onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';},500);">
-                <p style="font-family:var(--font-ui);font-size:0.85rem;color:var(--nn-text-muted);margin-bottom:var(--sp-3);">Pick the shows you want in your weekly digest:</p>
+                  onsubmit="
+                    var boxes = this.querySelectorAll('input[name=tag]:checked');
+                    if (boxes.length === 0) {
+                      alert('Please pick at least one show to subscribe to.');
+                      return false;
+                    }
+                    var btn=this.querySelector('button[type=submit]');
+                    btn.disabled=true;btn.textContent='Subscribing…';
+                    setTimeout(function(){btn.textContent='Check your email ✓';},500);
+                  ">
+                <p style="font-family:var(--font-ui);font-size:0.85rem;color:var(--nn-text-muted);margin-bottom:var(--sp-3);">
+                    Pick the shows you want — everything's selected by default. Uncheck any you'd rather skip.
+                    <a href="#" onclick="event.preventDefault();this.closest('form').querySelectorAll('input[name=tag]').forEach(function(b){b.checked=false;});return false;" style="color:var(--nn-text-muted);font-size:0.8rem;">Clear all</a>
+                    ·
+                    <a href="#" onclick="event.preventDefault();this.closest('form').querySelectorAll('input[name=tag]').forEach(function(b){b.checked=true;});return false;" style="color:var(--nn-text-muted);font-size:0.8rem;">Select all</a>
+                </p>
                 <div class="nn-subscribe-tags" style="margin-bottom:var(--sp-4);">
                     {% for s in all_shows %}
-                    <label><input type="checkbox" name="tag" value="{{ s.name }}"> {{ s.name }}</label>
+                    <label><input type="checkbox" name="tag" value="{{ s.name }}" checked> {{ s.name }}</label>
                     {% endfor %}
                 </div>
                 <div class="nn-subscribe-row">

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -358,3 +358,76 @@ class TestSendShowNewsletter(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# Hardened error semantics added during P0/P1 cleanup
+# ---------------------------------------------------------------------------
+
+def test_validate_api_key_returns_false_on_5xx(monkeypatch):
+    """5xx Buttondown response should NOT pass validation (was previously
+    a silent True, creating false confidence pre-flight)."""
+    from engine import newsletter
+
+    class _Resp:
+        status_code = 503
+        text = "service unavailable"
+
+    monkeypatch.setattr(newsletter.requests, "get",
+                        lambda *a, **kw: _Resp())
+    assert newsletter.validate_api_key("any-key") is False
+
+
+def test_validate_api_key_returns_false_on_429(monkeypatch):
+    """Rate-limit during pre-flight = unknown key health = treat as fail."""
+    from engine import newsletter
+
+    class _Resp:
+        status_code = 429
+        text = "rate limited"
+
+    monkeypatch.setattr(newsletter.requests, "get",
+                        lambda *a, **kw: _Resp())
+    assert newsletter.validate_api_key("any-key") is False
+
+
+def test_validate_api_key_returns_false_on_403(monkeypatch):
+    """403 = bad permissions = clearly invalid key."""
+    from engine import newsletter
+
+    class _Resp:
+        status_code = 403
+        text = "forbidden"
+
+    monkeypatch.setattr(newsletter.requests, "get",
+                        lambda *a, **kw: _Resp())
+    assert newsletter.validate_api_key("any-key") is False
+
+
+def test_validate_api_key_returns_true_on_200(monkeypatch):
+    from engine import newsletter
+
+    class _Resp:
+        status_code = 200
+        text = "[]"
+
+    monkeypatch.setattr(newsletter.requests, "get",
+                        lambda *a, **kw: _Resp())
+    assert newsletter.validate_api_key("any-key") is True
+
+
+def test_send_newsletter_rejects_invalid_status(monkeypatch):
+    """Catch typos in newsletter.status before hitting Buttondown's 400."""
+    from engine import newsletter
+
+    # Sentinel — should never be called because we reject the status first.
+    def _no_post(*a, **kw):
+        raise AssertionError("send_newsletter should not call requests.post"
+                             " for invalid status")
+
+    monkeypatch.setattr(newsletter.requests, "post", _no_post)
+    out = newsletter.send_newsletter(
+        subject="t", body="b", api_key="key",
+        status="publish",  # typo
+    )
+    assert out is None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -164,3 +164,46 @@ class TestUploadEpisode:
             url = upload_episode(mp3, config)
 
         assert url == "https://audio.example.com/tesla/ep.mp3"
+
+
+# ---------------------------------------------------------------------------
+# Hardened error semantics added during P0/P1 cleanup
+# ---------------------------------------------------------------------------
+
+def test_upload_episode_returns_none_on_boto_exception(monkeypatch, tmp_path):
+    """upload_episode() should swallow boto3 / network exceptions and
+    return None, so run_show.py's "if r2_audio_url is None" branch
+    fires correctly instead of getting an uncaught exception."""
+    from types import SimpleNamespace
+
+    from engine import storage
+
+    f = tmp_path / "episode.mp3"
+    f.write_bytes(b"\x00" * 16)
+
+    # Provide a config whose env vars resolve to non-empty strings so
+    # we get past the credential-skip path.
+    monkeypatch.setenv("R2_ENDPOINT_URL", "https://r2.example.com")
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "ak")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "sk")
+
+    cfg = SimpleNamespace(
+        slug="testshow",
+        storage=SimpleNamespace(
+            provider="r2",
+            bucket="podcast-audio",
+            endpoint_env="R2_ENDPOINT_URL",
+            access_key_env="R2_ACCESS_KEY_ID",
+            secret_key_env="R2_SECRET_ACCESS_KEY",
+            public_base_url="https://audio.example.com",
+        ),
+    )
+
+    def _boom(*args, **kwargs):
+        # Mimic a botocore.exceptions.ClientError surface — any
+        # non-trivial exception class works.
+        raise RuntimeError("boto3: credentials are bad")
+
+    monkeypatch.setattr(storage, "upload_to_r2", _boom)
+    result = storage.upload_episode(f, cfg)
+    assert result is None


### PR DESCRIPTION
## Summary

Bundles the prioritized fixes from the recent codebase review with the website signup tightening so existing subscribers and new ones both actually receive newsletters.

## Reliability (P0)

- **`engine/storage.py`** — `upload_episode` now swallows boto3 / botocore exceptions and returns `None` instead of propagating, so the `if r2_audio_url is None: sys.exit(3)` branch in `run_show.py` actually fires on credential errors and network failures.
- **`engine/newsletter.py`** — `validate_api_key` returns `False` on 5xx and 429 instead of `True`. Previous behavior passed pre-flight when Buttondown was down, then failed at send. `send_newsletter` now refuses statuses outside `{about_to_send, draft, scheduled}` so a YAML typo doesn't burn an API call on a guaranteed 400.
- **`engine/captions.py`** — wrap SRT `write_text` in try/except so permission/disk errors surface in logs instead of being silently lost.

## Observability (P1)

- **`run_show.py`** — newsletter caller distinguishes three failure modes in the log line: missing API key, tag filter matched nobody, generic "see prior log lines". (Previously all three collapsed to "Newsletter skipped or failed.")
- **`run_show.py`** — preflight warns when `youtube.enabled: true` but `podcast_playlist_id` is empty (silent YouTube Music Podcasts reach loss), and rejects invalid `privacy_status` / `newsletter.status` upfront.
- **`run_show.py`** — record `youtube_long_form_uploaded` / `youtube_short_uploaded` / `youtube_enabled` into per-episode metrics.
- **`scripts/generate_dashboard.py`** — aggregate the new counters into `pipeline_health.<show>.youtube`, plus a new landmine `item_13_youtube_health` that fails when YouTube-enabled shows are missing playlist IDs.

## Cron stagger (P1)

`.github/workflows/run-show.yml` — Tesla moves from 9:30 → 10:00 UTC daily so its 45-min pipeline doesn't overlap Modern Investing's 9:00 UTC weekday slot. `CRON_MAP` updated to match.

## Newsletter signup unblock

- **`scripts/buttondown_tag_subscriber.py`** — one-off CLI to add/remove Buttondown subscriber tags across one show, several shows, or all of them. Reads tag values from each show's YAML.
- **`.github/workflows/buttondown-tag-subscriber.yml`** — workflow_dispatch wrapper so you can run the tagging script from the Actions UI without setting up Python locally. **Use this to tag `patricknovak1@gmail.com` (or any subscriber) across all show tags so per-show emails reach their inbox immediately.**
- **`templates/network_page.html.j2`** — the network signup form now:
  1. Pre-checks every show by default (was: all unchecked → users who didn't pick boxes ended up untagged and silently skipped by every per-show send)
  2. Adds **Select all** / **Clear all** helpers above the checkbox grid
  3. Blocks submit when zero boxes are checked, with an alert explaining why

Per-show + per-blog-post forms already pass a hidden tag, no change needed there.

## Operator next step (1 click)

After this merges, go to **Actions → Tag Buttondown Subscriber → Run workflow**:

- Email: `patricknovak1@gmail.com`
- Mode: `add-all`

Tomorrow's even-day cron (FF + MAB + finansy_prosto + privet_russian) should land in your inbox. Tesla daily lands the same morning.

## Test plan

- [x] `pytest tests/test_newsletter.py tests/test_storage.py tests/test_captions.py` — 71 pass
- [x] Full `pytest` — 1,203 passed, 3 env-skipped, no regressions
- [x] `ruff check engine/ run_show.py scripts/ tests/ --select=E9,F63,F7,F82` — clean
- [ ] **Operator (manual)**: trigger the new "Tag Buttondown Subscriber" workflow with your email + `add-all`; confirm the run prints `Added tag(s) [...] on patricknovak1@gmail.com`. Verify in Buttondown's Subscribers UI that the tags now appear.
- [ ] **Operator (manual)**: wait for tomorrow's cron, confirm at least one show's newsletter arrives.

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_