### PR TITLE
Migrate 7 English shows to Grok TTS (sal voice); Tesla stays on ElevenLabs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,14 @@ Automated daily podcast generation system running 10 shows via a unified
 | Show | Legacy Script | YAML Config | Schedule | X Account | TTS |
 |------|--------------|-------------|----------|-----------|-----|
 | Tesla Shorts Time | — (deleted) | `shows/tesla.yaml` | Daily | `@teslashortstime` | ElevenLabs |
-| Omni View | — (deleted) | `shows/omni_view.yaml` | Odd days | `@omniviewnews` | ElevenLabs |
-| Fascinating Frontiers | — (deleted) | `shows/fascinating_frontiers.yaml` | Even days | `@planetterrian` | ElevenLabs |
-| Planetterrian Daily | — (deleted) | `shows/planetterrian.yaml` | Odd days | `@planetterrian` | ElevenLabs |
-| Env Intel | — | `shows/env_intel.yaml` | Odd weekdays | `@teslashortstime` | ElevenLabs |
-| Models & Agents | — | `shows/models_agents.yaml` | Odd days | — (X disabled) | ElevenLabs |
-| Models & Agents for Beginners | — | `shows/models_agents_beginners.yaml` | Even days | — (X disabled) | ElevenLabs |
+| Omni View | — (deleted) | `shows/omni_view.yaml` | Odd days | `@omniviewnews` | Grok TTS (sal) |
+| Fascinating Frontiers | — (deleted) | `shows/fascinating_frontiers.yaml` | Even days | `@planetterrian` | Grok TTS (sal) |
+| Planetterrian Daily | — (deleted) | `shows/planetterrian.yaml` | Odd days | `@planetterrian` | Grok TTS (sal) |
+| Env Intel | — | `shows/env_intel.yaml` | Odd weekdays | `@teslashortstime` | Grok TTS (sal) |
+| Models & Agents | — | `shows/models_agents.yaml` | Odd days | — (X disabled) | Grok TTS (sal) |
+| Models & Agents for Beginners | — | `shows/models_agents_beginners.yaml` | Even days | — (X disabled) | Grok TTS (sal) |
 | Финансы Просто | — | `shows/finansy_prosto.yaml` | Even days | — (X disabled) | Grok TTS (Olya) |
-| Modern Investing Techniques | — | `shows/modern_investing.yaml` | Weekdays | — (X disabled) | ElevenLabs |
+| Modern Investing Techniques | — | `shows/modern_investing.yaml` | Weekdays | — (X disabled) | Grok TTS (sal) |
 | Привет, Русский! | — | `shows/privet_russian.yaml` | Even days | — (X disabled) | Grok TTS (Olya) |
 
 **Science That Changes Everything** (`digests/science_that_changes.py`, ~83 lines)
@@ -139,7 +139,7 @@ nerranetworks/
 - `GROK_API_KEY` — primary xAI key (all shows)
 - `ELEVENLABS_API_KEY` — ElevenLabs TTS (all shows)
 - `X_*` / `PLANETTERRIAN_X_*` — two separate X accounts
-- Voice IDs: English shows share ElevenLabs voice `dTrBzPvD2GpAqkk1MUzA`. Russian shows (FP/PR) use the **Grok TTS** custom voice `0b875ae2` ("Olya") since May 2026 — see landmine #16.
+- Voice IDs: 9 of 10 shows are on **Grok TTS** as of May 2026 — English shows use the `sal` built-in voice, Russian shows (FP/PR) use the custom `0b875ae2` ("Olya"). Tesla Shorts Time is the lone holdout on ElevenLabs voice `dTrBzPvD2GpAqkk1MUzA`. See landmine #16.
 - See `docs/env_var_inventory.md` for the complete inventory
 
 ### RSS Feeds
@@ -252,14 +252,16 @@ decision); everything else has a live status card.
    reintroduced without updating `_defaults.yaml`.
 10. **Early episodes deleted** — first 20 Tesla, 10 FF, 10 PT, 10 OV episodes
     removed (quality issues). RSS entries removed where applicable.
