### PR TITLE
Fix UC pipeline preflight: skip RSS check for narrative-mode shows

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -274,8 +274,16 @@ jobs:
           assert Path(config.llm.podcast_prompt_file).exists(), f'Podcast prompt not found: {config.llm.podcast_prompt_file}'
           if config.llm.system_prompt_file:
               assert Path(config.llm.system_prompt_file).exists(), f'System prompt not found: {config.llm.system_prompt_file}'
-          assert len(config.sources) > 0, 'No RSS sources configured'
-          print(f'Config validated: {config.name} ({len(config.sources)} sources, model={config.llm.model})')
+          # Narrative-mode shows (e.g. unintended_consequences) are
+          # topic-queue-driven — they intentionally ship with no RSS
+          # sources. Validate the topic queue file instead.
+          if getattr(config, 'narrative_mode', False):
+              assert config.topic_queue_file, 'narrative_mode requires topic_queue_file'
+              assert Path(config.topic_queue_file).exists(), f'Topic queue not found: {config.topic_queue_file}'
+              print(f'Config validated: {config.name} (narrative mode, queue={config.topic_queue_file}, model={config.llm.model})')
+          else:
+              assert len(config.sources) > 0, 'No RSS sources configured'
+              print(f'Config validated: {config.name} ({len(config.sources)} sources, model={config.llm.model})')
           "
 
       - name: Backfill Content Lake from committed digests


### PR DESCRIPTION
**Fixes today's UC pipeline failure** (run #25329847795).

## What broke
The workflow's pre-flight config validation step ran an unconditional `assert len(config.sources) > 0`. Unintended Consequences (`narrative_mode: true`) is topic-queue-driven by design — no RSS sources. The assertion fired before the runner started.

```
AssertionError: No RSS sources configured
```

I caught and gated the same assertion in `tests/test_integration.py::test_config_loads` when shipping PR #298 (it also had to learn about narrative_mode), but missed this duplicate copy in the workflow file.

## Fix
Branch the preflight on `narrative_mode`:
- **Narrative shows**: assert `topic_queue_file` is set and the file exists; log `queue=<path>` instead of source count
- **News shows**: keep the existing `len(sources) > 0` check unchanged

## After merge
Tomorrow's 11:30 UTC weekday slot picks up the first topic from the queue (`cobra-effect`) and ships Episode 1 end-to-end. (Today's slot is already past — the next weekday run is the live test.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_