### PR TITLE
Full-network Grok TTS migration + broadcast-quality audio pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,15 +9,15 @@ Automated daily podcast generation system running 10 shows via a unified
 
 | Show | Legacy Script | YAML Config | Schedule | X Account | TTS |
 |------|--------------|-------------|----------|-----------|-----|
-| Tesla Shorts Time | — (deleted) | `shows/tesla.yaml` | Daily | `@teslashortstime` | ElevenLabs |
-| Omni View | — (deleted) | `shows/omni_view.yaml` | Odd days | `@omniviewnews` | Grok TTS (sal) |
-| Fascinating Frontiers | — (deleted) | `shows/fascinating_frontiers.yaml` | Even days | `@planetterrian` | Grok TTS (sal) |
-| Planetterrian Daily | — (deleted) | `shows/planetterrian.yaml` | Odd days | `@planetterrian` | Grok TTS (sal) |
-| Env Intel | — | `shows/env_intel.yaml` | Odd weekdays | `@teslashortstime` | Grok TTS (sal) |
-| Models & Agents | — | `shows/models_agents.yaml` | Odd days | — (X disabled) | Grok TTS (sal) |
-| Models & Agents for Beginners | — | `shows/models_agents_beginners.yaml` | Even days | — (X disabled) | Grok TTS (sal) |
+| Tesla Shorts Time | — (deleted) | `shows/tesla.yaml` | Daily | `@teslashortstime` | Grok TTS (custom) |
+| Omni View | — (deleted) | `shows/omni_view.yaml` | Odd days | `@omniviewnews` | Grok TTS (custom) |
+| Fascinating Frontiers | — (deleted) | `shows/fascinating_frontiers.yaml` | Even days | `@planetterrian` | Grok TTS (custom) |
+| Planetterrian Daily | — (deleted) | `shows/planetterrian.yaml` | Odd days | `@planetterrian` | Grok TTS (custom) |
+| Env Intel | — | `shows/env_intel.yaml` | Odd weekdays | `@teslashortstime` | Grok TTS (custom) |
+| Models & Agents | — | `shows/models_agents.yaml` | Odd days | — (X disabled) | Grok TTS (custom) |
+| Models & Agents for Beginners | — | `shows/models_agents_beginners.yaml` | Even days | — (X disabled) | Grok TTS (custom) |
 | Финансы Просто | — | `shows/finansy_prosto.yaml` | Even days | — (X disabled) | Grok TTS (Olya) |
-| Modern Investing Techniques | — | `shows/modern_investing.yaml` | Weekdays | — (X disabled) | Grok TTS (sal) |
+| Modern Investing Techniques | — | `shows/modern_investing.yaml` | Weekdays | — (X disabled) | Grok TTS (custom) |
 | Привет, Русский! | — | `shows/privet_russian.yaml` | Even days | — (X disabled) | Grok TTS (Olya) |
 
 **Science That Changes Everything** (`digests/science_that_changes.py`, ~83 lines)
@@ -139,7 +139,7 @@ nerranetworks/
 - `GROK_API_KEY` — primary xAI key (all shows)
 - `ELEVENLABS_API_KEY` — ElevenLabs TTS (all shows)
 - `X_*` / `PLANETTERRIAN_X_*` — two separate X accounts
-- Voice IDs: 9 of 10 shows are on **Grok TTS** as of May 2026 — English shows use the `sal` built-in voice, Russian shows (FP/PR) use the custom `0b875ae2` ("Olya"). Tesla Shorts Time is the lone holdout on ElevenLabs voice `dTrBzPvD2GpAqkk1MUzA`. See landmine #16.
+- Voice IDs: **All 10 shows are on Grok TTS** as of the May 2026 full-network migration. The 8 English shows (including Tesla Shorts Time) share the operator's custom-trained voice `b4cusb2omvkz`. Russian shows (FP/PR) use the custom Olya voice `0b875ae2`. ElevenLabs is no longer used in production but the API key + legacy settings stay in `_defaults.yaml` for emergency rollback. See landmine #17.
 - See `docs/env_var_inventory.md` for the complete inventory
 
 ### RSS Feeds
@@ -252,16 +252,15 @@ decision); everything else has a live status card.
    reintroduced without updating `_defaults.yaml`.
 10. **Early episodes deleted** — first 20 Tesla, 10 FF, 10 PT, 10 OV episodes
     removed (quality issues). RSS entries removed where applicable.
-11. **9 of 10 shows on Grok TTS; Tesla Shorts Time stays on ElevenLabs
-    (May 2026)** — Chatterbox, Kokoro, and Fish Audio were trialled
-    and removed. English shows other than Tesla migrated to xAI's
-    Grok TTS with the `sal` built-in voice; Russian shows use the
-    custom Olya voice (`0b875ae2`). Tesla Shorts Time remains on
-    ElevenLabs `eleven_flash_v2_5` (voice `dTrBzPvD2GpAqkk1MUzA`)
-    because voice continuity matters most on the network's largest
-    public-facing show. Network cost: ~36× cheaper per character on
-    Grok ($4.20/M vs $150/M for ElevenLabs Flash). Reuses
-    `GROK_API_KEY` / `XAI_API_KEY` — no new secret. See landmine #16.
+11. **All 10 shows on Grok TTS (May 2026, full-network migration)** —
+    Chatterbox, Kokoro, and Fish Audio were trialled and removed.
+    English shows (including Tesla Shorts Time as of the third migration
+    wave) all use the operator's custom-trained voice `b4cusb2omvkz`
+    for a single consistent host identity. Russian shows use the
+    custom Olya voice (`0b875ae2`). ElevenLabs is no longer used in
+    production. Network cost: ~36× cheaper per character on Grok
+    ($4.20/M vs $150/M for ElevenLabs Flash). Reuses `GROK_API_KEY` /
+    `XAI_API_KEY` — no new secret. See landmines #16 and #17.
 12. **Summaries JSONs moved** — all summaries live in per-show subdirectories
     (`digests/<show>/summaries_*.json`), not at the `digests/` top level.
 13. **LLM default migrated to `grok-4.3` (May 2026)** — released 2026-04-30,
@@ -343,3 +342,61 @@ decision); everything else has a live status card.
     Tesla ever migrates, the env-var requirement disappears
     (`run_show.py:_validate_environment` already gates the check on
     `provider == "elevenlabs"`).
+17. **Full-network voice migration + broadcast-quality audio pipeline
+    (third TTS wave, May 2026)** — Tesla Shorts Time joined the rest of
+    the network on Grok TTS. Every English show now inherits the
+    operator's custom-trained voice `b4cusb2omvkz` from
+    [`shows/_defaults.yaml`](shows/_defaults.yaml); the previous `sal`
+    built-in voice was retired and TST's ElevenLabs override
+    (`provider: elevenlabs`, voice `dTrBzPvD2GpAqkk1MUzA`) was removed.
+
+    Same migration shipped a broadcast-quality audio pipeline. Cumulative
+    changes to the per-episode signal flow:
+
+    - **Grok TTS request:** now requests **WAV at 48 kHz** with
+      `text_normalization: true` (`engine/tts.py:grok_speak_chunk`).
+      Previously MP3 at 24 kHz with no normalization. The pipeline
+      crossfades chunks in WAV and only encodes to MP3 once at the very
+      end (one lossy pass instead of two). Server-side text normalization
+      handles dates, currencies, and ordinary numbers — the
+      `pronunciation_map.yaml` layer remains for proper-noun / acronym
+      overrides.
+    - **Voice EQ chain** (`engine/audio.py:_voice_norm_full_cmd`)
+      gained a 6.5 kHz dip (`equalizer=f=6500:t=q:w=1.5:g=-3`) for
+      gentle de-essing on the new custom voice. Previous chain
+      (highpass / lowpass / loudnorm / compressor / limiter) is
+      otherwise unchanged.
+    - **Final mix** (`engine/audio.py:_final_mix_cmd`) replaced the
+      simple `amix` with sidechain-ducked music + EBU R128 loudnorm
+      to **-16 LUFS** (Apple Podcasts / Spotify spec). Music
+      automatically pulls down 8 dB when voice is present and rises
+      smoothly when voice pauses. The fixed-curve `mix_with_music`
+      music timeline still runs upstream to control intro / overlap /
+      fadeout / outro volumes; the sidechain ducking adds the
+      moment-to-moment dynamic response that makes voice + music feel
+      cinematic instead of mechanical.
+    - **Final encode** bumped from CBR 192 kbps to VBR `-q:a 0`
+      (~245 kbps) for archival-quality spoken-word + music. ~6.5 MB
+      per 30-min episode (was ~5 MB).
+    - **Speech tags** are now allowed in podcast prompts (every
+      `shows/prompts/*_podcast.txt` carries a `DELIVERY` block).
+      Allowed: `[breath]`, `[pause]`, `[long-pause]`,
+      `<emphasis>...</emphasis>`. Banned: every other Grok tag
+      (`[laugh]` / `<whisper>` / `<slow>` / etc. — they sound
+      performative). The TTS path keeps tags; every non-TTS consumer
+      runs through `engine.utils.strip_speech_tags()` before publishing
+      so blog markdown, RSS show notes, X teaser, and YouTube
+      descriptions never see them.
+    - **Drift guards:** `tests/test_tts_grok.py` now has
+      `test_english_shows_resolve_to_custom_voice` (every English show
+      including Tesla resolves to `b4cusb2omvkz`),
+      `test_no_show_uses_elevenlabs_in_production` (catches accidental
+      rollback flips), and `test_russian_shows_use_grok_tts` (Olya
+      voice unchanged).
+
+    `ELEVENLABS_API_KEY` is **kept** in GitHub Secrets / `.env` for
+    emergency rollback even though no show currently needs it. The
+    legacy ElevenLabs settings in `_defaults.yaml` (model, stability,
+    similarity_boost, style, etc.) are also preserved — harmless under
+    `provider=grok` and a one-line YAML flip back to ElevenLabs if
+    Grok TTS has an outage.