-11. **English shows use ElevenLabs TTS; Russian shows use Grok TTS (May
-    2026)** — Chatterbox, Kokoro, and Fish Audio were trialled and removed.
-    English shows still use ElevenLabs `eleven_flash_v2_5` (voice
-    `dTrBzPvD2GpAqkk1MUzA`). Russian shows (Финансы Просто, Привет
-    Русский!) migrated to xAI's Grok TTS (`/v1/tts`, voice `0b875ae2`
-    "Olya") for the same persona at ~36× lower per-character cost
-    ($4.20/M vs $150/M for Flash). Reuses `GROK_API_KEY` / `XAI_API_KEY`
-    — no new secret. See landmine #16.
+11. **9 of 10 shows on Grok TTS; Tesla Shorts Time stays on ElevenLabs
+    (May 2026)** — Chatterbox, Kokoro, and Fish Audio were trialled
+    and removed. English shows other than Tesla migrated to xAI's
+    Grok TTS with the `sal` built-in voice; Russian shows use the
+    custom Olya voice (`0b875ae2`). Tesla Shorts Time remains on
+    ElevenLabs `eleven_flash_v2_5` (voice `dTrBzPvD2GpAqkk1MUzA`)
+    because voice continuity matters most on the network's largest
+    public-facing show. Network cost: ~36× cheaper per character on
+    Grok ($4.20/M vs $150/M for ElevenLabs Flash). Reuses
+    `GROK_API_KEY` / `XAI_API_KEY` — no new secret. See landmine #16.
 12. **Summaries JSONs moved** — all summaries live in per-show subdirectories
     (`digests/<show>/summaries_*.json`), not at the `digests/` top level.
 13. **LLM default migrated to `grok-4.3` (May 2026)** — released 2026-04-30,
@@ -302,20 +304,42 @@ decision); everything else has a live status card.
     Data API has no endpoint for this flag. Once flagged once, every
     future video added via the API automatically becomes a podcast
     episode. **One-time setup per playlist — not a code change.**
-16. **Russian shows on Grok TTS, not ElevenLabs (May 2026)** — Финансы
-    Просто and Привет, Русский! switched their `tts.provider` from
-    `elevenlabs` to `grok` and their voice ID from
-    `gedzfqL7OGdPbwm0ynTP` to `0b875ae2` (custom "Olya" voice trained on
-    the xAI Console). Same on-air persona, ~36× cheaper per character
-    ($4.20/M vs $150/M for ElevenLabs Flash v2.5). Implementation
-    details: `engine/tts.py:synthesize()` dispatches on the new
-    `provider` kwarg; the Grok path posts to `https://api.x.ai/v1/tts`
-    and reuses `GROK_API_KEY` / `XAI_API_KEY` (no new secret). Voice
-    settings that are ElevenLabs-only (`stability`, `similarity_boost`,
-    `style`, `use_speaker_boost`, `model`, `speed`) are intentionally
-    absent from the two Russian YAMLs because Grok TTS doesn't expose
-    them. Pricing is per-provider in
-    [`engine/tracking.py`](engine/tracking.py): `TTS_PROVIDER_PRICING`.
-    The `test_russian_shows_use_grok_tts` test in
-    [`tests/test_tts_grok.py`](tests/test_tts_grok.py) blocks accidental
-    rollback to the old ElevenLabs voice.
+16. **TTS network default flipped to Grok TTS (May 2026)** — staged in
+    two PRs:
+    - **First wave (Russian shows):** Финансы Просто and Привет,
+      Русский! switched from ElevenLabs voice `gedzfqL7OGdPbwm0ynTP` to
+      Grok TTS with the custom "Olya" voice `0b875ae2` (trained on the
+      xAI Console). Validated with one live episode (PR Ep017,
+      2026-05-02) before broader rollout.
+    - **Second wave (English shows):** Network default in
+      [`shows/_defaults.yaml`](shows/_defaults.yaml) flipped to
+      `provider: grok`, `voice_id: sal` (Grok built-in named voice),
+      `language_code: en`. The 7 non-Tesla English shows (Omni View,
+      Fascinating Frontiers, Planetterrian, Env Intel, Models &
+      Agents, Models & Agents for Beginners, Modern Investing) now
+      inherit those defaults — their `tts:` blocks are intentionally
+      empty (`{}`) to make inheritance the contract. Tesla Shorts Time
+      explicitly overrides back to `provider: elevenlabs`,
+      `voice_id: dTrBzPvD2GpAqkk1MUzA` because voice continuity on the
+      network's largest show outweighs the cost delta.
+
+    Implementation details: `engine/tts.py:synthesize()` dispatches on
+    the `provider` kwarg; the Grok path posts to
+    `https://api.x.ai/v1/tts` and reuses `GROK_API_KEY` /
+    `XAI_API_KEY` (no new secret). ElevenLabs-only voice settings
+    (`stability`, `similarity_boost`, `style`, `use_speaker_boost`,
+    `model`, `speed`) live in [`shows/_defaults.yaml`](shows/_defaults.yaml)
+    under a `# ---- Legacy ElevenLabs baseline ----` block — harmless
+    when `provider=grok` (Grok path silently ignores them) and a tuned
+    starting point if any show flips back to ElevenLabs. Pricing is
+    per-provider in [`engine/tracking.py`](engine/tracking.py):
+    `TTS_PROVIDER_PRICING`. Three drift guards in
+    [`tests/test_tts_grok.py`](tests/test_tts_grok.py) block silent
+    regressions: `test_russian_shows_use_grok_tts` (Olya voice on
+    Russian shows), `test_english_shows_resolve_to_grok_sal` (sal voice
+    on the 7 English shows after deep-merge), and
+    `test_tesla_stays_on_elevenlabs` (TST voice continuity).
+    `ELEVENLABS_API_KEY` is still required because Tesla uses it; if
+    Tesla ever migrates, the env-var requirement disappears
+    (`run_show.py:_validate_environment` already gates the check on
+    `provider == "elevenlabs"`).

