### PR TITLE
Localize Russian page chrome (footer subscribe form, AI notice, copyright)

### DIFF
--- a/404.html
+++ b/404.html
@@ -572,8 +572,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/about.html
+++ b/about.html
@@ -802,8 +802,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/api/articles.json
+++ b/api/articles.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-05-05T19:34:22Z",
+  "updated": "2026-05-05T21:42:16Z",
   "articles": [
     {
       "show_id": "tesla",
@@ -129,7 +129,7 @@
       "episode_number": "452",
       "title": "Tesla Shorts Time — Episode 452",
       "date": "2026-05-05",
-      "read_time": "48 min",
+      "read_time": "47 min",
       "hook": "Tesla Shorts Time Date: April 27, 2026 REAL-TIME TSLA price: $371.39 ▼ $3.86 (1.0%) Tesla is rolling out a Virtual Queue for Superchargers to end the fights ove",
       "url": "https://nerranetwork.com/blog/tesla/ep452.html"
     },
@@ -162,7 +162,7 @@
       "episode_number": "449",
       "title": "Tesla Shorts Time — Episode 449",
       "date": "2026-05-05",
-      "read_time": "49 min",
+      "read_time": "48 min",
       "hook": "Tesla Shorts Time Date: April 26, 2026 REAL-TIME TSLA price: $376.30 ▲ $3.12 (0.8%) Giga Berlin is ramping up output by 20% and adding 1,000 new hires after a r",
       "url": "https://nerranetwork.com/blog/tesla/ep449.html"
     },
@@ -415,7 +415,7 @@
       "episode_number": "426",
       "title": "Tesla Shorts Time — Episode 426",
       "date": "2026-05-05",
-      "read_time": "56 min",
+      "read_time": "57 min",
       "hook": "# Tesla Shorts Time Date: April 04, 2026 REAL-TIME TSLA price: $360.59 ▼ $20.32 (5.3%) A Tesla in Israel took a direct hit from Iranian missile debris yet its g",
       "url": "https://nerranetwork.com/blog/tesla/ep426.html"
     },
@@ -547,7 +547,7 @@
       "episode_number": "414",
       "title": "Tesla Shorts Time — Episode 414",
       "date": "2026-05-05",
-      "read_time": "53 min",
+      "read_time": "54 min",
       "hook": "Tesla Shorts Time Date: March 22, 2026 REAL-TIME TSLA price: $367.96 ▼ $14.64 (3.8%) NHTSA has escalated its investigation into Tesla's Full Self-Driving softwa",
       "url": "https://nerranetwork.com/blog/tesla/ep414.html"
     },
@@ -668,7 +668,7 @@
       "episode_number": "400",
       "title": "Tesla Shorts Time — Episode 400",
       "date": "2026-05-05",
-      "read_time": "46 min",
+      "read_time": "45 min",
       "hook": "Tesla Shorts Time Date: March 06, 2026 REAL-TIME TSLA price: $405.55 ▲ $0.07 (0.0%) Tesla's patent for a one-piece composite seat signals the next-gen Roadster ",
       "url": "https://nerranetwork.com/blog/tesla/ep400.html"
     },
@@ -712,7 +712,7 @@
       "episode_number": "396",
       "title": "Tesla Shorts Time — Episode 396",
       "date": "2026-05-05",
-      "read_time": "42 min",
+      "read_time": "41 min",
       "hook": "Tesla Shorts Time Date: March 02, 2026 REAL-TIME TSLA price: $402.51 ▲ $0.71 (0.2%) Tesla raised the Cybertruck AWD price by $10K to $69,990 after strong initia",
       "url": "https://nerranetwork.com/blog/tesla/ep396.html"
     },
@@ -767,7 +767,7 @@
       "episode_number": "041",
       "title": "Omni View — Omni‑View Briefing — Episode 41",
       "date": "2026-05-05",
-      "read_time": "63 min",
+      "read_time": "62 min",
       "hook": "Omni View — Omni‑View Briefing President Trump is reviewing a new peace proposal from Iran but doubts it will be acceptable since Tehran has not paid a big enou",
       "url": "https://nerranetwork.com/blog/omni_view/ep041.html"
     },
@@ -811,7 +811,7 @@
       "episode_number": "037",
       "title": "King Charles faces US pressure over Falklands sovereignty as Trump envoys head t... — Episode 37",
       "date": "2026-05-05",
-      "read_time": "68 min",
+      "read_time": "69 min",
       "hook": "King Charles faces US pressure over Falklands sovereignty as Trump envoys head to Iran peace talks in Pakistan. Top stories (5) 1) King flies into US storm over",
       "url": "https://nerranetwork.com/blog/omni_view/ep037.html"
     },
@@ -932,7 +932,7 @@
       "episode_number": "026",
       "title": "Omni View — Episode 26",
       "date": "2026-05-05",
-      "read_time": "64 min",
+      "read_time": "65 min",
       "hook": "# Omni View — Omni‑View Briefing Date: March 31, 2026 Oil prices fell after reports President Trump is willing to end the Iran conflict even if the Strait of Ho",
       "url": "https://nerranetwork.com/blog/omni_view/ep026.html"
     },
@@ -965,7 +965,7 @@
       "episode_number": "023",
       "title": "Omni View — Episode 23",
       "date": "2026-05-05",
-      "read_time": "67 min",
+      "read_time": "66 min",
       "hook": "# Omni View — Omni‑View Briefing Date: March 26, 2026 Iran has rejected President Trump’s proposed peace plan as a pretext for invasion, while Israel claims it ",
       "url": "https://nerranetwork.com/blog/omni_view/ep023.html"
     },
@@ -1020,7 +1020,7 @@
       "episode_number": "018",
       "title": "Omni View — Episode 18",
       "date": "2026-05-05",
-      "read_time": "59 min",
+      "read_time": "58 min",
       "hook": "# Omni View — Omni‑View Briefing Date: March 20, 2026 Oil prices fall as U.S. considers releasing sanctioned Iranian crude while Israel-Iran conflict disrupts g",
       "url": "https://nerranetwork.com/blog/omni_view/ep018.html"
     },

--- a/api/env_intel.json
+++ b/api/env_intel.json
@@ -12,7 +12,7 @@
   "blog_url": "https://nerranetwork.com/blog/env_intel/",
   "page_url": "https://nerranetwork.com/env-intel.html",
   "category": "Environment",
-  "updated": "2026-05-05T19:34:23Z",
+  "updated": "2026-05-05T21:42:16Z",
   "episode_count": 29,
   "episodes": [
     {
@@ -372,7 +372,7 @@
       "episode_number": "031",
       "title": "Environmental Intelligence — Episode 31",
       "date": "2026-05-05",
-      "read_time": "36 min",
+      "read_time": "37 min",
       "hook": "Environmental Intelligence 🔬 Environmental Intelligence — Canadian Environmental Professional Briefing Ontario relocates decades-old mine tailings in Nipissing ",
       "url": "https://nerranetwork.com/blog/env_intel/ep031.html"
     },
@@ -383,7 +383,7 @@
       "episode_number": "030",
       "title": "Environmental Intelligence — Episode 30",
       "date": "2026-05-05",
-      "read_time": "41 min",
+      "read_time": "40 min",
       "hook": "Environmental Intelligence Date: May 01, 2026 🔬 Environmental Intelligence — Canadian Environmental Professional Briefing Ontario's ban on green rules for devel",
       "url": "https://nerranetwork.com/blog/env_intel/ep030.html"
     },
@@ -394,7 +394,7 @@
       "episode_number": "029",
       "title": "BC court rejects Wet'suwet'en chief's Indigenous law defence in Coastal GasLink ... — Episode 29",
       "date": "2026-05-05",
-      "read_time": "45 min",
+      "read_time": "44 min",
       "hook": "BC court rejects Wet'suwet'en chief's Indigenous law defence in Coastal GasLink conviction while First Nation launches logging lawsuit, sharpening pipeline and ",
       "url": "https://nerranetwork.com/blog/env_intel/ep029.html"
     },
@@ -581,7 +581,7 @@
       "episode_number": "011",
       "title": "Environmental Intelligence — Episode 11",
       "date": "2026-05-05",
-      "read_time": "42 min",
+      "read_time": "43 min",
       "hook": "Environmental Intelligence Date: March 13, 2026 🔬 Environmental Intelligence — Canadian Environmental Professional Briefing NS enforcement order mandates remova",
       "url": "https://nerranetwork.com/blog/env_intel/ep011.html"
     },
@@ -658,7 +658,7 @@
       "episode_number": "004",
       "title": "Environmental Intelligence — Episode 4",
       "date": "2026-05-05",
-      "read_time": "42 min",
+      "read_time": "43 min",
       "hook": "Environmental Intelligence Date: March 03, 2026 🔬 Environmental Intelligence — Canadian Environmental Professional Briefing New Antarctic meltwater data shows m",
       "url": "https://nerranetwork.com/blog/env_intel/ep004.html"
     },
@@ -680,7 +680,7 @@
       "episode_number": "002",
       "title": "Environmental Intelligence — Episode 2",
       "date": "2026-05-05",
-      "read_time": "41 min",
+      "read_time": "40 min",
       "hook": "Environmental Intelligence Date: February 27, 2026 🔬 Environmental Intelligence — Canadian Environmental Professional Briefing Port of Churchill expansion push ",
       "url": "https://nerranetwork.com/blog/env_intel/ep002.html"
     }

--- a/api/episodes.json
+++ b/api/episodes.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-05-05T19:34:21Z",
+  "updated": "2026-05-05T21:42:15Z",
   "episodes": [
     {
       "show_id": "tesla",

--- a/api/fascinating_frontiers.json
+++ b/api/fascinating_frontiers.json
@@ -12,7 +12,7 @@
   "blog_url": "https://nerranetwork.com/blog/fascinating_frontiers/",
   "page_url": "https://nerranetwork.com/fascinating-frontiers.html",
   "category": "Science",
-  "updated": "2026-05-05T19:34:22Z",
+  "updated": "2026-05-05T21:42:16Z",
   "episode_count": 52,
   "episodes": [
     {
@@ -659,7 +659,7 @@
       "episode_number": "062",
       "title": "Fascinating Frontiers — Episode 62",
       "date": "2026-05-05",
-      "read_time": "41 min",
+      "read_time": "42 min",
       "hook": "Fascinating Frontiers 🚀 Fascinating Frontiers - Space & Astronomy News Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.",
       "url": "https://nerranetwork.com/blog/fascinating_frontiers/ep062.html"
     },
@@ -692,7 +692,7 @@
       "episode_number": "059",
       "title": "Fascinating Frontiers — Episode 59",
       "date": "2026-05-05",
-      "read_time": "47 min",
+      "read_time": "46 min",
       "hook": "Fascinating Frontiers Date: April 28, 2026 🚀 Fascinating Frontiers - Space & Astronomy News NASA's Artemis III crewed lunar landing slips to no earlier than lat",
       "url": "https://nerranetwork.com/blog/fascinating_frontiers/ep059.html"
     },
@@ -703,7 +703,7 @@
       "episode_number": "058",
       "title": "Fascinating Frontiers — Episode 58",
       "date": "2026-05-05",
-      "read_time": "46 min",
+      "read_time": "45 min",
       "hook": "Fascinating Frontiers Date: April 26, 2026 🚀 Fascinating Frontiers - Space & Astronomy News NASA's Webb telescope has directly imaged water-ice clouds in the at",
       "url": "https://nerranetwork.com/blog/fascinating_frontiers/ep058.html"
     },
@@ -835,7 +835,7 @@
       "episode_number": "046",
       "title": "Mars-like exoplanets orbiting M-dwarfs could lose their atmospheres in just mill... — Episode 46",
       "date": "2026-05-05",
-      "read_time": "48 min",
+      "read_time": "47 min",
       "hook": "Mars-like exoplanets orbiting M-dwarfs could lose their atmospheres in just millions of years. Top 15 Space & Astronomy Stories Mars-like Worlds Near M-Dwarfs M",
       "url": "https://nerranetwork.com/blog/fascinating_frontiers/ep046.html"
     },

--- a/api/finansy_prosto.json
+++ b/api/finansy_prosto.json
@@ -12,7 +12,7 @@
   "blog_url": "https://nerranetwork.com/blog/finansy_prosto/",
   "page_url": "https://nerranetwork.com/finansy-prosto.html",
   "category": "Finance",
-  "updated": "2026-05-05T19:34:23Z",
+  "updated": "2026-05-05T21:42:17Z",
   "episode_count": 31,
   "episodes": [
     {

--- a/api/models_agents.json
+++ b/api/models_agents.json
@@ -12,7 +12,7 @@
   "blog_url": "https://nerranetwork.com/blog/models_agents/",
   "page_url": "https://nerranetwork.com/models-agents.html",
   "category": "Technology",
-  "updated": "2026-05-05T19:34:23Z",
+  "updated": "2026-05-05T21:42:16Z",
   "episode_count": 40,
   "episodes": [
     {
@@ -526,7 +526,7 @@
       "episode_number": "038",
       "title": "Models & Agents — Episode 38",
       "date": "2026-05-05",
-      "read_time": "40 min",
+      "read_time": "41 min",
       "hook": "Models & Agents Date: May 01, 2026 Anthropic gives defenders early access to Mythos Preview to patch AI cyber vulnerabilities before wider release. What You Nee",
       "url": "https://nerranetwork.com/blog/models_agents/ep038.html"
     },
@@ -537,7 +537,7 @@
       "episode_number": "037",
       "title": "DeepSeek's first native multimodal model drops in the LocalLLaMA community, fina... — Episode 37",
       "date": "2026-05-05",
-      "read_time": "50 min",
+      "read_time": "51 min",
       "hook": "DeepSeek's first native multimodal model drops in the LocalLLaMA community, finally giving the open-source whale vision capabilities. What You Need to Know: Tod",
       "url": "https://nerranetwork.com/blog/models_agents/ep037.html"
     },
@@ -790,7 +790,7 @@
       "episode_number": "014",
       "title": "Models & Agents — Episode 14",
       "date": "2026-05-05",
-      "read_time": "47 min",
+      "read_time": "48 min",
       "hook": "Models & Agents Date: March 13, 2026 Perplexity launches \"Personal Computer,\" a $200/month AI agent that automates emails, presentations, and app control 24/7. ",
       "url": "https://nerranetwork.com/blog/models_agents/ep014.html"
     },
@@ -856,7 +856,7 @@
       "episode_number": "008",
       "title": "Models & Agents — Episode 8",
       "date": "2026-05-05",
-      "read_time": "47 min",
+      "read_time": "48 min",
       "hook": "Models & Agents Date: March 07, 2026 Anthropic's Claude AI discovered over 100 Firefox vulnerabilities that human testing missed for decades. What You Need to K",
       "url": "https://nerranetwork.com/blog/models_agents/ep008.html"
     },

