### PR TITLE
Wire 7 shows to their dedicated music files

### DIFF
--- a/assets/music/README.md
+++ b/assets/music/README.md
@@ -8,12 +8,20 @@ config under `audio.music_file` and optionally `audio.background_music_file`.
 
 ```
 assets/music/
-├── tesla_shorts_time.mp3          # TST + EI + M&A — energetic tech/financial news theme
+├── tesla_shorts_time.mp3          # TST — energetic tech/financial news theme
 ├── fascinatingfrontiers.mp3       # FF — short cosmic intro jingle (~5 s)
 ├── fascinatingfrontiers_bg.mp3    # FF — longer ambient space background/outro
 ├── oilers-pride.mp3               # PT — science/discovery theme
-├── LubechangeOilers.mp3           # OV — balanced news theme
-├── modern_investing.mp3           # MIT — financial/market intelligence theme (TODO: generate)
+├── OmniView.mp3                   # OV — balanced news theme (May 2026; replaced LubechangeOilers.mp3)
+├── EnvIntel.mp3                   # EI — Canadian environmental-policy theme (May 2026)
+├── ModelsAgents.mp3               # M&A and M&AB — AI/agents theme (shared across both shows)
+├── ModernInvesting.mp3            # MIT — financial/market intelligence theme (May 2026)
+├── Финансы Просто.mp3             # FP — Russian financial-literacy theme (May 2026)
+├── ПриветРусский.mp3              # PR — Russian language-learning theme (May 2026; on-disk filename
+│                                  #       is in Unicode NFD form — keep YAML music_file in sync if
+│                                  #       the file is ever renamed; see shows/privet_russian.yaml)
+├── LubechangeOilers.mp3           # ORPHANED (May 2026) — OV moved to OmniView.mp3; kept on disk
+│                                  #   for rollback. Safe to delete after a few clean OV runs.
 └── README.md                      # This file
 ```
 

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -185,7 +185,7 @@ tts:
   {}
 
 audio:
-  music_file: assets/music/tesla_shorts_time.mp3
+  music_file: assets/music/EnvIntel.mp3
   transition_sting: assets/music/transition_sting.mp3
   voice_intro_delay: 5.0
   intro_duration: 5.0

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -182,7 +182,7 @@ tts:
   max_chars: 10000
 
 audio:
-  music_file: assets/music/tesla_shorts_time.mp3
+  music_file: "assets/music/Финансы Просто.mp3"
   transition_sting: assets/music/transition_sting.mp3
   voice_intro_delay: 5.0
   intro_duration: 5.0

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -174,7 +174,7 @@ tts:
   {}
 
 audio:
-  music_file: assets/music/tesla_shorts_time.mp3
+  music_file: assets/music/ModelsAgents.mp3
   transition_sting: assets/music/transition_sting.mp3
   voice_intro_delay: 5.0
   intro_duration: 5.0

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -152,7 +152,7 @@ tts:
   {}
 
 audio:
-  music_file: assets/music/tesla_shorts_time.mp3
+  music_file: assets/music/ModelsAgents.mp3
   transition_sting: assets/music/transition_sting.mp3
   voice_intro_delay: 5.0
   intro_duration: 5.0

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -153,7 +153,7 @@ tts:
 audio:
   # TODO: Generate dedicated music file — see assets/music/README.md for prompt.
   # Falling back to TST theme until modern_investing.mp3 is created.
-  music_file: assets/music/tesla_shorts_time.mp3
+  music_file: assets/music/ModernInvesting.mp3
   voice_intro_delay: 5.0
   intro_duration: 5.0
   overlap_duration: 10.0

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -161,7 +161,7 @@ tts:
   {}
 
 audio:
-  music_file: assets/music/LubechangeOilers.mp3
+  music_file: assets/music/OmniView.mp3
   transition_sting: assets/music/transition_sting.mp3
   voice_intro_delay: 5.0
   intro_duration: 5.0

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -129,7 +129,7 @@ tts:
   max_chars: 10000
 
 audio:
-  music_file: assets/music/tesla_shorts_time.mp3
+  music_file: "assets/music/ПриветРусский.mp3"
   voice_intro_delay: 5.0
   intro_duration: 5.0
   overlap_duration: 10.0

--- a/tests/test_audio_commands.py
+++ b/tests/test_audio_commands.py
@@ -565,11 +565,15 @@ class TestShowMusicConfigs:
 
     def test_ov_has_music(self, load_config):
         cfg = load_config("shows/omni_view.yaml")
-        assert cfg.audio.music_file == "assets/music/LubechangeOilers.mp3"
+        # OV got its own dedicated theme in May 2026
+        # (replaced the old shared `LubechangeOilers.mp3`).
+        assert cfg.audio.music_file == "assets/music/OmniView.mp3"
 
     def test_ei_has_music(self, load_config):
         cfg = load_config("shows/env_intel.yaml")
