### PR TITLE
Wrap Grok TTS chunks in &lt;fast&gt;&lt;build-intensity&gt; for cloned voices

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -89,6 +89,15 @@ class TTSConfig:
     use_speaker_boost: bool = True
     speed: float = 1.0  # Speech speed (0.7–1.2); Flash v2.5 supports this range
     apply_text_normalization: str = "on"  # "auto", "on", or "off"; helps with number/date pronunciation
+    # Speech-tag wrap applied to every chunk sent to Grok TTS. Grok
+    # cloned voices respond noticeably to ``<fast><build-intensity>`` —
+    # the operator A/B'd against bare text on Tesla Ep459 / Ep460 and
+    # the wrapped read had clearly more energy and dynamic range. Empty
+    # strings = no wrap (back-compat). The Grok backend strips these
+    # tags before producing audio, so they never appear as spoken
+    # words. ElevenLabs path ignores both fields.
+    speech_wrap_open: str = "<fast><build-intensity>"
+    speech_wrap_close: str = "</build-intensity></fast>"
     # Post-TTS transcription validation (opt-in)
     validate_transcription: bool = False
     whisper_model: str = "base"  # "tiny", "base", "small", "medium"

--- a/engine/tts.py
+++ b/engine/tts.py
@@ -740,6 +740,8 @@ def _speak_with_grok(
     language_code: str = "auto",
     timeout: int = GROK_TTS_TIMEOUT_SECONDS,
     append_exclamation: bool = False,
+    speech_wrap_open: str = "",
+    speech_wrap_close: str = "",
 ) -> None:
     """Grok-TTS counterpart of ``speak()``.
 
@@ -752,8 +754,16 @@ def _speak_with_grok(
     text = prepare_text_for_tts(text)
     # Cap at Grok's 15k-char request limit even when caller passes a
     # higher max_chars (e.g. shows that inherited the ElevenLabs default).
-    effective_max = min(max_chars, GROK_MAX_CHARS_PER_REQUEST)
+    # Reserve space for the speech-tag wrap so ``open + chunk + close``
+    # still fits under Grok's per-request cap.
+    wrap_overhead = len(speech_wrap_open) + len(speech_wrap_close)
+    effective_max = min(max_chars, GROK_MAX_CHARS_PER_REQUEST - wrap_overhead)
     chunks = chunk_text(text, max_chars=effective_max)
+
+    def _wrap(s: str) -> str:
+        if not (speech_wrap_open or speech_wrap_close):
+            return s
+        return f"{speech_wrap_open}{s}{speech_wrap_close}"
 
     import tempfile as _tmpmod
     tmp_dir = Path(_tmpmod.mkdtemp(prefix="tts_grok_", dir=str(Path(filename).parent)))
@@ -762,6 +772,7 @@ def _speak_with_grok(
         out_text = chunks[0]
         if append_exclamation:
             out_text = out_text + "!"
+        out_text = _wrap(out_text)
         # Single chunk: WAV from Grok → final MP3 in one encode pass.
         wav_chunk = tmp_dir / "tts_chunk.wav"
         try:
@@ -809,6 +820,7 @@ def _speak_with_grok(
                     chunk_text_str = chunk_text_str.rstrip(".!?") + "."
                 else:
                     chunk_text_str = chunk_text_str + "!"
+            chunk_text_str = _wrap(chunk_text_str)
             grok_speak_chunk(
                 chunk_text_str, voice_id, chunk_file,
                 api_key=api_key, language_code=language_code, timeout=timeout,
@@ -907,6 +919,8 @@ def synthesize(
     apply_text_normalization: str = "on",
     timeout: int = GROK_TTS_TIMEOUT_SECONDS,
     append_exclamation: bool = False,
+    speech_wrap_open: str = "",
+    speech_wrap_close: str = "",
 ) -> Path:
     """Top-level entry point: text in, audio file path out.
 
@@ -932,6 +946,8 @@ def synthesize(
             language_code=language_code or "auto",
             timeout=timeout,
             append_exclamation=append_exclamation,
+            speech_wrap_open=speech_wrap_open,
+            speech_wrap_close=speech_wrap_close,
         )
         return output_path
     # Default: ElevenLabs
