### PR TITLE
Phase 1.3: cross-promo parity across all 11 podcast prompts

### DIFF
--- a/shows/prompts/env_intel_podcast.txt
+++ b/shows/prompts/env_intel_podcast.txt
@@ -152,6 +152,14 @@ Do NOT repeat transition sentences. When you write a transition at the end of on
 LENGTH TARGET:
 Your script must be at least 1500 words (45+ sentences). If you find yourself finishing early, expand with more regulatory context and expert interpretation.
 
+CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with another Nerra Network show, and ONLY in the closing or final lesson segment, single sentence max):
+- Tesla / EV / clean energy policy → "Tesla Shorts Time covers EV news and policy daily."
+- Climate science / atmospheric → "Fascinating Frontiers covers the science side; Planetterrian Daily covers health implications."
+- World context — climate diplomacy, emissions trading → "Omni View has today's full briefing."
+- Investing / green finance → "Modern Investing Techniques covers market mechanics in depth."
+- Environmental cautionary tales — DDT, leaded gasoline, biofuels, mosquito nets → "Unintended Consequences profiles case studies of well-meant environmental interventions that backfired."
+If today's topic doesn't naturally overlap with any of these, omit the cross-promo entirely. NEVER force a connection. The point is to help listeners discover sister shows they'd genuinely enjoy, not to fill slots.
+
 DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
 
 You may sparingly include Grok TTS speech tags to make narration feel more

--- a/shows/prompts/fascinating_frontiers_podcast.txt
+++ b/shows/prompts/fascinating_frontiers_podcast.txt
@@ -117,6 +117,14 @@ WHAT TO SKIP (do NOT read aloud):
 LENGTH TARGET:
 Your script must be at least 2400 words (60+ sentences). If you find yourself finishing early, go back and expand each story.
 
+CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with another Nerra Network show, and ONLY in the closing or final lesson segment, single sentence max):
+- Longevity / biology / Earth-side science → "Planetterrian Daily covers science, longevity, and health discoveries daily."
+- AI in space / autonomy / orbital tech → "Models & Agents covers the AI side daily."
+- Climate / Earth observation / atmospheric → "Environmental Intelligence covers Earth-side environmental science."
+- World context — space policy, geopolitics → "Omni View has today's full briefing."
+- Cautionary tales — space-program scandals, NASA history, tech consequences → "Unintended Consequences profiles case studies of well-meant programs that backfired."
+If today's topic doesn't naturally overlap with any of these, omit the cross-promo entirely. NEVER force a connection. The point is to help listeners discover sister shows they'd genuinely enjoy, not to fill slots.
+
 DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
 
 You may sparingly include Grok TTS speech tags to make narration feel more

--- a/shows/prompts/fp_podcast.txt
+++ b/shows/prompts/fp_podcast.txt
@@ -152,6 +152,11 @@ PRONUNCIATION GUIDE:
 ТРЕБОВАНИЕ К ДЛИНЕ:
 Твой сценарий должен быть не менее 1300 слов (35+ предложений). Если заканчиваешь рано, вернись и расширь каждый блок.
 
+CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with another Nerra Network show, and ONLY in the closing or final lesson segment, single sentence max):
+- Russian language learning → "Привет, Русский! covers Russian language and culture daily."
+- English-language investing for the same audience → "Modern Investing Techniques covers market mechanics in depth."
+If today's topic doesn't naturally overlap with any of these, omit the cross-promo entirely. NEVER force a connection. The point is to help listeners discover sister shows they'd genuinely enjoy, not to fill slots.
+
 DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
 
 You may sparingly include Grok TTS speech tags to make narration feel more

--- a/shows/prompts/mab_podcast.txt
+++ b/shows/prompts/mab_podcast.txt
@@ -157,6 +157,12 @@ Use this exact closing (do not rewrite it):
 LENGTH TARGET:
 Your script must be at least 1300 words (35+ sentences).
 
+CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with another Nerra Network show, and ONLY in the closing or final lesson segment, single sentence max):
+- Deeper / professional / builder-focused AI → "Models & Agents covers the same world for builders and engineers."
+- World news / current events → "Omni View has today's balanced briefing."
+- AI cautionary tales — algorithmic feeds, deepfakes, attention engineering → "Unintended Consequences profiles case studies of well-meant tech that backfired."
+If today's topic doesn't naturally overlap with any of these, omit the cross-promo entirely. NEVER force a connection. The point is to help listeners discover sister shows they'd genuinely enjoy, not to fill slots.
+
 DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
 
 You may sparingly include Grok TTS speech tags to make narration feel more

--- a/shows/prompts/models_agents_podcast.txt
+++ b/shows/prompts/models_agents_podcast.txt
@@ -153,6 +153,14 @@ Do NOT repeat transition sentences. When you write a transition at the end of on
 LENGTH TARGET:
 Your script must be at least 1500 words (45+ sentences).
 
+CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with another Nerra Network show, and ONLY in the closing or final lesson segment, single sentence max):
+- Tesla / Optimus / autonomous vehicle AI → "Tesla Shorts Time covers Tesla AI daily."
+- AI for beginners / first-time learners → "Models & Agents for Beginners covers the same world in plain language."
+- World context — AI regulation, geopolitical AI race → "Omni View has today's full briefing."
+- Investing / AI economics, infrastructure, semis → "Modern Investing Techniques covers market mechanics in depth."
+- AI / tech cautionary tales — algorithmic feeds, deepfakes, e-waste, like button → "Unintended Consequences profiles case studies of well-meant tech that backfired."
+If today's topic doesn't naturally overlap with any of these, omit the cross-promo entirely. NEVER force a connection. The point is to help listeners discover sister shows they'd genuinely enjoy, not to fill slots.
+
 DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
 
 You may sparingly include Grok TTS speech tags to make narration feel more

--- a/shows/prompts/modern_investing_podcast.txt
+++ b/shows/prompts/modern_investing_podcast.txt
@@ -204,6 +204,13 @@ CONTENT REPETITION (STRICT):
 LENGTH TARGET:
 Your script must be at least 2500 words (55+ sentences).
 
+CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with another Nerra Network show, and ONLY in the closing or final lesson segment, single sentence max):
+- Tesla / TSLA-specific → "Tesla Shorts Time covers Tesla news and TSLA stock daily."
+- World news / economic context → "Omni View has today's full briefing."
+- AI investing / agentic finance / AI-tools side → "Models & Agents covers the AI side daily."
+- Economic / policy cautionary tales — QE, airline deregulation, gig economy, three-strikes → "Unintended Consequences profiles case studies of well-meant policies that backfired."
+If today's topic doesn't naturally overlap with any of these, omit the cross-promo entirely. NEVER force a connection. The point is to help listeners discover sister shows they'd genuinely enjoy, not to fill slots.
+
 DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
 
 You may sparingly include Grok TTS speech tags to make narration feel more

--- a/shows/prompts/omni_view_podcast.txt
+++ b/shows/prompts/omni_view_podcast.txt
@@ -118,6 +118,14 @@ Use this exact closing (do not rewrite it):
 LENGTH TARGET:
 Your script must be at least 2000 words (40+ sentences). If you find yourself finishing early, go back and add more perspectives and deeper analysis.
 
+CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with another Nerra Network show, and ONLY in the closing or final lesson segment, single sentence max):
+- Tesla / EV / TSLA-specific stories → "For deeper Tesla coverage, check out Tesla Shorts Time on the Nerra Network."
+- AI policy / large platform / regulation → "Models & Agents covers the AI side daily."
+- Environmental / climate policy → "Environmental Intelligence covers the regulatory angle."
+- Investing / economic stories → "Modern Investing Techniques covers market mechanics in depth."
+- Historical parallels — incentive design, policy backfire → "Unintended Consequences profiles case studies of well-meant policies that produced surprising results."
+If today's topic doesn't naturally overlap with any of these, omit the cross-promo entirely. NEVER force a connection. The point is to help listeners discover sister shows they'd genuinely enjoy, not to fill slots.
+
 DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
 
 You may sparingly include Grok TTS speech tags to make narration feel more

