### PR TITLE
Description + voice polish: hook prominence, scaffold scrub, EQ retune

### DIFF
--- a/engine/audio.py
+++ b/engine/audio.py
@@ -110,27 +110,29 @@ def _voice_norm_codec_args(output_path: str) -> list:
 
 
 def _voice_norm_full_cmd(voice_in: str, voice_out: str) -> list:
-    """Build the full 6-stage voice normalization ffmpeg command.
+    """Build the 5-stage voice normalization ffmpeg command.
 
     Order matters — each stage operates on the output of the previous:
 
       1. highpass=80 Hz       — strip sub-bass rumble / TTS artifacts
       2. lowpass=15 kHz       — strip ultrasonic hiss above intelligibility
-      3. equalizer=6.5 kHz -3 dB — gentle de-esser, softens "s"/"sh" sibilants
-      4. loudnorm I=-18      — voice-only LUFS target (mix gets re-norm'd to -16)
-      5. acompressor 4:1     — gentle dynamics control (NPR-ish consistency)
-      6. alimiter level_out=0.95 — peak protection, prevents clipping into mix
+      3. loudnorm I=-18      — voice-only LUFS target (mix gets re-norm'd to -16)
+      4. acompressor 4:1     — gentle dynamics control (NPR-ish consistency)
+      5. alimiter level_out=0.95 — peak protection, prevents clipping into mix
 
-    The 6.5 kHz dip is new in May 2026 — the custom Grok voice introduced
-    with the full network migration was noticeably sibilant on the raw
-    output, and the dip restores broadcast feel without making the voice
-    sound dull. See landmine #17.
+    History: the chain briefly carried a 6.5 kHz -3 dB dip in May 2026
+    to de-ess the original ``b4cusb2omvkz`` clone, which had a noisy
+    high end. The replacement custom voice ``kdif6sqjcyiq`` (recorded
+    on a better microphone) doesn't need it — Patrick's A/B against
+    Tesla Ep457 / Ep459 showed the dip making the new voice feel
+    duller without removing audible sibilance, so the dip was retired.
+    Re-add it if a future voice clone reintroduces "s" / "sh" hiss.
+    See landmine #17.
     """
     return [
         "ffmpeg", "-y", "-threads", "0", "-i", voice_in,
         "-af",
         "highpass=f=80,lowpass=f=15000,"
-        "equalizer=f=6500:t=q:w=1.5:g=-3,"
         "loudnorm=I=-18:TP=-1.5:LRA=11:linear=true,"
         "acompressor=threshold=-20dB:ratio=4:attack=1:release=100:makeup=2,"
         "alimiter=level_in=1:level_out=0.95:limit=0.95",

--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -371,7 +371,18 @@ def send_show_newsletter(
     # Body transforms — clean up scaffold + render Tesla price /
     # Russian vocab. Run *before* wrap_with_branding so the wrapper
     # sees clean markdown.
-    from engine.newsletter_body import transform_daily_body
+    #
+    # Two stages: ``transform_daily_body`` is the canonical (markdown
+    # -safe) pass that already ran in ``run_show.py`` on the digest
+    # source; we re-run it here as defense-in-depth (idempotent).
+    # ``transform_email_body`` is the email-only layer that produces
+    # inline HTML (TSLA stock-watch table, styled ``<hr>``, vocab
+    # cards) — applying it at the canonical stage would corrupt the
+    # blog / RSS / GitHub Pages surfaces, which is why it lives here.
+    from engine.newsletter_body import (
+        transform_daily_body,
+        transform_email_body,
+    )
     from engine.newsletter_sanitizer import (
         ScaffoldLeakError,
         assert_clean,
@@ -379,6 +390,7 @@ def send_show_newsletter(
     )
     body_clean = scrub_scaffold(digest_text or "")
     body_clean = transform_daily_body(body_clean, slug=slug)
+    body_clean = transform_email_body(body_clean, slug=slug)
 
     # Hard tripwire: if any blocklisted label survived scrubbing, the
     # prompt regressed and the operator should fix the prompt before

--- a/engine/newsletter_body.py
+++ b/engine/newsletter_body.py
@@ -1,26 +1,31 @@
-"""Body-text transforms applied to a daily newsletter's markdown.
+"""Body-text transforms applied to a daily digest's markdown.
 
-The wrapper (``engine.newsletter_template.wrap_with_branding``) handles
-hero / featured-episode / footer / etc. — but the *middle of the email*
-is still the raw markdown body produced by the LLM (the digest text).
+Two stages:
 
-This module post-processes that body so:
+1. ``transform_daily_body`` — markdown-safe transforms applied at the
+   canonical-write site in ``run_show.py``. The output is still valid
+   markdown (no inline HTML), so the blog reader, RSS show notes, and
+   GitHub Pages summary all see the same clean source. Includes:
 
-  - Russian vocabulary list (Привет, Русский!) renders as a card stack
-    instead of a `field: value` plaintext dump (spec §2.3).
-  - Tesla daily's box-drawing horizontal rules become proper ``<hr>``
-    HTML separators that respect dark mode (spec §5.2).
-  - Tesla's "REAL-TIME TSLA price:" line becomes a styled stock-watch
-    block instead of a bold label + raw text (spec §5.3).
+      - Box-drawing rules → markdown ``---`` (renders fine everywhere)
+      - Hook line → markdown blockquote ``> **<text>**`` (visual lift)
+      - Source URL shortening (Google News blob → `[Google News](...)`)
+      - Bare ``@handle`` → markdown link
+      - Omni View "Read more" duplicate-URL dedup
 
-The transforms are conservative: they pattern-match a recognisable
-shape and only fire when matched. A digest that doesn't contain (e.g.)
-the vocab format passes through unchanged.
+2. ``transform_email_body`` — HTML upgrades layered on top of the
+   canonical text inside ``send_show_newsletter``. These would corrupt
+   plaintext / blog / RSS surfaces if applied at the canonical stage
+   (raw inline HTML showing up in markdown), so they're email-only:
 
-All transforms are idempotent — running twice produces the same output
-as once. They're also applied *after* ``scrub_scaffold`` from
-``engine.newsletter_sanitizer`` so labels like ``**Vocabulary List
-(8-12 words/phrases):**`` are already gone by the time we run.
+      - Markdown ``---`` rules → styled ``<hr>`` (dark-mode aware)
+      - Tesla ``**TSLA today:**`` line → styled stock-watch table
+      - Privet vocab list → card-stack table
+
+All transforms are idempotent. They're also applied *after*
+``scrub_scaffold`` from ``engine.newsletter_sanitizer`` so labels like
+``**Vocabulary List (8-12 words/phrases):**`` are already gone by the
+time we run.
 """
 
 from __future__ import annotations
@@ -30,24 +35,37 @@ from typing import List
 
 
 # ---------------------------------------------------------------------------
-# Box-drawing horizontal rules → <hr>
+# Box-drawing horizontal rules → markdown / HTML
 # ---------------------------------------------------------------------------
 
 _BOX_RULE_RE = re.compile(r"(?m)^\s*(?:━|─|═){3,}\s*$")
+_MD_HR_RE = re.compile(r"(?m)^\s*-{3,}\s*$")
 
 
-def replace_box_rules_with_hr(body: str) -> str:
-    """Replace runs of box-drawing horizontal rules with HTML ``<hr>``.
+def replace_box_rules_with_md_hr(body: str) -> str:
+    """Canonical-stage: box-drawing rules → markdown ``---``.
 
-    The Tesla daily previously rendered ``━━━━━━━━━━━━━━━━━━━━`` as
-    section separators. In email those characters are visible literals
-    (most fonts don't merge them into a horizontal line) and Outlook
-    Win renders them as boxes. Replace with a styled ``<hr>`` that
-    respects dark-mode override (set in ``_DARK_MODE_STYLE``).
+    Markdown's standard horizontal rule renders cleanly in every
+    surface that consumes the canonical .md (blog, RSS show notes,
+    GitHub Pages summary). The email pipeline upgrades ``---`` to a
+    styled ``<hr>`` later via ``upgrade_md_hr_to_html``.
     """
     if not body:
         return body
-    return _BOX_RULE_RE.sub(
+    return _BOX_RULE_RE.sub("---", body)
+
+
+def upgrade_md_hr_to_html(body: str) -> str:
+    """Email-stage: markdown ``---`` rules → styled ``<hr>``.
+
+    Outlook Win renders box-drawing characters (━━━) as boxes; even
+    plain ``---`` is rendered as a faint thin rule by some clients
+    and as nothing by others. Replace with an inline-styled ``<hr>``
+    that respects dark mode (overridden in ``_DARK_MODE_STYLE``).
+    """
+    if not body:
+        return body
+    return _MD_HR_RE.sub(
         '<hr style="border:none;border-top:1px solid #e2e8f0;'
         'margin:24px 0;" />',
         body,
@@ -250,30 +268,120 @@ def render_russian_vocab_cards(body: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Hook line → blockquote (visual prominence)
+# ---------------------------------------------------------------------------
+
+# After ``scrub_scaffold`` strips the ``**HOOK:**`` label, the hook
+# becomes a plain paragraph at the top of the digest — visually
+# indistinguishable from the body. Promote it to a markdown blockquote
+# (``> **<text>**``) so it stands out across every surface (blog
+# renders it indented, email wraps it as a styled quote, RSS readers
+# show it as a callout). The hook is a single sentence that follows
+# the price line and precedes the first horizontal rule.
+#
+# Match the first non-empty content line that sits between the
+# price/header lines and the first ``---`` (or end of body), and
+# only if it doesn't already start with ``>`` (idempotent) and isn't
+# already a heading / list item / blockquote / table.
+
+# A bold-label line looks like ``**Field name:** value`` — the colon
+# inside the bold span is the giveaway. We skip those (they're header
+# metadata) and only consider plain prose lines for promotion.
+_BOLD_LABEL_LINE_RE = re.compile(r"^\*\*[^*]+:\*\*")
+# Markdown bullet (``- foo`` or ``* foo``) — single marker followed by
+# whitespace. ``**foo**`` is legitimate bold prose, NOT a bullet, so
+# we use a regex (single char + space) instead of ``startswith("*")``.
+_BULLET_LINE_RE = re.compile(r"^[-*]\s")
+_HOOK_SKIP_PREFIXES = ("#", ">", "1.", "|", "<", "```")
+
+
+def promote_hook_to_blockquote(body: str) -> str:
+    """Wrap the post-scrub hook line in a markdown blockquote.
+
+    The transform finds the first prose line after the header block
+    (Date / TSLA today / etc.) and rewrites it as ``> **<text>**``.
+    Returns the body unchanged if no plausible hook is found —
+    conservative by design.
+
+    Idempotent: skips lines that already start with ``>``.
+    """
+    if not body:
+        return body
+
+    lines = body.split("\n")
+    # Skip the title and any leading metadata lines (bold-label or
+    # blank). Find the first line that's plain prose.
+    for i, raw in enumerate(lines):
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        # Skip title (`# Tesla Shorts Time`) and any bold-label header
+        # lines (``**TSLA today:** ...``).
+        if stripped.startswith("#"):
+            continue
+        if _BOLD_LABEL_LINE_RE.match(stripped):
+            continue
+        # Stop at structural markers — if we hit an HR or a list /
+        # heading before any prose, there's no hook to promote.
+        if stripped.startswith(_HOOK_SKIP_PREFIXES):
+            return body
+        if _BULLET_LINE_RE.match(stripped):
+            return body
+        # Plausible hook — wrap it.
+        # Strip any surrounding `**bold**` so we don't end up with
+        # ``> **\*\*text\*\***``.
+        text = stripped
+        if text.startswith("**") and text.endswith("**") and len(text) > 4:
+            text = text[2:-2].strip()
+        lines[i] = f"> **{text}**"
+        return "\n".join(lines)
+    return body
+
+
+# ---------------------------------------------------------------------------
 # Public combined transform
 # ---------------------------------------------------------------------------
 
 def transform_daily_body(body: str, *, slug: str = "") -> str:
-    """Apply every body transform in the right order.
+    """Canonical-stage transforms (markdown-safe; no inline HTML).
 
-    Order matters:
+    Applied at the canonical .md write site in ``run_show.py`` so every
+    downstream surface (blog, RSS show notes, GitHub Pages summary,
+    email) sees the same source. Order matters:
 
-      1. Box rules → ``<hr>`` (cheapest, fires for everyone)
-      2. Shorten Google News tracking URLs in "Source: …" lines
-         (universal — every show is potentially affected)
-      3. Linkify trailing X/Twitter @handles (every show)
-      4. Dedup "Read more" source lists (Omni View — repeated URLs)
-      5. TSLA price block (Tesla only)
-      6. Russian vocab cards (Привет only)
+      1. Box-drawing rules → markdown ``---``
+      2. Hook line → markdown blockquote
+      3. Shorten Google News tracking URLs in "Source: …" lines
+      4. Linkify trailing X/Twitter @handles
+      5. Dedup Omni View "Read more" duplicate URLs
 
     Each transform is a no-op when its trigger pattern isn't present,
     so calling this for every show is safe.
     """
-    body = replace_box_rules_with_hr(body)
+    body = replace_box_rules_with_md_hr(body)
+    body = promote_hook_to_blockquote(body)
     body = shorten_source_urls(body)
     body = linkify_x_handles(body)
     if slug == "omni_view":
         body = dedup_read_more_sources(body)
+    return body
+
+
+def transform_email_body(body: str, *, slug: str = "") -> str:
+    """Email-only transforms — inline HTML upgrades for layout.
+
+    Applied inside ``send_show_newsletter`` *after* the canonical
+    transforms have already run on the source. These produce HTML
+    that's only safe inside an email (the canonical .md path can't
+    contain raw HTML — Markdown viewers strip or escape it):
+
+      1. Markdown ``---`` → styled ``<hr>`` (dark-mode aware)
+      2. Tesla ``**TSLA today:**`` line → styled stock-watch table
+      3. Privet vocab list → card-stack table
+
+    Idempotent — repeated runs produce the same HTML output.
+    """
+    body = upgrade_md_hr_to_html(body)
     if slug == "tesla":
         body = render_tsla_price_block(body)
     if slug == "privet_russian":

--- a/engine/newsletter_sanitizer.py
+++ b/engine/newsletter_sanitizer.py
@@ -127,6 +127,16 @@ _RAW_RULES: List[Tuple[str, str, str]] = [
         "",
         "**LENGTH TARGET:** ... line",
     ),
+    # Tesla Short Spot ``**Catchy Title: <real title>...**`` — the LLM
+    # mirrored the prompt's placeholder ``Catchy Title:`` instead of
+    # replacing it with an actual title. Strip the placeholder prefix
+    # but keep the real title that follows. Capture group 1 is the
+    # rest of the bold line (the title + dateline + source).
+    (
+        r"(?im)\*\*\s*Catchy Title:\s*([^*\n]+?)\s*\*\*",
+        r"**\1**",
+        "**Catchy Title: ...**",
+    ),
     # M&AB / Russian-language-show labels.
     (r"(?im)^\s*\*\*What's Cool Today:\*\*\s*", "", "**What's Cool Today:**"),
     (r"(?im)^\s*\*\*What's today's hot story:\*\*\s*", "", "**What's today's hot story:**"),

--- a/shows/prompts/tesla_digest.txt
+++ b/shows/prompts/tesla_digest.txt
@@ -100,29 +100,25 @@ If fewer than 5 quality articles are available today:
 ━━━━━━━━━━━━━━━━━━━━
 ## Short Spot
 One critical or challenging item from pre-fetched news that Tesla needs to address.
-**Catchy Title: DD Month, YYYY, HH:MM AM/PM PST, @username/Source**
+**[Specific story title — replace this bracketed placeholder with the actual title]: DD Month, YYYY, HH:MM AM/PM PST, @username/Source**
 2–4 sentences explaining the challenge honestly and how Tesla is positioned to address it. Source/Post: [EXACT URL]
+
+CRITICAL: Do NOT output the literal words "Catchy Title", "Story Title", or any bracketed placeholder. Replace the bracketed text with the actual headline of the story you chose.
 
 ━━━━━━━━━━━━━━━━━━━━
 ### Tesla First Principles
-🧠 Tesla First Principles - Cutting Through the Noise
 
-**TOPIC SELECTION:** Choose the topic where conventional wisdom about Tesla is MOST WRONG right now. Look for areas where the popular narrative (from bulls or bears) diverges most from what physics, economics, or engineering data actually show. The best First Principles topics make listeners rethink something they thought they already understood.
-
-**TOPIC FRESHNESS — MUST choose a DIFFERENT topic than recent episodes:**
+INSTRUCTIONS FOR THIS SECTION (do not output these instructions):
+- Choose the topic where conventional wisdom about Tesla is MOST WRONG right now. Look for areas where the popular narrative (from bulls or bears) diverges most from what physics, economics, or engineering data actually show. The best First Principles topics make listeners rethink something they thought they already understood.
+- MUST be a DIFFERENT topic than recent episodes:
 {recent_deep_dive_topics}
-
-Taking a step back from today's headlines, let's apply first principles thinking to [chosen topic]...
-
-**The Surprising Truth:** [Open with one specific, counterintuitive fact or data point that challenges conventional wisdom. This should make the reader pause and think "wait, really?"]
-
-**The Fundamental Question:** [Core question that actually matters for Tesla long-term]
-
-**The Data Says:** [Factual analysis based on Tesla's actual numbers, physics, market realities — no hype. Include at least one specific number, ratio, or comparison that makes the answer concrete.]
-
-**The Tesla Approach:** [How Tesla would actually solve this problem using their proven methodologies]
-
-**The Bottom Line:** [What this means practically — for Tesla's business, for the technology, for the industry]
+- Output a flowing 3-paragraph editorial essay (4–6 sentences each). Do NOT output labeled bullets ("The Surprising Truth:", "The Fundamental Question:", etc.) — those are scaffolding for your thinking, not for the reader. Write as a journalist would write a measured analytical column.
+- The three paragraphs should cover, in order:
+  1. The counterintuitive opening: a specific surprising fact or data point that challenges the popular narrative, plus the question it forces.
+  2. The data: at least one concrete number, ratio, or comparison anchoring the analysis. Show how physics, economics, or engineering data actually answer the question.
+  3. The implication: how Tesla's vertical-integration, manufacturing, or engineering playbook would solve the problem, and what that means practically — for the business, the technology, or the industry.
+- Open the section with a single editorial transition sentence ("Taking a step back from today's headlines, ..." or similar). Do NOT begin a paragraph with a bold label.
+- Specific numbers > vague qualifiers. "560 miles per charge" beats "long range".
 {market_movers_section}
 
 ━━━━━━━━━━━━━━━━━━━━

--- a/tests/test_audio_commands.py
+++ b/tests/test_audio_commands.py
@@ -23,13 +23,14 @@ import pytest
 # ---------------------------------------------------------------------------
 
 def voice_normalization_full(voice_in: str, voice_out: str) -> list:
-    """The full 6-stage filter chain for voice normalization (May 2026:
-    added 6.5 kHz de-essing dip for the new custom Grok voice)."""
+    """The 5-stage filter chain for voice normalization. The 6.5 kHz
+    de-essing dip was retired May 2026 once the second custom voice
+    clone (kdif6sqjcyiq, recorded on a better mic) replaced the
+    sibilant b4cusb2omvkz."""
     return [
         "ffmpeg", "-y", "-threads", "0", "-i", voice_in,
         "-af",
         "highpass=f=80,lowpass=f=15000,"
-        "equalizer=f=6500:t=q:w=1.5:g=-3,"
         "loudnorm=I=-18:TP=-1.5:LRA=11:linear=true,"
         "acompressor=threshold=-20dB:ratio=4:attack=1:release=100:makeup=2,"
         "alimiter=level_in=1:level_out=0.95:limit=0.95",

--- a/tests/test_newsletter_body.py
+++ b/tests/test_newsletter_body.py
@@ -1,47 +1,68 @@
 """Tests for newsletter_body — Tesla price block, Russian vocab cards,
-box-rule replacement, OV source-list dedup."""
+box-rule replacement, OV source-list dedup, and the canonical/email
+two-stage split."""
 
 from __future__ import annotations
 
 from engine.newsletter_body import (
     dedup_read_more_sources,
+    promote_hook_to_blockquote,
     render_russian_vocab_cards,
     render_tsla_price_block,
-    replace_box_rules_with_hr,
+    replace_box_rules_with_md_hr,
     shorten_source_urls,
     transform_daily_body,
+    transform_email_body,
+    upgrade_md_hr_to_html,
 )
 
 
 # ---------------------------------------------------------------------------
-# Box rules
+# Box rules — canonical (markdown) and email (HTML) stages
 # ---------------------------------------------------------------------------
 
-class TestBoxRules:
+class TestBoxRulesCanonical:
 
-    def test_replaces_run_of_box_chars(self):
+    def test_replaces_run_of_box_chars_with_md_hr(self):
         text = "Section A\n━━━━━━━━━━━━━━━━━━━━\nSection B"
-        out = replace_box_rules_with_hr(text)
+        out = replace_box_rules_with_md_hr(text)
         assert "━━━" not in out
-        assert "<hr" in out
+        assert "---" in out
+        # No HTML at canonical stage.
+        assert "<hr" not in out
 
     def test_idempotent(self):
         text = "A\n━━━━━━━━━\nB"
-        once = replace_box_rules_with_hr(text)
-        twice = replace_box_rules_with_hr(once)
+        once = replace_box_rules_with_md_hr(text)
+        twice = replace_box_rules_with_md_hr(once)
         assert once == twice
 
     def test_empty(self):
-        assert replace_box_rules_with_hr("") == ""
+        assert replace_box_rules_with_md_hr("") == ""
 
     def test_does_not_match_short_runs(self):
-        # Two-character "──" is a typo, not a section rule.
         text = "Some prose with ── inline."
-        assert replace_box_rules_with_hr(text) == text
+        assert replace_box_rules_with_md_hr(text) == text
+
+
+class TestBoxRulesEmail:
+
+    def test_upgrades_md_hr_to_styled_hr(self):
+        text = "Section A\n---\nSection B"
+        out = upgrade_md_hr_to_html(text)
+        assert "<hr" in out
+        # Inline-styled (dark-mode-aware via _DARK_MODE_STYLE).
+        assert "border-top:1px solid" in out
+
+    def test_idempotent(self):
+        text = "A\n---\nB"
+        once = upgrade_md_hr_to_html(text)
+        twice = upgrade_md_hr_to_html(once)
+        assert once == twice
 
 
 # ---------------------------------------------------------------------------
-# Tesla price block
+# Tesla price block — email stage only
 # ---------------------------------------------------------------------------
 
 class TestTeslaPriceBlock:
@@ -51,7 +72,6 @@ class TestTeslaPriceBlock:
         out = render_tsla_price_block(text)
         assert "TSLA today" in out
         assert "$390.82" in out
-        # Up = green
         assert "#10b981" in out
 
     def test_renders_down_arrow_red(self):
@@ -63,6 +83,76 @@ class TestTeslaPriceBlock:
     def test_no_match_returns_unchanged(self):
         text = "Some prose, no TSLA price line here."
         assert render_tsla_price_block(text) == text
+
+
+# ---------------------------------------------------------------------------
+# Hook → blockquote
+# ---------------------------------------------------------------------------
+
+class TestHookBlockquote:
+    """After ``scrub_scaffold`` strips the ``**HOOK:**`` label, the
+    hook becomes plain prose. ``promote_hook_to_blockquote`` wraps it
+    in a markdown blockquote so it stands out across every surface."""
+
+    def test_promotes_first_prose_after_header(self):
+        text = (
+            "# Tesla Shorts Time\n"
+            "**TSLA today:** $390 ▲ $9 (2%)\n"
+            "\n"
+            "Tesla introduced the Roadster.\n"
+            "\n"
+            "---\n"
+            "More content.\n"
+        )
+        out = promote_hook_to_blockquote(text)
+        assert "> **Tesla introduced the Roadster.**" in out
+
+    def test_idempotent(self):
+        text = (
+            "# Tesla Shorts Time\n"
+            "**TSLA today:** $390 ▲ $9 (2%)\n"
+            "\n"
+            "The hook line.\n"
+        )
+        once = promote_hook_to_blockquote(text)
+        twice = promote_hook_to_blockquote(once)
+        assert once == twice
+
+    def test_skips_when_first_line_is_already_blockquote(self):
+        text = (
+            "# Tesla Shorts Time\n"
+            "\n"
+            "> **Already a quote.**\n"
+        )
+        out = promote_hook_to_blockquote(text)
+        # Already a blockquote — no double-wrap.
+        assert out.count("> **") == 1
+
+    def test_skips_when_no_prose_before_structure(self):
+        text = (
+            "# Tesla Shorts Time\n"
+            "\n"
+            "## Top 10 News Items\n"
+            "1. First item\n"
+        )
+        out = promote_hook_to_blockquote(text)
+        # Hit a heading before any prose — bail.
+        assert out == text
+
+    def test_strips_existing_bold_wrapping(self):
+        text = (
+            "# Tesla Shorts Time\n"
+            "\n"
+            "**Already bold hook**\n"
+        )
+        out = promote_hook_to_blockquote(text)
+        # Don't end up with `> ****Already bold hook****` — the inner
+        # ** are stripped before re-wrapping.
+        assert "> **Already bold hook**" in out
+        assert "****" not in out
+
+    def test_empty_input(self):
+        assert promote_hook_to_blockquote("") == ""
 
 
 # ---------------------------------------------------------------------------
@@ -85,9 +175,7 @@ class TestRussianVocabCards:
         assert "KOS-mos" in out
         assert "space" in out
         assert "Мы летим в космос" in out
-        # Cyrillic word renders large.
         assert "font-size:22px" in out
-        # Memory hook in yellow callout.
         assert "💡" in out
 
     def test_no_vocab_block_returns_unchanged(self):
@@ -119,11 +207,8 @@ class TestDedupReadMore:
             "- [Daily Mail](https://dailymail.com/x) — Background\n"
         )
         out = dedup_read_more_sources(text)
-        # Only the first bullet survives.
         assert out.count("https://dailymail.com/x") == 1
-        # First description preserved.
         assert "Threat level details" in out
-        # Other descriptions gone.
         assert "Suspect info" not in out
         assert "Background" not in out
 
@@ -155,21 +240,42 @@ class TestDedupReadMore:
 
 
 # ---------------------------------------------------------------------------
-# transform_daily_body — orchestration order
+# transform_daily_body — canonical (markdown-safe) orchestration
 # ---------------------------------------------------------------------------
 
 class TestTransformDailyBody:
+    """Canonical-stage: every transform output must be valid markdown
+    that renders cleanly on the blog, RSS, and GitHub Pages surfaces."""
 
-    def test_tesla_runs_price_block_and_box_rules(self):
+    def test_tesla_keeps_price_line_as_markdown(self):
         text = (
+            "# Tesla Shorts Time\n"
             "**REAL-TIME TSLA price:** $390 ▲ $9 (2%)\n"
+            "\n"
+            "Tesla introduced something.\n"
+            "\n"
             "━━━━━━━━━━━━━━━━━━━━\n"
             "Section content."
         )
         out = transform_daily_body(text, slug="tesla")
-        assert "TSLA today" in out
-        assert "<hr" in out
+        # No inline HTML at canonical stage.
+        assert "<table" not in out
+        assert "<hr" not in out
+        # TSLA price stays as a bold-label markdown line.
+        assert "**REAL-TIME TSLA price:**" in out
+        # Box rule became markdown ---.
+        assert "---" in out
         assert "━━━" not in out
+
+    def test_tesla_promotes_hook_to_blockquote(self):
+        text = (
+            "# Tesla Shorts Time\n"
+            "**REAL-TIME TSLA price:** $390 ▲ $9 (2%)\n"
+            "\n"
+            "Tesla introduced the Roadster.\n"
+        )
+        out = transform_daily_body(text, slug="tesla")
+        assert "> **Tesla introduced the Roadster.**" in out
 
     def test_omni_view_runs_dedup_and_box_rules(self):
         text = (
@@ -181,15 +287,58 @@ class TestTransformDailyBody:
         )
         out = transform_daily_body(text, slug="omni_view")
         assert out.count("https://a.com") == 1
-        assert "<hr" in out
+        # Markdown HR, not HTML.
+        assert "---" in out
+        assert "<hr" not in out
 
     def test_unknown_slug_only_runs_universal_transforms(self):
         text = "━━━━━━━━━━\nFiller."
         out = transform_daily_body(text, slug="some_other_show")
-        # Box rule still gone (universal).
         assert "━━━" not in out
-        # No show-specific render.
         assert "TSLA today" not in out
+
+
+# ---------------------------------------------------------------------------
+# transform_email_body — HTML upgrades
+# ---------------------------------------------------------------------------
+
+class TestTransformEmailBody:
+    """Email-stage: applied AFTER transform_daily_body, layers in the
+    inline HTML that would corrupt non-email surfaces."""
+
+    def test_tesla_renders_html_table_for_tsla_line(self):
+        # Body comes in already canonical-transformed.
+        body = (
+            "# Tesla Shorts Time\n"
+            "**REAL-TIME TSLA price:** $390 ▲ $9 (2%)\n"
+            "\n"
+            "> **Tesla introduced something.**\n"
+            "\n"
+            "---\n"
+            "Section."
+        )
+        out = transform_email_body(body, slug="tesla")
+        # Stock-watch table appears.
+        assert "TSLA today" in out
+        assert "<table" in out
+        assert "$390" in out
+        # Markdown HR upgraded to styled <hr>.
+        assert "<hr" in out
+
+    def test_non_tesla_only_runs_hr_upgrade(self):
+        body = "Section A\n---\nSection B"
+        out = transform_email_body(body, slug="omni_view")
+        assert "<hr" in out
+        assert "TSLA today" not in out
+
+    def test_idempotent_after_canonical(self):
+        canonical = transform_daily_body(
+            "**REAL-TIME TSLA price:** $390 ▲ $9 (2%)\n\nHook line.\n\n---\nA",
+            slug="tesla",
+        )
+        once = transform_email_body(canonical, slug="tesla")
+        twice = transform_email_body(once, slug="tesla")
+        assert once == twice
 
 
 # ---------------------------------------------------------------------------
@@ -205,16 +354,8 @@ class TestShortenSourceUrls:
         )
         text = f"Story body. Source: {long_url}"
         out = shorten_source_urls(text)
-        # Visible label is "Google News" (Buttondown renders the
-        # markdown link, only the label text shows in the email body).
         assert "[Google News]" in out
-        # Original URL is still inside the markdown link target so
-        # the click goes to the right place.
         assert long_url in out
-        # Critical: the bare "Source: https://news.google.com/..."
-        # form is replaced — there's no longer a raw URL emitted as
-        # plaintext for the reader to see. The only place the URL
-        # appears is inside the (URL) of [label](URL).
         assert f"Source: {long_url}" not in out
 
     def test_collapses_publisher_url_to_domain(self):
@@ -228,7 +369,6 @@ class TestShortenSourceUrls:
     def test_strips_trailing_punctuation_from_url(self):
         text = "Read it. Source: https://example.com/foo)."
         out = shorten_source_urls(text)
-        # Punctuation stays in the prose; URL inside the link doesn't have it.
         assert "(https://example.com/foo)" in out
 
     def test_no_match_returns_unchanged(self):
@@ -264,40 +404,24 @@ class TestLinkifyXHandles:
         assert "[@SawyerMerritt](https://x.com/SawyerMerritt)" in out
 
     def test_skips_handle_inside_existing_markdown_link(self):
-        """A handle already inside ``[@x](url)`` must not be double-linkified."""
         text = "[See @teslashortstime](https://x.com/teslashortstime) for updates."
         out = self._linkify(text)
-        # The original markdown link is preserved unchanged — the @ inside
-        # the link label is the only @ in the input, and it's preceded by
-        # a space which our negative-lookbehind doesn't block. So it WILL
-        # be rewritten. That's actually the right behavior — the inner
-        # text becomes a nested link, which markdown renders as the
-        # outer link wins. Idempotency is the contract that matters.
         twice = self._linkify(out)
         assert out == twice  # idempotent
 
     def test_skips_handle_inside_url(self):
-        """An @ that's part of a URL like ``https://x.com/@foo`` must not
-        be touched."""
         text = "See https://x.com/@teslashortstime for the feed."
         out = self._linkify(text)
-        # The @ is preceded by `/` which is in our exclusion class.
         assert out == text
 
     def test_skips_email_addresses(self):
         text = "Email me at user@example.com for details."
         out = self._linkify(text)
-        # @ preceded by a word char (`r`) → excluded.
         assert out == text
 
     def test_handle_length_cap_at_15(self):
-        # 16-char handle isn't valid on X — don't grab the trailing char.
-        text = "@aaaaaaaaaaaaaaab x"  # 15 a's then b
+        text = "@aaaaaaaaaaaaaaab x"
         out = self._linkify(text)
-        # First 15 chars become the handle; trailing 'b' stays in prose.
-        # Actually our regex matches 1-15 chars then a word boundary,
-        # and 'aaaaaaaaaaaaaaab' is 16 word chars so no boundary at 15.
-        # The match fails, leaving the text unchanged.
         assert "[@aaa" not in out
 
     def test_idempotent(self):
@@ -312,20 +436,17 @@ class TestLinkifyXHandles:
 
 
 # ---------------------------------------------------------------------------
-# Canonical-scrub integration — transform_daily_body now applied at .md write
+# Canonical + email integration — end-to-end TST shape
 # ---------------------------------------------------------------------------
 
 class TestCanonicalScrubIntegration:
-    """The transforms ALSO need to run before the .md is written, not
-    only inside `send_show_newsletter`. Verifies the orchestration covers
-    every leak that showed up in TST Ep458's published markdown."""
+    """The transforms run at TWO sites: canonical-write in run_show.py
+    (markdown only) and email-send in send_show_newsletter (HTML
+    upgrades on top). Verifies both stages cover every leak that
+    showed up in TST Ep458 / Ep459's published output."""
 
-    def test_full_tesla_post_scrub_is_clean(self):
-        """End-to-end: a TST-shaped digest with every known leak scrubs
-        + transforms cleanly under transform_daily_body(slug='tesla')."""
-        from engine.newsletter_sanitizer import scrub_scaffold
-
-        raw = (
+    def _raw_tst(self) -> str:
+        return (
             "# Tesla Shorts Time\n"
             "**Date:** May 02, 2026\n"
             "**REAL-TIME TSLA price:** $390.82 ▲ $9.44 (2.5%)\n"
@@ -339,43 +460,54 @@ class TestCanonicalScrubIntegration:
             + "x" * 200 + "?oc=5\n"
             "\n"
             "━━━━━━━━━━━━━━━━━━━━\n"
-            "### Tesla First Principles\n"
-            "**TOPIC SELECTION:** At what point does power matter\n"
-            "**The Surprising Truth:** EVs can be energy assets.\n"
-            "**The Fundamental Question:** When does it pay off?\n"
+            "## Short Spot\n"
+            "**Catchy Title: Brand-New Cybertruck Crashed: May 02, Yahoo**\n"
+            "Body about the crash.\n"
             "\n"
             "━━━━━━━━━━━━━━━━━━━━\n"
             "Let me know your thoughts at @teslashortstime."
         )
 
-        cleaned = scrub_scaffold(raw)
+    def test_canonical_stage_is_markdown_only(self):
+        from engine.newsletter_sanitizer import scrub_scaffold
+
+        cleaned = scrub_scaffold(self._raw_tst())
         cleaned = transform_daily_body(cleaned, slug="tesla")
 
-        # All scaffold gone:
+        # Scaffold removed.
         assert "**Date:**" not in cleaned
         assert "**HOOK:**" not in cleaned
-        assert "**TOPIC SELECTION:**" not in cleaned
-        assert "**The Surprising Truth:**" not in cleaned
-        assert "**The Fundamental Question:**" not in cleaned
+        # Catchy Title placeholder stripped, real title preserved.
+        assert "Catchy Title:" not in cleaned
+        assert "Brand-New Cybertruck Crashed" in cleaned
+        # Box rules → markdown ---, no HTML.
         assert "━━━" not in cleaned
-
-        # Box rules became <hr>:
-        assert "<hr" in cleaned
-
-        # TSLA price block rendered:
-        assert "TSLA today" in cleaned
-
-        # Long Google News URL collapsed to "Google News" label
-        # (the URL is still in the link target, but the visible text
-        # is the label and there's no longer a literal "Source: <long-url>"
-        # plaintext form):
+        assert "<hr" not in cleaned
+        assert "---" in cleaned
+        # TSLA price stays as bold-label markdown.
+        assert "**REAL-TIME TSLA price:**" in cleaned
+        assert "<table" not in cleaned
+        # Hook gets blockquote prominence.
+        assert "> **California closed a loophole" in cleaned
+        # Long Google News URL collapsed to label.
         assert "[Google News]" in cleaned
         assert "Source: https://news.google.com/rss/articles/CBMii" not in cleaned
-
-        # X handle linkified:
+        # X handle linkified.
         assert "[@teslashortstime](https://x.com/teslashortstime)" in cleaned
 
-        # Story content survives:
-        assert "California closed a loophole" in cleaned
-        assert "EVs can be energy assets" in cleaned
-        assert "Story body." in cleaned
+    def test_email_stage_layers_html_on_top(self):
+        from engine.newsletter_sanitizer import scrub_scaffold
+
+        cleaned = scrub_scaffold(self._raw_tst())
+        cleaned = transform_daily_body(cleaned, slug="tesla")
+        emailed = transform_email_body(cleaned, slug="tesla")
+
+        # Markdown --- now becomes styled HTML <hr>.
+        assert "<hr" in emailed
+        # TSLA price line becomes the styled stock-watch table.
+        assert "<table" in emailed
+        assert "TSLA today" in emailed
+        # Canonical content survives.
+        assert "California closed a loophole" in emailed
+        assert "Story body." in emailed
+        assert "Brand-New Cybertruck Crashed" in emailed

--- a/tests/test_newsletter_sanitizer.py
+++ b/tests/test_newsletter_sanitizer.py
@@ -47,8 +47,8 @@ class TestScrubScaffold:
 
     def test_does_not_strip_box_drawing_rules(self):
         """Spec v2 follow-up: the sanitizer leaves box rules alone so
-        engine.newsletter_body.replace_box_rules_with_hr can convert
-        them to ``<hr>``. Stripping here would defeat that conversion."""
+        engine.newsletter_body.replace_box_rules_with_md_hr can convert
+        them to ``---``. Stripping here would defeat that conversion."""
         text = (
             "Section A\n"
             "━━━━━━━━━━━━━━━━━━━━\n"
@@ -175,9 +175,10 @@ class TestPatternCoverage:
             "Source: General concept",
             "(full URL from pre-fetched: …)",
             # Box-drawing rules are NOT in the sanitizer anymore — they're
-            # converted to <hr> by engine.newsletter_body in the body-
-            # transform stage. The presence of `replace_box_rules_with_hr`
-            # is exercised in tests/test_newsletter_body.py.
+            # converted to markdown ``---`` by engine.newsletter_body in
+            # the canonical body-transform stage, then upgraded to styled
+            # ``<hr>`` in the email-only transform. Both are exercised
+            # in tests/test_newsletter_body.py.
             #
             # Added in the canonical-digest-scrub follow-up — Tesla
             # Ep458 .md leaked **TOPIC SELECTION:** verbatim.
@@ -185,6 +186,9 @@ class TestPatternCoverage:
             "**TOPIC FRESHNESS:** ... line",
             "**WHAT TO SKIP:** ... line",
             "**LENGTH TARGET:** ... line",
+            # Added in the description+voice polish follow-up — Tesla
+            # Ep459 leaked the literal ``Catchy Title:`` placeholder.
+            "**Catchy Title: ...**",
         ]
         for r in required:
             assert r in names, (
@@ -214,3 +218,25 @@ class TestPatternCoverage:
         out = scrub_scaffold(text)
         assert "TOPIC FRESHNESS" not in out
         assert "Next line." in out
+
+    def test_strips_catchy_title_placeholder_keeps_real_title(self):
+        """Tesla Ep459 leaked ``**Catchy Title: <real title>: <date>...**``
+        because the LLM mirrored the prompt's placeholder. The sanitizer
+        strips the ``Catchy Title:`` prefix while preserving the real
+        headline that follows."""
+        text = (
+            "## Short Spot\n"
+            "**Catchy Title: Brand-New Cybertruck Crashed: May 02, 2026, Yahoo**\n"
+            "Body about the crash."
+        )
+        out = scrub_scaffold(text)
+        assert "Catchy Title:" not in out
+        # The real headline survives, still bold.
+        assert "**Brand-New Cybertruck Crashed: May 02, 2026, Yahoo**" in out
+        assert "Body about the crash." in out
+
+    def test_catchy_title_strip_idempotent(self):
+        text = "**Catchy Title: Some Real Headline: May 02, Source**"
+        once = scrub_scaffold(text)
+        twice = scrub_scaffold(once)
+        assert once == twice


### PR DESCRIPTION
Follow-up to the Tesla Ep457 vs Ep459 review. Five description fixes plus one voice EQ tweak.

## Description fixes

**1. Two-stage transform pipeline** — `transform_daily_body` is now markdown-safe (canonical .md doesn't ship raw inline HTML). A new `transform_email_body` layers the HTML upgrades inside `send_show_newsletter`:
- TSLA stock-watch `<table>` (was bleeding 480 chars of inline HTML into the canonical .md)
- Styled `<hr>` (was the same)
- Russian vocab cards (already email-only by intent, just moved for symmetry)

The canonical pass keeps `**REAL-TIME TSLA price:**` as a bold-label markdown line and box rules as `---`. Blog, RSS show notes, and GitHub Pages summaries now read clean.

**2. Hook gets visual prominence.** After `scrub_scaffold` strips the `**HOOK:**` label, the hook becomes plain prose at the top of the body — visually identical to the rest of the digest. New `promote_hook_to_blockquote` wraps the first prose line in `> **<text>**` so it stands out across every surface.

**3. `**Catchy Title:**` placeholder scrubbed.** Ep459 shipped with `**Catchy Title: Brand-New Tesla Cybertruck Crashed...**` — the LLM mirrored the prompt's literal placeholder. Sanitizer now strips the `Catchy Title:` prefix while keeping the real headline that follows. Tesla digest prompt also clarifies the placeholder is a placeholder.

**4. First Principles → flowing essay.** The labeled-bullet format (`**The Surprising Truth:** ...` etc.) plus the sanitizer that strips those labels = choppy one-line orphans in the published .md. Tesla digest prompt now asks for a 3-paragraph editorial essay (4–6 sentences each), no labels.

**5. Defense-in-depth.** Both transform stages stay idempotent — re-running the canonical pass inside `send_show_newsletter` is a no-op when the upstream canonical-write site already ran it.

## Voice tweak

**Removed the 6.5 kHz -3 dB dip** from the voice EQ chain in `engine/audio.py`. Added in May 2026 to de-ess the original `b4cusb2omvkz` clone (it had noisy "s"/"sh"); the replacement custom voice `kdif6sqjcyiq` (recorded on a better mic) doesn't need it. A/B between Ep457 (ElevenLabs `dTrBzPvD2GpAqkk1MUzA`) and Ep459 (Grok `kdif6sqjcyiq` + 6.5 kHz dip) showed the dip making the new voice feel duller without removing audible sibilance.

5-stage chain now: highpass=80 → lowpass=15k → loudnorm=-18 → compressor 4:1 → limiter. Re-add the dip if a future clone reintroduces hiss.

## Test plan
- [x] `pytest tests/test_newsletter_body.py` — 30+ tests, including new `TestHookBlockquote`, `TestBoxRulesCanonical`/`Email`, `TestTransformEmailBody`, integration test
- [x] `pytest tests/test_newsletter_sanitizer.py` — adds `test_strips_catchy_title_placeholder_keeps_real_title` and idempotency
- [x] `pytest tests/test_audio_commands.py` — voice-norm-full reflects 5-stage chain
- [x] Full suite: 1468 passing, 2 pre-existing failures unrelated to this PR (`google.oauth2` import in test env)
- [ ] Live test on next Tesla daily: voice should sound brighter, hook should render as styled quote in email + indented in blog, no `**Catchy Title:**` leak, First Principles reads as prose

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_