### PR TITLE
Pipeline resilience: TTS timeout + section fallback + repetition false-positive filters

### DIFF
--- a/engine/generator.py
+++ b/engine/generator.py
@@ -399,6 +399,40 @@ def _validate_llm_output(
 
     # Check for potential hallucinations — words repeated 4+ times in close
     # proximity often indicate corruption (e.g. "Nano Banana 2" x4)
+    #
+    # False-positive guard added May 2026: the Tesla Ep459 run flagged
+    # "may 02, 2026," (9×), "02, 2026," (7×), "it matters" (11×) and
+    # similar — every story timestamp + the prompt-template "this
+    # matters for X" pattern. None were hallucinations; they were
+    # purely structural artefacts of the digest format. Filter both
+    # date-fragment patterns and known prompt-template phrases below
+    # before counting toward `_suspicious_count`.
+    _DATE_FRAGMENT_RE = re.compile(
+        # Matches things like "02, 2026,", "may 02,", "may, 2026,",
+        # "02 may," — any combination of an optional month name with
+        # a 1-2 digit day-of-month and a 4-digit year, possibly comma-
+        # separated. These appear once per story timestamp and trip
+        # the detector at high story counts without indicating
+        # hallucination.
+        r"^"
+        r"(?:(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*"
+        r"\s*[,]?\s*)?"
+        r"(?:\d{1,2}\s*[,]?\s*)?"
+        r"(?:(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*"
+        r"\s*[,]?\s*)?"
+        r"(?:\d{4}\s*[,]?\s*)?"
+        r"$",
+        re.IGNORECASE,
+    )
+
+    def _is_date_fragment(phrase: str) -> bool:
+        """True if the phrase is just a date-shape with no content."""
+        # Require at least one numeric token (year or day) — otherwise
+        # this matches every English word.
+        if not any(c.isdigit() for c in phrase):
+            return False
+        return bool(_DATE_FRAGMENT_RE.match(phrase.strip()))
+
     _suspicious_count = 0
     words = text.split()
     if len(words) > 50:
@@ -438,6 +472,11 @@ def _validate_llm_output(
             "━━━━━━━━━━ ###", "━━━━━━━━━━━━━━━━━━━━ ###",
             # Article reference patterns
             "according to", "going to", "we're going",
+            # Prompt-template artefacts. The "this matters for X" line
+            # appears once per story by prompt design, so the bigrams
+            # below trip the detector at high story counts even though
+            # nothing is hallucinated. Spec v2 follow-up after Ep459.
+            "it matters", "matters for", "this matters",
         }
         # Podcast scripts are longer and naturally have more repeated phrases
         _rep_threshold = 5 if stage == "podcast_script" else 4
@@ -448,6 +487,9 @@ def _validate_llm_output(
             # Skip phrases that are mostly stopwords or very short tokens
             tokens = phrase.split()
             if all(len(t) <= 3 for t in tokens):
+                continue
+            # Skip date-shape fragments — purely structural, not hallucination.
+            if _is_date_fragment(phrase):
                 continue
             if count >= _rep_threshold:
                 _suspicious_count += 1
@@ -465,6 +507,12 @@ def _validate_llm_output(
             "of the the", "in the the", "one of the", "some of the",
             "a lot of", "going to be", "it's going to",
             "according to the", "is going to", "we're going to",
+            # Prompt-template artefacts — "this matters for X" appears
+            # once per story by prompt design. Spec v2 follow-up after
+            # Ep459 flagged "it matters for" 11×.
+            "it matters for", "this matters for", "matters for the",
+            "matters for tesla", "matters for investors",
+            "matters for the", "matters for business",
             # Language learning pedagogical patterns
             "it sounds like", "sounds like the", "the english word",
             "the russian word", "in russian it", "means it is",
@@ -497,6 +545,10 @@ def _validate_llm_output(
             if all(len(t) <= 3 for t in tokens):
                 continue
             if any(p.match(phrase) for p in _PEDAGOGICAL_TRIGRAM_PATTERNS):
+                continue
+            # Skip date-shape trigrams (e.g. "may 02, 2026," appearing
+            # once per story timestamp). Spec v2 follow-up after Ep459.
+            if _is_date_fragment(phrase):
                 continue
             if count >= _rep_threshold:
                 _suspicious_count += 1

--- a/engine/tts.py
+++ b/engine/tts.py
@@ -39,6 +39,13 @@ GROK_TTS_ENDPOINT = "https://api.x.ai/v1/tts"
 # Grok caps per-request text at 15,000 chars; we use 14,000 as the chunk
 # ceiling to leave a small headroom for any trailing punctuation we add.
 GROK_MAX_CHARS_PER_REQUEST = 14000
+# Per-request timeout for Grok TTS (in seconds). Bumped from 120 to 300
+# in May 2026 after Tesla Ep459 hit a real Grok-side slow response that
+# burned through all 3 tenacity retries at the old 120s wall and killed
+# a ~20-minute pipeline run. 300s gives enough headroom for a custom
+# voice + ~14k-char chunk under load; normal calls finish in 30-60s and
+# don't notice the higher cap.
+GROK_TTS_TIMEOUT_SECONDS = 300
 
 
 def _ffmpeg_escape(path: Path) -> str:
@@ -418,7 +425,7 @@ def speak(
     language_code: str = "",
     speed: float = 1.0,
     apply_text_normalization: str = "on",
-    timeout: int = 120,
+    timeout: int = GROK_TTS_TIMEOUT_SECONDS,
     append_exclamation: bool = False,
 ) -> None:
     """Generate audio with automatic chunking and ffmpeg concatenation.
@@ -629,7 +636,7 @@ def grok_speak_chunk(
     *,
     api_key: str,
     language_code: str = "auto",
-    timeout: int = 120,
+    timeout: int = GROK_TTS_TIMEOUT_SECONDS,
     output_codec: str = "wav",
     output_sample_rate: int = 48000,
     text_normalization: bool = True,
@@ -731,7 +738,7 @@ def _speak_with_grok(
     api_key: str,
     max_chars: int = GROK_MAX_CHARS_PER_REQUEST,
     language_code: str = "auto",
-    timeout: int = 120,
+    timeout: int = GROK_TTS_TIMEOUT_SECONDS,
     append_exclamation: bool = False,
 ) -> None:
     """Grok-TTS counterpart of ``speak()``.
@@ -898,7 +905,7 @@ def synthesize(
     language_code: str = "",
     speed: float = 1.0,
     apply_text_normalization: str = "on",
-    timeout: int = 120,
+    timeout: int = GROK_TTS_TIMEOUT_SECONDS,
     append_exclamation: bool = False,
 ) -> Path:
     """Top-level entry point: text in, audio file path out.
@@ -963,7 +970,7 @@ def synthesize_sections(
     language_code: str = "",
     speed: float = 1.0,
     apply_text_normalization: str = "on",
-    timeout: int = 120,
+    timeout: int = GROK_TTS_TIMEOUT_SECONDS,
 ) -> List[Path]:
     """Synthesize multiple script sections into individual audio files.
 
@@ -997,14 +1004,9 @@ def synthesize_sections(
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     section_files: List[Path] = []
+    section_failed = False
 
-    for i, section_text in enumerate(sections):
-        section_text = section_text.strip()
-        if not section_text:
-            logger.warning("Skipping empty section %d", i)
-            continue
-
-        section_path = output_dir / f"{section_prefix}_{i:03d}.mp3"
+    def _synth_one(section_text: str, section_path: Path) -> None:
         if provider == "grok":
             _speak_with_grok(
                 section_text,
@@ -1031,11 +1033,64 @@ def synthesize_sections(
                 apply_text_normalization=apply_text_normalization,
                 timeout=timeout,
             )
+
+    for i, section_text in enumerate(sections):
+        section_text = section_text.strip()
+        if not section_text:
+            logger.warning("Skipping empty section %d", i)
+            continue
+
+        section_path = output_dir / f"{section_prefix}_{i:03d}.mp3"
+        try:
+            _synth_one(section_text, section_path)
+        except Exception as exc:
+            # Per-section failure (typically a Grok TTS read timeout
+            # after tenacity exhausted its retries). Bail out of
+            # section-mode and trigger the single-pass fallback below
+            # so the episode still ships, just without the per-chapter
+            # transition stings.
+            logger.error(
+                "Section %d/%d TTS failed (%s: %s) — falling back to "
+                "single-pass synthesis to save the episode.",
+                i + 1, len(sections), type(exc).__name__, str(exc)[:200],
+            )
+            section_failed = True
+            break
+
         section_files.append(section_path)
         logger.info(
             "Synthesized section %d/%d (%d chars): %s",
             i + 1, len(sections), len(section_text), section_path.name,
         )
+
+    if section_failed:
+        # Clean up any partially-written section files from the failed
+        # attempt so they don't get concatenated by mistake.
+        for sf in section_files:
+            try:
+                if sf.exists():
+                    sf.unlink()
+            except OSError:
+                pass
+        section_files = []
+
+        # Single-pass fallback: synthesize the joined script as one
+        # piece. We lose chapter-marker transitions but ship audio.
+        # The caller's `concatenate_with_stings` handles a 1-element
+        # list by passing the file through (no stings inserted).
+        joined = "\n\n".join(s.strip() for s in sections if s.strip())
+        if joined:
+            fallback_path = output_dir / f"{section_prefix}_fallback.mp3"
+            logger.warning(
+                "Section TTS fallback: synthesizing %d chars as one chunk "
+                "(no per-chapter stings).",
+                len(joined),
+            )
+            _synth_one(joined, fallback_path)
+            section_files.append(fallback_path)
+            logger.info(
+                "Section TTS fallback succeeded: %s", fallback_path.name,
+            )
 
     return section_files
 

--- a/run_show.py
+++ b/run_show.py
@@ -1033,7 +1033,28 @@ def run(args: argparse.Namespace) -> None:
                 ]
                 metrics.record("cross_episode_repeats", len(_repeat_issues))
                 _repeat_threshold = getattr(config.slow_news, "repeat_trigger_threshold", 3) or 3
-                if len(_repeat_issues) >= _repeat_threshold:
+                # Spec v2 follow-up after Tesla Ep459: a daily news show
+                # legitimately revisits 3-6 ongoing stories per day
+                # (Tesla earnings cadence, FSD lawsuit, Cybertruck
+                # production updates) without that meaning "the LLM
+                # ignored the content tracker." Today's run had 6
+                # cross-episode repeats out of 22 articles (27%) — far
+                # under "the digest is mostly recycled" — but the
+                # absolute threshold of 3 still triggered slow-news
+                # fallback, burning ~5 minutes regenerating from
+                # evergreen segments instead of just shipping the
+                # surviving 16 fresh stories. Add a ratio gate: only
+                # fall back when repeats are BOTH above the absolute
+                # threshold AND >=40% of the digest. This lets healthy
+                # news cycles ship; protects against actual tracker-
+                # ignoring runs.
+                total_digest_items = max(1, len(articles))
+                repeat_ratio = len(_repeat_issues) / total_digest_items
+                metrics.record("cross_episode_repeat_ratio", round(repeat_ratio, 3))
+                if (
+                    len(_repeat_issues) >= _repeat_threshold
+                    and repeat_ratio >= 0.40
+                ):
                     # If slow news mode is available, fall back to it instead
                     # of skipping entirely — the repeat articles are stale but
                     # evergreen segments can fill the episode.

--- a/tests/test_tts_grok.py
+++ b/tests/test_tts_grok.py
@@ -403,3 +403,89 @@ def test_no_show_uses_elevenlabs_in_production():
             "rolled back this show and forgot to update this guard, or "
             "(b) shows/_defaults.yaml regressed."
         )
+
+
+# ---------------------------------------------------------------------------
+# Spec v2 follow-up: bumped timeout + section-fallback resilience
+# ---------------------------------------------------------------------------
+
+def test_grok_tts_timeout_default_is_300_seconds():
+    """The default request timeout is 300s — bumped from 120 in May 2026
+    after a Grok-side slow response burned through tenacity retries and
+    killed a 20-minute Tesla run."""
+    from engine.tts import GROK_TTS_TIMEOUT_SECONDS, grok_speak_chunk
+    import inspect
+    assert GROK_TTS_TIMEOUT_SECONDS == 300
+    sig = inspect.signature(grok_speak_chunk)
+    assert sig.parameters["timeout"].default == GROK_TTS_TIMEOUT_SECONDS
+
+
+def test_synthesize_sections_falls_back_on_timeout(tmp_path: Path, monkeypatch):
+    """If a section TTS call raises (e.g. tenacity exhausted retries on
+    a Grok read timeout), the function falls back to single-pass
+    synthesis of the joined text instead of failing the whole episode.
+    """
+    from engine import tts as _tts
+
+    calls = {"per_section": 0, "fallback": 0}
+
+    def _fake_speak_with_grok(text, voice_id, filename, **kwargs):
+        # First call (section #1) succeeds, second (section #2) times out,
+        # then the fallback succeeds.
+        if calls["per_section"] == 0 and calls["fallback"] == 0:
+            calls["per_section"] += 1
+            Path(filename).write_bytes(b"\xff\xfb\x90")
+            return
+        if calls["per_section"] == 1 and calls["fallback"] == 0:
+            calls["per_section"] += 1
+            raise RuntimeError("simulated read timeout after retries")
+        # Fallback call.
+        calls["fallback"] += 1
+        Path(filename).write_bytes(b"\xff\xfb\x90")
+
+    monkeypatch.setattr(_tts, "_speak_with_grok", _fake_speak_with_grok)
+
+    out_dir = tmp_path / "sections"
+    result = _tts.synthesize_sections(
+        ["Section A text.", "Section B text.", "Section C text."],
+        voice_id="kdif6sqjcyiq",
+        output_dir=out_dir,
+        api_key="k",
+        provider="grok",
+        section_prefix="ep001",
+    )
+
+    # Section #1 was rendered, section #2 raised, fallback ran once.
+    assert calls["per_section"] == 2
+    assert calls["fallback"] == 1
+    # Result contains exactly one file (the fallback) — caller's
+    # `concatenate_with_stings` handles 1-element lists by passing
+    # the file through with no transition stings.
+    assert len(result) == 1
+    assert result[0].name.endswith("_fallback.mp3")
+    assert result[0].exists()
+
+
+def test_synthesize_sections_succeeds_when_all_sections_synth(tmp_path: Path, monkeypatch):
+    """Happy path: every section succeeds, no fallback needed."""
+    from engine import tts as _tts
+
+    def _fake_speak_with_grok(text, voice_id, filename, **kwargs):
+        Path(filename).write_bytes(b"\xff\xfb\x90")
+
+    monkeypatch.setattr(_tts, "_speak_with_grok", _fake_speak_with_grok)
+
+    out_dir = tmp_path / "sections"
+    result = _tts.synthesize_sections(
+        ["A", "B", "C"],
+        voice_id="kdif6sqjcyiq",
+        output_dir=out_dir,
+        api_key="k",
+        provider="grok",
+        section_prefix="ep002",
+    )
+
+    assert len(result) == 3
+    assert all(p.exists() for p in result)
+    # No fallback file generated.
+    assert not (out_dir / "ep002_fallback.mp3").exists()


### PR DESCRIPTION
## Summary

Tesla Ep459 failed at minute 20 to a Grok TTS read timeout that exhausted all 3 tenacity retries against a 120s wall, **after** also burning ~10 minutes on repetition-retry false positives. Four focused defensive fixes:

| Fix | File | Time saved on failure path |
|---|---|---|
| TTS timeout 120s → 300s | `engine/tts.py` | Prevents the exact Ep459 failure (TTS timeout) |
| Section TTS single-chunk fallback | `engine/tts.py` | Episode ships even when one section times out |
| Repetition detection skips date-shape + prompt-template phrases | `engine/generator.py` | ~180s — kills false-positive lower-temp retry |
| Cross-episode repeat ratio gate (≥40%) | `run_show.py` | ~310s — stops slow-news fallback firing on healthy news cycles |

**~10 minutes saved per affected run. Quality unchanged.** Every structural piece (RSS, X, dedup, content tracker, slow-news as a real backstop, chain prompts, section TTS, broadcast audio pipeline) stays.

## What each fix does

### 1. TTS timeout → 300s
New `GROK_TTS_TIMEOUT_SECONDS = 300` constant. Propagates to `grok_speak_chunk`, `_speak_with_grok`, `synthesize`, `synthesize_sections`. Normal calls finish in 30-60s — they don't notice the higher cap. The headroom is for slow Grok responses on custom voices + 14k-char chunks under load.

### 2. Section TTS single-chunk fallback
`synthesize_sections` now wraps each per-section synth in try/except. On failure: clean up partial files, synth the joined script as one fallback chunk, return `[fallback_path]`. Caller's `concatenate_with_stings` already passes a 1-file list through without transition stings. Ships the episode losing chapter granularity rather than failing the run.

### 3. Repetition false-positive filters
Ep459 logged 9 false-positive "suspicious repetitions":
- `"may 02, 2026,"` 7-9× — every story timestamp
- `"02, 2026,"` 7× — same
- `"it matters"` 11× — prompt-template `"this matters for X"`

None were hallucinations. All structural. Added:
- `_is_date_fragment()` regex skip — matches month-name/day/year combinations and skips them in counting
- `"it matters"`, `"matters for"`, `"this matters"` added to `_COMMON_BIGRAMS`
- `"it matters for"`, `"this matters for"`, `"matters for the/tesla/investors/business"` added to `_COMMON_TRIGRAMS`

Today's run would have produced 0 suspicious phrases instead of 6+, skipped the lower-temp retry (~180s) and the slow-news fallback's own retry (~180s).

### 4. Cross-episode repeat ratio gate
Today's run had 6 cross-episode repeats out of 22 articles (27%). The absolute threshold (≥3 repeats) triggered slow-news fallback even though 16 fresh stories survived. New gate requires BOTH `≥repeat_threshold absolute` AND `≥40% ratio`. Daily news shows legitimately revisit 3-6 ongoing stories per day without that meaning the LLM ignored the tracker. Today: 27% < 40% → no fallback, episode ships fresh content.

New metric `cross_episode_repeat_ratio` recorded for dashboard observability.

## Tests

- `test_grok_tts_timeout_default_is_300_seconds`
- `test_synthesize_sections_falls_back_on_timeout` (sim'd timeout on section #2 → fallback fires, ships [fallback])
- `test_synthesize_sections_succeeds_when_all_sections_synth` (happy path unchanged)

`pytest tests/ -x -q --tb=short` — **1562 / 1562 pass**.
`ruff check engine/ run_show.py` — clean.

## Test plan

- [x] Local pytest + lint
- [ ] **Re-run Tesla Ep459 manually** to confirm:
  - Repetition detector: 0 suspicious phrases (no `02, 2026,` / `it matters` flags)
  - No slow-news fallback fires (ratio 27% < 40%)
  - TTS finishes within the 300s window
  - Pipeline completes inside ~5-7 min instead of 20+ min
- [ ] Watch the dashboard's new `cross_episode_repeat_ratio` metric over the next week. If any show consistently sits at >35%, the LLM IS struggling with that show's content tracker and we should investigate.

## What I deliberately did NOT change

- Multi-stage chain prompts (digest → outline → script). The chain produces measurably better narrative.
- Slow-news mode. It's the right answer on actual slow days, just not today's healthy news cycle.
- Section TTS as the default. Chapter markers + transition stings are real listener UX.
- Content tracker. Cross-episode dedup is the entire reason listeners can listen daily.
- The X-account fetch loop. Already parallel via `ThreadPoolExecutor(5)`; today's 146s was one slow call sitting in queue, not a structural problem.

## Rollback

Revert this PR. The `GROK_TTS_TIMEOUT_SECONDS` constant goes back to inline `120`; `synthesize_sections` raises again on per-section failure; repetition detection counts dates as suspicious; slow-news triggers on absolute count.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_