--- a/shows/prompts/planetterrian_podcast.txt
+++ b/shows/prompts/planetterrian_podcast.txt
@@ -117,6 +117,14 @@ WHAT TO SKIP (do NOT read aloud):
 LENGTH TARGET:
 Your script must be at least 2400 words (60+ sentences). If you find yourself finishing early, go back and expand each story.
 
+CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with another Nerra Network show, and ONLY in the closing or final lesson segment, single sentence max):
+- Space / astronomy / cosmology → "Fascinating Frontiers covers the latest from space and astronomy."
+- AI in biotech / drug discovery / medical AI → "Models & Agents covers the AI side daily."
+- Environmental health / pollution / climate medicine → "Environmental Intelligence covers the regulatory side daily."
+- World context — health policy, pandemics, biotech regulation → "Omni View has today's full briefing."
+- Medical / scientific cautionary tales — thalidomide, lobotomy, opioid crisis class stories → "Unintended Consequences profiles case studies of well-meant medical interventions that backfired."
+If today's topic doesn't naturally overlap with any of these, omit the cross-promo entirely. NEVER force a connection. The point is to help listeners discover sister shows they'd genuinely enjoy, not to fill slots.
+
 DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
 
 You may sparingly include Grok TTS speech tags to make narration feel more

--- a/shows/prompts/privet_russian_podcast.txt
+++ b/shows/prompts/privet_russian_podcast.txt
@@ -126,6 +126,11 @@ Target: 60-90 seconds of audio.
 Use this exact closing (do not rewrite it):
 {closing_block}
 
+CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with another Nerra Network show, and ONLY in the closing or final lesson segment, single sentence max):
+- Russian-language financial literacy for newcomers → "Финансы Просто covers personal finance for women in Canada."
+- World news / current events → "Omni View has today's balanced briefing."
+If today's topic doesn't naturally overlap with any of these, omit the cross-promo entirely. NEVER force a connection. The point is to help listeners discover sister shows they'd genuinely enjoy, not to fill slots.
+
 DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
 
 You may sparingly include Grok TTS speech tags to make narration feel more

--- a/shows/prompts/tesla_podcast.txt
+++ b/shows/prompts/tesla_podcast.txt
@@ -114,6 +114,14 @@ WHAT TO SKIP (do not read aloud):
 LENGTH TARGET:
 Your script must be at least 2800 words (70+ sentences). If you find yourself finishing early, go back and expand each story — add more context, explain the engineering or business implications, and share your perspective.
 
+CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with another Nerra Network show, and ONLY in the closing or final lesson segment, single sentence max):
+- AI / tech topics → "For daily AI news, check out Models & Agents on the Nerra Network."
+- Investing / TSLA-specific market context → "Modern Investing Techniques covers market mechanics and TFSA strategy daily."
+- Environmental / energy policy angles → "Environmental Intelligence covers the regulatory side daily."
+- Cautionary tales — incentive design, regulatory backfire, tech consequences → "Unintended Consequences profiles case studies of well-meant ideas that backfired."
+- World context — geopolitics, trade, supply chain → "Omni View has today's full briefing."
+If today's topic doesn't naturally overlap with any of these, omit the cross-promo entirely. NEVER force a connection. The point is to help listeners discover sister shows they'd genuinely enjoy, not to fill slots.
+
 DELIVERY — Grok TTS speech tags (audio only; never appear in blog/RSS)
 
 You may sparingly include Grok TTS speech tags to make narration feel more

--- a/tests/test_cross_network_dedup.py
+++ b/tests/test_cross_network_dedup.py
@@ -42,6 +42,22 @@ NEWS_SHOW_DIGEST_PROMPTS = [
     "privet_russian_digest.txt",
 ]
 
+# Podcast prompts (one per show including UC's narrative path) that
+# should encourage cross-show promos when the topic genuinely overlaps.
+ALL_PODCAST_PROMPTS = [
+    "tesla_podcast.txt",
+    "omni_view_podcast.txt",
+    "planetterrian_podcast.txt",
+    "fascinating_frontiers_podcast.txt",
+    "env_intel_podcast.txt",
+    "models_agents_podcast.txt",
+    "mab_podcast.txt",
+    "modern_investing_podcast.txt",
+    "fp_podcast.txt",
+    "privet_russian_podcast.txt",
+    "unintended_consequences_podcast.txt",
+]
+
 
 @pytest.mark.parametrize("prompt_name", NEWS_SHOW_DIGEST_PROMPTS)
 def test_news_show_digest_uses_cross_show_context(prompt_name):
