### PR TITLE
Newsletter engagement layer + mobile/dark-mode/a11y (rebased PR-B/C)

### DIFF
--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -174,8 +174,17 @@ def _build_hero_html(show: Dict[str, str], pill_text: str) -> str:
     brand = show["brand_color"]
     brand_dark = show["brand_color_dark"]
 
+    # Descriptive alt text per WCAG: identifies the show, not the file.
+    # Tagline (when present) gives screen-reader users the same context
+    # the cover communicates visually.
+    alt_text = name
+    if tagline:
+        alt_text = f"{name} — {tagline}"
+    # Strip any double-quotes from alt (guards against odd YAML data
+    # breaking the attribute).
+    alt_text = alt_text.replace('"', "")
     cover_img = (
-        f'<img src="{cover_url}" alt="{name} cover" '
+        f'<img src="{cover_url}" alt="{alt_text}" '
         f'width="120" height="120" '
         f'style="display:block;border-radius:18px;width:120px;'
         f'height:120px;object-fit:cover;margin:0 auto 16px;'
@@ -209,6 +218,29 @@ def _build_hero_html(show: Dict[str, str], pill_text: str) -> str:
         f'{pill_text}</div>'
         f'</td></tr></table>'
     )
+
+
+_DARK_MODE_STYLE = """\
+<style>
+  /* Dark-mode overrides for clients that respect prefers-color-scheme
+   * (Apple Mail iOS/macOS, some Outlook versions). Gmail/Outlook 365
+   * apply their own algorithmic dark mode and ignore <style>; for those
+   * we rely on inline styles on the gradient hero looking acceptable
+   * either way (the brand-color background dominates the cell). */
+  @media (prefers-color-scheme: dark) {
+    body, table, td { background-color:#0f172a !important; }
+    body, p, h1, h2, h3, h4, td, span, div { color:#e2e8f0 !important; }
+    a { color:#93c5fd !important; }
+    /* Soft override on the off-white card backgrounds so they don't
+     * shine out against the dark page. */
+    table[role=presentation] td[style*='background:#ffffff'],
+    table[role=presentation] td[style*='background:#fafafa'],
+    table[role=presentation] td[style*='background:#f8fafc'] {
+      background-color:#1e293b !important;
+    }
+  }
+</style>
+"""
 
 
 def _build_preheader_html(preheader: str) -> str:
@@ -344,6 +376,145 @@ def _strip_repeated_show_title(body_md: str, show_name: str) -> str:
     if norm == show_lower or norm.startswith(show_lower + " "):
         return "\n".join(lines[1:]).lstrip()
     return body_md