--- a/engine/config.py
+++ b/engine/config.py
@@ -67,15 +67,22 @@ class LLMConfig:
 
 @dataclass
 class TTSConfig:
-    provider: str = "elevenlabs"
-    voice_id: str = "dTrBzPvD2GpAqkk1MUzA"
+    # Network default since May 2026: Grok TTS with the "sal" built-in
+    # voice. Russian shows override voice_id to their custom Olya
+    # (`0b875ae2`) and language_code to `ru`. Tesla Shorts Time stays on
+    # ElevenLabs by overriding provider+voice_id.
+    provider: str = "grok"
+    voice_id: str = "sal"
+    language_code: str = "en"  # BCP-47 (Grok) / ISO 639-1 (ElevenLabs); shows override for non-English
+    max_chars: int = 10000
+    # ---- Legacy ElevenLabs baseline ----
+    # Active only when a show overrides ``provider: elevenlabs``. The
+    # Grok TTS code path silently ignores all of these.
     model: str = "eleven_flash_v2_5"
     stability: float = 0.5
     similarity_boost: float = 0.75
     style: float = 0.0
     use_speaker_boost: bool = True
-    max_chars: int = 10000
-    language_code: str = ""  # ISO 639-1 code (e.g. "ru" for Russian)
     speed: float = 1.0  # Speech speed (0.7–1.2); Flash v2.5 supports this range
     apply_text_normalization: str = "on"  # "auto", "on", or "off"; helps with number/date pronunciation
     # Post-TTS transcription validation (opt-in)

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -38,14 +38,27 @@ llm:
   reviewer_temperature: 0.3
 
 tts:
-  provider: elevenlabs
-  voice_id: dTrBzPvD2GpAqkk1MUzA
+  # Network default since May 2026: xAI Grok TTS at $4.20/M chars
+  # (~36× cheaper than ElevenLabs Flash). Voice "sal" is a Grok built-in
+  # named voice — no training required. Russian shows (FP/PR) override
+  # voice_id to their custom "Olya" (`0b875ae2`) and language_code to
+  # `ru`. Tesla Shorts Time stays on ElevenLabs by overriding
+  # provider+voice_id back; see shows/tesla.yaml.
+  provider: grok
+  voice_id: sal
+  language_code: en
+  max_chars: 10000
+  # ---- Legacy ElevenLabs baseline ----
+  # Active only when a show overrides `provider: elevenlabs` (currently
+  # Tesla Shorts Time). Kept here so any future ElevenLabs flip-back
+  # inherits the same baseline rather than re-discovering tuned values.
+  # The Grok TTS code path silently ignores all of these — they cost
+  # nothing to leave in defaults.
   model: eleven_flash_v2_5
   stability: 0.5
   similarity_boost: 0.75
   style: 0.0
   use_speaker_boost: true