-        assert cfg.audio.music_file == "assets/music/tesla_shorts_time.mp3"
+        # EI got its own dedicated theme in May 2026
+        # (replaced the shared `tesla_shorts_time.mp3`).
+        assert cfg.audio.music_file == "assets/music/EnvIntel.mp3"
 
     def test_ei_standard_timing(self, load_config):
         """EI uses standard intro timing with lower volumes for briefing format."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -455,7 +455,8 @@ class TestLoadConfigRealFiles:
         assert cfg.llm.max_tokens == 4000
         assert cfg.tts.stability == 0.5
         assert cfg.tts.style == 0.0
-        assert cfg.audio.music_file == "assets/music/LubechangeOilers.mp3"
+        # OV got its own dedicated theme in May 2026 (replaced LubechangeOilers.mp3).
+        assert cfg.audio.music_file == "assets/music/OmniView.mp3"
         assert cfg.publishing.rss_category == "News"
         assert cfg.publishing.guid_prefix == "omni-view"
         assert cfg.episode.prefix == "Omni_View"
@@ -481,7 +482,9 @@ class TestLoadConfigRealFiles:
         assert cfg.tts.stability == 0.5  # Inherited from legacy ElevenLabs baseline
         assert cfg.tts.style == 0.0
         assert cfg.tts.max_chars == 10000
-        assert cfg.audio.music_file == "assets/music/tesla_shorts_time.mp3"
+        # EI got its own dedicated theme in May 2026
+        # (replaced the shared tesla_shorts_time.mp3).
+        assert cfg.audio.music_file == "assets/music/EnvIntel.mp3"
         assert cfg.publishing.x_enabled is False
         assert cfg.episode.prefix == "Env_Intel"
         assert cfg.episode.output_dir == "digests/env_intel"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -466,7 +466,8 @@ class TestShowConfigs:
         assert config.slug == "env_intel"
         assert config.publishing.x_enabled is False
         assert config.newsletter.enabled is True
-        assert config.audio.music_file == "assets/music/tesla_shorts_time.mp3"
+        # EI got its own dedicated theme in May 2026 (replaced tesla_shorts_time.mp3).
+        assert config.audio.music_file == "assets/music/EnvIntel.mp3"
 
     def test_models_agents_config_details(self):
         """Models & Agents config has expected properties."""


### PR DESCRIPTION
## Summary

Wires each of the 7 newly-uploaded music files to its target show. Tesla, FF, and PT are unchanged.

| Show | New music | Replaces |
|---|---|---|
| Omni View | `OmniView.mp3` | `LubechangeOilers.mp3` |
| Env Intel | `EnvIntel.mp3` | `tesla_shorts_time.mp3` (shared) |
| Models & Agents | `ModelsAgents.mp3` | `tesla_shorts_time.mp3` (shared) |
| Models & Agents for Beginners | `ModelsAgents.mp3` (same as M&A per request) | `tesla_shorts_time.mp3` (shared) |
| Modern Investing Techniques | `ModernInvesting.mp3` | `tesla_shorts_time.mp3` (shared) |
| Финансы Просто | `Финансы Просто.mp3` | `tesla_shorts_time.mp3` (shared) |
| Привет, Русский! | `ПриветРусский.mp3` | `tesla_shorts_time.mp3` (shared) |

After this PR, every show has a dedicated theme — no more cross-show music borrowing.

## The one tricky thing — Unicode NFD on disk

`ПриветРусский.mp3` was uploaded in **NFD** form (the trailing `й` is `и` U+0438 + combining breve U+0306, not the precomposed U+0439). On the first attempt my Edit tool normalized my YAML write to NFC and the path lookup failed:
```
privet_russian   assets/music/ПриветРусский.mp3   [MISSING]
```

Fixed by writing the YAML byte-for-byte from `os.listdir()` so the YAML preserves the same NFD bytes that exist on disk. **Verified all 10 shows now resolve to real files under `assets/music/`.**

The README flags this caveat for future moves: if anyone renames or re-uploads `ПриветРусский.mp3`, they need to keep `shows/privet_russian.yaml`'s `audio.music_file` byte-for-byte in sync. Easiest long-term fix would be to rename the file to ASCII (`privet_russian.mp3`) — flagged in the previous Slack-style discussion as the operator's call.

## Cleanup

- `LubechangeOilers.mp3` is now orphaned (no show references it). Left on disk for rollback. README marks it as safe-to-delete after a few clean OV runs.
- `tesla_shorts_time.mp3` is no longer the network's de-facto fallback — only Tesla itself uses it now.

## Stale test assertions caught + fixed

CI's full pytest run (1451 tests with all dependencies installed) caught 5 stale assertions pinning the old shared filenames. All updated to the new dedicated tracks:

- `tests/test_audio_commands.py`: `test_ov_has_music`, `test_ei_has_music`
- `tests/test_config.py`: `test_omni_view_show`, `test_env_intel_show`
- `tests/test_integration.py`: `test_env_intel_config_details`

## Test plan

- [x] `pytest tests/ -x -q --tb=short` — 1451 / 1451 pass (3 skipped intentionally) under the same setup CI uses
- [x] Each show's `audio.music_file` was resolved against the on-disk path via `pathlib.Path.exists()` before commit — all 10 shows OK
- [ ] **Live verification** — first cron run that hits each affected show should produce an episode whose intro/outro is the new dedicated music. Worth listening to one episode from each migrated show as it lands. If any show's mix sounds off (volume, tempo of intro vs voice timing), per-show audio timing knobs (`intro_duration`, `fade_duration`, etc.) are tunable in the show YAML.
- [ ] After ~3-5 clean OV runs, `git rm assets/music/LubechangeOilers.mp3` to clean up the orphan.

## Rollback

Per-show: revert that show's `music_file:` line. Network-wide: revert this PR. The new files stay on disk regardless.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_