### PR TITLE
Switch Russian shows from ElevenLabs to Grok TTS (Olya voice, ~36× cheaper)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,9 @@ Automated daily podcast generation system running 10 shows via a unified
 | Env Intel | — | `shows/env_intel.yaml` | Odd weekdays | `@teslashortstime` | ElevenLabs |
 | Models & Agents | — | `shows/models_agents.yaml` | Odd days | — (X disabled) | ElevenLabs |
 | Models & Agents for Beginners | — | `shows/models_agents_beginners.yaml` | Even days | — (X disabled) | ElevenLabs |
-| Финансы Просто | — | `shows/finansy_prosto.yaml` | Even days | — (X disabled) | ElevenLabs |
+| Финансы Просто | — | `shows/finansy_prosto.yaml` | Even days | — (X disabled) | Grok TTS (Olya) |
 | Modern Investing Techniques | — | `shows/modern_investing.yaml` | Weekdays | — (X disabled) | ElevenLabs |
-| Привет, Русский! | — | `shows/privet_russian.yaml` | Even days | — (X disabled) | ElevenLabs |
+| Привет, Русский! | — | `shows/privet_russian.yaml` | Even days | — (X disabled) | Grok TTS (Olya) |
 
 **Science That Changes Everything** (`digests/science_that_changes.py`, ~83 lines)
 is a standalone X-posting script, not a podcast show.
@@ -139,7 +139,7 @@ nerranetworks/
 - `GROK_API_KEY` — primary xAI key (all shows)
 - `ELEVENLABS_API_KEY` — ElevenLabs TTS (all shows)
 - `X_*` / `PLANETTERRIAN_X_*` — two separate X accounts
-- Voice IDs: All English shows share `dTrBzPvD2GpAqkk1MUzA`, Russian shows (FP/PR) use `gedzfqL7OGdPbwm0ynTP`
+- Voice IDs: English shows share ElevenLabs voice `dTrBzPvD2GpAqkk1MUzA`. Russian shows (FP/PR) use the **Grok TTS** custom voice `0b875ae2` ("Olya") since May 2026 — see landmine #16.
 - See `docs/env_var_inventory.md` for the complete inventory
 
 ### RSS Feeds
@@ -252,8 +252,14 @@ decision); everything else has a live status card.
    reintroduced without updating `_defaults.yaml`.
 10. **Early episodes deleted** — first 20 Tesla, 10 FF, 10 PT, 10 OV episodes
     removed (quality issues). RSS entries removed where applicable.
-11. **All shows use ElevenLabs TTS** — Chatterbox, Kokoro, and Fish Audio
-    were trialled and removed. All shows use ElevenLabs `eleven_flash_v2_5`.
+11. **English shows use ElevenLabs TTS; Russian shows use Grok TTS (May
+    2026)** — Chatterbox, Kokoro, and Fish Audio were trialled and removed.
+    English shows still use ElevenLabs `eleven_flash_v2_5` (voice
+    `dTrBzPvD2GpAqkk1MUzA`). Russian shows (Финансы Просто, Привет
+    Русский!) migrated to xAI's Grok TTS (`/v1/tts`, voice `0b875ae2`
+    "Olya") for the same persona at ~36× lower per-character cost
+    ($4.20/M vs $150/M for Flash). Reuses `GROK_API_KEY` / `XAI_API_KEY`
+    — no new secret. See landmine #16.
 12. **Summaries JSONs moved** — all summaries live in per-show subdirectories
     (`digests/<show>/summaries_*.json`), not at the `digests/` top level.
 13. **LLM default migrated to `grok-4.3` (May 2026)** — released 2026-04-30,
@@ -296,3 +302,20 @@ decision); everything else has a live status card.
     Data API has no endpoint for this flag. Once flagged once, every
     future video added via the API automatically becomes a podcast
     episode. **One-time setup per playlist — not a code change.**
+16. **Russian shows on Grok TTS, not ElevenLabs (May 2026)** — Финансы
+    Просто and Привет, Русский! switched their `tts.provider` from
+    `elevenlabs` to `grok` and their voice ID from
+    `gedzfqL7OGdPbwm0ynTP` to `0b875ae2` (custom "Olya" voice trained on
+    the xAI Console). Same on-air persona, ~36× cheaper per character
+    ($4.20/M vs $150/M for ElevenLabs Flash v2.5). Implementation
+    details: `engine/tts.py:synthesize()` dispatches on the new
+    `provider` kwarg; the Grok path posts to `https://api.x.ai/v1/tts`
+    and reuses `GROK_API_KEY` / `XAI_API_KEY` (no new secret). Voice
+    settings that are ElevenLabs-only (`stability`, `similarity_boost`,
+    `style`, `use_speaker_boost`, `model`, `speed`) are intentionally
+    absent from the two Russian YAMLs because Grok TTS doesn't expose
+    them. Pricing is per-provider in
+    [`engine/tracking.py`](engine/tracking.py): `TTS_PROVIDER_PRICING`.
+    The `test_russian_shows_use_grok_tts` test in
+    [`tests/test_tts_grok.py`](tests/test_tts_grok.py) blocks accidental
+    rollback to the old ElevenLabs voice.

--- a/engine/tracking.py
+++ b/engine/tracking.py
@@ -15,8 +15,18 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-# TTS pricing per 1000 characters
-ELEVENLABS_COST_PER_1K_CHARS = 0.15  # Flash v2.5: 0.5 credits/char = $0.15/1K chars
+# TTS pricing per 1000 characters, by provider.
+# - ElevenLabs Flash v2.5: $0.15/1K chars  (0.5 credits/char × $0.30/1K credits)
+# - Grok TTS (xAI /v1/tts): $0.0042/1K chars ($4.20 per 1M chars, ~36× cheaper
+#   than ElevenLabs Flash; introduced April 2026, used for the Russian shows
+#   since May 2026).
+ELEVENLABS_COST_PER_1K_CHARS = 0.15
+GROK_TTS_COST_PER_1K_CHARS = 0.0042
+
+TTS_PROVIDER_PRICING = {
+    "elevenlabs": ELEVENLABS_COST_PER_1K_CHARS,
+    "grok": GROK_TTS_COST_PER_1K_CHARS,
+}
 
 # xAI Grok pricing per 1M tokens (input/output).
 # Only models actually reachable by the current code are listed — historical
