### PR TITLE
Backfill Content Lake before runs that read from it (fixes empty weekly newsletters + broken cross-episode dedup)

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -268,6 +268,15 @@ jobs:
           print(f'Config validated: {config.name} ({len(config.sources)} sources, model={config.llm.model})')
           "
 
+      - name: Backfill Content Lake from committed digests
+        # data/content_lake.db is in .gitignore, so each fresh checkout
+        # has zero episodes. Without this step, the pipeline's
+        # cross-episode deduplication queries see no historical
+        # content and let through stories the network already
+        # covered. Backfill is fast (~5 s for ~50 episodes) and
+        # rebuilds from the committed digests/<slug>/*.md files.
+        run: python scripts/backfill_content_lake.py
+
       - name: Run show pipeline
         id: pipeline
         run: |

--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -48,6 +48,17 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Backfill Content Lake from committed digests
+        # The Content Lake DB (data/content_lake.db) is in .gitignore,
+        # so every fresh checkout starts with zero episodes — including
+        # this scheduled runner. The daily run_show.py pipeline writes
+        # to the DB but that copy is discarded when the runner shuts
+        # down. Rebuilding from the committed digests/<slug>/*.md
+        # files is fast (~5 s) and gives the synthesizer the past
+        # week of episodes it needs. Without this step, every show
+        # reported "Only 0 episodes for <show> week of …, skipping".
+        run: python scripts/backfill_content_lake.py
+
       - name: Run weekly newsletters
         env:
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}


### PR DESCRIPTION
## Summary

Diagnosis of the recent run that printed `Only 0 episodes for tesla week of 2026-04-30, skipping` for every single show:

1. `data/content_lake.db` is in `.gitignore` — never committed.
2. Every GitHub Actions runner starts on a fresh checkout with no DB.
3. The daily `run_show.py` pipeline does write to `data/content_lake.db` but that copy is discarded when the runner shuts down.
4. The weekly newsletter runner sees an empty DB and skips every show.

`scripts/backfill_content_lake.py` already existed for exactly this case — it scans the committed `digests/<slug>/*.md` files and reconstructs the DB. Local timing: **8.7 s to import 313 episodes across 10 shows** (309 unique episodes from Feb–Apr 2026).

## Fix

Add the backfill as a step before each workflow invocation that reads from the DB:

- **`weekly-newsletter.yml`** — runs before `run_weekly_newsletters.py`. Unblocks the user's complaint.
- **`run-show.yml`** — runs before `run_show.py`. The daily pipeline's `query_show_range()` cross-episode dedup is also broken without it (DB only contained the episode just generated). Same fix; same step.

Cost: ~8 s × 10 daily runs = ~80 s/day extra CI time. Negligible.

## Test plan

- [x] Local backfill run: 313 episodes imported, 309 stored after dedup, 8.7 s wall time
- [x] Full `pytest` — 1,220 passed, 3 skipped
- [x] `ruff check` — clean
- [ ] **Operator**: after merge, re-run the **Weekly Newsletters** workflow manually. Expected output is the "WEEKLY NEWSLETTER SUMMARY" section showing each show as `sent` (or at least not `skipped` with the "0 episodes" warning).
- [ ] **Operator (passive)**: tomorrow's daily Tesla run will start emitting non-zero `cross_episode_repeats` metric values now that dedup has real history to compare against.

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_