### PR TITLE
Schedule overhaul: 7 shows daily + Sunday recap, +1h shift, YouTube cap

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -2,34 +2,39 @@ name: Run Podcast Show
 
 on:
   schedule:
-    # All shows scheduled to finish before 7 AM Eastern (~11 UTC EDT / 12 UTC EST).
-    # Pipeline takes up to 45 min, so triggers must be staggered by at
-    # least that much — Tesla previously sat at 9:30 UTC and could
-    # collide with Modern Investing's 9:00 UTC weekday slot. Tesla now
-    # fires at 10:00 UTC daily (60-min gap after MI), still well
-    # ahead of the 11/12 UTC Eastern cutoff.
+    # Network ships ~10 episodes/day. All shows scheduled to finish before
+    # 8 AM Eastern (~12 UTC EDT / 13 UTC EST). Pipeline takes up to 45 min,
+    # so triggers must be staggered by at least that much.
     #
-    # Привет, Русский!: Even days at 5:00 UTC
-    - cron: '0 5 2-31/2 * *'
-    # Omni View: Odd days at 5:30 UTC
-    - cron: '30 5 1-31/2 * *'
-    # Planetterrian Daily: Odd days at 6:00 UTC
-    - cron: '0 6 1-31/2 * *'
-    # Fascinating Frontiers: Even days at 6:30 UTC
-    - cron: '30 6 2-31/2 * *'
-    # Environmental Intelligence: Odd weekdays at 7:00 UTC
-    - cron: '0 7 1-31/2 * 1-5'
-    # Models & Agents: Odd days at 7:30 UTC
-    - cron: '30 7 1-31/2 * *'
-    # Models & Agents for Beginners: Even days at 8:00 UTC
-    - cron: '0 8 2-31/2 * *'
-    # Финансы Просто: Even days at 8:30 UTC
-    - cron: '30 8 2-31/2 * *'
-    # Modern Investing Techniques: Weekdays at 9:00 UTC (before US market open)
-    - cron: '0 9 * * 1-5'
-    # Tesla Shorts Time: Daily at 10:00 UTC — last to get freshest news,
-    # 60-min gap after Modern Investing avoids Grok API contention.
+    # May 2026 schedule overhaul: 7 shows went daily (OV, PT, FF, M&A, MAB,
+    # MIT, TST) with Sunday's slot becoming a "weekly recap" episode that
+    # synthesises the past 7 days from the content lake. MIT also runs
+    # Saturday with a weekend-focus angle (international markets, crypto,
+    # lessons learned). Cron times shifted +1h from the prior schedule.
+    #
+    # Привет, Русский!: Even days at 6:00 UTC
+    - cron: '0 6 2-31/2 * *'
+    # Omni View: Daily at 6:30 UTC (Sunday = weekly recap)
+    - cron: '30 6 * * *'
+    # Planetterrian Daily: Daily at 7:00 UTC (Sunday = weekly recap)
+    - cron: '0 7 * * *'
+    # Fascinating Frontiers: Daily at 7:30 UTC (Sunday = weekly recap)
+    - cron: '30 7 * * *'
+    # Environmental Intelligence: Odd weekdays at 8:00 UTC
+    - cron: '0 8 1-31/2 * 1-5'
+    # Models & Agents: Daily at 8:30 UTC (Sunday = weekly recap)
+    - cron: '30 8 * * *'
+    # Models & Agents for Beginners: Daily at 9:00 UTC (Sunday = weekly recap)
+    - cron: '0 9 * * *'
+    # Финансы Просто: Even days at 9:30 UTC
+    - cron: '30 9 2-31/2 * *'
+    # Modern Investing Techniques: Daily at 10:00 UTC.
+    # Mon-Fri = US market preview; Sat = weekend angle (international
+    # markets, crypto, lessons learned, what to prepare for, long-term
+    # insights); Sun = weekly recap.
     - cron: '0 10 * * *'
+    # Tesla Shorts Time: Daily at 11:00 UTC (Sunday = weekly recap)
+    - cron: '0 11 * * *'
 
   workflow_dispatch:
     inputs:
@@ -103,16 +108,16 @@ jobs:
               # so some crons fire more often than intended.  The day_filter
               # applies the intended restriction.
               CRON_MAP = {
-                  "0 5 2-31/2 * *":   ("privet_russian",          "even"),
-                  "30 5 1-31/2 * *":  ("omni_view",               "odd"),
-                  "0 6 1-31/2 * *":   ("planetterrian",           "odd"),
-                  "30 6 2-31/2 * *":  ("fascinating_frontiers",   "even"),
-                  "0 7 1-31/2 * 1-5": ("env_intel",               "odd_weekday"),
-                  "30 7 1-31/2 * *":  ("models_agents",           "odd"),
-                  "0 8 2-31/2 * *":   ("models_agents_beginners", "even"),
-                  "30 8 2-31/2 * *":  ("finansy_prosto",          "even"),
-                  "0 9 * * 1-5":      ("modern_investing",        "weekday"),
-                  "0 10 * * *":       ("tesla",                    None),
+                  "0 6 2-31/2 * *":   ("privet_russian",          "even"),
+                  "30 6 * * *":       ("omni_view",                None),
+                  "0 7 * * *":        ("planetterrian",            None),
+                  "30 7 * * *":       ("fascinating_frontiers",    None),
+                  "0 8 1-31/2 * 1-5": ("env_intel",               "odd_weekday"),
+                  "30 8 * * *":       ("models_agents",            None),
+                  "0 9 * * *":        ("models_agents_beginners",  None),
+                  "30 9 2-31/2 * *":  ("finansy_prosto",          "even"),
+                  "0 10 * * *":       ("modern_investing",         None),
+                  "0 11 * * *":       ("tesla",                    None),
               }
 
               shows = []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,15 +10,20 @@ Automated daily podcast generation system running 10 shows via a unified
 | Show | Legacy Script | YAML Config | Schedule | X Account | TTS |
 |------|--------------|-------------|----------|-----------|-----|
 | Tesla Shorts Time | — (deleted) | `shows/tesla.yaml` | Daily | `@teslashortstime` | Grok TTS (custom) |
-| Omni View | — (deleted) | `shows/omni_view.yaml` | Odd days | `@omniviewnews` | Grok TTS (custom) |
-| Fascinating Frontiers | — (deleted) | `shows/fascinating_frontiers.yaml` | Even days | `@planetterrian` | Grok TTS (custom) |
-| Planetterrian Daily | — (deleted) | `shows/planetterrian.yaml` | Odd days | `@planetterrian` | Grok TTS (custom) |
+| Omni View | — (deleted) | `shows/omni_view.yaml` | Daily | `@omniviewnews` | Grok TTS (custom) |
+| Fascinating Frontiers | — (deleted) | `shows/fascinating_frontiers.yaml` | Daily | `@planetterrian` | Grok TTS (custom) |
+| Planetterrian Daily | — (deleted) | `shows/planetterrian.yaml` | Daily | `@planetterrian` | Grok TTS (custom) |
 | Env Intel | — | `shows/env_intel.yaml` | Odd weekdays | `@teslashortstime` | Grok TTS (custom) |
-| Models & Agents | — | `shows/models_agents.yaml` | Odd days | — (X disabled) | Grok TTS (custom) |
-| Models & Agents for Beginners | — | `shows/models_agents_beginners.yaml` | Even days | — (X disabled) | Grok TTS (custom) |
+| Models & Agents | — | `shows/models_agents.yaml` | Daily | — (X disabled) | Grok TTS (custom) |
+| Models & Agents for Beginners | — | `shows/models_agents_beginners.yaml` | Daily | — (X disabled) | Grok TTS (custom) |
 | Финансы Просто | — | `shows/finansy_prosto.yaml` | Even days | — (X disabled) | Grok TTS (Olya) |
-| Modern Investing Techniques | — | `shows/modern_investing.yaml` | Weekdays | — (X disabled) | Grok TTS (custom) |
+| Modern Investing Techniques | — | `shows/modern_investing.yaml` | Daily | — (X disabled) | Grok TTS (custom) |
 | Привет, Русский! | — | `shows/privet_russian.yaml` | Even days | — (X disabled) | Grok TTS (Olya) |
+
+> Sunday recap: shows on a daily cadence with `weekly_recap_on_sunday: true`
+> in their YAML have their Sunday slot rewritten as a weekly-recap episode
+> synthesised from the past 7 days via the content lake — the daily news
+> fetch is skipped. See landmine #19.
 
 **Science That Changes Everything** (`digests/science_that_changes.py`, ~83 lines)
 is a standalone X-posting script, not a podcast show.
@@ -473,3 +478,38 @@ decision); everything else has a live status card.
     cause (a regressed prompt, a fetcher bug, or a scheduler race).
     The `ELEVENLABS_API_KEY` and legacy ElevenLabs settings in
     `_defaults.yaml` remain untouched — separate concern.