@@ -971,6 +987,8 @@ def synthesize_sections(
     speed: float = 1.0,
     apply_text_normalization: str = "on",
     timeout: int = GROK_TTS_TIMEOUT_SECONDS,
+    speech_wrap_open: str = "",
+    speech_wrap_close: str = "",
 ) -> List[Path]:
     """Synthesize multiple script sections into individual audio files.
 
@@ -1016,6 +1034,8 @@ def synthesize_sections(
                 max_chars=max_chars,
                 language_code=language_code or "auto",
                 timeout=timeout,
+                speech_wrap_open=speech_wrap_open,
+                speech_wrap_close=speech_wrap_close,
             )
         else:
             speak(

--- a/run_show.py
+++ b/run_show.py
@@ -1594,6 +1594,8 @@ def run(args: argparse.Namespace) -> None:
                         language_code=config.tts.language_code,
                         speed=config.tts.speed,
                         apply_text_normalization=config.tts.apply_text_normalization,
+                        speech_wrap_open=config.tts.speech_wrap_open,
+                        speech_wrap_close=config.tts.speech_wrap_close,
                     )
 
                     generate_transition_sting(sting_path)
@@ -1622,6 +1624,8 @@ def run(args: argparse.Namespace) -> None:
                         language_code=config.tts.language_code,
                         speed=config.tts.speed,
                         apply_text_normalization=config.tts.apply_text_normalization,
+                        speech_wrap_open=config.tts.speech_wrap_open,
+                        speech_wrap_close=config.tts.speech_wrap_close,
                     )
             else:
                 synthesize(
@@ -1634,6 +1638,8 @@ def run(args: argparse.Namespace) -> None:
                     language_code=config.tts.language_code,
                     speed=config.tts.speed,
                     apply_text_normalization=config.tts.apply_text_normalization,
+                    speech_wrap_open=config.tts.speech_wrap_open,
+                    speech_wrap_close=config.tts.speech_wrap_close,
                 )
 
             _tts_duration = time.monotonic() - t0

--- a/scripts/test_speech_wrap.py
+++ b/scripts/test_speech_wrap.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Test the ``<fast><build-intensity>`` speech-tag wrap on a single
+sentence so you can compare against bare text on the same clone.
+
+Outputs two MP3s side-by-side so you can A/B them in any audio player:
+
+  /tmp/speech_wrap_test/bare.mp3       (no wrap)
+  /tmp/speech_wrap_test/wrapped.mp3    (<fast><build-intensity>...</...></...>)
+
+Usage:
+    python scripts/test_speech_wrap.py
+    python scripts/test_speech_wrap.py "your custom sentence here"
+
+Requires GROK_API_KEY (or XAI_API_KEY) in the environment / .env.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Allow importing engine/* from anywhere.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+from engine.tts import synthesize
+
+
+DEFAULT_SENTENCE = (
+    "Tesla just opened a new Supercharger corridor connecting Vancouver to "
+    "Calgary, adding twelve stations along the Trans-Canada Highway."
+)
+
+
+def main() -> int:
+    load_dotenv()
+    api_key = os.environ.get("GROK_API_KEY") or os.environ.get("XAI_API_KEY")
+    if not api_key:
+        print("ERROR: set GROK_API_KEY or XAI_API_KEY", file=sys.stderr)
+        return 1
+
+    sentence = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_SENTENCE
+    voice_id = os.environ.get("TEST_VOICE_ID", "kdif6sqjcyiq")
+
+    out_dir = Path("/tmp/speech_wrap_test")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    bare = out_dir / "bare.mp3"
+    wrapped = out_dir / "wrapped.mp3"
+
+    print(f"Voice: {voice_id}")
+    print(f"Sentence: {sentence!r}")
+    print()
+    print(f"Synthesizing bare → {bare}")
+    synthesize(
+        sentence, voice_id, bare,
+        api_key=api_key, provider="grok", language_code="en",
+    )
+    print(f"Synthesizing wrapped → {wrapped}")
+    synthesize(
+        sentence, voice_id, wrapped,
+        api_key=api_key, provider="grok", language_code="en",
+        speech_wrap_open="<fast><build-intensity>",
+        speech_wrap_close="</build-intensity></fast>",
+    )
+    print()
+    print("Done. A/B compare:")
+    print(f"  open {bare}")
+    print(f"  open {wrapped}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -50,6 +50,15 @@ tts:
   voice_id: kdif6sqjcyiq
   language_code: en
   max_chars: 10000
+  # Speech-tag wrap applied to every chunk sent to Grok TTS. The
+  # ``<fast><build-intensity>`` combo is the single biggest delivery
+  # lever on cloned voices — A/B'd on the operator's kdif6sqjcyiq
+  # voice in May 2026, the wrapped read had visibly more energy and
+  # dynamic range than bare text. Tags are consumed by the Grok
+  # backend (never appear as spoken words). To disable for a show,
+  # override both fields to empty strings in the show's tts: block.
+  speech_wrap_open: "<fast><build-intensity>"
+  speech_wrap_close: "</build-intensity></fast>"
   # ---- Legacy ElevenLabs baseline ----
   # No show currently overrides `provider: elevenlabs`. Kept here so
   # an emergency rollback (e.g. Grok TTS outage) is a one-line YAML

--- a/tests/test_tts_grok.py
+++ b/tests/test_tts_grok.py
@@ -489,3 +489,107 @@ def test_synthesize_sections_succeeds_when_all_sections_synth(tmp_path: Path, mo
     assert all(p.exists() for p in result)
     # No fallback file generated.
     assert not (out_dir / "ep002_fallback.mp3").exists()
+
+
+# ---------------------------------------------------------------------------
+# Speech-tag wrap — <fast><build-intensity>...</...></...>
+# ---------------------------------------------------------------------------
+
+def test_grok_path_wraps_text_with_speech_tags(tmp_path: Path, monkeypatch):
+    """When ``speech_wrap_open`` / ``close`` are set, every chunk sent
+    to ``grok_speak_chunk`` must arrive wrapped. The kdif6sqjcyiq clone
+    A/B'd cleaner with ``<fast><build-intensity>`` than bare text — this
+    drift guard catches any regression that drops the wrap."""
+    captured_texts: list = []
+
+    def fake_chunk(text, *args, **kwargs):
+        captured_texts.append(text)
+        # Touch the output path so the surrounding pipeline doesn't
+        # bail looking for a non-existent file.
+        out = args[1] if len(args) > 1 else kwargs.get("out_path")
+        if out:
+            Path(out).write_bytes(b"\xff\xfb\x90")
+
+    monkeypatch.setattr(tts, "grok_speak_chunk", fake_chunk)
+    # Stub ffmpeg so the encode steps don't actually run.
+    monkeypatch.setattr(tts.subprocess, "run", MagicMock())
+
+    tts.synthesize(
+        "Tesla just opened a new Supercharger corridor.",
+        voice_id="kdif6sqjcyiq",
+        output_path=tmp_path / "o.mp3",
+        api_key="k",
+        provider="grok",
+        language_code="en",
+        speech_wrap_open="<fast><build-intensity>",
+        speech_wrap_close="</build-intensity></fast>",
+    )
+
+    assert captured_texts, "grok_speak_chunk was never called"
+    sent = captured_texts[0]
+    assert sent.startswith("<fast><build-intensity>"), sent
+    assert sent.endswith("</build-intensity></fast>"), sent
+    assert "Tesla just opened a new Supercharger corridor." in sent
+
+
+def test_grok_path_wrap_is_empty_string_safe(tmp_path: Path, monkeypatch):
+    """No wrap configured = bare text, byte-identical to pre-wrap behavior."""
+    captured_texts: list = []
+
+    def fake_chunk(text, *args, **kwargs):
+        captured_texts.append(text)
+        out = args[1] if len(args) > 1 else kwargs.get("out_path")
+        if out:
+            Path(out).write_bytes(b"\xff\xfb\x90")
+
+    monkeypatch.setattr(tts, "grok_speak_chunk", fake_chunk)
+    monkeypatch.setattr(tts.subprocess, "run", MagicMock())
+
+    tts.synthesize(
+        "Bare sentence.",
+        voice_id="kdif6sqjcyiq",
+        output_path=tmp_path / "o.mp3",
+        api_key="k",
+        provider="grok",
+        # No speech_wrap_* args at all (defaults to "").
+    )
+
+    sent = captured_texts[0]
+    assert "<fast>" not in sent
+    assert "<build-intensity>" not in sent
+    assert sent == "Bare sentence."
+
+
+def test_default_tts_config_has_fast_build_intensity_wrap():
+    """The network default is ``<fast><build-intensity>...</...></...>`` — the
+    operator's A/B verdict on cloned voices. Drift guard so a quiet
+    config change doesn't silently revert this for every show."""
+    from engine.config import TTSConfig
+    cfg = TTSConfig()
+    assert cfg.speech_wrap_open == "<fast><build-intensity>"
+    assert cfg.speech_wrap_close == "</build-intensity></fast>"
+
+
+def test_synthesize_sections_passes_wrap_through(tmp_path: Path, monkeypatch):
+    """``synthesize_sections`` is the multi-section entry point used by
+    shows that emit transition stings between sections. The wrap kwargs
+    must reach ``_speak_with_grok`` for each section."""
+    grok_called = MagicMock()
+    monkeypatch.setattr(tts, "_speak_with_grok", grok_called)
+
+    tts.synthesize_sections(
+        ["First section.", "Second section."],
+        voice_id="kdif6sqjcyiq",
+        output_dir=tmp_path,
+        api_key="k",
+        provider="grok",
+        language_code="en",
+        speech_wrap_open="<fast><build-intensity>",
+        speech_wrap_close="</build-intensity></fast>",
+    )
+
+    assert grok_called.call_count == 2
+    for call in grok_called.call_args_list:
+        _, kwargs = call
+        assert kwargs["speech_wrap_open"] == "<fast><build-intensity>"
+        assert kwargs["speech_wrap_close"] == "</build-intensity></fast>"