@@ -187,14 +197,18 @@ def save_usage(tracker: dict, output_dir: Path) -> Path | None:
         x_api = tracker["services"]["x_api"]
         x_api["total_calls"] = x_api["search_calls"] + x_api["post_calls"]
 
-        # TTS cost
+        # TTS cost — rate depends on provider (ElevenLabs vs Grok TTS;
+        # Grok is ~36× cheaper per character so the provider switch matters
+        # for accurate per-episode cost reporting).
         tts = tracker["services"]["tts_api"]
         provider = tts.get("provider", "elevenlabs")
-        tts["estimated_cost_usd"] = (
-            tts["characters"] / 1000
-        ) * ELEVENLABS_COST_PER_1K_CHARS
+        rate_per_1k = TTS_PROVIDER_PRICING.get(provider, ELEVENLABS_COST_PER_1K_CHARS)
+        tts["estimated_cost_usd"] = (tts["characters"] / 1000) * rate_per_1k
 
-        # Also keep legacy key for backward compatibility
+        # Also keep legacy key for backward compatibility (the dashboard
+        # historically read `services.elevenlabs_api`; we mirror the tts
+        # block under that key regardless of provider so that path keeps
+        # working).
         if "elevenlabs_api" not in tracker["services"]:
             tracker["services"]["elevenlabs_api"] = tts
 

--- a/engine/tts.py
+++ b/engine/tts.py
@@ -1,13 +1,20 @@
 """TTS helpers for the podcast generation pipeline.
 
-Uses **ElevenLabs** cloud API for all shows.
+Supports two providers, selected per-show via ``tts.provider``:
+
+  - **elevenlabs** (default for English shows) — `eleven_flash_v2_5` via the
+    streaming endpoint. Stability / similarity_boost / style settings.
+  - **grok** (Russian shows since May 2026) — xAI's `/v1/tts` endpoint at
+    ~36× lower per-character cost than ElevenLabs Flash. Reuses the
+    `GROK_API_KEY` / `XAI_API_KEY` env var already used for LLM calls.
 
 Public API:
-  - synthesize(): top-level entry point — text in, audio file out
-  - validate_elevenlabs_auth(): fail-fast API key check
+  - synthesize(): top-level entry point — text in, audio file out, picks
+    the provider on the *provider* kwarg
+  - validate_elevenlabs_auth(): fail-fast API key check (ElevenLabs only)
   - chunk_text(): sentence-aware text splitting for the configurable chunk limit
-  - speak_chunk(): single-chunk TTS with retry
-  - speak(): full TTS with automatic chunking + ffmpeg concatenation
+  - speak_chunk(): single-chunk ElevenLabs TTS with retry
+  - speak(): full ElevenLabs TTS with automatic chunking + ffmpeg concatenation
   - synthesize_sections(): section-aware synthesis (per-section files)
 """
 
