### PR TITLE
Phase 1.6: tag-leak regression detector + post-Whisper integration

### DIFF
--- a/engine/tag_leak_detector.py
+++ b/engine/tag_leak_detector.py
@@ -1,0 +1,194 @@
+"""Tag-leak regression detector for Whisper-transcribed podcast audio.
+
+When Grok TTS fails to consume a speech tag (because the tag isn't in
+its documented set, or is malformed, or is wrapped weirdly), the
+listener hears the tag as literal spoken text. The May 2026
+``<build-intensity>`` regression cost a full network day before the
+operator caught it by ear; a regex scan of the Whisper transcript
+would have flagged it on the first episode.
+
+This module is the post-pipeline sentinel:
+
+  - ``scan_transcript(path)`` returns a list of ``Leak`` records, one
+    per match with line number + matched substring + pattern name.
+
+  - ``count_leaks(path)`` returns just the integer count (used for
+    metrics).
+
+  - ``LEAK_PATTERNS`` is the public regex registry; tests pin both
+    the patterns themselves AND their behaviour against real
+    fixtures.
+
+The detector is **prose-aware** — words like "emphasis" appear
+legitimately in news prose ("Tesla's emphasis on robotics") and we
+must not flag those. Each pattern includes a positive context guard
+that requires the surrounding text to look like a leaked tag (e.g.,
+the word ``intensity`` only flags when paired with ``build`` in the
+specific tag-shape that Grok produces when it fails).
+
+Reuses the documented Grok tag inventory from ``engine/utils.py`` so
+the patterns are kept in sync with the strip-side.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Pattern, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Leak:
+    """A single suspected tag-leak detection.
+
+    Attributes
+    ----------
+    pattern_name:
+        Human-readable name from ``LEAK_PATTERNS``. Used for metrics
+        + the operator's dashboard ("seen 3 build-intensity leaks
+        this week").
+    line_no:
+        1-indexed line number in the transcript where the match was
+        found.
+    snippet:
+        ~80-char window around the match for operator triage.
+    matched:
+        The exact substring that triggered the regex.
+    """
+
+    pattern_name: str
+    line_no: int
+    snippet: str
+    matched: str
+
+
+# Each entry: (compiled-regex, human-readable-name).
+# Regexes are case-insensitive. The patterns are deliberately
+# narrow to avoid false-positives on legitimate prose that happens
+# to share keywords with Grok tags.
+_RAW_PATTERNS: List[Tuple[str, str]] = [
+    # `<build-intensity>` was the network's wrap May 3-4 2026; Grok
+    # spoke it as "build intensity" or, in word-corrupted form,
+    # "build intended" / "build intending". Whisper sometimes
+    # transcribes the same audio as "build intensity" and sometimes
+    # as "build intended" depending on the surrounding phonetic
+    # context — both shapes caught here.
+    (r"\bbuild[ -]inten(?:sity|ded|ding|sified)\b", "build-intensity"),
+    # `<long-pause>` / `[long-pause]` — Grok occasionally speaks
+    # these as "long pause" (two words) or "long-pause" (hyphenated)
+    # when it fails to consume the tag.
+    (r"\blong[ -]pause\b", "long-pause"),
+    # `[breath]` — the most common bracketed inline tag. Whisper
+    # transcribes leaks as the literal word "breath" mid-sentence.
+    # Bare-word matches are too noisy ("breathtaking", "breathing")
+    # so we look for "breath" surrounded by sentence-boundary
+    # punctuation, which is how a leaked bracketed tag would appear.
+    (r"(?:^|[.!?]\s+)breath(?:\s+|[.!?]|$)", "breath"),
+    # `<emphasis>` — same word-boundary problem. Real prose uses
+    # "emphasis on X" / "Tesla's emphasis on robotics" all the time.
+    # Only flag when the surrounding shape suggests a tag-leak: the
+    # word "emphasis" alone surrounded by sentence boundaries with
+    # no preposition (no "on", "of", "in") near it.
+    (r"(?:^|[.!?]\s+)emphasis(?:\s*[.!?]|\s+(?!on|of|in|for|over|with))",
+     "emphasis"),
+    # Stray angle-bracket fragments from any TTS tag that escaped
+    # consumption. Pattern: `<word>` or `</word>` left in transcript
+    # text (Whisper sometimes preserves them when they're spoken).
+    (r"<\s*/?\s*[a-z][a-z-]{2,}\s*>", "stray-angle-bracket-tag"),
+    # Stray bracketed-tag fragments. Pattern: `[word]` where word
+    # is a known TTS-tag-shape (3+ chars, all lowercase / hyphens)
+    # left in the transcript text. Rare, but covers the case where
+    # Whisper transcribes both the bracket and the contents.
+    (r"\[\s*(?:pause|breath|sigh|gasp|laugh|cry|sniff|kiss|"
+     r"throat-clear|long-pause)\s*\]", "stray-bracketed-tag"),
+]
+
+LEAK_PATTERNS: List[Tuple[Pattern[str], str]] = [
+    (re.compile(rx, flags=re.IGNORECASE), name)
+    for rx, name in _RAW_PATTERNS
+]
+
+
+def _snippet_around(text: str, start: int, end: int, width: int = 80) -> str:
+    """Return ~width chars of text centered on the match."""
+    lo = max(0, start - width // 2)
+    hi = min(len(text), end + width // 2)
+    snip = text[lo:hi].replace("\n", " ")
+    if lo > 0:
+        snip = "…" + snip
+    if hi < len(text):
+        snip = snip + "…"
+    return snip.strip()
+
+
+def scan_transcript(path: Path) -> List[Leak]:
+    """Return every suspected tag-leak in ``path``.
+
+    Empty/missing transcript returns an empty list (caller treats as
+    a no-op — tag-leak detection is best-effort and never blocks
+    the pipeline on the first week).
+    """
+    if not path.exists():
+        logger.debug("Tag-leak detector: transcript missing at %s", path)
+        return []
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if not text.strip():
+        return []
+
+    # Compute line offsets once so we can map character match
+    # positions back to 1-indexed line numbers.
+    line_starts: List[int] = [0]
+    for i, ch in enumerate(text):
+        if ch == "\n":
+            line_starts.append(i + 1)
+
+    def line_of(pos: int) -> int:
+        # Binary search would be faster but transcripts are <500
+        # lines; linear is fine and clearer.
+        for ln, start in enumerate(line_starts):
+            if start > pos:
+                return ln  # 1-indexed because line_starts[0] is line 1's start
+        return len(line_starts)
+
+    leaks: List[Leak] = []
+    seen: set = set()  # dedupe overlapping match spans
+    for pattern, name in LEAK_PATTERNS:
+        for m in pattern.finditer(text):
+            key = (m.start(), m.end(), name)
+            if key in seen:
+                continue
+            seen.add(key)
+            leaks.append(Leak(
+                pattern_name=name,
+                line_no=line_of(m.start()),
+                snippet=_snippet_around(text, m.start(), m.end()),
+                matched=m.group(0).strip(),
+            ))
+    return leaks
+
+
+def count_leaks(path: Path) -> int:
+    """Return just the leak count — convenience wrapper for metrics."""
+    return len(scan_transcript(path))
+
+
+def summarize_leaks(leaks: List[Leak]) -> str:
+    """Format a leak list for log output / metrics."""
+    if not leaks:
+        return "no tag leaks detected"
+    by_name: dict = {}
+    for leak in leaks:
+        by_name.setdefault(leak.pattern_name, []).append(leak)
+    parts = []
+    for name in sorted(by_name):
+        cnt = len(by_name[name])
+        first = by_name[name][0]
+        parts.append(
+            f"{name}={cnt} (line {first.line_no}: {first.matched!r})"
+        )
+    return "; ".join(parts)

--- a/run_show.py
+++ b/run_show.py
@@ -1801,6 +1801,45 @@ def run(args: argparse.Namespace) -> None:
             except Exception as exc:
                 logger.warning("Transcript generation failed (non-fatal): %s", exc)
 
+            # 9c. Tag-leak regression detector — scan the Whisper
+            # transcript for tag-as-text bleeds (the May 2026
+            # ``<build-intensity>`` regression cost a full network
+            # day before being caught by ear). Best-effort: log
+            # warning + record metric; never blocks the pipeline.
+            # Will flip to hard-block once false-positive rate is
+            # calibrated (see audit plan Phase 1.6).
+            try:
+                from engine.tag_leak_detector import (
+                    scan_transcript, summarize_leaks,
+                )
+                _ep_prefix_t = (
+                    f"{config.episode.prefix}_Ep{episode_num:03d}_"
+                    f"{today:%Y%m%d}"
+                )
+                _transcript_txt = digests_dir / f"{_ep_prefix_t}_transcript.txt"
+                _leaks = scan_transcript(_transcript_txt)
+                metrics.record("tag_leaks", len(_leaks))
+                if _leaks:
+                    logger.warning(
+                        "Tag-leak detector flagged %d suspect line(s) in "
+                        "%s — %s",
+                        len(_leaks),
+                        _transcript_txt.name,
+                        summarize_leaks(_leaks),
+                    )
+                    # Record per-pattern counts so the dashboard can
+                    # show which leak families are still recurring.
+                    _by_pattern: dict = {}
+                    for _leak in _leaks:
+                        _by_pattern[_leak.pattern_name] = (
+                            _by_pattern.get(_leak.pattern_name, 0) + 1
+                        )
+                    metrics.record("tag_leaks_by_pattern", _by_pattern)
+                else:
+                    logger.info("Tag-leak detector: clean transcript.")
+            except Exception as exc:
+                logger.debug("Tag-leak detector failed (non-fatal): %s", exc)
+
             # 10. Audio mixing
             from engine.audio import get_audio_duration, mix_with_music, normalize_voice
 

--- a/tests/test_tag_leak_detector.py
+++ b/tests/test_tag_leak_detector.py
@@ -1,0 +1,232 @@
+"""Tests for engine.tag_leak_detector.
+
+Two layers:
+
+1. Synthetic tests — clean transcripts produce zero leaks; leaky
+   transcripts produce the expected count. False-positive prose
+   stays clean (the most important guarantee).
+
+2. Real-world fixtures — UC Ep001 (known 2 build-intensity leaks)
+   and Tesla Ep461 (known build-intensity bleed) reproduce the
+   leak counts the operator caught by ear. These are the cases
+   the detector was built for.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Synthetic — happy path + false-positive guards
+# ---------------------------------------------------------------------------
+
+class TestSyntheticTranscripts:
+
+    def test_clean_transcript_returns_zero_leaks(self, tmp_path: Path):
+        from engine.tag_leak_detector import scan_transcript, count_leaks
+        p = tmp_path / "t.txt"
+        p.write_text(
+            "Welcome to today's episode. Here is the news. "
+            "We're going to discuss three stories. The first is about Tesla. "
+            "Thanks for listening.",
+            encoding="utf-8",
+        )
+        assert count_leaks(p) == 0
+        assert scan_transcript(p) == []
+
+    def test_legitimate_emphasis_prose_does_not_flag(self, tmp_path: Path):
+        """The word 'emphasis' appears legitimately in news prose
+        ('Tesla's emphasis on robotics', 'an emphasis on safety').
+        These must NOT trigger the detector."""
+        from engine.tag_leak_detector import count_leaks
+        p = tmp_path / "t.txt"
+        p.write_text(
+            "Tesla's emphasis on robotics is the lede here. "
+            "There is also an emphasis on safety in this report. "
+            "The emphasis of the talk was clear. "
+            "Many companies place an emphasis on quality.",
+            encoding="utf-8",
+        )
+        assert count_leaks(p) == 0, (
+            "Legitimate 'emphasis on / of / in / for' prose was "
+            "flagged — false-positive guard regressed."
+        )
+
+    def test_legitimate_breath_prose_does_not_flag(self, tmp_path: Path):
+        """'breathtaking' / 'breathing' / 'breath of' in normal prose
+        must not trigger."""
+        from engine.tag_leak_detector import count_leaks
+        p = tmp_path / "t.txt"
+        p.write_text(
+            "It was a breathtaking discovery. "
+            "Heavy breathing was reported by witnesses. "
+            "He took a breath of fresh air outside. "
+            "The breathwork community embraced the technique.",
+            encoding="utf-8",
+        )
+        assert count_leaks(p) == 0
+
+    def test_legitimate_long_pause_in_prose_does_flag(self, tmp_path: Path):
+        """The phrase 'long pause' appears in tag-leak shape.
+        Without context disambiguation the detector flags it. This
+        is acceptable false-positive behaviour for week 1; once
+        calibrated we can tighten if needed."""
+        from engine.tag_leak_detector import count_leaks
+        p = tmp_path / "t.txt"
+        p.write_text(
+            "The senator took a long pause before responding.",
+            encoding="utf-8",
+        )
+        # Yes — flagged. Operator will see this in the dashboard;
+        # if it's a recurring false-positive we tighten the regex.
+        assert count_leaks(p) == 1
+
+    def test_build_intensity_leak_detected(self, tmp_path: Path):
+        from engine.tag_leak_detector import scan_transcript
+        p = tmp_path / "t.txt"
+        p.write_text(
+            "Welcome to today's episode. Build intensity. "
+            "Today we'll discuss three stories.",
+            encoding="utf-8",
+        )
+        leaks = scan_transcript(p)
+        assert len(leaks) == 1
+        assert leaks[0].pattern_name == "build-intensity"
+        assert "build intensity" in leaks[0].matched.lower()
+
+    def test_build_intended_corruption_detected(self, tmp_path: Path):
+        """When Whisper hears the trailing closing wrap as 'build
+        intended to dig' (UC Ep001 line 127), the detector should
+        catch the 'build intended' shape."""
+        from engine.tag_leak_detector import scan_transcript
+        p = tmp_path / "t.txt"
+        p.write_text(
+            "I'm Patrick and Vancouver, build intended to dig.",
+            encoding="utf-8",
+        )
+        leaks = scan_transcript(p)
+        assert len(leaks) == 1
+        assert leaks[0].pattern_name == "build-intensity"
+
+    def test_stray_angle_bracket_tag_detected(self, tmp_path: Path):
+        """If a TTS tag escapes consumption and ends up rendered
+        in the transcript (`<emphasis>` left as text), flag it."""
+        from engine.tag_leak_detector import scan_transcript
+        p = tmp_path / "t.txt"
+        p.write_text(
+            "He spoke of <emphasis>three</emphasis> reasons.",
+            encoding="utf-8",
+        )
+        leaks = scan_transcript(p)
+        # Should match opening <emphasis> and closing </emphasis>.
+        names = {leak.pattern_name for leak in leaks}
+        assert "stray-angle-bracket-tag" in names
+
+
+# ---------------------------------------------------------------------------
+# Real-world fixtures — the cases the detector was built to catch
+# ---------------------------------------------------------------------------
+
+class TestRealWorldFixtures:
+    """Run the detector against actual transcripts the operator
+    flagged. If these counts ever drop to zero, either the wrap fix
+    landed (good) OR the detector regressed (bad — investigate)."""
+
+    def test_uc_ep001_finds_two_build_intensity_leaks(self):
+        """UC Ep001 transcript has 'Build intensity.' on line 3 and
+        'build intended to dig' on line 127 — both are
+        ``<build-intensity>`` wrap leaks."""
+        from engine.tag_leak_detector import scan_transcript
+        path = (REPO_ROOT / "digests" / "unintended_consequences"
+                / "Unintended_Consequences_Ep001_20260504_transcript.txt")
+        if not path.exists():
+            pytest.skip("UC Ep001 transcript fixture not present")
+
+        leaks = scan_transcript(path)
+        bi_leaks = [
+            leak for leak in leaks if leak.pattern_name == "build-intensity"
+        ]
+        assert len(bi_leaks) == 2, (
+            f"Expected 2 build-intensity leaks in UC Ep001, got "
+            f"{len(bi_leaks)}: {[(l.line_no, l.matched) for l in bi_leaks]}"
+        )
+        line_numbers = {leak.line_no for leak in bi_leaks}
+        assert 3 in line_numbers, "Line 3 leak ('Build intensity.') missed"
+        assert 127 in line_numbers, "Line 127 leak ('build intended') missed"
+
+    def test_tesla_ep461_finds_build_intensity_leak(self):
+        """Tesla Ep461 transcript line 112 has the wrap leak."""
+        from engine.tag_leak_detector import scan_transcript
+        path = (REPO_ROOT / "digests" / "tesla_shorts_time"
+                / "Tesla_Shorts_Time_Pod_Ep461_20260503_transcript.txt")
+        if not path.exists():
+            pytest.skip("Tesla Ep461 transcript fixture not present")
+
+        leaks = scan_transcript(path)
+        bi_leaks = [
+            leak for leak in leaks if leak.pattern_name == "build-intensity"
+        ]
+        assert len(bi_leaks) >= 1, (
+            f"Expected at least 1 build-intensity leak in Tesla Ep461, "
+            f"got {len(bi_leaks)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# API surface
+# ---------------------------------------------------------------------------
+
+class TestAPISurface:
+
+    def test_count_leaks_matches_scan_transcript_length(self, tmp_path: Path):
+        from engine.tag_leak_detector import scan_transcript, count_leaks
+        p = tmp_path / "t.txt"
+        p.write_text("Build intensity. Long pause. Build intensity.",
+                     encoding="utf-8")
+        assert count_leaks(p) == len(scan_transcript(p))
+
+    def test_missing_transcript_returns_empty(self, tmp_path: Path):
+        from engine.tag_leak_detector import scan_transcript, count_leaks
+        nonexistent = tmp_path / "no_such_file.txt"
+        assert scan_transcript(nonexistent) == []
+        assert count_leaks(nonexistent) == 0
+
+    def test_summarize_leaks_groups_by_pattern(self, tmp_path: Path):
+        from engine.tag_leak_detector import scan_transcript, summarize_leaks
+        p = tmp_path / "t.txt"
+        p.write_text(
+            "Build intensity. Build intensity. Long pause. ",
+            encoding="utf-8",
+        )
+        leaks = scan_transcript(p)
+        summary = summarize_leaks(leaks)
+        assert "build-intensity=2" in summary
+        assert "long-pause=1" in summary
+
+    def test_summarize_empty_leaks(self):
+        from engine.tag_leak_detector import summarize_leaks
+        assert summarize_leaks([]) == "no tag leaks detected"
+
+
+# ---------------------------------------------------------------------------
+# Runner integration — non-blocking, always records metric
+# ---------------------------------------------------------------------------
+
+def test_runner_imports_tag_leak_detector():
+    """``run_show.py`` imports and uses the detector after Whisper.
+    Drift guard so refactors don't accidentally remove the wiring."""
+    runner = (REPO_ROOT / "run_show.py").read_text(encoding="utf-8")
+    assert "from engine.tag_leak_detector import" in runner, (
+        "run_show.py no longer imports tag_leak_detector — the "
+        "post-Whisper sentinel is silently disabled."
+    )
+    assert 'metrics.record("tag_leaks"' in runner, (
+        "run_show.py no longer records tag_leaks metric — operator "
+        "loses visibility into tag-leak rate over time."
+    )


### PR DESCRIPTION
**Phase 1.6** of the audit. The post-Whisper sentinel that would have caught the `<build-intensity>` regression on the first episode instead of after a full network day.

## What ships

**`engine/tag_leak_detector.py`** (~150 lines):
- `LEAK_PATTERNS` regex registry (build-intensity, long-pause, stray bracketed tags, stray angle-bracket tags, prose-aware emphasis/breath)
- `scan_transcript(path)` → list of `Leak` records (line number + snippet + matched substring + pattern name)
- `count_leaks(path)` for metrics
- `summarize_leaks(leaks)` for log output

**Runner integration** — fires immediately after Whisper produces `*_transcript.txt`. Records `tag_leaks` (int) and `tag_leaks_by_pattern` (dict) in metrics. Logs WARNING with summary when leaks > 0. **Best-effort, never blocks** — will flip to hard-block after week 1 false-positive calibration.

## False-positive guards (the critical property)

- ✅ "Tesla's emphasis on robotics" — does NOT flag (preposition guard)
- ✅ "breathtaking" / "breathing" / "breath of fresh air" — does NOT flag (sentence-boundary guard)
- ⚠️ "the senator took a long pause" — DOES flag (acceptable for week 1; tighten if recurring)

## Real-world fixtures

- **UC Ep001 transcript**: detector finds the 2 known leaks (line 3 "Build intensity.", line 127 "build intended to dig" — Whisper mishear of the closing wrap)
- **Tesla Ep461 transcript**: detector finds the line-112 leak

If these fixture counts ever drop to 0, either the fix landed permanently (good) OR the detector regressed (investigate).

## Test plan
- [x] 14 new tests passing — synthetic happy path, false-positive guards, real-world fixtures, runner integration drift guard
- [x] Full suite: **1565 passing** (was 1551 + 14 new), 2 pre-existing `google.oauth2` failures unrelated
- [ ] **Tomorrow's episodes**: every show's `metrics_ep*.json` includes `tag_leaks: 0` (post-`<build-intensity>` removal). Any non-zero count gets logged for operator review.

## Coming next
Phase 1.8 — UC Ep001 re-render with all Phase 1 fixes applied. Once that's done, Phase 2 begins (cross-network briefing scheduling, contrast hard-block, subject lines, featured-episode block, blog hooks, dashboard cards).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_