### PR TITLE
Phase 1.1: wire cross-network dedup signal into 10 digest prompts

### DIFF
--- a/run_show.py
+++ b/run_show.py
@@ -865,10 +865,14 @@ def run(args: argparse.Namespace) -> None:
                 )
                 logger.info("Injecting cross-show context (%d shows) into digest prompt", len(lines))
         if "cross_show_context" not in template_vars:
-            template_vars["cross_show_context"] = ""
+            template_vars["cross_show_context"] = (
+                "(No recent cross-network coverage to dedupe against today.)"
+            )
     except Exception as exc:
         logger.debug("Cross-show context unavailable (non-fatal): %s", exc)
-        template_vars["cross_show_context"] = ""
+        template_vars["cross_show_context"] = (
+            "(Cross-network context unavailable — proceed without dedupe signal.)"
+        )
 
     # Merge extra context from hooks (e.g. price, change_str, x_posts_section)
     template_vars.update(extra_context)

--- a/shows/prompts/env_intel_digest.txt
+++ b/shows/prompts/env_intel_digest.txt
@@ -119,6 +119,12 @@ Source: [EXACT URL FROM PRE-FETCHED — no modifications]
 The following stories were covered in recent episodes. Prioritize genuinely NEW regulatory developments. Do not re-cover the same regulation, consultation, or enforcement action unless there is a material new development.
 {recent_content_summary}
 
+### CROSS-NETWORK CONTEXT — Topics covered by sister Nerra Network shows in the past 7 days (do not include in your output):
+{cross_show_context}
+
+If any item above overlaps with a story you are about to lead with, change course. Listeners who follow more than one Nerra Network show will recognize when the same story is recycled across the network within hours. Pick a different angle, a different story, or a deeper dive on the SAME story that adds something the sister shows did not cover. The goal is for the network to feel coherent and complementary, not redundant.
+
+
 **ANTI-DUPLICATION RULE:** The Lead Story must NOT repeat the exact sentences or phrases used in the Executive Summary. The Exec Summary gives the headline; the Lead Story gives the full details. If the Exec Summary already said "the claim engages Alberta EPEA, federal Fisheries Act, and Species at Risk Act", the Lead Story must describe those regulatory engagements with DIFFERENT wording, or move that detail to a sentence the Exec Summary did not cover.
 
 **JURISDICTION/REGULATION UNIQUENESS:** Each specific regulation citation (e.g. "Alberta EPEA", "CCME PFAS guideline", "Ontario O. Reg. 153/04") may anchor at most ONE paragraph block across the entire digest. If multiple stories touch the same regulation, combine them into one block or pick the strongest one. Do NOT write separate paragraphs that reference the same 3+ regulation names.

--- a/shows/prompts/fascinating_frontiers_digest.txt
+++ b/shows/prompts/fascinating_frontiers_digest.txt
@@ -51,6 +51,12 @@ A mind-expanding deep dive into one space or astronomy concept. This section use
 The following stories were covered in recent episodes. Prioritize NEW stories and genuinely new developments. If a story appeared recently, cover ONLY what is new (not a reframe of the same information).
 {recent_content_summary}
 
+### CROSS-NETWORK CONTEXT — Topics covered by sister Nerra Network shows in the past 7 days (do not include in your output):
+{cross_show_context}
+
+If any item above overlaps with a story you are about to lead with, change course. Listeners who follow more than one Nerra Network show will recognize when the same story is recycled across the network within hours. Pick a different angle, a different story, or a deeper dive on the SAME story that adds something the sister shows did not cover. The goal is for the network to feel coherent and complementary, not redundant.
+
+
 **TOPIC FRESHNESS — MUST choose a DIFFERENT topic than recent episodes:**
 {recent_deep_dive_topics}
 

--- a/shows/prompts/fp_digest.txt
+++ b/shows/prompts/fp_digest.txt
@@ -113,6 +113,12 @@ Source: [ТОЧНАЯ ССЫЛКА или "Общее понятие"]
 Следующие темы были освещены в недавних выпусках. Выбирайте НОВЫЕ и ОТЛИЧАЮЩИЕСЯ темы и углы.
 {recent_content_summary}
 
