### PR TITLE
UC YAML: drop music_file (voice-only until score exists) — fixes preflight

### DIFF
--- a/shows/unintended_consequences.yaml
+++ b/shows/unintended_consequences.yaml
@@ -36,7 +36,12 @@ tts:
   {}
 
 audio:
-  music_file: assets/music/unintended_consequences.mp3
+  # No music_file yet — UC ships voice-only until operator generates a
+  # narrative-tone score (slower, reflective, documentary feel rather
+  # than the news-show intro stings used by peer shows). The runner's
+  # ``if config.audio.music_file:`` guard at run_show.py:1786 means
+  # leaving this empty cleanly skips the mix step. Once a track exists,
+  # add `music_file: assets/music/unintended_consequences.mp3` here.
   transition_sting: assets/music/transition_sting.mp3
   voice_intro_delay: 5.0
   intro_duration: 5.0


### PR DESCRIPTION
**Fixes today's second UC pipeline failure** (the one after PR #302 unblocked the RSS-sources preflight).

## What broke
```
[ERROR] Pre-flight check FAILED: Audio file not found: assets/music/unintended_consequences.mp3
```

The UC YAML referenced a music file the operator hasn't generated yet. Other shows have specific intro/outro tracks (e.g. `tesla_shorts_time.mp3`, `EnvIntel.mp3`, `ModelsAgents.mp3`); UC was missing one and pre-flight refused to run with the broken reference.

## Fix
Remove `music_file` from the UC YAML. The runner already supports voice-only mode — `if config.audio.music_file:` at `run_show.py:1786` guards the mix step. Empty/missing field cleanly skips the music mix and publishes voice-only audio.

Once the operator generates a narrative-tone score (slower, reflective, documentary feel — different from the news-show stings other shows use), it's a one-line YAML edit to re-enable music.

## Tests
33 schedule + UC tests still pass. No code change in `run_show.py` — the voice-only path was already there.

## After merge
Tomorrow's 11:30 UTC slot ships UC Episode 1 (Cobra Effect) end-to-end as voice-only audio. Listeners get clean spoken narration; intro/outro music can be added later without touching any code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_