### PR TITLE
Buttondown predicate enum is "and"/"or" (fixes weekly newsletter 422)

### DIFF
--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -216,16 +216,17 @@ def send_newsletter(
     if tags:
         # Buttondown's email-send filters use a tree structure with
         # ``filters`` (leaf conditions), ``groups`` (nested filter
-        # groups), and ``predicate`` ("any"/"all") for the join.
-        # The previous ``{operator, predicates}`` shape now returns
-        # HTTP 422 — they tightened the schema validator.
+        # groups), and ``predicate`` ("and"/"or") for the join.
+        # Older clients sent ``{operator, predicates}`` and got
+        # HTTP 422; the predicate enum is also strict — only "and"
+        # or "or" are accepted (not "any"/"all").
         data["filters"] = {
             "filters": [
                 {"field": "tag", "operator": "equals", "value": t}
                 for t in tags
             ],
             "groups": [],
-            "predicate": "any",  # OR semantics across the listed tags
+            "predicate": "or",  # OR semantics across the listed tags
         }
 
     resp = requests.post(

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -471,7 +471,8 @@ def test_send_newsletter_uses_v2_filter_tree_when_tags_set(monkeypatch):
     filters = captured["payload"]["filters"]
     # The required v2 keys.
     assert set(filters.keys()) == {"filters", "groups", "predicate"}
-    assert filters["predicate"] in {"any", "all"}
+    # Buttondown's predicate enum: "and" or "or" (not "any"/"all").
+    assert filters["predicate"] in {"and", "or"}
     assert filters["groups"] == []
     # Each tag becomes a leaf condition.
     leaf_tags = {f["value"] for f in filters["filters"]}


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #269. After updating to the v2 filter tree shape, the next workflow run got a more specific 422:

```
{"type":"literal_error","loc":["body","payload","filters","predicate"],
 "msg":"Input should be 'and' or 'or'",
 "ctx":{"expected":"'and' or 'or'"}}
```

PR #269 used `predicate: "any"` based on a guess. Buttondown's enum is actually `"and"` / `"or"`. Switching to `"or"` (same OR semantics across the listed tag filters as before).

Tests updated to match. All 55 newsletter tests pass; ruff clean.

## Test plan

- [x] `pytest tests/test_newsletter.py` — 55/55
- [x] `ruff check` — clean
- [ ] **Operator**: re-run the **Weekly Newsletters** workflow once more. Expected: each show shows `sent` with an email ID; subscribers tagged for each show receive the email.

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_