--- a/api/models_agents_beginners.json
+++ b/api/models_agents_beginners.json
@@ -12,7 +12,7 @@
   "blog_url": "https://nerranetwork.com/blog/models_agents_beginners/",
   "page_url": "https://nerranetwork.com/models-agents-beginners.html",
   "category": "Technology",
-  "updated": "2026-05-05T19:34:23Z",
+  "updated": "2026-05-05T21:42:17Z",
   "episode_count": 29,
   "episodes": [
     {
@@ -405,7 +405,7 @@
       "episode_number": "026",
       "title": "Google just dropped super-fast AI chips built for helpful agents that actually d... — Episode 26",
       "date": "2026-05-05",
-      "read_time": "48 min",
+      "read_time": "47 min",
       "hook": "Google just dropped super-fast AI chips built for helpful agents that actually do stuff for you. What's Cool Today: Google unveiled its eighth-generation TPUs —",
       "url": "https://nerranetwork.com/blog/models_agents_beginners/ep026.html"
     },

--- a/api/modern_investing.json
+++ b/api/modern_investing.json
@@ -12,7 +12,7 @@
   "blog_url": "https://nerranetwork.com/blog/modern_investing/",
   "page_url": "https://nerranetwork.com/modern-investing.html",
   "category": "Finance",
-  "updated": "2026-05-05T19:34:23Z",
+  "updated": "2026-05-05T21:42:17Z",
   "episode_count": 34,
   "episodes": [
     {
@@ -520,7 +520,7 @@
       "episode_number": "026",
       "title": "Modern Investing Techniques — Episode 26",
       "date": "2026-05-05",
-      "read_time": "46 min",
+      "read_time": "47 min",
       "hook": "Modern Investing Techniques Date: April 23, 2026 💰 Modern Investing Techniques — AI-Powered Daily Market Intelligence Canada Growth Fund acquires 22% of Nouveau",
       "url": "https://nerranetwork.com/blog/modern_investing/ep026.html"
     },
@@ -652,7 +652,7 @@
       "episode_number": "014",
       "title": "Modern Investing Techniques — Episode 14",
       "date": "2026-05-05",
-      "read_time": "50 min",
+      "read_time": "51 min",
       "hook": "# Modern Investing Techniques Date: April 07, 2026 💰 Modern Investing Techniques — AI-Powered Daily Market Intelligence Samsung forecasts 8-fold Q1 profit jump ",
       "url": "https://nerranetwork.com/blog/modern_investing/ep014.html"
     },
@@ -685,7 +685,7 @@
       "episode_number": "011",
       "title": "Modern Investing Techniques — Episode 11",
       "date": "2026-05-05",
-      "read_time": "52 min",
+      "read_time": "51 min",
       "hook": "# Modern Investing Techniques Date: April 02, 2026 💰 Modern Investing Techniques — AI-Powered Daily Market Intelligence Alberta’s potential US$1T lithium resour",
       "url": "https://nerranetwork.com/blog/modern_investing/ep011.html"
     },

--- a/api/omni_view.json
+++ b/api/omni_view.json
@@ -12,7 +12,7 @@
   "blog_url": "https://nerranetwork.com/blog/omni_view/",
   "page_url": "https://nerranetwork.com/omni-view.html",
   "category": "News",
-  "updated": "2026-05-05T19:34:22Z",
+  "updated": "2026-05-05T21:42:16Z",
   "episode_count": 42,
   "episodes": [
     {
@@ -539,7 +539,7 @@
       "episode_number": "041",
       "title": "Omni View — Omni‑View Briefing — Episode 41",
       "date": "2026-05-05",
-      "read_time": "63 min",
+      "read_time": "62 min",
       "hook": "Omni View — Omni‑View Briefing President Trump is reviewing a new peace proposal from Iran but doubts it will be acceptable since Tehran has not paid a big enou",
       "url": "https://nerranetwork.com/blog/omni_view/ep041.html"
     },
@@ -583,7 +583,7 @@
       "episode_number": "037",
       "title": "King Charles faces US pressure over Falklands sovereignty as Trump envoys head t... — Episode 37",
       "date": "2026-05-05",
-      "read_time": "68 min",
+      "read_time": "69 min",
       "hook": "King Charles faces US pressure over Falklands sovereignty as Trump envoys head to Iran peace talks in Pakistan. Top stories (5) 1) King flies into US storm over",
       "url": "https://nerranetwork.com/blog/omni_view/ep037.html"
     },
@@ -704,7 +704,7 @@
       "episode_number": "026",
       "title": "Omni View — Episode 26",
       "date": "2026-05-05",
-      "read_time": "64 min",
+      "read_time": "65 min",
       "hook": "# Omni View — Omni‑View Briefing Date: March 31, 2026 Oil prices fell after reports President Trump is willing to end the Iran conflict even if the Strait of Ho",
       "url": "https://nerranetwork.com/blog/omni_view/ep026.html"
     },
@@ -737,7 +737,7 @@
       "episode_number": "023",
       "title": "Omni View — Episode 23",
       "date": "2026-05-05",
-      "read_time": "67 min",
+      "read_time": "66 min",
       "hook": "# Omni View — Omni‑View Briefing Date: March 26, 2026 Iran has rejected President Trump’s proposed peace plan as a pretext for invasion, while Israel claims it ",
       "url": "https://nerranetwork.com/blog/omni_view/ep023.html"
     },
@@ -792,7 +792,7 @@
       "episode_number": "018",
       "title": "Omni View — Episode 18",
       "date": "2026-05-05",
-      "read_time": "59 min",
+      "read_time": "58 min",
       "hook": "# Omni View — Omni‑View Briefing Date: March 20, 2026 Oil prices fall as U.S. considers releasing sanctioned Iranian crude while Israel-Iran conflict disrupts g",
       "url": "https://nerranetwork.com/blog/omni_view/ep018.html"
     },

--- a/api/planetterrian.json
+++ b/api/planetterrian.json
@@ -12,7 +12,7 @@
   "blog_url": "https://nerranetwork.com/blog/planetterrian/",
   "page_url": "https://nerranetwork.com/planetterrian.html",
   "category": "Science",
-  "updated": "2026-05-05T19:34:22Z",
+  "updated": "2026-05-05T21:42:16Z",
   "episode_count": 43,
   "episodes": [
     {
@@ -584,7 +584,7 @@
       "episode_number": "051",
       "title": "Planetterrian Daily — Episode 51",
       "date": "2026-05-05",
-      "read_time": "42 min",
+      "read_time": "41 min",
       "hook": "Planetterrian Daily Date: April 27, 2026 🌍 Planetterrian Daily - Science, Longevity & Health Discoveries Mixing workout types over decades lowers mortality risk",
       "url": "https://nerranetwork.com/blog/planetterrian/ep051.html"
     },
@@ -793,7 +793,7 @@
       "episode_number": "032",
       "title": "Planetterrian Daily — Episode 32",
       "date": "2026-05-05",
-      "read_time": "46 min",
+      "read_time": "45 min",
       "hook": "Planetterrian Daily Date: March 20, 2026 🌍 Planetterrian Daily - Science, Longevity & Health Discoveries Ravens in Yellowstone navigate directly to likely wolf ",
       "url": "https://nerranetwork.com/blog/planetterrian/ep032.html"
     },

--- a/api/privet_russian.json
+++ b/api/privet_russian.json
@@ -12,7 +12,7 @@
   "blog_url": "https://nerranetwork.com/blog/privet_russian/",
   "page_url": "https://nerranetwork.com/privet-russian.html",
   "category": "Education",
-  "updated": "2026-05-05T19:34:23Z",
+  "updated": "2026-05-05T21:42:17Z",
   "episode_count": 19,
   "episodes": [
     {
@@ -351,7 +351,7 @@
       "episode_number": "010",
       "title": "Привет, Русский! — Episode 10",
       "date": "2026-05-05",
-      "read_time": "38 min",
+      "read_time": "39 min",
       "hook": "Привет, Русский! — Episode Plan Date: April 10, 2026 Spring & Nature (Весна и природа) Vocabulary List (10 words/phrases): Russian (Cyrillic): весна Translitera",
       "url": "https://nerranetwork.com/blog/privet_russian/ep010.html"
     },

--- a/api/shows.json
+++ b/api/shows.json
@@ -1,6 +1,6 @@
 {
   "network": "Nerra Network",
-  "updated": "2026-05-05T19:34:21Z",
+  "updated": "2026-05-05T21:42:15Z",
   "shows": [
     {
       "id": "tesla",

--- a/api/tesla.json
+++ b/api/tesla.json
@@ -12,7 +12,7 @@
   "blog_url": "https://nerranetwork.com/blog/tesla/",
   "page_url": "https://nerranetwork.com/tesla.html",
   "category": "Business",
-  "updated": "2026-05-05T19:34:22Z",
+  "updated": "2026-05-05T21:42:16Z",
   "episode_count": 116,
   "episodes": [
     {
@@ -1537,7 +1537,7 @@
       "episode_number": "452",
       "title": "Tesla Shorts Time — Episode 452",
       "date": "2026-05-05",
-      "read_time": "48 min",
+      "read_time": "47 min",
       "hook": "Tesla Shorts Time Date: April 27, 2026 REAL-TIME TSLA price: $371.39 ▼ $3.86 (1.0%) Tesla is rolling out a Virtual Queue for Superchargers to end the fights ove",
       "url": "https://nerranetwork.com/blog/tesla/ep452.html"
     },
@@ -1570,7 +1570,7 @@
       "episode_number": "449",
       "title": "Tesla Shorts Time — Episode 449",
       "date": "2026-05-05",
-      "read_time": "49 min",
+      "read_time": "48 min",
       "hook": "Tesla Shorts Time Date: April 26, 2026 REAL-TIME TSLA price: $376.30 ▲ $3.12 (0.8%) Giga Berlin is ramping up output by 20% and adding 1,000 new hires after a r",
       "url": "https://nerranetwork.com/blog/tesla/ep449.html"
     },
@@ -1823,7 +1823,7 @@
       "episode_number": "426",
       "title": "Tesla Shorts Time — Episode 426",
       "date": "2026-05-05",
-      "read_time": "56 min",
+      "read_time": "57 min",
       "hook": "# Tesla Shorts Time Date: April 04, 2026 REAL-TIME TSLA price: $360.59 ▼ $20.32 (5.3%) A Tesla in Israel took a direct hit from Iranian missile debris yet its g",
       "url": "https://nerranetwork.com/blog/tesla/ep426.html"
     },
@@ -1955,7 +1955,7 @@
       "episode_number": "414",
       "title": "Tesla Shorts Time — Episode 414",
       "date": "2026-05-05",
-      "read_time": "53 min",
+      "read_time": "54 min",
       "hook": "Tesla Shorts Time Date: March 22, 2026 REAL-TIME TSLA price: $367.96 ▼ $14.64 (3.8%) NHTSA has escalated its investigation into Tesla's Full Self-Driving softwa",
       "url": "https://nerranetwork.com/blog/tesla/ep414.html"
     },
@@ -2076,7 +2076,7 @@
       "episode_number": "400",
       "title": "Tesla Shorts Time — Episode 400",
       "date": "2026-05-05",
-      "read_time": "46 min",
+      "read_time": "45 min",
       "hook": "Tesla Shorts Time Date: March 06, 2026 REAL-TIME TSLA price: $405.55 ▲ $0.07 (0.0%) Tesla's patent for a one-piece composite seat signals the next-gen Roadster ",
       "url": "https://nerranetwork.com/blog/tesla/ep400.html"
     },
@@ -2120,7 +2120,7 @@
       "episode_number": "396",
       "title": "Tesla Shorts Time — Episode 396",
       "date": "2026-05-05",
-      "read_time": "42 min",
+      "read_time": "41 min",
       "hook": "Tesla Shorts Time Date: March 02, 2026 REAL-TIME TSLA price: $402.51 ▲ $0.71 (0.2%) Tesla raised the Cybertruck AWD price by $10K to $69,990 after strong initia",
       "url": "https://nerranetwork.com/blog/tesla/ep396.html"
     },

--- a/api/unintended_consequences.json
+++ b/api/unintended_consequences.json
@@ -12,7 +12,7 @@
   "blog_url": "https://nerranetwork.com/blog/unintended_consequences/",
   "page_url": "https://nerranetwork.com/unintended-consequences.html",
   "category": "Education",
