### PR TITLE
Switch English Grok voice to kdif6sqjcyiq

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ nerranetworks/
 - `GROK_API_KEY` — primary xAI key (all shows)
 - `ELEVENLABS_API_KEY` — ElevenLabs TTS (all shows)
 - `X_*` / `PLANETTERRIAN_X_*` — two separate X accounts
-- Voice IDs: **All 10 shows are on Grok TTS** as of the May 2026 full-network migration. The 8 English shows (including Tesla Shorts Time) share the operator's custom-trained voice `b4cusb2omvkz`. Russian shows (FP/PR) use the custom Olya voice `0b875ae2`. ElevenLabs is no longer used in production but the API key + legacy settings stay in `_defaults.yaml` for emergency rollback. See landmine #17.
+- Voice IDs: **All 10 shows are on Grok TTS** as of the May 2026 full-network migration. The 8 English shows (including Tesla Shorts Time) share the operator's custom-trained voice `kdif6sqjcyiq`. Russian shows (FP/PR) use the custom Olya voice `0b875ae2`. ElevenLabs is no longer used in production but the API key + legacy settings stay in `_defaults.yaml` for emergency rollback. See landmine #17.
 - See `docs/env_var_inventory.md` for the complete inventory
 
 ### RSS Feeds
@@ -255,7 +255,7 @@ decision); everything else has a live status card.
 11. **All 10 shows on Grok TTS (May 2026, full-network migration)** —
     Chatterbox, Kokoro, and Fish Audio were trialled and removed.
     English shows (including Tesla Shorts Time as of the third migration
-    wave) all use the operator's custom-trained voice `b4cusb2omvkz`
+    wave) all use the operator's custom-trained voice `kdif6sqjcyiq`
     for a single consistent host identity. Russian shows use the
     custom Olya voice (`0b875ae2`). ElevenLabs is no longer used in
     production. Network cost: ~36× cheaper per character on Grok
@@ -345,7 +345,7 @@ decision); everything else has a live status card.
 17. **Full-network voice migration + broadcast-quality audio pipeline
     (third TTS wave, May 2026)** — Tesla Shorts Time joined the rest of
     the network on Grok TTS. Every English show now inherits the
-    operator's custom-trained voice `b4cusb2omvkz` from
+    operator's custom-trained voice `kdif6sqjcyiq` from
     [`shows/_defaults.yaml`](shows/_defaults.yaml); the previous `sal`
     built-in voice was retired and TST's ElevenLabs override
     (`provider: elevenlabs`, voice `dTrBzPvD2GpAqkk1MUzA`) was removed.
@@ -389,7 +389,7 @@ decision); everything else has a live status card.
       descriptions never see them.
     - **Drift guards:** `tests/test_tts_grok.py` now has
       `test_english_shows_resolve_to_custom_voice` (every English show
-      including Tesla resolves to `b4cusb2omvkz`),
+      including Tesla resolves to `kdif6sqjcyiq`),
       `test_no_show_uses_elevenlabs_in_production` (catches accidental
       rollback flips), and `test_russian_shows_use_grok_tts` (Olya
       voice unchanged).

--- a/engine/config.py
+++ b/engine/config.py
@@ -68,14 +68,15 @@ class LLMConfig:
 @dataclass
 class TTSConfig:
     # Network default since May 2026: Grok TTS with the operator's
-    # custom-trained voice `b4cusb2omvkz`, used for every English
-    # show on the network for a single consistent host identity.
+    # English voice `kdif6sqjcyiq`, used for every English show on
+    # the network for a single consistent host identity. Replaced
+    # the prior `b4cusb2omvkz` voice in May 2026.
     # Russian shows (FP/PR) override voice_id to their custom Olya
     # (`0b875ae2`) and language_code to `ru`. No show is on ElevenLabs
     # in production; the legacy fields below remain only for emergency
     # rollback.
     provider: str = "grok"
