### PR TITLE
Newsletter quick wins: hook subject, preheader, P.S., stats, dedup

### DIFF
--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 
 import datetime
 import logging
+import re
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +64,14 @@ def _load_show_branding(slug: str) -> Dict[str, str]:
         "brand_color_dark": _DEFAULT_BRAND_DARK,
         "rss_url": "",
         "youtube_playlist_url": "",
+        # Newsletter-specific branding bits. ``short_label`` and ``emoji``
+        # feed the subject-line composer; ``newsletter_start_date`` lets
+        # us derive a per-show issue number deterministically without
+        # storing mutable state.
+        "short_label": "",
+        "emoji": "",
+        "newsletter_start_date": "",
+        "requires_financial_disclaimer": "false",
     }
 
     # Lazy import to avoid pulling jinja into engine layer at import
@@ -91,22 +100,47 @@ def _load_show_branding(slug: str) -> Dict[str, str]:
             out["rss_url"] = f"{_NETWORK_SITE}/{cfg['rss_file']}"
         out["blog_page"] = f"{_NETWORK_SITE}/blog/{slug}/index.html"
 
-    # YouTube playlist URL — read straight from the show YAML so we
+    # YouTube playlist URL + newsletter branding bits — read straight
+    # from the show YAML (with _defaults.yaml as the fallback) so we
     # don't double-source it. Fail-soft if the YAML is missing.
     try:
         import yaml as _yaml
 
+        defaults_path = _shows_yaml_dir() / "_defaults.yaml"
+        defaults = (
+            _yaml.safe_load(defaults_path.read_text(encoding="utf-8")) or {}
+            if defaults_path.exists() else {}
+        )
+
         yaml_path = _shows_yaml_dir() / f"{slug}.yaml"
+        data: Dict[str, Any] = {}
         if yaml_path.exists():
             data = _yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
-            yt = data.get("youtube") or {}
-            playlist_id = (yt.get("podcast_playlist_id") or "").strip()
-            if playlist_id:
-                out["youtube_playlist_url"] = (
-                    f"https://www.youtube.com/playlist?list={playlist_id}"
-                )
+
+        yt = data.get("youtube") or {}
+        playlist_id = (yt.get("podcast_playlist_id") or "").strip()
+        if playlist_id:
+            out["youtube_playlist_url"] = (
+                f"https://www.youtube.com/playlist?list={playlist_id}"
+            )
+
+        # Merge newsletter block: per-show overrides defaults.
+        nl_default = defaults.get("newsletter") or {}
+        nl_show = data.get("newsletter") or {}
+        for key in (
+            "short_label", "emoji", "newsletter_start_date",
+        ):
+            val = nl_show.get(key) or nl_default.get(key) or ""
+            if val:
+                out[key] = str(val)
+        # Bool flag: stored as str so the dict stays Dict[str, str].
+        flag = nl_show.get(
+            "requires_financial_disclaimer",
+            nl_default.get("requires_financial_disclaimer", False),
+        )
+        out["requires_financial_disclaimer"] = "true" if flag else "false"
     except Exception as exc:  # pragma: no cover — defensive
-        logger.warning("Could not read YouTube playlist for %s: %s", slug, exc)
+        logger.warning("Could not read newsletter branding for %s: %s", slug, exc)
 
     return out
 
@@ -177,6 +211,141 @@ def _build_hero_html(show: Dict[str, str], pill_text: str) -> str:
     )
 
 
+def _build_preheader_html(preheader: str) -> str:
+    """Hidden preview-text div for inbox snippets.
+
+    Inboxes show this as the snippet next to the subject line. It must
+    be visually hidden (display:none + opacity:0 + max-height:0) but
+    present in the DOM so Gmail / Apple Mail picks it up. Trailing
+    zero-width-non-joiners pad past short snippets so the inbox doesn't
+    bleed body text into the preview.
+    """
+    if not preheader:
+        return ""
+    pad = "&nbsp;&zwnj;" * 24
+    safe = preheader.replace("<", "&lt;").replace(">", "&gt;")
+    return (
+        '<div style="display:none;font-size:1px;color:#fafafa;'
+        'line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;'
+        'mso-hide:all;">'
+        f'{safe}{pad}'
+        '</div>'
+    )
+
+
+def _build_by_the_numbers_html(
+    stats: Optional[List[Dict[str, str]]], brand: str
+) -> str:
+    """Render up to 3 stat tiles right under the hero, before the body."""
+    if not stats:
+        return ""
+    cells: List[str] = []
+    for item in stats[:3]:
+        value = (item.get("value") or "").strip()
+        label = (item.get("label") or "").strip()
+        if not value or not label:
+            continue
+        v_safe = value.replace("<", "&lt;").replace(">", "&gt;")
+        l_safe = label.replace("<", "&lt;").replace(">", "&gt;")
+        cells.append(
+            f'<td align="center" valign="top" '
+            f'style="padding:8px 6px;width:33%;">'
+            f'<div style="font-size:22px;font-weight:700;color:{brand};'
+            f'line-height:1.1;letter-spacing:-0.01em;">{v_safe}</div>'
+            f'<div style="font-size:11px;color:#64748b;'
+            f'text-transform:uppercase;letter-spacing:0.06em;'
+            f'margin-top:4px;line-height:1.3;">{l_safe}</div>'
+            f'</td>'
+        )
+    if not cells:
+        return ""
+    return (
+        '<table role="presentation" width="100%" cellpadding="0" '
+        'cellspacing="0" border="0" '
+        'style="background:#ffffff;border-bottom:1px solid #e2e8f0;">'
+        '<tr><td align="center" '
+        'style="padding:18px 16px;'
+        'font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\','
+        'Roboto,Helvetica,Arial,sans-serif;">'
+        '<div style="font-size:11px;color:#94a3b8;font-weight:600;'
+        'text-transform:uppercase;letter-spacing:0.08em;'
+        'margin-bottom:10px;">By the numbers</div>'
+        '<table role="presentation" width="100%" cellpadding="0" '
+        'cellspacing="0" border="0" style="max-width:480px;margin:0 auto;">'
+        f'<tr>{"".join(cells)}</tr>'
+        '</table>'
+        '</td></tr></table>'
+    )
+
+
+def _build_financial_disclaimer_html() -> str:
+    """Styled callout box for shows that discuss financial topics.
+
+    Replaces the old in-prose ``**FINANCIAL DISCLAIMER:**`` line with
+    a visually-distinct amber sidebar so it doesn't get lost in the
+    body and is unmistakable to subscribers.
+    """
+    return (
+        '<table role="presentation" width="100%" cellpadding="0" '
+        'cellspacing="0" border="0" '
+        'style="background:#FFF7ED;border-left:4px solid #F59E0B;">'
+        '<tr><td '
+        'style="padding:12px 16px;'
+        'font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\','
+        'Roboto,Helvetica,Arial,sans-serif;'
+        'font-size:13px;color:#78350F;line-height:1.5;">'
+        '<strong>Heads up:</strong> Educational and entertainment only. '
+        'Not financial advice. Any trades discussed are simulated. '
+        'Always do your own research.'
+        '</td></tr></table>'
+    )
+
+
+def _build_p_s_html(p_s: str, brand: str) -> str:
+    """Render the P.S. block between the body and the footer.
+
+    P.S. is one of the most-read elements of any newsletter; we render
+    it in its own card with a brand-colored left border so it visually
+    separates from the body and footer.
+    """
+    if not p_s:
+        return ""
+    safe = p_s.replace("<", "&lt;").replace(">", "&gt;")
+    return (
+        '<table role="presentation" width="100%" cellpadding="0" '
+        'cellspacing="0" border="0" style="background:#ffffff;">'
+        '<tr><td '
+        'style="padding:8px 24px 24px;'
+        'font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\','
+        'Roboto,Helvetica,Arial,sans-serif;">'
+        f'<p style="font-size:15px;line-height:1.6;color:#0f172a;'
+        f'margin:0;border-left:3px solid {brand};padding:4px 0 4px 14px;">'
+        f'<strong style="color:{brand};letter-spacing:0.04em;">P.S.</strong>'
+        f'&nbsp;{safe}</p>'
+        '</td></tr></table>'
+    )
+
+
+def _strip_repeated_show_title(body_md: str, show_name: str) -> str:
+    """Drop a leading ``**<Show> Weekly**`` / ``# <Show>`` line if the LLM
+    repeats the show title at the top of the body.
+
+    The branded hero already shows the title in big text, so a body
+    that opens with the title again is visual duplication. Idempotent
+    with the synthesizer's own strip — safe to call twice.
+    """
+    if not body_md:
+        return body_md
+    lines = body_md.lstrip().split("\n")
+    first = lines[0].strip()
+    show_lower = show_name.lower().strip()
+    norm = re.sub(r"^[#*\s_]+|[#*\s_]+$", "", first).lower().strip()
+    norm = re.sub(r"\s+(weekly|weekly digest|digest)$", "", norm).strip()
+    if norm == show_lower or norm.startswith(show_lower + " "):
+        return "\n".join(lines[1:]).lstrip()
+    return body_md
+
+
 def _build_footer_html(show: Dict[str, str]) -> str:
     """Render the email's footer block as inline-styled HTML."""
     brand = show["brand_color"]