@@ -28,6 +35,10 @@ from tenacity import (
 logger = logging.getLogger(__name__)
 
 ELEVENLABS_API_BASE = "https://api.elevenlabs.io/v1"
+GROK_TTS_ENDPOINT = "https://api.x.ai/v1/tts"
+# Grok caps per-request text at 15,000 chars; we use 14,000 as the chunk
+# ceiling to leave a small headroom for any trailing punctuation we add.
+GROK_MAX_CHARS_PER_REQUEST = 14000
 
 
 def _ffmpeg_escape(path: Path) -> str:
@@ -587,12 +598,251 @@ def _speak_with_model(
             pass
 
 
+# ---------------------------------------------------------------------------
+# Grok TTS (xAI /v1/tts)
+# ---------------------------------------------------------------------------
+
+class GrokTTSClientError(Exception):
+    """Non-retryable Grok TTS API error (4xx)."""
+
+    def __init__(self, message: str, status_code: int, body: str = ""):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+
+
+class _GrokTTSServerError(requests.HTTPError):
+    """Retryable Grok TTS server error (5xx / 429)."""
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    retry=retry_if_exception_type(
+        (requests.ConnectionError, requests.Timeout, _GrokTTSServerError),
+    ),
+)
+def grok_speak_chunk(
+    text: str,
+    voice_id: str,
+    out_path: Path,
+    *,
+    api_key: str,
+    language_code: str = "auto",
+    timeout: int = 120,
+) -> None:
+    """Generate audio for a single text chunk via the Grok ``/v1/tts`` endpoint.
+
+    Returns MP3 bytes by default (24 kHz / 128 kbps, per xAI docs). Retries
+    only on transient errors (timeouts, connection failures, 429/5xx). The
+    API key reuses ``GROK_API_KEY`` / ``XAI_API_KEY`` — the same one used
+    for LLM calls — so no new env var is needed.
+    """
+    if not text or not text.strip():
+        raise ValueError(
+            "grok_speak_chunk: text is empty — refusing to produce a silent chunk",
+        )
+    if len(text) > GROK_MAX_CHARS_PER_REQUEST + 1000:
+        # The API caps at 15k; we pre-chunk under that. If a caller bypassed
+        # chunking, fail loudly rather than truncating silently.
+        raise ValueError(
+            f"grok_speak_chunk: text length {len(text)} exceeds Grok's "
+            f"15,000-char per-request cap. Caller must chunk first.",
+        )
+
+    payload = {
+        "text": text,
+        "voice_id": voice_id,
+        "language": language_code or "auto",
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    with requests.post(
+        GROK_TTS_ENDPOINT, json=payload, headers=headers,
+        stream=True, timeout=timeout,
+    ) as r:
+        if r.status_code == 401:
+            raise GrokTTSClientError(
+                "Grok TTS returned 401 Unauthorized. Verify GROK_API_KEY / "
+                "XAI_API_KEY and that the voice_id is accessible.",
+                status_code=401,
+            )
+        if 400 <= r.status_code < 500 and r.status_code != 429:
+            body = r.text[:500]
+            logger.error(
+                "Grok TTS returned %d for chunk (%d chars): %s",
+                r.status_code, len(text), body,
+            )
+            raise GrokTTSClientError(
+                f"Grok TTS returned {r.status_code}: {body}",
+                status_code=r.status_code,
+                body=body,
+            )
+        if r.status_code == 429 or r.status_code >= 500:
+            body = r.text[:500]
+            logger.warning(
+                "Grok TTS returned %d (retryable) for chunk (%d chars): %s",
+                r.status_code, len(text), body,
+            )
+            raise _GrokTTSServerError(
+                f"Grok TTS returned {r.status_code}: {body}",
+                response=r,
+            )
+        r.raise_for_status()
+        with open(out_path, "wb") as f:
+            for data in r.iter_content(chunk_size=8192):
+                f.write(data)
+
+
+def _speak_with_grok(
+    text: str,
+    voice_id: str,
+    filename: str,
+    *,
+    api_key: str,
+    max_chars: int = GROK_MAX_CHARS_PER_REQUEST,
+    language_code: str = "auto",
+    timeout: int = 120,
+    append_exclamation: bool = False,
+) -> None:
+    """Grok-TTS counterpart of ``speak()``.
+
+    Same chunk → WAV → crossfade → final MP3 pipeline as the ElevenLabs
+    path. Single chunks short-circuit to a direct MP3 write (no re-encode).
+    """
+    text = prepare_text_for_tts(text)
+    # Cap at Grok's 15k-char request limit even when caller passes a
+    # higher max_chars (e.g. shows that inherited the ElevenLabs default).
+    effective_max = min(max_chars, GROK_MAX_CHARS_PER_REQUEST)
+    chunks = chunk_text(text, max_chars=effective_max)
+
+    if len(chunks) == 1:
+        out_text = chunks[0]
+        if append_exclamation:
+            out_text = out_text + "!"
+        grok_speak_chunk(
+            out_text, voice_id, Path(filename),
+            api_key=api_key, language_code=language_code, timeout=timeout,
+        )
+        logger.info("Grok TTS: Generated single chunk (%d chars)", len(out_text))
+        return
+
+    logger.info(
+        "Grok TTS: Splitting into %d chunks for seamless generation",
+        len(chunks),
+    )
+    import tempfile as _tmpmod
+    tmp_dir = Path(_tmpmod.mkdtemp(prefix="tts_grok_", dir=str(Path(filename).parent)))
+    chunk_files: List[Path] = []
+    wav_files: List[Path] = []
+    try:
+        for i, chunk_text_str in enumerate(chunks):
+            chunk_file = tmp_dir / f"tts_chunk_{i:03d}.mp3"
+            if append_exclamation:
+                if i < len(chunks) - 1:
+                    chunk_text_str = chunk_text_str.rstrip(".!?") + "."
+                else:
+                    chunk_text_str = chunk_text_str + "!"
+            grok_speak_chunk(
+                chunk_text_str, voice_id, chunk_file,
+                api_key=api_key, language_code=language_code, timeout=timeout,
+            )
+            chunk_files.append(chunk_file)
+            logger.info(
+                "Grok TTS: Generated chunk %d/%d (%d chars)",
+                i + 1, len(chunks), len(chunk_text_str),
+            )
+
+        # Decode each MP3 chunk to WAV for lossless concatenation, mirroring
+        # the ElevenLabs path. Output is mono 44.1 kHz to match the rest
+        # of the pipeline (Grok's default is 24 kHz; ffmpeg upsamples on
+        # decode and we re-encode once at the end).
+        for cf in chunk_files:
+            wav_file = cf.with_suffix(".wav")
+            subprocess.run(
+                ["ffmpeg", "-y", "-i", str(cf), "-ar", "44100", "-ac", "1", str(wav_file)],
+                check=True, capture_output=True, timeout=120,
+            )
+            wav_files.append(wav_file)
+
+        _XFADE_SECS = "0.05"
+        if len(wav_files) == 2:
+            merged_wav = tmp_dir / "tts_merged.wav"
+            subprocess.run(
+                [
+                    "ffmpeg", "-y",
+                    "-i", str(wav_files[0]), "-i", str(wav_files[1]),
+                    "-filter_complex", f"acrossfade=d={_XFADE_SECS}:c1=tri:c2=tri",
+                    str(merged_wav),
+                ],
+                check=True, capture_output=True, timeout=300,
+            )
+        else:
+            merged_wav = wav_files[0]
+            for idx in range(1, len(wav_files)):
+                step_out = tmp_dir / f"tts_xfade_{idx:03d}.wav"
+                subprocess.run(
+                    [
+                        "ffmpeg", "-y",
+                        "-i", str(merged_wav), "-i", str(wav_files[idx]),
+                        "-filter_complex", f"acrossfade=d={_XFADE_SECS}:c1=tri:c2=tri",
+                        str(step_out),
+                    ],
+                    check=True, capture_output=True, timeout=300,
+                )
+                merged_wav = step_out
+
+        subprocess.run(
+            [
+                "ffmpeg", "-y",
+                "-i", str(merged_wav),
+                "-c:a", "libmp3lame", "-q:a", "2",
+                str(filename),
+            ],
+            check=True, capture_output=True, timeout=300,
+        )
+        logger.info(
+            "Grok TTS: Concatenated %d chunks via WAV intermediates "
+            "(single MP3 encode)", len(chunks),
+        )
+    finally:
+        for cf in chunk_files + wav_files:
+            try:
+                if cf.exists():
+                    cf.unlink()
+            except Exception:
+                pass
+        for tmp_file in tmp_dir.glob("tts_xfade_*.wav"):
+            try:
+                tmp_file.unlink()
+            except Exception:
+                pass
+        for tmp_file in tmp_dir.glob("tts_merged.wav"):
+            try:
+                tmp_file.unlink()
+            except Exception:
+                pass
+        try:
+            if tmp_dir.exists() and tmp_dir != Path(filename).parent:
+                tmp_dir.rmdir()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Public entry points (provider-aware)
+# ---------------------------------------------------------------------------
+
 def synthesize(
     text: str,
     voice_id: str,
     output_path: str | Path,
     *,
     api_key: str,
+    provider: str = "elevenlabs",
     max_chars: int = 10000,
     model_id: str = "eleven_flash_v2_5",
     stability: float = 0.5,
@@ -606,10 +856,31 @@ def synthesize(
 ) -> Path:
     """Top-level entry point: text in, audio file path out.
 
+    *provider* picks the backend:
+
+      - ``"elevenlabs"`` (default) — uses the ElevenLabs streaming endpoint
+        with the full ElevenLabs voice-settings palette (stability /
+        similarity_boost / style / speed / model_id).
+      - ``"grok"`` — uses xAI's ``/v1/tts`` endpoint. Voice settings other
+        than ``language_code`` are ignored (Grok doesn't expose them).
+
     Handles chunking and concatenation internally so callers just pass
-    text and get back a path.  Always uses the ElevenLabs streaming endpoint.
+    text and get back a path.
     """
     output_path = Path(output_path)
+    if provider == "grok":
+        # Grok's "auto" detects language; explicit codes (e.g. "ru") are
+        # the safer choice for non-English shows.
+        _speak_with_grok(
+            text, voice_id, str(output_path),
+            api_key=api_key,
+            max_chars=max_chars,
+            language_code=language_code or "auto",
+            timeout=timeout,
+            append_exclamation=append_exclamation,
+        )
+        return output_path
+    # Default: ElevenLabs
     speak(
         text,
         voice_id,
@@ -635,6 +906,7 @@ def synthesize_sections(
     output_dir: Path,
     *,
     api_key: str,
+    provider: str = "elevenlabs",
     section_prefix: str = "section",
     max_chars: int = 10000,
     model_id: str = "eleven_flash_v2_5",
@@ -648,21 +920,24 @@ def synthesize_sections(
 ) -> List[Path]:
     """Synthesize multiple script sections into individual audio files.
 
-    Each section is synthesized via ``speak()`` (which handles chunking
-    internally for sections exceeding *max_chars*).  Returns an ordered
-    list of MP3 paths — one per section.  Always uses the ElevenLabs
-    streaming endpoint.
+    Each section is synthesized via the configured *provider* backend
+    (``elevenlabs`` or ``grok``), reusing the chunking / concatenation
+    pipeline of that provider. Returns an ordered list of MP3 paths —
+    one per section.
 
     Parameters
     ----------
     sections:
         Ordered list of text sections to synthesize.
     voice_id:
-        ElevenLabs voice ID.
+        Backend-specific voice ID. ElevenLabs uses 20-char alphanumeric
+        IDs; Grok uses the named voices (``eve``, ``ara``, etc.) or
+        custom 8-char alphanumeric IDs.
     output_dir:
         Directory for intermediate per-section MP3 files.
     api_key:
-        ElevenLabs API key.
+        ElevenLabs key for ``provider="elevenlabs"``; xAI / Grok key for
+        ``provider="grok"``.
     section_prefix:
         Filename prefix for section files.
     max_chars:
@@ -683,21 +958,32 @@ def synthesize_sections(
             continue
 
         section_path = output_dir / f"{section_prefix}_{i:03d}.mp3"
-        speak(
-            section_text,
-            voice_id,
-            str(section_path),
-            api_key=api_key,
-            max_chars=max_chars,
-            model_id=model_id,
-            stability=stability,
-            similarity_boost=similarity_boost,
-            style=style,
-            language_code=language_code,
-            speed=speed,
-            apply_text_normalization=apply_text_normalization,
-            timeout=timeout,
-        )
+        if provider == "grok":
+            _speak_with_grok(
+                section_text,
+                voice_id,
+                str(section_path),
+                api_key=api_key,
+                max_chars=max_chars,
+                language_code=language_code or "auto",
+                timeout=timeout,
+            )
+        else:
+            speak(
+                section_text,
+                voice_id,
+                str(section_path),
+                api_key=api_key,
+                max_chars=max_chars,
+                model_id=model_id,
+                stability=stability,
+                similarity_boost=similarity_boost,
+                style=style,
+                language_code=language_code,
+                speed=speed,
+                apply_text_normalization=apply_text_normalization,
+                timeout=timeout,
+            )
         section_files.append(section_path)
         logger.info(
             "Synthesized section %d/%d (%d chars): %s",

--- a/run_show.py
+++ b/run_show.py
@@ -219,14 +219,19 @@ def _preflight_checks(config, *, dry_run: bool = False) -> None:
             issues.append(f"Audio file not found: {path_str}")
 
     # Validate TTS provider name
-    if config.tts.provider != "elevenlabs":
-        issues.append(f"Unknown TTS provider: {config.tts.provider!r} (only 'elevenlabs' is supported)")
+    if config.tts.provider not in ("elevenlabs", "grok"):
+        issues.append(
+            f"Unknown TTS provider: {config.tts.provider!r} "
+            "(supported: 'elevenlabs', 'grok')"
+        )
 
-    # Check critical API key env vars are populated
-    if not os.environ.get("ELEVENLABS_API_KEY"):
+    # Check critical API key env vars are populated. For TTS, only require
+    # the key matching the configured provider — shows on Grok TTS don't
+    # need ELEVENLABS_API_KEY and vice versa.
+    if config.tts.provider == "elevenlabs" and not os.environ.get("ELEVENLABS_API_KEY"):
         issues.append("ELEVENLABS_API_KEY env var is empty or missing")
 
-    if not os.environ.get("GROK_API_KEY"):
+    if not (os.environ.get("GROK_API_KEY") or os.environ.get("XAI_API_KEY")):
         issues.append("GROK_API_KEY env var is empty or missing")
 
     # Validate numeric config bounds
@@ -1467,16 +1472,29 @@ def run(args: argparse.Namespace) -> None:
         tts_script_path.write_text(podcast_script, encoding="utf-8")
         logger.info("TTS script saved: %s", tts_script_path)
 
-        # 9. TTS — ElevenLabs
-        # 9. TTS — ElevenLabs
+        # 9. TTS — provider-aware (ElevenLabs default; Grok for Russian shows)
+        tts_provider = (config.tts.provider or "elevenlabs").lower()
         tts_ready = False
-        api_key = (os.getenv("ELEVENLABS_API_KEY") or "").strip()
-        if not api_key:
-            logger.error("ELEVENLABS_API_KEY not set. Skipping TTS.")
+        if tts_provider == "grok":
+            api_key = (
+                os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY") or ""
+            ).strip()
+            if not api_key:
+                logger.error("GROK_API_KEY (or XAI_API_KEY) not set. Skipping TTS.")
+            else:
+                from engine.tts import synthesize  # noqa: F401 (import below)
+                # No fail-fast auth ping for Grok TTS — the same key drives
+                # the LLM stage which has already validated upstream. A bad
+                # key would have failed the digest run before we reached TTS.
+                tts_ready = True
         else:
-            from engine.tts import synthesize, validate_elevenlabs_auth
-            validate_elevenlabs_auth(api_key)
-            tts_ready = True
+            api_key = (os.getenv("ELEVENLABS_API_KEY") or "").strip()
+            if not api_key:
+                logger.error("ELEVENLABS_API_KEY not set. Skipping TTS.")
+            else:
+                from engine.tts import synthesize, validate_elevenlabs_auth
+                validate_elevenlabs_auth(api_key)
+                tts_ready = True
 
         if tts_ready:
             raw_mp3 = digests_dir / f"{config.episode.prefix}_Ep{episode_num:03d}_{today:%Y%m%d}_raw.mp3"
@@ -1530,6 +1548,7 @@ def run(args: argparse.Namespace) -> None:
                         config.tts.voice_id,
                         section_tmp_dir,
                         api_key=api_key,
+                        provider=tts_provider,
                         section_prefix=f"sec_ep{episode_num:03d}",
                         max_chars=config.tts.max_chars,
                         model_id=config.tts.model,
@@ -1559,7 +1578,8 @@ def run(args: argparse.Namespace) -> None:
                     # Not enough sections — fall back to single synthesis
                     synthesize(
                         podcast_script, config.tts.voice_id, raw_mp3,
-                        api_key=api_key, max_chars=config.tts.max_chars,
+                        api_key=api_key, provider=tts_provider,
+                        max_chars=config.tts.max_chars,
                         model_id=config.tts.model, stability=config.tts.stability,
                         similarity_boost=config.tts.similarity_boost,
                         style=config.tts.style,
@@ -1570,7 +1590,8 @@ def run(args: argparse.Namespace) -> None:
             else:
                 synthesize(
                     podcast_script, config.tts.voice_id, raw_mp3,
-                    api_key=api_key, max_chars=config.tts.max_chars,
+                    api_key=api_key, provider=tts_provider,
+                    max_chars=config.tts.max_chars,
                     model_id=config.tts.model, stability=config.tts.stability,
                     similarity_boost=config.tts.similarity_boost,
                     style=config.tts.style,

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -170,12 +170,15 @@ llm:
   min_podcast_words: 1100
 
 tts:
-  voice_id: gedzfqL7OGdPbwm0ynTP
+  # Olya — Russian voice. Migrated from ElevenLabs (`gedzfqL7OGdPbwm0ynTP`)
+  # to xAI's Grok TTS (May 2026) for the same persona at ~36× lower
+  # per-character cost ($4.20/M vs $150/M). Reuses GROK_API_KEY /
+  # XAI_API_KEY — no new secret needed. ElevenLabs-specific voice
+  # settings (stability / similarity_boost / style / use_speaker_boost)
+  # are not exposed by Grok TTS and are intentionally absent here.
+  provider: grok
+  voice_id: 0b875ae2
   language_code: ru
-  stability: 0.5
-  similarity_boost: 0.75
-  style: 0.0
-  use_speaker_boost: true
   max_chars: 10000
 
 audio:

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -117,12 +117,15 @@ llm:
   min_podcast_words: 800
 
 tts:
-  voice_id: gedzfqL7OGdPbwm0ynTP
+  # Olya — Russian voice. Migrated from ElevenLabs (`gedzfqL7OGdPbwm0ynTP`)
+  # to xAI's Grok TTS (May 2026) for the same persona at ~36× lower
+  # per-character cost ($4.20/M vs $150/M). Reuses GROK_API_KEY /
+  # XAI_API_KEY — no new secret needed. ElevenLabs-specific voice
+  # settings (stability / similarity_boost / style / use_speaker_boost)
+  # are not exposed by Grok TTS and are intentionally absent here.
+  provider: grok
+  voice_id: 0b875ae2
   language_code: ru
-  stability: 0.5
-  similarity_boost: 0.75
-  style: 0.0
-  use_speaker_boost: true
   max_chars: 10000
 
 audio:

--- a/tests/test_tts_grok.py
+++ b/tests/test_tts_grok.py
@@ -1,0 +1,313 @@
+"""Tests for the Grok TTS code path (xAI /v1/tts).
+
+The HTTP layer is mocked end-to-end so the suite never hits the network.
+We verify the request shape sent to xAI, the dispatch from `synthesize()`
+based on `provider`, and the per-character pricing in the tracking layer.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from engine import tts
+from engine.tracking import (
+    GROK_TTS_COST_PER_1K_CHARS,
+    TTS_PROVIDER_PRICING,
+    create_tracker,
+    record_tts_usage,
+    save_usage,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper — fake the requests.post context manager pattern used by the module
+# ---------------------------------------------------------------------------
+
+def _make_fake_post(status_code: int = 200, body_bytes: bytes = b"\xff\xfb\x90"):
+    """Return a `requests.post` replacement returning `body_bytes` as MP3."""
+    captured: dict = {}
+
+    class _FakeResponse:
+        def __init__(self):
+            self.status_code = status_code
+            self.text = "" if status_code < 400 else "fake-error-body"
+
+        def iter_content(self, chunk_size=8192):
+            yield body_bytes
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise tts.requests.HTTPError(f"{self.status_code}")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_post(url, *, json=None, headers=None, stream=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["stream"] = stream
+        captured["timeout"] = timeout
+        return _FakeResponse()
+
+    return fake_post, captured
+
+
+# ---------------------------------------------------------------------------
+# grok_speak_chunk: request shape + endpoint
+# ---------------------------------------------------------------------------
+
+def test_grok_speak_chunk_posts_to_xai_endpoint(tmp_path: Path, monkeypatch):
+    fake_post, captured = _make_fake_post()
+    monkeypatch.setattr(tts.requests, "post", fake_post)
+
+    out = tmp_path / "out.mp3"
+    tts.grok_speak_chunk(
+        "Привет, как дела?",
+        voice_id="0b875ae2",
+        out_path=out,
+        api_key="secret-xai-key",
+        language_code="ru",
+    )
+
+    assert captured["url"] == "https://api.x.ai/v1/tts"
+    assert captured["headers"]["Authorization"] == "Bearer secret-xai-key"
+    assert captured["headers"]["Content-Type"] == "application/json"
+    body = captured["json"]
+    assert body["voice_id"] == "0b875ae2"
+    assert body["language"] == "ru"
+    assert body["text"] == "Привет, как дела?"
+    # Audio bytes were written to disk.
+    assert out.exists()
+    assert out.read_bytes() == b"\xff\xfb\x90"
+
+
+def test_grok_speak_chunk_defaults_language_to_auto(tmp_path: Path, monkeypatch):
+    fake_post, captured = _make_fake_post()
+    monkeypatch.setattr(tts.requests, "post", fake_post)
+
+    tts.grok_speak_chunk(
+        "Hello world",
+        voice_id="eve",
+        out_path=tmp_path / "o.mp3",
+        api_key="k",
+        language_code="",
+    )
+    assert captured["json"]["language"] == "auto"
+
+
+def test_grok_speak_chunk_rejects_empty_text(tmp_path: Path):
+    with pytest.raises(ValueError, match="empty"):
+        tts.grok_speak_chunk(
+            "   ",
+            voice_id="0b875ae2",
+            out_path=tmp_path / "o.mp3",
+            api_key="k",
+        )
+
+
+def test_grok_speak_chunk_rejects_oversize_text(tmp_path: Path):
+    """Caller is responsible for chunking under the 15k cap."""
+    with pytest.raises(ValueError, match="exceeds Grok's"):
+        tts.grok_speak_chunk(
+            "x" * 20000,
+            voice_id="0b875ae2",
+            out_path=tmp_path / "o.mp3",
+            api_key="k",
+        )
+
+
+def test_grok_speak_chunk_raises_on_401(tmp_path: Path, monkeypatch):
+    fake_post, _ = _make_fake_post(status_code=401)
+    monkeypatch.setattr(tts.requests, "post", fake_post)
+
+    with pytest.raises(tts.GrokTTSClientError) as exc_info:
+        tts.grok_speak_chunk(
+            "test", voice_id="x", out_path=tmp_path / "o.mp3", api_key="bad",
+        )
+    assert exc_info.value.status_code == 401
+
+
+def test_grok_speak_chunk_raises_on_4xx(tmp_path: Path, monkeypatch):
+    fake_post, _ = _make_fake_post(status_code=422)
+    monkeypatch.setattr(tts.requests, "post", fake_post)
+
+    with pytest.raises(tts.GrokTTSClientError):
+        tts.grok_speak_chunk(
+            "test", voice_id="x", out_path=tmp_path / "o.mp3", api_key="k",
+        )
+
+
+# ---------------------------------------------------------------------------
+# synthesize() dispatch on provider
+# ---------------------------------------------------------------------------
+
+def test_synthesize_dispatches_to_grok_when_provider_grok(tmp_path: Path, monkeypatch):
+    """`synthesize(provider='grok')` must NOT call the ElevenLabs path."""
+    eleven_called = MagicMock()
+    grok_called = MagicMock()
+
+    monkeypatch.setattr(tts, "speak", eleven_called)
+    monkeypatch.setattr(tts, "_speak_with_grok", grok_called)
+
+    out = tmp_path / "out.mp3"
+    tts.synthesize(
+        "Привет, мир.",
+        voice_id="0b875ae2",
+        output_path=out,
+        api_key="xai-key",
+        provider="grok",
+        language_code="ru",
+    )
+
+    grok_called.assert_called_once()
+    eleven_called.assert_not_called()
+    # Provider got the right kwargs; no ElevenLabs voice settings leaked through.
+    _args, kwargs = grok_called.call_args
+    assert kwargs["api_key"] == "xai-key"
+    assert kwargs["language_code"] == "ru"
+    assert "stability" not in kwargs
+    assert "similarity_boost" not in kwargs
+    assert "style" not in kwargs
+    assert "model_id" not in kwargs
+
+
+def test_synthesize_defaults_to_elevenlabs(tmp_path: Path, monkeypatch):
+    """No `provider` arg → ElevenLabs path runs (no behaviour change for English shows)."""
+    eleven_called = MagicMock()
+    grok_called = MagicMock()
+
+    monkeypatch.setattr(tts, "speak", eleven_called)
+    monkeypatch.setattr(tts, "_speak_with_grok", grok_called)
+
+    tts.synthesize(
+        "Hello",
+        voice_id="dTrBzPvD2GpAqkk1MUzA",
+        output_path=tmp_path / "o.mp3",
+        api_key="elevenlabs-key",
+    )
+
+    eleven_called.assert_called_once()
+    grok_called.assert_not_called()
+
+
+def test_synthesize_grok_translates_empty_language_to_auto(tmp_path: Path, monkeypatch):
+    grok_called = MagicMock()
+    monkeypatch.setattr(tts, "_speak_with_grok", grok_called)
+
+    tts.synthesize(
+        "Привет",
+        voice_id="0b875ae2",
+        output_path=tmp_path / "o.mp3",
+        api_key="k",
+        provider="grok",
+        language_code="",
+    )
+
+    _, kwargs = grok_called.call_args
+    assert kwargs["language_code"] == "auto"
+
+
+# ---------------------------------------------------------------------------
+# synthesize_sections() dispatch
+# ---------------------------------------------------------------------------
+
+def test_synthesize_sections_dispatches_to_grok_path(tmp_path: Path, monkeypatch):
+    grok_called = MagicMock()
+    eleven_called = MagicMock()
+    monkeypatch.setattr(tts, "_speak_with_grok", grok_called)
+    monkeypatch.setattr(tts, "speak", eleven_called)
+
+    tts.synthesize_sections(
+        ["Привет.", "Как дела?"],
+        voice_id="0b875ae2",
+        output_dir=tmp_path,
+        api_key="k",
+        provider="grok",
+        language_code="ru",
+    )
+
+    assert grok_called.call_count == 2  # one per section
+    eleven_called.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Pricing — Grok TTS is in the per-provider map, ~36× cheaper than ElevenLabs
+# ---------------------------------------------------------------------------
+
+def test_grok_tts_pricing_is_per_provider_map():
+    assert "grok" in TTS_PROVIDER_PRICING
+    assert TTS_PROVIDER_PRICING["grok"] == GROK_TTS_COST_PER_1K_CHARS
+
+
+def test_grok_tts_is_substantially_cheaper_than_elevenlabs():
+    """Whole point of the migration — Grok must be at least 10× cheaper."""
+    el = TTS_PROVIDER_PRICING["elevenlabs"]
+    grok = TTS_PROVIDER_PRICING["grok"]
+    assert grok < el / 10, (
+        f"Grok TTS at ${grok}/1K vs ElevenLabs at ${el}/1K — "
+        "expected at least 10× savings; got "
+        f"{el / grok:.1f}× ratio."
+    )
+
+
+def test_save_usage_uses_grok_rate_when_provider_grok(tmp_path: Path):
+    """End-to-end: tracker recorded provider=grok → cost computed at Grok rate."""
+    tracker = create_tracker("Финансы Просто", 30)
+    record_tts_usage(tracker, characters=10_000, provider="grok")
+    save_usage(tracker, tmp_path)
+
+    tts_block = tracker["services"]["tts_api"]
+    assert tts_block["provider"] == "grok"
+    expected = (10_000 / 1000) * GROK_TTS_COST_PER_1K_CHARS
+    assert tts_block["estimated_cost_usd"] == pytest.approx(expected)
+    # Sanity: this is much less than what ElevenLabs would have charged.
+    elevenlabs_equiv = (10_000 / 1000) * TTS_PROVIDER_PRICING["elevenlabs"]
+    assert tts_block["estimated_cost_usd"] < elevenlabs_equiv / 10
+
+
+def test_save_usage_uses_elevenlabs_rate_when_provider_unspecified(tmp_path: Path):
+    """Existing English shows: provider defaults to ElevenLabs, rate unchanged."""
+    tracker = create_tracker("Tesla", 1)
+    record_tts_usage(tracker, characters=10_000)  # no provider arg
+    save_usage(tracker, tmp_path)
+
+    tts_block = tracker["services"]["tts_api"]
+    assert tts_block["provider"] == "elevenlabs"
+    expected = (10_000 / 1000) * TTS_PROVIDER_PRICING["elevenlabs"]
+    assert tts_block["estimated_cost_usd"] == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# Russian show YAML coverage — guard against config drift
+# ---------------------------------------------------------------------------
+
+def test_russian_shows_use_grok_tts():
+    """Both Russian shows must be on Grok TTS with the Olya custom voice ID.
+
+    This guards against accidental rollback to the old ElevenLabs voice
+    (`gedzfqL7OGdPbwm0ynTP`), which was ~36× more expensive per character.
+    """
+    import yaml as _yaml
+    shows_dir = Path(__file__).resolve().parent.parent / "shows"
+    for slug in ("finansy_prosto", "privet_russian"):
+        data = _yaml.safe_load(
+            (shows_dir / f"{slug}.yaml").read_text(encoding="utf-8")
+        ) or {}
+        tts_block = data.get("tts") or {}
+        assert tts_block.get("provider") == "grok", (
+            f"{slug}.yaml: tts.provider must be 'grok' "
+            f"(got {tts_block.get('provider')!r})"
+        )
+        assert tts_block.get("voice_id") == "0b875ae2", (
+            f"{slug}.yaml: tts.voice_id must be the Olya Grok ID 0b875ae2 "
+            f"(got {tts_block.get('voice_id')!r})"
+        )
+        assert tts_block.get("language_code") == "ru", (
+            f"{slug}.yaml: tts.language_code must be 'ru' "
+            f"(got {tts_block.get('language_code')!r})"
+        )


### PR DESCRIPTION
## Summary

Switches Финансы Просто and Привет, Русский! from ElevenLabs TTS to **xAI's Grok TTS** (`POST https://api.x.ai/v1/tts`) using your custom-trained Olya voice **`0b875ae2`**. Same persona on-air — same name in the show description, RSS metadata, host fields — different synthesis backend.

**Cost impact:** Grok TTS is **$4.20 per 1M characters** vs ElevenLabs Flash v2.5 at **$150/M** — **~36× cheaper per character**. For the Russian shows generating ~7-10k chars/episode, TTS cost drops from ~$1.05–$1.50/episode to ~$0.03–$0.04/episode. Across both shows running every other day, ~$30/month → ~$1/month. No new secret required — Grok TTS reuses `GROK_API_KEY` / `XAI_API_KEY` already used for the LLM stage.

## Architecture

`engine/tts.py` already chunked / concat'd / crossfaded ElevenLabs audio. The Grok path drops in alongside, sharing the same WAV-intermediate concat pipeline. Dispatch is on a new `provider` kwarg defaulting to `elevenlabs`, so English shows are unchanged.

```
synthesize(text, voice_id, output_path, *, api_key, provider="elevenlabs", ...)
                                                    │
                                                    ├── "elevenlabs" → speak() → speak_chunk() → /v1/text-to-speech/{voice_id}/stream
                                                    └── "grok"       → _speak_with_grok() → grok_speak_chunk() → /v1/tts
```

## Changes

### `engine/tts.py`
- New `grok_speak_chunk()` — single-chunk POST to `/v1/tts`, MP3 bytes streamed to disk, retries only on 429/5xx/transient.
- New `_speak_with_grok()` — chunked synthesis using the same WAV→crossfade→MP3 pipeline as the ElevenLabs path.
- `synthesize()` and `synthesize_sections()` accept `provider=` and route accordingly. ElevenLabs-only kwargs (`stability`, `similarity_boost`, `style`, `model_id`, `speed`) are silently ignored on the Grok path since Grok doesn't expose them.

### `engine/tracking.py`
- New `GROK_TTS_COST_PER_1K_CHARS = 0.0042` and `TTS_PROVIDER_PRICING` map.
- `save_usage()` resolves the per-character rate from the recorded `tts_api.provider`, so `credit_usage_*.json` files attribute cost correctly. Default still ElevenLabs — no change for English shows.

### `run_show.py`
- TTS stage picks the right API key (`GROK_API_KEY`/`XAI_API_KEY` for grok, `ELEVENLABS_API_KEY` for elevenlabs).
- Skips the ElevenLabs auth ping when provider is grok — that key is already validated upstream by the LLM stage.
- `_validate_environment()` accepts both providers and only requires `ELEVENLABS_API_KEY` when at least one show is on ElevenLabs.

### `shows/finansy_prosto.yaml` + `shows/privet_russian.yaml`
```yaml
tts:
  provider: grok
  voice_id: 0b875ae2
  language_code: ru
  max_chars: 10000
```
Removed `stability`, `similarity_boost`, `style`, `use_speaker_boost`, `model` — Grok TTS doesn't expose them. `host_name`, RSS description, podcast title, all "Olya" branding unchanged.

### `tests/test_tts_grok.py` (new — 15 tests)
- Endpoint URL, headers, request body shape (`voice_id`, `language`, `text`)
- Response → MP3 bytes on disk
- 401/4xx/oversize-text error paths
- `synthesize()` dispatch — grok path doesn't leak ElevenLabs kwargs; default path stays on ElevenLabs
- Pricing — Grok in the map, at least 10× cheaper than ElevenLabs, `save_usage()` uses Grok rate when `provider=grok`
- **Drift guard:** both Russian YAMLs asserted to use `provider=grok` and `voice_id=0b875ae2` — blocks accidental rollback to ElevenLabs.

### `CLAUDE.md`
- Shows table TTS column updated to "Grok TTS (Olya)" for FP/PR.
- Voice-IDs convention note updated.
- Landmine #11 rewritten to reflect dual-provider state.
- New landmine #16 documents the migration end-to-end (endpoint, pricing, drift guard, why ElevenLabs voice settings aren't in the YAMLs anymore).

## Test plan

- [x] `pytest tests/test_tts_grok.py` — 15/15 pass
- [x] `pytest tests/test_tts_grok.py tests/test_tts_chunking.py tests/test_visual_assets.py tests/test_config.py tests/test_tracking.py tests/test_utils.py tests/test_rss.py tests/test_audio_commands.py tests/test_dashboard_mit_section.py` — 373/373 pass
- [ ] **Run one Russian show end-to-end against the live xAI API** to confirm `0b875ae2` synthesizes Russian text cleanly and the resulting MP3 sounds like the Olya voice you trained. Recommended:
  ```bash
  python run_show.py finansy_prosto --skip-x --skip-newsletter --skip-youtube
  ```
  Listen to the resulting MP3 in `digests/finansy_prosto/` and compare voice quality to the last ElevenLabs episode. If something's off (wrong voice, wrong language, garbled audio), don't merge.
- [ ] Verify `credit_usage_*.json` for the next Russian episode shows `services.tts_api.provider: "grok"` and a much lower `estimated_cost_usd` than recent ElevenLabs runs.
- [ ] After 1–2 successful runs, confirm management dashboard's TTS-cost graph shows the step-down for FP/PR.

## Rollback

If Olya's Grok TTS audio comes out wrong, revert this PR — the ElevenLabs voice ID `gedzfqL7OGdPbwm0ynTP` is preserved in git history and the test guard would just need flipping. No data is lost; no migrations to undo.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_