-  "updated": "2026-05-05T19:34:23Z",
+  "updated": "2026-05-05T21:42:17Z",
   "episode_count": 3,
   "episodes": [
     {

--- a/blog/env_intel/ep002.html
+++ b/blog/env_intel/ep002.html
@@ -1296,11 +1296,18 @@ That's Environmental Intelligence for February twenty-seventh, twenty twenty-six
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                     <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
@@ -1308,13 +1315,6 @@ That's Environmental Intelligence for February twenty-seventh, twenty twenty-six
                         <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
                         <h3>Planetterrian Daily</h3>
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1438,8 +1438,7 @@ That's Environmental Intelligence for February twenty-seventh, twenty twenty-six
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep003.html
+++ b/blog/env_intel/ep003.html
@@ -1334,11 +1334,11 @@ That's Environmental Intelligence for March second, twenty twenty-six. If this b
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1348,11 +1348,11 @@ That's Environmental Intelligence for March second, twenty twenty-six. If this b
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1476,8 +1476,7 @@ That's Environmental Intelligence for March second, twenty twenty-six. If this b
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep004.html
+++ b/blog/env_intel/ep004.html
@@ -1299,13 +1299,6 @@ That's Environmental Intelligence for March third, twenty twenty-six. If this br
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
-                    </a>
-                    
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
@@ -1313,11 +1306,18 @@ That's Environmental Intelligence for March third, twenty twenty-six. If this br
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1441,8 +1441,7 @@ That's Environmental Intelligence for March third, twenty twenty-six. If this br
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep005.html
+++ b/blog/env_intel/ep005.html
@@ -1282,25 +1282,25 @@ That's Environmental Intelligence for March fifth, twenty twenty-six. If this br
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
-                    </a>
-                    
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1424,8 +1424,7 @@ That's Environmental Intelligence for March fifth, twenty twenty-six. If this br
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep006.html
+++ b/blog/env_intel/ep006.html
@@ -1273,25 +1273,25 @@ That's Environmental Intelligence for March sixth, twenty twenty-six. If this br
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1415,8 +1415,7 @@ That's Environmental Intelligence for March sixth, twenty twenty-six. If this br
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep007.html
+++ b/blog/env_intel/ep007.html
@@ -1268,11 +1268,18 @@ That's Environmental Intelligence for March ninth, twenty twenty-six. If this br
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                     <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
@@ -1280,13 +1287,6 @@ That's Environmental Intelligence for March ninth, twenty twenty-six. If this br
                         <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
                         <h3>Planetterrian Daily</h3>
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1410,8 +1410,7 @@ That's Environmental Intelligence for March ninth, twenty twenty-six. If this br
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep008.html
+++ b/blog/env_intel/ep008.html
@@ -1311,13 +1311,6 @@ That's Environmental Intelligence for March tenth, twenty twenty-six. If this br
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
                     <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
@@ -1325,11 +1318,18 @@ That's Environmental Intelligence for March tenth, twenty twenty-six. If this br
                         <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1453,8 +1453,7 @@ That's Environmental Intelligence for March tenth, twenty twenty-six. If this br
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep009.html
+++ b/blog/env_intel/ep009.html
@@ -1289,25 +1289,25 @@ That's Environmental Intelligence for March eleventh, twenty twenty-six. If this
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
                         <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1431,8 +1431,7 @@ That's Environmental Intelligence for March eleventh, twenty twenty-six. If this
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep010.html
+++ b/blog/env_intel/ep010.html
@@ -1249,18 +1249,18 @@ That's Environmental Intelligence for March twelfth, twenty twenty-six. If this 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1391,8 +1391,7 @@ That's Environmental Intelligence for March twelfth, twenty twenty-six. If this 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep011.html
+++ b/blog/env_intel/ep011.html
@@ -1270,25 +1270,25 @@ That's Environmental Intelligence for March thirteenth, twenty twenty-six. If th
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1412,8 +1412,7 @@ That's Environmental Intelligence for March thirteenth, twenty twenty-six. If th
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep012.html
+++ b/blog/env_intel/ep012.html
@@ -1345,25 +1345,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1487,8 +1487,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep014.html
+++ b/blog/env_intel/ep014.html
@@ -1404,25 +1404,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1546,8 +1546,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep015.html
+++ b/blog/env_intel/ep015.html
@@ -1373,25 +1373,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1515,8 +1515,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep016.html
+++ b/blog/env_intel/ep016.html
@@ -1344,18 +1344,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1479,8 +1479,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep017.html
+++ b/blog/env_intel/ep017.html
@@ -1305,25 +1305,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1447,8 +1447,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep018.html
+++ b/blog/env_intel/ep018.html
@@ -1319,25 +1319,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1461,8 +1461,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep019.html
+++ b/blog/env_intel/ep019.html
@@ -1347,25 +1347,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1489,8 +1489,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep020.html
+++ b/blog/env_intel/ep020.html
@@ -1319,25 +1319,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1461,8 +1461,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep021.html
+++ b/blog/env_intel/ep021.html
@@ -1385,13 +1385,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
@@ -1399,11 +1392,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1527,8 +1527,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep022.html
+++ b/blog/env_intel/ep022.html
@@ -1380,11 +1380,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1394,11 +1394,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1522,8 +1522,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep023.html
+++ b/blog/env_intel/ep023.html
@@ -1366,25 +1366,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
                         <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1508,8 +1508,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep024.html
+++ b/blog/env_intel/ep024.html
@@ -1365,11 +1365,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
@@ -1377,13 +1384,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
                         <h3>Models & Agents</h3>
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1507,8 +1507,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep025.html
+++ b/blog/env_intel/ep025.html
@@ -1344,6 +1344,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
@@ -1351,18 +1358,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1486,8 +1486,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep026.html
+++ b/blog/env_intel/ep026.html
@@ -1382,25 +1382,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1524,8 +1524,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep027.html
+++ b/blog/env_intel/ep027.html
@@ -1354,13 +1354,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
@@ -1368,11 +1361,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1496,8 +1496,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep028.html
+++ b/blog/env_intel/ep028.html
@@ -1378,18 +1378,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
@@ -1397,6 +1390,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
                         <h3>Modern Investing Techniques</h3>
                         <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1520,8 +1520,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep029.html
+++ b/blog/env_intel/ep029.html
@@ -1372,18 +1372,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1507,8 +1507,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep030.html
+++ b/blog/env_intel/ep030.html
@@ -1375,25 +1375,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1517,8 +1517,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/ep031.html
+++ b/blog/env_intel/ep031.html
@@ -1245,13 +1245,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
@@ -1259,11 +1252,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1387,8 +1387,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/env_intel/index.html
+++ b/blog/env_intel/index.html
@@ -962,8 +962,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep032.html
+++ b/blog/fascinating_frontiers/ep032.html
@@ -1247,13 +1247,6 @@
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
-                    </a>
-                    
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
@@ -1261,11 +1254,18 @@
                         <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1389,8 +1389,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep033.html
+++ b/blog/fascinating_frontiers/ep033.html
@@ -1371,25 +1371,25 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
-                    </a>
-                    
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1513,8 +1513,7 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep034.html
+++ b/blog/fascinating_frontiers/ep034.html
@@ -1358,13 +1358,6 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
@@ -1372,11 +1365,18 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                         <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1500,8 +1500,7 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep035.html
+++ b/blog/fascinating_frontiers/ep035.html
@@ -1336,25 +1336,25 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1478,8 +1478,7 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep036.html
+++ b/blog/fascinating_frontiers/ep036.html
@@ -1313,18 +1313,18 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1455,8 +1455,7 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep037.html
+++ b/blog/fascinating_frontiers/ep037.html
@@ -1274,25 +1274,25 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1416,8 +1416,7 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep038.html
+++ b/blog/fascinating_frontiers/ep038.html
@@ -1269,18 +1269,18 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
@@ -1411,8 +1411,7 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep039.html
+++ b/blog/fascinating_frontiers/ep039.html
@@ -1274,6 +1274,13 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
                     <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
@@ -1281,18 +1288,11 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1416,8 +1416,7 @@ That's Fascinating Frontiers for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep040.html
+++ b/blog/fascinating_frontiers/ep040.html
@@ -1395,11 +1395,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
@@ -1407,13 +1414,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
                         <h3>Omni View — Omni‑View Briefing</h3>
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1537,8 +1537,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep041.html
+++ b/blog/fascinating_frontiers/ep041.html
@@ -1404,25 +1404,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
                         <h3>Omni View — Omni‑View Briefing</h3>
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1546,8 +1546,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep042.html
+++ b/blog/fascinating_frontiers/ep042.html
@@ -1347,25 +1347,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1489,8 +1489,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep043.html
+++ b/blog/fascinating_frontiers/ep043.html
@@ -1314,25 +1314,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1456,8 +1456,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep044.html
+++ b/blog/fascinating_frontiers/ep044.html
@@ -1360,11 +1360,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
@@ -1374,11 +1374,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1502,8 +1502,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep045.html
+++ b/blog/fascinating_frontiers/ep045.html
@@ -1340,18 +1340,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                     <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
@@ -1482,8 +1482,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep046.html
+++ b/blog/fascinating_frontiers/ep046.html
@@ -1351,25 +1351,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1493,8 +1493,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep047.html
+++ b/blog/fascinating_frontiers/ep047.html
@@ -1357,18 +1357,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                     <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
@@ -1376,6 +1369,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
                         <h3>Привет, Русский! — Episode Plan</h3>
                         <p>- Russian (Cyrillic): Космос</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1499,8 +1499,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep048.html
+++ b/blog/fascinating_frontiers/ep048.html
@@ -1350,18 +1350,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1485,8 +1485,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep049.html
+++ b/blog/fascinating_frontiers/ep049.html
@@ -1448,18 +1448,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1583,8 +1583,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep050.html
+++ b/blog/fascinating_frontiers/ep050.html
@@ -1346,25 +1346,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
                         <h3>Modern Investing Techniques</h3>
                         <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1488,8 +1488,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep051.html
+++ b/blog/fascinating_frontiers/ep051.html
@@ -1361,25 +1361,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
                         <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1503,8 +1503,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep052.html
+++ b/blog/fascinating_frontiers/ep052.html
@@ -1355,25 +1355,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1497,8 +1497,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep053.html
+++ b/blog/fascinating_frontiers/ep053.html
@@ -1375,25 +1375,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1517,8 +1517,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep054.html
+++ b/blog/fascinating_frontiers/ep054.html
@@ -1426,18 +1426,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
                         <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
@@ -1568,8 +1568,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep055.html
+++ b/blog/fascinating_frontiers/ep055.html
@@ -1392,18 +1392,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1411,6 +1404,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1534,8 +1534,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep056.html
+++ b/blog/fascinating_frontiers/ep056.html
@@ -1413,13 +1413,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
@@ -1432,6 +1425,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1555,8 +1555,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep057.html
+++ b/blog/fascinating_frontiers/ep057.html
@@ -1415,13 +1415,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
@@ -1434,6 +1427,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1557,8 +1557,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep058.html
+++ b/blog/fascinating_frontiers/ep058.html
@@ -1413,25 +1413,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
+                    </a>
+                    
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
                         <h3>Environmental Intelligence</h3>
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1555,8 +1555,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep059.html
+++ b/blog/fascinating_frontiers/ep059.html
@@ -1448,11 +1448,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
@@ -1460,13 +1467,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
                         <h3>Environmental Intelligence</h3>
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1590,8 +1590,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep060.html
+++ b/blog/fascinating_frontiers/ep060.html
@@ -1489,18 +1489,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
                         <h3>Models & Agents</h3>
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1624,8 +1624,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep061.html
+++ b/blog/fascinating_frontiers/ep061.html
@@ -1403,18 +1403,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
@@ -1422,6 +1415,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
                         <h3>Omni View — Omni‑View Briefing</h3>
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1545,8 +1545,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep062.html
+++ b/blog/fascinating_frontiers/ep062.html
@@ -1388,11 +1388,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1402,11 +1402,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1530,8 +1530,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/ep063.html
+++ b/blog/fascinating_frontiers/ep063.html
@@ -1224,25 +1224,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
                         <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1366,8 +1366,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/fascinating_frontiers/index.html
+++ b/blog/fascinating_frontiers/index.html
@@ -1001,8 +1001,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/finansy_prosto/ep007.html
+++ b/blog/finansy_prosto/ep007.html
@@ -1400,18 +1400,11 @@ Algoma Steel понесла убытки, а Transat показала прибы
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
@@ -1419,6 +1412,13 @@ Algoma Steel понесла убытки, а Transat показала прибы
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
                         <h3>Omni View — Omni‑View Briefing</h3>
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1542,11 +1542,10 @@ Algoma Steel понесла убытки, а Transat показала прибы
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1557,18 +1556,18 @@ Algoma Steel понесла убытки, а Transat показала прибы
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep008.html
+++ b/blog/finansy_prosto/ep008.html
@@ -1281,25 +1281,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1423,11 +1423,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1438,18 +1437,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep009.html
+++ b/blog/finansy_prosto/ep009.html
@@ -1312,6 +1312,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
@@ -1324,13 +1331,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1454,11 +1454,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1469,18 +1468,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep010.html
+++ b/blog/finansy_prosto/ep010.html
@@ -1293,13 +1293,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
@@ -1307,11 +1300,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1435,11 +1435,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1450,18 +1449,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep011.html
+++ b/blog/finansy_prosto/ep011.html
@@ -1285,11 +1285,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1297,13 +1304,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1427,11 +1427,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1442,18 +1441,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep012.html
+++ b/blog/finansy_prosto/ep012.html
@@ -1288,25 +1288,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
                         <h3>Environmental Intelligence</h3>
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1430,11 +1430,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1445,18 +1444,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep013.html
+++ b/blog/finansy_prosto/ep013.html
@@ -1312,18 +1312,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1331,6 +1324,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1454,11 +1454,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1469,18 +1468,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep014.html
+++ b/blog/finansy_prosto/ep014.html
@@ -1262,11 +1262,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1276,11 +1276,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1404,11 +1404,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1419,18 +1418,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep015.html
+++ b/blog/finansy_prosto/ep015.html
@@ -1307,11 +1307,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1319,13 +1326,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
-                    </a>
-                    
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1449,11 +1449,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1464,18 +1463,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep016.html
+++ b/blog/finansy_prosto/ep016.html
@@ -1287,25 +1287,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1429,11 +1429,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1444,18 +1443,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep017.html
+++ b/blog/finansy_prosto/ep017.html
@@ -1313,25 +1313,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1455,11 +1455,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1470,18 +1469,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep018.html
+++ b/blog/finansy_prosto/ep018.html
@@ -1360,25 +1360,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1502,11 +1502,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1517,18 +1516,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep019.html
+++ b/blog/finansy_prosto/ep019.html
@@ -1436,18 +1436,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1571,11 +1571,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1586,18 +1585,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep020.html
+++ b/blog/finansy_prosto/ep020.html
@@ -1465,13 +1465,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
                     <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
@@ -1479,11 +1472,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1607,11 +1607,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1622,18 +1621,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep021.html
+++ b/blog/finansy_prosto/ep021.html
@@ -1333,25 +1333,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
                     <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1475,11 +1475,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1490,18 +1489,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep022.html
+++ b/blog/finansy_prosto/ep022.html
@@ -1351,25 +1351,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1493,11 +1493,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1508,18 +1507,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep023.html
+++ b/blog/finansy_prosto/ep023.html
@@ -1313,25 +1313,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1455,11 +1455,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1470,18 +1469,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep024.html
+++ b/blog/finansy_prosto/ep024.html
@@ -1389,25 +1389,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1531,11 +1531,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1546,18 +1545,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep025.html
+++ b/blog/finansy_prosto/ep025.html
@@ -1372,25 +1372,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1514,11 +1514,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1529,18 +1528,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep026.html
+++ b/blog/finansy_prosto/ep026.html
@@ -1326,25 +1326,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1468,11 +1468,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1483,18 +1482,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep027.html
+++ b/blog/finansy_prosto/ep027.html
@@ -1306,25 +1306,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1448,11 +1448,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1463,18 +1462,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep028.html
+++ b/blog/finansy_prosto/ep028.html
@@ -1358,25 +1358,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
                         <h3>Models & Agents</h3>
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1500,11 +1500,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1515,18 +1514,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep029.html
+++ b/blog/finansy_prosto/ep029.html
@@ -1357,25 +1357,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                    </a>
+                    
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1499,11 +1499,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1514,18 +1513,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep030.html
+++ b/blog/finansy_prosto/ep030.html
@@ -1377,18 +1377,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
@@ -1396,6 +1389,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
                         <h3>Models & Agents</h3>
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1519,11 +1519,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1534,18 +1533,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/ep031.html
+++ b/blog/finansy_prosto/ep031.html
@@ -1303,25 +1303,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1445,11 +1445,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1460,18 +1459,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/finansy_prosto/index.html
+++ b/blog/finansy_prosto/index.html
@@ -910,8 +910,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/index.html
+++ b/blog/index.html
@@ -6599,8 +6599,7 @@
                 <a href="../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep001.html
+++ b/blog/models_agents/ep001.html
@@ -1255,11 +1255,18 @@
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
@@ -1267,13 +1274,6 @@
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
                         <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1397,8 +1397,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep002.html
+++ b/blog/models_agents/ep002.html
@@ -1283,25 +1283,25 @@ That's Models and Agents for February twenty-seventh, twenty twenty-six. If you 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1425,8 +1425,7 @@ That's Models and Agents for February twenty-seventh, twenty twenty-six. If you 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep003.html
+++ b/blog/models_agents/ep003.html
@@ -1276,25 +1276,25 @@ That's Models and Agents for February twenty-eighth, twenty twenty-six. If you f
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
                     <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
                         <h3>Planetterrian Daily</h3>
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1418,8 +1418,7 @@ That's Models and Agents for February twenty-eighth, twenty twenty-six. If you f
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep004.html
+++ b/blog/models_agents/ep004.html
@@ -1269,25 +1269,25 @@ That's Models and Agents for March first, twenty twenty-six. If you found this u
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
                         <h3>Omni View — Omni‑View Briefing</h3>
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1411,8 +1411,7 @@ That's Models and Agents for March first, twenty twenty-six. If you found this u
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep005.html
+++ b/blog/models_agents/ep005.html
@@ -1276,18 +1276,11 @@ That's Models and Agents for March second, twenty twenty-six. If you found this 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
@@ -1295,6 +1288,13 @@ That's Models and Agents for March second, twenty twenty-six. If you found this 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
                         <h3>Environmental Intelligence</h3>
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1418,8 +1418,7 @@ That's Models and Agents for March second, twenty twenty-six. If you found this 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep006.html
+++ b/blog/models_agents/ep006.html
@@ -1286,25 +1286,25 @@ That's Models and Agents for March fifth, twenty twenty-six. If you found this u
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1428,8 +1428,7 @@ That's Models and Agents for March fifth, twenty twenty-six. If you found this u
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep007.html
+++ b/blog/models_agents/ep007.html
@@ -1278,25 +1278,25 @@ That's Models and Agents for March sixth, twenty twenty-six. If you found this u
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1420,8 +1420,7 @@ That's Models and Agents for March sixth, twenty twenty-six. If you found this u
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep008.html
+++ b/blog/models_agents/ep008.html
@@ -1301,25 +1301,25 @@ That's Models and Agents for March seventh, twenty twenty-six. If you found this
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1443,8 +1443,7 @@ That's Models and Agents for March seventh, twenty twenty-six. If you found this
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep009.html
+++ b/blog/models_agents/ep009.html
@@ -1254,25 +1254,25 @@ That's Models and Agents for March eighth, twenty twenty-six. If you found this 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1396,8 +1396,7 @@ That's Models and Agents for March eighth, twenty twenty-six. If you found this 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep010.html
+++ b/blog/models_agents/ep010.html
@@ -1305,25 +1305,25 @@ That's Models and Agents for March ninth, twenty twenty-six. If you found this u
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
                         <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1447,8 +1447,7 @@ That's Models and Agents for March ninth, twenty twenty-six. If you found this u
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep011.html
+++ b/blog/models_agents/ep011.html
@@ -1312,11 +1312,11 @@ That's Models and Agents for March tenth, twenty twenty-six. If you found this u
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
@@ -1326,11 +1326,11 @@ That's Models and Agents for March tenth, twenty twenty-six. If you found this u
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1454,8 +1454,7 @@ That's Models and Agents for March tenth, twenty twenty-six. If you found this u
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep012.html
+++ b/blog/models_agents/ep012.html
@@ -1279,13 +1279,6 @@ That's Models and Agents for March eleventh, twenty twenty-six. If you found thi
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
@@ -1293,11 +1286,18 @@ That's Models and Agents for March eleventh, twenty twenty-six. If you found thi
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1421,8 +1421,7 @@ That's Models and Agents for March eleventh, twenty twenty-six. If you found thi
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep013.html
+++ b/blog/models_agents/ep013.html
@@ -1290,25 +1290,25 @@ That's Models and Agents for March twelfth, twenty twenty-six. If you found this
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
                         <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1432,8 +1432,7 @@ That's Models and Agents for March twelfth, twenty twenty-six. If you found this
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep014.html
+++ b/blog/models_agents/ep014.html
@@ -1292,25 +1292,25 @@ That's Models and Agents for March thirteenth, twenty twenty-six. If you found t
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1434,8 +1434,7 @@ That's Models and Agents for March thirteenth, twenty twenty-six. If you found t
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep015.html
+++ b/blog/models_agents/ep015.html
@@ -1312,11 +1312,11 @@ That's Models and Agents for March fourteenth, twenty twenty-six. If you found t
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1440,8 +1440,7 @@ That's Models and Agents for March fourteenth, twenty twenty-six. If you found t
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep016.html
+++ b/blog/models_agents/ep016.html
@@ -1242,25 +1242,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1384,8 +1384,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep017.html
+++ b/blog/models_agents/ep017.html
@@ -1294,25 +1294,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1436,8 +1436,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep018.html
+++ b/blog/models_agents/ep018.html
@@ -1346,18 +1346,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
@@ -1488,8 +1488,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep019.html
+++ b/blog/models_agents/ep019.html
@@ -1422,13 +1422,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
                     <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
@@ -1436,11 +1429,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1564,8 +1564,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep020.html
+++ b/blog/models_agents/ep020.html
@@ -1475,25 +1475,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1617,8 +1617,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep021.html
+++ b/blog/models_agents/ep021.html
@@ -1350,18 +1350,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1492,8 +1492,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep022.html
+++ b/blog/models_agents/ep022.html
@@ -1350,11 +1350,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
@@ -1364,11 +1364,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1492,8 +1492,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep023.html
+++ b/blog/models_agents/ep023.html
@@ -1349,11 +1349,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
@@ -1491,8 +1491,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep024.html
+++ b/blog/models_agents/ep024.html
@@ -1444,18 +1444,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
@@ -1463,6 +1456,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
                         <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1586,8 +1586,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep025.html
+++ b/blog/models_agents/ep025.html
@@ -1345,18 +1345,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1480,8 +1480,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep026.html
+++ b/blog/models_agents/ep026.html
@@ -1340,25 +1340,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1482,8 +1482,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep027.html
+++ b/blog/models_agents/ep027.html
@@ -1434,25 +1434,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1576,8 +1576,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep028.html
+++ b/blog/models_agents/ep028.html
@@ -1461,11 +1461,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
@@ -1473,13 +1480,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
                         <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1603,8 +1603,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep029.html
+++ b/blog/models_agents/ep029.html
@@ -1455,11 +1455,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
@@ -1469,11 +1469,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1597,8 +1597,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep030.html
+++ b/blog/models_agents/ep030.html
@@ -1398,25 +1398,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1540,8 +1540,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep031.html
+++ b/blog/models_agents/ep031.html
@@ -1436,25 +1436,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1578,8 +1578,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep032.html
+++ b/blog/models_agents/ep032.html
@@ -1415,25 +1415,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1557,8 +1557,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep033.html
+++ b/blog/models_agents/ep033.html
@@ -1381,11 +1381,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1395,11 +1395,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1523,8 +1523,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep034.html
+++ b/blog/models_agents/ep034.html
@@ -1436,25 +1436,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1578,8 +1578,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep035.html
+++ b/blog/models_agents/ep035.html
@@ -1471,11 +1471,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1485,11 +1485,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1613,8 +1613,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep036.html
+++ b/blog/models_agents/ep036.html
@@ -1429,25 +1429,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1571,8 +1571,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep037.html
+++ b/blog/models_agents/ep037.html
@@ -1458,6 +1458,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
@@ -1465,18 +1472,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1600,8 +1600,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep038.html
+++ b/blog/models_agents/ep038.html
@@ -1353,25 +1353,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1495,8 +1495,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep039.html
+++ b/blog/models_agents/ep039.html
@@ -1366,6 +1366,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
@@ -1373,18 +1380,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1508,8 +1508,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/ep040.html
+++ b/blog/models_agents/ep040.html
@@ -1377,25 +1377,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1519,8 +1519,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents/index.html
+++ b/blog/models_agents/index.html
@@ -1105,8 +1105,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep007.html
+++ b/blog/models_agents_beginners/ep007.html
@@ -1248,25 +1248,25 @@ That's it for today! Remember, every A I expert started exactly where you are ri
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1390,8 +1390,7 @@ That's it for today! Remember, every A I expert started exactly where you are ri
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep008.html
+++ b/blog/models_agents_beginners/ep008.html
@@ -1400,25 +1400,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1542,8 +1542,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep009.html
+++ b/blog/models_agents_beginners/ep009.html
@@ -1371,25 +1371,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1513,8 +1513,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep010.html
+++ b/blog/models_agents_beginners/ep010.html
@@ -1425,18 +1425,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
@@ -1444,6 +1437,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
                         <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1567,8 +1567,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep011.html
+++ b/blog/models_agents_beginners/ep011.html
@@ -1385,25 +1385,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
                         <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1527,8 +1527,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep012.html
+++ b/blog/models_agents_beginners/ep012.html
@@ -1380,13 +1380,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
                     <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
@@ -1394,11 +1387,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1522,8 +1522,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep013.html
+++ b/blog/models_agents_beginners/ep013.html
@@ -1286,11 +1286,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                     <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
@@ -1300,11 +1300,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1428,8 +1428,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep014.html
+++ b/blog/models_agents_beginners/ep014.html
@@ -1392,25 +1392,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1534,8 +1534,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep015.html
+++ b/blog/models_agents_beginners/ep015.html
@@ -1373,18 +1373,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1515,8 +1515,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep016.html
+++ b/blog/models_agents_beginners/ep016.html
@@ -1406,11 +1406,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
@@ -1418,13 +1425,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
                         <h3>Modern Investing Techniques</h3>
                         <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1548,8 +1548,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep017.html
+++ b/blog/models_agents_beginners/ep017.html
@@ -1403,25 +1403,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1545,8 +1545,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep018.html
+++ b/blog/models_agents_beginners/ep018.html
@@ -1398,25 +1398,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
                 </div>
@@ -1540,8 +1540,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep019.html
+++ b/blog/models_agents_beginners/ep019.html
@@ -1373,25 +1373,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
                         <h3>Omni View — Omni‑View Briefing</h3>
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
                 </div>
@@ -1515,8 +1515,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep020.html
+++ b/blog/models_agents_beginners/ep020.html
@@ -1380,11 +1380,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
@@ -1394,11 +1394,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1522,8 +1522,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep021.html
+++ b/blog/models_agents_beginners/ep021.html
@@ -1389,25 +1389,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
                         <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1531,8 +1531,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep022.html
+++ b/blog/models_agents_beginners/ep022.html
@@ -1407,25 +1407,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1549,8 +1549,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep023.html
+++ b/blog/models_agents_beginners/ep023.html
@@ -1438,25 +1438,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1580,8 +1580,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep024.html
+++ b/blog/models_agents_beginners/ep024.html
@@ -1359,25 +1359,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1501,8 +1501,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep025.html
+++ b/blog/models_agents_beginners/ep025.html
@@ -1377,13 +1377,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
                     <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
@@ -1396,6 +1389,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
                         <h3>Modern Investing Techniques</h3>
                         <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1519,8 +1519,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep026.html
+++ b/blog/models_agents_beginners/ep026.html
@@ -1364,25 +1364,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1506,8 +1506,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep027.html
+++ b/blog/models_agents_beginners/ep027.html
@@ -1328,13 +1328,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
@@ -1342,11 +1335,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1470,8 +1470,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep028.html
+++ b/blog/models_agents_beginners/ep028.html
@@ -1334,6 +1334,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
@@ -1341,18 +1348,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
-                    </a>
-                    
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1476,8 +1476,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/ep029.html
+++ b/blog/models_agents_beginners/ep029.html
@@ -1307,25 +1307,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
                 </div>
@@ -1449,8 +1449,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/models_agents_beginners/index.html
+++ b/blog/models_agents_beginners/index.html
@@ -884,8 +884,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep001.html
+++ b/blog/modern_investing/ep001.html
@@ -1376,11 +1376,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
@@ -1388,13 +1395,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
                         <h3>Omni View — Omni‑View Briefing</h3>
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1518,8 +1518,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep002.html
+++ b/blog/modern_investing/ep002.html
@@ -1345,6 +1345,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
@@ -1352,18 +1359,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1487,8 +1487,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep003.html
+++ b/blog/modern_investing/ep003.html
@@ -1360,6 +1360,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
@@ -1367,18 +1374,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1502,8 +1502,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep004.html
+++ b/blog/modern_investing/ep004.html
@@ -1352,6 +1352,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
@@ -1359,18 +1366,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1494,8 +1494,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep005.html
+++ b/blog/modern_investing/ep005.html
@@ -1364,13 +1364,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
@@ -1378,11 +1371,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1506,8 +1506,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep006.html
+++ b/blog/modern_investing/ep006.html
@@ -1443,18 +1443,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1578,8 +1578,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep007.html
+++ b/blog/modern_investing/ep007.html
@@ -1355,25 +1355,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1497,8 +1497,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep008.html
+++ b/blog/modern_investing/ep008.html
@@ -1368,25 +1368,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1510,8 +1510,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep009.html
+++ b/blog/modern_investing/ep009.html
@@ -1466,25 +1466,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1608,8 +1608,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep010.html
+++ b/blog/modern_investing/ep010.html
@@ -1395,18 +1395,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1530,8 +1530,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep011.html
+++ b/blog/modern_investing/ep011.html
@@ -1382,25 +1382,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1524,8 +1524,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep012.html
+++ b/blog/modern_investing/ep012.html
@@ -1354,11 +1354,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
@@ -1368,11 +1368,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1496,8 +1496,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep013.html
+++ b/blog/modern_investing/ep013.html
@@ -1405,11 +1405,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1533,8 +1533,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep014.html
+++ b/blog/modern_investing/ep014.html
@@ -1524,25 +1524,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1666,8 +1666,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep015.html
+++ b/blog/modern_investing/ep015.html
@@ -1502,11 +1502,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1514,13 +1521,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1644,8 +1644,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep016.html
+++ b/blog/modern_investing/ep016.html
@@ -1393,11 +1393,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1535,8 +1535,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep017.html
+++ b/blog/modern_investing/ep017.html
@@ -1396,18 +1396,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
                         <h3>Models & Agents</h3>
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1531,8 +1531,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep018.html
+++ b/blog/modern_investing/ep018.html
@@ -1384,18 +1384,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1403,6 +1396,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1526,8 +1526,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep019.html
+++ b/blog/modern_investing/ep019.html
@@ -1394,25 +1394,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1536,8 +1536,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep020.html
+++ b/blog/modern_investing/ep020.html
@@ -1392,25 +1392,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
                         <h3>Environmental Intelligence</h3>
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1534,8 +1534,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep021.html
+++ b/blog/modern_investing/ep021.html
@@ -1394,18 +1394,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
                     <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1529,8 +1529,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep022.html
+++ b/blog/modern_investing/ep022.html
@@ -1472,25 +1472,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1614,8 +1614,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep023.html
+++ b/blog/modern_investing/ep023.html
@@ -1511,13 +1511,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
@@ -1525,11 +1518,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1653,8 +1653,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep024.html
+++ b/blog/modern_investing/ep024.html
@@ -1491,25 +1491,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1633,8 +1633,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep025.html
+++ b/blog/modern_investing/ep025.html
@@ -1434,18 +1434,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1453,6 +1446,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
                         <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1576,8 +1576,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep026.html
+++ b/blog/modern_investing/ep026.html
@@ -1463,25 +1463,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
                         <h3>Models & Agents</h3>
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1605,8 +1605,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep027.html
+++ b/blog/modern_investing/ep027.html
@@ -1520,25 +1520,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1662,8 +1662,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep028.html
+++ b/blog/modern_investing/ep028.html
@@ -1538,25 +1538,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1680,8 +1680,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep029.html
+++ b/blog/modern_investing/ep029.html
@@ -1547,11 +1547,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1559,13 +1566,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
                         <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1689,8 +1689,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep030.html
+++ b/blog/modern_investing/ep030.html
@@ -1476,18 +1476,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1611,8 +1611,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep031.html
+++ b/blog/modern_investing/ep031.html
@@ -1449,11 +1449,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
@@ -1591,8 +1591,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep032.html
+++ b/blog/modern_investing/ep032.html
@@ -1408,18 +1408,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
@@ -1427,6 +1420,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
                         <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1550,8 +1550,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep033.html
+++ b/blog/modern_investing/ep033.html
@@ -1433,25 +1433,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1575,8 +1575,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/ep034.html
+++ b/blog/modern_investing/ep034.html
@@ -1380,25 +1380,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1522,8 +1522,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/modern_investing/index.html
+++ b/blog/modern_investing/index.html
@@ -1027,8 +1027,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep003.html
+++ b/blog/omni_view/ep003.html
@@ -1315,25 +1315,25 @@
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1457,8 +1457,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep004.html
+++ b/blog/omni_view/ep004.html
@@ -1449,11 +1449,18 @@ That's Omni View. For full source links and more context, check out today's writ
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1461,13 +1468,6 @@ That's Omni View. For full source links and more context, check out today's writ
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
                         <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1591,8 +1591,7 @@ That's Omni View. For full source links and more context, check out today's writ
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep005.html
+++ b/blog/omni_view/ep005.html
@@ -1505,18 +1505,18 @@ That's Omni View. For full source links and more context, check out today's writ
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1647,8 +1647,7 @@ That's Omni View. For full source links and more context, check out today's writ
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep006.html
+++ b/blog/omni_view/ep006.html
@@ -1394,11 +1394,18 @@ That's Omni View. For full source links and more context, check out today's writ
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
@@ -1406,13 +1413,6 @@ That's Omni View. For full source links and more context, check out today's writ
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
                         <h3>Modern Investing Techniques</h3>
                         <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1536,8 +1536,7 @@ That's Omni View. For full source links and more context, check out today's writ
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep007.html
+++ b/blog/omni_view/ep007.html
@@ -1501,13 +1501,6 @@ That's Omni View. For full source links and more context, check out today's writ
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
@@ -1515,11 +1508,18 @@ That's Omni View. For full source links and more context, check out today's writ
                         <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1643,8 +1643,7 @@ That's Omni View. For full source links and more context, check out today's writ
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep008.html
+++ b/blog/omni_view/ep008.html
@@ -1527,6 +1527,13 @@ That's Omni View. For full source links and more context, check out today's writ
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
@@ -1539,13 +1546,6 @@ That's Omni View. For full source links and more context, check out today's writ
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1669,8 +1669,7 @@ That's Omni View. For full source links and more context, check out today's writ
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep009.html
+++ b/blog/omni_view/ep009.html
@@ -1383,6 +1383,13 @@ That's Omni View. For full source links and more context, check out today's writ
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
@@ -1390,18 +1397,11 @@ That's Omni View. For full source links and more context, check out today's writ
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1525,8 +1525,7 @@ That's Omni View. For full source links and more context, check out today's writ
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep010.html
+++ b/blog/omni_view/ep010.html
@@ -1431,25 +1431,25 @@ That's Omni View. For full source links and more context, check out today's writ
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1573,8 +1573,7 @@ That's Omni View. For full source links and more context, check out today's writ
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep011.html
+++ b/blog/omni_view/ep011.html
@@ -1418,11 +1418,11 @@ That's Omni View. For full source links and more context, check out today's writ
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
@@ -1432,11 +1432,11 @@ That's Omni View. For full source links and more context, check out today's writ
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1560,8 +1560,7 @@ That's Omni View. For full source links and more context, check out today's writ
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep012.html
+++ b/blog/omni_view/ep012.html
@@ -1409,18 +1409,18 @@ That's Omni View. For full source links and more context, check out today's writ
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
                         <h3>Environmental Intelligence</h3>
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1544,8 +1544,7 @@ That's Omni View. For full source links and more context, check out today's writ
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep013.html
+++ b/blog/omni_view/ep013.html
@@ -1390,25 +1390,25 @@ That's Omni View. For full source links and more context, check out today's writ
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1532,8 +1532,7 @@ That's Omni View. For full source links and more context, check out today's writ
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep014.html
+++ b/blog/omni_view/ep014.html
@@ -1435,11 +1435,11 @@ That's Omni View. For full source links and more context, check out today's writ
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1577,8 +1577,7 @@ That's Omni View. For full source links and more context, check out today's writ
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep015.html
+++ b/blog/omni_view/ep015.html
@@ -1456,18 +1456,11 @@ That's Omni View. For full source links and more context, check out today's writ
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1475,6 +1468,13 @@ That's Omni View. For full source links and more context, check out today's writ
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1598,8 +1598,7 @@ That's Omni View. For full source links and more context, check out today's writ
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep016.html
+++ b/blog/omni_view/ep016.html
@@ -1404,6 +1404,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
@@ -1411,18 +1418,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1546,8 +1546,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep017.html
+++ b/blog/omni_view/ep017.html
@@ -1442,6 +1442,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
@@ -1449,18 +1456,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1584,8 +1584,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep018.html
+++ b/blog/omni_view/ep018.html
@@ -1523,11 +1523,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                     <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
@@ -1535,13 +1542,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
                         <h3>Planetterrian Daily</h3>
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1665,8 +1665,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep019.html
+++ b/blog/omni_view/ep019.html
@@ -1242,25 +1242,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1384,8 +1384,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep020.html
+++ b/blog/omni_view/ep020.html
@@ -1526,25 +1526,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1668,8 +1668,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep021.html
+++ b/blog/omni_view/ep021.html
@@ -1509,25 +1509,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1651,8 +1651,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep022.html
+++ b/blog/omni_view/ep022.html
@@ -1470,25 +1470,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1612,8 +1612,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep023.html
+++ b/blog/omni_view/ep023.html
@@ -1637,25 +1637,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1779,8 +1779,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep024.html
+++ b/blog/omni_view/ep024.html
@@ -1656,11 +1656,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1668,13 +1675,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
                         <h3>Models & Agents for Beginners</h3>
                         <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1798,8 +1798,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep025.html
+++ b/blog/omni_view/ep025.html
@@ -1284,25 +1284,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
                         <h3>Models & Agents</h3>
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1426,8 +1426,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep026.html
+++ b/blog/omni_view/ep026.html
@@ -1601,13 +1601,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
@@ -1620,6 +1613,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
                         <h3>Planetterrian Daily</h3>
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1743,8 +1743,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep027.html
+++ b/blog/omni_view/ep027.html
@@ -1643,25 +1643,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
                         <h3>Modern Investing Techniques</h3>
                         <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1785,8 +1785,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep028.html
+++ b/blog/omni_view/ep028.html
@@ -1614,18 +1614,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
                         <h3>Environmental Intelligence</h3>
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1749,8 +1749,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep029.html
+++ b/blog/omni_view/ep029.html
@@ -1642,11 +1642,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1656,11 +1656,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1784,8 +1784,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep030.html
+++ b/blog/omni_view/ep030.html
@@ -1625,25 +1625,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1767,8 +1767,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep031.html
+++ b/blog/omni_view/ep031.html
@@ -1613,25 +1613,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1755,8 +1755,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep032.html
+++ b/blog/omni_view/ep032.html
@@ -1597,25 +1597,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1739,8 +1739,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep033.html
+++ b/blog/omni_view/ep033.html
@@ -1601,25 +1601,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
                         <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1743,8 +1743,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep034.html
+++ b/blog/omni_view/ep034.html
@@ -1604,18 +1604,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1623,6 +1616,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1746,8 +1746,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep035.html
+++ b/blog/omni_view/ep035.html
@@ -1595,25 +1595,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1737,8 +1737,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep036.html
+++ b/blog/omni_view/ep036.html
@@ -1522,18 +1522,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
@@ -1541,6 +1534,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
                         <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1664,8 +1664,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep037.html
+++ b/blog/omni_view/ep037.html
@@ -1592,25 +1592,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1734,8 +1734,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep038.html
+++ b/blog/omni_view/ep038.html
@@ -1678,11 +1678,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
@@ -1820,8 +1820,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep039.html
+++ b/blog/omni_view/ep039.html
@@ -1681,25 +1681,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1823,8 +1823,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep040.html
+++ b/blog/omni_view/ep040.html
@@ -1604,6 +1604,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
@@ -1611,18 +1618,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1746,8 +1746,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep041.html
+++ b/blog/omni_view/ep041.html
@@ -1674,25 +1674,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1816,8 +1816,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/ep042.html
+++ b/blog/omni_view/ep042.html
@@ -1657,25 +1657,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1799,8 +1799,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/omni_view/index.html
+++ b/blog/omni_view/index.html
@@ -1105,8 +1105,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep022.html
+++ b/blog/planetterrian/ep022.html
@@ -1242,18 +1242,18 @@
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1384,8 +1384,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep023.html
+++ b/blog/planetterrian/ep023.html
@@ -1360,18 +1360,18 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1502,8 +1502,7 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep024.html
+++ b/blog/planetterrian/ep024.html
@@ -1325,25 +1325,25 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1467,8 +1467,7 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep025.html
+++ b/blog/planetterrian/ep025.html
@@ -1339,25 +1339,25 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                    </a>
+                    
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
                         <h3>Environmental Intelligence</h3>
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1481,8 +1481,7 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep027.html
+++ b/blog/planetterrian/ep027.html
@@ -1247,25 +1247,25 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1389,8 +1389,7 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep029.html
+++ b/blog/planetterrian/ep029.html
@@ -1259,25 +1259,25 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1401,8 +1401,7 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep030.html
+++ b/blog/planetterrian/ep030.html
@@ -1276,11 +1276,18 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
@@ -1288,13 +1295,6 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
                         <h3>Environmental Intelligence</h3>
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1418,8 +1418,7 @@ That's Planet-terry-an Daily for today. If you enjoyed this episode, a rating or
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep031.html
+++ b/blog/planetterrian/ep031.html
@@ -1326,25 +1326,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1468,8 +1468,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep032.html
+++ b/blog/planetterrian/ep032.html
@@ -1313,25 +1313,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1455,8 +1455,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep033.html
+++ b/blog/planetterrian/ep033.html
@@ -1347,18 +1347,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
@@ -1366,6 +1359,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
                         <h3>Models & Agents</h3>
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1489,8 +1489,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep034.html
+++ b/blog/planetterrian/ep034.html
@@ -1357,6 +1357,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
@@ -1369,13 +1376,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
                         <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1499,8 +1499,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep035.html
+++ b/blog/planetterrian/ep035.html
@@ -1341,11 +1341,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
@@ -1355,11 +1355,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1483,8 +1483,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep036.html
+++ b/blog/planetterrian/ep036.html
@@ -1341,18 +1341,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1483,8 +1483,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep037.html
+++ b/blog/planetterrian/ep037.html
@@ -1367,13 +1367,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
@@ -1381,11 +1374,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1509,8 +1509,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep038.html
+++ b/blog/planetterrian/ep038.html
@@ -1310,18 +1310,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1329,6 +1322,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
                         <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1452,8 +1452,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep039.html
+++ b/blog/planetterrian/ep039.html
@@ -1347,25 +1347,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1489,8 +1489,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep040.html
+++ b/blog/planetterrian/ep040.html
@@ -1334,25 +1334,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1476,8 +1476,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep041.html
+++ b/blog/planetterrian/ep041.html
@@ -1376,18 +1376,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1518,8 +1518,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep042.html
+++ b/blog/planetterrian/ep042.html
@@ -1377,6 +1377,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
@@ -1384,18 +1391,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1519,8 +1519,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep043.html
+++ b/blog/planetterrian/ep043.html
@@ -1346,11 +1346,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
@@ -1358,13 +1365,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
                         <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1488,8 +1488,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep044.html
+++ b/blog/planetterrian/ep044.html
@@ -1363,25 +1363,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1505,8 +1505,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep045.html
+++ b/blog/planetterrian/ep045.html
@@ -1353,13 +1353,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
@@ -1367,11 +1360,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1495,8 +1495,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep046.html
+++ b/blog/planetterrian/ep046.html
@@ -1325,13 +1325,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
@@ -1339,11 +1332,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1467,8 +1467,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep047.html
+++ b/blog/planetterrian/ep047.html
@@ -1386,18 +1386,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1405,6 +1398,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1528,8 +1528,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep048.html
+++ b/blog/planetterrian/ep048.html
@@ -1354,6 +1354,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
@@ -1361,18 +1368,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1496,8 +1496,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep049.html
+++ b/blog/planetterrian/ep049.html
@@ -1352,25 +1352,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1494,8 +1494,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep050.html
+++ b/blog/planetterrian/ep050.html
@@ -1365,18 +1365,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1507,8 +1507,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep051.html
+++ b/blog/planetterrian/ep051.html
@@ -1345,18 +1345,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1487,8 +1487,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep052.html
+++ b/blog/planetterrian/ep052.html
@@ -1322,25 +1322,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                    </a>
+                    
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1464,8 +1464,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep053.html
+++ b/blog/planetterrian/ep053.html
@@ -1325,13 +1325,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
@@ -1339,11 +1332,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1467,8 +1467,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep054.html
+++ b/blog/planetterrian/ep054.html
@@ -1308,25 +1308,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1450,8 +1450,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/ep055.html
+++ b/blog/planetterrian/ep055.html
@@ -1280,11 +1280,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1422,8 +1422,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/planetterrian/index.html
+++ b/blog/planetterrian/index.html
@@ -1001,8 +1001,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/privet_russian/ep001.html
+++ b/blog/privet_russian/ep001.html
@@ -1267,25 +1267,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1409,11 +1409,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1424,18 +1423,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep002.html
+++ b/blog/privet_russian/ep002.html
@@ -1380,11 +1380,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
@@ -1392,13 +1399,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
                         <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1522,11 +1522,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1537,18 +1536,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep003.html
+++ b/blog/privet_russian/ep003.html
@@ -1392,25 +1392,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1534,11 +1534,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1549,18 +1548,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep004.html
+++ b/blog/privet_russian/ep004.html
@@ -1410,25 +1410,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1552,11 +1552,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1567,18 +1566,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep005.html
+++ b/blog/privet_russian/ep005.html
@@ -1420,25 +1420,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1562,11 +1562,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1577,18 +1576,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep006.html
+++ b/blog/privet_russian/ep006.html
@@ -1366,25 +1366,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1508,11 +1508,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1523,18 +1522,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep007.html
+++ b/blog/privet_russian/ep007.html
@@ -1749,18 +1749,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
@@ -1891,11 +1891,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1906,18 +1905,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep008.html
+++ b/blog/privet_russian/ep008.html
@@ -1461,18 +1461,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1596,11 +1596,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1611,18 +1610,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep009.html
+++ b/blog/privet_russian/ep009.html
@@ -1508,25 +1508,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1650,11 +1650,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1665,18 +1664,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep010.html
+++ b/blog/privet_russian/ep010.html
@@ -1613,18 +1613,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1748,11 +1748,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1763,18 +1762,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep011.html
+++ b/blog/privet_russian/ep011.html
@@ -1386,11 +1386,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
@@ -1398,13 +1405,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
                         <h3>Models & Agents</h3>
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1528,11 +1528,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1543,18 +1542,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep012.html
+++ b/blog/privet_russian/ep012.html
@@ -1392,25 +1392,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1534,11 +1534,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1549,18 +1548,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep013.html
+++ b/blog/privet_russian/ep013.html
@@ -1416,11 +1416,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                     <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
@@ -1428,13 +1435,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
                         <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1558,11 +1558,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1573,18 +1572,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep014.html
+++ b/blog/privet_russian/ep014.html
@@ -1612,18 +1612,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1747,11 +1747,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1762,18 +1761,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep015.html
+++ b/blog/privet_russian/ep015.html
@@ -1494,11 +1494,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
@@ -1508,11 +1508,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1636,11 +1636,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1651,18 +1650,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep016.html
+++ b/blog/privet_russian/ep016.html
@@ -1595,25 +1595,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1737,11 +1737,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1752,18 +1751,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep017.html
+++ b/blog/privet_russian/ep017.html
@@ -1291,25 +1291,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1433,11 +1433,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1448,18 +1447,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep018.html
+++ b/blog/privet_russian/ep018.html
@@ -1475,18 +1475,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
-                    </a>
-                    
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
                         <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1610,11 +1610,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1625,18 +1624,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/ep019.html
+++ b/blog/privet_russian/ep019.html
@@ -1484,11 +1484,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
-                        <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1496,13 +1503,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1626,11 +1626,10 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1641,18 +1640,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../../privacy-policy.html">Privacy</a> &middot;
                     <a href="../../terms-of-service.html">Terms</a> &middot;

--- a/blog/privet_russian/index.html
+++ b/blog/privet_russian/index.html
@@ -832,8 +832,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep393.html
+++ b/blog/tesla/ep393.html
@@ -1420,18 +1420,18 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-nine do
                         <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1555,8 +1555,7 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-nine do
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep394.html
+++ b/blog/tesla/ep394.html
@@ -1357,6 +1357,13 @@ That's your Tesla news for today. T S L A closed at four hundred two dollars and
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                    </a>
+                    
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
@@ -1364,18 +1371,11 @@ That's your Tesla news for today. T S L A closed at four hundred two dollars and
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1499,8 +1499,7 @@ That's your Tesla news for today. T S L A closed at four hundred two dollars and
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep395.html
+++ b/blog/tesla/ep395.html
@@ -1425,18 +1425,18 @@ That's your Tesla news for today. T S L A closed at four hundred two dollars and
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
@@ -1567,8 +1567,7 @@ That's your Tesla news for today. T S L A closed at four hundred two dollars and
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep396.html
+++ b/blog/tesla/ep396.html
@@ -1342,6 +1342,13 @@ That's your Tesla news for today. T S L A closed at four hundred two dollars and
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
+                    </a>
+                    
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
@@ -1354,13 +1361,6 @@ That's your Tesla news for today. T S L A closed at four hundred two dollars and
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1484,8 +1484,7 @@ That's your Tesla news for today. T S L A closed at four hundred two dollars and
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep397.html
+++ b/blog/tesla/ep397.html
@@ -1357,25 +1357,25 @@ That's your Tesla news for today. T S L A closed at four hundred three dollars a
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1499,8 +1499,7 @@ That's your Tesla news for today. T S L A closed at four hundred three dollars a
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep398.html
+++ b/blog/tesla/ep398.html
@@ -1358,13 +1358,6 @@ That's your Tesla news for today. T S L A closed at four hundred five dollars an
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
-                    </a>
-                    
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
@@ -1372,11 +1365,18 @@ That's your Tesla news for today. T S L A closed at four hundred five dollars an
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
                 </div>
@@ -1500,8 +1500,7 @@ That's your Tesla news for today. T S L A closed at four hundred five dollars an
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep399.html
+++ b/blog/tesla/ep399.html
@@ -1399,25 +1399,25 @@ That's your Tesla news for today. T S L A closed at four hundred five dollars an
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1541,8 +1541,7 @@ That's your Tesla news for today. T S L A closed at four hundred five dollars an
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep400.html
+++ b/blog/tesla/ep400.html
@@ -1380,25 +1380,25 @@ That's your Tesla news for today. T S L A closed at four hundred five dollars an
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1522,8 +1522,7 @@ That's your Tesla news for today. T S L A closed at four hundred five dollars an
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep401.html
+++ b/blog/tesla/ep401.html
@@ -1402,11 +1402,18 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-six dol
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1414,13 +1421,6 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-six dol
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
                         <h3>Models & Agents for Beginners</h3>
                         <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
                 </div>
@@ -1544,8 +1544,7 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-six dol
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep402.html
+++ b/blog/tesla/ep402.html
@@ -1248,13 +1248,6 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-six dol
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
@@ -1262,11 +1255,18 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-six dol
                         <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1390,8 +1390,7 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-six dol
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep403.html
+++ b/blog/tesla/ep403.html
@@ -1402,6 +1402,13 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-eight d
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
@@ -1409,18 +1416,11 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-eight d
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1544,8 +1544,7 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-eight d
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep404.html
+++ b/blog/tesla/ep404.html
@@ -1279,25 +1279,25 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-nine do
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
                     <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
                         <h3>Planetterrian Daily</h3>
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1421,8 +1421,7 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-nine do
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep405.html
+++ b/blog/tesla/ep405.html
@@ -1407,11 +1407,18 @@ That's your Tesla news for today. T S L A closed at four hundred seven dollars a
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
@@ -1419,13 +1426,6 @@ That's your Tesla news for today. T S L A closed at four hundred seven dollars a
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
                         <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1549,8 +1549,7 @@ That's your Tesla news for today. T S L A closed at four hundred seven dollars a
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep406.html
+++ b/blog/tesla/ep406.html
@@ -1368,25 +1368,25 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-five do
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
                     <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
                         <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
                         <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1510,8 +1510,7 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-five do
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep407.html
+++ b/blog/tesla/ep407.html
@@ -1351,13 +1351,6 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-one dol
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
@@ -1365,11 +1358,18 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-one dol
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1493,8 +1493,7 @@ That's your Tesla news for today. T S L A closed at three hundred ninety-one dol
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep408.html
+++ b/blog/tesla/ep408.html
@@ -1378,18 +1378,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
                     <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
                         <h3>Привет, Русский! — Episode Plan</h3>
                         <p>- Russian (Cyrillic): Космос</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                     <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
@@ -1520,8 +1520,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep411.html
+++ b/blog/tesla/ep411.html
@@ -1422,18 +1422,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1564,8 +1564,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep413.html
+++ b/blog/tesla/ep413.html
@@ -1354,6 +1354,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
@@ -1366,13 +1373,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
                         <h3>Models & Agents for Beginners</h3>
                         <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1496,8 +1496,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep414.html
+++ b/blog/tesla/ep414.html
@@ -1357,6 +1357,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
@@ -1364,18 +1371,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1499,8 +1499,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep415.html
+++ b/blog/tesla/ep415.html
@@ -1382,25 +1382,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
                     <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
                         <h3>Привет, Русский! — Episode Plan</h3>
                         <p>- Russian (Cyrillic): Космос</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1524,8 +1524,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep416.html
+++ b/blog/tesla/ep416.html
@@ -1398,25 +1398,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1540,8 +1540,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep417.html
+++ b/blog/tesla/ep417.html
@@ -1352,25 +1352,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1494,8 +1494,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep418.html
+++ b/blog/tesla/ep418.html
@@ -1357,18 +1357,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1376,6 +1369,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1499,8 +1499,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep419.html
+++ b/blog/tesla/ep419.html
@@ -1363,13 +1363,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
                     <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
@@ -1377,11 +1370,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1505,8 +1505,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep420.html
+++ b/blog/tesla/ep420.html
@@ -1236,25 +1236,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1378,8 +1378,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep421.html
+++ b/blog/tesla/ep421.html
@@ -1262,11 +1262,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
@@ -1274,13 +1281,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
                         <h3>Omni View — Omni‑View Briefing</h3>
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1404,8 +1404,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep422.html
+++ b/blog/tesla/ep422.html
@@ -1263,18 +1263,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                     <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
@@ -1282,6 +1275,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
                         <h3>Привет, Русский! — Episode Plan</h3>
                         <p>- Russian (Cyrillic): Космос</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1405,8 +1405,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep423.html
+++ b/blog/tesla/ep423.html
@@ -1260,11 +1260,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                     <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
@@ -1274,11 +1274,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1402,8 +1402,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep424.html
+++ b/blog/tesla/ep424.html
@@ -1242,18 +1242,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1377,8 +1377,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep425.html
+++ b/blog/tesla/ep425.html
@@ -1446,25 +1446,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1588,8 +1588,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep426.html
+++ b/blog/tesla/ep426.html
@@ -1383,25 +1383,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
-                    </a>
-                    
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1525,8 +1525,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep427.html
+++ b/blog/tesla/ep427.html
@@ -1369,13 +1369,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
                     <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
@@ -1383,11 +1376,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                 </div>
@@ -1511,8 +1511,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep428.html
+++ b/blog/tesla/ep428.html
@@ -1301,25 +1301,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1443,8 +1443,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep429.html
+++ b/blog/tesla/ep429.html
@@ -1334,11 +1334,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
@@ -1348,11 +1348,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1476,8 +1476,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep430.html
+++ b/blog/tesla/ep430.html
@@ -1359,11 +1359,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
                     <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
@@ -1371,13 +1378,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
                         <h3>Привет, Русский! — Episode Plan</h3>
                         <p>- Russian (Cyrillic): Космос</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1501,8 +1501,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep431.html
+++ b/blog/tesla/ep431.html
@@ -1372,25 +1372,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1514,8 +1514,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep432.html
+++ b/blog/tesla/ep432.html
@@ -1356,11 +1356,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
@@ -1370,11 +1370,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1498,8 +1498,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep433.html
+++ b/blog/tesla/ep433.html
@@ -1355,13 +1355,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
-                    </a>
-                    
                     <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
@@ -1369,11 +1362,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1497,8 +1497,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep434.html
+++ b/blog/tesla/ep434.html
@@ -1389,18 +1389,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1524,8 +1524,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep435.html
+++ b/blog/tesla/ep435.html
@@ -1374,25 +1374,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1516,8 +1516,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep436.html
+++ b/blog/tesla/ep436.html
@@ -1377,18 +1377,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
                     <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
                         <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
                         <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                     <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
@@ -1519,8 +1519,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep437.html
+++ b/blog/tesla/ep437.html
@@ -1378,25 +1378,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
-                    </a>
-                    
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
                         <h3>Modern Investing Techniques</h3>
                         <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
                 </div>
@@ -1520,8 +1520,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep438.html
+++ b/blog/tesla/ep438.html
@@ -1397,11 +1397,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
@@ -1411,11 +1411,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
                 </div>
@@ -1539,8 +1539,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep439.html
+++ b/blog/tesla/ep439.html
@@ -1283,25 +1283,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1425,8 +1425,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep440.html
+++ b/blog/tesla/ep440.html
@@ -1378,18 +1378,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1513,8 +1513,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep441.html
+++ b/blog/tesla/ep441.html
@@ -1397,25 +1397,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1539,8 +1539,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep442.html
+++ b/blog/tesla/ep442.html
@@ -1444,18 +1444,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                     <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
@@ -1463,6 +1456,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
                         <h3>Привет, Русский! — Episode Plan</h3>
                         <p>- Russian (Cyrillic): Космос</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1586,8 +1586,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep443.html
+++ b/blog/tesla/ep443.html
@@ -1402,25 +1402,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                 </div>
@@ -1544,8 +1544,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep444.html
+++ b/blog/tesla/ep444.html
@@ -1344,11 +1344,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
@@ -1358,11 +1358,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1486,8 +1486,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep445.html
+++ b/blog/tesla/ep445.html
@@ -1408,13 +1408,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
-                    </a>
-                    
                     <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
@@ -1422,11 +1415,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
+                    </a>
+                    
+                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
+                        <h3>Omni View — Omni‑View Briefing</h3>
+                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1550,8 +1550,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep446.html
+++ b/blog/tesla/ep446.html
@@ -1404,25 +1404,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
                 </div>
@@ -1546,8 +1546,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep447.html
+++ b/blog/tesla/ep447.html
@@ -1450,25 +1450,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
+                    </a>
+                    
                     <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
                         <h3>Modern Investing Techniques</h3>
                         <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1592,8 +1592,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep448.html
+++ b/blog/tesla/ep448.html
@@ -1428,6 +1428,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
                     <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
@@ -1435,18 +1442,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
-                    </a>
-                    
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1570,8 +1570,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep449.html
+++ b/blog/tesla/ep449.html
@@ -1421,25 +1421,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1563,8 +1563,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep450.html
+++ b/blog/tesla/ep450.html
@@ -1419,25 +1419,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1561,8 +1561,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep451.html
+++ b/blog/tesla/ep451.html
@@ -1395,25 +1395,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
-                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
-                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1537,8 +1537,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep452.html
+++ b/blog/tesla/ep452.html
@@ -1441,25 +1441,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1583,8 +1583,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep453.html
+++ b/blog/tesla/ep453.html
@@ -1416,25 +1416,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
+                        <h3>Привет, Русский! — Episode Plan</h3>
+                        <p>- Russian (Cyrillic): Космос</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1558,8 +1558,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep454.html
+++ b/blog/tesla/ep454.html
@@ -1412,18 +1412,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1547,8 +1547,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep455.html
+++ b/blog/tesla/ep455.html
@@ -1397,25 +1397,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                    </a>
+                    
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
                         <h3>Models & Agents</h3>
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
-                    </a>
-                    
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1539,8 +1539,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep456.html
+++ b/blog/tesla/ep456.html
@@ -1465,25 +1465,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <h3>Models & Agents for Beginners</h3>
+                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1607,8 +1607,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep457.html
+++ b/blog/tesla/ep457.html
@@ -1404,25 +1404,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
                         <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
                         <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
                 </div>
@@ -1546,8 +1546,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep458.html
+++ b/blog/tesla/ep458.html
@@ -1385,11 +1385,18 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                     <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
@@ -1397,13 +1404,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
                         <h3>Models & Agents</h3>
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
-                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
-                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
                     </a>
                     
                 </div>
@@ -1527,8 +1527,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep459.html
+++ b/blog/tesla/ep459.html
@@ -1362,11 +1362,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
@@ -1376,11 +1376,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                 </div>
@@ -1504,8 +1504,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep460.html
+++ b/blog/tesla/ep460.html
@@ -1378,25 +1378,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/privet_russian/ep019.html" class="blog-related-card" style="--card-show-color: #4F46E5">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #4F46E5, white 35%)">Привет, Русский!</span>
-                        <h3>Привет, Русский! — Episode Plan</h3>
-                        <p>- Russian (Cyrillic): Космос</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
-                        <h3>Models & Agents</h3>
-                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1520,8 +1520,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep461.html
+++ b/blog/tesla/ep461.html
@@ -1391,6 +1391,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/finansy_prosto/ep031.html" class="blog-related-card" style="--card-show-color: #BE185D">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #BE185D, white 35%)">Финансы Просто</span>
+                        <h3>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бю...</h3>
+                        <p>Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом</p>
+                    </a>
+                    
                     <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
@@ -1403,13 +1410,6 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
                         <h3>Models & Agents</h3>
                         <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
-                    </a>
-                    
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
                     </a>
                     
                 </div>
@@ -1533,8 +1533,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep462.html
+++ b/blog/tesla/ep462.html
@@ -1373,25 +1373,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
-                        <h3>Planetterrian Daily</h3>
-                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/unintended_consequences/ep003.html" class="blog-related-card" style="--card-show-color: #B45309">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #B45309, white 35%)">Unintended Consequences</span>
+                        <h3>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine k...</h3>
+                        <p>In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would&hellip;</p>
                     </a>
                     
-                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
-                        <h3>Modern Investing Techniques</h3>
-                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
+                        <h3>Fascinating Frontiers</h3>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
                 </div>
@@ -1515,8 +1515,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/ep463.html
+++ b/blog/tesla/ep463.html
@@ -1390,25 +1390,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
+                        <h3>Environmental Intelligence</h3>
+                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
                     </a>
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
                     </a>
                     
-                    <a href="../../blog/omni_view/ep042.html" class="blog-related-card" style="--card-show-color: #0B6FD6">
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #0B6FD6, white 35%)">Omni View</span>
-                        <h3>Omni View — Omni‑View Briefing</h3>
-                        <p>Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
                     </a>
                     
                 </div>
@@ -1532,8 +1532,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/tesla/index.html
+++ b/blog/tesla/index.html
@@ -1469,8 +1469,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/unintended_consequences/ep001.html
+++ b/blog/unintended_consequences/ep001.html
@@ -1398,18 +1398,11 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/planetterrian/ep055.html" class="blog-related-card" style="--card-show-color: #017A99">
                         
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
-                        <h3>Fascinating Frontiers</h3>
-                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep029.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Models & Agents for Beginners</h3>
-                        <p>Google just launched 10 free AI courses anyone can start today — no coding or experience required.</p>
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #017A99, white 35%)">Planetterrian Daily</span>
+                        <h3>Planetterrian Daily</h3>
+                        <p>Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</p>
                     </a>
                     
                     <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
@@ -1417,6 +1410,13 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                         <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
                         <h3>Environmental Intelligence</h3>
                         <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                    </a>
+                    
+                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
+                        <h3>Tesla Shorts Time</h3>
+                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
                     </a>
                     
                 </div>
@@ -1540,8 +1540,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/unintended_consequences/ep002.html
+++ b/blog/unintended_consequences/ep002.html
@@ -1391,25 +1391,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
-                    <a href="../../blog/fascinating_frontiers/ep063.html" class="blog-related-card" style="--card-show-color: #6B47FF">
+                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
+                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
+                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
+                    </a>
+                    
+                    <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
-                        <p>Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</p>
+                        <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
                     </a>
                     
-                    <a href="../../blog/tesla/ep463.html" class="blog-related-card" style="--card-show-color: #E31937">
+                    <a href="../../blog/tesla/ep462.html" class="blog-related-card" style="--card-show-color: #E31937">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #E31937, white 35%)">Tesla Shorts Time</span>
                         <h3>Tesla Shorts Time</h3>
-                        <p>Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
+                        <p>Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</p>
                     </a>
                     
                 </div>
@@ -1533,8 +1533,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/unintended_consequences/ep003.html
+++ b/blog/unintended_consequences/ep003.html
@@ -1352,25 +1352,25 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <h2>You Might Also Like</h2>
                 <div class="blog-related-grid">
                     
+                    <a href="../../blog/modern_investing/ep034.html" class="blog-related-card" style="--card-show-color: #047857">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #047857, white 35%)">Modern Investing Techniques</span>
+                        <h3>Modern Investing Techniques</h3>
+                        <p>US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities&hellip;</p>
+                    </a>
+                    
+                    <a href="../../blog/models_agents/ep040.html" class="blog-related-card" style="--card-show-color: #7C3AED">
+                        
+                        <span class="blog-related-show" style="color: color-mix(in srgb, #7C3AED, white 35%)">Models & Agents</span>
+                        <h3>Models & Agents</h3>
+                        <p>OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</p>
+                    </a>
+                    
                     <a href="../../blog/fascinating_frontiers/ep062.html" class="blog-related-card" style="--card-show-color: #6B47FF">
                         
                         <span class="blog-related-show" style="color: color-mix(in srgb, #6B47FF, white 35%)">Fascinating Frontiers</span>
                         <h3>Fascinating Frontiers</h3>
                         <p>Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</p>
-                    </a>
-                    
-                    <a href="../../blog/env_intel/ep031.html" class="blog-related-card" style="--card-show-color: #1B5E20">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #1B5E20, white 35%)">Environmental Intelligence</span>
-                        <h3>Environmental Intelligence</h3>
-                        <p>Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</p>
-                    </a>
-                    
-                    <a href="../../blog/models_agents_beginners/ep028.html" class="blog-related-card" style="--card-show-color: #C2410C">
-                        
-                        <span class="blog-related-show" style="color: color-mix(in srgb, #C2410C, white 35%)">Models & Agents for Beginners</span>
-                        <h3>Three AIs debating your toughest questions on a shared canvas could make getting...</h3>
-                        <p>Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</p>
                     </a>
                     
                 </div>
@@ -1494,8 +1494,7 @@ This podcast is curated by Patrick but generated using AI voice synthesis of my 
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/blog/unintended_consequences/index.html
+++ b/blog/unintended_consequences/index.html
@@ -624,8 +624,7 @@
                 <a href="../../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/contact.html
+++ b/contact.html
@@ -624,8 +624,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/env-intel-summaries.html
+++ b/env-intel-summaries.html
@@ -741,8 +741,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/env-intel.html
+++ b/env-intel.html
@@ -966,7 +966,6 @@
     
 
     <!-- Newsletter Subscribe -->
-    
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
             <div class="show-subscribe-inline">
@@ -1275,8 +1274,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/faq.html
+++ b/faq.html
@@ -775,8 +775,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/fascinating-frontiers-summaries.html
+++ b/fascinating-frontiers-summaries.html
@@ -751,8 +751,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/fascinating-frontiers.html
+++ b/fascinating-frontiers.html
@@ -983,7 +983,6 @@
     
 
     <!-- Newsletter Subscribe -->
-    
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
             <div class="show-subscribe-inline">
@@ -1292,8 +1291,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/generate_network_rss.py
+++ b/generate_network_rss.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate a combined Nerra Network RSS feed from all 9 show feeds."""
+"""Generate a combined Nerra Network RSS feed from all 11 show feeds."""
 
 import xml.etree.ElementTree as ET
 from email.utils import parsedate_to_datetime, format_datetime

--- a/how-to-listen.html
+++ b/how-to-listen.html
@@ -1056,8 +1056,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/index.html
+++ b/index.html
@@ -2039,8 +2039,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/models-agents-beginners-summaries.html
+++ b/models-agents-beginners-summaries.html
@@ -749,8 +749,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/models-agents-beginners.html
+++ b/models-agents-beginners.html
@@ -951,7 +951,6 @@
     
 
     <!-- Newsletter Subscribe -->
-    
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
             <div class="show-subscribe-inline">
@@ -1260,8 +1259,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/models-agents-summaries.html
+++ b/models-agents-summaries.html
@@ -749,8 +749,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/models-agents.html
+++ b/models-agents.html
@@ -981,7 +981,6 @@
     
 
     <!-- Newsletter Subscribe -->
-    
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
             <div class="show-subscribe-inline">
@@ -1290,8 +1289,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/modern-investing-summaries.html
+++ b/modern-investing-summaries.html
@@ -749,8 +749,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/modern-investing.html
+++ b/modern-investing.html
@@ -1452,7 +1452,6 @@
     
 
     <!-- Newsletter Subscribe -->
-    
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
             <div class="show-subscribe-inline">
@@ -1761,8 +1760,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/network.rss
+++ b/network.rss
@@ -5,7 +5,7 @@
     <description>Eleven podcasts in two languages keeping you informed about exciting changes in the world. Unbiased, multi-perspective coverage of Tesla, world news, space, science, AI, the environment, modern investing, financial literacy, Russian language learning, and the unintended consequences of well-meant ideas.</description>
     <link>https://nerranetwork.com/</link>
     <language>en</language>
-    <lastBuildDate>Tue, 05 May 2026 11:59:54 +0000</lastBuildDate>
+    <lastBuildDate>Tue, 05 May 2026 21:43:54 +0000</lastBuildDate>
     <image>
       <url>https://nerranetwork.com/assets/covers/svg/Nerra-Network-Logo.svg</url>
       <title>Nerra Network</title>
@@ -1625,29 +1625,6 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:season>1</itunes:season>
       <itunes:episode>59</itunes:episode>
       <itunes:title>Ep 59: NASA's Artemis III crewed lunar landing slips to no earlier than late 2027 as planners refine the timeline.</itunes:title>
-      <itunes:episodeType>full</itunes:episodeType>
-    </item>
-    <item>
-      <title>Ep 25: A 20-year-old in Algeria just built his own AI platform with 40+ models you can compare side-by-side — no team, no money, just pure hustle.</title>
-      <description>**HOOK:** A 20-year-old in Algeria just built his own AI platform with 40+ models you can compare side-by-side — no team, no money, just pure hustle.
-
-**What's Cool Today:** A teenager from Algeria launched a solo AI comparison platform after just two weeks of work, letting anyone test the latest ChatGPT, Claude, and other models next to each other for free or cheap. It’s proof that one curious person can create something useful for the whole world without a big company behind them. ...
-
-AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice synthesis (ElevenLabs) for audio production.</description>
-      <guid isPermaLink="false">mab-ep025-20260428-090339854828</guid>
-      <enclosure url="https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep025_20260428.mp3" length="10305036" type="audio/mpeg" />
-      <pubDate>Tue, 28 Apr 2026 08:00:00 +0000</pubDate>
-      <itunes:image href="https://nerranetwork.com/assets/covers/models-agents-beginners.jpg" />
-      <itunes:duration>07:09</itunes:duration>
-      <itunes:explicit>no</itunes:explicit>
-      <itunes:summary>**HOOK:** A 20-year-old in Algeria just built his own AI platform with 40+ models you can compare side-by-side — no team, no money, just pure hustle.
-
-**What's Cool Today:** A teenager from Algeria launched a solo AI comparison platform after just two weeks of work, letting anyone test the latest ChatGPT, Claude, and other models next to each other for free or cheap. It’s proof that one curious person can create something useful for the whole world without a big company behind them. ...
-
-AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice synthesis (ElevenLabs) for audio production.</itunes:summary>
-      <itunes:season>1</itunes:season>
-      <itunes:episode>25</itunes:episode>
-      <itunes:title>Ep 25: A 20-year-old in Algeria just built his own AI platform with 40+ models you can compare side-by-side — no team, no money, just pure hustle.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
     </item>
   </channel>

--- a/omni-view-summaries.html
+++ b/omni-view-summaries.html
@@ -751,8 +751,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/omni-view.html
+++ b/omni-view.html
@@ -996,7 +996,6 @@
     
 
     <!-- Newsletter Subscribe -->
-    
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
             <div class="show-subscribe-inline">
@@ -1305,8 +1304,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/planetterrian-summaries.html
+++ b/planetterrian-summaries.html
@@ -751,8 +751,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/planetterrian.html
+++ b/planetterrian.html
@@ -971,7 +971,6 @@
     
 
     <!-- Newsletter Subscribe -->
-    
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
             <div class="show-subscribe-inline">
@@ -1280,8 +1279,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/player.html
+++ b/player.html
@@ -1000,8 +1000,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/press.html
+++ b/press.html
@@ -843,8 +843,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/ru/finansy-prosto-summaries.html
+++ b/ru/finansy-prosto-summaries.html
@@ -749,11 +749,10 @@
                 <a href="../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -764,18 +763,18 @@
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../privacy-policy.html">Privacy</a> &middot;
                     <a href="../terms-of-service.html">Terms</a> &middot;

--- a/ru/finansy-prosto.html
+++ b/ru/finansy-prosto.html
@@ -945,18 +945,17 @@
     
 
     <!-- Newsletter Subscribe -->
-    
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
             <div class="show-subscribe-inline">
-                <h3>Get Финансы Просто in your inbox</h3>
-                <p>New episode alerts delivered straight to your email — no spam, unsubscribe anytime.</p>
+                <h3>Получайте Финансы Просто на почту</h3>
+                <p>Уведомления о новых выпусках прямо на email — без спама, отписаться можно в любой момент.</p>
                 <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow">
                     <input type="hidden" name="tag" value="Finansy Prosto">
                     <input type="hidden" value="1" name="embed">
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <button type="submit">Subscribe</button>
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
@@ -1254,11 +1253,10 @@
                 <a href="../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1269,18 +1267,18 @@
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../privacy-policy.html">Privacy</a> &middot;
                     <a href="../terms-of-service.html">Terms</a> &middot;

--- a/ru/privet-russian-summaries.html
+++ b/ru/privet-russian-summaries.html
@@ -749,11 +749,10 @@
                 <a href="../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -764,18 +763,18 @@
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../privacy-policy.html">Privacy</a> &middot;
                     <a href="../terms-of-service.html">Terms</a> &middot;

--- a/ru/privet-russian.html
+++ b/ru/privet-russian.html
@@ -939,18 +939,17 @@
     
 
     <!-- Newsletter Subscribe -->
-    
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
             <div class="show-subscribe-inline">
-                <h3>Get Привет, Русский! in your inbox</h3>
-                <p>New episode alerts delivered straight to your email — no spam, unsubscribe anytime.</p>
+                <h3>Получайте Привет, Русский! на почту</h3>
+                <p>Уведомления о новых выпусках прямо на email — без спама, отписаться можно в любой момент.</p>
                 <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow">
                     <input type="hidden" name="tag" value="Privet Russian">
                     <input type="hidden" value="1" name="embed">
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <button type="submit">Subscribe</button>
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
@@ -1248,11 +1247,10 @@
                 <a href="../management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Подписка…';setTimeout(function(){btn.textContent='Проверьте почту ✓';btn.disabled=false;},500);">
+                    <h4>Подписка на обновления</h4>
+                    <p>Выберите подкасты, которые хотите получать на почту:</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -1263,18 +1261,18 @@
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">Подписаться</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>&copy; 2026 Nerra Network. Все шоу — независимое производство.</span>
                 <a href="../index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="../ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">Nerra Network использует ИИ-инструменты в производстве контента. <a href="../ai-disclosure.html">Подробнее</a></p>
                 <div>
                     <a href="../privacy-policy.html">Privacy</a> &middot;
                     <a href="../terms-of-service.html">Terms</a> &middot;

--- a/start-here.html
+++ b/start-here.html
@@ -865,8 +865,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -262,10 +262,11 @@
             </div>
             <!-- Newsletter Subscribe -->
             <div class="nn-footer-subscribe">
+                {%- set _is_ru = (page_lang | default('en')) == 'ru' -%}
                 <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
-                    <h4>Get Show Updates</h4>
-                    <p>Pick the shows you want in your inbox:</p>
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent={% if _is_ru %}'Подписка…'{% else %}'Subscribing…'{% endif %};setTimeout(function(){btn.textContent={% if _is_ru %}'Проверьте почту ✓'{% else %}'Check your email ✓'{% endif %};btn.disabled=false;},500);">
+                    <h4>{% if _is_ru %}Подписка на обновления{% else %}Get Show Updates{% endif %}</h4>
+                    <p>{% if _is_ru %}Выберите подкасты, которые хотите получать на почту:{% else %}Pick the shows you want in your inbox:{% endif %}</p>
                     <div class="nn-subscribe-tags">
                         <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
@@ -276,18 +277,18 @@
                         <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="email" name="email" placeholder="{% if _is_ru %}ваш@email.ru{% else %}your@email.com{% endif %}" required aria-label="{% if _is_ru %}Адрес электронной почты{% else %}Email address{% endif %}">
                         <input type="hidden" value="1" name="embed">
-                        <button type="submit">Subscribe</button>
+                        <button type="submit">{% if _is_ru %}Подписаться{% else %}Subscribe{% endif %}</button>
                     </div>
                 </form>
             </div>
             <div class="nn-footer-bottom">
-                <span>&copy; 2026 Nerra Network. All shows independently produced.</span>
+                <span>{% if _is_ru %}&copy; 2026 Nerra Network. Все шоу — независимое производство.{% else %}&copy; 2026 Nerra Network. All shows independently produced.{% endif %}</span>
                 <a href="{{ path_prefix }}index.html">nerranetwork.com</a>
             </div>
             <div class="nn-footer-legal">
-                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="{{ path_prefix }}ai-disclosure.html">Learn more</a></p>
+                <p class="ai-notice">{% if _is_ru %}Nerra Network использует ИИ-инструменты в производстве контента.{% else %}Nerra Network uses AI tools in content production.{% endif %} <a href="{{ path_prefix }}ai-disclosure.html">{% if _is_ru %}Подробнее{% else %}Learn more{% endif %}</a></p>
                 <div>
                     <a href="{{ path_prefix }}privacy-policy.html">Privacy</a> &middot;
                     <a href="{{ path_prefix }}terms-of-service.html">Terms</a> &middot;

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -604,17 +604,18 @@
 
     <!-- Newsletter Subscribe -->
     {% if newsletter_tag %}
+    {%- set _is_ru = (page_lang | default('en')) == 'ru' -%}
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
             <div class="show-subscribe-inline">
-                <h3>Get {{ show_name }} in your inbox</h3>
-                <p>New episode alerts delivered straight to your email — no spam, unsubscribe anytime.</p>
+                <h3>{% if _is_ru %}Получайте {{ show_name }} на почту{% else %}Get {{ show_name }} in your inbox{% endif %}</h3>
+                <p>{% if _is_ru %}Уведомления о новых выпусках прямо на email — без спама, отписаться можно в любой момент.{% else %}New episode alerts delivered straight to your email — no spam, unsubscribe anytime.{% endif %}</p>
                 <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow">
                     <input type="hidden" name="tag" value="{{ newsletter_tag }}">
                     <input type="hidden" value="1" name="embed">
                     <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <button type="submit">Subscribe</button>
+                        <input type="email" name="email" placeholder="{% if _is_ru %}ваш@email.ru{% else %}your@email.com{% endif %}" required aria-label="{% if _is_ru %}Адрес электронной почты{% else %}Email address{% endif %}">
+                        <button type="submit">{% if _is_ru %}Подписаться{% else %}Subscribe{% endif %}</button>
                     </div>
                 </form>
             </div>

--- a/tesla-summaries.html
+++ b/tesla-summaries.html
@@ -751,8 +751,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/tesla.html
+++ b/tesla.html
@@ -1044,7 +1044,6 @@
     
 
     <!-- Newsletter Subscribe -->
-    
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
             <div class="show-subscribe-inline">
@@ -1353,8 +1352,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/unintended-consequences-summaries.html
+++ b/unintended-consequences-summaries.html
@@ -739,8 +739,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>

--- a/unintended-consequences.html
+++ b/unintended-consequences.html
@@ -745,7 +745,6 @@
     
 
     <!-- Newsletter Subscribe -->
-    
     <section class="nn-section" style="padding-top:0;">
         <div class="container" style="max-width:700px;">
             <div class="show-subscribe-inline">
@@ -1054,8 +1053,7 @@
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
-            <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+            <div class="nn-footer-subscribe"><form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent='Subscribing…';setTimeout(function(){btn.textContent='Check your email ✓';btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>


### PR DESCRIPTION
## Summary

Closes the Severity 3 finding from the May 2026 site audit: Russian-language pages (`ru/finansy-prosto.html`, `ru/privet-russian.html`) were rendering with English copy in the footer chrome and inline subscribe blocks.

## Localized strings

`templates/base.html.j2` and `templates/show_page.html.j2` already receive a `page_lang` context variable (`generate_html.py:1426` / `:1570`), so the localization is pure inline conditionals — no new infra.

| EN | RU |
|----|----|
| Get Show Updates | Подписка на обновления |
| Pick the shows you want in your inbox: | Выберите подкасты, которые хотите получать на почту: |
| your@email.com | ваш@email.ru |
| Email address *(aria-label)* | Адрес электронной почты |
| Subscribe | Подписаться |
| Subscribing… / Check your email ✓ | Подписка… / Проверьте почту ✓ |
| All shows independently produced. | Все шоу — независимое производство. |
| uses AI tools in content production | использует ИИ-инструменты в производстве контента |
| Learn more | Подробнее |
| Get *<show>* in your inbox | Получайте *<show>* на почту |
| New episode alerts delivered straight to your email — no spam, unsubscribe anytime. | Уведомления о новых выпусках прямо на email — без спама, отписаться можно в любой момент. |

## Bonus polish

- Stale docstring in `generate_network_rss.py` ("9 show feeds" → "11 show feeds"). The list literal was already correct.

## Static regen

`python generate_html.py --all` re-rendered every page so the new strings reach Russian users immediately.

## Test plan

- [x] Full pytest suite: **1574 passed**, 6 skipped, 2 deselected (pre-existing env-only)
- [x] `grep -c "All shows independently produced\|Get Show Updates" ru/*.html` → `0`
- [x] English equivalents still render on English shows (Tesla, Omni View, Env Intel, etc.)
- [ ] Visual sanity check on rendered Russian pages (operator)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_