### PR TITLE
Russian newsletter tags → ASCII (Buttondown rejects Cyrillic-only)

### DIFF
--- a/engine/blog.py
+++ b/engine/blog.py
@@ -613,7 +613,12 @@ def generate_blog_post_html(
         "tagline": show_config.get("tagline", ""),
         "transcript": transcript_text,
         "related_posts": related_posts or [],
-        "newsletter_tag": show_config["name"],
+        # Use the show's Buttondown newsletter tag when set in
+        # NETWORK_SHOWS — falls back to the display name. Russian
+        # shows override this with an ASCII transliteration because
+        # Buttondown rejects tags with no ASCII letter/number.
+        "newsletter_tag": show_config.get("newsletter_tag")
+            or show_config["name"],
         "page_lang": "ru" if show_slug in ("finansy_prosto", "privet_russian") else "en",
         # YouTube cross-posting — when present, the template renders a
         # "Watch on YouTube" button next to the existing podcast/summaries CTAs.

--- a/generate_html.py
+++ b/generate_html.py
@@ -810,6 +810,9 @@ NETWORK_SHOWS = {
     "finansy_prosto": {
         "name": "Финансы Просто",
         "slug": "finansy_prosto",
+        # Buttondown rejects non-ASCII tags; keep the display name in
+        # Cyrillic but tag in ASCII to match shows/finansy_prosto.yaml.
+        "newsletter_tag": "Finansy Prosto",
         "display_order": 9,
         "description": "Ежедневный подкаст о финансах на русском языке для женщин в Канаде.",
         "show_page": "ru/finansy-prosto.html",
@@ -903,6 +906,9 @@ NETWORK_SHOWS = {
     "privet_russian": {
         "name": "Привет, Русский!",
         "slug": "privet_russian",
+        # Buttondown rejects non-ASCII tags; keep the display name in
+        # Cyrillic but tag in ASCII to match shows/privet_russian.yaml.
+        "newsletter_tag": "Privet Russian",
         "display_order": 10,
         "description": "Bilingual Russian language learning podcast for English speakers.",
         "show_page": "ru/privet-russian.html",
@@ -1158,6 +1164,30 @@ _SHOW_PICKER_TAGS = {
 }
 
 
+def _newsletter_tag_for_slug(slug: str, fallback_name: str) -> str:
+    """Return the Buttondown tag for a show.
+
+    Reads ``newsletter.tag`` from the show's YAML when available so
+    the network signup form posts the same tag string the per-show
+    forms use. Falls back to the show's display name. Buttondown
+    requires tags to contain at least one ASCII letter or digit, so
+    Russian shows now ship ASCII tags ("Privet Russian", "Finansy
+    Prosto") rather than their Cyrillic display names.
+    """
+    import yaml as _yaml
+
+    yaml_path = SHOWS_DIR / f"{slug}.yaml"
+    if yaml_path.exists():
+        try:
+            data = _yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+            tag = ((data.get("newsletter") or {}).get("tag") or "").strip()
+            if tag:
+                return tag
+        except _yaml.YAMLError:
+            pass
+    return fallback_name
+
+
 def _build_all_shows_list():
     """Build a list of all shows with metadata needed by templates."""
     shows = [
@@ -1179,6 +1209,7 @@ def _build_all_shows_list():
             "spotify_url": cfg.get("spotify_url"),
             "picker_tags": _SHOW_PICKER_TAGS.get(cfg["slug"], {}),
             "blog_page": f"blog/{cfg['slug']}/index.html",
+            "newsletter_tag": _newsletter_tag_for_slug(cfg["slug"], cfg["name"]),
             "_order": cfg.get("display_order", 99),
         }
         for cfg in NETWORK_SHOWS.values()
@@ -1441,7 +1472,7 @@ def generate_show_page(slug, *, dry_run=False):
         "blog_page": f"blog/{cfg['slug']}/index.html",
         "latest_blog_posts": latest_blog_posts,
         "static_episodes": static_episodes,
-        "newsletter_tag": cfg["name"],
+        "newsletter_tag": _newsletter_tag_for_slug(cfg["slug"], cfg["name"]),
         "all_shows": _build_all_shows_list(),
         "performance_data": performance_data,
         "page_lang": "ru" if is_russian else "en",

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -240,7 +240,9 @@ newsletter:
   platform: buttondown
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
-  tag: "Финансы Просто"
+  # Buttondown rejects tags with no ASCII letter/number, so we use the
+  # transliterated form rather than the Cyrillic show display name.
+  tag: "Finansy Prosto"
 
 slow_news:
   enabled: true

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -190,7 +190,9 @@ newsletter:
   platform: buttondown
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
-  tag: "Привет, Русский!"
+  # Buttondown rejects tags with no ASCII letter/number, so we use the
+  # transliterated form rather than the Cyrillic show display name.
+  tag: "Privet Russian"
 
 slow_news:
   enabled: true

--- a/templates/network_page.html.j2
+++ b/templates/network_page.html.j2
@@ -470,7 +470,7 @@
                 </p>
                 <div class="nn-subscribe-tags" style="margin-bottom:var(--sp-4);">
                     {% for s in all_shows %}
-                    <label><input type="checkbox" name="tag" value="{{ s.name }}" checked> {{ s.name }}</label>
+                    <label><input type="checkbox" name="tag" value="{{ s.newsletter_tag or s.name }}" checked> {{ s.name }}</label>
                     {% endfor %}
                 </div>
                 <div class="nn-subscribe-row">


### PR DESCRIPTION
## Summary

Buttondown rejects tags with no ASCII letter or digit, so "Финансы Просто" and "Привет, Русский!" failed with `HTTP 400 {"code":"tag_invalid"}` when the Tag Buttondown Subscriber workflow tried to apply them. Switching both Russian shows' newsletter tags to ASCII transliterations:

| Show | Display name (unchanged) | Old tag | New tag |
|---|---|---|---|
| Финансы Просто | Финансы Просто | `Финансы Просто` | `Finansy Prosto` |
| Привет, Русский! | Привет, Русский! | `Привет, Русский!` | `Privet Russian` |

Display names stay Cyrillic everywhere users see them (show pages, RSS titles, podcast metadata, YouTube playlists). The tag is purely a Buttondown-internal label used for filtering newsletter sends.

## Three places that use the tag, now reading it from YAML

- **`generate_html.py`** — new `_newsletter_tag_for_slug(slug, fallback_name)` helper pulls `newsletter.tag` from the show YAML. The network signup form's per-show checkbox values + the per-show page's hidden tag input flow through this.
- **`engine/blog.py`** — `generate_blog_post_html` now reads `show_config.get("newsletter_tag")` with `show_config["name"]` as fallback. `NETWORK_SHOWS` gains `"newsletter_tag"` entries for the two Russian shows.
- **`templates/network_page.html.j2`** — per-show checkbox now posts `{{ s.newsletter_tag or s.name }}`, so network-signup form posts apply the ASCII tag.

## Operator next step (1 click after merge)

Re-run the **Tag Buttondown Subscriber** workflow → email `patricknovak1@gmail.com`, mode `add-all`. The previous run added 8 of the 10 tags before failing on `Привет, Русский!`; this run should complete cleanly and add the remaining 2 (`Finansy Prosto` + `Privet Russian`).

## Test plan

- [x] Verify the tag-subscriber script reads ASCII for both Russian shows:
  ```
  finansy_prosto: 'Finansy Prosto'
  privet_russian: 'Privet Russian'
  ```
- [x] Full `pytest` — 1,206 passed, 3 skipped, no regressions
- [x] `ruff check` — clean
- [ ] **Operator**: re-run the Tag Buttondown Subscriber workflow with `--all`; confirm it completes without the `tag_invalid` error.

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_