-  max_chars: 10000
   apply_text_normalization: "on"
 
 audio:

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -179,12 +179,10 @@ llm:
   podcast_max_tokens: 8000
 
 tts:
-  voice_id: dTrBzPvD2GpAqkk1MUzA
-  stability: 0.5
-  similarity_boost: 0.75
-  style: 0.0
-  use_speaker_boost: true
-  max_chars: 10000
+  # Inherits provider=grok, voice_id=sal, language_code=en, max_chars=10000
+  # from shows/_defaults.yaml (network default since May 2026 — Grok TTS
+  # at $4.20/M chars vs ElevenLabs Flash $150/M).
+  {}
 
 audio:
   music_file: assets/music/tesla_shorts_time.mp3

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -151,12 +151,10 @@ llm:
   podcast_chain: true
 
 tts:
-  voice_id: dTrBzPvD2GpAqkk1MUzA
-  stability: 0.5
-  similarity_boost: 0.75
-  style: 0.0
-  use_speaker_boost: true
-  max_chars: 10000
+  # Inherits provider=grok, voice_id=sal, language_code=en, max_chars=10000
+  # from shows/_defaults.yaml (network default since May 2026 — Grok TTS
+  # at $4.20/M chars vs ElevenLabs Flash $150/M).
+  {}
 
 audio:
   music_file: assets/music/fascinatingfrontiers.mp3

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -168,12 +168,10 @@ llm:
   podcast_max_tokens: 8000
 
 tts:
-  voice_id: dTrBzPvD2GpAqkk1MUzA
-  stability: 0.5
-  similarity_boost: 0.75
-  style: 0.0
-  use_speaker_boost: true
-  max_chars: 10000
+  # Inherits provider=grok, voice_id=sal, language_code=en, max_chars=10000
+  # from shows/_defaults.yaml (network default since May 2026 — Grok TTS
+  # at $4.20/M chars vs ElevenLabs Flash $150/M).
+  {}
 
 audio:
   music_file: assets/music/tesla_shorts_time.mp3

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -146,12 +146,10 @@ llm:
   min_podcast_words: 1100
 
 tts:
-  voice_id: dTrBzPvD2GpAqkk1MUzA
-  stability: 0.5
-  similarity_boost: 0.75
-  style: 0.0
-  use_speaker_boost: true
-  max_chars: 10000
+  # Inherits provider=grok, voice_id=sal, language_code=en, max_chars=10000
+  # from shows/_defaults.yaml (network default since May 2026 — Grok TTS
+  # at $4.20/M chars vs ElevenLabs Flash $150/M).
+  {}
 
 audio:
   music_file: assets/music/tesla_shorts_time.mp3

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -145,12 +145,10 @@ llm:
   podcast_chain: true
 
 tts:
-  voice_id: dTrBzPvD2GpAqkk1MUzA
-  stability: 0.5
-  similarity_boost: 0.75
-  style: 0.0
-  use_speaker_boost: true
-  max_chars: 10000
+  # Inherits provider=grok, voice_id=sal, language_code=en, max_chars=10000
+  # from shows/_defaults.yaml (network default since May 2026 — Grok TTS
+  # at $4.20/M chars vs ElevenLabs Flash $150/M).
+  {}
 
 audio:
   # TODO: Generate dedicated music file — see assets/music/README.md for prompt.

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -155,12 +155,10 @@ llm:
   min_podcast_words: 1800
 
 tts:
-  voice_id: dTrBzPvD2GpAqkk1MUzA
-  stability: 0.5
-  similarity_boost: 0.75
-  style: 0.0
-  use_speaker_boost: true
-  max_chars: 10000
+  # Inherits provider=grok, voice_id=sal, language_code=en, max_chars=10000
+  # from shows/_defaults.yaml (network default since May 2026 — Grok TTS
+  # at $4.20/M chars vs ElevenLabs Flash $150/M).
+  {}
 
 audio:
   music_file: assets/music/LubechangeOilers.mp3

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -193,12 +193,10 @@ llm:
   podcast_chain: true
 
 tts:
-  voice_id: dTrBzPvD2GpAqkk1MUzA
-  stability: 0.5
-  similarity_boost: 0.75
-  style: 0.0
-  use_speaker_boost: true
-  max_chars: 10000
+  # Inherits provider=grok, voice_id=sal, language_code=en, max_chars=10000
+  # from shows/_defaults.yaml (network default since May 2026 — Grok TTS
+  # at $4.20/M chars vs ElevenLabs Flash $150/M).
+  {}
 
 audio:
   music_file: assets/music/oilers-pride.mp3

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -127,11 +127,15 @@ llm:
   podcast_chain: true
 
 tts:
+  # Tesla Shorts Time stays on ElevenLabs Flash v2.5 (the only English
+  # show not migrated to Grok TTS in May 2026). The voice listeners
+  # know is `dTrBzPvD2GpAqkk1MUzA`; preserving voice continuity on the
+  # network's largest show outweighs the per-character cost delta.
+  # All other ElevenLabs settings (stability/similarity_boost/style/
+  # use_speaker_boost/model/apply_text_normalization) inherit from
+  # shows/_defaults.yaml's legacy block.
+  provider: elevenlabs
   voice_id: dTrBzPvD2GpAqkk1MUzA
-  stability: 0.5
-  similarity_boost: 0.75
-  style: 0.0
-  use_speaker_boost: true
   max_chars: 10000
 
 audio:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -177,13 +177,21 @@ class TestDefaultValues:
 
     def test_tts_defaults(self):
         c = TTSConfig()
-        assert c.voice_id == "dTrBzPvD2GpAqkk1MUzA"
+        # Network default since May 2026 — Grok TTS with the "sal"
+        # built-in voice. Tesla Shorts Time is the only English show
+        # that overrides back to ElevenLabs.
+        assert c.provider == "grok"
+        assert c.voice_id == "sal"
+        assert c.language_code == "en"
+        assert c.max_chars == 10000
+        # Legacy ElevenLabs baseline — preserved on the dataclass so
+        # any show that overrides ``provider: elevenlabs`` inherits a
+        # tuned starting point. Harmless under provider=grok.
         assert c.model == "eleven_flash_v2_5"
         assert c.stability == 0.5
         assert c.similarity_boost == 0.75
         assert c.style == 0.0
         assert c.use_speaker_boost is True
-        assert c.max_chars == 10000
         assert c.speed == 1.0
         assert c.apply_text_normalization == "on"
 
@@ -412,7 +420,9 @@ class TestLoadConfigRealFiles:
         assert cfg.sources[0].label == "NASA Breaking"
         assert "space" in cfg.keywords
         assert cfg.llm.model == "grok-4.3"
-        assert cfg.tts.voice_id == "dTrBzPvD2GpAqkk1MUzA"
+        # English shows migrated to Grok TTS (sal voice) in May 2026.
+        assert cfg.tts.provider == "grok"
+        assert cfg.tts.voice_id == "sal"
         assert cfg.audio.music_file == "assets/music/fascinatingfrontiers.mp3"
         assert cfg.audio.background_music_file == "assets/music/fascinatingfrontiers_bg.mp3"
         assert cfg.audio.voice_intro_delay == 5.0
@@ -462,8 +472,13 @@ class TestLoadConfigRealFiles:
         assert "CCME" in cfg.keywords
         assert cfg.llm.model == "grok-4.3"
         assert cfg.llm.digest_temperature == 0.5
-        assert cfg.tts.voice_id == "dTrBzPvD2GpAqkk1MUzA"
-        assert cfg.tts.stability == 0.5  # Normalized to network standard
+        # English shows migrated to Grok TTS (sal voice) in May 2026. The
+        # ElevenLabs settings (stability/style) still inherit from the
+        # legacy block in _defaults.yaml — harmless since the Grok path
+        # ignores them — so these assertions still pass.
+        assert cfg.tts.provider == "grok"
+        assert cfg.tts.voice_id == "sal"
+        assert cfg.tts.stability == 0.5  # Inherited from legacy ElevenLabs baseline
         assert cfg.tts.style == 0.0
         assert cfg.tts.max_chars == 10000
         assert cfg.audio.music_file == "assets/music/tesla_shorts_time.mp3"
