### PR TITLE
Migrate LLM default to grok-4.3 for ~55% per-episode cost reduction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,3 +256,15 @@ decision); everything else has a live status card.
     were trialled and removed. All shows use ElevenLabs `eleven_flash_v2_5`.
 12. **Summaries JSONs moved** — all summaries live in per-show subdirectories
     (`digests/<show>/summaries_*.json`), not at the `digests/` top level.
+13. **LLM default migrated to `grok-4.3` (May 2026)** — released 2026-04-30,
+    always-on reasoning, $1.25/$2.50 per 1M tokens (~55% cheaper per
+    episode than the previous `grok-4.20-*` defaults). Network default,
+    synth model, and Tesla / Modern Investing per-show overrides all now
+    inherit `grok-4.3` from [`shows/_defaults.yaml`](shows/_defaults.yaml).
+    Refusal fallback stays on `grok-4.20-reasoning` so refusals genuinely
+    switch model snapshot. Tool-use path in `digests/xai_grok.py` (X /
+    web search via the Responses API) still defaults to
+    `grok-4.20-non-reasoning` until 4.3 + tool calls are verified
+    end-to-end. Pricing for the historical 4.20 family is retained in
+    `engine/tracking.py` so old `credit_usage_*.json` files still cost
+    out correctly.

--- a/docs/llm_model_audit.md
+++ b/docs/llm_model_audit.md
@@ -9,6 +9,21 @@
 > recommended" items remain deliberately unimplemented. The inventory
 > below describes the state *before* those changes; current state is
 > captured in `shows/_defaults.yaml` and the show YAMLs.
+>
+> **2026-05-01 update — Grok 4.3 migration (branch
+> `claude/review-grok-model-7wx4c`):** xAI released `grok-4.3` on
+> 2026-04-30 with always-on reasoning at **$1.25 / $2.50 per 1M
+> tokens** (vs. the entire `grok-4.20-*` family at $2 / $6). The
+> network default, synth model, and the Tesla / Modern Investing
+> per-show overrides were all flipped to `grok-4.3`. This collapses
+> recommendations §7.4 (A/B reasoning on Tesla / MIT) and §7.6 (widen
+> synthesiser to reasoning variant) into a single drop-in upgrade
+> that is also ~55% cheaper per episode. Refusal fallback stays on
+> `grok-4.20-reasoning` so a refusal genuinely switches snapshot.
+> The tool-use path in `digests/xai_grok.py` (Responses API with
+> `web_search` / `x_search` built-in tools) still defaults to
+> `grok-4.20-non-reasoning` pending end-to-end verification that
+> grok-4.3 supports those tools through the Responses endpoint.
 
 ---
 

--- a/engine/config.py
+++ b/engine/config.py
@@ -37,7 +37,7 @@ class XAccountConfig:
 @dataclass
 class LLMConfig:
     provider: str = "xai"
-    model: str = "grok-4.20-non-reasoning"
+    model: str = "grok-4.3"
     system_prompt_file: str = ""
     digest_prompt_file: str = ""
     podcast_prompt_file: str = ""
@@ -50,12 +50,12 @@ class LLMConfig:
     # Model used when the primary refuses after educational retry. A
     # different model (or different variant of the same family) often
     # has different refusal thresholds and can succeed where the primary
-    # won't. Keeping this in the same pricing tier as the primary avoids
-    # cost spikes on refusal.
+    # won't. Pointing back at the older 4.20-reasoning ensures the chain
+    # actually switches snapshots on a refusal of grok-4.3.
     fallback_model: str = "grok-4.20-reasoning"
     # Synthesizer (weekly newsletter, monthly report, cross-show briefing)
     # defaults. Empty synth_model means "use model".
-    synth_model: str = "grok-4.20-reasoning"
+    synth_model: str = "grok-4.3"
     synth_max_tokens: int = 8000
     synth_temperature: float = 0.4
     # Episode quality reviewer defaults. Fast/cheap variant is appropriate

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -40,7 +40,9 @@ class LLMRefusalError(RuntimeError):
 # after educational prompt retry.  A different model often has different
 # refusal thresholds and can succeed where the primary model won't.
 # Kept for back-compat and for call sites that don't have a config loaded;
-# prefer ``config.llm.fallback_model`` where possible.
+# prefer ``config.llm.fallback_model`` where possible. Points at the older
+# grok-4.20-reasoning so a refusal switches model family/snapshot rather
+# than re-asking the same primary (grok-4.3).
 _LLM_FALLBACK_MODEL = "grok-4.20-reasoning"
 
 
