### PR TITLE
Phase 2: cross-network briefing + subject-line + featured-ep + dashboard cards

### DIFF
--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -77,12 +77,21 @@ jobs:
           fi
           python scripts/run_weekly_newsletters.py $ARGS
 
+      - name: Generate cross-network intelligence briefing
+        # Editorial synthesis across all 11 shows for the past 7 days.
+        # Output: outputs/cross_network/cross_network_briefing_<YYYY-WW>.md.
+        # The synthesizer skips when fewer than 10 episodes are in
+        # window, so the script is no-op friendly.
+        env:
+          GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+        run: python scripts/run_cross_network_briefing.py
+
       - name: Commit newsletters
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add outputs/newsletters/
-          git diff --cached --quiet || git commit -m "Add weekly newsletters for $(date -I)"
+          git add outputs/newsletters/ outputs/cross_network/ 2>/dev/null || true
+          git diff --cached --quiet || git commit -m "Add weekly newsletters + cross-network briefing for $(date -I)"
           for attempt in 1 2 3 4; do
             git pull --rebase origin main && git push origin main && exit 0
             echo "Push failed (attempt $attempt), retrying in $((attempt * 2))s..."

--- a/api/dashboard.json
+++ b/api/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T16:59:01.426957+00:00",
+  "generated_at": "2026-05-04T18:20:06.056725+00:00",
   "network": {
     "landmines_counts": {
       "ok": 6,
@@ -8,8 +8,8 @@
     },
     "shows_count": 11,
     "stale_shows": 1,
-    "total_cost_last_7_days_usd": 49.8957,
-    "total_cost_last_30_days_usd": 253.9576,
+    "total_cost_last_7_days_usd": 49.8357,
+    "total_cost_last_30_days_usd": 253.8976,
     "shows": [
       {
         "slug": "env_intel",
@@ -191,12 +191,12 @@
         "blog_page": "blog/unintended_consequences/index.html",
         "newsletter_enabled": true,
         "x_enabled": false,
-        "latest_pub_date": "2026-05-04T08:00:00+00:00",
+        "latest_pub_date": null,
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.0601,
-        "episodes_last_7_days": 1,
-        "p50_pipeline_s": 48.46,
-        "success_rate": 1.0
+        "cost_last_7_days_usd": 0.0,
+        "episodes_last_7_days": 0,
+        "p50_pipeline_s": 0.0,
+        "success_rate": 0.0
       }
     ]
   },
@@ -320,7 +320,7 @@
       "details": "11 MP3s tracked in git, digests/ is 638 MB. Above comfort threshold — keep an eye on it.",
       "evidence": {
         "tracked_mp3_count": 11,
-        "digests_mb": 638.1
+        "digests_mb": 637.8
       }
     },
     {
@@ -348,8 +348,8 @@
         "total": 95,
         "by_extension": {
           ".json": 47,
-          ".py": 3,
-          ".txt": 45
+          ".txt": 45,
+          ".py": 3
         },
         "previous_total": 95
       }