@@ -499,9 +514,13 @@ class TestNestedConfigOverrides:
         p.write_text(yaml.dump(data), encoding="utf-8")
 
         cfg = load_config(p)
+        # Overrides applied
         assert cfg.tts.stability == 0.3
         assert cfg.tts.max_chars == 9999
-        assert cfg.tts.voice_id == "dTrBzPvD2GpAqkk1MUzA"
+        # Network defaults preserved (Grok TTS + sal voice; legacy
+        # ElevenLabs baseline still set on the dataclass for back-compat).
+        assert cfg.tts.provider == "grok"
+        assert cfg.tts.voice_id == "sal"
         assert cfg.tts.model == "eleven_flash_v2_5"
 
     def test_partial_audio_override(self, tmp_path):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -52,9 +52,11 @@ def test_mab_and_ma_are_separate():
     assert ma["name"] != mab["name"]
     assert ma["cfg"].publishing.rss_file != mab["cfg"].publishing.rss_file
     assert ma["cfg"].publishing.rss_title != mab["cfg"].publishing.rss_title
-    # Each must resolve tts.provider to elevenlabs on its own.
-    assert ma["cfg"].tts.provider == "elevenlabs"
-    assert mab["cfg"].tts.provider == "elevenlabs"
+    # Each must resolve tts.provider to grok on its own (network default
+    # since May 2026; the original "elevenlabs" assertion regressed when
+    # the network flipped — see CLAUDE.md landmines #11 and #16).
+    assert ma["cfg"].tts.provider == "grok"
+    assert mab["cfg"].tts.provider == "grok"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -483,7 +483,9 @@ class TestShowConfigs:
         assert config.newsletter.enabled is True
         assert config.newsletter.api_key_env == "BUTTONDOWN_API_KEY"
         assert len(config.sources) > 10  # Has many RSS feeds
-        assert config.tts.voice_id == "dTrBzPvD2GpAqkk1MUzA"
+        # M&A migrated from ElevenLabs (`dTrBzPvD2GpAqkk1MUzA`) to Grok TTS
+        # with the `sal` built-in voice in May 2026 — see landmine #16.
+        assert config.tts.voice_id == "sal"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tts_grok.py
+++ b/tests/test_tts_grok.py
@@ -270,10 +270,10 @@ def test_save_usage_uses_grok_rate_when_provider_grok(tmp_path: Path):
     assert tts_block["estimated_cost_usd"] < elevenlabs_equiv / 10
 
 
-def test_save_usage_uses_elevenlabs_rate_when_provider_unspecified(tmp_path: Path):
-    """Existing English shows: provider defaults to ElevenLabs, rate unchanged."""
-    tracker = create_tracker("Tesla", 1)
-    record_tts_usage(tracker, characters=10_000)  # no provider arg
+def test_save_usage_uses_elevenlabs_rate_when_provider_elevenlabs(tmp_path: Path):
+    """Tesla Shorts Time stays on ElevenLabs and is charged at that rate."""
+    tracker = create_tracker("Tesla Shorts Time", 460)
+    record_tts_usage(tracker, characters=10_000, provider="elevenlabs")
     save_usage(tracker, tmp_path)
 
     tts_block = tracker["services"]["tts_api"]
@@ -283,7 +283,7 @@ def test_save_usage_uses_elevenlabs_rate_when_provider_unspecified(tmp_path: Pat
 
 
 # ---------------------------------------------------------------------------
-# Russian show YAML coverage — guard against config drift
+# Show-YAML coverage — drift guards for the May 2026 TTS layout
 # ---------------------------------------------------------------------------
 
 def test_russian_shows_use_grok_tts():
@@ -311,3 +311,64 @@ def test_russian_shows_use_grok_tts():
             f"{slug}.yaml: tts.language_code must be 'ru' "
             f"(got {tts_block.get('language_code')!r})"
         )