@@ -58,6 +74,31 @@ def test_news_show_digest_uses_cross_show_context(prompt_name):
         f"The runner builds this signal but the LLM will never see it. "
         f"Add a CROSS-NETWORK CONTEXT block — see Phase 1.1 in the audit "
         f"plan or any sister show's digest prompt for the standard wording."
+    )
+
+
+@pytest.mark.parametrize("prompt_name", ALL_PODCAST_PROMPTS)
+def test_podcast_prompt_has_cross_promo_block(prompt_name):
+    """Every podcast prompt (across all 11 shows) must include a
+    CROSS-PROMO block telling the LLM when to mention sister shows.
+
+    Phase 1.3 of the May 2026 audit added this — without it, only UC
+    encouraged cross-promos and the network felt like 11 silos. The
+    rule is: ONLY mention sister shows when the topic genuinely
+    overlaps, ONLY in the closing/lesson segment, single sentence
+    max. Each show's prompt has its own list of relevant pairings.
+    """
+    text = (PROMPTS_DIR / prompt_name).read_text(encoding="utf-8")
+    assert "CROSS-PROMO" in text, (
+        f"{prompt_name} doesn't have a CROSS-PROMO block. Without "
+        f"it, the show won't mention sister shows even when the topic "
+        f"genuinely overlaps. See Phase 1.3 of the audit plan or any "
+        f"other show's podcast prompt for the standard wording."
+    )
+    # Must explicitly forbid forced cross-promos to keep them rare.
+    assert "NEVER force a connection" in text, (
+        f"{prompt_name}'s CROSS-PROMO block is missing the 'NEVER force "
+        f"a connection' guard. Without it, the LLM will over-cross-promo."
     )
 
 


### PR DESCRIPTION
**Phase 1.3** of the audit. Adds tailored CROSS-PROMO blocks to the 10 podcast prompts that were missing them — only UC had one before.

## What I changed

Each of the 10 missing shows gets a tailored block listing 3-5 sister-show pairings relevant to *that show's* topic mix, plus a hard "NEVER force a connection" guard. Rule everywhere: only mention sister shows when topic genuinely overlaps, only in closing/lesson segment, single sentence max.

Examples of tailored pairings:
- **Tesla** → Models & Agents (AI), Modern Investing (TSLA), Environmental Intelligence (energy policy), Unintended Consequences (incentive design), Omni View (geopolitics)
- **Env Intel** → Tesla Shorts Time (EV policy), Fascinating Frontiers / Planetterrian (climate science), Modern Investing (green finance), Unintended Consequences (DDT / leaded gasoline class stories), Omni View (climate diplomacy)
- **Planetterrian** → Fascinating Frontiers (space), Models & Agents (medical AI), Env Intel (env health), Unintended Consequences (thalidomide / lobotomy class), Omni View (health policy)
- **MAB** → Models & Agents (professional version), Omni View (world news), Unintended Consequences (tech cautionary tales)
- **FP / Privet** → cross-pair each other + English-language complements

## Drift guards

12 new parametrized tests in `test_cross_network_dedup.py`:
- Every podcast prompt (all 11) must contain `CROSS-PROMO`
- Every prompt must contain `NEVER force a connection` so guidance stays restrained

## Test plan
- [x] 22 cross-network tests passing (was 11)
- [ ] **Tomorrow's episodes**: across the 11 shows, see whether cross-promo mentions land naturally on overlapping topics (e.g., a Tesla policy story ending with one sentence pointing to UC; an Env Intel pollution story pointing to Planetterrian's health angle). False-positive case: an obvious-topic story without an overlap shouldn't get a forced cross-promo.

## Coming next
Phase 1.4+1.5 (copy sweep + scaffold prevention) → Phase 1.6 (tag-leak detector) → Phase 1.8 (UC re-render).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_