### PR TITLE
Drop &lt;build-intensity&gt; from speech wrap (Grok was speaking it aloud)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,6 +406,21 @@ decision); everything else has a live status card.
     similarity_boost, style, etc.) are also preserved — harmless under
     `provider=grok` and a one-line YAML flip back to ElevenLabs if
     Grok TTS has an outage.
+
+    **May 4 2026 update — speech-tag wrap simplified.** The chunk-
+    send wrap was originally `<fast><build-intensity>...</build-intensity></fast>`
+    (PR #293). Whisper transcripts of UC Ep001 ("Build intensity." at
+    line 3 + "build intended to dig" at line 127) and Tesla Ep461 (line
+    112) showed Grok occasionally **speaking** "build intensity" out
+    loud instead of consuming the tag — `<build-intensity>` was never
+    in Grok's documented tag list. Wrap simplified to `<fast>...</fast>`
+    in `shows/_defaults.yaml` and `engine.config.TTSConfig` defaults.
+    `<fast>` IS documented and consumed correctly; the energy lift
+    survives without the leakage. Drift guard
+    `test_default_tts_config_has_fast_wrap_only` blocks accidental
+    re-introduction. Re-add nested tags only with transcript-level
+    evidence that Grok consumes them.
+
 18. **Newsletter pipeline spec v2 (May 2026)** — multi-day refinement
     pass on the Buttondown send pipeline addressing contrast bugs,
     LLM scaffold leaks, and daily-vs-weekly template parity. Files:

--- a/engine/config.py
+++ b/engine/config.py
@@ -89,15 +89,21 @@ class TTSConfig:
     use_speaker_boost: bool = True
     speed: float = 1.0  # Speech speed (0.7–1.2); Flash v2.5 supports this range
     apply_text_normalization: str = "on"  # "auto", "on", or "off"; helps with number/date pronunciation