+
+
+def test_english_shows_resolve_to_grok_sal():
+    """Every English show except Tesla Shorts Time must resolve to Grok TTS
+    with the ``sal`` built-in voice after deep-merging _defaults.yaml.
+
+    Inheritance is the contract here — the per-show YAMLs intentionally
+    leave the tts: block empty so the network default carries them.
+    Adding an override silently puts a show on a different voice and
+    breaks the Listener-side voice continuity.
+    """
+    from engine.config import load_config
+    shows_dir = Path(__file__).resolve().parent.parent / "shows"
+    english_grok_shows = (
+        "omni_view",
+        "fascinating_frontiers",
+        "planetterrian",
+        "env_intel",
+        "models_agents",
+        "models_agents_beginners",
+        "modern_investing",
+    )
+    for slug in english_grok_shows:
+        cfg = load_config(shows_dir / f"{slug}.yaml")
+        assert cfg.tts.provider == "grok", (
+            f"{slug}.yaml: post-merge tts.provider must be 'grok' "
+            f"(got {cfg.tts.provider!r}); check shows/_defaults.yaml didn't "
+            "regress and the show YAML didn't add an override."
+        )
+        assert cfg.tts.voice_id == "sal", (
+            f"{slug}.yaml: post-merge tts.voice_id must be 'sal' "
+            f"(got {cfg.tts.voice_id!r}); the network voted on a single "
+            "shared voice in May 2026 — per-show overrides need a "
+            "documented reason."
+        )
+        assert cfg.tts.language_code == "en", (
+            f"{slug}.yaml: post-merge tts.language_code must be 'en' "
+            f"(got {cfg.tts.language_code!r})"
+        )
+
+
+def test_tesla_stays_on_elevenlabs():
+    """Tesla Shorts Time is the lone English-show ElevenLabs holdout.
+
+    The voice listeners know is `dTrBzPvD2GpAqkk1MUzA`. If anyone strips
+    the tts.provider override or changes voice_id, this test catches it
+    before the next Tesla episode renders with a different voice.
+    """
+    from engine.config import load_config
+    shows_dir = Path(__file__).resolve().parent.parent / "shows"
+    cfg = load_config(shows_dir / "tesla.yaml")
+    assert cfg.tts.provider == "elevenlabs", (
+        f"tesla.yaml: tts.provider must be 'elevenlabs' (got "
+        f"{cfg.tts.provider!r}). TST is the only show that didn't migrate "
+        "to Grok TTS in May 2026; voice continuity on the network's "
+        "largest show outweighs the cost delta."
+    )
+    assert cfg.tts.voice_id == "dTrBzPvD2GpAqkk1MUzA", (
+        f"tesla.yaml: tts.voice_id must be 'dTrBzPvD2GpAqkk1MUzA' "
+        f"(got {cfg.tts.voice_id!r})"
+    )


### PR DESCRIPTION
## Summary

Switches the 7 non-Tesla English shows from ElevenLabs Flash v2.5 to **Grok TTS** with the `sal` built-in voice. Tesla Shorts Time stays on ElevenLabs to preserve voice continuity on the network's largest public-facing show. Russian shows already migrated in [PR #281](https://github.com/patricknovak/nerranetworks/pull/281) — no change here.

After this PR:

| Show | Provider | Voice |
|---|---|---|
| Tesla Shorts Time | ElevenLabs | `dTrBzPvD2GpAqkk1MUzA` (unchanged) |
| Omni View, Fascinating Frontiers, Planetterrian, Env Intel, Models & Agents, M&A for Beginners, Modern Investing | **Grok** | **`sal`** |
| Финансы Просто, Привет, Русский! | Grok | `0b875ae2` (Olya, unchanged) |

## Architecture choice — flip the network default, not 7 overrides

Two ways to wire this:
- (A) Each of 7 YAMLs sets `provider: grok / voice_id: sal` explicitly → 7 overrides.
- (B) Flip `shows/_defaults.yaml` to `provider: grok / voice_id: sal`; only Tesla and the Russian shows override → 1 + 2 overrides.

Picked (B). 9 of 10 shows are now on Grok, so the default should reflect the majority case. The 7 migrated YAMLs now have empty `tts:` blocks (`{}`) with a comment explaining inheritance — the contract reads cleanly as "everyone's on the default unless they say so."

