### PR TITLE
Self-heal stale invalid Buttondown tags so the workflow can recover

### DIFF
--- a/scripts/buttondown_tag_subscriber.py
+++ b/scripts/buttondown_tag_subscriber.py
@@ -65,6 +65,16 @@ def _load_show_tags() -> Dict[str, str]:
     return tags
 
 
+def _is_valid_buttondown_tag(tag: str) -> bool:
+    """Buttondown rejects tags that contain no ASCII letter or digit
+    (HTTP 400 ``tag_invalid``). Mirror that rule client-side so we
+    can drop stale invalid tags from a subscriber's record without
+    triggering the same error in our PATCH payload."""
+    if not tag:
+        return False
+    return any(c.isascii() and c.isalnum() for c in tag)
+
+
 def _get_subscriber(email: str, api_key: str) -> Optional[dict]:
     """Look up a subscriber by email. Returns the JSON record or None."""
     resp = requests.get(
@@ -192,14 +202,26 @@ def main(argv: Optional[List[str]] = None) -> int:
               f"with tags: {new_tags}")
         return 0
 
-    existing = set(sub.get("tags") or [])
+    raw_existing = set(sub.get("tags") or [])
+    # Filter out tags Buttondown would reject in a PATCH body — these
+    # are stale entries from before the YAML migration to ASCII tags
+    # (e.g. "Привет, Русский!" / "Финансы Просто"). Including them in
+    # the PATCH request triggers HTTP 400 tag_invalid and aborts the
+    # whole update, even when the new tag is valid. Logging the
+    # dropped names so the operator sees what got cleaned up.
+    existing = {t for t in raw_existing if _is_valid_buttondown_tag(t)}
+    dropped = raw_existing - existing
+    if dropped:
+        print(f"Dropping {len(dropped)} stale invalid tag(s) from "
+              f"{args.email} that Buttondown would now reject: "
+              f"{sorted(dropped)}")
     if args.remove:
         new = existing - target_tags
         action = "Removed"
     else:
         new = existing | target_tags
         action = "Added"
-    if new == existing:
+    if new == existing and not dropped:
         print(f"No-op: {args.email} already has the requested tags "
               f"({sorted(existing)}).")
         return 0

--- a/tests/test_buttondown_tag_subscriber.py
+++ b/tests/test_buttondown_tag_subscriber.py
@@ -1,0 +1,70 @@
+"""Tests for the Buttondown subscriber tagging script.
+
+The script lives under ``scripts/`` rather than ``engine/`` so we
+import it via the path. We exercise the pure helpers — the HTTP
+calls themselves are not tested here (they're guarded by a
+``BUTTONDOWN_API_KEY`` env var the test suite never has).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import buttondown_tag_subscriber as bts  # noqa: E402  (path manipulation needed)
+
+
+# ---------------------------------------------------------------------------
+# Tag validity
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("tag", [
+    "Tesla Shorts Time",
+    "Privet Russian",
+    "Finansy Prosto",
+    "ABC123",
+    "a",                     # one char, valid
+    "1",                     # one digit, valid
+    "Tesla — 2026",          # mixed but has ASCII letters
+])
+def test_valid_buttondown_tag_accepts_with_ascii_alphanum(tag):
+    assert bts._is_valid_buttondown_tag(tag) is True
+
+
+@pytest.mark.parametrize("tag", [
+    "Привет, Русский!",      # all Cyrillic + punctuation
+    "Финансы Просто",        # all Cyrillic
+    "!!!",                   # punctuation only
+    "—",                     # em-dash only
+    "",                      # empty
+])
+def test_valid_buttondown_tag_rejects_no_ascii_alphanum(tag):
+    assert bts._is_valid_buttondown_tag(tag) is False
+
+
+# ---------------------------------------------------------------------------
+# YAML tag loader
+# ---------------------------------------------------------------------------
+
+def test_load_show_tags_returns_only_ascii_friendly():
+    """All shipped show tags should pass Buttondown's validator."""
+    tags = bts._load_show_tags()
+    assert tags, "expected at least one show tag"
+    invalid = {
+        slug: tag for slug, tag in tags.items()
+        if not bts._is_valid_buttondown_tag(tag)
+    }
+    assert not invalid, f"these tags would be rejected by Buttondown: {invalid}"
+
+
+def test_load_show_tags_includes_russian_shows_with_ascii():
+    tags = bts._load_show_tags()
+    # Russian shows have ASCII transliterations — verify they're set.
+    assert tags.get("privet_russian") == "Privet Russian"
+    assert tags.get("finansy_prosto") == "Finansy Prosto"


### PR DESCRIPTION
## Summary

The previous tagging workflow run added 8 of 10 tags before failing on `"Привет, Русский!"`. PR #266 then renamed the YAML to ASCII (`"Privet Russian"`), but re-running still failed because:

1. The subscriber already had `"Привет, Русский!"` attached from the partial first run.
2. The script computes `new = existing | target_tags`, so the PATCH payload still contained the Cyrillic tag.
3. Buttondown re-validates every tag on every PATCH, so the stale Cyrillic tag tripped `HTTP 400 tag_invalid` again.

## Fix

Client-side validator (`_is_valid_buttondown_tag`) that mirrors Buttondown's "must contain at least one ASCII letter or digit" rule. Stale tags that fail the check get filtered out of the `existing` set before we union with `target_tags`, so the PATCH payload no longer contains anything Buttondown will reject.

The script logs which tags it dropped so the operator sees the cleanup. The no-op short-circuit ("subscriber already has the requested tags") now correctly forces a PATCH when the only change is dropping invalid tags.

## Test plan

- [x] `pytest tests/test_buttondown_tag_subscriber.py` — 14 new cases (validator accepts ASCII-alphanum, rejects Cyrillic-only / punctuation-only / empty; guard that all shipped show tags pass)
- [x] Full `pytest` — 1,220 passed, 3 skipped
- [x] `ruff check` — clean
- [ ] **Operator**: re-run the Tag Buttondown Subscriber workflow with `patricknovak1@gmail.com` + `add-all`. Expected log line: `Dropping 1 stale invalid tag(s) from patricknovak1@gmail.com that Buttondown would now reject: ['Привет, Русский!']`, followed by `Added tag(s) [...]`. Final state: 10 ASCII tags, no Cyrillic.

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_