@@ -1884,36 +1884,31 @@
       },
       "unintended_consequences": {
         "last_7_days": {
-          "grok": 0.0148,
-          "tts": 0.0453,
-          "total": 0.0601,
-          "episodes": 1
+          "grok": 0.0,
+          "tts": 0.0,
+          "total": 0.0,
+          "episodes": 0
         },
         "last_30_days": {
-          "grok": 0.0148,
-          "tts": 0.0453,
-          "total": 0.0601,
-          "episodes": 1
+          "grok": 0.0,
+          "tts": 0.0,
+          "total": 0.0,
+          "episodes": 0
         },
-        "daily_series": [
-          [
-            "2026-05-04",
-            0.0601
-          ]
-        ]
+        "daily_series": []
       }
     },
     "network_last_7_days": {
-      "grok": 2.8171,
-      "tts": 47.0787,
-      "total": 49.8957,
-      "episodes": 52
+      "grok": 2.8023,
+      "tts": 47.0334,
+      "total": 49.8357,
+      "episodes": 51
     },
     "network_last_30_days": {
-      "grok": 11.3953,
-      "tts": 242.5623,
-      "total": 253.9576,
-      "episodes": 166
+      "grok": 11.3806,
+      "tts": 242.517,
+      "total": 253.8976,
+      "episodes": 165
     }
   },
   "pipeline_health": {
@@ -2006,7 +2001,19 @@
         "long_form_success_rate": 0.0,
         "shorts_attempts": 0,
         "shorts_uploaded": 0,
-        "shorts_success_rate": 0.0
+        "shorts_success_rate": 0.0,
+        "long_form_errors": []
+      },
+      "weekly_recap": {
+        "attempts": 0,
+        "synthesised": 0,
+        "success_rate": 0.0
+      },
+      "tag_leaks": {
+        "episodes_with_leaks": 0,
+        "total_leaks": 0,
+        "by_pattern": {},
+        "rate": 0.0
       }
     },
     "fascinating_frontiers": {
@@ -2098,7 +2105,25 @@
         "long_form_success_rate": 0.5,
         "shorts_attempts": 2,
         "shorts_uploaded": 1,
-        "shorts_success_rate": 0.5
+        "shorts_success_rate": 0.5,
+        "long_form_errors": [
+          {
+            "type": "ResumableUploadError",
+            "status": 400,
+            "message": "<HttpError 400 when requesting None returned \"The request metadata specifies an invalid video description.\". Details: \"[{'message': 'The request metadata specifies an invalid video description.', 'domain': 'youtube.video', 'reason': 'invalidDescription', 'location': 'body.snippet.description', 'loca"
+          }
+        ]
+      },
+      "weekly_recap": {
+        "attempts": 0,
+        "synthesised": 0,
+        "success_rate": 0.0
+      },
+      "tag_leaks": {
+        "episodes_with_leaks": 0,
+        "total_leaks": 0,
+        "by_pattern": {},
+        "rate": 0.0
       }
     },
     "finansy_prosto": {
@@ -2191,7 +2216,19 @@
         "long_form_success_rate": 0.0,
         "shorts_attempts": 0,
         "shorts_uploaded": 0,
-        "shorts_success_rate": 0.0
+        "shorts_success_rate": 0.0,
+        "long_form_errors": []
+      },
+      "weekly_recap": {
+        "attempts": 0,
+        "synthesised": 0,
+        "success_rate": 0.0
+      },
+      "tag_leaks": {
+        "episodes_with_leaks": 0,
+        "total_leaks": 0,
+        "by_pattern": {},
+        "rate": 0.0
       }
     },
     "models_agents": {
@@ -2282,7 +2319,19 @@
         "long_form_success_rate": 0.0,
         "shorts_attempts": 0,
         "shorts_uploaded": 0,
-        "shorts_success_rate": 0.0
+        "shorts_success_rate": 0.0,
+        "long_form_errors": []
+      },
+      "weekly_recap": {
+        "attempts": 0,
+        "synthesised": 0,
+        "success_rate": 0.0
+      },
+      "tag_leaks": {
+        "episodes_with_leaks": 0,
+        "total_leaks": 0,
+        "by_pattern": {},
+        "rate": 0.0
       }
     },
     "models_agents_beginners": {
@@ -2373,7 +2422,25 @@
         "long_form_success_rate": 0.5,
         "shorts_attempts": 2,
         "shorts_uploaded": 2,
-        "shorts_success_rate": 1.0
+        "shorts_success_rate": 1.0,
+        "long_form_errors": [
+          {
+            "type": "ResumableUploadError",
+            "status": 400,
+            "message": "<HttpError 400 when requesting None returned \"The request metadata specifies an invalid video description.\". Details: \"[{'message': 'The request metadata specifies an invalid video description.', 'domain': 'youtube.video', 'reason': 'invalidDescription', 'location': 'body.snippet.description', 'loca"
+          }
+        ]
+      },
+      "weekly_recap": {
+        "attempts": 0,
+        "synthesised": 0,
+        "success_rate": 0.0
+      },
+      "tag_leaks": {
+        "episodes_with_leaks": 0,
+        "total_leaks": 0,
+        "by_pattern": {},
+        "rate": 0.0
       }
     },
     "modern_investing": {
@@ -2465,7 +2532,19 @@
         "long_form_success_rate": 0.0,
         "shorts_attempts": 0,
         "shorts_uploaded": 0,
-        "shorts_success_rate": 0.0
+        "shorts_success_rate": 0.0,
+        "long_form_errors": []
+      },
+      "weekly_recap": {
+        "attempts": 0,
+        "synthesised": 0,
+        "success_rate": 0.0
+      },
+      "tag_leaks": {
+        "episodes_with_leaks": 0,
+        "total_leaks": 0,
+        "by_pattern": {},
+        "rate": 0.0
       }
     },
     "omni_view": {
@@ -2557,7 +2636,19 @@
         "long_form_success_rate": 0.0,
         "shorts_attempts": 0,
         "shorts_uploaded": 0,
-        "shorts_success_rate": 0.0
+        "shorts_success_rate": 0.0,
+        "long_form_errors": []
+      },
+      "weekly_recap": {
+        "attempts": 0,
+        "synthesised": 0,
+        "success_rate": 0.0
+      },
+      "tag_leaks": {
+        "episodes_with_leaks": 0,
+        "total_leaks": 0,
+        "by_pattern": {},
+        "rate": 0.0
       }
     },
     "planetterrian": {
@@ -2649,7 +2740,19 @@
         "long_form_success_rate": 0.0,
         "shorts_attempts": 0,
         "shorts_uploaded": 0,
-        "shorts_success_rate": 0.0
+        "shorts_success_rate": 0.0,
+        "long_form_errors": []
+      },
+      "weekly_recap": {
+        "attempts": 0,
+        "synthesised": 0,
+        "success_rate": 0.0
+      },
+      "tag_leaks": {
+        "episodes_with_leaks": 0,
+        "total_leaks": 0,
+        "by_pattern": {},
+        "rate": 0.0
       }
     },
     "privet_russian": {
@@ -2740,7 +2843,19 @@
         "long_form_success_rate": 0.0,
         "shorts_attempts": 0,
         "shorts_uploaded": 0,
-        "shorts_success_rate": 0.0
+        "shorts_success_rate": 0.0,
+        "long_form_errors": []
+      },
+      "weekly_recap": {
+        "attempts": 0,
+        "synthesised": 0,
+        "success_rate": 0.0
+      },
+      "tag_leaks": {
+        "episodes_with_leaks": 0,
+        "total_leaks": 0,
+        "by_pattern": {},
+        "rate": 0.0
       }
     },
     "tesla": {
@@ -2832,27 +2947,34 @@
         "long_form_success_rate": 0.429,
         "shorts_attempts": 7,
         "shorts_uploaded": 7,
-        "shorts_success_rate": 1.0
+        "shorts_success_rate": 1.0,
+        "long_form_errors": [
+          {
+            "type": "ResumableUploadError",
+            "status": 400,
+            "message": "<HttpError 400 when requesting None returned \"The request metadata specifies an invalid video description.\". Details: \"[{'message': 'The request metadata specifies an invalid video description.', 'domain': 'youtube.video', 'reason': 'invalidDescription', 'location': 'body.snippet.description', 'loca"
+          }
+        ]
+      },
+      "weekly_recap": {
+        "attempts": 0,
+        "synthesised": 0,
+        "success_rate": 0.0
+      },
+      "tag_leaks": {
+        "episodes_with_leaks": 0,
+        "total_leaks": 0,
+        "by_pattern": {},
+        "rate": 0.0
       }
     },
     "unintended_consequences": {
-      "sample_size": 1,
-      "p50_duration_s": 48.46,
-      "p95_duration_s": 48.46,
-      "success_rate": 1.0,
-      "stage_mean_s": {
-        "fetch_and_dedup": 0.0,
-        "generate_digest": 48.46
-      },
-      "recent": [
-        {
-          "episode_num": 1,
-          "total_duration_s": 48.46,
-          "success": true,
-          "youtube_long_url": false,
-          "youtube_short_url": false
-        }
-      ],
+      "sample_size": 0,
+      "p50_duration_s": 0.0,
+      "p95_duration_s": 0.0,
+      "success_rate": 0.0,
+      "stage_mean_s": {},
+      "recent": [],
       "youtube": {
         "enabled_in_recent": false,
         "long_form_attempts": 0,
@@ -2860,7 +2982,19 @@
         "long_form_success_rate": 0.0,
         "shorts_attempts": 0,
         "shorts_uploaded": 0,
-        "shorts_success_rate": 0.0
+        "shorts_success_rate": 0.0,
+        "long_form_errors": []
+      },
+      "weekly_recap": {
+        "attempts": 0,
+        "synthesised": 0,
+        "success_rate": 0.0
+      },
+      "tag_leaks": {
+        "episodes_with_leaks": 0,
+        "total_leaks": 0,
+        "by_pattern": {},
+        "rate": 0.0
       }
     }
   },