--- a/engine/audio.py
+++ b/engine/audio.py
@@ -110,11 +110,27 @@ def _voice_norm_codec_args(output_path: str) -> list:
 
 
 def _voice_norm_full_cmd(voice_in: str, voice_out: str) -> list:
-    """Build the full 5-stage voice normalization ffmpeg command."""
+    """Build the full 6-stage voice normalization ffmpeg command.
+
+    Order matters — each stage operates on the output of the previous:
+
+      1. highpass=80 Hz       — strip sub-bass rumble / TTS artifacts
+      2. lowpass=15 kHz       — strip ultrasonic hiss above intelligibility
+      3. equalizer=6.5 kHz -3 dB — gentle de-esser, softens "s"/"sh" sibilants
+      4. loudnorm I=-18      — voice-only LUFS target (mix gets re-norm'd to -16)
+      5. acompressor 4:1     — gentle dynamics control (NPR-ish consistency)
+      6. alimiter level_out=0.95 — peak protection, prevents clipping into mix
+
+    The 6.5 kHz dip is new in May 2026 — the custom Grok voice introduced
+    with the full network migration was noticeably sibilant on the raw
+    output, and the dip restores broadcast feel without making the voice
+    sound dull. See landmine #17.
+    """
     return [
         "ffmpeg", "-y", "-threads", "0", "-i", voice_in,
         "-af",
         "highpass=f=80,lowpass=f=15000,"
+        "equalizer=f=6500:t=q:w=1.5:g=-3,"
         "loudnorm=I=-18:TP=-1.5:LRA=11:linear=true,"
         "acompressor=threshold=-20dB:ratio=4:attack=1:release=100:makeup=2,"
         "alimiter=level_in=1:level_out=0.95:limit=0.95",
@@ -449,13 +465,43 @@ def _music_concat_cmd(concat_list: str, music_full_out: str) -> list:
 
 
 def _final_mix_cmd(voice_in: str, music_in: str, final_out: str) -> list:
+    """Voice + music final mix with sidechain ducking + EBU R128 loudnorm.
+
+    Filter graph stages:
+
+      1. ``asplit`` — duplicate the voice signal so it can drive both the
+         sidechain compressor (as the trigger) and the final amix (as audio).
+      2. ``sidechaincompress`` — when voice is present, music is pulled
+         down 8 dB; when voice pauses, music rises smoothly. ``threshold=-30 dB``
+         and ``ratio=8`` mean even modest voice levels duck the music; the
+         ``attack=20 ms`` / ``release=300 ms`` pair gives broadcast feel
+         (fast enough to catch syllable transients, slow enough not to pump).
+         ``level_sc=2`` doubles the trigger sensitivity so quieter narration
+         still ducks the bed reliably.
+      3. ``amix`` — sums voice + ducked music with longest-duration semantics.
+      4. ``loudnorm I=-16`` — final integrated-loudness target. Apple
+         Podcasts and Spotify both auto-normalize listener-side, so episodes
+         well under -16 LUFS get attenuated and feel quiet next to NPR-mastered
+         shows. ``TP=-1.5`` keeps headroom to absorb true-peak intersample
+         peaks without clipping. ``LRA=11`` preserves natural dynamics
+         (a denser LRA flatlines the audio).
+
+    Final encode is libmp3lame -q:a 0 (~245 kbps VBR — archival quality
+    spoken-word + music; ~6.5 MB per 30-min episode).
+    """
     return [
         "ffmpeg", "-y", "-threads", "0",
         "-i", voice_in, "-i", music_in,
         "-filter_complex",
-        "[0:a][1:a]amix=inputs=2:duration=longest:dropout_transition=2",
+        "[0:a]asplit=2[voice_mix][voice_sc];"
+        "[1:a][voice_sc]sidechaincompress="
+        "threshold=-30dB:ratio=8:attack=20:release=300:level_sc=2"
+        "[music_ducked];"
+        "[voice_mix][music_ducked]amix=inputs=2:duration=longest:dropout_transition=2[mixed];"
+        "[mixed]loudnorm=I=-16:TP=-1.5:LRA=11[out]",
+        "-map", "[out]",
         "-ar", "44100", "-ac", "2",
-        "-c:a", "libmp3lame", "-b:a", "192k", "-preset", "fast",
+        "-c:a", "libmp3lame", "-q:a", "0",
         final_out,
     ]
 

--- a/engine/config.py
+++ b/engine/config.py
@@ -67,17 +67,20 @@ class LLMConfig:
 
 @dataclass
 class TTSConfig:
-    # Network default since May 2026: Grok TTS with the "sal" built-in
-    # voice. Russian shows override voice_id to their custom Olya
-    # (`0b875ae2`) and language_code to `ru`. Tesla Shorts Time stays on
-    # ElevenLabs by overriding provider+voice_id.
+    # Network default since May 2026: Grok TTS with the operator's
+    # custom-trained voice `b4cusb2omvkz`, used for every English
+    # show on the network for a single consistent host identity.
+    # Russian shows (FP/PR) override voice_id to their custom Olya
+    # (`0b875ae2`) and language_code to `ru`. No show is on ElevenLabs
+    # in production; the legacy fields below remain only for emergency
+    # rollback.
     provider: str = "grok"
-    voice_id: str = "sal"
+    voice_id: str = "b4cusb2omvkz"
     language_code: str = "en"  # BCP-47 (Grok) / ISO 639-1 (ElevenLabs); shows override for non-English
     max_chars: int = 10000
     # ---- Legacy ElevenLabs baseline ----
-    # Active only when a show overrides ``provider: elevenlabs``. The
-    # Grok TTS code path silently ignores all of these.
+    # No show overrides ``provider: elevenlabs`` in production. Kept
+    # here so emergency rollback is a one-line flip. Grok path ignores.
     model: str = "eleven_flash_v2_5"
     stability: float = 0.5
     similarity_boost: float = 0.75

--- a/engine/tts.py
+++ b/engine/tts.py
@@ -630,13 +630,34 @@ def grok_speak_chunk(
     api_key: str,
     language_code: str = "auto",
     timeout: int = 120,
+    output_codec: str = "wav",
+    output_sample_rate: int = 48000,
+    text_normalization: bool = True,
 ) -> None:
     """Generate audio for a single text chunk via the Grok ``/v1/tts`` endpoint.
 
-    Returns MP3 bytes by default (24 kHz / 128 kbps, per xAI docs). Retries
-    only on transient errors (timeouts, connection failures, 429/5xx). The
-    API key reuses ``GROK_API_KEY`` / ``XAI_API_KEY`` — the same one used
-    for LLM calls — so no new env var is needed.
+    Defaults to **WAV at 48 kHz** so the chunk-concat pipeline can crossfade
+    in lossless PCM and only encode to MP3 once at the very end. The previous
+    default (MP3 24 kHz / 128 kbps) forced a decode + upsample on every
+    chunk, throwing away high-frequency detail and stacking lossy passes.
+
+    Also defaults ``text_normalization=True`` so Grok handles numbers, dates,
+    currency, and abbreviations server-side ("$381.63" → "three hundred
+    eighty-one dollars and sixty-three cents", "2026-05-02" → "May second,
+    twenty twenty-six"). Combined with ``shows/pronunciation_map.yaml`` the
+    pipeline now has two layers of pronunciation correction.
+
+    Speech tags supported in *text*: inline ``[breath]``, ``[pause]``,
+    ``[long-pause]``, ``[sigh]``, ``[laugh]``; wrapping ``<emphasis>...</emphasis>``,
+    ``<whisper>...</whisper>``, ``<soft>...</soft>``, ``<loud>...</loud>``,
+    ``<slow>...</slow>``, ``<fast>...</fast>``. The Grok backend consumes
+    them — they don't appear in the audio as literal words. Use
+    ``engine.text_utils.strip_speech_tags()`` before any non-TTS consumer
+    (blog text, RSS show notes, X teaser).
+
+    Retries only on transient errors (timeouts, connection failures, 429/5xx).
+    The API key reuses ``GROK_API_KEY`` / ``XAI_API_KEY`` — same one used for
+    LLM calls — so no new env var is needed.
     """
     if not text or not text.strip():
         raise ValueError(
@@ -654,6 +675,11 @@ def grok_speak_chunk(
         "text": text,
         "voice_id": voice_id,
         "language": language_code or "auto",
+        "output_format": {
+            "codec": output_codec,
+            "sample_rate": output_sample_rate,
+        },
+        "text_normalization": text_normalization,
     }
     headers = {
         "Authorization": f"Bearer {api_key}",
@@ -710,8 +736,11 @@ def _speak_with_grok(
 ) -> None:
     """Grok-TTS counterpart of ``speak()``.
 
-    Same chunk → WAV → crossfade → final MP3 pipeline as the ElevenLabs
-    path. Single chunks short-circuit to a direct MP3 write (no re-encode).
+    Pipeline: per-chunk Grok TTS → WAV 48 kHz → crossfade in WAV →
+    encode once to MP3 at the very end (single lossy pass). Skips the
+    MP3-decode step the older path used because Grok now returns WAV
+    directly. Single chunks short-circuit to one ffmpeg encode (no
+    crossfade needed).
     """
     text = prepare_text_for_tts(text)
     # Cap at Grok's 15k-char request limit even when caller passes a
@@ -719,28 +748,55 @@ def _speak_with_grok(
     effective_max = min(max_chars, GROK_MAX_CHARS_PER_REQUEST)
     chunks = chunk_text(text, max_chars=effective_max)
 
+    import tempfile as _tmpmod
+    tmp_dir = Path(_tmpmod.mkdtemp(prefix="tts_grok_", dir=str(Path(filename).parent)))
+
     if len(chunks) == 1:
         out_text = chunks[0]
         if append_exclamation:
             out_text = out_text + "!"
-        grok_speak_chunk(
-            out_text, voice_id, Path(filename),
-            api_key=api_key, language_code=language_code, timeout=timeout,
-        )
-        logger.info("Grok TTS: Generated single chunk (%d chars)", len(out_text))
+        # Single chunk: WAV from Grok → final MP3 in one encode pass.
+        wav_chunk = tmp_dir / "tts_chunk.wav"
+        try:
+            grok_speak_chunk(
+                out_text, voice_id, wav_chunk,
+                api_key=api_key, language_code=language_code, timeout=timeout,
+            )
+            subprocess.run(
+                [
+                    "ffmpeg", "-y", "-i", str(wav_chunk),
+                    "-c:a", "libmp3lame", "-q:a", "0",
+                    str(filename),
+                ],
+                check=True, capture_output=True, timeout=300,
+            )
+            logger.info(
+                "Grok TTS: Generated single chunk (%d chars) → MP3 (one encode)",
+                len(out_text),
+            )
+        finally:
+            if wav_chunk.exists():
+                try:
+                    wav_chunk.unlink()
+                except OSError:
+                    pass
+            try:
+                if tmp_dir.exists() and tmp_dir != Path(filename).parent:
+                    tmp_dir.rmdir()
+            except OSError:
+                pass
         return
 
     logger.info(
         "Grok TTS: Splitting into %d chunks for seamless generation",
         len(chunks),
     )
-    import tempfile as _tmpmod
-    tmp_dir = Path(_tmpmod.mkdtemp(prefix="tts_grok_", dir=str(Path(filename).parent)))
     chunk_files: List[Path] = []
     wav_files: List[Path] = []
     try:
         for i, chunk_text_str in enumerate(chunks):
-            chunk_file = tmp_dir / f"tts_chunk_{i:03d}.mp3"
+            # Grok now returns WAV 48 kHz directly — no MP3 decode step.
+            chunk_file = tmp_dir / f"tts_chunk_{i:03d}.wav"
             if append_exclamation:
                 if i < len(chunks) - 1:
                     chunk_text_str = chunk_text_str.rstrip(".!?") + "."
@@ -751,22 +807,11 @@ def _speak_with_grok(
                 api_key=api_key, language_code=language_code, timeout=timeout,
             )
             chunk_files.append(chunk_file)
+            wav_files.append(chunk_file)
             logger.info(
                 "Grok TTS: Generated chunk %d/%d (%d chars)",
                 i + 1, len(chunks), len(chunk_text_str),
             )
-
-        # Decode each MP3 chunk to WAV for lossless concatenation, mirroring
-        # the ElevenLabs path. Output is mono 44.1 kHz to match the rest
-        # of the pipeline (Grok's default is 24 kHz; ffmpeg upsamples on
-        # decode and we re-encode once at the end).
-        for cf in chunk_files:
-            wav_file = cf.with_suffix(".wav")
-            subprocess.run(
-                ["ffmpeg", "-y", "-i", str(cf), "-ar", "44100", "-ac", "1", str(wav_file)],
-                check=True, capture_output=True, timeout=120,
-            )
-            wav_files.append(wav_file)
 
         _XFADE_SECS = "0.05"
         if len(wav_files) == 2:
@@ -799,7 +844,7 @@ def _speak_with_grok(
             [
                 "ffmpeg", "-y",
                 "-i", str(merged_wav),
-                "-c:a", "libmp3lame", "-q:a", "2",
+                "-c:a", "libmp3lame", "-q:a", "0",
                 str(filename),
             ],
             check=True, capture_output=True, timeout=300,
@@ -809,7 +854,9 @@ def _speak_with_grok(
             "(single MP3 encode)", len(chunks),
         )
     finally:
-        for cf in chunk_files + wav_files:
+        # chunk_files and wav_files reference the same on-disk files now;
+        # use a set to avoid double-unlink errors.
+        for cf in set(chunk_files) | set(wav_files):
             try:
                 if cf.exists():
                     cf.unlink()

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -489,3 +489,65 @@ DEFAULT_HEADERS = {
     "User-Agent": "PodcastBot/1.0 (+https://github.com/patricknovak/nerranetworks)"
 }
 HTTP_TIMEOUT_SECONDS = 10
+
+
+# ---------------------------------------------------------------------------
+# Speech tag stripping (Grok TTS)
+# ---------------------------------------------------------------------------
+
+# Inline tags used by Grok TTS: bracketed single-token directives that
+# instruct the speech model to insert non-verbal audio (breath, pause, etc.)
+# at that point in the stream. Listed verbatim from the Grok TTS docs:
+# https://docs.x.ai/developers/model-capabilities/audio/text-to-speech
+_INLINE_SPEECH_TAGS = (
+    "pause", "long-pause", "laugh", "cry",
+    "sniff", "kiss", "throat-clear",
+    "breath", "sigh", "gasp",
+)
+_INLINE_TAG_PATTERN = re.compile(
+    r"\[\s*(?:" + "|".join(re.escape(t) for t in _INLINE_SPEECH_TAGS) + r")\s*\]",
+    flags=re.IGNORECASE,
+)
+
+# Wrapping tags surround a span of text and modify its delivery (whisper,
+# emphasis, etc.). The Grok backend interprets and consumes them; we strip
+# them for any non-TTS consumer (blog markdown, RSS show notes, X teaser).
+_WRAPPING_TAGS = (
+    "soft", "loud", "whisper",
+    "slow", "fast", "high", "low",
+    "singing", "emphasis",
+)
+_WRAPPING_TAG_PATTERN = re.compile(
+    r"</?\s*(?:" + "|".join(re.escape(t) for t in _WRAPPING_TAGS) + r")\s*>",
+    flags=re.IGNORECASE,
+)
+
+
+def strip_speech_tags(text: str) -> str:
+    """Remove Grok TTS speech tags from text.
+
+    Strips inline tags (``[breath]``, ``[pause]``, ``[long-pause]``,
+    ``[laugh]``, etc.) and the open/close pair of every wrapping tag
+    (``<emphasis>...</emphasis>``, ``<whisper>...</whisper>``, etc. —
+    only the brackets are removed; the wrapped text content is preserved
+    so the digest reads as written prose).
+
+    Apply at every non-TTS consumer of the podcast script: blog markdown,
+    RSS show notes, X teaser, transcript fallback when Whisper isn't
+    available, chapter section detection, etc. The TTS path itself
+    deliberately keeps the tags so the Grok backend can consume them.
+
+    Idempotent: stripping an already-stripped string is a no-op.
+    """
+    if not text:
+        return text
+    out = _INLINE_TAG_PATTERN.sub("", text)
+    out = _WRAPPING_TAG_PATTERN.sub("", out)
+    # Collapse any double spaces left behind by removed inline tags
+    # (e.g. ``"sentence one. [breath] sentence two."`` → two spaces between
+    # the period and "sentence two.").
+    out = re.sub(r"  +", " ", out)
+    # Tighten "tag-eats-newline" cases like ``"... line.\n[breath]\nNext line ..."``
+    # which leave a stray double-newline-with-space artifact.
+    out = re.sub(r"\n[ \t]+\n", "\n\n", out)
+    return out

--- a/run_show.py
+++ b/run_show.py
@@ -1610,9 +1610,14 @@ def run(args: argparse.Namespace) -> None:
             if config.tts.validate_transcription:
                 import json as _json
                 from engine.tts_validation import validate_tts_transcription
+                from engine.utils import strip_speech_tags
                 logger.info("Running post-TTS transcription validation...")
+                # Whisper transcribes audio (no tag literals come back), so
+                # we compare against the tag-stripped script — otherwise the
+                # match score is artificially lowered by every [breath] /
+                # <emphasis>...</emphasis> in the reference text.
                 tts_val = validate_tts_transcription(
-                    raw_mp3, podcast_script,
+                    raw_mp3, strip_speech_tags(podcast_script),
                     model_size=config.tts.whisper_model,
                     threshold=config.tts.whisper_threshold,
                 )

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -39,21 +39,22 @@ llm:
 
 tts:
   # Network default since May 2026: xAI Grok TTS at $4.20/M chars
-  # (~36× cheaper than ElevenLabs Flash). Voice "sal" is a Grok built-in
-  # named voice — no training required. Russian shows (FP/PR) override
-  # voice_id to their custom "Olya" (`0b875ae2`) and language_code to
-  # `ru`. Tesla Shorts Time stays on ElevenLabs by overriding
-  # provider+voice_id back; see shows/tesla.yaml.
+  # (~36× cheaper than ElevenLabs Flash). Voice `b4cusb2omvkz` is the
+  # operator's custom-trained voice — every English show on the
+  # network shares it for a single consistent "host" identity.
+  # Russian shows (FP/PR) override voice_id to their custom "Olya"
+  # (`0b875ae2`) and language_code to `ru`. No show is on ElevenLabs
+  # in production any more; the legacy block below is retained only
+  # for emergency rollback.
   provider: grok
-  voice_id: sal
+  voice_id: b4cusb2omvkz
   language_code: en
   max_chars: 10000
   # ---- Legacy ElevenLabs baseline ----
-  # Active only when a show overrides `provider: elevenlabs` (currently
-  # Tesla Shorts Time). Kept here so any future ElevenLabs flip-back
-  # inherits the same baseline rather than re-discovering tuned values.
-  # The Grok TTS code path silently ignores all of these — they cost
-  # nothing to leave in defaults.
+  # No show currently overrides `provider: elevenlabs`. Kept here so
+  # an emergency rollback (e.g. Grok TTS outage) is a one-line YAML
+  # flip rather than a re-tune. Harmless when `provider=grok` (Grok
+  # path silently ignores these fields).
   model: eleven_flash_v2_5
   stability: 0.5
   similarity_boost: 0.75

--- a/shows/prompts/env_intel_podcast.txt
+++ b/shows/prompts/env_intel_podcast.txt
@@ -152,6 +152,33 @@ Do NOT repeat transition sentences. When you write a transition at the end of on
 LENGTH TARGET:
 Your script must be at least 1500 words (45+ sentences). If you find yourself finishing early, expand with more regulatory context and expert interpretation.
 
+DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
+
+You may sparingly include Grok TTS speech tags to make narration feel more
+human. The TTS engine consumes them — they do NOT come out as spoken
+words. Tags are stripped before the script reaches blog markdown, RSS show
+notes, the X teaser, and YouTube descriptions, so listeners hear the
+effect but readers see clean prose.
+
+ALLOWED TAGS (use sparingly, see frequency caps):
+  [breath]                  — between dense factual paragraphs.
+                              Max ~1 per 150 words. Never inside a sentence.
+  [pause]                   — at major topic transitions.
+                              Max 3 per episode.
+  [long-pause]              — between major sections (e.g. before a closing).
+                              Max 1 per episode.
+  <emphasis>word</emphasis> — around 1–2 KEY words per minute, only on
+                              claims that benefit from spoken stress.
+
+DO NOT use any other tags ([laugh], [sigh], [gasp], <whisper>, <slow>,
+<fast>, <high>, <low>, <singing>, <soft>, <loud>). They make narration
+sound performative and fake.
+
+DO NOT place tags inside numbers, ticker symbols, currency amounts, or
+proper-noun phrases. DO NOT cluster tags (no "[breath] [pause]"). DO NOT
+narrate the tag itself ("comma breath" or "pause for emphasis") — write
+the literal bracketed tag and trust the engine.
+
 Here is today's complete briefing. Use ONLY this content:
 
 {digest}

--- a/shows/prompts/fascinating_frontiers_podcast.txt
+++ b/shows/prompts/fascinating_frontiers_podcast.txt
@@ -117,6 +117,33 @@ WHAT TO SKIP (do NOT read aloud):
 LENGTH TARGET:
 Your script must be at least 2400 words (60+ sentences). If you find yourself finishing early, go back and expand each story.
 
+DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
+
+You may sparingly include Grok TTS speech tags to make narration feel more
+human. The TTS engine consumes them — they do NOT come out as spoken
+words. Tags are stripped before the script reaches blog markdown, RSS show
+notes, the X teaser, and YouTube descriptions, so listeners hear the
+effect but readers see clean prose.
+
+ALLOWED TAGS (use sparingly, see frequency caps):
+  [breath]                  — between dense factual paragraphs.
+                              Max ~1 per 150 words. Never inside a sentence.
+  [pause]                   — at major topic transitions.
+                              Max 3 per episode.
+  [long-pause]              — between major sections (e.g. before a closing).
+                              Max 1 per episode.
+  <emphasis>word</emphasis> — around 1–2 KEY words per minute, only on
+                              claims that benefit from spoken stress.
+
+DO NOT use any other tags ([laugh], [sigh], [gasp], <whisper>, <slow>,
+<fast>, <high>, <low>, <singing>, <soft>, <loud>). They make narration
+sound performative and fake.
+
+DO NOT place tags inside numbers, ticker symbols, currency amounts, or
+proper-noun phrases. DO NOT cluster tags (no "[breath] [pause]"). DO NOT
+narrate the tag itself ("comma breath" or "pause for emphasis") — write
+the literal bracketed tag and trust the engine.
+
 Here is today's complete formatted digest. Use ONLY this content:
 
 {digest}

--- a/shows/prompts/fp_podcast.txt
+++ b/shows/prompts/fp_podcast.txt
@@ -152,6 +152,33 @@ PRONUNCIATION GUIDE:
 ТРЕБОВАНИЕ К ДЛИНЕ:
 Твой сценарий должен быть не менее 1300 слов (35+ предложений). Если заканчиваешь рано, вернись и расширь каждый блок.
 
+DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
+
+You may sparingly include Grok TTS speech tags to make narration feel more
+human. The TTS engine consumes them — they do NOT come out as spoken
+words. Tags are stripped before the script reaches blog markdown, RSS show
+notes, the X teaser, and YouTube descriptions, so listeners hear the
+effect but readers see clean prose.
+
+ALLOWED TAGS (use sparingly, see frequency caps):
+  [breath]                  — between dense factual paragraphs.
+                              Max ~1 per 150 words. Never inside a sentence.
+  [pause]                   — at major topic transitions.
+                              Max 3 per episode.
+  [long-pause]              — between major sections (e.g. before a closing).
+                              Max 1 per episode.
+  <emphasis>word</emphasis> — around 1–2 KEY words per minute, only on
+                              claims that benefit from spoken stress.
+
+DO NOT use any other tags ([laugh], [sigh], [gasp], <whisper>, <slow>,
+<fast>, <high>, <low>, <singing>, <soft>, <loud>). They make narration
+sound performative and fake.
+
+DO NOT place tags inside numbers, ticker symbols, currency amounts, or
+proper-noun phrases. DO NOT cluster tags (no "[breath] [pause]"). DO NOT
+narrate the tag itself ("comma breath" or "pause for emphasis") — write
+the literal bracketed tag and trust the engine.
+
 Вот сегодняшний обзор. Используй ТОЛЬКО этот контент:
 
 {digest}

--- a/shows/prompts/mab_podcast.txt
+++ b/shows/prompts/mab_podcast.txt
@@ -157,6 +157,33 @@ Use this exact closing (do not rewrite it):
 LENGTH TARGET:
 Your script must be at least 1300 words (35+ sentences).
 
+DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
+
+You may sparingly include Grok TTS speech tags to make narration feel more
+human. The TTS engine consumes them — they do NOT come out as spoken
+words. Tags are stripped before the script reaches blog markdown, RSS show
+notes, the X teaser, and YouTube descriptions, so listeners hear the
+effect but readers see clean prose.
+
+ALLOWED TAGS (use sparingly, see frequency caps):
+  [breath]                  — between dense factual paragraphs.
+                              Max ~1 per 150 words. Never inside a sentence.
+  [pause]                   — at major topic transitions.
+                              Max 3 per episode.
+  [long-pause]              — between major sections (e.g. before a closing).
+                              Max 1 per episode.
+  <emphasis>word</emphasis> — around 1–2 KEY words per minute, only on
+                              claims that benefit from spoken stress.
+
+DO NOT use any other tags ([laugh], [sigh], [gasp], <whisper>, <slow>,
+<fast>, <high>, <low>, <singing>, <soft>, <loud>). They make narration
+sound performative and fake.
+
+DO NOT place tags inside numbers, ticker symbols, currency amounts, or
+proper-noun phrases. DO NOT cluster tags (no "[breath] [pause]"). DO NOT
+narrate the tag itself ("comma breath" or "pause for emphasis") — write
+the literal bracketed tag and trust the engine.
+
 Here is today's complete briefing. Use ONLY this content:
 
 {digest}

--- a/shows/prompts/models_agents_podcast.txt
+++ b/shows/prompts/models_agents_podcast.txt
@@ -153,6 +153,33 @@ Do NOT repeat transition sentences. When you write a transition at the end of on
 LENGTH TARGET:
 Your script must be at least 1500 words (45+ sentences).
 
+DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
+
+You may sparingly include Grok TTS speech tags to make narration feel more
+human. The TTS engine consumes them — they do NOT come out as spoken
+words. Tags are stripped before the script reaches blog markdown, RSS show
+notes, the X teaser, and YouTube descriptions, so listeners hear the
+effect but readers see clean prose.
+
+ALLOWED TAGS (use sparingly, see frequency caps):
+  [breath]                  — between dense factual paragraphs.
+                              Max ~1 per 150 words. Never inside a sentence.
+  [pause]                   — at major topic transitions.
+                              Max 3 per episode.
+  [long-pause]              — between major sections (e.g. before a closing).
+                              Max 1 per episode.
+  <emphasis>word</emphasis> — around 1–2 KEY words per minute, only on
+                              claims that benefit from spoken stress.
+
+DO NOT use any other tags ([laugh], [sigh], [gasp], <whisper>, <slow>,
+<fast>, <high>, <low>, <singing>, <soft>, <loud>). They make narration
+sound performative and fake.
+
+DO NOT place tags inside numbers, ticker symbols, currency amounts, or
+proper-noun phrases. DO NOT cluster tags (no "[breath] [pause]"). DO NOT
+narrate the tag itself ("comma breath" or "pause for emphasis") — write
+the literal bracketed tag and trust the engine.
+
 Here is today's complete briefing. Use ONLY this content:
 
 {digest}

--- a/shows/prompts/modern_investing_monthly_podcast.txt
+++ b/shows/prompts/modern_investing_monthly_podcast.txt
@@ -51,4 +51,31 @@ You are {host_name}, host of Modern Investing Techniques. You are recording the 
 - Do not repeat any lesson that appeared in the daily show more than twice this month (the "Lessons recently taught" signal in the operator dashboard drives this — if a topic already fatigued listeners, do not re-teach it here).
 - Be honest about losses. The show's credibility comes from accountable reckoning, not from spinning losses as "learnings".
 
-Output the spoken script only. No markdown headers. No bracketed labels. No stage directions.
+DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
+
+You may sparingly include Grok TTS speech tags to make narration feel more
+human. The TTS engine consumes them — they do NOT come out as spoken
+words. Tags are stripped before the script reaches blog markdown, RSS show
+notes, the X teaser, and YouTube descriptions, so listeners hear the
+effect but readers see clean prose.
+
+ALLOWED TAGS (use sparingly, see frequency caps):
+  [breath]                  — between dense factual paragraphs.
+                              Max ~1 per 150 words. Never inside a sentence.
+  [pause]                   — at major topic transitions.
+                              Max 3 per episode.
+  [long-pause]              — between major sections (e.g. before a closing).
+                              Max 1 per episode.
+  <emphasis>word</emphasis> — around 1–2 KEY words per minute, only on
+                              claims that benefit from spoken stress.
+
+DO NOT use any other tags ([laugh], [sigh], [gasp], <whisper>, <slow>,
+<fast>, <high>, <low>, <singing>, <soft>, <loud>). They make narration
+sound performative and fake.
+
+DO NOT place tags inside numbers, ticker symbols, currency amounts, or
+proper-noun phrases. DO NOT cluster tags (no "[breath] [pause]"). DO NOT
+narrate the tag itself ("comma breath" or "pause for emphasis") — write
+the literal bracketed tag and trust the engine.
+
+Output the spoken script only. No markdown headers. No bracketed labels. No stage directions (other than the speech tags allowed above).

--- a/shows/prompts/modern_investing_podcast.txt
+++ b/shows/prompts/modern_investing_podcast.txt
@@ -202,6 +202,33 @@ CONTENT REPETITION (STRICT):
 LENGTH TARGET:
 Your script must be at least 2500 words (55+ sentences).
 
+DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
+
+You may sparingly include Grok TTS speech tags to make narration feel more
+human. The TTS engine consumes them — they do NOT come out as spoken
+words. Tags are stripped before the script reaches blog markdown, RSS show
+notes, the X teaser, and YouTube descriptions, so listeners hear the
+effect but readers see clean prose.
+
+ALLOWED TAGS (use sparingly, see frequency caps):
+  [breath]                  — between dense factual paragraphs.
+                              Max ~1 per 150 words. Never inside a sentence.
+  [pause]                   — at major topic transitions.
+                              Max 3 per episode.
+  [long-pause]              — between major sections (e.g. before a closing).
+                              Max 1 per episode.
+  <emphasis>word</emphasis> — around 1–2 KEY words per minute, only on
+                              claims that benefit from spoken stress.
+
+DO NOT use any other tags ([laugh], [sigh], [gasp], <whisper>, <slow>,
+<fast>, <high>, <low>, <singing>, <soft>, <loud>). They make narration
+sound performative and fake.
+
+DO NOT place tags inside numbers, ticker symbols, currency amounts, or
+proper-noun phrases. DO NOT cluster tags (no "[breath] [pause]"). DO NOT
+narrate the tag itself ("comma breath" or "pause for emphasis") — write
+the literal bracketed tag and trust the engine.
+
 Here is today's complete briefing. Use ONLY this content:
 
 {digest}

--- a/shows/prompts/omni_view_podcast.txt
+++ b/shows/prompts/omni_view_podcast.txt
@@ -118,6 +118,33 @@ Use this exact closing (do not rewrite it):
 LENGTH TARGET:
 Your script must be at least 2000 words (40+ sentences). If you find yourself finishing early, go back and add more perspectives and deeper analysis.
 
+DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
+
+You may sparingly include Grok TTS speech tags to make narration feel more
+human. The TTS engine consumes them — they do NOT come out as spoken
+words. Tags are stripped before the script reaches blog markdown, RSS show
+notes, the X teaser, and YouTube descriptions, so listeners hear the
+effect but readers see clean prose.
+
+ALLOWED TAGS (use sparingly, see frequency caps):
+  [breath]                  — between dense factual paragraphs.
+                              Max ~1 per 150 words. Never inside a sentence.
+  [pause]                   — at major topic transitions.
+                              Max 3 per episode.
+  [long-pause]              — between major sections (e.g. before a closing).
+                              Max 1 per episode.
+  <emphasis>word</emphasis> — around 1–2 KEY words per minute, only on
+                              claims that benefit from spoken stress.
+
+DO NOT use any other tags ([laugh], [sigh], [gasp], <whisper>, <slow>,
+<fast>, <high>, <low>, <singing>, <soft>, <loud>). They make narration
+sound performative and fake.
+
+DO NOT place tags inside numbers, ticker symbols, currency amounts, or
+proper-noun phrases. DO NOT cluster tags (no "[breath] [pause]"). DO NOT
+narrate the tag itself ("comma breath" or "pause for emphasis") — write
+the literal bracketed tag and trust the engine.
+
 Here is today's complete briefing. Use ONLY this content:
 
 {digest}

--- a/shows/prompts/planetterrian_podcast.txt
+++ b/shows/prompts/planetterrian_podcast.txt
@@ -117,6 +117,33 @@ WHAT TO SKIP (do NOT read aloud):
 LENGTH TARGET:
 Your script must be at least 2400 words (60+ sentences). If you find yourself finishing early, go back and expand each story.
 
+DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
+
+You may sparingly include Grok TTS speech tags to make narration feel more
+human. The TTS engine consumes them — they do NOT come out as spoken
+words. Tags are stripped before the script reaches blog markdown, RSS show
+notes, the X teaser, and YouTube descriptions, so listeners hear the
+effect but readers see clean prose.
+
+ALLOWED TAGS (use sparingly, see frequency caps):
+  [breath]                  — between dense factual paragraphs.
+                              Max ~1 per 150 words. Never inside a sentence.
+  [pause]                   — at major topic transitions.
+                              Max 3 per episode.
+  [long-pause]              — between major sections (e.g. before a closing).
+                              Max 1 per episode.
+  <emphasis>word</emphasis> — around 1–2 KEY words per minute, only on
+                              claims that benefit from spoken stress.
+
+DO NOT use any other tags ([laugh], [sigh], [gasp], <whisper>, <slow>,
+<fast>, <high>, <low>, <singing>, <soft>, <loud>). They make narration
+sound performative and fake.
+
+DO NOT place tags inside numbers, ticker symbols, currency amounts, or
+proper-noun phrases. DO NOT cluster tags (no "[breath] [pause]"). DO NOT
+narrate the tag itself ("comma breath" or "pause for emphasis") — write
+the literal bracketed tag and trust the engine.
+
 Here is today's complete formatted digest. Use ONLY this content:
 
 {digest}

--- a/shows/prompts/privet_russian_podcast.txt
+++ b/shows/prompts/privet_russian_podcast.txt
@@ -126,6 +126,33 @@ Target: 60-90 seconds of audio.
 Use this exact closing (do not rewrite it):
 {closing_block}
 
+DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
+
+You may sparingly include Grok TTS speech tags to make narration feel more
+human. The TTS engine consumes them — they do NOT come out as spoken
+words. Tags are stripped before the script reaches blog markdown, RSS show
+notes, the X teaser, and YouTube descriptions, so listeners hear the
+effect but readers see clean prose.
+
+ALLOWED TAGS (use sparingly, see frequency caps):
+  [breath]                  — between dense factual paragraphs.
+                              Max ~1 per 150 words. Never inside a sentence.
+  [pause]                   — at major topic transitions.
+                              Max 3 per episode.
+  [long-pause]              — between major sections (e.g. before a closing).
+                              Max 1 per episode.
+  <emphasis>word</emphasis> — around 1–2 KEY words per minute, only on
+                              claims that benefit from spoken stress.
+
+DO NOT use any other tags ([laugh], [sigh], [gasp], <whisper>, <slow>,
+<fast>, <high>, <low>, <singing>, <soft>, <loud>). They make narration
+sound performative and fake.
+
+DO NOT place tags inside numbers, ticker symbols, currency amounts, or
+proper-noun phrases. DO NOT cluster tags (no "[breath] [pause]"). DO NOT
+narrate the tag itself ("comma breath" or "pause for emphasis") — write
+the literal bracketed tag and trust the engine.
+
 Here is today's episode plan. Use ONLY this content:
 
 {digest}

--- a/shows/prompts/tesla_podcast.txt
+++ b/shows/prompts/tesla_podcast.txt
@@ -114,6 +114,33 @@ WHAT TO SKIP (do not read aloud):
 LENGTH TARGET:
 Your script must be at least 2800 words (70+ sentences). If you find yourself finishing early, go back and expand each story — add more context, explain the engineering or business implications, and share your perspective.
 
+DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
+
+You may sparingly include Grok TTS speech tags to make narration feel more
+human. The TTS engine consumes them — they do NOT come out as spoken
+words. Tags are stripped before the script reaches blog markdown, RSS show
+notes, the X teaser, and YouTube descriptions, so listeners hear the
+effect but readers see clean prose.
+
+ALLOWED TAGS (use sparingly, see frequency caps):
+  [breath]                  — between dense factual paragraphs.
+                              Max ~1 per 150 words. Never inside a sentence.
+  [pause]                   — at major topic transitions.
+                              Max 3 per episode.
+  [long-pause]              — between major sections (e.g. before a closing).
+                              Max 1 per episode.
+  <emphasis>word</emphasis> — around 1–2 KEY words per minute, only on
+                              claims that benefit from spoken stress.
+
+DO NOT use any other tags ([laugh], [sigh], [gasp], <whisper>, <slow>,
+<fast>, <high>, <low>, <singing>, <soft>, <loud>). They make narration
+sound performative and fake.
+
+DO NOT place tags inside numbers, ticker symbols, currency amounts, or
+proper-noun phrases. DO NOT cluster tags (no "[breath] [pause]"). DO NOT
+narrate the tag itself ("comma breath" or "pause for emphasis") — write
+the literal bracketed tag and trust the engine.
+
 Here is today's complete formatted digest. Use ONLY this content:
 
 {digest}

--- a/shows/pronunciation_map.yaml
+++ b/shows/pronunciation_map.yaml
@@ -1,20 +1,55 @@
-# Pronunciation map for ElevenLabs TTS.
+# Pronunciation map for Grok TTS.
 #
-# Purpose: override the TTS input text for a small set of proper nouns or
-# acronyms where ElevenLabs consistently mispronounces the standard spelling.
-# This map is applied ONLY to the TTS copy of the text — the digest, blog,
-# transcript, and social posts still use the standard written form.
+# Purpose: override the TTS input text for a small set of proper nouns,
+# acronyms, or product names where Grok TTS consistently mispronounces the
+# standard spelling. Applied ONLY to the TTS copy of the text — the digest,
+# blog, transcript, and social posts continue to use the standard written
+# form. The map is layered on top of Grok's server-side `text_normalization`
+# (which already handles dates, currencies, and ordinary numbers).
 #
 # Rules for adding entries:
-# 1. Only add an entry after confirming that ElevenLabs mispronounces the
-#    standard written form on the current voice and model.  Most common
-#    acronyms (NASA, NATO, FBI, AI, EV, FSD, etc.) are handled correctly.
+# 1. Only add an entry after confirming Grok mispronounces the standard
+#    written form on the production voice (`b4cusb2omvkz` for English shows,
+#    `0b875ae2` "Olya" for Russian shows). With `text_normalization: true`
+#    the engine handles most things natively — additions here should be
+#    rare exceptions.
 # 2. Match is case-insensitive, whole-word.
 # 3. Replacement is the respelling sent to the TTS engine only.
 # 4. Keep the list minimal — every entry is a maintenance burden.
+# 5. Leave a comment recording WHEN the entry was added and WHY (which
+#    show / which voice / what the symptom was).
 #
 # Format:
 #   corrections:
 #     "Written Form": "tts respelling"
 
-corrections: {}
+corrections:
+  # ---------------- Tickers / financial ----------------
+  # Stock tickers should be read as letters, not as words. Grok will
+  # otherwise occasionally pronounce "TSLA" as "tezz-luh".
+  TSLA: "T S L A"
+  NVDA: "N V D A"
+  MSFT: "M S F T"
+  AAPL: "A A P L"
+
+  # ---------------- Canadian registered accounts ----------------
+  # Spelled-out is universally how listeners refer to these vehicles
+  # (TFSA, RRSP, FHSA), so the audio should match.
+  TFSA: "T F S A"
+  RRSP: "R R S P"
+  FHSA: "F H S A"
+  RESP: "R E S P"
+
+  # ---------------- Tesla-specific ----------------
+  # HW4 / HW5 / AI5 are read as "hardware four", "hardware five",
+  # "A I five" — letter-by-letter avoids the engine attempting to
+  # pronounce the alphanumeric tokens phonetically.
+  HW4: "H W four"
+  HW5: "H W five"
+  AI5: "A I five"
+
+  # ---------------- AI / tech ----------------
+  # LLM and MCP are universally said as letter-by-letter; without this
+  # entry Grok occasionally tries "lum" / "mick-pee".
+  LLM: "L L M"
+  MCP: "M C P"

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -127,16 +127,12 @@ llm:
   podcast_chain: true
 
 tts:
-  # Tesla Shorts Time stays on ElevenLabs Flash v2.5 (the only English
-  # show not migrated to Grok TTS in May 2026). The voice listeners
-  # know is `dTrBzPvD2GpAqkk1MUzA`; preserving voice continuity on the
-  # network's largest show outweighs the per-character cost delta.
-  # All other ElevenLabs settings (stability/similarity_boost/style/
-  # use_speaker_boost/model/apply_text_normalization) inherit from
-  # shows/_defaults.yaml's legacy block.
-  provider: elevenlabs
-  voice_id: dTrBzPvD2GpAqkk1MUzA
-  max_chars: 10000
+  # Inherits provider=grok, voice_id=b4cusb2omvkz, language_code=en,
+  # max_chars=10000 from shows/_defaults.yaml. Tesla Shorts Time was
+  # the last ElevenLabs holdout; flipped to the operator's custom Grok
+  # voice in the May 2026 full-network migration so every English show
+  # speaks with a single consistent host identity. See landmine #17.
+  {}
 
 audio:
   music_file: assets/music/tesla_shorts_time.mp3

--- a/tests/test_audio_commands.py
+++ b/tests/test_audio_commands.py
@@ -23,11 +23,13 @@ import pytest
 # ---------------------------------------------------------------------------
 
 def voice_normalization_full(voice_in: str, voice_out: str) -> list:
-    """The full filter chain for voice normalization."""
+    """The full 6-stage filter chain for voice normalization (May 2026:
+    added 6.5 kHz de-essing dip for the new custom Grok voice)."""
     return [
         "ffmpeg", "-y", "-threads", "0", "-i", voice_in,
         "-af",
         "highpass=f=80,lowpass=f=15000,"
+        "equalizer=f=6500:t=q:w=1.5:g=-3,"
         "loudnorm=I=-18:TP=-1.5:LRA=11:linear=true,"
         "acompressor=threshold=-20dB:ratio=4:attack=1:release=100:makeup=2,"
         "alimiter=level_in=1:level_out=0.95:limit=0.95",
@@ -116,14 +118,21 @@ def music_concat(concat_list: str, music_full_out: str) -> list:
 
 
 def final_mix(voice_in: str, music_in: str, final_out: str) -> list:
-    """Mix voice and music tracks together."""
+    """Mix voice and music tracks together with sidechain ducking +
+    EBU R128 loudnorm (May 2026 broadcast-quality upgrade)."""
     return [
         "ffmpeg", "-y", "-threads", "0",
         "-i", voice_in, "-i", music_in,
         "-filter_complex",
-        "[0:a][1:a]amix=inputs=2:duration=longest:dropout_transition=2",
+        "[0:a]asplit=2[voice_mix][voice_sc];"
+        "[1:a][voice_sc]sidechaincompress="
+        "threshold=-30dB:ratio=8:attack=20:release=300:level_sc=2"
+        "[music_ducked];"
+        "[voice_mix][music_ducked]amix=inputs=2:duration=longest:dropout_transition=2[mixed];"
+        "[mixed]loudnorm=I=-16:TP=-1.5:LRA=11[out]",
+        "-map", "[out]",
         "-ar", "44100", "-ac", "2",
-        "-c:a", "libmp3lame", "-b:a", "192k", "-preset", "fast",
+        "-c:a", "libmp3lame", "-q:a", "0",
         final_out,
     ]
 
@@ -245,13 +254,36 @@ class TestMusicConcatenation:
 
 class TestFinalMix:
 
-    def test_amix_filter(self):
+    def test_filter_complex_has_sidechain_ducking(self):
         cmd = final_mix("/voice.mp3", "/music.mp3", "/final.mp3")
         fc = cmd[cmd.index("-filter_complex") + 1]
-        assert "[0:a][1:a]" in fc
+        # Voice is split so it can both drive the sidechain compressor AND
+        # be summed back into the mix.
+        assert "asplit=2" in fc
+        assert "[voice_mix]" in fc and "[voice_sc]" in fc
+        # Music is ducked under voice presence.
+        assert "sidechaincompress=" in fc
+        assert "threshold=-30dB" in fc
+        assert "ratio=8" in fc
+        assert "[music_ducked]" in fc
+        # Voice + ducked music summed.
         assert "amix=inputs=2" in fc
         assert "duration=longest" in fc
         assert "dropout_transition=2" in fc
+
+    def test_filter_complex_has_loudnorm_target(self):
+        """Final mix must hit -16 LUFS / TP=-1.5 (Apple Podcasts / Spotify spec)."""
+        cmd = final_mix("/voice.mp3", "/music.mp3", "/final.mp3")
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        assert "loudnorm=I=-16" in fc
+        assert "TP=-1.5" in fc
+
+    def test_final_mix_maps_filter_output(self):
+        """`-map [out]` must point at the loudnorm tail; otherwise ffmpeg
+        emits the raw amix stream and we lose loudness normalization."""
+        cmd = final_mix("/v.mp3", "/m.mp3", "/f.mp3")
+        assert "-map" in cmd
+        assert cmd[cmd.index("-map") + 1] == "[out]"
 
     def test_final_mix_stereo(self):
         cmd = final_mix("/v.mp3", "/m.mp3", "/f.mp3")
@@ -259,7 +291,9 @@ class TestFinalMix:
 
     def test_final_mix_encoding(self):
         cmd = final_mix("/v.mp3", "/m.mp3", "/f.mp3")
-        assert cmd[cmd.index("-b:a") + 1] == "192k"
+        # Bumped from CBR 192k to VBR -q:a 0 (~245 kbps) for archival-quality
+        # spoken-word + music in May 2026.
+        assert "-q:a" in cmd and cmd[cmd.index("-q:a") + 1] == "0"
         assert cmd[cmd.index("-ar") + 1] == "44100"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -177,11 +177,11 @@ class TestDefaultValues:
 
     def test_tts_defaults(self):
         c = TTSConfig()
-        # Network default since May 2026 — Grok TTS with the "sal"
-        # built-in voice. Tesla Shorts Time is the only English show
-        # that overrides back to ElevenLabs.
+        # Network default since May 2026 (full-network migration) —
+        # Grok TTS with the operator's custom-trained voice
+        # `b4cusb2omvkz`, used by every English show including Tesla.
         assert c.provider == "grok"
-        assert c.voice_id == "sal"
+        assert c.voice_id == "b4cusb2omvkz"
         assert c.language_code == "en"
         assert c.max_chars == 10000
         # Legacy ElevenLabs baseline — preserved on the dataclass so
@@ -405,7 +405,10 @@ class TestLoadConfigRealFiles:
         assert cfg.llm.model == "grok-4.3"
         assert cfg.llm.digest_temperature == 0.5
         assert cfg.llm.podcast_temperature == 0.7
-        assert cfg.tts.voice_id == "dTrBzPvD2GpAqkk1MUzA"
+        # Tesla migrated off ElevenLabs in May 2026; now inherits the
+        # network's Grok TTS custom voice from _defaults.yaml.
+        assert cfg.tts.provider == "grok"
+        assert cfg.tts.voice_id == "b4cusb2omvkz"
         assert cfg.audio.music_file == "assets/music/tesla_shorts_time.mp3"
         assert cfg.publishing.rss_title == "Tesla Shorts Time Daily"
         assert cfg.publishing.x_enabled is True
@@ -422,7 +425,7 @@ class TestLoadConfigRealFiles:
         assert cfg.llm.model == "grok-4.3"
         # English shows migrated to Grok TTS (sal voice) in May 2026.
         assert cfg.tts.provider == "grok"
-        assert cfg.tts.voice_id == "sal"
+        assert cfg.tts.voice_id == "b4cusb2omvkz"
         assert cfg.audio.music_file == "assets/music/fascinatingfrontiers.mp3"
         assert cfg.audio.background_music_file == "assets/music/fascinatingfrontiers_bg.mp3"
         assert cfg.audio.voice_intro_delay == 5.0
@@ -478,7 +481,7 @@ class TestLoadConfigRealFiles:
         # legacy block in _defaults.yaml — harmless since the Grok path
         # ignores them — so these assertions still pass.
         assert cfg.tts.provider == "grok"
-        assert cfg.tts.voice_id == "sal"
+        assert cfg.tts.voice_id == "b4cusb2omvkz"
         assert cfg.tts.stability == 0.5  # Inherited from legacy ElevenLabs baseline
         assert cfg.tts.style == 0.0
         assert cfg.tts.max_chars == 10000
@@ -523,7 +526,7 @@ class TestNestedConfigOverrides:
         # Network defaults preserved (Grok TTS + sal voice; legacy
         # ElevenLabs baseline still set on the dataclass for back-compat).
         assert cfg.tts.provider == "grok"
-        assert cfg.tts.voice_id == "sal"
+        assert cfg.tts.voice_id == "b4cusb2omvkz"
         assert cfg.tts.model == "eleven_flash_v2_5"
 
     def test_partial_audio_override(self, tmp_path):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -484,9 +484,10 @@ class TestShowConfigs:
         assert config.newsletter.enabled is True
         assert config.newsletter.api_key_env == "BUTTONDOWN_API_KEY"
         assert len(config.sources) > 10  # Has many RSS feeds
-        # M&A migrated from ElevenLabs (`dTrBzPvD2GpAqkk1MUzA`) to Grok TTS
-        # with the `sal` built-in voice in May 2026 — see landmine #16.
-        assert config.tts.voice_id == "sal"
+        # Network-wide voice migration in May 2026: every English show
+        # inherits the operator's custom-trained Grok voice
+        # `b4cusb2omvkz` from _defaults.yaml. See landmine #17.
+        assert config.tts.voice_id == "b4cusb2omvkz"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tts_grok.py
+++ b/tests/test_tts_grok.py
@@ -81,9 +81,35 @@ def test_grok_speak_chunk_posts_to_xai_endpoint(tmp_path: Path, monkeypatch):
     assert body["voice_id"] == "0b875ae2"
     assert body["language"] == "ru"
     assert body["text"] == "Привет, как дела?"
+    # Default output_format is WAV/48 kHz (May 2026 audio-quality upgrade);
+    # text_normalization is on by default so Grok handles numbers/dates/
+    # currency server-side.
+    assert body["output_format"]["codec"] == "wav"
+    assert body["output_format"]["sample_rate"] == 48000
+    assert body["text_normalization"] is True
     # Audio bytes were written to disk.
     assert out.exists()
     assert out.read_bytes() == b"\xff\xfb\x90"
+
+
+def test_grok_speak_chunk_request_overrides(tmp_path: Path, monkeypatch):
+    """Caller can override output codec/sample_rate and text_normalization
+    if a future show needs MP3 streaming or wants raw text passthrough."""
+    fake_post, captured = _make_fake_post()
+    monkeypatch.setattr(tts.requests, "post", fake_post)
+
+    tts.grok_speak_chunk(
+        "Hello",
+        voice_id="b4cusb2omvkz",
+        out_path=tmp_path / "o.wav",
+        api_key="k",
+        output_codec="mp3",
+        output_sample_rate=24000,
+        text_normalization=False,
+    )
+    body = captured["json"]
+    assert body["output_format"] == {"codec": "mp3", "sample_rate": 24000}
+    assert body["text_normalization"] is False
 
 
 def test_grok_speak_chunk_defaults_language_to_auto(tmp_path: Path, monkeypatch):
@@ -313,18 +339,21 @@ def test_russian_shows_use_grok_tts():
         )
 
 
-def test_english_shows_resolve_to_grok_sal():
-    """Every English show except Tesla Shorts Time must resolve to Grok TTS
-    with the ``sal`` built-in voice after deep-merging _defaults.yaml.
+def test_english_shows_resolve_to_custom_voice():
+    """Every English show — including Tesla Shorts Time — must resolve to
+    Grok TTS with the operator's custom-trained voice ``b4cusb2omvkz``
+    after deep-merging _defaults.yaml.
 
-    Inheritance is the contract here — the per-show YAMLs intentionally
-    leave the tts: block empty so the network default carries them.
-    Adding an override silently puts a show on a different voice and
-    breaks the Listener-side voice continuity.
+    This is the result of the May 2026 full-network migration: a single
+    consistent host identity across every English show. Inheritance is
+    the contract here — per-show YAMLs intentionally leave the ``tts:``
+    block empty so the network default carries them. An override silently
+    puts a show on a different voice and breaks listener-side continuity.
     """
     from engine.config import load_config
     shows_dir = Path(__file__).resolve().parent.parent / "shows"
     english_grok_shows = (
+        "tesla",  # was the lone ElevenLabs holdout; migrated May 2026
         "omni_view",
         "fascinating_frontiers",
         "planetterrian",
@@ -340,11 +369,11 @@ def test_english_shows_resolve_to_grok_sal():
             f"(got {cfg.tts.provider!r}); check shows/_defaults.yaml didn't "
             "regress and the show YAML didn't add an override."
         )
-        assert cfg.tts.voice_id == "sal", (
-            f"{slug}.yaml: post-merge tts.voice_id must be 'sal' "
-            f"(got {cfg.tts.voice_id!r}); the network voted on a single "
-            "shared voice in May 2026 — per-show overrides need a "
-            "documented reason."
+        assert cfg.tts.voice_id == "b4cusb2omvkz", (
+            f"{slug}.yaml: post-merge tts.voice_id must be 'b4cusb2omvkz' "
+            f"(got {cfg.tts.voice_id!r}); the network adopted the operator's "
+            "custom-trained voice for every English show in May 2026 — "
+            "per-show overrides need a documented reason."
         )
         assert cfg.tts.language_code == "en", (
             f"{slug}.yaml: post-merge tts.language_code must be 'en' "
@@ -352,23 +381,25 @@ def test_english_shows_resolve_to_grok_sal():
         )
 
 
-def test_tesla_stays_on_elevenlabs():
-    """Tesla Shorts Time is the lone English-show ElevenLabs holdout.
-
-    The voice listeners know is `dTrBzPvD2GpAqkk1MUzA`. If anyone strips
-    the tts.provider override or changes voice_id, this test catches it
-    before the next Tesla episode renders with a different voice.
+def test_no_show_uses_elevenlabs_in_production():
+    """No production show should be configured for ElevenLabs after the
+    May 2026 full-network migration. The legacy fields in
+    `shows/_defaults.yaml` exist only for emergency rollback — if any
+    show silently falls back to provider=elevenlabs the cost
+    (~$150/M chars) and the voice mismatch would surprise listeners.
     """
     from engine.config import load_config
     shows_dir = Path(__file__).resolve().parent.parent / "shows"
-    cfg = load_config(shows_dir / "tesla.yaml")
-    assert cfg.tts.provider == "elevenlabs", (
-        f"tesla.yaml: tts.provider must be 'elevenlabs' (got "
-        f"{cfg.tts.provider!r}). TST is the only show that didn't migrate "
-        "to Grok TTS in May 2026; voice continuity on the network's "
-        "largest show outweighs the cost delta."
+    all_shows = (
+        "tesla", "omni_view", "fascinating_frontiers", "planetterrian",
+        "env_intel", "models_agents", "models_agents_beginners",
+        "modern_investing", "finansy_prosto", "privet_russian",
     )
-    assert cfg.tts.voice_id == "dTrBzPvD2GpAqkk1MUzA", (
-        f"tesla.yaml: tts.voice_id must be 'dTrBzPvD2GpAqkk1MUzA' "
-        f"(got {cfg.tts.voice_id!r})"
-    )
+    for slug in all_shows:
+        cfg = load_config(shows_dir / f"{slug}.yaml")
+        assert cfg.tts.provider != "elevenlabs", (
+            f"{slug}.yaml resolves to provider='elevenlabs' — emergency "
+            "rollback flip detected. Either (a) the operator manually "
+            "rolled back this show and forgot to update this guard, or "
+            "(b) shows/_defaults.yaml regressed."
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -207,3 +207,95 @@ class TestRemoveSimilarItems:
         ]
         result = omni_remove_similar_items(items)
         assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# strip_speech_tags — Grok TTS speech-tag scrubber for non-TTS consumers
+# ---------------------------------------------------------------------------
+
+class TestStripSpeechTags:
+    """Speech tags must never reach blog/RSS/X — only the TTS engine sees them."""
+
+    def setup_method(self):
+        from engine.utils import strip_speech_tags
+        self._strip = strip_speech_tags
+
+    def test_strips_inline_breath_tag(self):
+        out = self._strip("Sentence one. [breath] Sentence two.")
+        assert "[breath]" not in out
+        assert "Sentence one. Sentence two." == out
+
+    def test_strips_inline_pause_and_long_pause(self):
+        out = self._strip("Section A. [pause] Section B. [long-pause] Section C.")
+        assert "[pause]" not in out
+        assert "[long-pause]" not in out
+        assert out == "Section A. Section B. Section C."
+
+    def test_strips_all_documented_inline_tags(self):
+        """All Grok TTS inline tags must be removed."""
+        text = (
+            "[pause][long-pause][laugh][cry][sniff][kiss]"
+            "[throat-clear][breath][sigh][gasp]"
+        )
+        assert self._strip(text) == ""
+
+    def test_case_insensitive_stripping(self):
+        assert self._strip("Hi [BREATH] world.") == "Hi world."
+        assert self._strip("Hi [Pause] world.") == "Hi world."
+
+    def test_strips_emphasis_open_and_close_keeps_inner_text(self):
+        """Wrapping tags drop the brackets but preserve the prose."""
+        out = self._strip("This is <emphasis>critical</emphasis>.")
+        assert out == "This is critical."
+
+    def test_strips_whisper_brackets(self):
+        out = self._strip("She said <whisper>be quiet</whisper> firmly.")
+        assert out == "She said be quiet firmly."
+
+    def test_strips_all_documented_wrapping_tags(self):
+        text = (
+            "<soft>a</soft><loud>b</loud><whisper>c</whisper>"
+            "<slow>d</slow><fast>e</fast><high>f</high><low>g</low>"
+            "<singing>h</singing><emphasis>i</emphasis>"
+        )
+        assert self._strip(text) == "abcdefghi"
+
+    def test_idempotent(self):
+        text = "[breath] Hello, <emphasis>world</emphasis>."
+        once = self._strip(text)
+        twice = self._strip(once)
+        assert once == twice
+
+    def test_empty_and_none(self):
+        assert self._strip("") == ""
+        assert self._strip(None) is None  # type: ignore[arg-type]
+
+    def test_collapses_double_space_left_by_inline_tag(self):
+        """Removing `[breath]` between two spaces shouldn't leave a double space."""
+        out = self._strip("Word one [breath] word two.")
+        assert "  " not in out
+        assert out == "Word one word two."
+
+    def test_preserves_unrelated_brackets(self):
+        """Brackets not matching a known tag must survive (e.g. citations)."""
+        out = self._strip("Per [Smith 2024], the data shows growth.")
+        assert "[Smith 2024]" in out
+
+    def test_preserves_unrelated_html_like_tags(self):
+        """Wrapping tags outside the speech-tag whitelist are preserved
+        (the strip is conservative — false positives would mangle prose)."""
+        out = self._strip("She wrote <em>important</em> things.")
+        assert "<em>" in out and "</em>" in out
+
+    def test_real_world_podcast_excerpt(self):
+        text = (
+            "Welcome to Tesla Shorts Time. [breath] Today, "
+            "<emphasis>three</emphasis> stories rocked the EV world. "
+            "[pause] Let's get into it."
+        )
+        out = self._strip(text)
+        assert "[breath]" not in out
+        assert "[pause]" not in out
+        assert "<emphasis>" not in out and "</emphasis>" not in out
+        assert "three" in out  # inner text preserved
+        assert "Let's get into it." in out


### PR DESCRIPTION
## Summary

Third TTS migration wave — every English show including Tesla Shorts Time now uses your custom-trained Grok voice **`b4cusb2omvkz`**. Russian shows continue on Olya (`0b875ae2`). **No production show is on ElevenLabs after this PR.**

Same change set ships a broadcast-quality audio pipeline targeting the sound floor of NPR / Apple Podcasts / Spotify.

## After this PR

| Show | Provider | Voice |
|---|---|---|
| Tesla, Omni View, Fascinating Frontiers, Planetterrian, Env Intel, M&A, M&AB, Modern Investing | **Grok** | **`b4cusb2omvkz` (custom)** |
| Финансы Просто, Привет, Русский! | Grok | `0b875ae2` (Olya, unchanged) |
| ~~ElevenLabs~~ | — | — (legacy fallback only) |

## What changed

### 1. Voice flip
- **`shows/_defaults.yaml`** — `tts.voice_id: sal` → `b4cusb2omvkz`. Legacy ElevenLabs settings retained under a `# ---- Legacy ElevenLabs baseline ----` block for emergency rollback.
- **`shows/tesla.yaml`** — removed the ElevenLabs override; TST now inherits like everyone else.
- **`engine/config.py:TTSConfig`** — dataclass defaults match.

### 2. Audio quality (the big lift)
- **Grok TTS request** (`engine/tts.py:grok_speak_chunk`) now requests **WAV at 48 kHz** with **`text_normalization: true`**. Previously MP3 at 24 kHz, no normalization. Grok now handles dates / currencies / numbers server-side; `pronunciation_map.yaml` stays for proper-noun overrides.
- **Pipeline** (`_speak_with_grok`) skips the MP3-decode step the older path needed. Single chunks: WAV → one MP3 encode. Multi-chunk: WAV crossfade → one MP3 encode. Eliminates a lossy round-trip per episode.
- **Voice EQ** (`engine/audio.py:_voice_norm_full_cmd`) gained a 6.5 kHz dip (`equalizer=f=6500:t=q:w=1.5:g=-3`) — gentle de-esser for the new voice's sibilants. 3 dB cut, narrow Q.
- **Final mix** (`_final_mix_cmd`) replaced simple `amix` with **sidechain-ducked music + EBU R128 loudnorm**:
  ```
  [voice]asplit=2 → drives sidechaincompress on music
       threshold=-30dB ratio=8 attack=20 release=300 level_sc=2
  → amix(voice + ducked_music) → loudnorm I=-16 TP=-1.5 LRA=11
  ```
  Music dips ~8 dB when voice is present, rises smoothly when voice pauses. Final integrated loudness hits the **-16 LUFS** target Apple Podcasts and Spotify use for listener-side normalization.
- **Final encode** bumped from CBR 192 kbps to VBR `-q:a 0` (~245 kbps) for archival-quality. ~6.5 MB per 30-min episode.

### 3. Speech tags
- **`engine/utils.py:strip_speech_tags()`** — new helper. Strips Grok inline tags (`[breath]` / `[pause]` / `[long-pause]` / `[laugh]` / etc.) and wrapping tag brackets (`<emphasis>...</emphasis>` keeps inner text). Idempotent. Conservative — preserves unrelated brackets (citations) and unrelated HTML-like tags.
- **`run_show.py`** — applies the strip before `validate_tts_transcription` so Whisper-vs-script comparison isn't penalized for tag literals.
- **All 10 podcast prompts** (`shows/prompts/*_podcast.txt`) carry a uniform `DELIVERY` block. Allowed: `[breath]`, `[pause]`, `[long-pause]`, `<emphasis>...</emphasis>`. Banned: `[laugh]`, `[sigh]`, `[gasp]`, `<whisper>`, `<slow>`, `<fast>`, `<high>`, `<low>`, `<singing>`, `<soft>`, `<loud>` (they sound performative). Frequency caps inline.
- The TTS path keeps tags for the Grok backend to consume; every non-TTS consumer (blog, RSS show notes, X teaser, YouTube) goes through `strip_speech_tags()`.

### 4. Pronunciation map (conservative)
~15 pre-emptive entries — tickers (TSLA / NVDA / MSFT / AAPL), registered accounts (TFSA / RRSP / FHSA / RESP), Tesla SKUs (HW4 / HW5 / AI5), AI acronyms (LLM / MCP). Header rewritten for Grok TTS context. We'll iterate as we hear specific issues on the new voice.

### 5. Drift guards
- `test_english_shows_resolve_to_custom_voice` — every English show including Tesla resolves to `provider=grok` / `voice_id=b4cusb2omvkz`.
- `test_no_show_uses_elevenlabs_in_production` — catches accidental rollback flips.
- `test_russian_shows_use_grok_tts` — unchanged.
- New audio-command tests for sidechain ducking shape + -16 LUFS target.
- 13 new tests covering `strip_speech_tags`.

## Test plan

- [x] `pytest tests/ -x -q --tb=short` — **1467 / 1467 pass, 3 skipped** (CI's exact invocation, all deps installed).
- [x] Every show's deep-merged config verified — all 10 resolve to the right (provider, voice_id, language) tuple.
- [ ] **Live API test on Tesla — most important** — run `python run_show.py tesla --skip-x --skip-newsletter --skip-youtube` against the live xAI API. Listen to the resulting MP3 before any cron run hits production. The new voice on TST is the highest-stakes change in this PR; if `b4cusb2omvkz` doesn't sound right on Tesla content, hold the merge.
- [ ] Spot-listen one episode from each migrated show on the next cron cycle. Specifically check:
  - Voice character / tone matches what you trained
  - Sidechain ducking sounds natural (not pumping; music recovers smoothly)
  - Final mix is at the right loudness vs other podcasts you listen to
  - No speech tags audible as literal words
  - No tags appearing in the published blog / RSS / X teaser
- [ ] Verify `credit_usage_*.json` entries show `provider: "grok"` for every show, no `elevenlabs` ones.

## Possible failure modes (what to listen for)

- **Sidechain pumping** — if music attacks/releases sound "breathing", we tune `attack=20 / release=300` looser. YAML-knob worthy if it matters.
- **Loudnorm clipping** — `TP=-1.5` should leave headroom. If you hear distortion peaks, drop TP to `-2.0`.
- **6.5 kHz dip too aggressive** — voice could sound dull. Reduce gain from `g=-3` to `g=-2` or remove the equalizer line.
- **Speech tag leak** — if you ever see `[breath]` in published text, that's a `strip_speech_tags` bug. The 13 new unit tests guard against the obvious cases.

## Rollback

- **One show**: add `provider: elevenlabs` and `voice_id: dTrBzPvD2GpAqkk1MUzA` to that show's `tts:` block. Update the drift-guard test's tuple. Done.
- **Network-wide**: revert this PR. Legacy ElevenLabs settings preserved in `_defaults.yaml`, `ELEVENLABS_API_KEY` still in secrets. Single-line YAML flip in `_defaults.yaml` switches everyone back.

## Diff scope

25 files, 845 insertions / 135 deletions:
- 4 engine files (audio.py, tts.py, config.py, utils.py)
- 1 runner (run_show.py)
- 3 show config files (_defaults.yaml, tesla.yaml, pronunciation_map.yaml)
- 11 podcast prompts
- 5 test files
- CLAUDE.md (table + landmines #11 / #17)

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_