-    voice_id: str = "b4cusb2omvkz"
+    voice_id: str = "kdif6sqjcyiq"
     language_code: str = "en"  # BCP-47 (Grok) / ISO 639-1 (ElevenLabs); shows override for non-English
     max_chars: int = 10000
     # ---- Legacy ElevenLabs baseline ----

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -39,15 +39,15 @@ llm:
 
 tts:
   # Network default since May 2026: xAI Grok TTS at $4.20/M chars
-  # (~36× cheaper than ElevenLabs Flash). Voice `b4cusb2omvkz` is the
-  # operator's custom-trained voice — every English show on the
+  # (~36× cheaper than ElevenLabs Flash). Voice `kdif6sqjcyiq` is the
+  # operator's current English voice — every English show on the
   # network shares it for a single consistent "host" identity.
   # Russian shows (FP/PR) override voice_id to their custom "Olya"
   # (`0b875ae2`) and language_code to `ru`. No show is on ElevenLabs
   # in production any more; the legacy block below is retained only
   # for emergency rollback.
   provider: grok
-  voice_id: b4cusb2omvkz
+  voice_id: kdif6sqjcyiq
   language_code: en
   max_chars: 10000
   # ---- Legacy ElevenLabs baseline ----

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -179,9 +179,9 @@ class TestDefaultValues:
         c = TTSConfig()
         # Network default since May 2026 (full-network migration) —
         # Grok TTS with the operator's custom-trained voice
-        # `b4cusb2omvkz`, used by every English show including Tesla.
+        # `kdif6sqjcyiq`, used by every English show including Tesla.
         assert c.provider == "grok"
-        assert c.voice_id == "b4cusb2omvkz"
+        assert c.voice_id == "kdif6sqjcyiq"
         assert c.language_code == "en"
         assert c.max_chars == 10000
         # Legacy ElevenLabs baseline — preserved on the dataclass so
@@ -408,7 +408,7 @@ class TestLoadConfigRealFiles:
         # Tesla migrated off ElevenLabs in May 2026; now inherits the
         # network's Grok TTS custom voice from _defaults.yaml.
         assert cfg.tts.provider == "grok"
-        assert cfg.tts.voice_id == "b4cusb2omvkz"
+        assert cfg.tts.voice_id == "kdif6sqjcyiq"
         assert cfg.audio.music_file == "assets/music/tesla_shorts_time.mp3"
         assert cfg.publishing.rss_title == "Tesla Shorts Time Daily"
         assert cfg.publishing.x_enabled is True
@@ -425,7 +425,7 @@ class TestLoadConfigRealFiles:
         assert cfg.llm.model == "grok-4.3"
         # English shows migrated to Grok TTS (sal voice) in May 2026.
         assert cfg.tts.provider == "grok"
-        assert cfg.tts.voice_id == "b4cusb2omvkz"
+        assert cfg.tts.voice_id == "kdif6sqjcyiq"
         assert cfg.audio.music_file == "assets/music/fascinatingfrontiers.mp3"
         assert cfg.audio.background_music_file == "assets/music/fascinatingfrontiers_bg.mp3"
         assert cfg.audio.voice_intro_delay == 5.0
@@ -481,7 +481,7 @@ class TestLoadConfigRealFiles:
         # legacy block in _defaults.yaml — harmless since the Grok path
         # ignores them — so these assertions still pass.
         assert cfg.tts.provider == "grok"
-        assert cfg.tts.voice_id == "b4cusb2omvkz"
+        assert cfg.tts.voice_id == "kdif6sqjcyiq"
         assert cfg.tts.stability == 0.5  # Inherited from legacy ElevenLabs baseline
         assert cfg.tts.style == 0.0
         assert cfg.tts.max_chars == 10000
@@ -526,7 +526,7 @@ class TestNestedConfigOverrides:
         # Network defaults preserved (Grok TTS + sal voice; legacy
         # ElevenLabs baseline still set on the dataclass for back-compat).
         assert cfg.tts.provider == "grok"
-        assert cfg.tts.voice_id == "b4cusb2omvkz"
+        assert cfg.tts.voice_id == "kdif6sqjcyiq"
         assert cfg.tts.model == "eleven_flash_v2_5"
 
     def test_partial_audio_override(self, tmp_path):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -486,8 +486,8 @@ class TestShowConfigs:
         assert len(config.sources) > 10  # Has many RSS feeds
         # Network-wide voice migration in May 2026: every English show
         # inherits the operator's custom-trained Grok voice