@@ -86,7 +88,7 @@ def _get_api_key() -> str:
 def _call_grok(
     prompt: str,
     *,
-    model: str = "grok-4.20-non-reasoning",
+    model: str = "grok-4.3",
     system_prompt: Optional[str] = None,
     temperature: float = 0.7,
     max_tokens: int = 3500,

--- a/engine/synthesizer.py
+++ b/engine/synthesizer.py
@@ -228,7 +228,7 @@ def _network_synth_defaults() -> tuple[str, int, float]:
     """
     import yaml
 
-    model = "grok-4.20-reasoning"
+    model = "grok-4.3"
     max_tokens = 8000
     temperature = 0.4
     defaults_path = Path("shows/_defaults.yaml")
@@ -399,7 +399,7 @@ def _pick_featured_episode(
 def _cfg_synth_params(cfg, default_max_tokens: int, default_temperature: float) -> tuple[str, int, float]:
     """Return the per-show synthesiser params, falling back to show's model."""
     llm = getattr(cfg, "llm", None)
-    model = getattr(llm, "synth_model", "") or getattr(llm, "model", "") or "grok-4.20-reasoning"
+    model = getattr(llm, "synth_model", "") or getattr(llm, "model", "") or "grok-4.3"
     max_tokens = getattr(llm, "synth_max_tokens", 0) or default_max_tokens
     temperature = getattr(llm, "synth_temperature", 0.0) or default_temperature
     return model, max_tokens, temperature

--- a/engine/tracking.py
+++ b/engine/tracking.py
@@ -23,11 +23,17 @@ ELEVENLABS_COST_PER_1K_CHARS = 0.15  # Flash v2.5: 0.5 credits/char = $0.15/1K c
 # ids (grok-2, grok-3, grok-3-mini, grok-4.20-0309-*) were pruned April 2026
 # once the audit confirmed no live call site resolves to them.
 GROK_PRICING = {
-    # Grok 4 (previous refusal fallback — retained because historical
+    # Grok 4.3 — current network default (released 2026-04-30). Always-on
+    # reasoning, 1M context, ~37% cheaper input and ~58% cheaper output
+    # than grok-4.20 at the same or better intelligence tier.
+    "grok-4.3": {"input_per_1m": 1.25, "output_per_1m": 2.50},
+    # Grok 4 (legacy refusal fallback — retained because older
     # credit_usage JSONs still report it, and _estimate_grok_cost may be
     # re-run against them).
     "grok-4": {"input_per_1m": 3.00, "output_per_1m": 15.00},
-    # Grok 4.20 — current production family
+    # Grok 4.20 — superseded by 4.3 as default but retained because
+    # historical credit_usage JSONs reference these ids and the multi-agent
+    # variant is still used for the tool-use (web/x_search) path.
     "grok-4.20-non-reasoning": {"input_per_1m": 2.00, "output_per_1m": 6.00},
     "grok-4.20-reasoning": {"input_per_1m": 2.00, "output_per_1m": 6.00},
     "grok-4.20-multi-agent": {"input_per_1m": 2.00, "output_per_1m": 6.00},

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -10,19 +10,26 @@
 
 llm:
   provider: xai
-  model: grok-4.20-non-reasoning
+  # Grok 4.3 (released 2026-04-30) — always-on reasoning, $1.25/$2.50 per
+  # 1M tokens (vs grok-4.20 at $2/$6). ~55% cheaper per episode at higher
+  # intelligence tier; supersedes the previous grok-4.20-non-reasoning
+  # default and the grok-4.20-reasoning override on Tesla / Modern
+  # Investing (reasoning is no longer a separate variant).
+  model: grok-4.3
   digest_temperature: 0.5
   podcast_temperature: 0.7
   max_tokens: 3500
   podcast_max_tokens: 8000
   min_podcast_words: 1500
   podcast_chain: false
-  # Refusal fallback — same price as the primary, different refusal
-  # thresholds. Replaces the previous grok-4 fallback (2.5x output cost).
+  # Refusal fallback — keep on the older 4.20-reasoning variant so a
+  # refusal genuinely switches model family/training-snapshot rather than
+  # retrying the same model. Still cheaper than the historical grok-4
+  # fallback ($3/$15) we replaced in April 2026.
   fallback_model: grok-4.20-reasoning
   # Synthesizer (weekly newsletter, monthly report, cross-show briefing).
-  # Reasoning variant is same-price, benefits longer-form synthesis.
-  synth_model: grok-4.20-reasoning
+  # Inherits the cheaper, smarter primary by default.
+  synth_model: grok-4.3
   synth_max_tokens: 8000
   synth_temperature: 0.4
   # Episode quality reviewer — fast/cheap variant, headroom for critique.

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -127,12 +127,12 @@ keywords:
 
 llm:
   provider: xai
-  # Reasoning variant — same price as the non-reasoning primary ($2/$6 per
-  # 1M tokens), better factual grounding for a show that reports on live
-  # markets, central-bank policy, and numerical data.
-  model: grok-4.20-reasoning
-  # Refusal fallback points back at the non-reasoning variant so the chain
-  # actually switches models on a refusal (default would equal `model`).
+  # Inherits grok-4.3 from _defaults.yaml. Modern Investing previously
+  # pinned grok-4.20-reasoning for factual grounding on live markets,
+  # central-bank policy, and numerical data; grok-4.3 has always-on
+  # reasoning at lower cost so we no longer need the per-show override.
+  # Refusal fallback points at a different family so the chain actually
+  # switches models on a refusal (default would equal `model`).
   fallback_model: grok-4.20-non-reasoning
   system_prompt_file: shows/prompts/modern_investing_system.txt
   digest_prompt_file: shows/prompts/modern_investing_digest.txt

--- a/shows/templates/show_template.yaml
+++ b/shows/templates/show_template.yaml
@@ -62,7 +62,7 @@ keywords:
 # ---------------------------------------------------------------------------
 llm:
   provider: xai
-  # model: inherited from _defaults.yaml (grok-4.20-non-reasoning)
+  # model: inherited from _defaults.yaml (grok-4.3)
   digest_prompt_file: shows/prompts/{slug}_digest.txt
   podcast_prompt_file: shows/prompts/{slug}_podcast.txt
   digest_temperature: 0.5          # Lower = more factual/consistent. 0.4-0.6 for news.

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -109,12 +109,12 @@ keywords:
 
 llm:
   provider: xai
-  # Reasoning variant — same price as the non-reasoning primary ($2/$6 per
-  # 1M tokens), better step-by-step grounding for a show that mixes live
-  # stock data, FSD claims, and corporate announcements.
-  model: grok-4.20-reasoning
-  # Refusal fallback points back at the non-reasoning variant so the chain
-  # actually switches models on a refusal (default would equal `model`).
+  # Inherits grok-4.3 from _defaults.yaml. Tesla previously pinned
+  # grok-4.20-reasoning for step-by-step grounding on live market data
+  # and FSD claims; grok-4.3 has always-on reasoning at lower cost so
+  # we no longer need the per-show override.
+  # Refusal fallback points at a different family so the chain actually
+  # switches models on a refusal (default would equal `model`).
   fallback_model: grok-4.20-non-reasoning
   system_prompt_file: shows/prompts/tesla_system.txt
   digest_prompt_file: shows/prompts/tesla_digest.txt

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -167,7 +167,7 @@ class TestDefaultValues:
     def test_llm_defaults(self):
         c = LLMConfig()
         assert c.provider == "xai"
-        assert c.model == "grok-4.20-non-reasoning"
+        assert c.model == "grok-4.3"
         assert c.system_prompt_file == ""
         assert c.digest_prompt_file == ""
         assert c.podcast_prompt_file == ""
@@ -391,9 +391,10 @@ class TestLoadConfigRealFiles:
         assert cfg.sources[0].label == "Teslarati"
         assert "tsla" in cfg.keywords
         assert len(cfg.web_search_queries) == 4
-        # Tesla uses the reasoning variant for factual grounding on live
-        # market data — same price as the non-reasoning default.
-        assert cfg.llm.model == "grok-4.20-reasoning"
+        # Tesla inherits the network default (grok-4.3) — always-on
+        # reasoning at lower cost than the previous grok-4.20-reasoning
+        # override.
+        assert cfg.llm.model == "grok-4.3"
         assert cfg.llm.digest_temperature == 0.5
         assert cfg.llm.podcast_temperature == 0.7
         assert cfg.tts.voice_id == "dTrBzPvD2GpAqkk1MUzA"
@@ -410,7 +411,7 @@ class TestLoadConfigRealFiles:
         assert len(cfg.sources) == 25
         assert cfg.sources[0].label == "NASA Breaking"
         assert "space" in cfg.keywords
-        assert cfg.llm.model == "grok-4.20-non-reasoning"
+        assert cfg.llm.model == "grok-4.3"
         assert cfg.tts.voice_id == "dTrBzPvD2GpAqkk1MUzA"
         assert cfg.audio.music_file == "assets/music/fascinatingfrontiers.mp3"
         assert cfg.audio.background_music_file == "assets/music/fascinatingfrontiers_bg.mp3"
@@ -439,7 +440,7 @@ class TestLoadConfigRealFiles:
         assert len(cfg.sources) == 28
         assert cfg.sources[0].label == "NPR"
         assert "election" in cfg.keywords
-        assert cfg.llm.model == "grok-4.20-non-reasoning"
+        assert cfg.llm.model == "grok-4.3"
         assert cfg.llm.digest_temperature == 0.5
         assert cfg.llm.max_tokens == 4000
         assert cfg.tts.stability == 0.5
@@ -459,7 +460,7 @@ class TestLoadConfigRealFiles:
         assert cfg.sources[0].label == "BC Ministry of Environment"
         assert "contaminated sites" in cfg.keywords
         assert "CCME" in cfg.keywords
-        assert cfg.llm.model == "grok-4.20-non-reasoning"
+        assert cfg.llm.model == "grok-4.3"
         assert cfg.llm.digest_temperature == 0.5
         assert cfg.tts.voice_id == "dTrBzPvD2GpAqkk1MUzA"
         assert cfg.tts.stability == 0.5  # Normalized to network standard

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -819,13 +819,15 @@ class TestSystemPrompts:
         sp_path = Path(config.llm.system_prompt_file)
         assert sp_path.exists(), f"System prompt file not found: {sp_path}"
 
-    def test_all_shows_use_grok420(self, show_slug):
-        """All shows should use a current grok-4.20 variant.
+    def test_all_shows_use_current_grok(self, show_slug):
+        """All shows should use a currently-blessed Grok model.
 
-        Both ``grok-4.20-non-reasoning`` (default across the network) and
-        ``grok-4.20-reasoning`` (same price, used for fact-heavy shows like
-        Tesla and Modern Investing) are acceptable. The assertion exists to
-        block drift to older/unapproved models.
+        ``grok-4.3`` (network default since 2026-05-01, always-on reasoning,
+        $1.25/$2.50 per 1M tokens) is the canonical choice. The older
+        ``grok-4.20-non-reasoning`` / ``grok-4.20-reasoning`` are tolerated
+        during the rollout window but should be removed once every show is
+        confirmed running cleanly on 4.3. The assertion exists to block
+        drift to older/unapproved models (e.g. grok-3, grok-2).
         """
         from engine.config import load_config
 
@@ -833,7 +835,11 @@ class TestSystemPrompts:
         if not config_path.exists():
             pytest.skip(f"Config not found: {config_path}")
 
-        allowed = {"grok-4.20-non-reasoning", "grok-4.20-reasoning"}
+        allowed = {
+            "grok-4.3",
+            "grok-4.20-non-reasoning",
+            "grok-4.20-reasoning",
+        }
         config = load_config(config_path)
         assert config.llm.model in allowed, (
             f"{show_slug} should use one of {sorted(allowed)}, "

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -323,6 +323,23 @@ class TestGrokPricing:
         assert "grok-4.20-non-reasoning" in GROK_PRICING
         assert "grok-4.20-reasoning" in GROK_PRICING
 
+    def test_grok43_pricing_exists(self):
+        """grok-4.3 is the current network default (since 2026-05-01)."""
+        assert "grok-4.3" in GROK_PRICING
+        assert GROK_PRICING["grok-4.3"]["input_per_1m"] == 1.25
+        assert GROK_PRICING["grok-4.3"]["output_per_1m"] == 2.50
+
+    def test_grok43_cheaper_than_grok420(self):
+        """The whole point of switching to grok-4.3 is cost savings."""
+        assert (
+            GROK_PRICING["grok-4.3"]["input_per_1m"]
+            < GROK_PRICING["grok-4.20-non-reasoning"]["input_per_1m"]
+        )
+        assert (
+            GROK_PRICING["grok-4.3"]["output_per_1m"]
+            < GROK_PRICING["grok-4.20-non-reasoning"]["output_per_1m"]
+        )
+
     def test_reviewer_model_priced(self):
         """Reviewer model must have pricing so its cost is attributed."""
         assert "grok-4-1-fast-non-reasoning" in GROK_PRICING


### PR DESCRIPTION
## Summary

xAI released **`grok-4.3`** on **2026-04-30** at **$1.25 / $2.50 per 1M tokens** (vs the entire `grok-4.20-*` family at **$2 / $6**), with always-on reasoning, a 1M context window, and ~206 tok/s output. This PR migrates the network default to `grok-4.3` and drops the per-show overrides on Tesla / Modern Investing.

**Cost impact (per episode, ~4k input + 6k output):** $0.044 → $0.020 — **~55% reduction**.

**Strategic bonus:** this collapses two open recommendations from the April 2026 audit (`docs/llm_model_audit.md`) into a single drop-in upgrade:
- §7.4 — A/B the reasoning variant on Tesla / Modern Investing → `grok-4.3` is reasoning by default
- §7.6 — Widen synthesiser to a reasoning model → `synth_model` now defaults to `grok-4.3`

## Changes

- **`engine/tracking.py`** — added `grok-4.3` to `GROK_PRICING` at `$1.25 / $2.50`. The historical `grok-4.20-*` entries are retained because old `credit_usage_*.json` files still reference them and `_estimate_grok_cost` may be re-run against them.
- **`shows/_defaults.yaml` + `engine/config.py`** — flipped network default `model` and `synth_model` to `grok-4.3`.
- **`shows/tesla.yaml` + `shows/modern_investing.yaml`** — removed the `grok-4.20-reasoning` per-show override; both shows now inherit `grok-4.3` from defaults. `fallback_model` overrides on these two are preserved (they intentionally point at a different family snapshot for refusal recovery).
- **`engine/generator.py` + `engine/synthesizer.py`** — updated hard-coded defaults that fire when no config is loaded.
- **Refusal fallback** stays on `grok-4.20-reasoning` so a refusal genuinely switches snapshot rather than retrying the same primary.
- **`digests/xai_grok.py`** (Responses API tool-use path with `web_search` / `x_search`) is **unchanged** pending end-to-end verification that grok-4.3 supports those built-in tools through the Responses endpoint.
- **Tests** — `test_integration.py` allowlist accepts `grok-4.3` alongside the 4.20 variants (rollout window). `test_config.py` updated for new defaults + per-show assertions. `test_tracking.py` adds two assertions: `grok-4.3` is in the pricing table, and is strictly cheaper than `grok-4.20-non-reasoning`.
- **Docs** — `CLAUDE.md` adds landmine #13 documenting the migration; `docs/llm_model_audit.md` adds a 2026-05-01 update note.

## Verification

All 10 shows resolve to `grok-4.3` after the migration:

```
tesla                          model=grok-4.3   fallback=grok-4.20-non-reasoning
omni_view                      model=grok-4.3   fallback=grok-4.20-reasoning
fascinating_frontiers          model=grok-4.3   fallback=grok-4.20-reasoning
planetterrian                  model=grok-4.3   fallback=grok-4.20-reasoning
env_intel                      model=grok-4.3   fallback=grok-4.20-reasoning
models_agents                  model=grok-4.3   fallback=grok-4.20-reasoning
models_agents_beginners        model=grok-4.3   fallback=grok-4.20-reasoning
finansy_prosto                 model=grok-4.3   fallback=grok-4.20-reasoning
privet_russian                 model=grok-4.3   fallback=grok-4.20-reasoning
modern_investing               model=grok-4.3   fallback=grok-4.20-non-reasoning
```

## Test plan

- [x] `pytest tests/test_tracking.py tests/test_config.py` — 92 / 92 pass
- [x] `pytest tests/test_integration.py -k test_all_shows_use_current_grok` — 10 / 10 pass
- [x] `pytest tests/test_tracking.py tests/test_config.py tests/test_utils.py tests/test_rss.py tests/test_audio_commands.py tests/test_dashboard_mit_section.py` — 300 / 300 pass
- [ ] Run `tesla` show end-to-end against the live xAI API to confirm grok-4.3 is reachable through the OpenAI-compatible client (`base_url=https://api.x.ai/v1`) and that the `temperature` parameter is honored — sandbox here can't hit the real API
- [ ] Spot-check first post-migration episode of Tesla / Modern Investing for quality drift (these were on the reasoning variant for factual grounding)
- [ ] Once stable for a few days, narrow the `test_all_shows_use_current_grok` allowlist to `{"grok-4.3"}` only, removing the rollout-window tolerance
- [ ] Verify whether `digests/xai_grok.py` Responses-API path can be migrated to grok-4.3 (separate follow-up)

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_