@@ -3176,17 +3310,9 @@
       },
       {
         "file": "unintended_consequences_podcast.rss",
-        "entry_count": 1,
-        "latest_pub_date": "2026-05-04T08:00:00+00:00",
-        "latest_enclosures": [
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep001_20260504.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-05-04T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          }
-        ],
+        "entry_count": 0,
+        "latest_pub_date": null,
+        "latest_enclosures": [],
         "malformed": false,
         "error": null
       }

--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -426,6 +426,20 @@ def send_show_newsletter(
 
     # Pre-send contrast tripwire (§7.3). Light-mode-only check — the
     # dark-mode <style> block is unit-tested separately.
+    #
+    # Phase 2.2 of the May 2026 audit attempted to flip this from
+    # soft warning to hard block. Discovered that the network's
+    # primary brand color ``#7C5CFF`` on white renders at 4.35:1
+    # which fails WCAG AA's 4.5:1 threshold for normal text (passes
+    # 3:1 for large/bold text but the validator is element-blind).
+    # CTA links and engagement-block buttons all use the brand
+    # color, so hard-blocking blocks every newsletter.
+    #
+    # Pre-req before the flip: either (a) bump brand color slightly
+    # darker (e.g. ``#7C5CFF`` → ``#6B47FF`` raises ratio above 4.5),
+    # OR (b) extend the validator to honor ``font-size`` /
+    # ``font-weight: 700`` for the WCAG large-text 3:1 exemption.
+    # Until one of those lands, stay on warning.
     from engine.contrast_validator import (
         ContrastError,
         assert_contrast_ok,
@@ -433,11 +447,6 @@ def send_show_newsletter(
     try:
         assert_contrast_ok(branded_body)
     except ContrastError as exc:
-        # Don't hard-block on contrast for now — log loudly so
-        # operator sees it, but ship the email. Contrast failures
-        # are quality bugs, not safety bugs; an LLM scaffold leak
-        # IS a safety bug. Once the validator has been calibrated
-        # against a few real renders we can flip this to return None.
         logger.warning("Newsletter contrast issues (sending anyway): %s", exc)
 
     # Buttondown slug — explicit transliterated form for Russian

--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -1135,9 +1135,28 @@ def build_subject_line(
     emoji = show.get("emoji") or ""
 
     hook = (subject_hook or "").strip().rstrip(" .,;:")
-    # Apply the per-call hook cap before the suffix join.
+    # Apply the per-call hook cap before the suffix join. Use
+    # semantic (word-boundary) truncation rather than hard cut —
+    # truncating mid-word ("Scientists map a neural feedba…") looks
+    # lazy in inbox previews. We allow up to +5 chars over the cap
+    # if the next word boundary is within reach; otherwise we cut
+    # at the last word boundary before the cap.
     if hook and len(hook) > hook_max_chars:
-        hook = hook[:hook_max_chars].rstrip(" ,.;:") + "…"
+        # Look ahead 1-5 chars for a space; if found, cut there.
+        extended = hook[:hook_max_chars + 5]
+        far_space = extended.rfind(" ", hook_max_chars)
+        if far_space > 0:
+            hook = hook[:far_space].rstrip(" ,.;:") + "…"
+        else:
+            # No nearby boundary forward — cut at last word boundary
+            # within the cap.
+            cut = hook.rfind(" ", 0, hook_max_chars)
+            if cut > hook_max_chars - 15:
+                # Word boundary exists within last 15 chars before cap.
+                hook = hook[:cut].rstrip(" ,.;:") + "…"
+            else:
+                # Pathological — fall back to original hard cut.
+                hook = hook[:hook_max_chars].rstrip(" ,.;:") + "…"
     if not hook:
         # No hook from the LLM — degrade to a clean date-stamped fallback.
         when = send_date or datetime.date.today()
@@ -1218,10 +1237,41 @@ def wrap_with_branding(
     )
     # Stamp the slug into the featured-episode dict so the block can
     # build the listen URL even if the caller didn't pre-resolve it.
+    # Phase 2.4 (May 2026 audit): when the synthesizer doesn't supply
+    # a featured episode, auto-fall-back to the most recent episode
+    # from this show via the content lake. The featured-episode
+    # block is the highest-converting CTA in the newsletter; skipping
+    # it on missing-data was a missed opportunity, not a quality gate.
     featured_with_slug = None
     if featured_episode:
         featured_with_slug = dict(featured_episode)
         featured_with_slug.setdefault("show_slug", slug)
+    else:
+        try:
+            from engine.content_lake import query_show_range
+            from datetime import date as _date, timedelta as _td
+            _today = _date.today()
+            _recent = query_show_range(
+                slug,
+                (_today - _td(days=14)).isoformat(),
+                _today.isoformat(),
+            ) or []
+            if _recent:
+                _latest = sorted(
+                    _recent,
+                    key=lambda e: (e.get("date") or "", e.get("episode_num") or 0),
+                    reverse=True,
+                )[0]
+                featured_with_slug = {
+                    "show_slug": slug,
+                    "episode_num": _latest.get("episode_num"),
+                    "title": _latest.get("hook")
+                    or f"Episode {_latest.get('episode_num', '?')}",
+                    "hook": _latest.get("hook", ""),
+                    "date": _latest.get("date", ""),
+                }
+        except Exception:  # noqa: BLE001 — best-effort fallback only
+            featured_with_slug = None
     featured_block = _build_featured_episode_html(featured_with_slug, show)
     # Russian shows that need the disclaimer (currently only Финансы
     # Просто) get the Cyrillic version. Spec §4.4.

--- a/engine/synthesizer.py
+++ b/engine/synthesizer.py
@@ -776,9 +776,12 @@ def synthesize_cross_show_briefing(
     ]
 
     prompt = f"""\
-You are the editor-in-chief of the Nerra Network, a podcast network with 9 \
-daily shows covering AI, Tesla/energy, space, biotech, environmental policy, \
-world news, Russian finance, and Russian language learning.
+You are the editor-in-chief of the Nerra Network, a podcast network with 11 \
+daily shows covering AI (Models & Agents + a Beginners edition), Tesla & \
+energy, space & astronomy, longevity & health science, environmental policy, \
+world news, modern investing, narrative case studies of unintended \
+consequences, Russian-language financial literacy, and Russian language \
+learning.
 
 Write the weekly cross-network intelligence briefing for the week of \
 {start_date} to {end_date}.

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -787,6 +787,14 @@ def aggregate_metrics(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]
         yt_short_attempts = 0
         yt_short_uploaded = 0
         yt_enabled_recent = False
+        # Phase 2.6 health cards: track recent metrics that have no
+        # dedicated dashboard surface yet.
+        recap_attempts = 0  # Sundays where this show's runner ticked
+        recap_synthesised = 0  # Sundays where the recap actually built
+        tag_leak_episodes = 0  # episodes with tag_leaks > 0
+        tag_leak_total = 0  # sum of leak counts across recent episodes
+        tag_leak_pattern_counts: Dict[str, int] = {}
+        yt_long_errors: List[Dict[str, Any]] = []  # last few error payloads
         for f in last30:
             try:
                 data = json.loads(f.read_text(encoding="utf-8"))
@@ -810,6 +818,28 @@ def aggregate_metrics(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]
                     yt_long_uploaded += 1
                 if counters.get("youtube_short_uploaded"):
                     yt_short_uploaded += 1
+                _err = counters.get("youtube_long_error")
+                if isinstance(_err, dict):
+                    yt_long_errors.append(_err)
+            # Sunday weekly-recap health (Phase 1.1 of the May 2026
+            # schedule overhaul wired weekly_recap_mode into metrics).
+            if "weekly_recap_mode" in counters:
+                recap_attempts += 1
+                if counters.get("weekly_recap_mode"):
+                    recap_synthesised += 1
+            # Tag-leak rate (Phase 1.6 of the audit added tag_leaks
+            # metric — every episode now records 0 or N).
+            _tag_leaks = counters.get("tag_leaks")
+            if isinstance(_tag_leaks, int) and _tag_leaks > 0:
+                tag_leak_episodes += 1
+                tag_leak_total += _tag_leaks
+                _by_pat = counters.get("tag_leaks_by_pattern") or {}
+                if isinstance(_by_pat, dict):
+                    for _name, _cnt in _by_pat.items():
+                        if isinstance(_cnt, int):
+                            tag_leak_pattern_counts[_name] = (
+                                tag_leak_pattern_counts.get(_name, 0) + _cnt
+                            )
             recent_samples.append({
                 "episode_num": data.get("episode_num"),
                 "total_duration_s": total,
@@ -841,6 +871,38 @@ def aggregate_metrics(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]
                 "shorts_success_rate": (
                     round(yt_short_uploaded / yt_short_attempts, 3)
                     if yt_short_attempts else 0.0
+                ),
+                # Last few HTTP error payloads from failed long-form
+                # uploads. Most-likely values for `status` are
+                # ``quotaExceeded`` (need quota increase),
+                # ``authError`` (refresh token expired), or 5xx
+                # (transient — retry next slot).
+                "long_form_errors": yt_long_errors[-5:],
+            },
+            # Sunday weekly-recap synthesis health (Phase 1.1 of
+            # the schedule overhaul). recap_attempts is the count
+            # of Sunday slots in the last 30 episodes; recap_synthesised
+            # is how many actually built a recap from the content lake.
+            # A gap means the lake had <2 episodes in the 7-day window
+            # (the runner falls back to a normal daily fetch).
+            "weekly_recap": {
+                "attempts": recap_attempts,
+                "synthesised": recap_synthesised,
+                "success_rate": (
+                    round(recap_synthesised / recap_attempts, 3)
+                    if recap_attempts else 0.0
+                ),
+            },
+            # Tag-leak rate (Phase 1.6 of the audit). Aggregates the
+            # `tag_leaks` and `tag_leaks_by_pattern` per-episode
+            # metrics. Any non-zero count is a regression signal.
+            "tag_leaks": {
+                "episodes_with_leaks": tag_leak_episodes,
+                "total_leaks": tag_leak_total,
+                "by_pattern": tag_leak_pattern_counts,
+                "rate": (
+                    round(tag_leak_episodes / len(totals), 3)
+                    if totals else 0.0
                 ),
             },
         }

--- a/scripts/run_cross_network_briefing.py
+++ b/scripts/run_cross_network_briefing.py
@@ -1,0 +1,89 @@
+"""Generate the weekly cross-network intelligence briefing.
+
+Calls ``engine.synthesizer.synthesize_cross_show_briefing`` for the
+week ending today (or the date supplied via ``--week-ending``) and
+writes the resulting markdown to
+``outputs/cross_network/cross_network_briefing_<YYYY-WWW>.md``.
+
+The Sunday newsletter workflow runs this after the per-show weekly
+newsletters land. The briefing is the editorial synthesis the
+``_build_cross_network_data`` newsletter module currently doesn't
+produce — surfaces threads no single-show coverage would catch
+("AI x energy", "regulatory move ripples across 3 shows", etc.).
+
+Usage:
+    python scripts/run_cross_network_briefing.py
+    python scripts/run_cross_network_briefing.py --week-ending 2026-05-04
+    python scripts/run_cross_network_briefing.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+# Allow running from repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stdout,
+)
+logger = logging.getLogger("cross_network_briefing")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--week-ending",
+        help="ISO date (YYYY-MM-DD) for the week ending. Defaults to today.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate but do not write the file.",
+    )
+    args = parser.parse_args()
+
+    if args.week_ending:
+        try:
+            week_ending = datetime.strptime(args.week_ending, "%Y-%m-%d").date()
+        except ValueError:
+            logger.error("Invalid --week-ending; expected YYYY-MM-DD")
+            return 2
+    else:
+        week_ending = date.today()
+
+    from engine.synthesizer import synthesize_cross_show_briefing
+    text = synthesize_cross_show_briefing(week_ending)
+
+    if not text:
+        logger.warning(
+            "Cross-network briefing returned empty (likely <10 episodes "
+            "in window). Skipping write.",
+        )
+        return 0
+
+    out_dir = Path(__file__).resolve().parent.parent / "outputs" / "cross_network"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    iso_year, iso_week, _ = week_ending.isocalendar()
+    out_path = out_dir / f"cross_network_briefing_{iso_year}-W{iso_week:02d}.md"
+
+    if args.dry_run:
+        logger.info(
+            "DRY RUN — would write %d chars to %s", len(text), out_path,
+        )
+        print(text[:500] + ("..." if len(text) > 500 else ""))
+        return 0
+
+    out_path.write_text(text, encoding="utf-8")
+    logger.info("Cross-network briefing written: %s (%d chars)", out_path, len(text))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**Phase 2** of the audit — bundles 4 wins. Phase 2.5 was no-op (blog index already renders hooks). Phase 2.2 was deferred — revealed a brand-color contrast pre-req.

## Shipped

### Phase 2.1 — scheduled cross-network briefing
The orphaned `synthesize_cross_show_briefing` is now scheduled. Adds `scripts/run_cross_network_briefing.py` (wraps the synthesizer + writes `outputs/cross_network/cross_network_briefing_<YYYY-WWW>.md`), a new step in `weekly-newsletter.yml` that runs after the per-show newsletters, and committing logic. Synthesizer prompt updated from stale "9 daily shows" to "11 daily shows" with the full topic enumeration.

### Phase 2.3 — subject-line semantic truncation
Previously hard-cut at the char cap leaving "Scientists map a neural feedba…". Now looks for a word boundary within +5 chars of the cap, falling back to the last boundary within cap-15. Pathological case keeps original hard cut.

### Phase 2.4 — featured-episode auto-fallback
Highest-converting newsletter CTA was being skipped when the synthesizer didn't supply a `featured_episode`. Now falls back to the most recent episode from the same show via the content lake (last 14 days). Block renders on every newsletter as long as the show has shipped at least one episode.

### Phase 2.6 — dashboard health cards
`api/dashboard.json` now exposes three new per-show health surfaces in `pipeline_health.<slug>`:
- `weekly_recap` — Sunday recap synthesis attempts vs successes
- `tag_leaks` — episodes with leaks, total count, by-pattern breakdown, per-show rate (built on Phase 1.6's metrics)
- `youtube.long_form_errors` — last 5 HTTP error payloads (so operator immediately sees if it's `quotaExceeded`, `authError`, or 5xx)

## Deferred / no-op

### Phase 2.2 (deferred)
Hard-blocking the contrast validator revealed that the network's primary color `#7C5CFF` renders at 4.35:1 on white — fails WCAG AA's 4.5:1 normal-text threshold (passes 3:1 large-text). Hard-blocking would block every newsletter because the CTA links use the brand color.

**Pre-req before flipping the gate:** either (a) bump brand color (e.g., `#7C5CFF` → `#6B47FF`, raises ratio above 4.5) — operator brand-identity decision, or (b) extend `contrast_validator` to honor `font-size` / `font-weight: 700` for the WCAG large-text exemption.

Comment in `newsletter.py` documents the gate state for the next attempt.

### Phase 2.5 (no-op)
Blog index hook preview is already rendered in `templates/blog_index.html.j2:100` and `templates/network_blog_index.html.j2:162`. Audit was incorrect.

## Test plan
- [x] Full suite: 1564 passing + 7 skipped, 2 pre-existing `google.oauth2` failures unrelated
- [ ] **Sunday's run**: cross-network briefing committed to `outputs/cross_network/`, weekly newsletters land with hook-truncation working at word boundaries
- [ ] **Daily metrics tomorrow**: `api/dashboard.json` shows real values in the three new health surfaces

## Coming next
Phase 3 polish — per-show meta descriptions, intro rotations, P.S. prominence, inline citations, metrics schema versioning. Plus the Phase 2.2 pre-req as a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_