### PR TITLE
Update Buttondown filter payload to v2 tree schema (fixes HTTP 422 on every newsletter send)

### DIFF
--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -214,9 +214,18 @@ def send_newsletter(
     }
 
     if tags:
+        # Buttondown's email-send filters use a tree structure with
+        # ``filters`` (leaf conditions), ``groups`` (nested filter
+        # groups), and ``predicate`` ("any"/"all") for the join.
+        # The previous ``{operator, predicates}`` shape now returns
+        # HTTP 422 — they tightened the schema validator.
         data["filters"] = {
-            "operator": "or",
-            "predicates": [{"field": "tag", "operator": "is", "value": t} for t in tags],
+            "filters": [
+                {"field": "tag", "operator": "equals", "value": t}
+                for t in tags
+            ],
+            "groups": [],
+            "predicate": "any",  # OR semantics across the listed tags
         }
 
     resp = requests.post(

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -431,3 +431,81 @@ def test_send_newsletter_rejects_invalid_status(monkeypatch):
         status="publish",  # typo
     )
     assert out is None
+
+
+# ---------------------------------------------------------------------------
+# Buttondown filter shape — the v2 tree schema introduced after a
+# ``{operator, predicates}`` payload started returning HTTP 422
+# ---------------------------------------------------------------------------
+
+def test_send_newsletter_uses_v2_filter_tree_when_tags_set(monkeypatch):
+    """When tags are passed, the request body's ``filters`` must
+    match Buttondown's current ``{filters, groups, predicate}``
+    schema — old ``{operator, predicates}`` was rejected with
+    HTTP 422 missing-field errors on filters/groups/predicate."""
+    import json as _json
+    from engine import newsletter
+
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"id": "em_test", "num_recipients": 1}
+
+    def _fake_post(url, headers, json, timeout):
+        captured["payload"] = _json.loads(_json.dumps(json))
+        return _Resp()
+
+    monkeypatch.setattr(newsletter.requests, "post", _fake_post)
+
+    out = newsletter.send_newsletter(
+        subject="Subject",
+        body="Body",
+        api_key="key",
+        tags=["Tesla Shorts Time", "Privet Russian"],
+    )
+    assert out == "em_test"
+
+    filters = captured["payload"]["filters"]
+    # The required v2 keys.
+    assert set(filters.keys()) == {"filters", "groups", "predicate"}
+    assert filters["predicate"] in {"any", "all"}
+    assert filters["groups"] == []
+    # Each tag becomes a leaf condition.
+    leaf_tags = {f["value"] for f in filters["filters"]}
+    assert leaf_tags == {"Tesla Shorts Time", "Privet Russian"}
+    # No leftover keys from the old schema.
+    for leaf in filters["filters"]:
+        assert leaf["field"] == "tag"
+        assert leaf["operator"] == "equals"
+    # Old keys must NOT appear.
+    assert "predicates" not in filters
+    assert "operator" not in filters
+
+
+def test_send_newsletter_omits_filters_when_no_tags(monkeypatch):
+    """No tags = no ``filters`` key in the payload — sends to all
+    subscribers. (Empty filters would also work, but omitting is
+    cleaner and matches the existing behaviour.)"""
+    from engine import newsletter
+
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"id": "em_test", "num_recipients": 5}
+
+    def _fake_post(url, headers, json, timeout):
+        captured["payload"] = json
+        return _Resp()
+
+    monkeypatch.setattr(newsletter.requests, "post", _fake_post)
+
+    newsletter.send_newsletter(
+        subject="Subject", body="Body", api_key="key", tags=None,
+    )
+    assert "filters" not in captured["payload"]


### PR DESCRIPTION
## Summary

After PR #268 unblocked the Content Lake backfill, every show successfully generated a newsletter — but Buttondown rejected all 10 sends with HTTP 422:

```
{"detail":[
  {"type":"missing","loc":["body","payload","filters","filters"],"msg":"Field required"},
  {"type":"missing","loc":["body","payload","filters","groups"],"msg":"Field required"},
  {"type":"missing","loc":["body","payload","filters","predicate"],"msg":"Field required"}
]}
```

Buttondown tightened the email-send filter schema. The new payload shape is a filter tree.

## Old vs new shape

```diff
-filters: {
-  operator: "or",
-  predicates: [{field: "tag", operator: "is", value: "Tesla"}, ...],
-}
+filters: {
+  filters: [{field: "tag", operator: "equals", value: "Tesla"}, ...],
+  groups: [],
+  predicate: "any",
+}
```

Operator vocabulary also tightened: `is` → `equals`. Predicate moved from a top-level join (`operator: "or"`) to a sibling key (`predicate: "any"`).

## Test plan

- [x] 2 new tests pin the new shape:
  - With tags → payload has `{filters, groups, predicate}` and no leftover `{operator, predicates}` keys
  - Without tags → no `filters` key on the payload
- [x] Full `pytest` — 1,222 passed, 3 skipped, ruff clean
- [ ] **Operator**: re-run the **Weekly Newsletters** workflow after merge. Expected: each show shows `sent` instead of `send failed`. Verify in your inbox.

## Related work in this thread

This completes the newsletter unblocking that started with #263 (R2/captions/preflight reliability + signup form fix), continued with #266 (ASCII tag rename), #267 (self-heal stale tags), and #268 (Content Lake backfill). After this PR merges, the weekly cron should email subscribers who match each show's tag.

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_