+### CROSS-NETWORK CONTEXT — Topics covered by sister Nerra Network shows in the past 7 days (do not include in your output):
+{cross_show_context}
+
+If any item above overlaps with a story you are about to lead with, change course. Listeners who follow more than one Nerra Network show will recognize when the same story is recycled across the network within hours. Pick a different angle, a different story, or a deeper dive on the SAME story that adds something the sister shows did not cover. The goal is for the network to feel coherent and complementary, not redundant.
+
+
 ━━━━━━━━━━━━━━━━━━━━
 ### Практические советы
 2-3 полезных совета, инструмента или новости. Для каждого:

--- a/shows/prompts/mab_digest.txt
+++ b/shows/prompts/mab_digest.txt
@@ -77,6 +77,12 @@ Every section must cover DIFFERENT stories from DIFFERENT sources. Never repeat 
 The following stories were covered in recent episodes. Choose NEW and DIFFERENT stories that beginners haven't heard yet.
 {recent_content_summary}
 
+### CROSS-NETWORK CONTEXT — Topics covered by sister Nerra Network shows in the past 7 days (do not include in your output):
+{cross_show_context}
+
+If any item above overlaps with a story you are about to lead with, change course. Listeners who follow more than one Nerra Network show will recognize when the same story is recycled across the network within hours. Pick a different angle, a different story, or a deeper dive on the SAME story that adds something the sister shows did not cover. The goal is for the network to feel coherent and complementary, not redundant.
+
+
 {slow_news_context}
 
 ### FORMATTING (EXACT — USE MARKDOWN AS SHOWN)

--- a/shows/prompts/models_agents_digest.txt
+++ b/shows/prompts/models_agents_digest.txt
@@ -108,6 +108,12 @@ An engineering teardown of ONE AI concept, architecture, or technique. This sect
 The following stories were covered in recent episodes. Prioritize NEW model releases, agent frameworks, and developments. Do not lead with or re-cover the same story unless there is a genuinely new angle.
 {recent_content_summary}
 
+### CROSS-NETWORK CONTEXT — Topics covered by sister Nerra Network shows in the past 7 days (do not include in your output):
+{cross_show_context}
+
+If any item above overlaps with a story you are about to lead with, change course. Listeners who follow more than one Nerra Network show will recognize when the same story is recycled across the network within hours. Pick a different angle, a different story, or a deeper dive on the SAME story that adds something the sister shows did not cover. The goal is for the network to feel coherent and complementary, not redundant.
+
+
 **TOPIC FRESHNESS — MUST choose a DIFFERENT topic than recent episodes:**
 {recent_deep_dive_topics}
 

--- a/shows/prompts/modern_investing_digest.txt
+++ b/shows/prompts/modern_investing_digest.txt
@@ -50,6 +50,12 @@ Use ONLY the pre-fetched articles above. Do NOT hallucinate, invent, or fabricat
 **RECENTLY COVERED CONTENT (avoid repetition):**
 {recent_content_summary}
 
+### CROSS-NETWORK CONTEXT — Topics covered by sister Nerra Network shows in the past 7 days (do not include in your output):
+{cross_show_context}
+
+If any item above overlaps with a story you are about to lead with, change course. Listeners who follow more than one Nerra Network show will recognize when the same story is recycled across the network within hours. Pick a different angle, a different story, or a deeper dive on the SAME story that adds something the sister shows did not cover. The goal is for the network to feel coherent and complementary, not redundant.
+
+
 **RECENT PRACTICE INVESTMENT STRATEGIES (do NOT repeat the same approach):**
 {recent_strategies}
 

--- a/shows/prompts/omni_view_digest.txt
+++ b/shows/prompts/omni_view_digest.txt
@@ -38,6 +38,12 @@ Rules:
 ### RECENTLY COVERED STORIES — DO NOT REPEAT (do not include in output):
 {recent_content_summary}
 
+### CROSS-NETWORK CONTEXT — Topics covered by sister Nerra Network shows in the past 7 days (do not include in your output):
+{cross_show_context}
+
+If any item above overlaps with a story you are about to lead with, change course. Listeners who follow more than one Nerra Network show will recognize when the same story is recycled across the network within hours. Pick a different angle, a different story, or a deeper dive on the SAME story that adds something the sister shows did not cover. The goal is for the network to feel coherent and complementary, not redundant.
+
+
 Under each section, for each story:
 ### <N>) <short neutral headline>
 **What happened (neutral):** 2–4 sentences in plain language so any reader can follow.

--- a/shows/prompts/planetterrian_digest.txt
+++ b/shows/prompts/planetterrian_digest.txt
@@ -60,6 +60,12 @@ A myth-busting deep dive into one science, health, or longevity concept. This se
 The following stories were covered in recent episodes. Prioritize NEW stories and genuinely new developments. If a story appeared recently, cover ONLY what is new (not a reframe of the same information).
 {recent_content_summary}
 