The legacy ElevenLabs voice settings (`stability`, `similarity_boost`, `style`, `use_speaker_boost`, `model`, `apply_text_normalization`) live in `_defaults.yaml` under a `# ---- Legacy ElevenLabs baseline ----` block. Cost nothing at runtime (Grok path ignores them) and provide a tuned starting point if any show flips back.

## Drift guards (3 tests in `tests/test_tts_grok.py`)

- `test_russian_shows_use_grok_tts` — existing; asserts FP/PR on Olya.
- `test_english_shows_resolve_to_grok_sal` — **new**; loads each of the 7 English-Grok shows through `load_config()` and asserts `provider=grok`, `voice_id=sal`, `language_code=en` after the deep-merge with `_defaults.yaml`.
- `test_tesla_stays_on_elevenlabs` — **new**; pins TST to its current ElevenLabs voice. Catches anyone who strips the `provider: elevenlabs` override out of `tesla.yaml`.

If a future PR adds a `voice_id:` override to one of the 7 inheriting YAMLs without a documented reason, this test fails before merge — same pattern that caught the YouTube Studio image-relevance regressions.

## Cost impact

| Window | Network monthly TTS spend |
|---|---|
| Pre-PR-281 (everyone on ElevenLabs) | ~$200/month |
| Post-PR-281 (Russian shows on Grok) | ~$170/month |
| **After this PR** (only Tesla on ElevenLabs) | **~$30-40/month** (Tesla alone) |

The 7 migrated shows drop their per-character cost ~36× — that's the same delta the Russian shows just realized. Tesla's TTS cost unchanged. Total network savings vs. all-ElevenLabs baseline: ~$160-170/month.

## Other changes

- `engine/config.py:TTSConfig` dataclass defaults flipped (`provider="grok"`, `voice_id="sal"`, `language_code="en"`). Legacy ElevenLabs fields kept on the dataclass for back-compat.
- `tests/test_config.py` — `test_tts_defaults`, `test_partial_tts_override`, and per-show tests for FF and Env Intel updated to assert the new defaults.
- `test_save_usage_uses_elevenlabs_rate_when_provider_unspecified` renamed to `..._when_provider_elevenlabs` since "unspecified" now means Grok.
- `CLAUDE.md` — shows table TTS column rewritten, Voice IDs note rewritten, landmine #11 updated, landmine #16 expanded to document both migration waves.
- `ELEVENLABS_API_KEY` is still required because Tesla uses it. `_validate_environment()` already conditions on `provider == "elevenlabs"`, so if Tesla ever migrates the key becomes optional automatically (no code change needed).

## Test plan

- [x] `pytest tests/test_tts_grok.py tests/test_config.py` — 66/66 pass (3 new drift guards)
- [x] `pytest tests/test_tts_grok.py tests/test_tts_chunking.py tests/test_visual_assets.py tests/test_config.py tests/test_tracking.py tests/test_utils.py tests/test_rss.py tests/test_audio_commands.py tests/test_dashboard_mit_section.py` — 375/375 pass
- [x] `pytest tests/test_integration.py -k "test_all_shows or test_no_newsapi or test_digest_temp"` — 21/21 pass (no model/config-allowlist regressions)
- [x] Live deep-merge spot-check: every show resolves to the expected `(provider, voice_id, language_code)` tuple — verified by running `load_config()` on all 10 YAMLs.
- [ ] **Live API verification** — first cron run that hits any of the 7 migrated shows (most likely Omni View on the next odd-day run) should produce a `metrics_*.json` showing `tts_provider: "grok"` and a `credit_usage_*.json` with the much lower TTS cost. Tesla's next run should still show `provider: "elevenlabs"`.
- [ ] Spot-listen to one episode from each migrated show in the first cron cycle. The `sal` voice is a Grok stock voice, not the trained Olya — listeners on those English feeds will hear a voice change. If any show's audio identity feels too off-brand, the rollback is to add `voice_id: <old elevenlabs id>` and `provider: elevenlabs` back to that show's YAML.

## Rollback

Per-show: add `provider: elevenlabs` and `voice_id: dTrBzPvD2GpAqkk1MUzA` back to the show's `tts:` block. Update the drift-guard test's `english_grok_shows` tuple. Done.

Network-wide: revert this PR. The Russian shows stay on Grok regardless (they have explicit overrides).

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_