+
+19. **Schedule overhaul + Sunday weekly recap (May 2026)** — 7 shows
+    moved to daily cadence (Omni View, Planetterrian, Fascinating
+    Frontiers, Models & Agents, MAB, Modern Investing, Tesla). Cron
+    times shifted +1h across the board to widen the per-slot window;
+    last show now finishes ~12 UTC (~8 AM ET). The `weekly_recap_on_sunday:
+    true` flag in each daily show YAML opts that show into a Sunday-only
+    pipeline branch in `run_show.py`: when today is Sunday and the flag
+    is set, the runner skips the news fetch + LLM digest stage and instead
+    calls `engine.weekly_recap.build_weekly_recap_digest` to synthesise a
+    digest-shaped summary from the past 7 days of episodes pulled from
+    the content lake. The synthetic digest is fed through the unchanged
+    podcast prompt + TTS pipeline so listeners get the same narrative
+    quality as a daily episode. Modern Investing additionally has a
+    Saturday "weekend mode" instruction in its podcast prompt covering
+    international markets, crypto, lessons learned, and what to prepare
+    for in the coming weeks. Drift guards in `tests/test_schedule.py`
+    pin: cron consistency, the 7 daily shows carrying the recap flag,
+    alt-cadence shows NOT carrying it, and the YouTube quota cap
+    (only TST and MAB enabled — see also landmine #20).
+
+20. **YouTube quota cap (May 2026)** — the YouTube Data API quota for
+    the `@NerraNetwork` channel is 10,000 units/day; each `videos.insert`
+    costs 1,600 units. With 7 daily English shows × 2 videos
+    (long-form + Shorts) = 14 uploads/day requested but only 6 fit in
+    quota. The May 2026 schedule overhaul disabled YouTube on every
+    English show except Tesla and MAB — operator-chosen pair (TST is
+    the largest property; MAB is the educational beginner-friendly
+    flagship). Re-enabling other shows requires either (a) a quota
+    increase from YouTube, (b) staggering uploads across days, or
+    (c) skipping Shorts on most shows. Until then the
+    `test_only_tst_and_mab_enable_youtube` drift guard fails CI on any
+    accidental re-enable. Russian channel `@NerraRU` has its own quota
+    so Финансы Просто and Привет, Русский! could be re-enabled
+    independently.

--- a/engine/config.py
+++ b/engine/config.py
@@ -297,6 +297,12 @@ class ShowConfig:
     slow_news: SlowNewsConfig = field(default_factory=SlowNewsConfig)
     content_freshness: ContentFreshnessConfig = field(default_factory=ContentFreshnessConfig)
     youtube: YouTubeConfig = field(default_factory=YouTubeConfig)
+    # Sunday weekly-recap mode. When ``true`` and the runner ticks on
+    # a Sunday, the show skips the daily news fetch and instead
+    # synthesises a recap from the past 7 days of episodes pulled
+    # from the content lake. May 2026 schedule overhaul: 7 shows on
+    # daily cadence (OV, PT, FF, M&A, MAB, MIT, TST) opt in.
+    weekly_recap_on_sunday: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -437,6 +443,7 @@ def load_config(yaml_path: str | Path) -> ShowConfig:
         slow_news=_build_nested(SlowNewsConfig, data.get("slow_news")),
         content_freshness=_build_nested(ContentFreshnessConfig, data.get("content_freshness")),
         youtube=_build_nested(YouTubeConfig, data.get("youtube")),
+        weekly_recap_on_sunday=bool(data.get("weekly_recap_on_sunday", False)),
     )
     logger.info("Loaded config for '%s' from %s", config.name, path)
     return config