@@ -231,6 +400,71 @@ def _build_footer_html(show: Dict[str, str]) -> str:
     )
 
 
+def compute_issue_number(
+    slug: str, send_date: Optional[datetime.date] = None
+) -> int:
+    """Return a deterministic per-show issue number.
+
+    Derived from ``newsletter.newsletter_start_date`` in the show YAML
+    so the count survives rebuilds without state files. Falls back to
+    1 if the start date is missing or in the future.
+
+    Daily shows that send weekly newsletters tick once per send (i.e.
+    ``floor((send_date - start) / 7) + 1``).
+    """
+    if send_date is None:
+        send_date = datetime.date.today()
+    show = _load_show_branding(slug)
+    raw = show.get("newsletter_start_date") or ""
+    if not raw:
+        return 1
+    try:
+        start = datetime.date.fromisoformat(raw)
+    except ValueError:
+        logger.warning(
+            "Bad newsletter_start_date %r for %s; defaulting to issue 1",
+            raw, slug,
+        )
+        return 1
+    if send_date < start:
+        return 1
+    return ((send_date - start).days // 7) + 1
+
+
+def build_subject_line(
+    slug: str, subject_hook: str, *, send_date: Optional[datetime.date] = None
+) -> str:
+    """Compose the final email subject from a hook + show short label.
+
+    Format: ``"<hook> · <short_label> <emoji>"``. Falls back to the
+    full show name if no short label is configured. Hard-capped at
+    100 chars to stay within email-client subject limits.
+    """
+    show = _load_show_branding(slug)
+    short = show.get("short_label") or show.get("name") or slug
+    emoji = show.get("emoji") or ""
+
+    hook = (subject_hook or "").strip().rstrip(" .,;:")
+    if not hook:
+        # No hook from the LLM — degrade to a clean date-stamped fallback.
+        when = send_date or datetime.date.today()
+        hook = f"This week: {when.strftime('%b %-d')}"
+
+    suffix = f" · {short}".rstrip()
+    if emoji:
+        suffix += f" {emoji}"
+    full = f"{hook}{suffix}"
+    if len(full) <= 100:
+        return full
+    # Trim the hook side; never truncate the show short label.
+    headroom = 100 - len(suffix) - 1  # -1 for ellipsis
+    if headroom < 10:
+        # Pathological case: short_label alone is huge. Just trim the
+        # whole thing.
+        return full[:100]
+    return f"{hook[:headroom].rstrip()}…{suffix}"
+
+
 def wrap_with_branding(
     slug: str,
     markdown_body: str,
@@ -238,12 +472,27 @@ def wrap_with_branding(
     week_ending: Optional[datetime.date] = None,
     daily_label: Optional[str] = None,
     daily_date: Optional[datetime.date] = None,
+    preheader: str = "",
+    by_the_numbers: Optional[List[Dict[str, str]]] = None,
+    p_s: str = "",
+    requires_financial_disclaimer: bool = False,
 ) -> str:
-    """Wrap *markdown_body* with a branded hero and footer.
+    """Wrap *markdown_body* with a branded hero, optional middle blocks,
+    and footer.
 
     The result is a single string suitable for Buttondown's email
     body — markdown in the middle is left untouched, and the inline
     HTML at top/bottom passes through Buttondown's renderer.
+
+    Optional middle blocks (rendered top-to-bottom in this order):
+
+      1. Hidden preheader div (inbox preview text)
+      2. Hero (cover, name, tagline, date pill)
+      3. By-the-numbers stat tiles
+      4. Financial disclaimer callout
+      5. Markdown body
+      6. P.S. block
+      7. Footer (CTAs + Nerra Network credit)
 
     Pass *week_ending* for weekly newsletters; pass *daily_label* +
     *daily_date* for daily episode newsletters. If neither is set,
@@ -258,9 +507,25 @@ def wrap_with_branding(
     else:
         pill = _format_week_pill(None)
 
+    preheader_div = _build_preheader_html(preheader)
     hero = _build_hero_html(show, pill)
+    stats_block = _build_by_the_numbers_html(
+        by_the_numbers, show["brand_color"]
+    )
+    disclaimer = (
+        _build_financial_disclaimer_html()
+        if requires_financial_disclaimer else ""
+    )
+    p_s_block = _build_p_s_html(p_s, show["brand_color"])
     footer = _build_footer_html(show)
 
-    # Two blank lines between blocks so markdown processors treat
-    # them as separate sections.
-    return f"{hero}\n\n{markdown_body.strip()}\n\n{footer}\n"
+    # Idempotent strip in case the body still has the show title at top.
+    body_clean = _strip_repeated_show_title(
+        (markdown_body or "").strip(), show["name"]
+    )
+
+    # Blocks separated by two blank lines so markdown processors treat
+    # them as separate sections. Empty blocks contribute nothing.
+    parts = [preheader_div, hero, stats_block, disclaimer, body_clean,
+             p_s_block, footer]
+    return "\n\n".join(p for p in parts if p) + "\n"

--- a/engine/synthesizer.py
+++ b/engine/synthesizer.py
@@ -8,7 +8,9 @@ All synthesis uses the existing ``_call_grok()`` LLM interface from
 from __future__ import annotations
 
 import calendar
+import json
 import logging
+import re
 from collections import Counter
 from datetime import date, timedelta
 from pathlib import Path
@@ -18,6 +20,184 @@ from engine.content_lake import query_all_shows_range, query_show_range
 from engine.generator import _call_grok
 
 logger = logging.getLogger(__name__)
+
+
+# Envelope schema returned by synthesize_weekly_newsletter:
+#
+#   {
+#       "subject_hook": str,             # <=50 char one-liner for subject prefix
+#       "preheader": str,                # 90-110 char inbox preview teaser
+#       "by_the_numbers": [              # 0-3 stat tiles, optional per show
+#           {"value": "$372.80", "label": "TSLA close"},
+#           ...
+#       ],
+#       "body_md": str,                  # the full markdown digest body
+#       "p_s": str,                      # one-sentence P.S. closer
+#   }
+#
+# Callers (run_weekly_newsletters.py) consume this dict directly and pass each
+# field into the email template. If the LLM call fails or returns malformed
+# JSON, _parse_envelope falls back to wrapping the raw text in body_md and
+# synthesizing the other fields from show metadata so the send still goes out.
+
+_ENVELOPE_INSTRUCTIONS = """\
+
+## OUTPUT FORMAT (REQUIRED)
+
+Return your response as a single JSON object with exactly this schema. Do \
+NOT wrap it in markdown code fences. Do NOT include any prose outside the \
+JSON. Output the JSON object and nothing else.
+
+{{
+  "subject_hook": "<=50 chars; the single most newsworthy hook of the week, \
+no clickbait, no show name (we add it). Example: 'Cybercab production begins'>",
+  "preheader": "<90-110 chars; inbox preview teaser, complete sentence, \
+gives the reader a reason to open. Example: 'Cybercab rolls off the line in \
+Texas, Semi hits mass production, and the FSD v14 wave is coming.'>",
+  "by_the_numbers": [
+    {{"value": "<short stat>", "label": "<label>"}},
+    {{"value": "<short stat>", "label": "<label>"}},
+    {{"value": "<short stat>", "label": "<label>"}}
+  ],
+  "body_md": "<the full weekly newsletter markdown — all sections required \
+above, formatted as markdown. Do NOT repeat the show title at the top \
+(the email template already shows it). Start the body directly with the \
+first content section. Target word count: {target_words} words.>",
+  "p_s": "<one sentence; a personal aside, recommendation, or call to \
+action. Example: 'If you've been on the fence about FSD v14, this is \
+the week to grab the trial.'>"
+}}
+
+If you have fewer than 3 quantitative stats worth surfacing, return an empty \
+array for by_the_numbers (do not invent numbers). All other fields are required.
+"""
+
+
+def _strip_repeated_show_title(body_md: str, show_name: str) -> str:
+    """Drop a leading ``**<Show> Weekly**`` / ``# <Show>`` line if the LLM
+    repeats the show title at the top of the body.
+
+    The branded hero already shows the title in big text, so a body that
+    opens with the title again is visual duplication. We only strip the
+    very first non-empty line if it matches the show name pattern.
+    """
+    if not body_md:
+        return body_md
+    lines = body_md.lstrip().split("\n")
+    # The first non-blank line is what we examine.
+    first = lines[0].strip()
+    show_lower = show_name.lower().strip()
+    # Patterns: "# <Show>", "## <Show>", "**<Show> Weekly**", etc.
+    norm = re.sub(r"^[#*\s_]+|[#*\s_]+$", "", first).lower().strip()
+    norm = re.sub(r"\s+(weekly|weekly digest|digest)$", "", norm).strip()
+    if norm == show_lower or norm.startswith(show_lower + " "):
+        return "\n".join(lines[1:]).lstrip()
+    return body_md
+
+
+def _parse_envelope(
+    raw_text: str, *, show_name: str, week_ending: date
+) -> Dict[str, Any]:
+    """Parse the LLM JSON envelope; fall back to wrapping raw markdown.
+
+    Robust against:
+      - extra prose before/after the JSON
+      - markdown ``` fences around the JSON
+      - the LLM returning plain markdown (no JSON at all)
+    """
+    fallback_subject = f"This week on {show_name}"
+    fallback_preheader = (
+        f"Your weekly digest from {show_name} — top stories, trends, and "
+        f"what to watch next week."
+    )[:160]
+    fallback_p_s = ""
+
+    if not raw_text or not raw_text.strip():
+        return {
+            "subject_hook": fallback_subject,
+            "preheader": fallback_preheader,
+            "by_the_numbers": [],
+            "body_md": "",
+            "p_s": fallback_p_s,
+        }
+
+    text = raw_text.strip()
+    # Strip ```json ... ``` fences if the model added them despite instructions.
+    fence_match = re.search(
+        r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL
+    )
+    if fence_match:
+        text = fence_match.group(1)
+
+    # Try direct parse, then a fallback that grabs the first {...} block.
+    parsed: Optional[Dict[str, Any]] = None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        brace_match = re.search(r"\{.*\}", text, re.DOTALL)
+        if brace_match:
+            try:
+                parsed = json.loads(brace_match.group(0))
+            except json.JSONDecodeError:
+                parsed = None
+
+    if not isinstance(parsed, dict) or "body_md" not in parsed:
+        # The LLM ignored the envelope instruction and returned plain
+        # markdown. Wrap it so the send still works; downstream code
+        # only ever reads keys, so missing optional fields are fine.
+        logger.warning(
+            "[Synthesizer] LLM did not return JSON envelope, wrapping "
+            "raw markdown (len=%d)", len(raw_text),
+        )
+        return {
+            "subject_hook": fallback_subject,
+            "preheader": fallback_preheader,
+            "by_the_numbers": [],
+            "body_md": _strip_repeated_show_title(raw_text, show_name),
+            "p_s": fallback_p_s,
+        }
+
+    # Coerce + sanitize each field.
+    subject_hook = str(parsed.get("subject_hook") or fallback_subject).strip()
+    # Hard cap at 60 chars even though we ask for 50; subject lines have
+    # client-level limits and the template appends show short + emoji.
+    subject_hook = subject_hook[:60].rstrip(" .,;:")
+
+    preheader = str(parsed.get("preheader") or fallback_preheader).strip()
+    preheader = preheader[:160]
+
+    btn_raw = parsed.get("by_the_numbers") or []
+    by_the_numbers: List[Dict[str, str]] = []
+    if isinstance(btn_raw, list):
+        # Filter malformed items first so a sloppy LLM that emits
+        # ``[{}, {}, {}, {real}]`` still surfaces the real one;
+        # then cap at 3.
+        for item in btn_raw:
+            if len(by_the_numbers) >= 3:
+                break
+            if not isinstance(item, dict):
+                continue
+            value = str(item.get("value") or "").strip()
+            label = str(item.get("label") or "").strip()
+            if value and label:
+                by_the_numbers.append({"value": value[:24], "label": label[:32]})
+
+    body_md = str(parsed.get("body_md") or "").strip()
+    body_md = _strip_repeated_show_title(body_md, show_name)
+
+    p_s = str(parsed.get("p_s") or "").strip()
+    # Strip a leading "P.S." if the LLM added one — the template
+    # renders the label itself.
+    p_s = re.sub(r"^p\.?\s*s\.?\s*[—–\-:]?\s*", "", p_s, flags=re.IGNORECASE)
+    p_s = p_s[:280]
+
+    return {
+        "subject_hook": subject_hook,
+        "preheader": preheader,
+        "by_the_numbers": by_the_numbers,
+        "body_md": body_md,
+        "p_s": p_s,
+    }
 
 
 def _load_config_safe(show_slug: str, config_path: Optional[Path] = None):
@@ -119,11 +299,15 @@ def synthesize_weekly_newsletter(
     *,
     config_path: Optional[Path] = None,
     prompt_file: Optional[Path] = None,
-) -> Optional[str]:
+) -> Optional[Dict[str, Any]]:
     """Generate a weekly newsletter for a show from the past 7 days.
 
-    Returns markdown-formatted newsletter text, or ``None`` if insufficient
-    data.
+    Returns an envelope dict (see module docstring) with ``subject_hook``,
+    ``preheader``, ``by_the_numbers``, ``body_md``, and ``p_s`` keys, or
+    ``None`` if insufficient data.
+
+    Older callers that expect a plain markdown string should read
+    ``envelope["body_md"]``.
     """
     start_date = (week_ending - timedelta(days=6)).isoformat()
     end_date = week_ending.isoformat()
@@ -186,7 +370,12 @@ def synthesize_weekly_newsletter(
         prompt_template = _DEFAULT_WEEKLY_PROMPT
 
     show_name = getattr(cfg.publishing, "rss_title", show_slug)
-    prompt = prompt_template.format(
+
+    # Per-show length target (defaults to 1300 — see _defaults.yaml).
+    nl_cfg = getattr(cfg, "newsletter", None)
+    target_words = int(getattr(nl_cfg, "length_target_words", 0) or 1300)
+
+    body_prompt = prompt_template.format(
         show_name=show_name,
         episode_count=len(episodes),
         start_date=start_date,
@@ -194,10 +383,18 @@ def synthesize_weekly_newsletter(
         episodes_text=episodes_text + cross_show_section,
         entities=", ".join(sorted(all_entities)[:30]),
     )
+    # Append the JSON envelope output instructions. We do this after
+    # the per-show prompt so the editorial guidance still drives the
+    # body content; the envelope is a shape constraint, not a rewrite.
+    prompt = body_prompt + _ENVELOPE_INSTRUCTIONS.format(
+        target_words=target_words
+    )
 
     system_prompt = (
         f"You are the weekly newsletter editor for {show_name}, "
-        f"part of the Nerra Network podcast network."
+        f"part of the Nerra Network podcast network. You always return "
+        f"output as a single valid JSON object matching the schema in "
+        f"the user prompt."
     )
 
     synth_model, synth_max_tokens, synth_temperature = _cfg_synth_params(
@@ -211,11 +408,16 @@ def synthesize_weekly_newsletter(
             max_tokens=synth_max_tokens,
             system_prompt=system_prompt,
         )
-        logger.info(
-            "[Synthesizer] Weekly newsletter for %s: %d chars (model=%s)",
-            show_slug, len(text), synth_model,
+        envelope = _parse_envelope(
+            text, show_name=show_name, week_ending=week_ending
         )
-        return text
+        logger.info(
+            "[Synthesizer] Weekly newsletter for %s: subject=%r body=%d chars "
+            "p_s=%d chars stats=%d (model=%s)",
+            show_slug, envelope["subject_hook"], len(envelope["body_md"]),
+            len(envelope["p_s"]), len(envelope["by_the_numbers"]), synth_model,
+        )
+        return envelope
     except Exception as e:
         logger.error(
             "[Synthesizer] Weekly newsletter failed for %s: %s",

--- a/scripts/run_weekly_newsletters.py
+++ b/scripts/run_weekly_newsletters.py
@@ -5,7 +5,7 @@ import argparse
 import logging
 import os
 import sys
-from datetime import date, timedelta
+from datetime import date
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -66,18 +66,20 @@ def main():
 
         prompt_file = Path(f"shows/prompts/{show_slug}_weekly.txt")
 
-        newsletter_md = synthesize_weekly_newsletter(
+        envelope = synthesize_weekly_newsletter(
             show_slug=show_slug,
             week_ending=week_ending,
             prompt_file=prompt_file if prompt_file.exists() else None,
         )
 
-        if not newsletter_md:
+        if not envelope or not envelope.get("body_md"):
             logger.warning("  No newsletter generated for %s", show_slug)
             results[show_slug] = "skipped"
             continue
 
-        # Save to file
+        newsletter_md = envelope["body_md"]
+
+        # Save the body markdown so the operator can review it before send.
         filename = f"{show_slug}_weekly_{week_ending.isoformat()}.md"
         (output_dir / filename).write_text(newsletter_md, encoding="utf-8")
         logger.info("  Saved: %s", output_dir / filename)
@@ -105,22 +107,39 @@ def main():
                 continue
 
             from engine.newsletter import send_newsletter
-            from engine.newsletter_template import wrap_with_branding
+            from engine.newsletter_template import (
+                build_subject_line,
+                compute_issue_number,
+                wrap_with_branding,
+            )
 
-            week_start = (week_ending - timedelta(days=6)).strftime("%b %d")
-            week_end_str = week_ending.strftime("%b %d, %Y")
-            subject = f"{cfg.publishing.rss_title} — Weekly Digest ({week_start}\u2013{week_end_str})"
-
+            issue_number = compute_issue_number(show_slug, week_ending)
+            subject = build_subject_line(
+                show_slug, envelope.get("subject_hook", ""),
+                send_date=week_ending,
+            )
+            logger.info(
+                "  Issue #%d / subject=%r", issue_number, subject,
+            )
             tag = getattr(newsletter_cfg, "tag", "") or ""
             tags_list = [tag] if tag else None
 
-            # Wrap the synthesized markdown with a per-show branded
-            # hero (cover image + brand colour + week pill) and a
-            # footer (Listen / Watch on YouTube / Read the blog CTAs
-            # + Nerra Network credit). Buttondown passes inline HTML
-            # through its markdown renderer untouched.
+            requires_disclaimer = bool(
+                getattr(newsletter_cfg, "requires_financial_disclaimer", False)
+            )
+
+            # Wrap the synthesized markdown with the show's branded
+            # hero, optional by-the-numbers strip, optional financial
+            # disclaimer callout, body, P.S. block, and footer.
+            # Buttondown passes inline HTML through its markdown
+            # renderer untouched.
             branded_body = wrap_with_branding(
-                show_slug, newsletter_md, week_ending=week_ending,
+                show_slug, newsletter_md,
+                week_ending=week_ending,
+                preheader=envelope.get("preheader", ""),
+                by_the_numbers=envelope.get("by_the_numbers") or [],
+                p_s=envelope.get("p_s", ""),
+                requires_financial_disclaimer=requires_disclaimer,
             )
 
             email_id = send_newsletter(

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -82,6 +82,27 @@ newsletter:
   enabled: false
   platform: buttondown
   status: about_to_send
+  # ---- Branded-email defaults (PR-A: newsletter quick wins) ----
+  # Target word count for the LLM-generated body. The synthesizer
+  # passes this into the JSON-envelope output instructions so the
+  # model knows where to land. Per-show overrides are encouraged;
+  # 1300 is a sensible network default for a news-driven weekly.
+  length_target_words: 1300
+  # Compose flag for the styled "Heads up: educational only..."
+  # callout. Flip to true on shows that discuss money / trades.
+  requires_financial_disclaimer: false
+  # short_label is what we use in the subject suffix ("Cybercab
+  # production begins · Tesla Shorts 🚀"). Keep <=14 chars.
+  short_label: ""
+  # Per-show emoji that pairs with short_label in subject lines and
+  # cross-network modules. Single grapheme; pick one that's readable
+  # on iOS and Android.
+  emoji: ""
+  # The date the show's first newsletter went out. We derive a
+  # deterministic per-show issue number as
+  # ``floor((send_date - newsletter_start_date) / 7) + 1`` instead
+  # of carrying mutable state in git or R2.
+  newsletter_start_date: "2026-04-30"
 
 chapters:
   enabled: true

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -263,6 +263,11 @@ newsletter:
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
   tag: "Environmental Intelligence"
+  short_label: "Env Intel"
+  emoji: "🌲"
+  newsletter_start_date: "2026-04-30"
+  requires_financial_disclaimer: false
+  length_target_words: 1300
 
 youtube:
   podcast_playlist_id: PLRHMnzNNXPYCFXOTtrwHsydurFmReceXo

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -217,6 +217,11 @@ newsletter:
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
   tag: "Fascinating Frontiers"
+  short_label: "Frontiers"
+  emoji: "🛰️"
+  newsletter_start_date: "2026-04-30"
+  requires_financial_disclaimer: false
+  length_target_words: 1300
 
 slow_news:
   enabled: true

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -243,6 +243,11 @@ newsletter:
   # Buttondown rejects tags with no ASCII letter/number, so we use the
   # transliterated form rather than the Cyrillic show display name.
   tag: "Finansy Prosto"
+  short_label: "Финансы"
+  emoji: "💰"
+  newsletter_start_date: "2026-04-30"
+  requires_financial_disclaimer: true
+  length_target_words: 1300
 
 slow_news:
   enabled: true

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -252,6 +252,11 @@ newsletter:
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
   tag: "Models & Agents"
+  short_label: "M&A"
+  emoji: "🤖"
+  newsletter_start_date: "2026-04-30"
+  requires_financial_disclaimer: false
+  length_target_words: 1300
 
 youtube:
   podcast_playlist_id: PLRHMnzNNXPYAUq0HBfZahYXJaEaknuTGg

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -214,6 +214,11 @@ newsletter:
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
   tag: "Models & Agents for Beginners"
+  short_label: "M&A Beginners"
+  emoji: "🎓"
+  newsletter_start_date: "2026-04-30"
+  requires_financial_disclaimer: false
+  length_target_words: 1300
 
 slow_news:
   enabled: true

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -225,6 +225,11 @@ newsletter:
   status: about_to_send
   tag: "Modern Investing Techniques"
   weekly_prompt_file: shows/prompts/modern_investing_weekly.txt
+  short_label: "MIT"
+  emoji: "📈"
+  newsletter_start_date: "2026-04-30"
+  requires_financial_disclaimer: true
+  length_target_words: 1300
 
 slow_news:
   enabled: true

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -219,6 +219,11 @@ newsletter:
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
   tag: "Omni View"
+  short_label: "Omni View"
+  emoji: "🌍"
+  newsletter_start_date: "2026-04-30"
+  requires_financial_disclaimer: false
+  length_target_words: 1300
 
 slow_news:
   enabled: true

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -258,6 +258,11 @@ newsletter:
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
   tag: "Planetterrian Daily"
+  short_label: "Planetterrian"
+  emoji: "🧬"
+  newsletter_start_date: "2026-04-30"
+  requires_financial_disclaimer: false
+  length_target_words: 1300
 
 slow_news:
   enabled: true

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -193,6 +193,11 @@ newsletter:
   # Buttondown rejects tags with no ASCII letter/number, so we use the
   # transliterated form rather than the Cyrillic show display name.
   tag: "Privet Russian"
+  short_label: "Привет"
+  emoji: "🇷🇺"
+  newsletter_start_date: "2026-04-30"
+  requires_financial_disclaimer: false
+  length_target_words: 1300
 
 slow_news:
   enabled: true

--- a/shows/prompts/modern_investing_weekly.txt
+++ b/shows/prompts/modern_investing_weekly.txt
@@ -13,7 +13,7 @@ Synthesize this week's {episode_count} episodes (from {start_date} to {end_date}
 
 Write a weekly briefing in markdown format with these sections. Write for active Canadian and US investors — TFSA/RRSP/FHSA account holders, self-directed portfolio managers, and people who want to outperform index funds using modern tools.
 
-**FINANCIAL DISCLAIMER:** Include at the top: "This newsletter is for educational and entertainment purposes only. All trades discussed are simulated with no real money involved. This is not financial advice. Always do your own research."
+(Note: a styled financial-disclaimer callout is automatically rendered above the body by the email template — do NOT include any "Disclaimer" / "Educational only" / "Not financial advice" prose in your output.)
 
 1. **The Week in 60 Seconds** — A punchy opening paragraph that captures the week's narrative arc. What changed? What surprised? What matters for your portfolio? Write this like you're texting a smart friend the week's highlights.
 

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -210,6 +210,11 @@ newsletter:
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
   tag: "Tesla Shorts Time"
+  short_label: "Tesla Shorts"
+  emoji: "🚀"
+  newsletter_start_date: "2026-04-30"
+  requires_financial_disclaimer: false
+  length_target_words: 1300
 
 youtube:
   podcast_playlist_id: PLRHMnzNNXPYCRrcYpPwAzjaRXqzKRUl23

--- a/tests/test_newsletter_template.py
+++ b/tests/test_newsletter_template.py
@@ -146,3 +146,268 @@ def test_wrap_with_branding_renders_for_russian_show():
     )
     assert "Привет, Русский!" in out
     assert "Урок 1" in out
+
+
+# ---------------------------------------------------------------------------
+# Preheader (hidden inbox preview text)
+# ---------------------------------------------------------------------------
+
+def test_preheader_html_hides_via_inline_style():
+    out = nt._build_preheader_html("Cybercab production begins")
+    assert "Cybercab production begins" in out
+    # Must be visually hidden in inboxes (display:none + opacity:0).
+    assert "display:none" in out
+    assert "opacity:0" in out
+    # Mso-hide:all keeps Outlook from showing it.
+    assert "mso-hide:all" in out
+
+
+def test_preheader_empty_renders_nothing():
+    assert nt._build_preheader_html("") == ""
+
+
+def test_preheader_pads_short_strings():
+    """Short preheaders need zero-width-non-joiner padding so the inbox
+    snippet doesn't bleed body text into the preview."""
+    out = nt._build_preheader_html("Short")
+    assert "Short" in out
+    assert "&zwnj;" in out
+
+
+def test_preheader_html_escapes_user_input():
+    out = nt._build_preheader_html("<script>alert(1)</script>")
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+# ---------------------------------------------------------------------------
+# By the numbers stat tiles
+# ---------------------------------------------------------------------------
+
+def test_by_the_numbers_renders_three_cells():
+    stats = [
+        {"value": "$372", "label": "TSLA close"},
+        {"value": "+20%", "label": "Berlin output"},
+        {"value": "19", "label": "Robotaxi units"},
+    ]
+    out = nt._build_by_the_numbers_html(stats, "#E31937")
+    for s in stats:
+        assert s["value"] in out
+        assert s["label"] in out
+    assert "By the numbers" in out
+    # Brand color is reused for the value text.
+    assert "#E31937" in out
+
+
+def test_by_the_numbers_caps_at_three():
+    stats = [{"value": str(i), "label": f"L{i}"} for i in range(5)]
+    out = nt._build_by_the_numbers_html(stats, "#000000")
+    # Values 0..2 render; 3 and 4 do not.
+    assert ">0<" in out and ">2<" in out
+    assert ">3<" not in out
+
+
+def test_by_the_numbers_skips_blank_items():
+    stats = [
+        {"value": "", "label": "Empty"},
+        {"value": "$1", "label": ""},
+        {"value": "ok", "label": "Real"},
+    ]
+    out = nt._build_by_the_numbers_html(stats, "#000")
+    assert "Real" in out
+    # The two malformed items don't crash the render.
+    assert "Empty" not in out
+
+
+def test_by_the_numbers_empty_list_renders_nothing():
+    assert nt._build_by_the_numbers_html([], "#000") == ""
+    assert nt._build_by_the_numbers_html(None, "#000") == ""
+
+
+# ---------------------------------------------------------------------------
+# P.S. block
+# ---------------------------------------------------------------------------
+
+def test_p_s_html_renders_with_brand_left_border():
+    out = nt._build_p_s_html("If you've been on the fence about FSD…", "#E31937")
+    assert "P.S." in out
+    assert "FSD" in out
+    assert "border-left:3px solid #E31937" in out
+
+
+def test_p_s_empty_renders_nothing():
+    assert nt._build_p_s_html("", "#000") == ""
+
+
+def test_p_s_html_escapes_user_input():
+    out = nt._build_p_s_html("<b>bold</b>", "#000")
+    assert "<b>" not in out
+    assert "&lt;b&gt;" in out
+
+
+# ---------------------------------------------------------------------------
+# Financial disclaimer callout
+# ---------------------------------------------------------------------------
+
+def test_financial_disclaimer_renders():
+    out = nt._build_financial_disclaimer_html()
+    assert "Heads up" in out
+    assert "Not financial advice" in out
+    # Amber sidebar.
+    assert "#F59E0B" in out
+
+
+# ---------------------------------------------------------------------------
+# Strip repeated show title
+# ---------------------------------------------------------------------------
+
+def test_strip_repeated_show_title_removes_bold_weekly():
+    body = "**Tesla Shorts Time Daily Weekly**\n\n## Big picture\n\n…"
+    cleaned = nt._strip_repeated_show_title(body, "Tesla Shorts Time Daily")
+    assert cleaned.startswith("## Big picture")
+
+
+def test_strip_repeated_show_title_removes_h1():
+    body = "# Modern Investing Techniques\n\nSome content."
+    cleaned = nt._strip_repeated_show_title(body, "Modern Investing Techniques")
+    assert cleaned.startswith("Some content.")
+
+
+def test_strip_repeated_show_title_keeps_unrelated_first_line():
+    body = "## This Week's Big Picture\n\nNarrative arc here."
+    cleaned = nt._strip_repeated_show_title(body, "Tesla Shorts Time")
+    # Must not eat the actual section heading.
+    assert cleaned == body
+
+
+def test_strip_repeated_show_title_handles_empty():
+    assert nt._strip_repeated_show_title("", "X") == ""
+
+
+# ---------------------------------------------------------------------------
+# Subject line composer
+# ---------------------------------------------------------------------------
+
+def test_build_subject_line_uses_short_label_and_emoji():
+    s = nt.build_subject_line("tesla", "Cybercab production begins")
+    assert "Cybercab production begins" in s
+    assert "Tesla Shorts" in s
+    # Per-show emoji from YAML.
+    assert "🚀" in s
+
+
+def test_build_subject_line_truncates_over_100_chars():
+    very_long_hook = "a" * 200
+    s = nt.build_subject_line("tesla", very_long_hook)
+    assert len(s) <= 100
+    # Suffix preserved at the end.
+    assert s.endswith("Tesla Shorts 🚀")
+
+
+def test_build_subject_line_falls_back_when_hook_missing():
+    s = nt.build_subject_line(
+        "tesla", "", send_date=datetime.date(2026, 4, 30),
+    )
+    # Should still produce a usable subject.
+    assert "Tesla Shorts" in s
+    assert s.strip() != ""
+
+
+def test_build_subject_line_strips_trailing_punct():
+    s = nt.build_subject_line("tesla", "Big news...")
+    assert "Big news" in s
+    # No double punctuation before the separator.
+    assert "Big news... ·" not in s
+
+
+# ---------------------------------------------------------------------------
+# Per-show issue numbering
+# ---------------------------------------------------------------------------
+
+def test_compute_issue_number_first_week_is_one():
+    # Tesla newsletter_start_date is 2026-04-30; sending on the same
+    # day is issue #1.
+    n = nt.compute_issue_number("tesla", datetime.date(2026, 4, 30))
+    assert n == 1
+
+
+def test_compute_issue_number_second_week():
+    n = nt.compute_issue_number("tesla", datetime.date(2026, 5, 7))
+    assert n == 2
+
+
+def test_compute_issue_number_clamps_dates_before_start():
+    # If we somehow run before the configured start_date, fall back
+    # to issue 1 instead of returning a negative.
+    n = nt.compute_issue_number("tesla", datetime.date(2020, 1, 1))
+    assert n == 1
+
+
+# ---------------------------------------------------------------------------
+# wrap_with_branding — new optional blocks compose top-to-bottom
+# ---------------------------------------------------------------------------
+
+def test_wrap_with_branding_renders_all_blocks_in_order():
+    out = nt.wrap_with_branding(
+        "tesla", "## Body content\n\nLorem ipsum.",
+        week_ending=datetime.date(2026, 4, 30),
+        preheader="Inbox preview teaser",
+        by_the_numbers=[
+            {"value": "$372", "label": "TSLA close"},
+        ],
+        p_s="One more thing.",
+        requires_financial_disclaimer=False,
+    )
+    pre = out.find("Inbox preview teaser")
+    hero = out.find("Tesla Shorts Time")
+    stats = out.find("TSLA close")
+    body = out.find("## Body content")
+    p_s = out.find("One more thing.")
+    foot = out.find("Listen to the podcast")
+    # All present and in the documented order.
+    assert 0 <= pre < hero < stats < body < p_s < foot
+
+
+def test_wrap_with_branding_renders_disclaimer_when_flagged():
+    out = nt.wrap_with_branding(
+        "modern_investing", "## Body\n\nx",
+        week_ending=datetime.date(2026, 4, 30),
+        requires_financial_disclaimer=True,
+    )
+    assert "Heads up" in out
+    assert "Not financial advice" in out
+
+
+def test_wrap_with_branding_omits_disclaimer_by_default():
+    out = nt.wrap_with_branding(
+        "tesla", "## Body\n\nx",
+        week_ending=datetime.date(2026, 4, 30),
+    )
+    assert "Heads up" not in out
+
+
+def test_wrap_with_branding_strips_redundant_title():
+    """If the LLM body opens with the show title, it gets stripped so
+    the visual hero (which already shows it) isn't duplicated."""
+    body = "**Tesla Shorts Time Daily Weekly**\n\n## Big picture\n\n…"
+    out = nt.wrap_with_branding(
+        "tesla", body, week_ending=datetime.date(2026, 4, 30),
+    )
+    # The repeated "Weekly" line is gone; the section heading remains.
+    assert "## Big picture" in out
+    # Hero still shows the show name (this lives in the gradient block
+    # not the markdown body).
+    assert "Tesla Shorts Time" in out
+
+
+def test_wrap_with_branding_loads_disclaimer_flag_from_yaml_for_mit():
+    """Even without explicit requires_financial_disclaimer=True, the
+    show YAML should not auto-render the callout — the caller decides.
+    This locks in the contract that the wrapper does NOT silently
+    consult YAML; the YAML is read by the caller (run_weekly_newsletters).
+    """
+    out = nt.wrap_with_branding(
+        "modern_investing", "## Body\n\nx",
+        week_ending=datetime.date(2026, 4, 30),
+    )
+    assert "Heads up" not in out

--- a/tests/test_synthesizer_envelope.py
+++ b/tests/test_synthesizer_envelope.py
@@ -1,0 +1,194 @@
+"""Tests for the JSON-envelope parser in engine.synthesizer.
+
+The weekly synthesizer asks the LLM to return a structured envelope
+(``{subject_hook, preheader, by_the_numbers, body_md, p_s}``). These
+tests lock in the parser's robustness against the half-dozen ways LLMs
+mis-format JSON in practice — extra prose, code fences, missing keys,
+or just plain markdown.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+
+from engine.synthesizer import _parse_envelope, _strip_repeated_show_title
+
+
+SHOW_NAME = "Tesla Shorts Time Daily"
+WEEK = datetime.date(2026, 4, 30)
+
+
+def _envelope_text(**overrides) -> str:
+    """Build a JSON envelope as the LLM would emit it."""
+    payload = {
+        "subject_hook": "Cybercab production begins",
+        "preheader": "Cybercab rolls off the line in Texas this week.",
+        "by_the_numbers": [
+            {"value": "$372", "label": "TSLA close"},
+            {"value": "+20%", "label": "Berlin output"},
+        ],
+        "body_md": "## This Week\n\nLorem ipsum.",
+        "p_s": "If you've been on the fence about FSD v14, grab the trial.",
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+def test_parse_envelope_happy_path():
+    out = _parse_envelope(
+        _envelope_text(), show_name=SHOW_NAME, week_ending=WEEK
+    )
+    assert out["subject_hook"] == "Cybercab production begins"
+    assert "Cybercab rolls off" in out["preheader"]
+    assert len(out["by_the_numbers"]) == 2
+    assert out["by_the_numbers"][0] == {"value": "$372", "label": "TSLA close"}
+    assert out["body_md"].startswith("## This Week")
+    assert "FSD v14" in out["p_s"]
+
+
+# ---------------------------------------------------------------------------
+# Robustness against LLM mis-formatting
+# ---------------------------------------------------------------------------
+
+def test_parse_envelope_handles_markdown_code_fences():
+    raw = "```json\n" + _envelope_text() + "\n```"
+    out = _parse_envelope(raw, show_name=SHOW_NAME, week_ending=WEEK)
+    assert out["subject_hook"] == "Cybercab production begins"
+
+
+def test_parse_envelope_handles_extra_prose_around_json():
+    raw = (
+        "Sure! Here's the newsletter envelope:\n\n"
+        + _envelope_text()
+        + "\n\nLet me know if you'd like me to adjust anything."
+    )
+    out = _parse_envelope(raw, show_name=SHOW_NAME, week_ending=WEEK)
+    assert "Cybercab" in out["subject_hook"]
+
+
+def test_parse_envelope_falls_back_to_raw_markdown_when_no_json():
+    raw = "## This week's big picture\n\nNo JSON here, just markdown."
+    out = _parse_envelope(raw, show_name=SHOW_NAME, week_ending=WEEK)
+    assert out["body_md"].startswith("## This week's big picture")
+    # Fallback subject is non-empty so the send still goes out.
+    assert out["subject_hook"] != ""
+    assert out["preheader"] != ""
+
+
+def test_parse_envelope_empty_input_returns_empty_envelope():
+    out = _parse_envelope("", show_name=SHOW_NAME, week_ending=WEEK)
+    assert out["body_md"] == ""
+    assert out["subject_hook"] != ""  # fallback, not crash
+
+
+def test_parse_envelope_strips_show_title_from_body():
+    """If the LLM repeats the show title at the top of body_md, the
+    parser drops it so the email hero isn't visually duplicated."""
+    out = _parse_envelope(
+        _envelope_text(
+            body_md="# Tesla Shorts Time Daily\n\n## Big picture\n\nx",
+        ),
+        show_name=SHOW_NAME,
+        week_ending=WEEK,
+    )
+    assert out["body_md"].startswith("## Big picture")
+
+
+def test_parse_envelope_caps_subject_hook_at_60_chars():
+    """The subject composer adds a suffix; we cap the hook to leave
+    room for the suffix and stay within client limits."""
+    out = _parse_envelope(
+        _envelope_text(subject_hook="x" * 200),
+        show_name=SHOW_NAME, week_ending=WEEK,
+    )
+    assert len(out["subject_hook"]) <= 60
+
+
+def test_parse_envelope_caps_preheader_at_160_chars():
+    out = _parse_envelope(
+        _envelope_text(preheader="y" * 500),
+        show_name=SHOW_NAME, week_ending=WEEK,
+    )
+    assert len(out["preheader"]) <= 160
+
+
+def test_parse_envelope_caps_p_s_at_280_chars():
+    out = _parse_envelope(
+        _envelope_text(p_s="z" * 500),
+        show_name=SHOW_NAME, week_ending=WEEK,
+    )
+    assert len(out["p_s"]) <= 280
+
+
+def test_parse_envelope_strips_leading_p_s_label_from_p_s():
+    """If the LLM adds 'P.S. —' inside the P.S. text, drop it; the
+    template renders the label itself."""
+    out = _parse_envelope(
+        _envelope_text(p_s="P.S. — One more thing!"),
+        show_name=SHOW_NAME, week_ending=WEEK,
+    )
+    assert out["p_s"].startswith("One more thing")
+
+
+def test_parse_envelope_caps_by_the_numbers_at_3():
+    out = _parse_envelope(
+        _envelope_text(by_the_numbers=[
+            {"value": str(i), "label": f"L{i}"} for i in range(8)
+        ]),
+        show_name=SHOW_NAME, week_ending=WEEK,
+    )
+    assert len(out["by_the_numbers"]) == 3
+
+
+def test_parse_envelope_skips_malformed_stat_items():
+    out = _parse_envelope(
+        _envelope_text(by_the_numbers=[
+            {"value": "$1", "label": ""},        # missing label
+            {"value": "", "label": "Empty"},     # missing value
+            "not a dict",                         # wrong type
+            {"value": "ok", "label": "Real"},    # only this survives
+        ]),
+        show_name=SHOW_NAME, week_ending=WEEK,
+    )
+    assert out["by_the_numbers"] == [{"value": "ok", "label": "Real"}]
+
+
+def test_parse_envelope_handles_invalid_by_the_numbers_type():
+    """If the LLM returns a string instead of a list, we get an empty
+    list — never a crash."""
+    out = _parse_envelope(
+        _envelope_text(by_the_numbers="garbage"),
+        show_name=SHOW_NAME, week_ending=WEEK,
+    )
+    assert out["by_the_numbers"] == []
+
+
+# ---------------------------------------------------------------------------
+# _strip_repeated_show_title (also lives in engine.synthesizer)
+# ---------------------------------------------------------------------------
+
+def test_strip_repeated_show_title_removes_h1():
+    body = "# Tesla Shorts Time Daily\n\n## Big picture"
+    out = _strip_repeated_show_title(body, "Tesla Shorts Time Daily")
+    assert out.startswith("## Big picture")
+
+
+def test_strip_repeated_show_title_removes_bold_weekly():
+    body = "**Tesla Shorts Time Daily Weekly**\n\nbody"
+    out = _strip_repeated_show_title(body, "Tesla Shorts Time Daily")
+    assert out.startswith("body")
+
+
+def test_strip_repeated_show_title_keeps_unrelated_first_line():
+    body = "## Some real heading\n\nbody"
+    out = _strip_repeated_show_title(body, "Tesla")
+    assert out == body
+
+
+def test_strip_repeated_show_title_handles_blank_body():
+    assert _strip_repeated_show_title("", "X") == ""


### PR DESCRIPTION
## Summary

Ships the Week-1 quick wins from the newsletter improvement spec. Subject lines, preheaders, P.S., per-show issue numbers, stat tiles, and the styled financial-disclaimer callout — everything that doesn't need new infrastructure (charts, episode-level deep links, share buttons come in PR-B/C).

**Before:** 10 identical inboxes with `Tesla Shorts Time Daily — Weekly Digest (Apr 24–Apr 30, 2026)` and `Did someone forward you this?` as the preview snippet.
**After:** `Cybercab production begins · Tesla Shorts 🚀` + a hand-crafted inbox teaser + a P.S. that gives the reader a reason to reply.

## What changed

- **Synthesizer envelope refactor.** `synthesize_weekly_newsletter` now returns `{subject_hook, preheader, by_the_numbers, body_md, p_s}` instead of plain markdown. The LLM is asked to emit JSON; a robust parser handles markdown fences, extra prose, length caps (subject 60ch / preheader 160ch / P.S. 280ch / max 3 stats), and falls back to wrapping raw markdown if the model misbehaves so a misformatted response never blocks a send.
- **New template helpers** in `engine/newsletter_template.py`:
  - `_build_preheader_html` — hidden inbox-preview `<div>` with `display:none` + `mso-hide:all` + zero-width-non-joiner padding.
  - `_build_by_the_numbers_html` — up to 3 stat tiles in a brand-color row right under the hero.
  - `_build_p_s_html` — brand-color-bordered card right above the footer (P.S. is one of the highest-read elements of any newsletter).
  - `_build_financial_disclaimer_html` — amber-bordered "Heads up: educational only…" callout, applied when `newsletter.requires_financial_disclaimer: true`.
  - `_strip_repeated_show_title` — drops a leading `**<Show> Weekly**` / `# <Show>` line so the body doesn't visually duplicate the hero.
- **`compute_issue_number(slug, date)`** — derives per-show issue # from `newsletter.newsletter_start_date` in YAML. Deterministic, no mutable state in git/R2.
- **`build_subject_line(slug, hook, send_date)`** — composes `"<hook> · <short_label> <emoji>"` with a 100-char clamp, falls back to a date-stamped subject if the hook is empty.
- **`run_weekly_newsletters.py`** consumes the envelope and threads `preheader`, `by_the_numbers`, `p_s`, and the disclaimer flag into `wrap_with_branding`.
- **YAML schema** — adds `short_label`, `emoji`, `newsletter_start_date`, `length_target_words` (default 1300), and `requires_financial_disclaimer` to the `newsletter:` block. Network defaults in `shows/_defaults.yaml`; per-show overrides on all 10 shows. `modern_investing` and `finansy_prosto` get `requires_financial_disclaimer: true` and the styled callout replaces the in-prose disclaimer in the MIT weekly prompt.

## Test plan

- [x] `pytest tests/test_newsletter_template.py` — 41 passed (12 original + 29 new covering preheader, stats, P.S., subject, issue#, dedup, full-stack render order)
- [x] `pytest tests/test_synthesizer_envelope.py` — 17 new tests (happy path, ```json fences, extra prose, raw-markdown fallback, length caps, malformed stat filtering)
- [x] `pytest` — 1385 passed, 3 skipped
- [x] `ruff check` — clean on all changed files
- [ ] Manual eyeball on next live weekly send (Sun) — confirm subjects, preheaders, P.S., and stats render across Gmail web/iOS, Apple Mail, Outlook 365 web

## Out of scope (queued for follow-ups)

- PR-B: featured-episode block, per-episode deep links in Top Stories, adjacent-shows / cross-network module, reply/share button row, "Across the Network this week" module
- PR-C: mobile-safe HTML tables (replace markdown tables that break on Outlook/narrow mobile), dark-mode media queries, alt-text accessibility audit
- PR-D: Russian slug migration (`u041f-...` → `privet-russian`) + 301 redirects

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_