-    # Speech-tag wrap applied to every chunk sent to Grok TTS. Grok
-    # cloned voices respond noticeably to ``<fast><build-intensity>`` —
-    # the operator A/B'd against bare text on Tesla Ep459 / Ep460 and
-    # the wrapped read had clearly more energy and dynamic range. Empty
-    # strings = no wrap (back-compat). The Grok backend strips these
-    # tags before producing audio, so they never appear as spoken
-    # words. ElevenLabs path ignores both fields.
-    speech_wrap_open: str = "<fast><build-intensity>"
-    speech_wrap_close: str = "</build-intensity></fast>"
+    # Speech-tag wrap applied to every chunk sent to Grok TTS. The
+    # operator A/B'd ``<fast>`` against bare text in May 2026 and the
+    # wrapped read had clearly more energy and dynamic range. Empty
+    # strings = no wrap (back-compat). Grok strips ``<fast>`` tags
+    # before producing audio.
+    #
+    # History: the wrap originally paired ``<fast>`` with
+    # ``<build-intensity>`` (PR #293, May 3 2026). Whisper transcripts
+    # of UC Ep001 and Tesla Ep461 caught Grok occasionally SPEAKING
+    # "build intensity" instead of consuming the tag — it isn't in
+    # Grok's documented tag list. Dropped May 4 2026; ``<fast>`` alone
+    # delivers the energy lift without the leakage. Re-add only with
+    # transcript-level evidence that Grok consumes the new tag.
+    speech_wrap_open: str = "<fast>"
+    speech_wrap_close: str = "</fast>"
     # Post-TTS transcription validation (opt-in)
     validate_transcription: bool = False
     whisper_model: str = "base"  # "tiny", "base", "small", "medium"

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -513,12 +513,11 @@ _INLINE_TAG_PATTERN = re.compile(
 # emphasis, etc.). The Grok backend interprets and consumes them; we strip
 # them for any non-TTS consumer (blog markdown, RSS show notes, X teaser).
 #
-# ``build-intensity`` is the network's TTS-chunk wrap (paired with
-# ``fast``) added in May 2026 for cloned-voice energy. It's added at
-# the chunk-send layer in ``_speak_with_grok`` and shouldn't reach
-# any non-TTS surface — but inclusion here is defense-in-depth in case
-# a future code path stamps the wrap onto the script before it's
-# saved.
+# ``build-intensity`` is NOT in Grok's documented tag list — kept here
+# only as a defensive scrubber in case it sneaks back into a script.
+# (It was briefly part of the network's chunk-send wrap in May 2026
+# until Whisper caught Grok speaking "build intensity" out loud — see
+# the history block in ``shows/_defaults.yaml`` and landmine #17.)
 _WRAPPING_TAGS = (
     "soft", "loud", "whisper",
     "slow", "fast", "high", "low",

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -50,15 +50,20 @@ tts:
   voice_id: kdif6sqjcyiq
   language_code: en
   max_chars: 10000
-  # Speech-tag wrap applied to every chunk sent to Grok TTS. The
-  # ``<fast><build-intensity>`` combo is the single biggest delivery
-  # lever on cloned voices — A/B'd on the operator's kdif6sqjcyiq
-  # voice in May 2026, the wrapped read had visibly more energy and
-  # dynamic range than bare text. Tags are consumed by the Grok
-  # backend (never appear as spoken words). To disable for a show,
-  # override both fields to empty strings in the show's tts: block.
-  speech_wrap_open: "<fast><build-intensity>"
-  speech_wrap_close: "</build-intensity></fast>"
+  # Speech-tag wrap applied to every chunk sent to Grok TTS.
+  # ``<fast>`` is documented and consumed correctly by Grok; the
+  # operator A/B'd it against bare text in May 2026 and the wrapped
+  # read had visibly more energy on the kdif6sqjcyiq voice. To
+  # disable for a show, override both fields to empty strings in
+  # the show's tts: block.
+  #
+  # History: this wrap previously included ``<build-intensity>`` as
+  # an inner pair (``<fast><build-intensity>...</.../>``). Whisper
+  # caught Grok speaking "build intensity" out loud (UC Ep001
+  # opening, Tesla Ep461 mid-script) — the tag isn't in Grok's
+  # documented set. Dropped May 4 2026.
+  speech_wrap_open: "<fast>"
+  speech_wrap_close: "</fast>"
   # ---- Legacy ElevenLabs baseline ----
   # No show currently overrides `provider: elevenlabs`. Kept here so
   # an emergency rollback (e.g. Grok TTS outage) is a one-line YAML

--- a/tests/test_tts_grok.py
+++ b/tests/test_tts_grok.py
@@ -494,14 +494,17 @@ def test_synthesize_sections_succeeds_when_all_sections_synth(tmp_path: Path, mo
 
 
 # ---------------------------------------------------------------------------
-# Speech-tag wrap — <fast><build-intensity>...</...></...>
+# Speech-tag wrap — <fast>...</fast>
+# (Originally paired with <build-intensity>; dropped May 4 2026 after
+# Whisper caught Grok speaking "build intensity" out loud — see the
+# history block in shows/_defaults.yaml and landmine #17.)
 # ---------------------------------------------------------------------------
 
 def test_grok_path_wraps_text_with_speech_tags(tmp_path: Path, monkeypatch):
     """When ``speech_wrap_open`` / ``close`` are set, every chunk sent
     to ``grok_speak_chunk`` must arrive wrapped. The kdif6sqjcyiq clone
-    A/B'd cleaner with ``<fast><build-intensity>`` than bare text — this
-    drift guard catches any regression that drops the wrap."""
+    A/B'd cleaner with ``<fast>`` than bare text — this drift guard
+    catches any regression that drops the wrap."""
     captured_texts: list = []
 
     def fake_chunk(text, *args, **kwargs):
@@ -523,14 +526,14 @@ def test_grok_path_wraps_text_with_speech_tags(tmp_path: Path, monkeypatch):
         api_key="k",
         provider="grok",
         language_code="en",
-        speech_wrap_open="<fast><build-intensity>",
-        speech_wrap_close="</build-intensity></fast>",
+        speech_wrap_open="<fast>",
+        speech_wrap_close="</fast>",
     )
 
     assert captured_texts, "grok_speak_chunk was never called"
     sent = captured_texts[0]
-    assert sent.startswith("<fast><build-intensity>"), sent
-    assert sent.endswith("</build-intensity></fast>"), sent
+    assert sent.startswith("<fast>"), sent
+    assert sent.endswith("</fast>"), sent
     assert "Tesla just opened a new Supercharger corridor." in sent
 
 
@@ -562,14 +565,21 @@ def test_grok_path_wrap_is_empty_string_safe(tmp_path: Path, monkeypatch):
     assert sent == "Bare sentence."
 
 
-def test_default_tts_config_has_fast_build_intensity_wrap():
-    """The network default is ``<fast><build-intensity>...</...></...>`` — the
-    operator's A/B verdict on cloned voices. Drift guard so a quiet
-    config change doesn't silently revert this for every show."""
+def test_default_tts_config_has_fast_wrap_only():
+    """The network default is ``<fast>...</fast>`` — drift guard.
+
+    NB: paired with ``<build-intensity>`` in PR #293 (May 3 2026),
+    dropped May 4 2026 after Whisper showed Grok speaking "build
+    intensity" out loud on UC Ep001 and Tesla Ep461. ``<fast>`` IS
+    in Grok's documented tag list and is consumed correctly; the
+    inner pair was never documented and Grok read it as text.
+    """
     from engine.config import TTSConfig
     cfg = TTSConfig()
-    assert cfg.speech_wrap_open == "<fast><build-intensity>"
-    assert cfg.speech_wrap_close == "</build-intensity></fast>"
+    assert cfg.speech_wrap_open == "<fast>"
+    assert cfg.speech_wrap_close == "</fast>"
+    assert "build-intensity" not in cfg.speech_wrap_open
+    assert "build-intensity" not in cfg.speech_wrap_close
 
 
 def test_synthesize_sections_passes_wrap_through(tmp_path: Path, monkeypatch):
@@ -586,12 +596,12 @@ def test_synthesize_sections_passes_wrap_through(tmp_path: Path, monkeypatch):
         api_key="k",
         provider="grok",
         language_code="en",
-        speech_wrap_open="<fast><build-intensity>",
-        speech_wrap_close="</build-intensity></fast>",
+        speech_wrap_open="<fast>",
+        speech_wrap_close="</fast>",
     )
 
     assert grok_called.call_count == 2
     for call in grok_called.call_args_list:
         _, kwargs = call
-        assert kwargs["speech_wrap_open"] == "<fast><build-intensity>"
-        assert kwargs["speech_wrap_close"] == "</build-intensity></fast>"
+        assert kwargs["speech_wrap_open"] == "<fast>"
+        assert kwargs["speech_wrap_close"] == "</fast>"


### PR DESCRIPTION
**Fixes the spoken-tag leak you heard in UC Ep001.**

## What I found

Whisper transcripts of the actual audio caught Grok speaking the wrap tag out loud:

- **UC Ep001 line 3:** "Build intensity."
- **UC Ep001 line 127:** "I'm Patrick and Vancouver, build intended to dig."
- **Tesla Ep461 line 112:** "...continues to push its technology forward, build intensity."

## Root cause

PR #293 (May 3 2026) wrapped every chunk in `<fast><build-intensity>...</build-intensity></fast>`. `<fast>` IS in Grok's documented tag list and works correctly. `<build-intensity>` was never documented — Grok consumed it most of the time but occasionally read it as literal text. The leak rate scales with chunk count, which is why narrative-show UC (long single chunks) and Tesla (multiple chunks per episode) both hit it.

## Fix

Simplify the wrap to `<fast>...</fast>` — keeping the energy lift the operator originally A/B'd, dropping the leakage source. Single source of truth changes:

- `shows/_defaults.yaml` `tts.speech_wrap_open/close`
- `engine.config.TTSConfig` defaults
- Drift guard renamed: `test_default_tts_config_has_fast_wrap_only` (asserts both that the wrap is `<fast>` AND that `build-intensity` is NOT in either field, blocking accidental re-introduction)
- `<build-intensity>` stays in the `_WRAPPING_TAGS` strip list as defensive-only — comment updated to reflect that it's no longer used by the wrap

## CLAUDE.md
Landmine #17 gets a "May 4 2026 update" block recording the regression, the Whisper evidence, the simplification, and the rule for re-adding nested tags ("only with transcript-level evidence that Grok consumes them").

## Test plan
- [x] Full suite: 1524 passing, 2 pre-existing `google.oauth2` failures unrelated
- [ ] **Live validation**: tomorrow's episodes (Tesla, MA, OV, etc.) should ship with no "build intensity" / "build intended" / similar leaks in their Whisper transcripts. UC Ep002 will be the first narrative-show test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_