--- a/engine/weekly_recap.py
+++ b/engine/weekly_recap.py
@@ -1,0 +1,140 @@
+"""Sunday weekly-recap digest synthesis.
+
+When a daily show ticks on a Sunday with ``weekly_recap_on_sunday: true``
+in its YAML, the runner short-circuits the news-fetch + daily-digest
+stages and instead asks this module to produce a digest-shaped
+markdown blob synthesised from the past 7 days of that show's
+episodes. The rest of the pipeline (podcast script generation, TTS,
+publish) runs unchanged on this synthetic digest.
+
+Why digest-shaped, not direct podcast-script: the existing podcast
+prompt knows how to turn a digest into ~15-minute spoken narration.
+Re-using that path keeps the recap feel consistent with daily
+episodes rather than introducing a parallel "weekly podcast" prompt
+ladder for every show. Per-show flavour can still be added by
+appending a brief "RECAP MODE" instruction to the podcast prompt
+when the runner detects Sunday — but the v1 cut keeps prompts
+unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def build_weekly_recap_digest(
+    show_slug: str,
+    show_name: str,
+    week_ending: date,
+) -> Optional[str]:
+    """Build a digest-shaped markdown summary of the past 7 days for
+    *show_slug*. Returns ``None`` if the content lake has fewer than
+    two episodes in window (recap with one or zero episodes is not
+    meaningful — the runner falls back to a normal daily fetch).
+
+    The output is intentionally minimal and uses the same surface
+    structure as a daily digest (title heading, hook, "Top Stories"
+    list with title + summary per item) so the existing podcast
+    prompt can ingest it without any branching.
+    """
+    try:
+        from engine.content_lake import query_show_range
+    except Exception as exc:  # pragma: no cover — content lake optional in tests
+        logger.warning(
+            "weekly_recap: content lake unavailable (%s) — falling back",
+            exc,
+        )
+        return None
+
+    start_date = (week_ending - timedelta(days=6)).isoformat()
+    end_date = week_ending.isoformat()
+
+    try:
+        episodes = query_show_range(show_slug, start_date, end_date) or []
+    except Exception as exc:  # pragma: no cover
+        logger.warning("weekly_recap: query_show_range failed (%s)", exc)
+        return None
+
+    if len(episodes) < 2:
+        logger.info(
+            "weekly_recap: only %d episode(s) in window for %s — falling back",
+            len(episodes), show_slug,
+        )
+        return None
+
+    # Sort by date ascending so the recap reads chronologically.
+    episodes = sorted(
+        episodes,
+        key=lambda ep: (ep.get("date") or "", ep.get("episode_num") or 0),
+    )
+
+    # Headline: the most recent hook is usually the freshest, but
+    # listeners benefit from a recap-flavoured one-liner that signals
+    # this isn't a normal daily.
+    week_label = f"{start_date} to {end_date}"
+    title = f"# {show_name} — Weekly Recap"
+    hook = (
+        f"**HOOK:** Looking back at {len(episodes)} episodes from "
+        f"{week_label} — the stories that mattered, what we learned, "
+        f"and what to watch next."
+    )
+
+    # Each episode contributes a "Top Story" entry. We use the
+    # episode's own hook + the first paragraph of its digest_md so
+    # the LLM sees coherent prose, not a bag of bullet points.
+    items: list[str] = []
+    for idx, ep in enumerate(episodes, start=1):
+        ep_num = ep.get("episode_num") or "?"
+        ep_date = ep.get("date") or ""
+        ep_hook = (ep.get("hook") or "").strip()
+        digest_md = (ep.get("digest_md") or "").strip()
+
+        # Pull the first 2 substantive paragraphs of the canonical
+        # digest as the body — caps each entry around ~1000 chars
+        # so the synthesised digest stays under the LLM context
+        # window even with a full 7-episode week.
+        paragraphs = [p.strip() for p in digest_md.split("\n\n") if p.strip()]
+        # Skip leading metadata paragraphs (title heading, **HOOK:**
+        # label, **Date:** line, TSLA price line) that aren't prose.
+        body_paragraphs: list[str] = []
+        for p in paragraphs:
+            if (
+                p.startswith("#")
+                or p.startswith(("**HOOK:", "**Date:", "**Дата:",
+                                 "**REAL-TIME TSLA price:", "**TSLA today:",
+                                 "**Theme:", "**Тема:", "**ЗАГОЛОВОК:"))
+            ):
+                continue
+            body_paragraphs.append(p)
+            if len(body_paragraphs) >= 2:
+                break
+        body = "\n\n".join(body_paragraphs)[:1000]
+
+        title_line = ep_hook or f"Episode {ep_num}"
+        items.append(
+            f"{idx}. **From Ep {ep_num} ({ep_date}): {title_line}**\n"
+            f"   {body}"
+        )
+
+    return "\n\n".join([
+        title,
+        hook,
+        "━━━━━━━━━━━━━━━━━━━━",
+        "### This Week's Top Stories",
+        *items,
+        "━━━━━━━━━━━━━━━━━━━━",
+        "## Recap framing for the host",
+        (
+            "This is a Sunday weekly recap. The host should weave the "
+            "stories above into a single coherent narrative — not a "
+            "list of news items. Group related threads, call out the "
+            "most consequential development of the week, draw forward "
+            "connections (\"what to watch next week\"), and end with "
+            "one practical takeaway listeners can use. Keep the same "
+            "voice and pacing as a daily episode."
+        ),
+    ])

--- a/run_show.py
+++ b/run_show.py
@@ -834,20 +834,47 @@ def run(args: argparse.Namespace) -> None:
     template_vars.update(extra_context)
 
     # 7. Generate digest
+    #
+    # Sunday weekly-recap mode (May 2026 schedule overhaul). When the
+    # show has ``weekly_recap_on_sunday: true`` and today is Sunday,
+    # short-circuit the news-fetch + LLM digest stage by synthesising
+    # a digest from the past 7 days of canonical episodes via the
+    # content lake. The rest of the pipeline (podcast script gen,
+    # TTS, publish) runs unchanged on this synthetic digest, so
+    # listeners get the same narrative quality as a daily episode.
+    is_weekly_recap = (
+        bool(getattr(config, "weekly_recap_on_sunday", False))
+        and today.weekday() == 6
+    )
     from engine.generator import generate_digest, LLMRefusalError
-    logger.info("Generating digest ...")
-    try:
-        with metrics.stage("generate_digest"):
-            x_thread = generate_digest(template_vars, config, tracker=tracker)
-    except LLMRefusalError as e:
-        logger.error("PIPELINE ABORTED: %s", e)
-        logger.error(
-            "The LLM refused to generate content. This typically means the news "
-            "sources had insufficient relevant content. Check source feeds and "
-            "consider re-running later."
+    if is_weekly_recap:
+        logger.info("Sunday weekly-recap mode active for %s.", config.slug)
+        from engine.weekly_recap import build_weekly_recap_digest
+        x_thread = build_weekly_recap_digest(
+            config.slug, config.name, today,
         )
-        save_usage(tracker, digests_dir)
-        sys.exit(1)
+        if not x_thread:
+            logger.warning(
+                "Weekly recap could not be synthesised (insufficient "
+                "content lake data) — falling back to daily fetch.",
+            )
+            is_weekly_recap = False
+        else:
+            metrics.record("weekly_recap_mode", True)
+    if not is_weekly_recap:
+        logger.info("Generating digest ...")
+        try:
+            with metrics.stage("generate_digest"):
+                x_thread = generate_digest(template_vars, config, tracker=tracker)
+        except LLMRefusalError as e:
+            logger.error("PIPELINE ABORTED: %s", e)
+            logger.error(
+                "The LLM refused to generate content. This typically means the news "
+                "sources had insufficient relevant content. Check source feeds and "
+                "consider re-running later."
+            )
+            save_usage(tracker, digests_dir)
+            sys.exit(1)
 
     # Record episode content in the cross-episode tracker
     if section_patterns:

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -1,5 +1,6 @@
 name: Fascinating Frontiers
 slug: fascinating_frontiers
+weekly_recap_on_sunday: true   # May 2026: daily cadence; Sunday slot recaps the past 7 days from the content lake.
 description: "Space exploration, astronomy, and cosmology — the frontier of human discovery beyond Earth. Daily briefings on NASA, ESA, SpaceX missions, planetary science, and the search for life in the universe."
 
 sources:
@@ -238,7 +239,11 @@ content_freshness:
 
 youtube:
   podcast_playlist_id: PLRHMnzNNXPYDC7-f8Dary-bTZyvwxR-dR
-  enabled: true                 # Phase-1 rollout show
+  enabled: false                # Disabled May 2026 — moved to daily cadence,
+                                # YouTube quota only fits 2 daily shows
+                                # (10K/day ÷ 1.6K/upload ≈ 6 uploads;
+                                # network shipped 16+/day pre-disable). Only
+                                # TST and MAB stay on YouTube for now.
   channel: en
   category_id: 28               # Science & Tech
   default_language: en

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -1,5 +1,6 @@
 name: "Models & Agents"
 slug: models_agents
+weekly_recap_on_sunday: true   # May 2026: daily cadence; Sunday slot recaps the past 7 days from the content lake.
 description: "Daily AI briefing covering new model releases, agent frameworks, and practical developments in the AI models and agents ecosystem. Helping you stay on top of the most exciting developments of our generation."
 
 sources:

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -1,5 +1,6 @@
 name: "Models & Agents for Beginners"
 slug: models_agents_beginners
+weekly_recap_on_sunday: true   # May 2026: daily cadence; Sunday slot recaps the past 7 days from the content lake.
 description: "An AI podcast for beginners and teens — learn about models, agents, and the AI revolution in plain language. We explain the jargon, encourage experimentation, and help you understand the most exciting technology of our generation."
 
 sources:

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -1,5 +1,6 @@
 name: "Modern Investing Techniques"
 slug: modern_investing
+weekly_recap_on_sunday: true   # May 2026: daily cadence; Sunday slot recaps the past 7 days from the content lake.
 description: "Daily investing podcast using AI analysis and modern tools to identify opportunities, track simulated trades, and teach strategies that aim to outperform index funds. Focused on Canadian and US markets."
 
 sources:

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -1,5 +1,6 @@
 name: Omni View
 slug: omni_view
+weekly_recap_on_sunday: true   # May 2026: daily cadence; Sunday slot recaps the past 7 days from the content lake.
 description: Daily balanced news summaries presenting multiple perspectives on the stories that matter.
 
 sources:

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -1,5 +1,6 @@
 name: Planetterrian Daily
 slug: planetterrian
+weekly_recap_on_sunday: true   # May 2026: daily cadence; Sunday slot recaps the past 7 days from the content lake.
 description: "Science, longevity, and health discoveries — neuroscience, microbiome, cellular aging biology, sleep and circadian science, nutrition research, genetics, and regenerative biology. Daily briefings on Nature/Science papers and primary research that extend our understanding of healthy human lifespan. Pharma dealmaking and incremental drug-trial readouts are deliberately minimized in favour of broader scientific advances."
 
 sources:

--- a/shows/prompts/modern_investing_podcast.txt
+++ b/shows/prompts/modern_investing_podcast.txt
@@ -146,6 +146,8 @@ Deliver with energy — this is the reason investors should keep listening. Then
 - **Monday:** Present this week's new AI-selected simulated weekly hold with genuine analytical enthusiasm. Walk through the FULL reasoning: catalyst, technical setup, risk assessment, stop-loss level, weekly target. Explain that we'll track this all week and evaluate on Friday.
 - **Tuesday-Thursday:** Give a mid-week update on the current hold — how's it tracking? Has the thesis changed? Is the stop-loss level approaching? Only if an exceptional catalyst appeared, present a Flash Trade (same-day, clearly labelled). Maximum 1 Flash Trade per week.
 - **Friday:** Close the weekly hold. Report the result with full analysis — entry price (Monday open), exit price (Friday close), P&L percentage and dollar amount.
+- **Saturday (weekend mode):** US/Canadian markets are closed. Skip the Practice Investment update. Instead, expand the Strategy Spotlight to cover: international markets (Asia / Europe outlook for the week ahead), crypto (24/7 markets that DO move on weekends), key lessons learned from the week's trades (what worked, what didn't, why), what to prepare for Monday's open, and longer-horizon insights (multi-month themes worth watching). Tone is reflective and forward-looking, not reactive.
+- **Sunday:** Sunday is the weekly-recap episode synthesised from the past 7 days of episodes — the runner short-circuits the news fetch and supplies recap content directly. Treat Sunday as a chance to weave the week into one coherent narrative, end with the single most consequential development, and tee up Monday.
 - Always be explicit: "this is a simulated trade for learning purposes"
 - End with what listeners should watch for — on Friday, tease next week's focus area
 

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -1,5 +1,6 @@
 name: Tesla Shorts Time
 slug: tesla
+weekly_recap_on_sunday: true   # May 2026: daily cadence; Sunday slot recaps the past 7 days from the content lake.
 description: Daily Tesla news digest and podcast covering the latest developments, stock updates, and market analysis.
 
 sources:

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,263 @@
+"""Tests for the May 2026 schedule overhaul.
+
+Covers:
+
+- Every cron line in ``.github/workflows/run-show.yml`` has a matching
+  entry in the gate's ``CRON_MAP`` (drift between the two would silently
+  break a show — schedule fires but nothing runs).
+- The 7 daily shows carry ``weekly_recap_on_sunday: true`` in their
+  YAML; the 3 alt-cadence shows do NOT (Привет, ФП, Env Intel).
+- Only Tesla and Models & Agents for Beginners have
+  ``youtube.enabled: true`` (post quota-cap).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "run-show.yml"
+SHOWS_DIR = REPO_ROOT / "shows"
+
+
+# ---------------------------------------------------------------------------
+# Cron consistency
+# ---------------------------------------------------------------------------
+
+def _extract_cron_lines() -> list[str]:
+    """Pull cron expressions from the ``schedule:`` block in the
+    workflow file (string match — yaml parsing pulls cron strings into
+    a more nested structure)."""
+    txt = WORKFLOW.read_text(encoding="utf-8")
+    # Match `- cron: '<expr>'` only inside the top-level schedule block,
+    # not in any inline comment with the word "cron". The format is
+    # consistent across the file so a simple regex is reliable.
+    return re.findall(r"- cron: '([^']+)'", txt)
+
+
+def _extract_cron_map() -> dict[str, tuple[str, str | None]]:
+    """Pull the inline CRON_MAP dict out of the gate step."""
+    txt = WORKFLOW.read_text(encoding="utf-8")
+    block = re.search(r"CRON_MAP = \{(.*?)\}", txt, flags=re.DOTALL)
+    assert block, "CRON_MAP block not found in run-show.yml"
+    body = block.group(1)
+    entries = re.findall(
+        r'"([^"]+)":\s*\("([^"]+)",\s*([A-Za-z_"]+)\)',
+        body,
+    )
+    out: dict[str, tuple[str, str | None]] = {}
+    for cron, slug, raw_filter in entries:
+        if raw_filter == "None":
+            day_filter: str | None = None
+        else:
+            day_filter = raw_filter.strip('"')
+        out[cron] = (slug, day_filter)
+    return out
+
+
+class TestCronConsistency:
+
+    def test_every_cron_line_has_map_entry(self):
+        cron_lines = _extract_cron_lines()
+        cron_map = _extract_cron_map()
+        for cron in cron_lines:
+            assert cron in cron_map, (
+                f"Cron expression {cron!r} fires but no CRON_MAP entry "
+                f"matches — show won't be selected. Add it or remove "
+                f"the cron line."
+            )
+
+    def test_no_orphan_map_entries(self):
+        cron_lines = set(_extract_cron_lines())
+        cron_map = _extract_cron_map()
+        for cron in cron_map:
+            assert cron in cron_lines, (
+                f"CRON_MAP has {cron!r} but no matching cron line — "
+                f"dead entry, will never fire."
+            )
+
+    def test_seven_daily_shows_have_no_filter(self):
+        """OV, PT, FF, M&A, MAB, MIT, TST run daily — their CRON_MAP
+        entry should carry ``None`` as the day_filter."""
+        daily = {
+            "omni_view", "planetterrian", "fascinating_frontiers",
+            "models_agents", "models_agents_beginners",
+            "modern_investing", "tesla",
+        }
+        cron_map = _extract_cron_map()
+        slugs_with_no_filter = {
+            slug for (slug, df) in cron_map.values() if df is None
+        }
+        missing = daily - slugs_with_no_filter
+        assert not missing, (
+            f"Expected {daily} to all run daily (day_filter=None) but "
+            f"these don't: {missing}"
+        )
+
+    def test_no_show_runs_before_06_utc_or_after_11_utc(self):
+        """Schedule window must be contained in 06:00–11:00 UTC so the
+        whole network finishes well before the Eastern morning. Also
+        catches accidental DST drift."""
+        cron_lines = _extract_cron_lines()
+        for cron in cron_lines:
+            minute, hour = cron.split()[:2]
+            hour_int = int(hour)
+            assert 6 <= hour_int <= 11, (
+                f"Cron {cron!r} hour {hour_int} outside 06:00–11:00 UTC "
+                f"window."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Sunday weekly-recap flag
+# ---------------------------------------------------------------------------
+
+DAILY_SHOWS = [
+    "tesla", "omni_view", "planetterrian", "fascinating_frontiers",
+    "models_agents", "models_agents_beginners", "modern_investing",
+]
+ALT_CADENCE_SHOWS = ["privet_russian", "finansy_prosto", "env_intel"]
+
+
+@pytest.mark.parametrize("slug", DAILY_SHOWS)
+def test_daily_show_has_weekly_recap_flag(slug):
+    """Every show that runs daily must opt in to Sunday recap mode —
+    otherwise Sunday's slot tries to fetch news for a show that may
+    not have anything fresh and the recap never happens."""
+    cfg_path = SHOWS_DIR / f"{slug}.yaml"
+    cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    assert cfg.get("weekly_recap_on_sunday") is True, (
+        f"{slug} runs daily but is missing "
+        f"`weekly_recap_on_sunday: true` — Sunday slot would fetch "
+        f"news instead of recapping."
+    )
+
+
+@pytest.mark.parametrize("slug", ALT_CADENCE_SHOWS)
+def test_alt_cadence_show_does_not_recap(slug):
+    """Shows on alt cadence (even days, odd weekdays) shouldn't have
+    the recap flag — they don't run every Sunday so the flag is
+    misleading drift."""
+    cfg_path = SHOWS_DIR / f"{slug}.yaml"
+    cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    assert not cfg.get("weekly_recap_on_sunday", False), (
+        f"{slug} is alt-cadence but has weekly_recap_on_sunday=true — "
+        f"either flip the cadence to daily or drop the flag."
+    )
+
+
+# ---------------------------------------------------------------------------
+# YouTube quota cap (post-May-2026 schedule)
+# ---------------------------------------------------------------------------
+
+YOUTUBE_ENABLED_SHOWS = {"tesla", "models_agents_beginners"}
+
+
+def test_only_tst_and_mab_enable_youtube():
+    """YouTube Data API quota is 10,000 units/day, 1,600 per upload.
+    The @NerraNetwork channel can only ship ~6 uploads/day; with 8
+    English shows × 2 videos that's 16 — far over quota. Until quota
+    is increased, only TST and MAB ship to YouTube."""
+    enabled: set[str] = set()
+    for cfg_path in SHOWS_DIR.glob("*.yaml"):
+        if cfg_path.name.startswith("_"):
+            continue  # Skip _defaults.yaml etc.
+        cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+        slug = cfg.get("slug")
+        if not slug:
+            continue
+        yt = (cfg.get("youtube") or {})
+        if yt.get("enabled") is True:
+            enabled.add(slug)
+    assert enabled == YOUTUBE_ENABLED_SHOWS, (
+        f"YouTube uploads enabled on {enabled}; only "
+        f"{YOUTUBE_ENABLED_SHOWS} should be enabled until quota strategy "
+        f"lands."
+    )
+
+
+# ---------------------------------------------------------------------------
+# weekly_recap_digest behaviour (the helper itself)
+# ---------------------------------------------------------------------------
+
+class TestWeeklyRecapHelper:
+    """``build_weekly_recap_digest`` short-circuits when the content
+    lake is missing or has too few episodes. The runner falls back to
+    a normal daily fetch in that case — the function MUST return None
+    rather than raising or returning something the daily pipeline
+    would mistake for a real digest."""
+
+    def test_returns_none_when_lake_unavailable(self, monkeypatch):
+        from engine import weekly_recap
+        # Stub out content_lake import to simulate ImportError.
+        import sys
+        monkeypatch.setitem(sys.modules, "engine.content_lake", None)
+        from datetime import date
+        out = weekly_recap.build_weekly_recap_digest(
+            "tesla", "Tesla Shorts Time", date(2026, 5, 3),
+        )
+        # We don't strictly require None on import-fail (different
+        # branch), but it must not raise. Acceptable: None or a string
+        # we never use as a real digest.
+        assert out is None or isinstance(out, str)
+
+    def test_returns_none_when_too_few_episodes(self, monkeypatch):
+        from engine import weekly_recap
+        # Force the helper to see only one episode.
+        monkeypatch.setattr(
+            weekly_recap,
+            "build_weekly_recap_digest",
+            weekly_recap.build_weekly_recap_digest,  # keep real
+        )
+
+        # Patch query_show_range inside the helper to return one episode
+        import engine.content_lake as _cl
+
+        def fake_query(slug, start, end):
+            return [
+                {"episode_num": 1, "date": "2026-05-01",
+                 "hook": "Solo episode", "digest_md": "Body"}
+            ]
+
+        monkeypatch.setattr(_cl, "query_show_range", fake_query)
+        from datetime import date
+        out = weekly_recap.build_weekly_recap_digest(
+            "tesla", "Tesla Shorts Time", date(2026, 5, 3),
+        )
+        assert out is None
+
+    def test_synthesises_digest_with_two_or_more_episodes(self, monkeypatch):
+        from engine import weekly_recap
+        import engine.content_lake as _cl
+
+        def fake_query(slug, start, end):
+            return [
+                {
+                    "episode_num": 1, "date": "2026-04-28",
+                    "hook": "Story A happened.", "digest_md": "Body A.",
+                },
+                {
+                    "episode_num": 2, "date": "2026-04-29",
+                    "hook": "Story B happened.", "digest_md": "Body B.",
+                },
+            ]
+
+        monkeypatch.setattr(_cl, "query_show_range", fake_query)
+        from datetime import date
+        out = weekly_recap.build_weekly_recap_digest(
+            "tesla", "Tesla Shorts Time", date(2026, 5, 3),
+        )
+        assert out is not None
+        # Title and recap framing present.
+        assert "Tesla Shorts Time" in out
+        assert "Weekly Recap" in out
+        # Both hooks survive into the synthetic digest.
+        assert "Story A happened." in out
+        assert "Story B happened." in out
+        # Recap-mode framing instruction at the bottom for the host.
+        assert "Sunday weekly recap" in out


### PR DESCRIPTION
Operator's May 2026 schedule overhaul — three coupled changes.

## 1. Seven shows on daily cadence + Sunday-recap mode

**Omni View, Planetterrian, Fascinating Frontiers, Models & Agents, MAB, Modern Investing, Tesla** now run every day. New YAML flag `weekly_recap_on_sunday: true` makes the runner skip the news fetch on Sundays and synthesise a digest from the past 7 days of episodes via the content lake. The synthetic digest goes through the unchanged podcast prompt + TTS pipeline.

## 2. Cron times shifted +1 hour

All shows fire 06:00–11:00 UTC. Tesla last at 11:00 UTC = 7 AM ET (operator-accepted).

## 3. YouTube quota cap

Disabled YouTube on every English show except TST and MAB. Quota is 6 uploads/day; 7 daily shows × 2 videos was 14.

## Test plan
- [x] `pytest tests/test_schedule.py` — 18 tests
- [x] Full suite: 1500 passing, 2 pre-existing `google.oauth2` failures unrelated

PR #298 (new show) and #299 (website refresh) follow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_