+
+
+_MD_TABLE_HEADER_RE = re.compile(
+    r"""
+    ^[ \t]*(?:\|[^\n]*\|)[ \t]*\n          # header row (pipe-bounded)
+    [ \t]*(?:\|[ \t]*:?-+:?[ \t]*)+\|[ \t]*\n  # separator row (---|---)
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+
+def _md_table_cells(line: str) -> List[str]:
+    """Split a markdown table row into stripped cell strings."""
+    # Drop leading/trailing pipes, then split.
+    s = line.strip()
+    if s.startswith("|"):
+        s = s[1:]
+    if s.endswith("|"):
+        s = s[:-1]
+    return [c.strip() for c in s.split("|")]
+
+
+def _render_md_inline_to_html(text: str) -> str:
+    """Convert a small subset of inline markdown to HTML for table cells.
+
+    Handles ``**bold**``, ``*italic*``, and ``[label](url)``. Anything
+    else is HTML-escaped. Email-only — keep simple, don't pull a full
+    markdown engine into an email-template module.
+    """
+    escaped = (
+        text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+    )
+    # Links: [label](url)
+    escaped = re.sub(
+        r"\[([^\]]+)\]\(([^)]+)\)",
+        r'<a href="\2" style="color:#2563eb;">\1</a>',
+        escaped,
+    )
+    # Bold
+    escaped = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", escaped)
+    # Italic
+    escaped = re.sub(r"\*([^*]+)\*", r"<em>\1</em>", escaped)
+    return escaped
+
+
+def render_html_table(
+    headers: List[str], rows: List[List[str]], *, brand: str = "#7C5CFF"
+) -> str:
+    """Render a mobile-friendly inline-styled HTML table.
+
+    Email clients vary wildly in their CSS support — we use ``<table>``
+    with ``border-collapse:collapse`` (works everywhere), alternating row
+    backgrounds for scanability, and a brand-colored header band. Outlook
+    2019+ honors ``border-collapse``; older versions degrade gracefully.
+
+    Each cell content is rendered through the small inline-markdown
+    helper so ``**bold**`` and links survive the conversion.
+    """
+    if not headers or not rows:
+        return ""
+    head_cells = "".join(
+        f'<th align="left" '
+        f'style="padding:10px 12px;background:{brand};color:#ffffff;'
+        f'font-size:12px;font-weight:700;text-transform:uppercase;'
+        f'letter-spacing:0.04em;border:1px solid {brand};">'
+        f'{_render_md_inline_to_html(h)}</th>'
+        for h in headers
+    )
+    body_rows: List[str] = []
+    for i, row in enumerate(rows):
+        bg = "#ffffff" if i % 2 == 0 else "#f8fafc"
+        cells = "".join(
+            f'<td valign="top" '
+            f'style="padding:10px 12px;background:{bg};'
+            f'border:1px solid #e2e8f0;font-size:14px;'
+            f'color:#0f172a;line-height:1.4;">'
+            f'{_render_md_inline_to_html(c)}</td>'
+            for c in row
+        )
+        body_rows.append(f"<tr>{cells}</tr>")
+    return (
+        '<table role="presentation" width="100%" cellpadding="0" '
+        'cellspacing="0" border="0" '
+        'style="border-collapse:collapse;margin:14px 0;'
+        'font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\','
+        'Roboto,Helvetica,Arial,sans-serif;">'
+        f'<thead><tr>{head_cells}</tr></thead>'
+        f'<tbody>{"".join(body_rows)}</tbody>'
+        '</table>'
+    )
+
+
+def convert_md_tables_to_html(body_md: str, *, brand: str = "#7C5CFF") -> str:
+    """Replace markdown tables in *body_md* with inline-styled HTML
+    tables.
+
+    Outlook 2019, Yahoo, and ProtonMail all render markdown tables
+    inconsistently — many strip the formatting entirely. We pre-render
+    them to HTML so they survive any client. Non-table markdown is
+    untouched (Buttondown's renderer handles it).
+    """
+    if not body_md or "|" not in body_md:
+        return body_md
+    out_lines: List[str] = []
+    lines = body_md.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        # Cheap pre-check: is this the start of a possible table? It's
+        # a header row if it contains pipes AND the next line is a
+        # separator row.
+        if "|" in line and i + 1 < len(lines):
+            sep = lines[i + 1].strip()
+            sep_cells = _md_table_cells(sep) if sep.startswith(
+                ("|", ":", "-")
+            ) else []
+            looks_like_sep = bool(sep_cells) and all(
+                re.match(r"^:?-+:?$", c) for c in sep_cells
+            )
+            if looks_like_sep and "|" in line:
+                headers = _md_table_cells(line)
+                rows: List[List[str]] = []
+                j = i + 2
+                while j < len(lines) and "|" in lines[j] and lines[j].strip():
+                    rows.append(_md_table_cells(lines[j]))
+                    j += 1
+                # Pad/truncate rows to header width so the rendered
+                # HTML stays well-formed even if the LLM emitted ragged
+                # rows.
+                w = len(headers)
+                rows = [r[:w] + [""] * (w - len(r)) for r in rows]
+                out_lines.append(render_html_table(headers, rows, brand=brand))
+                i = j
+                continue
+        out_lines.append(line)
+        i += 1
+    return "\n".join(out_lines)
 
 
 def episode_blog_url(slug: str, episode_num: int) -> str:
@@ -747,10 +918,19 @@ def wrap_with_branding(
     body_clean = _strip_repeated_show_title(
         (markdown_body or "").strip(), show["name"]
     )
+    # Pre-render any markdown tables in the body to inline HTML so they
+    # survive Outlook / Yahoo / ProtonMail. Non-table markdown is left
+    # alone for Buttondown's renderer to handle.
+    body_clean = convert_md_tables_to_html(
+        body_clean, brand=show["brand_color"]
+    )
 
     # Blocks separated by two blank lines so markdown processors treat
-    # them as separate sections. Empty blocks contribute nothing.
+    # them as separate sections. Empty blocks contribute nothing. The
+    # dark-mode <style> block goes at the very top so any client that
+    # respects @media queries picks it up before parsing the body.
     parts = [
+        _DARK_MODE_STYLE,
         preheader_div,
         hero,
         stats_block,

--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -346,6 +346,211 @@ def _strip_repeated_show_title(body_md: str, show_name: str) -> str:
     return body_md
 
 
+def episode_blog_url(slug: str, episode_num: int) -> str:
+    """Canonical per-episode permalink on nerranetwork.com.
+
+    Pattern: ``https://nerranetwork.com/blog/<slug>/ep<NNN>.html``.
+    Locked in by the static site (see ``blog/<slug>/`` directories).
+    """
+    return f"{_NETWORK_SITE}/blog/{slug}/ep{int(episode_num):03d}.html"
+
+
+def episode_link_table(
+    episodes: List[Dict[str, Any]], slug: str
+) -> str:
+    """Render a markdown reference table of episode → URL pairs for the
+    LLM prompt context.
+
+    Lets the synthesizer instruct the model to use ``[▶ Episode N
+    · {date}]({url})`` whenever it cites an episode in body text,
+    without the model hallucinating URLs.
+    """
+    if not episodes:
+        return ""
+    lines = ["Episode reference (use these exact URLs when citing episodes):"]
+    for ep in episodes:
+        num = ep.get("episode_num")
+        if num is None:
+            continue
+        url = episode_blog_url(slug, num)
+        date_str = ep.get("date", "")
+        lines.append(f"- Episode {num} ({date_str}): {url}")
+    return "\n".join(lines)
+
+
+def _build_featured_episode_html(
+    featured: Optional[Dict[str, Any]], show: Dict[str, str]
+) -> str:
+    """Render the "If you only have 10 minutes" block at top of body.
+
+    *featured* is a dict with at least ``episode_num``, ``hook``, and
+    ``date``. We compute the listen URL from ``episode_blog_url``.
+    Returns an empty string if no featured episode is provided.
+    """
+    if not featured:
+        return ""
+    num = featured.get("episode_num")
+    hook = (featured.get("hook") or "").strip()
+    date_str = featured.get("date", "")
+    if num is None or not hook:
+        return ""
+    brand = show["brand_color"]
+    slug = featured.get("show_slug", "")
+    listen = featured.get("listen_url") or (
+        episode_blog_url(slug, int(num)) if slug else show["show_page"]
+    )
+    safe_hook = hook.replace("<", "&lt;").replace(">", "&gt;")
+    safe_date = (date_str or "").replace("<", "&lt;").replace(">", "&gt;")
+    return (
+        '<table role="presentation" width="100%" cellpadding="0" '
+        'cellspacing="0" border="0" style="background:#ffffff;">'
+        '<tr><td '
+        'style="padding:20px 24px 8px;'
+        'font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\','
+        'Roboto,Helvetica,Arial,sans-serif;">'
+        f'<div style="border:1px solid {brand}33;background:{brand}0a;'
+        f'border-radius:12px;padding:18px 18px 16px;">'
+        '<div style="font-size:11px;font-weight:700;'
+        f'color:{brand};letter-spacing:0.08em;'
+        'text-transform:uppercase;margin-bottom:6px;">'
+        '🎧 If you only have 10 minutes this week'
+        '</div>'
+        f'<div style="font-size:17px;font-weight:600;color:#0f172a;'
+        f'line-height:1.4;margin:0 0 10px;">'
+        f'Episode {num} · {safe_hook}'
+        '</div>'
+        f'<div style="font-size:12px;color:#64748b;margin:0 0 14px;">'
+        f'{safe_date}</div>'
+        f'<a href="{listen}" '
+        f'style="display:inline-block;background:{brand};color:#ffffff;'
+        f'text-decoration:none;font-weight:600;font-size:14px;'
+        f'padding:8px 16px;border-radius:8px;">'
+        '▶ Listen now</a>'
+        '</div></td></tr></table>'
+    )
+
+
+def _build_cross_network_html(
+    adjacent_shows: Optional[List[Dict[str, Any]]], brand: str
+) -> str:
+    """Render the "Across the Nerra Network" cross-promo block.
+
+    *adjacent_shows* is a list of dicts:
+        ``{"name": ..., "slug": ..., "emoji": ..., "hook": ..., "url": ...}``
+
+    Renders as a styled card list between the body and the footer.
+    Empty input → empty string (the block is opt-out by data, not a
+    feature flag).
+    """
+    if not adjacent_shows:
+        return ""
+    rows: List[str] = []
+    for adj in adjacent_shows[:3]:
+        name = (adj.get("name") or "").strip()
+        emoji = (adj.get("emoji") or "").strip()
+        hook = (adj.get("hook") or "").strip()
+        url = (adj.get("url") or "").strip()
+        if not name or not hook:
+            continue
+        n_safe = name.replace("<", "&lt;").replace(">", "&gt;")
+        h_safe = hook.replace("<", "&lt;").replace(">", "&gt;")
+        prefix = f"{emoji} " if emoji else ""
+        if url:
+            link_open = (
+                f'<a href="{url}" '
+                f'style="color:#0f172a;text-decoration:none;'
+                f'border-bottom:1px solid {brand};">'
+            )
+            link_close = "</a>"
+        else:
+            link_open = link_close = ""
+        rows.append(
+            '<tr><td '
+            'style="padding:10px 0;border-top:1px solid #e2e8f0;'
+            'font-size:14px;line-height:1.5;color:#334155;">'
+            f'<strong style="color:#0f172a;">{prefix}{link_open}'
+            f'{n_safe}{link_close}</strong>'
+            f'<span style="color:#64748b;"> — {h_safe}</span>'
+            '</td></tr>'
+        )
+    if not rows:
+        return ""
+    return (
+        '<table role="presentation" width="100%" cellpadding="0" '
+        'cellspacing="0" border="0" style="background:#f8fafc;">'
+        '<tr><td '
+        'style="padding:24px;'
+        'font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\','
+        'Roboto,Helvetica,Arial,sans-serif;">'
+        '<div style="font-size:11px;font-weight:700;color:#64748b;'
+        'letter-spacing:0.08em;text-transform:uppercase;margin-bottom:8px;">'
+        '🌐 Across the Nerra Network'
+        '</div>'
+        '<table role="presentation" width="100%" cellpadding="0" '
+        'cellspacing="0" border="0">'
+        + "".join(rows) +
+        '</table>'
+        '</td></tr></table>'
+    )
+
+
+def _build_reply_share_html(
+    show: Dict[str, str], *, archive_url: str = ""
+) -> str:
+    """Render a reply-CTA + share-intents row above the footer CTAs.
+
+    Mailto opens a prefilled message. Twitter/LinkedIn/WhatsApp share
+    intents point to the archive_url (the show landing page, since
+    Buttondown's per-issue archive URL isn't known until after send).
+    """
+    name = show["name"]
+    brand = show["brand_color"]
+    target = (archive_url or show["show_page"]).strip()
+
+    # Pre-encode the share intents (URL-encoded query strings).
+    import urllib.parse as _u
+    share_text = f"I'm reading {name} this week — give it a listen:"
+    twitter = (
+        "https://twitter.com/intent/tweet?"
+        + _u.urlencode({"text": share_text, "url": target})
+    )
+    linkedin = (
+        "https://www.linkedin.com/sharing/share-offsite/?"
+        + _u.urlencode({"url": target})
+    )
+    whatsapp = (
+        "https://wa.me/?"
+        + _u.urlencode({"text": f"{share_text} {target}"})
+    )
+
+    def _chip(href: str, label: str) -> str:
+        return (
+            f'<a href="{href}" '
+            f'style="display:inline-block;color:{brand};text-decoration:none;'
+            f'font-weight:600;font-size:13px;padding:6px 12px;'
+            f'margin:2px;border:1px solid {brand}55;border-radius:100px;'
+            f'background:#ffffff;">{label}</a>'
+        )
+
+    return (
+        '<table role="presentation" width="100%" cellpadding="0" '
+        'cellspacing="0" border="0" style="background:#ffffff;">'
+        '<tr><td align="center" '
+        'style="padding:8px 16px 20px;'
+        'font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\','
+        'Roboto,Helvetica,Arial,sans-serif;color:#475569;">'
+        '<p style="font-size:13px;margin:0 0 10px;line-height:1.5;">'
+        '💬 <strong>Reply to this email</strong> — Patrick reads every one.'
+        '</p>'
+        '<div>'
+        + _chip(twitter, "Share on X")
+        + _chip(linkedin, "Share on LinkedIn")
+        + _chip(whatsapp, "Share on WhatsApp")
+        + '</div>'
+        '</td></tr></table>'
+    )
+
+
 def _build_footer_html(show: Dict[str, str]) -> str:
     """Render the email's footer block as inline-styled HTML."""
     brand = show["brand_color"]
@@ -474,7 +679,10 @@ def wrap_with_branding(
     daily_date: Optional[datetime.date] = None,
     preheader: str = "",
     by_the_numbers: Optional[List[Dict[str, str]]] = None,
+    featured_episode: Optional[Dict[str, Any]] = None,
     p_s: str = "",
+    adjacent_shows: Optional[List[Dict[str, Any]]] = None,
+    show_reply_share: bool = True,
     requires_financial_disclaimer: bool = False,
 ) -> str:
     """Wrap *markdown_body* with a branded hero, optional middle blocks,
@@ -489,10 +697,13 @@ def wrap_with_branding(
       1. Hidden preheader div (inbox preview text)
       2. Hero (cover, name, tagline, date pill)
       3. By-the-numbers stat tiles
-      4. Financial disclaimer callout
-      5. Markdown body
-      6. P.S. block
-      7. Footer (CTAs + Nerra Network credit)
+      4. Featured-episode "if you only have 10 minutes" block
+      5. Financial disclaimer callout
+      6. Markdown body
+      7. P.S. block
+      8. Cross-network "Across the Nerra Network" module
+      9. Reply / share row
+      10. Footer (CTAs + Nerra Network credit)
 
     Pass *week_ending* for weekly newsletters; pass *daily_label* +
     *daily_date* for daily episode newsletters. If neither is set,
@@ -512,11 +723,24 @@ def wrap_with_branding(
     stats_block = _build_by_the_numbers_html(
         by_the_numbers, show["brand_color"]
     )
+    # Stamp the slug into the featured-episode dict so the block can
+    # build the listen URL even if the caller didn't pre-resolve it.
+    featured_with_slug = None
+    if featured_episode:
+        featured_with_slug = dict(featured_episode)
+        featured_with_slug.setdefault("show_slug", slug)
+    featured_block = _build_featured_episode_html(featured_with_slug, show)
     disclaimer = (
         _build_financial_disclaimer_html()
         if requires_financial_disclaimer else ""
     )
     p_s_block = _build_p_s_html(p_s, show["brand_color"])
+    cross_network = _build_cross_network_html(
+        adjacent_shows, show["brand_color"]
+    )
+    reply_share = (
+        _build_reply_share_html(show) if show_reply_share else ""
+    )
     footer = _build_footer_html(show)
 
     # Idempotent strip in case the body still has the show title at top.
@@ -526,6 +750,16 @@ def wrap_with_branding(
 
     # Blocks separated by two blank lines so markdown processors treat
     # them as separate sections. Empty blocks contribute nothing.
-    parts = [preheader_div, hero, stats_block, disclaimer, body_clean,
-             p_s_block, footer]
+    parts = [
+        preheader_div,
+        hero,
+        stats_block,
+        featured_block,
+        disclaimer,
+        body_clean,
+        p_s_block,
+        cross_network,
+        reply_share,
+        footer,
+    ]
     return "\n\n".join(p for p in parts if p) + "\n"

--- a/engine/synthesizer.py
+++ b/engine/synthesizer.py
@@ -119,6 +119,8 @@ def _parse_envelope(
             "by_the_numbers": [],
             "body_md": "",
             "p_s": fallback_p_s,
+            "featured_episode": None,
+            "cross_network": [],
         }
 
     text = raw_text.strip()
@@ -155,6 +157,8 @@ def _parse_envelope(
             "by_the_numbers": [],
             "body_md": _strip_repeated_show_title(raw_text, show_name),
             "p_s": fallback_p_s,
+            "featured_episode": None,
+            "cross_network": [],
         }
 
     # Coerce + sanitize each field.
@@ -197,6 +201,10 @@ def _parse_envelope(
         "by_the_numbers": by_the_numbers,
         "body_md": body_md,
         "p_s": p_s,
+        # featured_episode + cross_network are populated by the caller
+        # after parse — they don't come from the LLM.
+        "featured_episode": None,
+        "cross_network": [],
     }
 
 
@@ -235,6 +243,157 @@ def _network_synth_defaults() -> tuple[str, int, float]:
         except Exception as exc:
             logger.warning("Failed to read synth defaults: %s", exc)
     return model, max_tokens, temperature
+
+
+def _load_network_adjacencies() -> Dict[str, List[str]]:
+    """Read the network-wide adjacency map from ``shows/_defaults.yaml``.
+
+    Returns ``{slug: [sibling_slugs]}``. Used as the fallback when a
+    show YAML doesn't pin its own ``newsletter.adjacent_shows`` list.
+    Empty dict on failure (so the cross-network module just degrades
+    to "no adjacencies surfaced this week" rather than crashing).
+    """
+    import yaml
+
+    defaults_path = Path("shows/_defaults.yaml")
+    if not defaults_path.exists():
+        return {}
+    try:
+        data = yaml.safe_load(defaults_path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        logger.warning("Failed to read network adjacencies: %s", exc)
+        return {}
+    nl = data.get("newsletter") or {}
+    adj = nl.get("network_adjacencies") or {}
+    return {k: list(v or []) for k, v in adj.items()}
+
+
+def _show_short_label(slug: str) -> Dict[str, str]:
+    """Return ``{name, emoji, short_label}`` for a slug from its YAML.
+
+    Used by the cross-network module to render sibling shows with
+    their per-show emoji + short name. Falls back to the slug if the
+    YAML is missing.
+    """
+    import yaml
+
+    out = {"name": slug, "emoji": "", "short_label": slug}
+    yp = Path("shows") / f"{slug}.yaml"
+    if not yp.exists():
+        return out
+    try:
+        data = yaml.safe_load(yp.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return out
+    name = (data.get("publishing") or {}).get("rss_title") or data.get("name") or slug
+    nl = data.get("newsletter") or {}
+    out.update({
+        "name": str(name),
+        "emoji": str(nl.get("emoji") or ""),
+        "short_label": str(nl.get("short_label") or name),
+    })
+    return out
+
+
+def _build_cross_network_data(
+    show_slug: str, start_date: str, end_date: str
+) -> List[Dict[str, str]]:
+    """Pull top story-of-the-week from up to 3 adjacent shows.
+
+    Returns a list of dicts shaped for ``_build_cross_network_html``:
+        ``{name, slug, emoji, hook, url}``.
+
+    Lookup order for adjacent shows:
+      1. Per-show ``newsletter.adjacent_shows`` (explicit pinning)
+      2. Network-wide ``newsletter.network_adjacencies[slug]``
+      3. Empty (no module rendered)
+    """
+    import yaml
+
+    # Per-show pinned adjacencies, if any.
+    pinned: List[str] = []
+    yp = Path("shows") / f"{show_slug}.yaml"
+    if yp.exists():
+        try:
+            data = yaml.safe_load(yp.read_text(encoding="utf-8")) or {}
+            pinned = list(((data.get("newsletter") or {}).get("adjacent_shows") or []))
+        except Exception as exc:
+            logger.warning("adjacent_shows read failed for %s: %s", show_slug, exc)
+
+    # Fallback to the network-wide map.
+    if not pinned:
+        pinned = _load_network_adjacencies().get(show_slug, [])
+    pinned = pinned[:3]
+    if not pinned:
+        return []
+
+    # Pull each sibling's top-of-week episode (the most recent one
+    # with a non-empty hook). One query covers all shows.
+    try:
+        all_eps = query_all_shows_range(start_date, end_date)
+    except Exception as exc:
+        logger.debug("Cross-network query failed: %s", exc)
+        return []
+
+    by_show: Dict[str, List[Dict[str, Any]]] = {}
+    for ep in all_eps:
+        slug = ep.get("show_slug") or ""
+        if slug and slug != show_slug:
+            by_show.setdefault(slug, []).append(ep)
+
+    out: List[Dict[str, str]] = []
+    for sib_slug in pinned:
+        eps = by_show.get(sib_slug) or []
+        if not eps:
+            continue
+        eps.sort(key=lambda e: (e.get("date") or ""), reverse=True)
+        top = next((e for e in eps if e.get("hook")), eps[0])
+        meta = _show_short_label(sib_slug)
+        from engine.newsletter_template import episode_blog_url
+        url = (
+            episode_blog_url(sib_slug, top["episode_num"])
+            if top.get("episode_num") else ""
+        )
+        out.append({
+            "name": meta["short_label"],
+            "slug": sib_slug,
+            "emoji": meta["emoji"],
+            "hook": (top.get("hook") or "")[:140],
+            "url": url,
+        })
+    return out
+
+
+def _pick_featured_episode(
+    episodes: List[Dict[str, Any]], show_slug: str
+) -> Optional[Dict[str, Any]]:
+    """Pick the week's featured episode for the "10-minutes" block.
+
+    Heuristic: the most recent episode with a non-empty hook (the
+    fresher the episode, the more likely the reader hasn't heard it
+    yet). Falls back to the most recent episode period. Returns None
+    if the list is empty.
+    """
+    if not episodes:
+        return None
+    sorted_eps = sorted(
+        episodes, key=lambda e: (e.get("date") or ""), reverse=True
+    )
+    candidate = next(
+        (e for e in sorted_eps if (e.get("hook") or "").strip()),
+        sorted_eps[0],
+    )
+    from engine.newsletter_template import episode_blog_url
+    return {
+        "show_slug": show_slug,
+        "episode_num": candidate.get("episode_num"),
+        "date": candidate.get("date", ""),
+        "title": candidate.get("title", ""),
+        "hook": candidate.get("hook", ""),
+        "listen_url": episode_blog_url(
+            show_slug, candidate.get("episode_num", 0)
+        ),
+    }
 
 
 def _cfg_synth_params(cfg, default_max_tokens: int, default_temperature: float) -> tuple[str, int, float]:
@@ -338,30 +497,17 @@ def synthesize_weekly_newsletter(
 
     episodes_text = "\n\n---\n\n".join(episode_summaries)
 
-    # Cross-show highlights: top stories from OTHER shows this week that
-    # subscribers of THIS show might find interesting. This is a key
-    # cross-promotion mechanism for the network.
-    cross_show_section = ""
-    try:
-        all_shows_eps = query_all_shows_range(start_date, end_date)
-        other_shows = [
-            ep for ep in all_shows_eps
-            if ep.get("show_slug") != show_slug and ep.get("hook")
-        ]
-        if other_shows:
-            highlights = other_shows[:5]
-            cross_lines = []
-            for ep in highlights:
-                show_label = ep.get("show_name") or ep.get("show_slug", "")
-                hook = (ep.get("hook") or "")[:120]
-                cross_lines.append(f"- **{show_label}**: {hook}")
-            cross_show_section = (
-                "\n\n## From the Nerra Network This Week\n"
-                "Other shows in the network covered these notable stories:\n"
-                + "\n".join(cross_lines)
-            )
-    except Exception as exc:
-        logger.debug("Cross-show highlights failed: %s", exc)
+    # Episode link reference table — fed into the prompt so the LLM
+    # cites episodes with their canonical blog URLs instead of
+    # hallucinating links. Format: "Episode N (date): URL".
+    from engine.newsletter_template import episode_link_table
+    episode_links_text = episode_link_table(episodes, show_slug)
+
+    # Cross-network adjacencies: top stories from sibling shows this
+    # week, used to populate the "Across the Nerra Network" module
+    # rendered between the body and footer. We pre-fetch this rather
+    # than asking the LLM to fill it so the data stays accurate.
+    cross_network = _build_cross_network_data(show_slug, start_date, end_date)
 
     # Load show-specific or default prompt
     if prompt_file and prompt_file.exists():
@@ -380,13 +526,24 @@ def synthesize_weekly_newsletter(
         episode_count=len(episodes),
         start_date=start_date,
         end_date=end_date,
-        episodes_text=episodes_text + cross_show_section,
+        episodes_text=episodes_text,
         entities=", ".join(sorted(all_entities)[:30]),
     )
+
+    # Episode-link reference table — we instruct the LLM to use these
+    # canonical URLs whenever it cites an episode in body text. Without
+    # this, models routinely hallucinate URLs.
+    link_block = (
+        f"\n\n## Episode link reference (use these URLs when citing "
+        f"episodes; format: `[▶ Episode N · {{date}}]({{url}})`):\n"
+        f"{episode_links_text}\n"
+        if episode_links_text else ""
+    )
+
     # Append the JSON envelope output instructions. We do this after
     # the per-show prompt so the editorial guidance still drives the
     # body content; the envelope is a shape constraint, not a rewrite.
-    prompt = body_prompt + _ENVELOPE_INSTRUCTIONS.format(
+    prompt = body_prompt + link_block + _ENVELOPE_INSTRUCTIONS.format(
         target_words=target_words
     )
 
@@ -411,11 +568,20 @@ def synthesize_weekly_newsletter(
         envelope = _parse_envelope(
             text, show_name=show_name, week_ending=week_ending
         )
+        # Attach the deterministically-built bits (not from the LLM):
+        # featured episode + cross-network siblings.
+        envelope["featured_episode"] = _pick_featured_episode(
+            episodes, show_slug
+        )
+        envelope["cross_network"] = cross_network
         logger.info(
             "[Synthesizer] Weekly newsletter for %s: subject=%r body=%d chars "
-            "p_s=%d chars stats=%d (model=%s)",
+            "p_s=%d chars stats=%d siblings=%d featured=%s (model=%s)",
             show_slug, envelope["subject_hook"], len(envelope["body_md"]),
-            len(envelope["p_s"]), len(envelope["by_the_numbers"]), synth_model,
+            len(envelope["p_s"]), len(envelope["by_the_numbers"]),
+            len(cross_network),
+            envelope["featured_episode"]["episode_num"] if envelope["featured_episode"] else None,
+            synth_model,
         )
         return envelope
     except Exception as e:

--- a/scripts/run_weekly_newsletters.py
+++ b/scripts/run_weekly_newsletters.py
@@ -138,7 +138,9 @@ def main():
                 week_ending=week_ending,
                 preheader=envelope.get("preheader", ""),
                 by_the_numbers=envelope.get("by_the_numbers") or [],
+                featured_episode=envelope.get("featured_episode"),
                 p_s=envelope.get("p_s", ""),
+                adjacent_shows=envelope.get("cross_network") or [],
                 requires_financial_disclaimer=requires_disclaimer,
             )
 

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -103,6 +103,26 @@ newsletter:
   # ``floor((send_date - newsletter_start_date) / 7) + 1`` instead
   # of carrying mutable state in git or R2.
   newsletter_start_date: "2026-04-30"
+  # ---- Cross-network ("Across the Nerra Network") adjacency map ----
+  # Each show points to 1-3 sibling shows whose top stories of the
+  # week are surfaced in the email's cross-network module. Override
+  # in a show's own YAML to pin specific siblings; otherwise the
+  # synthesizer falls back to "any other show" rotation.
+  adjacent_shows: []
+  # Network-wide map used as a fallback when a show YAML doesn't list
+  # its own adjacent_shows. Each key is a slug, value is an ordered
+  # list of preferred siblings.
+  network_adjacencies:
+    tesla: [modern_investing, models_agents]
+    modern_investing: [tesla, finansy_prosto]
+    omni_view: [modern_investing, env_intel]
+    models_agents: [models_agents_beginners, tesla]
+    models_agents_beginners: [models_agents, fascinating_frontiers]
+    fascinating_frontiers: [planetterrian, models_agents]
+    planetterrian: [env_intel, fascinating_frontiers]
+    env_intel: [planetterrian, omni_view]
+    finansy_prosto: [modern_investing, privet_russian]
+    privet_russian: [finansy_prosto]
 
 chapters:
   enabled: true

--- a/tests/test_newsletter_template.py
+++ b/tests/test_newsletter_template.py
@@ -649,3 +649,163 @@ def test_wrap_with_branding_show_reply_share_default_is_on():
         week_ending=datetime.date(2026, 4, 30),
     )
     assert "Reply to this email" in out
+
+
+# ---------------------------------------------------------------------------
+# Markdown table → mobile-safe HTML table
+# ---------------------------------------------------------------------------
+
+def test_render_html_table_renders_headers_and_rows():
+    out = nt.render_html_table(
+        ["Day", "Ticker", "P&L"],
+        [["Mon", "TSLA", "+1.2%"], ["Tue", "AAPL", "-0.4%"]],
+        brand="#E31937",
+    )
+    # Headers in brand-color band.
+    assert "Day" in out
+    assert "TSLA" in out
+    assert "AAPL" in out
+    # Brand color is the header background.
+    assert "#E31937" in out
+    # Alternating row backgrounds (white / slate-50).
+    assert "#ffffff" in out
+    assert "#f8fafc" in out
+
+
+def test_render_html_table_handles_inline_markdown_in_cells():
+    out = nt.render_html_table(
+        ["Header"],
+        [["**bold**"], ["[link](https://x.com)"]],
+    )
+    assert "<strong>bold</strong>" in out
+    assert '<a href="https://x.com"' in out
+
+
+def test_render_html_table_escapes_html():
+    out = nt.render_html_table(
+        ["H"], [["<script>x</script>"]],
+    )
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+def test_render_html_table_empty_returns_empty_string():
+    assert nt.render_html_table([], []) == ""
+    assert nt.render_html_table(["H"], []) == ""
+
+
+def test_convert_md_tables_to_html_swaps_a_simple_table():
+    body = (
+        "Some intro paragraph.\n\n"
+        "| Day | Ticker | P&L |\n"
+        "|-----|--------|-----|\n"
+        "| Mon | TSLA   | +1% |\n"
+        "| Tue | AAPL   | -2% |\n\n"
+        "And a closing paragraph."
+    )
+    out = nt.convert_md_tables_to_html(body)
+    assert "Some intro paragraph." in out
+    assert "<table" in out
+    assert "TSLA" in out
+    assert "AAPL" in out
+    assert "And a closing paragraph." in out
+    # The original markdown rows are gone (replaced by HTML).
+    assert "| Mon | TSLA" not in out
+
+
+def test_convert_md_tables_to_html_handles_multiple_tables():
+    body = (
+        "| A | B |\n|---|---|\n| 1 | 2 |\n\n"
+        "Some prose.\n\n"
+        "| X | Y |\n|---|---|\n| 9 | 8 |\n"
+    )
+    out = nt.convert_md_tables_to_html(body)
+    # Both tables converted.
+    assert out.count("<table") == 2
+
+
+def test_convert_md_tables_to_html_leaves_non_table_markdown_alone():
+    body = "## Heading\n\nA bullet:\n- item one\n- item two\n"
+    out = nt.convert_md_tables_to_html(body)
+    assert out == body
+
+
+def test_convert_md_tables_to_html_pads_ragged_rows():
+    """If the LLM emits a row missing a cell, we pad with empties so
+    the rendered HTML stays well-formed instead of breaking the table."""
+    body = (
+        "| A | B | C |\n"
+        "|---|---|---|\n"
+        "| 1 | 2 |\n"  # missing the C cell
+    )
+    out = nt.convert_md_tables_to_html(body)
+    assert "<table" in out
+    # Three <td>s rendered (with one empty) so column count matches.
+    assert out.count("<td") == 3
+
+
+def test_convert_md_tables_to_html_handles_pipe_in_text():
+    """Pipes inside cell text are not supported (markdown doesn't
+    escape them), but we shouldn't crash. The cell just splits on the
+    inner pipe — that's fine, it's how every markdown renderer does
+    it."""
+    body = (
+        "| Header |\n"
+        "|--------|\n"
+        "| just a regular cell |\n"
+    )
+    out = nt.convert_md_tables_to_html(body)
+    assert "<table" in out
+    assert "just a regular cell" in out
+
+
+def test_convert_md_tables_to_html_no_tables_returns_input_verbatim():
+    body = "Plain text, no pipes here."
+    assert nt.convert_md_tables_to_html(body) == body
+
+
+# ---------------------------------------------------------------------------
+# Dark mode + accessibility
+# ---------------------------------------------------------------------------
+
+def test_wrap_with_branding_includes_dark_mode_style_block():
+    out = nt.wrap_with_branding(
+        "tesla", "Body.", week_ending=datetime.date(2026, 4, 30),
+    )
+    assert "@media (prefers-color-scheme: dark)" in out
+    assert "#0f172a" in out  # dark page bg
+    assert "#e2e8f0" in out  # dark text
+
+
+def test_hero_alt_text_describes_show_not_file():
+    show = nt._load_show_branding("tesla")
+    hero = nt._build_hero_html(show, "Pill")
+    # Old behavior was alt="Tesla Shorts Time cover" (file-ish);
+    # new behavior should describe the show / tagline so screen
+    # readers convey the same info as the visual cover.
+    assert 'alt="Tesla Shorts Time' in hero
+    assert ' cover"' not in hero
+
+
+def test_hero_alt_text_includes_tagline_when_present():
+    show = dict(nt._load_show_branding("tesla"))
+    show["tagline"] = "Daily Tesla news at podcast speed."
+    hero = nt._build_hero_html(show, "Pill")
+    assert "Daily Tesla news at podcast speed." in hero
+
+
+def test_wrap_with_branding_converts_md_table_in_body():
+    """End-to-end: a markdown table inside the body markdown comes out
+    as an HTML <table> in the wrapped result."""
+    body = (
+        "## Scoreboard\n\n"
+        "| Day | Ticker |\n"
+        "|-----|--------|\n"
+        "| Mon | TSLA   |\n"
+    )
+    out = nt.wrap_with_branding(
+        "tesla", body, week_ending=datetime.date(2026, 4, 30),
+    )
+    assert "<table" in out
+    # Original markdown row is gone.
+    assert "| Mon | TSLA" not in out

--- a/tests/test_newsletter_template.py
+++ b/tests/test_newsletter_template.py
@@ -411,3 +411,241 @@ def test_wrap_with_branding_loads_disclaimer_flag_from_yaml_for_mit():
         week_ending=datetime.date(2026, 4, 30),
     )
     assert "Heads up" not in out
+
+
+# ---------------------------------------------------------------------------
+# Episode deep-link helpers
+# ---------------------------------------------------------------------------
+
+def test_episode_blog_url_pads_to_three_digits():
+    assert nt.episode_blog_url("tesla", 7) == (
+        "https://nerranetwork.com/blog/tesla/ep007.html"
+    )
+    assert nt.episode_blog_url("tesla", 100) == (
+        "https://nerranetwork.com/blog/tesla/ep100.html"
+    )
+
+
+def test_episode_link_table_renders_reference_block():
+    eps = [
+        {"episode_num": 100, "date": "2026-04-30"},
+        {"episode_num": 101, "date": "2026-05-01"},
+    ]
+    out = nt.episode_link_table(eps, "tesla")
+    assert "Episode 100" in out
+    assert "Episode 101" in out
+    assert "https://nerranetwork.com/blog/tesla/ep100.html" in out
+    assert "2026-04-30" in out
+
+
+def test_episode_link_table_skips_missing_episode_num():
+    eps = [{"date": "2026-04-30"}, {"episode_num": 5, "date": "2026-05-01"}]
+    out = nt.episode_link_table(eps, "tesla")
+    assert "Episode 5" in out
+    # The malformed row didn't add a stray "Episode None".
+    assert "Episode None" not in out
+
+
+def test_episode_link_table_empty_returns_empty_string():
+    assert nt.episode_link_table([], "tesla") == ""
+
+
+# ---------------------------------------------------------------------------
+# Featured episode block
+# ---------------------------------------------------------------------------
+
+def test_featured_episode_renders_with_listen_button():
+    show = nt._load_show_branding("tesla")
+    featured = {
+        "episode_num": 100,
+        "date": "2026-04-30",
+        "hook": "Cybercab production begins in Texas",
+        "show_slug": "tesla",
+    }
+    out = nt._build_featured_episode_html(featured, show)
+    assert "10 minutes" in out
+    assert "Episode 100" in out
+    assert "Cybercab production begins in Texas" in out
+    assert "Listen now" in out
+    assert "blog/tesla/ep100.html" in out
+
+
+def test_featured_episode_returns_empty_when_missing_data():
+    show = nt._load_show_branding("tesla")
+    assert nt._build_featured_episode_html(None, show) == ""
+    assert nt._build_featured_episode_html({}, show) == ""
+    # Hook missing → no render.
+    assert nt._build_featured_episode_html(
+        {"episode_num": 1, "show_slug": "tesla"}, show
+    ) == ""
+
+
+def test_featured_episode_uses_explicit_listen_url():
+    """If the caller supplies a listen_url (e.g. R2 mp3), use it
+    instead of the default blog deep link."""
+    show = nt._load_show_branding("tesla")
+    featured = {
+        "episode_num": 100,
+        "date": "2026-04-30",
+        "hook": "Hook here",
+        "show_slug": "tesla",
+        "listen_url": "https://custom.example.com/ep100",
+    }
+    out = nt._build_featured_episode_html(featured, show)
+    assert "https://custom.example.com/ep100" in out
+
+
+def test_featured_episode_html_escapes_user_input():
+    show = nt._load_show_branding("tesla")
+    featured = {
+        "episode_num": 5,
+        "hook": "<script>alert(1)</script>",
+        "date": "2026-04-30",
+        "show_slug": "tesla",
+    }
+    out = nt._build_featured_episode_html(featured, show)
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+# ---------------------------------------------------------------------------
+# Cross-network "Across the Nerra Network" module
+# ---------------------------------------------------------------------------
+
+def test_cross_network_renders_adjacent_shows():
+    siblings = [
+        {
+            "name": "MIT", "slug": "modern_investing", "emoji": "📈",
+            "hook": "Oil hit $126; Fed in stagflation trap.",
+            "url": "https://nerranetwork.com/blog/modern_investing/ep042.html",
+        },
+        {
+            "name": "M&A", "slug": "models_agents", "emoji": "🤖",
+            "hook": "Vision Banana redefines computer vision.",
+            "url": "https://nerranetwork.com/blog/models_agents/ep020.html",
+        },
+    ]
+    out = nt._build_cross_network_html(siblings, "#E31937")
+    assert "Across the Nerra Network" in out
+    assert "MIT" in out
+    assert "Oil hit" in out
+    assert "M&amp;A" not in out  # name passes through; only hook is escaped
+    # Both URLs present.
+    assert "ep042.html" in out
+    assert "ep020.html" in out
+
+
+def test_cross_network_caps_at_three():
+    siblings = [
+        {"name": f"S{i}", "hook": "h", "url": "", "emoji": ""}
+        for i in range(5)
+    ]
+    out = nt._build_cross_network_html(siblings, "#000")
+    assert ">S0<" in out and ">S2<" in out
+    assert ">S3<" not in out
+
+
+def test_cross_network_skips_blank_rows():
+    siblings = [
+        {"name": "", "hook": "h", "url": "", "emoji": ""},
+        {"name": "OK", "hook": "h", "url": "", "emoji": ""},
+    ]
+    out = nt._build_cross_network_html(siblings, "#000")
+    assert ">OK<" in out
+
+
+def test_cross_network_empty_renders_nothing():
+    assert nt._build_cross_network_html([], "#000") == ""
+    assert nt._build_cross_network_html(None, "#000") == ""
+
+
+def test_cross_network_html_escapes_hook():
+    siblings = [
+        {"name": "X", "hook": "<i>tag</i>", "url": "", "emoji": ""},
+    ]
+    out = nt._build_cross_network_html(siblings, "#000")
+    assert "<i>tag</i>" not in out
+    assert "&lt;i&gt;tag&lt;/i&gt;" in out
+
+
+# ---------------------------------------------------------------------------
+# Reply / share row
+# ---------------------------------------------------------------------------
+
+def test_reply_share_renders_three_intents():
+    show = nt._load_show_branding("tesla")
+    out = nt._build_reply_share_html(show)
+    assert "Reply to this email" in out
+    assert "Share on X" in out
+    assert "Share on LinkedIn" in out
+    assert "Share on WhatsApp" in out
+    # Twitter intent uses query params.
+    assert "twitter.com/intent/tweet" in out
+    assert "linkedin.com/sharing" in out
+    assert "wa.me" in out
+
+
+def test_reply_share_uses_show_page_when_no_archive_url():
+    show = nt._load_show_branding("tesla")
+    out = nt._build_reply_share_html(show)
+    # Show page is URL-encoded inside the share intent.
+    assert "tesla" in out
+
+
+# ---------------------------------------------------------------------------
+# wrap_with_branding — full block ordering with featured + cross-network
+# ---------------------------------------------------------------------------
+
+def test_wrap_with_branding_full_render_order_with_engagement_blocks():
+    """All optional blocks composed in the documented order."""
+    out = nt.wrap_with_branding(
+        "tesla", "## Body content\n\nLorem ipsum.",
+        week_ending=datetime.date(2026, 4, 30),
+        preheader="Inbox preview teaser",
+        by_the_numbers=[{"value": "$372", "label": "TSLA close"}],
+        featured_episode={
+            "episode_num": 100, "hook": "Cybercab begins",
+            "date": "2026-04-30", "show_slug": "tesla",
+        },
+        p_s="One more thing.",
+        adjacent_shows=[
+            {"name": "MIT", "hook": "Oil at $126", "url": "", "emoji": "📈"},
+        ],
+        show_reply_share=True,
+        requires_financial_disclaimer=False,
+    )
+    pre = out.find("Inbox preview teaser")
+    hero = out.find("Tesla Shorts Time")
+    stats = out.find("TSLA close")
+    featured = out.find("10 minutes")
+    body = out.find("## Body content")
+    p_s = out.find("One more thing.")
+    cross = out.find("Across the Nerra Network")
+    share = out.find("Share on X")
+    foot = out.find("Listen to the podcast")
+    # Documented block order (preheader → hero → stats → featured →
+    # body → p_s → cross-network → reply/share → footer).
+    assert 0 <= pre < hero < stats < featured < body < p_s < cross < share < foot
+
+
+def test_wrap_with_branding_omits_engagement_blocks_by_default():
+    """Backward-compat: existing callers that don't pass the new
+    fields get exactly what they got before (no surprise blocks)."""
+    out = nt.wrap_with_branding(
+        "tesla", "## Body\n\nx",
+        week_ending=datetime.date(2026, 4, 30),
+        show_reply_share=False,
+    )
+    assert "10 minutes" not in out
+    assert "Across the Nerra Network" not in out
+    assert "Share on X" not in out
+
+
+def test_wrap_with_branding_show_reply_share_default_is_on():
+    """Reply/share row is on by default — it's a near-zero-cost
+    engagement boost we want every newsletter to have."""
+    out = nt.wrap_with_branding(
+        "tesla", "## Body\n\nx",
+        week_ending=datetime.date(2026, 4, 30),
+    )
+    assert "Reply to this email" in out


### PR DESCRIPTION
## Summary

Reopens the engagement-layer + mobile/dark-mode/a11y work from the closed PR-B (#274) and merged-into-PR-B PR-C (#275). PR-B was auto-closed when PR-A (#273) merged and its base branch was deleted; PR-C was merged into PR-B's branch (not main), so its content also went with it. This PR rebases both onto the current `main` so the work actually lands.

**Two commits, cleanly rebased onto main:**

1. `Newsletter engagement layer: featured ep, deep links, share row` (was #274)
2. `Newsletter mobile + dark mode + a11y polish` (was #275)

## What changed

### Engagement layer (was PR-B)
- **Featured episode block** ("If you only have 10 minutes this week") under the by-the-numbers tiles. Synthesizer picks the most-recent episode with a non-empty hook; CTA links to `/blog/<slug>/ep<NNN>.html`.
- **Per-episode deep links in body.** Synthesizer prepends an episode reference table to the LLM prompt — no URL hallucinations.
- **"Across the Nerra Network" module** between body and footer. Pulls top-of-week story from up to 3 sibling shows (per-show pinned + network-wide fallback in `_defaults.yaml`).
- **Reply / share row** above footer CTAs: X / LinkedIn / WhatsApp share intents.

### Mobile + dark mode + a11y (was PR-C)
- **Markdown tables → inline-styled HTML tables** so MIT scoreboard / Privet vocab tables survive Outlook 2019, Yahoo, and ProtonMail.
- **Dark-mode `@media` block** for Apple Mail iOS/macOS.
- **Cover image alt text** upgraded from `"<Show> cover"` to `"<Show> — <tagline>"` per WCAG 2.1.

## Test plan

- [x] Clean rebase onto current `main` (no conflicts)
- [x] `pytest` — **1420 passed**, 3 skipped
- [x] `ruff check` — clean on all changed files
- [ ] On next live weekly send, eyeball: featured episode CTA, cross-network adjacencies, MIT table on Outlook, dark mode on Apple Mail iOS

https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016LABsE7JMXqchqdPuFptF9)_