### PR TITLE
Newsletter spec v2 follow-ups: dark-mode, issue counter, source URLs

### DIFF
--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -359,7 +359,6 @@ def send_show_newsletter(
         _today = _dt.date.today()
     from engine.newsletter_template import (
         build_subject_line,
-        compute_issue_number,
         wrap_with_branding,
     )
     subject = build_subject_line(
@@ -404,7 +403,13 @@ def send_show_newsletter(
         daily_date=_today,
         adjacent_shows=adjacent_shows,
         requires_financial_disclaimer=requires_disc,
-        issue_number=compute_issue_number(slug, _today),
+        # Daily emails count by episode, not by weeks-since-launch.
+        # The latter (compute_issue_number) is for weekly synthesis
+        # newsletters; on a daily it produces "Issue #1" for any show
+        # that launched within the last 7 days regardless of how many
+        # episodes have shipped (Tesla Ep 458 read "Issue #1" on
+        # the May 2 daily — bug). Pass the episode number explicitly.
+        issue_number=episode_num,
     )
 
     # Pre-send contrast tripwire (§7.3). Light-mode-only check — the

--- a/engine/newsletter_body.py
+++ b/engine/newsletter_body.py
@@ -97,12 +97,18 @@ def render_tsla_price_block(body: str) -> str:
                 f' <span style="color:{delta_color};font-size:14px;'
                 f'font-weight:600;">{arrow} {delta}</span>'.strip()
             )
+        # Dark-mode rules in `_DARK_MODE_STYLE` flip ``.surface-tsla``
+        # to a dark slate background. Without the class hook the cream
+        # `#fef2f2` survives into dark mode and the dark-text override
+        # turns the whole block into light-on-light = invisible. Spec
+        # v2 follow-up after the May 2 Tesla daily render bug.
         return (
             '<table role="presentation" cellpadding="0" cellspacing="0" '
             'border="0" '
             'class="surface-white" '
             'style="background:#ffffff;margin:0 0 16px;">'
             '<tr><td '
+            'class="surface-tsla" '
             'style="padding:10px 14px;border-left:4px solid #E31937;'
             'background:#fef2f2;border-radius:0 6px 6px 0;'
             "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',"
@@ -111,7 +117,8 @@ def render_tsla_price_block(body: str) -> str:
             'style="font-size:11px;font-weight:700;color:#475569;'
             'text-transform:uppercase;letter-spacing:0.06em;'
             'margin-bottom:2px;">TSLA today</div>'
-            '<div style="font-size:18px;font-weight:700;color:#0f172a;'
+            '<div class="brand-text-tesla" '
+            'style="font-size:18px;font-weight:700;color:#0f172a;'
             'line-height:1.2;">'
             f'{price}{delta_html}'
             '</div>'
@@ -252,14 +259,17 @@ def transform_daily_body(body: str, *, slug: str = "") -> str:
     Order matters:
 
       1. Box rules → ``<hr>`` (cheapest, fires for everyone)
-      2. Dedup "Read more" source lists (Omni View — repeated URLs)
-      3. TSLA price block (Tesla only)
-      4. Russian vocab cards (Привет only)
+      2. Shorten Google News tracking URLs in "Source: …" lines
+         (universal — every show is potentially affected)
+      3. Dedup "Read more" source lists (Omni View — repeated URLs)
+      4. TSLA price block (Tesla only)
+      5. Russian vocab cards (Привет only)
 
     Each transform is a no-op when its trigger pattern isn't present,
     so calling this for every show is safe.
     """
     body = replace_box_rules_with_hr(body)
+    body = shorten_source_urls(body)
     if slug == "omni_view":
         body = dedup_read_more_sources(body)
     if slug == "tesla":
@@ -267,6 +277,61 @@ def transform_daily_body(body: str, *, slug: str = "") -> str:
     if slug == "privet_russian":
         body = render_russian_vocab_cards(body)
     return body
+
+
+# ---------------------------------------------------------------------------
+# "Source: <long-url>" shortening (post-fetch defense)
+# ---------------------------------------------------------------------------
+
+# Match "Source: <url>" emitted by the LLM at the end of a story. The URL
+# can be Google News (`news.google.com/rss/articles/CBMi...`) which is
+# 200-600 chars, or any other publisher URL with utm_*-style noise.
+# Captures (1) the URL itself; we replace the whole "Source: …" tail.
+_SOURCE_URL_RE = re.compile(
+    r"\s*Source:\s*(https?://[^\s)]+)",
+    flags=re.IGNORECASE,
+)
+
+
+def shorten_source_urls(body: str) -> str:
+    """Render long bare-URL "Source:" trailers as compact "Source: <domain>"
+    markdown links. Spec v2 follow-up after the May 2 Tesla daily showed
+    the literal Google News redirect blob `CBMiig...` in the body.
+
+    The fetcher's ``resolve_google_news_url`` canonicalizes URLs at fetch
+    time, but (a) cached articles from before that fix landed still have
+    the long URLs and (b) network failures during resolution leave the
+    original Google-News URL in the article record. This transform is a
+    final visual cleanup applied to the rendered body so the email never
+    shows the 600-char tracking blob even when the upstream resolver
+    bailed.
+    """
+    if not body or "Source:" not in body:
+        return body
+
+    def _sub(match: re.Match) -> str:
+        url = match.group(1).rstrip(" ).,;")
+        # Extract a human-readable domain.
+        try:
+            from urllib.parse import urlparse
+            host = urlparse(url).netloc
+        except Exception:  # noqa: BLE001
+            host = ""
+        if not host:
+            return match.group(0)
+        # Strip leading "www."; if it's still Google News after our
+        # fetch-time resolver bailed, label it that way explicitly so
+        # the reader at least sees what they're getting.
+        host = host.lower()
+        if host.startswith("www."):
+            host = host[4:]
+        if host.startswith("news.google."):
+            label = "Google News"
+        else:
+            label = host
+        return f" Source: [{label}]({url})"
+
+    return _SOURCE_URL_RE.sub(_sub, body)
 
 
 # ---------------------------------------------------------------------------

--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -343,6 +343,12 @@ _DARK_MODE_STYLE = """\
     .brand-text-warn { color:#fbbf24 !important; }
     .surface-warn   { background:#3b2a13 !important; background-color:#3b2a13 !important; }
 
+    /* Tesla price-watch block. The light-mode cream `#fef2f2` has
+     * great contrast against `#0f172a` text, but in dark mode the
+     * universal text-color override flips text to `#e2e8f0` and
+     * cream-on-light-text becomes invisible. Flip the bg too. */
+    .surface-tsla   { background:#3b1c1f !important; background-color:#3b1c1f !important; }
+
     /* Hidden preheader stays hidden in dark mode too. Some Outlook
      * versions ignore display:none from inline styles when dark-mode
      * is active; the !important class hook fixes it. */
@@ -1260,6 +1266,28 @@ def wrap_with_branding(
             show, issue_number, send_date, slug=slug,
         )
 
+    # Wrap the body markdown in a ``surface-white`` table so the
+    # dark-mode ``<style>`` override flips its background. Without
+    # this wrapper Buttondown's markdown→HTML conversion produces
+    # bare ``<p>`` tags that the email client renders against its
+    # own page background, which on iOS Mail dark mode results in
+    # near-black body text (Buttondown default `#0f172a`-ish) against
+    # a darkening surface — barely readable. Spec v2 follow-up.
+    body_wrapped = ""
+    if body_clean.strip():
+        body_wrapped = (
+            '<table role="presentation" width="100%" cellpadding="0" '
+            'cellspacing="0" border="0" '
+            'class="surface-white" '
+            'style="background:#ffffff;">'
+            '<tr><td style="padding:8px 24px;'
+            "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',"
+            'Roboto,Helvetica,Arial,sans-serif;'
+            'font-size:15px;line-height:1.6;color:#0f172a;">'
+            f'{body_clean}'
+            '</td></tr></table>'
+        )
+
     # Blocks separated by two blank lines so markdown processors treat
     # them as separate sections. Empty blocks contribute nothing. The
     # dark-mode <style> block goes at the very top so any client that
@@ -1272,7 +1300,7 @@ def wrap_with_branding(
         stats_block,
         featured_block,
         disclaimer,
-        body_clean,
+        body_wrapped,
         p_s_block,
         cross_network,
         reply_share,

--- a/tests/test_newsletter_body.py
+++ b/tests/test_newsletter_body.py
@@ -8,6 +8,7 @@ from engine.newsletter_body import (
     render_russian_vocab_cards,
     render_tsla_price_block,
     replace_box_rules_with_hr,
+    shorten_source_urls,
     transform_daily_body,
 )
 
@@ -189,3 +190,53 @@ class TestTransformDailyBody:
         assert "━━━" not in out
         # No show-specific render.
         assert "TSLA today" not in out
+
+
+# ---------------------------------------------------------------------------
+# Source URL shortening (post-fetch defense)
+# ---------------------------------------------------------------------------
+
+class TestShortenSourceUrls:
+
+    def test_collapses_google_news_blob_to_label(self):
+        long_url = (
+            "https://news.google.com/rss/articles/CBMi" + "x" * 400
+            + "?oc=5"
+        )
+        text = f"Story body. Source: {long_url}"
+        out = shorten_source_urls(text)
+        # Visible label is "Google News" (Buttondown renders the
+        # markdown link, only the label text shows in the email body).
+        assert "[Google News]" in out
+        # Original URL is still inside the markdown link target so
+        # the click goes to the right place.
+        assert long_url in out
+        # Critical: the bare "Source: https://news.google.com/..."
+        # form is replaced — there's no longer a raw URL emitted as
+        # plaintext for the reader to see. The only place the URL
+        # appears is inside the (URL) of [label](URL).
+        assert f"Source: {long_url}" not in out
+
+    def test_collapses_publisher_url_to_domain(self):
+        text = (
+            "Story body. Source: "
+            "https://www.notebookcheck.net/very-long-tracking-path?utm_x=y"
+        )
+        out = shorten_source_urls(text)
+        assert "[notebookcheck.net]" in out
+
+    def test_strips_trailing_punctuation_from_url(self):
+        text = "Read it. Source: https://example.com/foo)."
+        out = shorten_source_urls(text)
+        # Punctuation stays in the prose; URL inside the link doesn't have it.
+        assert "(https://example.com/foo)" in out
+
+    def test_no_match_returns_unchanged(self):
+        text = "Body content with no source line."
+        assert shorten_source_urls(text) == text
+
+    def test_idempotent(self):
+        text = "Source: https://example.com/foo"
+        once = shorten_source_urls(text)
+        twice = shorten_source_urls(once)
+        assert once == twice


### PR DESCRIPTION
## Summary

Four real bugs you caught in the first post-merge Tesla daily (May 2 Ep 458 screenshots):

| Bug | Cause | Fix |
|---|---|---|
| **Issue counter showed "#1"** for ep 458 | `compute_issue_number` does a *weekly* count from `newsletter_start_date`. Tesla launched 2 days ago → 0 weeks → 1. | Pass `episode_num` explicitly from `send_show_newsletter`. Weekly synthesis caller is unchanged (still correct for that path). |
| **TSLA price block invisible in dark mode** | Inner `<td>` had inline `background:#fef2f2` (cream-pink) with no class hook. Dark-mode CSS flipped text to `#e2e8f0` but couldn't flip the bg → light-slate text on cream-pink, unreadable. | Added `.surface-tsla` class + dark-mode override flipping bg to `#3b1c1f` (dark Tesla red). Number also gets `.brand-text-tesla` for the lighter dark variant. |
| **Body markdown rendered faded in dark mode** | Buttondown's markdown→HTML conversion produces bare `<p>` tags with no class hooks. Dark-mode CSS targets `td[style*='background:#ffffff']` which doesn't match Buttondown's wrapper. Body kept its near-black text on a darkening surface. | Explicitly wrap the body markdown in `<table class="surface-white">` so the dark-mode override fires. |
| **Long Google News URLs visible in body** | `resolve_google_news_url` runs at fetch time, but cached articles from before that fix landed still have the long URLs, AND network failures during resolution leave the original. May 2 daily had the literal `CBMiig...?oc=5` blob. | New `shorten_source_urls()` body transform: converts bare "Source: <url>" trailers into `Source: [Google News](<url>)` markdown links — click target preserved, reader sees "Google News" label only. |

## Files

- `engine/newsletter.py` — daily caller passes `episode_num` as `issue_number`; drops unused `compute_issue_number` import.
- `engine/newsletter_template.py` — adds `.surface-tsla` dark-mode rule; wraps body markdown in `surface-white` table.
- `engine/newsletter_body.py` — adds `shorten_source_urls()` and runs it from `transform_daily_body`.
- `tests/test_newsletter_body.py` — 5 new tests for the URL shortening transform.

## Test plan

- [x] `pytest tests/ -x -q --tb=short` — 1548 / 1548 pass
- [x] `ruff check engine/ run_show.py` — clean
- [ ] **Live verification** — next Tesla daily should:
  - Show "Issue #459" in the footer counter (matching the episode)
  - Render TSLA price block legibly in iOS Mail dark mode (dark-red bg, light-pink price)
  - Render body paragraph text bright on dark in dark mode (no more faded gray)
  - Show "Source: Google News" labels instead of the literal `CBMiig...` blob
- [ ] Spot-check Omni View daily (which uses Google News heavily) for the source-label change

## Out of scope

The Buttondown auto-prepended **"Did someone forward you this? Subscribe to this newsletter"** banner at the top is a Buttondown account-level template feature — can't be styled or suppressed without the Studio settings, and the link colors / muted greys come from Buttondown's own CSS. If that becomes an issue, it's a Buttondown account configuration to chase, not a code change.

The hero gradient itself renders fine — the screenshots showed a duplicate header but that's iOS Mail's sticky-subject preview, not our HTML.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_