+### CROSS-NETWORK CONTEXT — Topics covered by sister Nerra Network shows in the past 7 days (do not include in your output):
+{cross_show_context}
+
+If any item above overlaps with a story you are about to lead with, change course. Listeners who follow more than one Nerra Network show will recognize when the same story is recycled across the network within hours. Pick a different angle, a different story, or a deeper dive on the SAME story that adds something the sister shows did not cover. The goal is for the network to feel coherent and complementary, not redundant.
+
+
 **TOPIC FRESHNESS — MUST choose a DIFFERENT topic than recent episodes:**
 {recent_deep_dive_topics}
 

--- a/shows/prompts/privet_russian_digest.txt
+++ b/shows/prompts/privet_russian_digest.txt
@@ -56,6 +56,12 @@ A "language detective" investigation into one word's surprising history. This se
 The following words and themes were covered in recent episodes. Choose COMPLETELY DIFFERENT vocabulary and a DIFFERENT theme.
 {recent_content_summary}
 
+### CROSS-NETWORK CONTEXT — Topics covered by sister Nerra Network shows in the past 7 days (do not include in your output):
+{cross_show_context}
+
+If any item above overlaps with a story you are about to lead with, change course. Listeners who follow more than one Nerra Network show will recognize when the same story is recycled across the network within hours. Pick a different angle, a different story, or a deeper dive on the SAME story that adds something the sister shows did not cover. The goal is for the network to feel coherent and complementary, not redundant.
+
+
 **TOPIC FRESHNESS — MUST choose a DIFFERENT word/topic than recent episodes:**
 {recent_deep_dive_topics}
 

--- a/shows/prompts/tesla_digest.txt
+++ b/shows/prompts/tesla_digest.txt
@@ -44,6 +44,12 @@ The following stories and topics were already covered in recent episodes. DO NOT
 
 {recent_content_summary}
 
+### CROSS-NETWORK CONTEXT — Topics covered by sister Nerra Network shows in the past 7 days (do not include in your output):
+{cross_show_context}
+
+If any item above overlaps with a story you are about to lead with, change course. Listeners who follow more than one Nerra Network show will recognize when the same story is recycled across the network within hours. Pick a different angle, a different story, or a deeper dive on the SAME story that adds something the sister shows did not cover. The goal is for the network to feel coherent and complementary, not redundant.
+
+
 ### FRESHNESS INSTRUCTIONS (do not include these in your output):
 - HOOK: Must feature a DIFFERENT story than recent episode hooks. Do not reuse the same lead story across consecutive episodes. Find the newest, freshest development to lead with.
 - Top 10: Prioritize stories NOT in the recently covered list. If all stories overlap with recent coverage, dig deeper into each for genuinely new angles rather than rehashing.

