### PR TITLE
Add X-Buttondown-Live-Dangerously header (fixes 400 sending_requires_confirmation)

### DIFF
--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -234,6 +234,12 @@ def send_newsletter(
         headers={
             "Authorization": f"Token {api_key}",
             "Content-Type": "application/json",
+            # Buttondown's safety gate against accidental mass-sends.
+            # The first email POST with status "about_to_send" for a
+            # given API key returns HTTP 400 sending_requires_confirmation
+            # unless this header is set. We always set it because we
+            # mean to send.
+            "X-Buttondown-Live-Dangerously": "true",
         },
         json=data,
         timeout=30,

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -510,3 +510,30 @@ def test_send_newsletter_omits_filters_when_no_tags(monkeypatch):
         subject="Subject", body="Body", api_key="key", tags=None,
     )
     assert "filters" not in captured["payload"]
+
+
+def test_send_newsletter_sets_live_dangerously_header(monkeypatch):
+    """Buttondown requires X-Buttondown-Live-Dangerously: true on the
+    first email POST with status="about_to_send" for an API key.
+    Without it: HTTP 400 sending_requires_confirmation. We send it
+    on every request because we always mean to send."""
+    from engine import newsletter
+
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"id": "em_test", "num_recipients": 1}
+
+    def _fake_post(url, headers, json, timeout):
+        captured["headers"] = headers
+        return _Resp()
+
+    monkeypatch.setattr(newsletter.requests, "post", _fake_post)
+
+    newsletter.send_newsletter(
+        subject="s", body="b", api_key="key", tags=None,
+    )
+    assert captured["headers"].get("X-Buttondown-Live-Dangerously") == "true"


### PR DESCRIPTION
## Summary

After the filter shape (#269) and `predicate: "or"` (#270) fixes, Buttondown returned a new gate:

```
HTTP 400 sending_requires_confirmation
"Creating an email with status 'about_to_send' requires the
 X-Buttondown-Live-Dangerously header. This is only required once
 per API key."
```

It's a safety gate against accidental mass-sending. Adding the header on every request — harmless when not strictly needed, required for the first send with any new API key.

## Test plan

- [x] `pytest tests/test_newsletter.py` — 56/56 (including new header assertion)
- [ ] **Operator**: re-run the **Weekly Newsletters** workflow once more. Expected: every show shows `sent`; 10 newsletters arrive in your inbox.

This should be the final newsletter fix. If anything else surfaces I'll keep going.

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_