### PR DESCRIPTION
Follow-up to PR #292: removing the 6.5 kHz EQ dip didn't move the cloned-voice quality enough. Operator's verdict: speech-tag wrap is the bigger lever on cloned voices, specifically `<fast><build-intensity>...</build-intensity></fast>`.

## What this does

Adds two new `TTSConfig` fields — `speech_wrap_open` and `speech_wrap_close` — plumbed through `synthesize()` and `synthesize_sections()` into the per-chunk `grok_speak_chunk` send. Network default in `shows/_defaults.yaml`:

```yaml
speech_wrap_open: "<fast><build-intensity>"
speech_wrap_close: "</build-intensity></fast>"
```

Every chunk sent to Grok TTS now arrives wrapped. The Grok backend consumes the tags before producing audio — they never appear as spoken words. Voice-only concern; doesn't touch any non-TTS surface (blog markdown, RSS show notes, X teaser, YouTube descriptions all see the original text).

Chunking accounts for the wrap overhead: `effective_max = 15000 - len(open) - len(close)` so the wrapped chunk still fits under Grok's per-request cap.

## Per-show override

Drop both into a show's `tts:` block to disable:

```yaml
tts:
  speech_wrap_open: ""
  speech_wrap_close: ""
```

Empty strings = byte-identical to pre-wrap behavior, gated by `test_grok_path_wrap_is_empty_string_safe`.

## Test sentence helper

`scripts/test_speech_wrap.py` synthesizes one sentence twice (bare + wrapped) so any future voice clone can be A/B'd in 30 seconds:

```bash
python scripts/test_speech_wrap.py
# or with custom text:
python scripts/test_speech_wrap.py "Tesla just opened a new corridor."
# Outputs to /tmp/speech_wrap_test/{bare,wrapped}.mp3
```

## Test plan
- [x] `pytest tests/test_tts_grok.py` — 25 tests including 4 new:
  - `test_grok_path_wraps_text_with_speech_tags` — wrap reaches the chunk
  - `test_grok_path_wrap_is_empty_string_safe` — back-compat
  - `test_default_tts_config_has_fast_build_intensity_wrap` — drift guard for the network default
  - `test_synthesize_sections_passes_wrap_through` — multi-section path also wraps
- [x] Full suite: 1472 passing, 2 pre-existing `google.oauth2` failures unrelated to this PR
- [ ] **Live test before merge**: run `python scripts/test_speech_wrap.py` and A/B compare. If the wrapped read sounds wrong, hold and we tune the wrap content. Once it sounds right, merge → next Tesla daily uses it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_