--- a/tests/test_cross_network_dedup.py
+++ b/tests/test_cross_network_dedup.py
@@ -1,0 +1,84 @@
+"""Tests for the cross-network dedup signal wired in May 2026.
+
+The runner builds a ``{cross_show_context}`` template variable from the
+last 7 days of cross-show episodes (``run_show.py:844-868``) and stuffs
+it into every digest prompt's ``template_vars``. This module guards two
+invariants:
+
+1. Every news-show digest prompt actually references the variable —
+   otherwise the runner builds a dedup signal that the LLM never sees,
+   which is exactly the bug Phase 1.1 fixed.
+
+2. The runner always provides SOME value for the variable (even when
+   the content lake has nothing or fails) so prompt rendering never
+   raises ``KeyError`` mid-run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROMPTS_DIR = REPO_ROOT / "shows" / "prompts"
+
+# News-show digest prompts. Narrative-mode shows (currently just UC,
+# whose digest prompt is ``unintended_consequences_episode.txt``) are
+# excluded — narrative-mode bypasses the news-fetch + cross-show
+# context construction entirely, so wiring the variable into a
+# narrative prompt would be cargo-culting.
+NEWS_SHOW_DIGEST_PROMPTS = [
+    "tesla_digest.txt",
+    "omni_view_digest.txt",
+    "planetterrian_digest.txt",
+    "fascinating_frontiers_digest.txt",
+    "env_intel_digest.txt",
+    "models_agents_digest.txt",
+    "mab_digest.txt",
+    "modern_investing_digest.txt",
+    "fp_digest.txt",
+    "privet_russian_digest.txt",
+]
+
+
+@pytest.mark.parametrize("prompt_name", NEWS_SHOW_DIGEST_PROMPTS)
+def test_news_show_digest_uses_cross_show_context(prompt_name):
+    """Drift guard: every news-show digest prompt must reference the
+    ``{cross_show_context}`` template variable.
+
+    If a prompt is missing this, the runner happily computes the
+    dedup signal in ``run_show.py:844-868`` and the LLM never sees
+    it — listeners get repeated topics across shows within 24 hours.
+    """
+    text = (PROMPTS_DIR / prompt_name).read_text(encoding="utf-8")
+    assert "{cross_show_context}" in text, (
+        f"{prompt_name} doesn't reference {{cross_show_context}}. "
+        f"The runner builds this signal but the LLM will never see it. "
+        f"Add a CROSS-NETWORK CONTEXT block — see Phase 1.1 in the audit "
+        f"plan or any sister show's digest prompt for the standard wording."
+    )
+
+
+def test_runner_always_supplies_cross_show_context():
+    """The runner must always populate ``cross_show_context`` (even on
+    content-lake failure or empty 7-day window) — otherwise prompt
+    rendering raises ``KeyError`` mid-run."""
+    runner = (REPO_ROOT / "run_show.py").read_text(encoding="utf-8")
+    # The runner sets the variable in three places:
+    # 1. With cross-show topics when the lake returns episodes
+    # 2. With "(No recent cross-network coverage...)" when lake is empty
+    # 3. With "(Cross-network context unavailable...)" when lake errors
+    assert 'template_vars["cross_show_context"]' in runner, (
+        "run_show.py no longer sets template_vars['cross_show_context'] — "
+        "every digest prompt that uses {cross_show_context} will KeyError."
+    )
+    # Both fallback strings must be present so the variable is always
+    # set, never missing.
+    assert "No recent cross-network coverage" in runner, (
+        "Empty-lake fallback for cross_show_context missing in run_show.py"
+    )
+    assert "Cross-network context unavailable" in runner, (
+        "Error fallback for cross_show_context missing in run_show.py"
+    )


### PR DESCRIPTION
**Phase 1.1 of the content-quality audit** (plan in `/root/.claude/plans/temporal-gathering-horizon.md`). Highest-leverage fix in the audit's punch list — this one alone should noticeably reduce cross-show topic overlap in tomorrow's episodes.

## What I found

The runner's `run_show.py:844-868` already builds a "Topics recently covered by other Nerra Network shows" string from the past 7 days of cross-show headlines and stuffs it into `template_vars["cross_show_context"]`. **Zero digest prompts reference the variable.** The dedup signal was being computed every run and discarded.

Listener consequence: a Tesla story leading TST today also leads M&A or Omni View tomorrow, because the LLM has no awareness that a sister show already covered it. Cross-network listeners experience the network as redundant.

## Fix

Appended a CROSS-NETWORK CONTEXT block to all 10 news-show digest prompts, right after `{recent_content_summary}` (same conceptual category — within-show dedup vs across-network dedup). The block instructs the LLM to either skip overlapping stories or pick a different angle.

Also hardened the runner's fallback strings — empty-lake and error cases now substitute coherent prose ("No recent cross-network coverage to dedupe against today.") instead of empty strings, so prompts always read cleanly.

UC excluded — narrative-mode bypasses the news-fetch + cross-show context construction entirely.

## Drift guards (`tests/test_cross_network_dedup.py`)

- 10 parametrized tests assert every news-show digest prompt contains the literal `{cross_show_context}` string. Catches any future show that ships without wiring.
- 1 test asserts the runner always populates the variable (both fallback paths verified) so prompt rendering never KeyErrors.

## Test plan
- [x] 11 new tests passing
- [x] Full suite: 1535 passing (+11 from baseline 1524), 2 pre-existing `google.oauth2` failures unrelated
- [ ] **Tomorrow's episodes**: ear test that cross-show topic repetition drops noticeably. Operator gut-check.

## Coming next

Phase 1.2 (UC Ep001-class fixes) → Phase 1.3 (cross-promo parity) → Phase 1.4-1.5 (copy sweep + scaffold prevention) → Phase 1.6 (tag-leak detector). All ship as separate PRs this week. Phase 1.8 (UC Ep001 re-render) waits for all of those to land first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_