### PR TITLE
Fix Cyrillic rendering in JSON-LD and Jinja tojson output

### DIFF
--- a/engine/blog.py
+++ b/engine/blog.py
@@ -501,7 +501,13 @@ def _build_jsonld(metadata: dict, show_name: str, blog_url: str,
         if show_config.get("podcast_image"):
             podcast_episode["image"] = f"https://nerranetwork.com/{show_config['podcast_image']}"
 
-    return json.dumps([blog_posting, podcast_episode], indent=2)
+    # ``ensure_ascii=False`` so Cyrillic show names ("Финансы Просто",
+    # "Привет, Русский!") render as readable Unicode in the page source
+    # instead of as ``Фи...`` escape sequences. Better for
+    # SEO indexing and shareable copy-paste.
+    return json.dumps(
+        [blog_posting, podcast_episode], indent=2, ensure_ascii=False
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/generate_html.py
+++ b/generate_html.py
@@ -1294,6 +1294,16 @@ def _get_jinja_env():
     # threading it through every render() call.
     env.globals["marketing"] = MARKETING_CONFIG
     env.filters["with_utm"] = _with_utm
+    # Jinja's default ``tojson`` filter inherits Python's
+    # ``ensure_ascii=True``, which escapes Cyrillic to ``Ф...``
+    # in rendered HTML. That's bad for SEO (Google parsers prefer
+    # readable Unicode) and bad for shareable copy-paste. Override the
+    # policy so ``{{ show_name | tojson }}`` for "Финансы Просто"
+    # renders as ``"Финансы Просто"`` instead of ``"Фи..."``.
+    env.policies["json.dumps_kwargs"] = {
+        "sort_keys": True,
+        "ensure_ascii": False,
+    }
     return env
 
 

--- a/tests/test_unicode_rendering.py
+++ b/tests/test_unicode_rendering.py
@@ -1,0 +1,63 @@
+"""Tests for Cyrillic rendering in generated HTML.
+
+The Russian shows ("Финансы Просто", "Привет, Русский!") were
+rendering with Python's default ``ensure_ascii=True`` JSON behavior,
+which produced unreadable ``\\u0424\\u0438...`` escape sequences
+inside ``<script type="application/ld+json">`` blocks and
+``const SHOW_NAME = ...`` template emissions. That's bad for SEO
+(Google parsers prefer Unicode) and bad for shareable copy-paste.
+
+These tests lock in the fix so a future change can't silently
+re-introduce the regression.
+"""
+
+from __future__ import annotations
+
+
+def test_jinja_env_emits_unicode_for_cyrillic_via_tojson():
+    """The shared Jinja env's ``tojson`` filter must render Cyrillic
+    show names as readable Unicode, not as ``\\u0424...`` escapes."""
+    from generate_html import _get_jinja_env
+
+    env = _get_jinja_env()
+    rendered = env.from_string("{{ s | tojson }}").render(s="Финансы Просто")
+    assert rendered == '"Финансы Просто"'
+    assert "\\u04" not in rendered
+
+
+def test_jinja_env_handles_attribute_dict_through_tojson():
+    """Schema.org JSON-LD blocks pass dicts through ``tojson``; make
+    sure nested Cyrillic strings come through unescaped too."""
+    from generate_html import _get_jinja_env
+
+    env = _get_jinja_env()
+    rendered = env.from_string("{{ d | tojson }}").render(
+        d={"name": "Привет, Русский!", "lang": "ru"}
+    )
+    assert "Привет, Русский!" in rendered
+    assert "\\u04" not in rendered
+
+
+def test_blog_jsonld_emits_unicode():
+    """``engine.blog._build_jsonld`` should produce a JSON-LD block
+    with readable Cyrillic, not ``\\u04..`` escapes."""
+    from engine.blog import _build_jsonld
+
+    metadata = {
+        "title": "Привет, Русский! — Урок 1",
+        "hook": "Сегодня учим погоду.",
+        "date_iso": "2026-04-30",
+        "word_count": 120,
+        "episode_num": 1,
+    }
+    out = _build_jsonld(
+        metadata,
+        show_name="Привет, Русский!",
+        blog_url="https://nerranetwork.com/blog/privet_russian/ep001.html",
+        show_config={"slug": "privet_russian", "name": "Привет, Русский!"},
+    )
+    assert "Привет, Русский!" in out
+    assert "Урок 1" in out
+    assert "Сегодня учим погоду." in out
+    # No Unicode escapes leaked through.
+    assert "\\u04" not in out


### PR DESCRIPTION
## Summary

Russian show pages were emitting unreadable `"Фи..."` escape sequences in two places, hurting SEO and breaking shareable copy-paste. Both fixes are one-liners.

## Where the regression came from

1. **Schema.org JSON-LD on every blog post** (`engine/blog.py:_build_jsonld`) — the `json.dumps` call defaulted to `ensure_ascii=True`. So every Russian episode page had `<script type="application/ld+json">` blocks like:
   ```
   "headline": "Финансы Просто",
   ```
2. **Inline `tojson` emissions in show / summaries page templates** — `{{ show_name | tojson }}` for `"Финансы Просто"` produced `"Ф..."` because Jinja inherits Python's `ensure_ascii=True` default unless `env.policies['json.dumps_kwargs']` is overridden.

## What changed

- `engine/blog.py`: pass `ensure_ascii=False` to the JSON-LD `json.dumps`.
- `generate_html.py:_get_jinja_env`: set `env.policies["json.dumps_kwargs"] = {"sort_keys": True, "ensure_ascii": False}`.

## Verified

```
$ python3 -c "from generate_html import _get_jinja_env; \
  print(_get_jinja_env().from_string('{{ s | tojson }}').render(s='Финансы Просто'))"
"Финансы Просто"
```

Local regen of the static site (then discarded — committing 360 regenerated HTML files would drown this PR) showed all `\u04` escape sequences gone from `ru/finansy-prosto.html`, `ru/privet-russian.html`, and every `blog/finansy_prosto/ep*.html` and `blog/privet_russian/ep*.html`. The next CI site-build workflow will pick up the fix and re-render all pages.

## Test plan

- [x] `pytest tests/test_unicode_rendering.py` — 3 new tests pass (Jinja env string, Jinja env nested dict, blog JSON-LD)
- [x] Manual: rendered `{{ show_name | tojson }}` for "Финансы Просто" — outputs `"Финансы Просто"`, no escapes.
- [ ] After merge, confirm the next site-build run produces escape-free `ru/*.html` and `blog/finansy_prosto/ep*.html` files.

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_