-        # `b4cusb2omvkz` from _defaults.yaml. See landmine #17.
-        assert config.tts.voice_id == "b4cusb2omvkz"
+        # `kdif6sqjcyiq` from _defaults.yaml. See landmine #17.
+        assert config.tts.voice_id == "kdif6sqjcyiq"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tts_grok.py
+++ b/tests/test_tts_grok.py
@@ -100,7 +100,7 @@ def test_grok_speak_chunk_request_overrides(tmp_path: Path, monkeypatch):
 
     tts.grok_speak_chunk(
         "Hello",
-        voice_id="b4cusb2omvkz",
+        voice_id="kdif6sqjcyiq",
         out_path=tmp_path / "o.wav",
         api_key="k",
         output_codec="mp3",
@@ -341,7 +341,7 @@ def test_russian_shows_use_grok_tts():
 
 def test_english_shows_resolve_to_custom_voice():
     """Every English show — including Tesla Shorts Time — must resolve to
-    Grok TTS with the operator's custom-trained voice ``b4cusb2omvkz``
+    Grok TTS with the operator's custom-trained voice ``kdif6sqjcyiq``
     after deep-merging _defaults.yaml.
 
     This is the result of the May 2026 full-network migration: a single
@@ -369,8 +369,8 @@ def test_english_shows_resolve_to_custom_voice():
             f"(got {cfg.tts.provider!r}); check shows/_defaults.yaml didn't "
             "regress and the show YAML didn't add an override."
         )
-        assert cfg.tts.voice_id == "b4cusb2omvkz", (
-            f"{slug}.yaml: post-merge tts.voice_id must be 'b4cusb2omvkz' "
+        assert cfg.tts.voice_id == "kdif6sqjcyiq", (
+            f"{slug}.yaml: post-merge tts.voice_id must be 'kdif6sqjcyiq' "
             f"(got {cfg.tts.voice_id!r}); the network adopted the operator's "
             "custom-trained voice for every English show in May 2026 — "
             "per-show overrides need a documented reason."


### PR DESCRIPTION
## Summary

Operator-requested voice change. All 8 English shows now inherit `voice_id: kdif6sqjcyiq` (from `b4cusb2omvkz`) via the network default in `shows/_defaults.yaml`. Russian shows unchanged.

## Verification — every show resolves correctly post-merge

```
tesla                    voice_id=kdif6sqjcyiq  lang=en
omni_view                voice_id=kdif6sqjcyiq  lang=en
fascinating_frontiers    voice_id=kdif6sqjcyiq  lang=en
planetterrian            voice_id=kdif6sqjcyiq  lang=en
env_intel                voice_id=kdif6sqjcyiq  lang=en
models_agents            voice_id=kdif6sqjcyiq  lang=en
models_agents_beginners  voice_id=kdif6sqjcyiq  lang=en
modern_investing         voice_id=kdif6sqjcyiq  lang=en
finansy_prosto           voice_id=0b875ae2      lang=ru  (Olya, unchanged)
privet_russian           voice_id=0b875ae2      lang=ru  (Olya, unchanged)
```

## Files

- `shows/_defaults.yaml` — `tts.voice_id` flipped
- `engine/config.py` — `TTSConfig` dataclass default
- `tests/test_config.py`, `tests/test_integration.py`, `tests/test_tts_grok.py` — drift-guard + per-show voice assertions
- `CLAUDE.md` — voice-IDs note + landmines #11 / #16 / #17

## Test plan

- [x] `pytest tests/ -x -q` — 1548 / 1548 pass
- [x] `ruff check` — clean
- [x] Live show config resolves correctly for all 10 shows
- [ ] First post-merge cron run on any English show should produce audio with the new voice. Easy A/B vs the previous voice if you have an Ep just before this PR.

## Rollback

Per-show or network-wide YAML revert. The previous voice ID `b4cusb2omvkz` is preserved in git history.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_