### PR TITLE
May 6 operator audit: music timing, RSS transcripts, chapter quality, speech tags

### DIFF
--- a/engine/audio.py
+++ b/engine/audio.py
@@ -517,10 +517,10 @@ def mix_with_music(
     music_path: Path,
     output_path: Path,
     *,
-    intro_duration: int = 15,
+    intro_duration: int = 25,
     overlap_duration: int = 10,
-    fade_duration: int = 15,
-    outro_duration: int = 40,
+    fade_duration: int = 20,
+    outro_duration: int = 60,
     intro_volume: float = 0.6,
     overlap_volume: float = 0.5,
     fade_volume: float = 0.4,
@@ -528,15 +528,17 @@ def mix_with_music(
     voice_intro_delay: float = 0.0,
     background_music_path: Optional[Path] = None,
     outro_crossfade: float = 0.0,
+    outro_fade_out_duration: float = 6.0,
 ) -> Path:
     """Full music mixing pipeline supporting three modes.
 
-    Defaults bumped May 2026 so the open / close feel like a real
-    podcast (NPR / Hard Fork / The Daily). Total intro music
-    presence = intro_duration (alone, before voice) + overlap_duration
+    Defaults bumped (revised May 2026) so the open / close feel like
+    a real podcast — operator reported the previous 15s/40s timing
+    still cut off too quickly. Total intro music presence =
+    intro_duration (alone, before voice) + overlap_duration
     (alongside voice) + fade_duration (gentle under-voice tail) =
-    15 + 10 + 15 = 40 seconds. Outro = 40 seconds of music after
-    voice ends.
+    25 + 10 + 20 = 55 seconds. Outro = 60 seconds of music after
+    voice ends with a 6-second graceful fade-out close.
 
     **Standard mode** (voice_intro_delay=0, no background_music_path):
       0–15 s:  music intro alone (intro_volume)
@@ -636,25 +638,27 @@ def mix_with_music(
             subprocess.run(cmd, check=True, capture_output=True)
             return name
 
-        # Calculate outro segment parameters with crossfade support
+        # Calculate outro segment parameters with crossfade support.
+        # ``outro_fade_out_duration`` is operator-tunable so the close
+        # can taper gracefully — the previous hardcoded 3s felt abrupt
+        # on long podcast outros (operator reported May 6, 2026).
+        outro_fade_out_dur = max(int(outro_fade_out_duration), 1)
         total_outro_duration = int(outro_crossfade + outro_duration)
         if outro_crossfade > 0:
-            # Fade-in over the crossfade period, fade-out over 3s at end
+            # Fade-in over the crossfade period, configurable fade-out at end
             outro_fade_in = int(outro_crossfade)
-            outro_fade_out_start = max(total_outro_duration - 3, 0)
-            outro_fade_out_dur = 3
+            outro_fade_out_start = max(total_outro_duration - outro_fade_out_dur, 0)
             logger.info(
                 "Outro crossfade: music starts %.0fs before voice ends, "
-                "%ds total outro (%ds fade-in, %ds tail).",
+                "%ds total outro (%ds fade-in, %ds tail-out).",
                 outro_crossfade, total_outro_duration,
-                outro_fade_in, outro_duration,
+                outro_fade_in, outro_fade_out_dur,
             )
         else:
-            # Default: short 2s fade-in, 3s fade-out at end
+            # Default: short 2s fade-in, configurable fade-out at end
             total_outro_duration = outro_duration
             outro_fade_in = 2
-            outro_fade_out_start = max(outro_duration - 3, 0)
-            outro_fade_out_dur = 3
+            outro_fade_out_start = max(outro_duration - outro_fade_out_dur, 0)
 
         segment_cmds = [
             ("intro", _music_intro_cmd(

--- a/engine/chapters.py
+++ b/engine/chapters.py
@@ -42,6 +42,9 @@ def parse_chapters(
     section_markers: list,
     *,
     show_name: str = "",
+    min_chapters: int = 4,
+    auto_segment_target_seconds: float = 90.0,
+    estimated_words_per_minute: float = 165.0,
 ) -> List[Chapter]:
     """Parse a podcast script to identify section boundaries.
 
@@ -126,6 +129,82 @@ def parse_chapters(
             char_start=c_start,
             char_end=c_end,
         ))
+
+    # ------------------------------------------------------------------
+    # Auto-segmentation fallback. Operator caught (May 2026) that TST
+    # episodes ship with only ``Introduction`` + ``Closing`` chapters
+    # because the per-show ``section_markers`` regex don't tolerate the
+    # variations the LLM and Whisper produce. The result was a 7-minute
+    # block called "Introduction" with no nav. When the matched chapter
+    # count is below ``min_chapters`` AND the first chapter spans most
+    # of the script, we splice extra chapters at paragraph boundaries
+    # roughly every ``auto_segment_target_seconds`` of speech so
+    # listeners always get useful navigation. The auto-titles are
+    # numeric (``Segment 2``, ``Segment 3`` …) — kept generic so they
+    # don't mislead about content.
+    if len(chapters) < min_chapters and total_words > 0:
+        words_per_segment = max(
+            int(estimated_words_per_minute * (auto_segment_target_seconds / 60.0)),
+            120,
+        )
+        # Find paragraph break offsets (blank-line-separated chunks).
+        para_break_word_idx: list[tuple[int, int]] = []  # (word_index, char_offset)
+        idx = 0
+        char_idx = 0
+        for line in lines:
+            line_word_count = len(line.split())
+            if line.strip() == "" and idx > 0:
+                para_break_word_idx.append((idx, char_idx))
+            idx += line_word_count
+            char_idx += len(line)
+
+        # Build augmented chapter list — splice auto-segments into the
+        # FIRST chapter (the long "Introduction") only. Splitting later
+        # chapters tends to cut hand-titled sections.
+        if chapters and para_break_word_idx:
+            head = chapters[0]
+            tail = chapters[1:]
+            head_w_end = head.word_end
+            head_c_end = head.char_end
+
+            # Accept paragraph breaks inside the head chapter that are at
+            # least ``words_per_segment`` words apart.
+            insertions: list[tuple[int, int]] = []
+            last_w = head.word_start
+            for w, c in para_break_word_idx:
+                if w <= head.word_start or w >= head_w_end:
+                    continue
+                if w - last_w >= words_per_segment:
+                    insertions.append((w, c))
+                    last_w = w
+
+            if insertions:
+                rebuilt: list[Chapter] = [Chapter(
+                    title=head.title,
+                    word_start=head.word_start,
+                    word_end=insertions[0][0],
+                    char_start=head.char_start,
+                    char_end=insertions[0][1],
+                )]
+                for n, (w, c) in enumerate(insertions, start=2):
+                    next_w = insertions[n - 1][0] if n - 1 < len(insertions) else head_w_end
+                    next_c = insertions[n - 1][1] if n - 1 < len(insertions) else head_c_end
+                    rebuilt.append(Chapter(
+                        title=f"Segment {n}",
+                        word_start=w,
+                        word_end=next_w,
+                        char_start=c,
+                        char_end=next_c,
+                    ))
+                chapters = rebuilt + tail
+                logger.info(
+                    "Auto-segmented head chapter for %s into %d segments "
+                    "(target %.0fs each, ~%d words)",
+                    show_name or "show",
+                    len(insertions) + 1,
+                    auto_segment_target_seconds,
+                    words_per_segment,
+                )
 
     logger.info(
         "Parsed %d chapters for %s: %s",

--- a/engine/config.py
+++ b/engine/config.py
@@ -115,24 +115,26 @@ class AudioConfig:
     music_file: Optional[str] = None
     background_music_file: Optional[str] = None
     transition_sting: Optional[str] = None
-    # Music timing — May 2026 podcast-feel bump. Aligned with
+    # Music timing — May 2026 podcast-feel bump (revised). Aligned with
     # ``shows/_defaults.yaml`` so a show running with the dataclass
     # defaults (no YAML) gets the same behaviour as a show inheriting
     # from the network baseline. Total intro music presence =
     # intro_duration (alone) + overlap_duration (with voice) +
-    # fade_duration (under-voice tail) = 15 + 10 + 15 = 40s. Outro =
-    # 40s after voice ends. ``voice_intro_delay`` MUST stay >=
-    # ``intro_duration`` so the voice doesn't enter while the music
-    # intro is still in its alone-period.
-    intro_duration: float = 15.0
+    # fade_duration (under-voice tail) = 25 + 10 + 20 = 55s. Outro =
+    # 60s after voice ends with a 6s graceful fade-out close.
+    # ``voice_intro_delay`` MUST stay >= ``intro_duration`` so the
+    # voice doesn't enter while the music intro is still in its
+    # alone-period. Operator's stated minimum is >= 30s on both ends.
+    intro_duration: float = 25.0
     overlap_duration: float = 10.0
-    fade_duration: float = 15.0
-    outro_duration: float = 40.0
+    fade_duration: float = 20.0
+    outro_duration: float = 60.0
+    outro_fade_out_duration: float = 6.0
     intro_volume: float = 0.6
     overlap_volume: float = 0.5
     fade_volume: float = 0.4
     outro_volume: float = 0.4
-    voice_intro_delay: float = 15.0
+    voice_intro_delay: float = 25.0
     outro_crossfade: float = 0.0
 
 

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -253,6 +253,31 @@ def update_rss_feed(
                             ep_data["itunes_season"] = elem.text or ""
                         elif tag == "{http://www.itunes.com/dtds/podcast-1.0.dtd}episodeType":
                             ep_data["itunes_episode_type"] = elem.text or ""
+                        elif tag == "{https://podcastindex.org/namespace/1.0}chapters":
+                            # Preserve Podcasting 2.0 chapters URL across
+                            # rebuilds. Without this every regen drops the
+                            # tag from prior episodes — Apple Podcasts then
+                            # shows chapters only on the latest episode.
+                            url = elem.get("url", "")
+                            if url:
+                                ep_data["podcast_chapters_url"] = url
+                                ep_data["podcast_chapters_type"] = elem.get(
+                                    "type", "application/json+chapters"
+                                )
+                        elif tag == "{https://podcastindex.org/namespace/1.0}transcript":
+                            # Same preservation logic as chapters — the
+                            # operator caught Apple Podcasts dropping
+                            # transcripts from every TST episode except
+                            # the very latest after this regression.
+                            url = elem.get("url", "")
+                            if url:
+                                ep_data["podcast_transcript_url"] = url
+                                ep_data["podcast_transcript_type"] = elem.get(
+                                    "type", "application/json"
+                                )
+                                lang = elem.get("language", "")
+                                if lang:
+                                    ep_data["podcast_transcript_language"] = lang
                     if ep_data.get("guid"):
                         existing_episodes.append(ep_data)
         except Exception as exc:
@@ -408,6 +433,17 @@ def update_rss_feed(
         # Add <podcast:transcript> for Podcasting 2.0 support
         if transcript_url:
             _inject_transcript_tag(Path(tmp_path), new_guid, transcript_url)
+
+        # Re-inject Podcasting 2.0 chapters/transcript tags for every
+        # episode the operator already published. ``feedgen`` doesn't
+        # know about the ``podcast:`` namespace, so each rebuild
+        # silently dropped these tags from prior items — Apple Podcasts
+        # then showed transcripts only on the latest episode (regression
+        # caught in May 2026 by the operator). Parsed URLs come from the
+        # existing-RSS pass at the top of update_rss_feed.
+        _reinject_preserved_podcast_tags(
+            Path(tmp_path), episodes_by_number, exclude_guid=new_guid,
+        )
 
         # Add <podcast:locked> to prevent unauthorized feed imports
         _inject_podcast_locked_tag(
@@ -622,6 +658,105 @@ def _inject_transcript_tag(rss_path: Path, guid: str, transcript_url: str) -> No
 
     except Exception as exc:
         logger.error("Failed to inject <podcast:transcript> tag: %s", exc)
+
+
+def _reinject_preserved_podcast_tags(
+    rss_path: Path,
+    episodes_by_number: dict,
+    *,
+    exclude_guid: str = "",
+) -> None:
+    """Walk every parsed episode in *episodes_by_number* and re-emit its
+    Podcasting 2.0 ``<podcast:chapters>`` / ``<podcast:transcript>`` tags
+    onto the matching ``<item>`` in *rss_path*.
+
+    Single-pass batch version of ``_inject_chapters_tag`` /
+    ``_inject_transcript_tag`` so a 100+ episode feed isn't re-parsed
+    once per episode. *exclude_guid* skips the episode just published —
+    its tags were already injected upstream and re-emitting would
+    duplicate them.
+    """
+    PODCAST_NS = "https://podcastindex.org/namespace/1.0"
+
+    # Build a guid → preserved-tag-data map. Episodes that didn't have
+    # the tags in the parsed feed simply contribute no entry, which means
+    # nothing happens for them. Skip the just-published episode.
+    by_guid: dict = {}
+    for ep_data in episodes_by_number.values():
+        guid = (ep_data.get("guid") or "").strip()
+        if not guid or guid == exclude_guid:
+            continue
+        chapters_url = ep_data.get("podcast_chapters_url")
+        transcript_url = ep_data.get("podcast_transcript_url")
+        if not chapters_url and not transcript_url:
+            continue
+        by_guid[guid] = ep_data
+
+    if not by_guid:
+        return
+
+    try:
+        ET.register_namespace("podcast", PODCAST_NS)
+        ET.register_namespace("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd")
+        ET.register_namespace("atom", "http://www.w3.org/2005/Atom")
+
+        tree = ET.parse(str(rss_path))
+        root = tree.getroot()
+
+        # Strip any duplicate xmlns:podcast attributes that ET would
+        # otherwise emit twice on serialization.
+        for attr in list(root.attrib):
+            if attr == "xmlns:podcast" or (
+                attr.startswith("xmlns:") and root.attrib[attr] == PODCAST_NS
+            ):
+                del root.attrib[attr]
+
+        channel = root.find("channel")
+        if channel is None:
+            return
+
+        injected = 0
+        for item in channel.findall("item"):
+            guid_el = item.find("guid")
+            if guid_el is None or not guid_el.text:
+                continue
+            ep_data = by_guid.get(guid_el.text.strip())
+            if not ep_data:
+                continue
+
+            chapters_url = ep_data.get("podcast_chapters_url")
+            if chapters_url and item.find(f"{{{PODCAST_NS}}}chapters") is None:
+                el = ET.SubElement(item, f"{{{PODCAST_NS}}}chapters")
+                el.set("url", chapters_url)
+                el.set(
+                    "type",
+                    ep_data.get(
+                        "podcast_chapters_type", "application/json+chapters"
+                    ),
+                )
+
+            transcript_url = ep_data.get("podcast_transcript_url")
+            if transcript_url and item.find(f"{{{PODCAST_NS}}}transcript") is None:
+                el = ET.SubElement(item, f"{{{PODCAST_NS}}}transcript")
+                el.set("url", transcript_url)
+                el.set(
+                    "type",
+                    ep_data.get("podcast_transcript_type", "application/json"),
+                )
+                lang = ep_data.get("podcast_transcript_language")
+                if lang:
+                    el.set("language", lang)
+
+            injected += 1
+
+        tree.write(str(rss_path), xml_declaration=True, encoding="UTF-8")
+        logger.info(
+            "Re-injected Podcasting 2.0 tags for %d preserved episode(s)",
+            injected,
+        )
+
+    except Exception as exc:
+        logger.error("Failed to re-inject preserved podcast tags: %s", exc)
 
 
 # ---------------------------------------------------------------------------

--- a/env_intel_podcast.rss
+++ b/env_intel_podcast.rss
@@ -294,7 +294,7 @@ Source: https://www.sciencedaily.com/releases/2026/03/260303201755.htm
       <itunes:episode>5</itunes:episode>
       <itunes:title>Ep 5: BC opens consultation on Koksilah Watershed Plan, requiring input by April 30 for water sustainability compliance under Water Sustainability Act.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep005.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 6: Carbon market additionality rules may exclude Indigenous-managed lands in BC and federal jurisdictions, limiting offset eligibility.</title>
       <description># Environmental Intelligence
@@ -357,7 +357,7 @@ Analysis shows Indigenous-managed lands in Canada sustain 10-20% higher c...</it
       <itunes:episode>6</itunes:episode>
       <itunes:title>Ep 6: Carbon market additionality rules may exclude Indigenous-managed lands in BC and federal jurisdictions, limiting offset eligibility.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep006.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 7: New Brunswick's delayed response to Vanier Highway chemical spill highlights gaps in provincial spill protocols under the Clean Environment Act.</title>
       <description># Environmental Intelligence
@@ -426,7 +426,7 @@ Source: https://insideclimatenews.org/news/06032026/florida-alligator-alcatraz-d
       <itunes:episode>7</itunes:episode>
       <itunes:title>Ep 7: New Brunswick's delayed response to Vanier Highway chemical spill highlights gaps in provincial spill protocols under the Clean Environment Act.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep007.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 8: BC's proposed FOI amendments could restrict access to EMA and CSR records, requiring immediate advocacy before legislative passage.</title>
       <description># Environmental Intelligence
@@ -489,7 +489,7 @@ US federal withdrawal of $1.5B in tribal clean energy funding under the Inflatio
       <itunes:episode>8</itunes:episode>
       <itunes:title>Ep 8: BC's proposed FOI amendments could restrict access to EMA and CSR records, requiring immediate advocacy before legislative passage.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep008.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 9: BC EAO proposes expedited EA process for major projects, seeking feedback by April 2026 to cut timelines.</title>
       <description># Environmental Intelligence
@@ -562,7 +562,7 @@ Source: https://insideclimatenews.org/news/11032026/epa-greenhouse-gas-reduction
       <itunes:episode>9</itunes:episode>
       <itunes:title>Ep 9: BC EAO proposes expedited EA process for major projects, seeking feedback by April 2026 to cut timelines.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep009.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 10: Ontario's fast-tracking of Great Bear mine permits under the Mining Act faces Grassy Narrows lawsuit, signaling risks for mining assessments in the province.</title>
       <description># Environmental Intelligence
@@ -605,7 +605,7 @@ With limited high-priority developments today, this briefing deep-dives into the
       <itunes:episode>10</itunes:episode>
       <itunes:title>Ep 10: Ontario's fast-tracking of Great Bear mine permits under the Mining Act faces Grassy Narrows lawsuit, signaling risks for mining assessments in the province.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep010.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 11: NS enforcement order mandates removal of two unauthorized building storeys, setting precedent for permit compliance in development projects.</title>
       <description># Environmental Intelligence
@@ -654,7 +654,7 @@ The International Seabed Authority (ISA) is advancing negotiations on a "mining 
       <itunes:episode>11</itunes:episode>
       <itunes:title>Ep 11: NS enforcement order mandates removal of two unauthorized building storeys, setting precedent for permit compliance in development projects.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep011.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 12: Aamjiwnaang First Nation demands full spill details and remediation plan from Suncor following discharge to St. Clair River.</title>
       <description>**Date:** March 20, 2026  
@@ -683,7 +683,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>12</itunes:episode>
       <itunes:title>Ep 12: Aamjiwnaang First Nation demands full spill details and remediation plan from Suncor following discharge to St. Clair River.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep012.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep012_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 14: Ontario's absence from federal Ring of Fire impact assessment creates immediate regulatory uncertainty for mining proponents in northern Ontario.</title>
       <description>**HOOK:** Ontario's absence from federal Ring of Fire impact assessment creates immediate regulatory uncertainty for mining proponents in northern Ontario.
@@ -706,7 +706,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>14</itunes:episode>
       <itunes:title>Ep 14: Ontario's absence from federal Ring of Fire impact assessment creates immediate regulatory uncertainty for mining proponents in northern Ontario.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep014.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep014_20260325_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 15: Trans Mountain pipeline reaches full capacity in April due to Middle East disruptions, directly affecting crude export scheduling and associated environmental compliance obligations in BC and Alberta.</title>
       <description>**# Environmental Intelligence**  
@@ -737,7 +737,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>15</itunes:episode>
       <itunes:title>Ep 15: Trans Mountain pipeline reaches full capacity in April due to Middle East disruptions, directly affecting crude export scheduling and associated environmental compliance obligations in BC and Alberta.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep015.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep015_20260326_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 16: Alberta First Nations and farmers demand full federal Impact Assessment for carbon capture pipeline project under IAA.</title>
       <description>**HOOK:** Alberta First Nations and farmers demand full federal Impact Assessment for carbon capture pipeline project under IAA.
@@ -760,7 +760,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>16</itunes:episode>
       <itunes:title>Ep 16: Alberta First Nations and farmers demand full federal Impact Assessment for carbon capture pipeline project under IAA.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep016.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep016_20260327_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 17: Alberta Bill 23 would eliminate government deadlines to respond to citizen petitions under the Citizen Initiative Act.</title>
       <description>**Date:** March 30, 2026  
@@ -789,7 +789,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>17</itunes:episode>
       <itunes:title>Ep 17: Alberta Bill 23 would eliminate government deadlines to respond to citizen petitions under the Citizen Initiative Act.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep017.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep017_20260330_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 18: Permafrost thaw slump vegetation recovery is now predictable from annual gross primary productivity, with direct implications for northern remediation and risk assessments.</title>
       <description>**# Environmental Intelligence**  
@@ -816,7 +816,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>18</itunes:episode>
       <itunes:title>Ep 18: Permafrost thaw slump vegetation recovery is now predictable from annual gross primary productivity, with direct implications for northern remediation and risk assessments.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep018.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep018_20260331_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 19: BC Environment adds formal issues resolution protocol to the environmental assessment process, improving dispute resolution and predictability for proponents and consultants.</title>
       <description>**Date:** April 01, 2026  
@@ -845,7 +845,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>19</itunes:episode>
       <itunes:title>Ep 19: BC Environment adds formal issues resolution protocol to the environmental assessment process, improving dispute resolution and predictability for proponents and consultants.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep019.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep019_20260401_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 20: BC invests over $10M in parks conservation and opens 2026 Clean Industry Fund intake for emissions-reduction projects.</title>
       <description>**Date:** April 03, 2026  
@@ -874,7 +874,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>20</itunes:episode>
       <itunes:title>Ep 20: BC invests over $10M in parks conservation and opens 2026 Clean Industry Fund intake for emissions-reduction projects.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep020.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep020_20260403_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 21: Ontario’s Species Conservation Act replaces the Endangered Species Act, leaving golden eagles, barn owls and many other species largely unprotected.</title>
       <description>**HOOK:** Ontario’s Species Conservation Act replaces the Endangered Species Act, leaving golden eagles, barn owls and many other species largely unprotected.
@@ -897,7 +897,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>21</itunes:episode>
       <itunes:title>Ep 21: Ontario’s Species Conservation Act replaces the Endangered Species Act, leaving golden eagles, barn owls and many other species largely unprotected.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep021.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep021_20260407_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 22: Piikani Nation member files notice to sue over selenium pollution in Crowsnest Lake, triggering Fisheries Act and provincial authorization compliance review in Alberta/BC border region.</title>
       <description>**HOOK:** Piikani Nation member files notice to sue over selenium pollution in Crowsnest Lake, triggering Fisheries Act and provincial authorization compliance review in Alberta/BC border region.
@@ -920,7 +920,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>22</itunes:episode>
       <itunes:title>Ep 22: Piikani Nation member files notice to sue over selenium pollution in Crowsnest Lake, triggering Fisheries Act and provincial authorization compliance review in Alberta/BC border region.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep022.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep022_20260409_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 23: Ontario advances 14 renewable energy projects while ArcelorMittal Dofasco completes final coke push at Hamilton facility, altering provincial decarbonization timelines.</title>
       <description>**HOOK:** Ontario advances 14 renewable energy projects while ArcelorMittal Dofasco completes final coke push at Hamilton facility, altering provincial decarbonization timelines.
@@ -943,7 +943,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>23</itunes:episode>
       <itunes:title>Ep 23: Ontario advances 14 renewable energy projects while ArcelorMittal Dofasco completes final coke push at Hamilton facility, altering provincial decarbonization timelines.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep023.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep023_20260413_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 24: BC NDP pauses DRIPA amendments amid minority-government risk, directly affecting Indigenous consultation requirements on contaminated sites and remediation projects.</title>
       <description>**HOOK:** BC NDP pauses DRIPA amendments amid minority-government risk, directly affecting Indigenous consultation requirements on contaminated sites and remediation projects.
@@ -966,7 +966,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>24</itunes:episode>
       <itunes:title>Ep 24: BC NDP pauses DRIPA amendments amid minority-government risk, directly affecting Indigenous consultation requirements on contaminated sites and remediation projects.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep024.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep024_20260415_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 25: BC launches free foam dock recycling events on the Sunshine Coast to curb marine debris under provincial waste diversion programs.</title>
       <description>**HOOK:** BC launches free foam dock recycling events on the Sunshine Coast to curb marine debris under provincial waste diversion programs.
@@ -989,7 +989,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>25</itunes:episode>
       <itunes:title>Ep 25: BC launches free foam dock recycling events on the Sunshine Coast to curb marine debris under provincial waste diversion programs.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep025.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep025_20260417_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 26: Electric ferry deployment in British Columbia highlights emerging vessel-strike risks to humpback whales under the Fisheries Act and Species at Risk Act.</title>
       <description>**HOOK:** Electric ferry deployment in British Columbia highlights emerging vessel-strike risks to humpback whales under the Fisheries Act and Species at Risk Act.
@@ -1012,7 +1012,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>26</itunes:episode>
       <itunes:title>Ep 26: Electric ferry deployment in British Columbia highlights emerging vessel-strike risks to humpback whales under the Fisheries Act and Species at Risk Act.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep026.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep026_20260421_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 27: Supreme Court decision backs Michigan’s authority to decommission Enbridge Line 5, with direct implications for Canadian cross-border pipeline risk assessments under federal IAA and Fisheries Act reviews.</title>
       <description># Environmental Intelligence
@@ -1043,7 +1043,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>27</itunes:episode>
       <itunes:title>Ep 27: Supreme Court decision backs Michigan’s authority to decommission Enbridge Line 5, with direct implications for Canadian cross-border pipeline risk assessments under federal IAA and Fisheries Act reviews.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep027.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep027_20260423_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 28: BC Energy Regulator cites LNG Canada for non-compliant black smoke flaring under provincial oversight, while new study attributes record Peace River seismic events to oil and gas wastewater injection.</title>
       <description>**HOOK:** BC Energy Regulator cites LNG Canada for non-compliant black smoke flaring under provincial oversight, while new study attributes record Peace River seismic events to oil and gas wastewater injection.
@@ -1066,7 +1066,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>28</itunes:episode>
       <itunes:title>Ep 28: BC Energy Regulator cites LNG Canada for non-compliant black smoke flaring under provincial oversight, while new study attributes record Peace River seismic events to oil and gas wastewater injection.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep028.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep028_20260427_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 29: BC court rejects Wet'suwet'en chief's Indigenous law defence in Coastal GasLink conviction while First Nation launches logging lawsuit, sharpening pipeline and forestry compliance risks.</title>
       <description>**HOOK:** BC court rejects Wet'suwet'en chief's Indigenous law defence in Coastal GasLink conviction while First Nation launches logging lawsuit, sharpening pipeline and forestry compliance risks.
@@ -1089,7 +1089,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>29</itunes:episode>
       <itunes:title>Ep 29: BC court rejects Wet'suwet'en chief's Indigenous law defence in Coastal GasLink conviction while First Nation launches logging lawsuit, sharpening pipeline and forestry compliance risks.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep029.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep029_20260429_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 30: Ontario's ban on green rules for developers may raise retrofit costs and slow climate adaptation for extreme weather.</title>
       <description># Environmental Intelligence
@@ -1120,7 +1120,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>30</itunes:episode>
       <itunes:title>Ep 30: Ontario's ban on green rules for developers may raise retrofit costs and slow climate adaptation for extreme weather.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/env_intel/chapters_ep030.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/env_intel/Env_Intel_Ep030_20260501_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 31: Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.</title>
       <link>https://op3.dev/e/audio.nerranetwork.com/env_intel/Env_Intel_Ep031_20260505.mp3</link>

--- a/fascinating_frontiers_podcast.rss
+++ b/fascinating_frontiers_podcast.rss
@@ -550,7 +550,7 @@
       <itunes:episode>35</itunes:episode>
       <itunes:title>Ep 35: China's new economic plan elevates space as a pillar industry with deep space goals.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep035.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 36: A new study proposes space weather scrambles alien radio signals, evading SETI detectors.</title>
       <description># Fascinating Frontiers
@@ -647,7 +647,7 @@ Today's stories blend cosmic mysteries with practical space tech, reminding us h
       <itunes:episode>36</itunes:episode>
       <itunes:title>Ep 36: A new study proposes space weather scrambles alien radio signals, evading SETI detectors.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep036.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 37: NASA's DART mission successfully altered an asteroid's solar orbit, proving deflection potential for planetary defense.</title>
       <description># Fascinating Frontiers
@@ -752,7 +752,7 @@ Today's stories blend cosmic mysteries with practical space tech, reminding us h
       <itunes:episode>37</itunes:episode>
       <itunes:title>Ep 37: NASA's DART mission successfully altered an asteroid's solar orbit, proving deflection potential for planetary defense.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep037.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 38: Scientists traced the most energetic neutrino ever detected to blazars powered by supermassive black holes.</title>
       <description># Fascinating Frontiers
@@ -849,7 +849,7 @@ Today's stories blend cosmic mysteries with practical space tech, reminding us h
       <itunes:episode>38</itunes:episode>
       <itunes:title>Ep 38: Scientists traced the most energetic neutrino ever detected to blazars powered by supermassive black holes.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep038.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 39: NASA confirms readiness for Artemis 2, targeting a crewed lunar orbit no earlier than April 1.</title>
       <description># Fascinating Frontiers
@@ -952,7 +952,7 @@ Today's stories blend cosmic mysteries with practical space tech, reminding us h
       <itunes:episode>39</itunes:episode>
       <itunes:title>Ep 39: NASA confirms readiness for Artemis 2, targeting a crewed lunar orbit no earlier than April 1.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep039.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 40: Blue Origin has filed plans for a massive constellation of up to 51,600 satellites to host data centers in orbit.</title>
       <description>**Fascinating Frontiers**
@@ -989,7 +989,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>40</itunes:episode>
       <itunes:title>Ep 40: Blue Origin has filed plans for a massive constellation of up to 51,600 satellites to host data centers in orbit.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep040_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 41: The vernal equinox arrives today at 10:46 A.M. EDT, marking astronomical spring as the Sun crosses directly over Earth’s equator.</title>
       <description>**Fascinating Frontiers**  
@@ -1026,7 +1026,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>41</itunes:episode>
       <itunes:title>Ep 41: The vernal equinox arrives today at 10:46 A.M. EDT, marking astronomical spring as the Sun crosses directly over Earth’s equator.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep041.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep041_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 42: ESA will charter its own dedicated SpaceX Crew Dragon flight to the ISS to expand astronaut flight opportunities.</title>
       <description># Fascinating Frontiers
@@ -1063,7 +1063,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>42</itunes:episode>
       <itunes:title>Ep 42: ESA will charter its own dedicated SpaceX Crew Dragon flight to the ISS to expand astronaut flight opportunities.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep042.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep042_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 43: Researchers are investigating how Mars gravity will change astronauts' skeletal muscle.</title>
       <description># Fascinating Frontiers
@@ -1100,7 +1100,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>43</itunes:episode>
       <itunes:title>Ep 43: Researchers are investigating how Mars gravity will change astronauts' skeletal muscle.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep043.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep043_20260322_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 44: Giant craters on metallic asteroid Psyche could finally confirm if it's the exposed core of a destroyed protoplanet.</title>
       <description>**HOOK:** Giant craters on metallic asteroid Psyche could finally confirm if it's the exposed core of a destroyed protoplanet.
@@ -1129,7 +1129,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>44</itunes:episode>
       <itunes:title>Ep 44: Giant craters on metallic asteroid Psyche could finally confirm if it's the exposed core of a destroyed protoplanet.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep044.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep044_20260324_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 45: [Slow News Edition] Hubble has caught a tiny comet slowing its spin and then reversing direction entirely.</title>
       <description>**HOOK:** Hubble has caught a tiny comet slowing its spin and then reversing direction entirely.
@@ -1158,7 +1158,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>45</itunes:episode>
       <itunes:title>Ep 45: [Slow News Edition] Hubble has caught a tiny comet slowing its spin and then reversing direction entirely.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep045.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep045_20260326_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 46: [Slow News Edition] Mars-like exoplanets orbiting M-dwarfs could lose their atmospheres in just millions of years.</title>
       <description>**HOOK:** Mars-like exoplanets orbiting M-dwarfs could lose their atmospheres in just millions of years.
@@ -1187,7 +1187,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>46</itunes:episode>
       <itunes:title>Ep 46: [Slow News Edition] Mars-like exoplanets orbiting M-dwarfs could lose their atmospheres in just millions of years.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep046.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep046_20260328_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 47: SpaceX is preparing to loft 119 small satellites in one rideshare launch from California this morning.</title>
       <description># Fascinating Frontiers
@@ -1224,7 +1224,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>47</itunes:episode>
       <itunes:title>Ep 47: SpaceX is preparing to loft 119 small satellites in one rideshare launch from California this morning.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep047.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep047_20260330_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 48: Artemis 2 astronauts have successfully repaired their toilet during the first crewed lunar mission in over 50 years.</title>
       <description>**HOOK:** Artemis 2 astronauts have successfully repaired their toilet during the first crewed lunar mission in over 50 years.
@@ -1253,7 +1253,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>48</itunes:episode>
       <itunes:title>Ep 48: Artemis 2 astronauts have successfully repaired their toilet during the first crewed lunar mission in over 50 years.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep048.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep048_20260402_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 49: Artemis II astronauts have entered the Moon's sphere of influence, marking humanity's return to lunar space.</title>
       <description>**HOOK:** Artemis II astronauts have entered the Moon's sphere of influence, marking humanity's return to lunar space.
@@ -1282,7 +1282,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>49</itunes:episode>
       <itunes:title>Ep 49: Artemis II astronauts have entered the Moon's sphere of influence, marking humanity's return to lunar space.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep049.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep049_20260406_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 50: Artemis II has broken the Apollo-era human distance record from Earth while looping around the Moon’s far side.</title>
       <description>**HOOK:** Artemis II has broken the Apollo-era human distance record from Earth while looping around the Moon’s far side.
@@ -1311,7 +1311,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>50</itunes:episode>
       <itunes:title>Ep 50: Artemis II has broken the Apollo-era human distance record from Earth while looping around the Moon’s far side.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep050.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep050_20260408_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 51: Artemis II crew prepares for high-stakes re-entry and Pacific splashdown after journey beyond the Moon.</title>
       <description># Fascinating Frontiers
@@ -1346,7 +1346,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>51</itunes:episode>
       <itunes:title>Ep 51: Artemis II crew prepares for high-stakes re-entry and Pacific splashdown after journey beyond the Moon.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep051.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep051_20260410_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 52: Theoretical models now link core magnetism in red giants to fossil fields on white dwarfs, illuminating our Sun’s eventual fate.</title>
       <description># Fascinating Frontiers
@@ -1381,7 +1381,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>52</itunes:episode>
       <itunes:title>Ep 52: Theoretical models now link core magnetism in red giants to fossil fields on white dwarfs, illuminating our Sun’s eventual fate.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep052_20260414_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 53: NASA's SPHEREx has mapped vast "interstellar glaciers" of ice stretching more than 600 light-years across the Milky Way.</title>
       <description>**HOOK:** NASA's SPHEREx has mapped vast "interstellar glaciers" of ice stretching more than 600 light-years across the Milky Way.
@@ -1410,7 +1410,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>53</itunes:episode>
       <itunes:title>Ep 53: NASA's SPHEREx has mapped vast "interstellar glaciers" of ice stretching more than 600 light-years across the Milky Way.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep053_20260416_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 54: NASA picks Falcon Heavy for ESA’s Rosalind Franklin Mars rover despite its own proposed budget cut.</title>
       <description># Fascinating Frontiers
@@ -1447,7 +1447,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>54</itunes:episode>
       <itunes:title>Ep 54: NASA picks Falcon Heavy for ESA’s Rosalind Franklin Mars rover despite its own proposed budget cut.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep054.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep054_20260418_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 55: Vera C. Rubin Observatory has already discovered 11,000 new asteroids before its main survey even begins.</title>
       <description># Fascinating Frontiers
@@ -1484,7 +1484,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>55</itunes:episode>
       <itunes:title>Ep 55: Vera C. Rubin Observatory has already discovered 11,000 new asteroids before its main survey even begins.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep055.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep055_20260420_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 56: NASA’s Nancy Grace Roman Space Telescope has completed final assembly and is on track for September launch.</title>
       <description>**HOOK:** NASA’s Nancy Grace Roman Space Telescope has completed final assembly and is on track for September launch.
@@ -1513,7 +1513,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>56</itunes:episode>
       <itunes:title>Ep 56: NASA’s Nancy Grace Roman Space Telescope has completed final assembly and is on track for September launch.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep056.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep056_20260422_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 57: NASA has released a fresh batch of images from Artemis II operations showing Earth, the Moon, and the Sun captured across multiple mission phases.</title>
       <description># Fascinating Frontiers
@@ -1548,7 +1548,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>57</itunes:episode>
       <itunes:title>Ep 57: NASA has released a fresh batch of images from Artemis II operations showing Earth, the Moon, and the Sun captured across multiple mission phases.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep057.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep057_20260424_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 58: NASA's Webb telescope has directly imaged water-ice clouds in the atmosphere of a nearby super-Jupiter exoplanet.</title>
       <description># Fascinating Frontiers
@@ -1583,7 +1583,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>58</itunes:episode>
       <itunes:title>Ep 58: NASA's Webb telescope has directly imaged water-ice clouds in the atmosphere of a nearby super-Jupiter exoplanet.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep058.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep058_20260426_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 59: NASA's Artemis III crewed lunar landing slips to no earlier than late 2027 as planners refine the timeline.</title>
       <description># Fascinating Frontiers
@@ -1620,7 +1620,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>59</itunes:episode>
       <itunes:title>Ep 59: NASA's Artemis III crewed lunar landing slips to no earlier than late 2027 as planners refine the timeline.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep059.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep059_20260428_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 60: A Falcon Heavy is rolling toward the pad for its first launch in 18 months while Europe prepares Ariane 6’s second flight with four boosters.</title>
       <description>**HOOK:** A Falcon Heavy is rolling toward the pad for its first launch in 18 months while Europe prepares Ariane 6’s second flight with four boosters.
@@ -1653,7 +1653,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>60</itunes:episode>
       <itunes:title>Ep 60: A Falcon Heavy is rolling toward the pad for its first launch in 18 months while Europe prepares Ariane 6’s second flight with four boosters.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep060.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep060_20260430_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 61: NASA's lithium-fed nuclear thruster has been tested for the first time, advancing options for Mars missions.</title>
       <description># Fascinating Frontiers
@@ -1694,7 +1694,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>61</itunes:episode>
       <itunes:title>Ep 61: NASA's lithium-fed nuclear thruster has been tested for the first time, advancing options for Mars missions.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep061.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep061_20260502_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 62: Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</title>
       <description># Fascinating Frontiers
@@ -1723,7 +1723,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>62</itunes:episode>
       <itunes:title>Ep 62: Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep062.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep062_20260504_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 63: Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</title>
       <description># Fascinating Frontiers
@@ -1754,7 +1754,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>63</itunes:episode>
       <itunes:title>Ep 63: Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/fascinating_frontiers/chapters_ep063.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/fascinating_frontiers/Fascinating_Frontiers_Ep063_20260505_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 64: JWST has directly examined the surface of a distant exoplanet for the first time.</title>
       <link>https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep064_20260506.mp3</link>

--- a/finansy_prosto_podcast.rss
+++ b/finansy_prosto_podcast.rss
@@ -343,7 +343,7 @@ Source: https://t-j.ru/kakaya-stavka-march-2026/
       <itunes:episode>7</itunes:episode>
       <itunes:title>Финансы Просто - Episode 7 - March 14, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep007.json" type="application/json+chapters" /></item>
     <item>
       <title>Финансы Просто - Episode 8 - March 20, 2026</title>
       <description>**# Финансы Просто**  
@@ -374,7 +374,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>8</itunes:episode>
       <itunes:title>Финансы Просто - Episode 8 - March 20, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep008.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep008_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 9 - March 20, 2026</title>
       <description>**# Финансы Просто**  
@@ -405,7 +405,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>9</itunes:episode>
       <itunes:title>Финансы Просто - Episode 9 - March 20, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep009.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep009_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 10 - March 20, 2026</title>
       <description>**# Финансы Просто**  
@@ -436,7 +436,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>10</itunes:episode>
       <itunes:title>Финансы Просто - Episode 10 - March 20, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep010.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep010_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 11 - March 20, 2026</title>
       <description>**# Финансы Просто**  
@@ -467,7 +467,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>11</itunes:episode>
       <itunes:title>Финансы Просто - Episode 11 - March 20, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep011.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep011_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 12 - March 22, 2026</title>
       <description>**# Финансы Просто**  
@@ -498,7 +498,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>12</itunes:episode>
       <itunes:title>Финансы Просто - Episode 12 - March 22, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep012.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep012_20260322_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 13 - March 24, 2026</title>
       <description>**# Финансы Просто**  
@@ -529,7 +529,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>13</itunes:episode>
       <itunes:title>Финансы Просто - Episode 13 - March 24, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep013.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep013_20260324_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 14 - March 26, 2026</title>
       <description>**Финансы Просто**
@@ -558,7 +558,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>14</itunes:episode>
       <itunes:title>Финансы Просто - Episode 14 - March 26, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep014.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep014_20260326_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 15: [Slow News Edition]</title>
       <description>**Финансы Просто**  
@@ -589,7 +589,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>15</itunes:episode>
       <itunes:title>Ep 15: [Slow News Edition]</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep015.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep015_20260328_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 16 - March 30, 2026</title>
       <description>**# Финансы Просто**  
@@ -618,7 +618,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>16</itunes:episode>
       <itunes:title>Финансы Просто - Episode 16 - March 30, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep016.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep016_20260330_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 17 - April 02, 2026</title>
       <description>**# Финансы Просто**  
@@ -649,7 +649,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>17</itunes:episode>
       <itunes:title>Финансы Просто - Episode 17 - April 02, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep017.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep017_20260402_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 18 - April 06, 2026</title>
       <description>**# Финансы Просто**  
@@ -680,7 +680,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>18</itunes:episode>
       <itunes:title>Финансы Просто - Episode 18 - April 06, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep018.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep018_20260406_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 19 - April 08, 2026</title>
       <description>**# Финансы Просто**  
@@ -711,7 +711,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>19</itunes:episode>
       <itunes:title>Финансы Просто - Episode 19 - April 08, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep019.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep019_20260408_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 20 - April 10, 2026</title>
       <description>**# Финансы Просто**  
@@ -742,7 +742,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>20</itunes:episode>
       <itunes:title>Финансы Просто - Episode 20 - April 10, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep020.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep020_20260410_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 21 - April 12, 2026</title>
       <description>**# Финансы Просто**  
@@ -773,7 +773,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>21</itunes:episode>
       <itunes:title>Финансы Просто - Episode 21 - April 12, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep021.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep021_20260412_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 22 - April 14, 2026</title>
       <description>**# Финансы Просто**  
@@ -802,7 +802,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>22</itunes:episode>
       <itunes:title>Финансы Просто - Episode 22 - April 14, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep022.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep022_20260414_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 23 - April 16, 2026</title>
       <description>**ЗАГОЛОВОК:** CREA снизила прогноз продаж жилья на 2026 год — что это значит для Ванкувера
@@ -827,7 +827,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>23</itunes:episode>
       <itunes:title>Финансы Просто - Episode 23 - April 16, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep023.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep023_20260416_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 24 - April 20, 2026</title>
       <description>**Финансы Просто**  
@@ -858,7 +858,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>24</itunes:episode>
       <itunes:title>Финансы Просто - Episode 24 - April 20, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep024.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep024_20260420_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 25 - April 22, 2026</title>
       <description>**# Финансы Просто**  
@@ -889,7 +889,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>25</itunes:episode>
       <itunes:title>Финансы Просто - Episode 25 - April 22, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep025.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep025_20260422_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 26 - April 24, 2026</title>
       <description>**# Финансы Просто**  
@@ -920,7 +920,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>26</itunes:episode>
       <itunes:title>Финансы Просто - Episode 26 - April 24, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep026.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep026_20260424_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 27 - April 26, 2026</title>
       <description>**# Финансы Просто**  
@@ -951,7 +951,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>27</itunes:episode>
       <itunes:title>Финансы Просто - Episode 27 - April 26, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep027.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep027_20260426_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 28 - April 28, 2026</title>
       <description>**# Финансы Просто**  
@@ -980,7 +980,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>28</itunes:episode>
       <itunes:title>Финансы Просто - Episode 28 - April 28, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep028.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep028_20260428_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 29 - April 30, 2026</title>
       <description>**Bank of Canada оставил ставку на уровне 2¼% — что это значит для вашей ипотеки и сбережений в Ванкувере**
@@ -1005,7 +1005,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>29</itunes:episode>
       <itunes:title>Финансы Просто - Episode 29 - April 30, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep029.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep029_20260430_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 30 - May 02, 2026</title>
       <description>**ЗАГОЛОВОК:** Bank of Canada готовит объявление о ключевой ставке — как это может изменить ваши платежи по ипотеке в Ванкувере
@@ -1028,7 +1028,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>30</itunes:episode>
       <itunes:title>Финансы Просто - Episode 30 - May 02, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep030.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep030_20260502_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 31 - May 04, 2026</title>
       <description>&gt; **Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом**
@@ -1051,7 +1051,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>31</itunes:episode>
       <itunes:title>Финансы Просто - Episode 31 - May 04, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/finansy_prosto/chapters_ep031.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/finansy_prosto/FP_Ep031_20260504_transcript.json" type="application/json" /></item>
     <item>
       <title>Финансы Просто - Episode 32 - May 06, 2026</title>
       <link>https://op3.dev/e/audio.nerranetwork.com/finansy_prosto/FP_Ep032_20260506.mp3</link>

--- a/models_agents_beginners_podcast.rss
+++ b/models_agents_beginners_podcast.rss
@@ -319,7 +319,7 @@ Let's break down how an AI agent like Aletheia actually tackles complex math res
       <itunes:episode>7</itunes:episode>
       <itunes:title>Ep 7: Imagine an AI that solves real math mysteries like a pro researcher—Google just made it happen!</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep007.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 8: Google just opened its powerful Colab computers so any AI agent can use them with free GPUs.</title>
       <description>**HOOK:** Google just opened its powerful Colab computers so any AI agent can use them with free GPUs.
@@ -342,7 +342,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>8</itunes:episode>
       <itunes:title>Ep 8: Google just opened its powerful Colab computers so any AI agent can use them with free GPUs.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep008.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep008_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 9: NVIDIA's new DLSS 5 is making gamers furious — here's why this AI upscaling change actually matters.</title>
       <description>**HOOK:** NVIDIA's new DLSS 5 is making gamers furious — here's why this AI upscaling change actually matters.
@@ -365,7 +365,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>9</itunes:episode>
       <itunes:title>Ep 9: NVIDIA's new DLSS 5 is making gamers furious — here's why this AI upscaling change actually matters.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep009.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep009_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 10: A new AI that helped build itself? Plus safe ways to test models without breaking anything — today’s news is wild.</title>
       <description>**Models &amp; Agents for Beginners**  
@@ -394,7 +394,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>10</itunes:episode>
       <itunes:title>Ep 10: A new AI that helped build itself? Plus safe ways to test models without breaking anything — today’s news is wild.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep010.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep010_20260322_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 11: Anthropic just confirmed their leaked model is a huge leap in AI reasoning — and it happened because of a simple security slip-up.</title>
       <description>**HOOK:** Anthropic just confirmed their leaked model is a huge leap in AI reasoning — and it happened because of a simple security slip-up.
@@ -417,7 +417,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>11</itunes:episode>
       <itunes:title>Ep 11: Anthropic just confirmed their leaked model is a huge leap in AI reasoning — and it happened because of a simple security slip-up.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep011.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep011_20260327_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 12: Meta built an AI that can predict how your brain will react to pictures, music, and speech — better than reading one real person's brain scan.</title>
       <description>**Models &amp; Agents for Beginners**  
@@ -446,7 +446,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>12</itunes:episode>
       <itunes:title>Ep 12: Meta built an AI that can predict how your brain will react to pictures, music, and speech — better than reading one real person's brain scan.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep012.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep012_20260328_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 13: Bluesky just dropped an AI that builds your perfect social feed from a simple sentence — no coding needed.</title>
       <description>**Models &amp; Agents for Beginners**  
@@ -475,7 +475,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>13</itunes:episode>
       <itunes:title>Ep 13: Bluesky just dropped an AI that builds your perfect social feed from a simple sentence — no coding needed.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep013.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep013_20260330_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 14: Chinese companies now make 41% of the AI chips used inside China — here's why that matters for your future phone and games.</title>
       <description>**# Models &amp; Agents for Beginners**  
@@ -504,7 +504,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>14</itunes:episode>
       <itunes:title>Ep 14: Chinese companies now make 41% of the AI chips used inside China — here's why that matters for your future phone and games.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep014.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep014_20260402_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 15: AI coding agents just got a “style guide” so they stop guessing your app’s entire look.</title>
       <description>**# Models &amp; Agents for Beginners**  
@@ -533,7 +533,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>15</itunes:episode>
       <itunes:title>Ep 15: AI coding agents just got a “style guide” so they stop guessing your app’s entire look.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep015.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep015_20260405_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 16: AI can now get its own email, phone number, and even a wallet — the agent stack is here.</title>
       <description>**# Models &amp; Agents for Beginners**  
@@ -562,7 +562,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>16</itunes:episode>
       <itunes:title>Ep 16: AI can now get its own email, phone number, and even a wallet — the agent stack is here.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep016.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep016_20260406_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 17: Google just dropped an AI that can dictate your essays perfectly — even with no internet. Your phone just got smarter offline.</title>
       <description>**# Models &amp; Agents for Beginners**  
@@ -591,7 +591,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>17</itunes:episode>
       <itunes:title>Ep 17: Google just dropped an AI that can dictate your essays perfectly — even with no internet. Your phone just got smarter offline.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep017.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep017_20260408_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 18: Meta just dropped a new AI that thinks in pictures AND teams up with helper agents — and their app jumped to #5 on the App Store!</title>
       <description>**HOOK:** Meta just dropped a new AI that thinks in pictures AND teams up with helper agents — and their app jumped to #5 on the App Store!
@@ -614,7 +614,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>18</itunes:episode>
       <itunes:title>Ep 18: Meta just dropped a new AI that thinks in pictures AND teams up with helper agents — and their app jumped to #5 on the App Store!</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep018.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep018_20260410_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 19: An AI agent secretly mined crypto on someone else's GPUs — here's why that should worry (and excite) all of us.</title>
       <description>**HOOK:** An AI agent secretly mined crypto on someone else's GPUs — here's why that should worry (and excite) all of us.
@@ -637,7 +637,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>19</itunes:episode>
       <itunes:title>Ep 19: An AI agent secretly mined crypto on someone else's GPUs — here's why that should worry (and excite) all of us.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep019.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep019_20260412_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 20: An AI just found a 27-year-old bug no human had spotted in decades — and it only cost $50.</title>
       <description>**HOOK:** An AI just found a 27-year-old bug no human had spotted in decades — and it only cost $50.
@@ -660,7 +660,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>20</itunes:episode>
       <itunes:title>Ep 20: An AI just found a 27-year-old bug no human had spotted in decades — and it only cost $50.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep020.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep020_20260414_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 21: What if your browser could chat with you about any webpage you're on — using ChatGPT or Claude?</title>
       <description>**HOOK:** What if your browser could chat with you about any webpage you're on — using ChatGPT or Claude?
@@ -683,7 +683,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>21</itunes:episode>
       <itunes:title>Ep 21: What if your browser could chat with you about any webpage you're on — using ChatGPT or Claude?</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep021.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep021_20260416_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 22: What happens when you borrow an AI brain for 10 minutes… then it gets taken away?</title>
       <description>**HOOK:** What happens when you borrow an AI brain for 10 minutes… then it gets taken away?
@@ -712,7 +712,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>22</itunes:episode>
       <itunes:title>Ep 22: What happens when you borrow an AI brain for 10 minutes… then it gets taken away?</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep022.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep022_20260420_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 23: An AI that remembers you feels like a real friend — but is that trust real or “counterfeit”?</title>
       <description># Models &amp; Agents for Beginners
@@ -741,7 +741,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>23</itunes:episode>
       <itunes:title>Ep 23: An AI that remembers you feels like a real friend — but is that trust real or “counterfeit”?</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep023.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep023_20260424_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 24: One AI video tool stood out for making real ads instead of random clips — and you can test it free today.</title>
       <description># Models &amp; Agents for Beginners
@@ -770,7 +770,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>24</itunes:episode>
       <itunes:title>Ep 24: One AI video tool stood out for making real ads instead of random clips — and you can test it free today.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep024.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep024_20260426_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 25: A 20-year-old in Algeria just built his own AI platform with 40+ models you can compare side-by-side — no team, no money, just pure hustle.</title>
       <description>**HOOK:** A 20-year-old in Algeria just built his own AI platform with 40+ models you can compare side-by-side — no team, no money, just pure hustle.
@@ -793,7 +793,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>25</itunes:episode>
       <itunes:title>Ep 25: A 20-year-old in Algeria just built his own AI platform with 40+ models you can compare side-by-side — no team, no money, just pure hustle.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep025.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep025_20260428_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 26: Google just dropped super-fast AI chips built for helpful agents that actually do stuff for you.</title>
       <description>**HOOK:** Google just dropped super-fast AI chips built for helpful agents that actually do stuff for you.
@@ -820,7 +820,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>26</itunes:episode>
       <itunes:title>Ep 26: Google just dropped super-fast AI chips built for helpful agents that actually do stuff for you.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep026.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep026_20260430_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 27: Google is inviting everyone to create fun AI-powered countdown projects and games for IO 2026 using their free tools – perfect for sparking your creativity!</title>
       <description>**HOOK:** Google is inviting everyone to create fun AI-powered countdown projects and games for IO 2026 using their free tools – perfect for sparking your creativity!
@@ -847,7 +847,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>27</itunes:episode>
       <itunes:title>Ep 27: Google is inviting everyone to create fun AI-powered countdown projects and games for IO 2026 using their free tools – perfect for sparking your creativity!</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep027.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep027_20260502_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 28: Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</title>
       <description>&gt; **Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.**
@@ -868,7 +868,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>28</itunes:episode>
       <itunes:title>Ep 28: Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep028.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep028_20260504_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 29: Google just launched 10 free AI courses anyone can start today — no coding or experience required.</title>
       <description># Models &amp; Agents for Beginners
@@ -891,7 +891,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>29</itunes:episode>
       <itunes:title>Ep 29: Google just launched 10 free AI courses anyone can start today — no coding or experience required.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents_beginners/chapters_ep029.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents_beginners/MAB_Ep029_20260505_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 30: ChatGPT just leveled up for everyone with a smarter, more reliable AI model rolling out right now.</title>
       <link>https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep030_20260506.mp3</link>

--- a/models_agents_podcast.rss
+++ b/models_agents_podcast.rss
@@ -360,7 +360,7 @@ A new greedy-based value representation (GVR) method improves multi-agent reinfo
       <itunes:episode>6</itunes:episode>
       <itunes:title>Ep 6: YuanLab AI launches Yuan 3.0 Ultra, a 1T-parameter multimodal MoE model cutting parameters by 33% while boosting efficiency 49%.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep006.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 7: Liquid AI launches LFM2-24B-A2B model and LocalCowork app for fully local, privacy-first agent workflows.</title>
       <description># Models &amp; Agents
@@ -421,7 +421,7 @@ SalamaBench offers a unified safety benchmark with 8,170 prompts across 12 categ
       <itunes:episode>7</itunes:episode>
       <itunes:title>Ep 7: Liquid AI launches LFM2-24B-A2B model and LocalCowork app for fully local, privacy-first agent workflows.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep007.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 8: Anthropic's Claude AI discovered over 100 Firefox vulnerabilities that human testing missed for decades.</title>
       <description># Models &amp; Agents
@@ -482,7 +482,7 @@ A new massive dataset for video reasoning reveals that models like Sora 2 and Ve
       <itunes:episode>8</itunes:episode>
       <itunes:title>Ep 8: Anthropic's Claude AI discovered over 100 Firefox vulnerabilities that human testing missed for decades.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep008.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 9: Meta's new research trains multimodal AI on unlabeled video, challenging assumptions about text-heavy scaling.</title>
       <description># Models &amp; Agents
@@ -539,7 +539,7 @@ This tutorial introduces a full framework for creating runtime agents driven by 
       <itunes:episode>9</itunes:episode>
       <itunes:title>Ep 9: Meta's new research trains multimodal AI on unlabeled video, challenging assumptions about text-heavy scaling.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep009.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 10: Claude Opus 4.6 independently cracked an encrypted AI benchmark, marking the first documented case of a model self-hacking a test.</title>
       <description># Models &amp; Agents
@@ -600,7 +600,7 @@ Omni-C is a Transformer-based encoder that unifies images, audio, and text into 
       <itunes:episode>10</itunes:episode>
       <itunes:title>Ep 10: Claude Opus 4.6 independently cracked an encrypted AI benchmark, marking the first documented case of a model self-hacking a test.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep010.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 11: Meta acquires Moltbook, a Reddit-like platform for AI agents to interact and collaborate.</title>
       <description># Models &amp; Agents
@@ -673,7 +673,7 @@ DeerFlow 2.0 is an open-source SuperAgent framework from ByteDance that orchestr
       <itunes:episode>11</itunes:episode>
       <itunes:title>Ep 11: Meta acquires Moltbook, a Reddit-like platform for AI agents to interact and collaborate.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep011.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 12: Google unveils Gemini Embedding 2, a multimodal model embedding text, images, video, audio, and docs for advanced RAG systems.</title>
       <description># Models &amp; Agents
@@ -734,7 +734,7 @@ The paper proposes a taxonomy for latent world models in driving, covering laten
       <itunes:episode>12</itunes:episode>
       <itunes:title>Ep 12: Google unveils Gemini Embedding 2, a multimodal model embedding text, images, video, audio, and docs for advanced RAG systems.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep012.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 13: Nvidia plans $26B investment in open-weight AI models to counter Chinese dominance and lock in developers.</title>
       <description># Models &amp; Agents
@@ -795,7 +795,7 @@ AraModernBERT adapts the ModernBERT encoder for Arabic with transtokenized initi
       <itunes:episode>13</itunes:episode>
       <itunes:title>Ep 13: Nvidia plans $26B investment in open-weight AI models to counter Chinese dominance and lock in developers.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep013.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 14: Perplexity launches "Personal Computer," a $200/month AI agent that automates emails, presentations, and app control 24/7.</title>
       <description># Models &amp; Agents
@@ -856,7 +856,7 @@ This paper proposes a dynamical theory for adaptive coordination in multi-agent 
       <itunes:episode>14</itunes:episode>
       <itunes:title>Ep 14: Perplexity launches "Personal Computer," a $200/month AI agent that automates emails, presentations, and app control 24/7.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep014.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 15: Google DeepMind's Aletheia agent autonomously advances from IMO math to professional research discoveries.</title>
       <description># Models &amp; Agents
@@ -919,7 +919,7 @@ Source: https://the-decoder.com/google-explains-the-differences-between-its-thre
       <itunes:episode>15</itunes:episode>
       <itunes:title>Ep 15: Google DeepMind's Aletheia agent autonomously advances from IMO math to professional research discoveries.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep015.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 16: RL agents scaled to 1,024 layers unlock emergent parkour skills from basic failures.</title>
       <description># Models &amp; Agents
@@ -994,7 +994,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>16</itunes:episode>
       <itunes:title>Ep 16: RL agents scaled to 1,024 layers unlock emergent parkour skills from basic failures.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep016.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 17: Picsart launches AI agent marketplace, starting with four agents and adding more weekly for creators.</title>
       <description># Models &amp; Agents
@@ -1023,7 +1023,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>17</itunes:episode>
       <itunes:title>Ep 17: Picsart launches AI agent marketplace, starting with four agents and adding more weekly for creators.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep017.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep017_20260317_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 18: LlamaIndex drops LiteParse, a spatial PDF parser built specifically for agentic RAG workflows.</title>
       <description>**HOOK:** LlamaIndex drops LiteParse, a spatial PDF parser built specifically for agentic RAG workflows.
@@ -1046,7 +1046,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>18</itunes:episode>
       <itunes:title>Ep 18: LlamaIndex drops LiteParse, a spatial PDF parser built specifically for agentic RAG workflows.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep018.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep018_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 19: TrustFlow introduces topic-aware vector reputation for multi-agent systems, replacing scalar scores with queryable multi-dimensional vectors.</title>
       <description>**HOOK:** TrustFlow introduces topic-aware vector reputation for multi-agent systems, replacing scalar scores with queryable multi-dimensional vectors.
@@ -1069,7 +1069,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>19</itunes:episode>
       <itunes:title>Ep 19: TrustFlow introduces topic-aware vector reputation for multi-agent systems, replacing scalar scores with queryable multi-dimensional vectors.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep019.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep019_20260323_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 20: Fair zero-determinant strategies break in the periodic prisoner's dilemma, unlike the classic repeated version.</title>
       <description>**Models &amp; Agents**
@@ -1098,7 +1098,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>20</itunes:episode>
       <itunes:title>Ep 20: Fair zero-determinant strategies break in the periodic prisoner's dilemma, unlike the classic repeated version.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep020.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep020_20260323_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 21: New arXiv papers expose critical flaws in how we evaluate depression-detection models, LLM pruning, and verbalized confidence.</title>
       <description>**Models &amp; Agents**
@@ -1127,7 +1127,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>21</itunes:episode>
       <itunes:title>Ep 21: New arXiv papers expose critical flaws in how we evaluate depression-detection models, LLM pruning, and verbalized confidence.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep021.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep021_20260327_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 22: Naver's Seoul World Model grounds video generation in real Street View geometry from over a million images and generalizes to other cities without fine-tuning.</title>
       <description>**HOOK:** Naver's Seoul World Model grounds video generation in real Street View geometry from over a million images and generalizes to other cities without fine-tuning.
@@ -1150,7 +1150,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>22</itunes:episode>
       <itunes:title>Ep 22: Naver's Seoul World Model grounds video generation in real Street View geometry from over a million images and generalizes to other cities without fine-tuning.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep022.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep022_20260329_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 23: Alibaba Qwen just dropped Qwen3.5-Omni, a native end-to-end multimodal model built for text, audio, video, and realtime interaction.</title>
       <description>**Models &amp; Agents**
@@ -1179,7 +1179,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>23</itunes:episode>
       <itunes:title>Ep 23: Alibaba Qwen just dropped Qwen3.5-Omni, a native end-to-end multimodal model built for text, audio, video, and realtime interaction.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep023.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep023_20260331_transcript.json" type="application/json" /></item>
     <item>
       <title>Models &amp; Agents - Episode 24 - April 01, 2026</title>
       <description>**What You Need to Know:** Hugging Face just shipped TRL v1.0, turning the messy post-training pipeline (SFT → Reward Modeling → DPO/GRPO) into a stable, production-ready unified API. Liquid AI dropped LFM2.5-350M, a 350M-parameter model trained on 28T tokens with scaled RL that challenges the “bigger is better” scaling narrative. ...
@@ -1198,7 +1198,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>24</itunes:episode>
       <itunes:title>Models &amp; Agents - Episode 24 - April 01, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep024.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep024_20260401_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 25: Google drops Gemma 4, claiming the strongest small multimodal open model yet with dramatic gains across every benchmark compared to Gemma 3.</title>
       <description>**# Models &amp; Agents**  
@@ -1229,7 +1229,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>25</itunes:episode>
       <itunes:title>Ep 25: Google drops Gemma 4, claiming the strongest small multimodal open model yet with dramatic gains across every benchmark compared to Gemma 3.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep025.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep025_20260403_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 26: AutoAgent autonomously optimizes its own harness using the same model to reach #1 on Terminal-Bench and financial modeling in under 24 hours.</title>
       <description>**HOOK:** AutoAgent autonomously optimizes its own harness using the same model to reach #1 on Terminal-Bench and financial modeling in under 24 hours.
@@ -1252,7 +1252,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>26</itunes:episode>
       <itunes:title>Ep 26: AutoAgent autonomously optimizes its own harness using the same model to reach #1 on Terminal-Bench and financial modeling in under 24 hours.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep026.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep026_20260405_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 27: Gemma 4 delivers massive gains across European languages while a 25.6M Rust model achieves 50× faster inference via hybrid attention.</title>
       <description>**HOOK:** Gemma 4 delivers massive gains across European languages while a 25.6M Rust model achieves 50× faster inference via hybrid attention.
@@ -1275,7 +1275,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>27</itunes:episode>
       <itunes:title>Ep 27: Gemma 4 delivers massive gains across European languages while a 25.6M Rust model achieves 50× faster inference via hybrid attention.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep027.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep027_20260407_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 28: Meta’s Muse Spark and a production-grade compiler-as-a-service approach for agents headline a day heavy on practical agent infrastructure.</title>
       <description>**Models &amp; Agents**  
@@ -1304,7 +1304,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>28</itunes:episode>
       <itunes:title>Ep 28: Meta’s Muse Spark and a production-grade compiler-as-a-service approach for agents headline a day heavy on practical agent infrastructure.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep028.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep028_20260409_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 29: Knowledge distillation now compresses full ensembles into single deployable models while preserving their collective intelligence.</title>
       <description>**HOOK:** Knowledge distillation now compresses full ensembles into single deployable models while preserving their collective intelligence.
@@ -1327,7 +1327,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>29</itunes:episode>
       <itunes:title>Ep 29: Knowledge distillation now compresses full ensembles into single deployable models while preserving their collective intelligence.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep029.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep029_20260411_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 30: Aaron Levie declares the enterprise AI shift from chatbots to agents is now underway, moving beyond the "Chat Era."</title>
       <description>**HOOK:** Aaron Levie declares the enterprise AI shift from chatbots to agents is now underway, moving beyond the "Chat Era."
@@ -1350,7 +1350,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>30</itunes:episode>
       <itunes:title>Ep 30: Aaron Levie declares the enterprise AI shift from chatbots to agents is now underway, moving beyond the "Chat Era."</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep030.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep030_20260413_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 31: Google DeepMind's Gemini Robotics-ER 1.6 upgrade delivers enhanced embodied reasoning and instrument reading for real-world robot control.</title>
       <description>**HOOK:** Google DeepMind's Gemini Robotics-ER 1.6 upgrade delivers enhanced embodied reasoning and instrument reading for real-world robot control.
@@ -1373,7 +1373,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>31</itunes:episode>
       <itunes:title>Ep 31: Google DeepMind's Gemini Robotics-ER 1.6 upgrade delivers enhanced embodied reasoning and instrument reading for real-world robot control.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep031.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep031_20260415_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 32: Qwen3.6-35B-A3B brings sparse MoE vision-language capabilities with only 3B active parameters and strong agentic coding performance.</title>
       <description>**HOOK:** Qwen3.6-35B-A3B brings sparse MoE vision-language capabilities with only 3B active parameters and strong agentic coding performance.
@@ -1396,7 +1396,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>32</itunes:episode>
       <itunes:title>Ep 32: Qwen3.6-35B-A3B brings sparse MoE vision-language capabilities with only 3B active parameters and strong agentic coding performance.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep032.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep032_20260417_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 33: MetaComp just released the world's first dedicated AI agent governance framework built specifically for regulated financial services.</title>
       <description>**HOOK:** MetaComp just released the world's first dedicated AI agent governance framework built specifically for regulated financial services.
@@ -1419,7 +1419,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>33</itunes:episode>
       <itunes:title>Ep 33: MetaComp just released the world's first dedicated AI agent governance framework built specifically for regulated financial services.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep033.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep033_20260421_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 34: Qwen3.6-27B paired with llama.cpp speculative decoding delivers 10x token speedups in real coding sessions, hitting 136 t/s on consumer hardware.</title>
       <description>**HOOK:** Qwen3.6-27B paired with llama.cpp speculative decoding delivers 10x token speedups in real coding sessions, hitting 136 t/s on consumer hardware.
@@ -1442,7 +1442,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>34</itunes:episode>
       <itunes:title>Ep 34: Qwen3.6-27B paired with llama.cpp speculative decoding delivers 10x token speedups in real coding sessions, hitting 136 t/s on consumer hardware.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep034.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep034_20260423_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 35: Google DeepMind's Vision Banana shows image generation pretraining may be the true foundation model path for computer vision, beating SAM 3 on segmentation and Depth Anything V3 on metric depth.</title>
       <description>**HOOK:** Google DeepMind's Vision Banana shows image generation pretraining may be the true foundation model path for computer vision, beating SAM 3 on segmentation and Depth Anything V3 on metric depth.
@@ -1465,7 +1465,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>35</itunes:episode>
       <itunes:title>Ep 35: Google DeepMind's Vision Banana shows image generation pretraining may be the true foundation model path for computer vision, beating SAM 3 on segmentation and Depth Anything V3 on metric depth.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep035.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep035_20260425_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 36: Anthropic’s Claude Opus 4.6 agent wiped a critical database in 9 seconds, exposing the real-world risks of deploying autonomous agents.</title>
       <description>**HOOK:** Anthropic’s Claude Opus 4.6 agent wiped a critical database in 9 seconds, exposing the real-world risks of deploying autonomous agents.
@@ -1488,7 +1488,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>36</itunes:episode>
       <itunes:title>Ep 36: Anthropic’s Claude Opus 4.6 agent wiped a critical database in 9 seconds, exposing the real-world risks of deploying autonomous agents.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep036.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep036_20260427_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 37: DeepSeek's first native multimodal model drops in the LocalLLaMA community, finally giving the open-source whale vision capabilities.</title>
       <description>**HOOK:** DeepSeek's first native multimodal model drops in the LocalLLaMA community, finally giving the open-source whale vision capabilities.
@@ -1511,7 +1511,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>37</itunes:episode>
       <itunes:title>Ep 37: DeepSeek's first native multimodal model drops in the LocalLLaMA community, finally giving the open-source whale vision capabilities.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep037.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep037_20260429_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 38: Anthropic gives defenders early access to Mythos Preview to patch AI cyber vulnerabilities before wider release.</title>
       <description># Models &amp; Agents
@@ -1540,7 +1540,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>38</itunes:episode>
       <itunes:title>Ep 38: Anthropic gives defenders early access to Mythos Preview to patch AI cyber vulnerabilities before wider release.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep038.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep038_20260501_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 39: Mistral AI launches a 128B model with remote agents and strong coding performance.</title>
       <description># Models &amp; Agents
@@ -1565,7 +1565,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>39</itunes:episode>
       <itunes:title>Ep 39: Mistral AI launches a 128B model with remote agents and strong coding performance.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep039.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep039_20260503_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 40: OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</title>
       <description># Models &amp; Agents
@@ -1590,7 +1590,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>40</itunes:episode>
       <itunes:title>Ep 40: OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/models_agents/chapters_ep040.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/models_agents/Models_Agents_Ep040_20260505_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 41: OpenAI rolls out GPT-5.5 Instant as the default ChatGPT model with better factuality and memory features.</title>
       <link>https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep041_20260506.mp3</link>

--- a/modern_investing_podcast.rss
+++ b/modern_investing_podcast.rss
@@ -51,7 +51,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>1</itunes:episode>
       <itunes:title>Modern Investing Techniques - Episode 1 - March 20, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep001.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep001_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 2: Stocks jump and oil eases after Trump says Iran is talking with the U.S., despite Tehran’s denials.</title>
       <description>**Modern Investing Techniques**  
@@ -82,7 +82,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>2</itunes:episode>
       <itunes:title>Ep 2: Stocks jump and oil eases after Trump says Iran is talking with the U.S., despite Tehran’s denials.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep002.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep002_20260323_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 3: Estée Lauder confirms a potential merger suitor yet its stock still struggles — a textbook lesson in market skepticism versus headline optimism.</title>
       <description>**# Modern Investing Techniques**  
@@ -113,7 +113,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>3</itunes:episode>
       <itunes:title>Ep 3: Estée Lauder confirms a potential merger suitor yet its stock still struggles — a textbook lesson in market skepticism versus headline optimism.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep003.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep003_20260324_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 4: Brookfield and La Caisse’s $37.25/share takeover of Boralex creates a textbook Canadian M&amp;A premium play worth dissecting.</title>
       <description>**# Modern Investing Techniques**  
@@ -144,7 +144,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>4</itunes:episode>
       <itunes:title>Ep 4: Brookfield and La Caisse’s $37.25/share takeover of Boralex creates a textbook Canadian M&amp;A premium play worth dissecting.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep004.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep004_20260325_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 5: Short sellers piling into SoFi while XRP gets positive SEC clarity — two clear signals worth dissecting for your portfolio.</title>
       <description>**# Modern Investing Techniques**  
@@ -175,7 +175,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>5</itunes:episode>
       <itunes:title>Ep 5: Short sellers piling into SoFi while XRP gets positive SEC clarity — two clear signals worth dissecting for your portfolio.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep005.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep005_20260326_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 6: Canada hits the NATO 2% GDP defence target, opening fresh capital-flow opportunities in Canadian aerospace and defence names.</title>
       <description>**# Modern Investing Techniques**  
@@ -206,7 +206,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>6</itunes:episode>
       <itunes:title>Ep 6: Canada hits the NATO 2% GDP defence target, opening fresh capital-flow opportunities in Canadian aerospace and defence names.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep006.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep006_20260326_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 7: Oil prices climb as Trump notes Iran allowed 10 tankers through the Strait of Hormuz, creating fresh energy-sector volatility.</title>
       <description>**# Modern Investing Techniques**  
@@ -237,7 +237,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>7</itunes:episode>
       <itunes:title>Ep 7: Oil prices climb as Trump notes Iran allowed 10 tankers through the Strait of Hormuz, creating fresh energy-sector volatility.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep007.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep007_20260327_transcript.json" type="application/json" /></item>
     <item>
       <title>Modern Investing Techniques - Episode 8 - March 30, 2026</title>
       <description>**Modern Investing Techniques – Special Educational Episode**  
@@ -266,7 +266,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>8</itunes:episode>
       <itunes:title>Modern Investing Techniques - Episode 8 - March 30, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep008.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep008_20260330_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 9: Geopolitical energy shock sends S&amp;P 500 toward its worst quarter since 2022 while pushing Eurozone inflation to 2.5%.</title>
       <description>**# Modern Investing Techniques**  
@@ -297,7 +297,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>9</itunes:episode>
       <itunes:title>Ep 9: Geopolitical energy shock sends S&amp;P 500 toward its worst quarter since 2022 while pushing Eurozone inflation to 2.5%.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep009.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep009_20260331_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 10: World stocks rocket higher on optimism the Iran war could end soon, lifting S&amp;P 500 futures +2.9%.</title>
       <description>**# Modern Investing Techniques**  
@@ -328,7 +328,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>10</itunes:episode>
       <itunes:title>Ep 10: World stocks rocket higher on optimism the Iran war could end soon, lifting S&amp;P 500 futures +2.9%.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep010.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep010_20260401_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 11: Alberta’s potential US$1T lithium resource meets geopolitical oil shock — creating a rare Canadian critical-minerals catalyst.</title>
       <description>**# Modern Investing Techniques**  
@@ -359,7 +359,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>11</itunes:episode>
       <itunes:title>Ep 11: Alberta’s potential US$1T lithium resource meets geopolitical oil shock — creating a rare Canadian critical-minerals catalyst.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep011.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep011_20260402_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 12: Norwegian Cruise Line dropped 24% in March after disappointing earnings and Iran-related travel fears — a reminder that external shocks can override fundamentals fast.</title>
       <description>**# Modern Investing Techniques**  
@@ -390,7 +390,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>12</itunes:episode>
       <itunes:title>Ep 12: Norwegian Cruise Line dropped 24% in March after disappointing earnings and Iran-related travel fears — a reminder that external shocks can override fundamentals fast.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep012.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep012_20260403_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 13: Global equity funds saw their second straight weekly inflow as investors price in Mideast ceasefire hopes, lifting futures and Bitcoin.</title>
       <description>**# Modern Investing Techniques**  
@@ -421,7 +421,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>13</itunes:episode>
       <itunes:title>Ep 13: Global equity funds saw their second straight weekly inflow as investors price in Mideast ceasefire hopes, lifting futures and Bitcoin.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep013.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep013_20260406_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 14: Samsung forecasts 8-fold Q1 profit jump on AI memory chip demand while oil surges above $110 on Iran deadline tension.</title>
       <description>**# Modern Investing Techniques**  
@@ -452,7 +452,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>14</itunes:episode>
       <itunes:title>Ep 14: Samsung forecasts 8-fold Q1 profit jump on AI memory chip demand while oil surges above $110 on Iran deadline tension.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep014.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep014_20260407_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 15: Iran ceasefire triggers 15% oil plunge, unwinding the geopolitical premium and shifting capital across energy, currencies, and defensives.</title>
       <description>**# Modern Investing Techniques**  
@@ -483,7 +483,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>15</itunes:episode>
       <itunes:title>Ep 15: Iran ceasefire triggers 15% oil plunge, unwinding the geopolitical premium and shifting capital across energy, currencies, and defensives.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep015.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep015_20260408_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 16: Surging fuel prices and fragile Middle East ceasefire are creating divergent winners in Canadian agriculture, EVs, and gold miners.</title>
       <description>**# Modern Investing Techniques**  
@@ -514,7 +514,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>16</itunes:episode>
       <itunes:title>Ep 16: Surging fuel prices and fragile Middle East ceasefire are creating divergent winners in Canadian agriculture, EVs, and gold miners.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep016.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep016_20260409_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 17: StatCan March jobs data lands today after Canada’s labour market stumbled in early 2026, creating fresh signals for rate-sensitive sectors.</title>
       <description>**# Modern Investing Techniques**  
@@ -545,7 +545,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>17</itunes:episode>
       <itunes:title>Ep 17: StatCan March jobs data lands today after Canada’s labour market stumbled in early 2026, creating fresh signals for rate-sensitive sectors.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep017.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep017_20260410_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 18: German €1.6B fuel relief and Philippines tax cuts signal broad input-cost easing that could widen margins for European and Asian consumer-exposed names.</title>
       <description># Modern Investing Techniques
@@ -576,7 +576,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>18</itunes:episode>
       <itunes:title>Ep 18: German €1.6B fuel relief and Philippines tax cuts signal broad input-cost easing that could widen margins for European and Asian consumer-exposed names.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep018.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep018_20260413_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 19: Stocks climb as investors price in US-Iran diplomatic progress despite shaky ceasefire and elevated oil.</title>
       <description># Modern Investing Techniques
@@ -607,7 +607,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>19</itunes:episode>
       <itunes:title>Ep 19: Stocks climb as investors price in US-Iran diplomatic progress despite shaky ceasefire and elevated oil.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep019.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep019_20260414_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 20: TSX hits six-week high at 34,102.36 as Middle East de-escalation hopes lift tech and financials while energy lags on softer oil.</title>
       <description># Modern Investing Techniques
@@ -638,7 +638,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>20</itunes:episode>
       <itunes:title>Ep 20: TSX hits six-week high at 34,102.36 as Middle East de-escalation hopes lift tech and financials while energy lags on softer oil.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep020.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep020_20260415_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 21: S&amp;P 500 hits fresh record highs while TSMC raises full-year outlook on unrelenting AI demand.</title>
       <description># Modern Investing Techniques
@@ -669,7 +669,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>21</itunes:episode>
       <itunes:title>Ep 21: S&amp;P 500 hits fresh record highs while TSMC raises full-year outlook on unrelenting AI demand.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep021.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep021_20260416_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 22: Hopes of an Israel-Lebanon ceasefire are supporting stocks near record highs while oil stays below $100, but insider moves and diversification gaps offer clearer portfolio actions today.</title>
       <description># Modern Investing Techniques
@@ -700,7 +700,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>22</itunes:episode>
       <itunes:title>Ep 22: Hopes of an Israel-Lebanon ceasefire are supporting stocks near record highs while oil stays below $100, but insider moves and diversification gaps offer clearer portfolio actions today.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep022.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep022_20260417_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 23: Narrow earnings revisions are powering S&amp;P records while commercial vacancies drop for the first time since 2020.</title>
       <description># Modern Investing Techniques
@@ -731,7 +731,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>23</itunes:episode>
       <itunes:title>Ep 23: Narrow earnings revisions are powering S&amp;P records while commercial vacancies drop for the first time since 2020.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep023.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep023_20260420_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 24: J.P. Morgan lifts S&amp;P 500 target to 7,600 on AI earnings strength and potential Iran ceasefire.</title>
       <description># Modern Investing Techniques
@@ -762,7 +762,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>24</itunes:episode>
       <itunes:title>Ep 24: J.P. Morgan lifts S&amp;P 500 target to 7,600 on AI earnings strength and potential Iran ceasefire.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep024.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep024_20260421_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 25: Adobe is staking roughly 25% of its market value on AI complementing rather than destroying its SaaS business model.</title>
       <description># Modern Investing Techniques
@@ -793,7 +793,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>25</itunes:episode>
       <itunes:title>Ep 25: Adobe is staking roughly 25% of its market value on AI complementing rather than destroying its SaaS business model.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep025.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep025_20260422_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 26: Canada Growth Fund acquires 22% of Nouveau Monde Graphite, triggering investor interest in Canadian critical minerals.</title>
       <description># Modern Investing Techniques
@@ -824,7 +824,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>26</itunes:episode>
       <itunes:title>Ep 26: Canada Growth Fund acquires 22% of Nouveau Monde Graphite, triggering investor interest in Canadian critical minerals.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep026.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep026_20260423_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 27: Fed faces stagflation trap as Hormuz closure removes 20% of global oil supply, with no painless policy option available.</title>
       <description># Modern Investing Techniques
@@ -855,7 +855,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>27</itunes:episode>
       <itunes:title>Ep 27: Fed faces stagflation trap as Hormuz closure removes 20% of global oil supply, with no painless policy option available.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep027.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep027_20260424_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 28: Stalled Iran talks lift oil $2.50 while global shares gain — value strategies offer Canadian investors a practical edge right now.</title>
       <description># Modern Investing Techniques
@@ -886,7 +886,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>28</itunes:episode>
       <itunes:title>Ep 28: Stalled Iran talks lift oil $2.50 while global shares gain — value strategies offer Canadian investors a practical edge right now.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep028.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep028_20260427_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 29: Oil tops $110 on stalled Iran talks while clean power eyes records despite policy risks — two signals demanding disciplined positioning.</title>
       <description># Modern Investing Techniques
@@ -917,7 +917,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>29</itunes:episode>
       <itunes:title>Ep 29: Oil tops $110 on stalled Iran talks while clean power eyes records despite policy risks — two signals demanding disciplined positioning.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep029.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep029_20260428_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 30: Big Tech earnings and Powell’s final FOMC tomorrow loom as stagflation concerns weigh on private credit and energy supply chains.</title>
       <description># Modern Investing Techniques
@@ -948,7 +948,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>30</itunes:episode>
       <itunes:title>Ep 30: Big Tech earnings and Powell’s final FOMC tomorrow loom as stagflation concerns weigh on private credit and energy supply chains.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep030.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep030_20260429_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 31: Oil topped $126 on Iran tensions yet equities stayed mixed, signaling the war is accelerating the shift to renewables.</title>
       <description># Modern Investing Techniques
@@ -979,7 +979,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>31</itunes:episode>
       <itunes:title>Ep 31: Oil topped $126 on Iran tensions yet equities stayed mixed, signaling the war is accelerating the shift to renewables.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep031.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep031_20260430_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 32: Clorox cuts profit forecast on weak demand while oil prices hold gains amid Iran tensions and yen intervention.</title>
       <description># Modern Investing Techniques
@@ -1010,7 +1010,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>32</itunes:episode>
       <itunes:title>Ep 32: Clorox cuts profit forecast on weak demand while oil prices hold gains amid Iran tensions and yen intervention.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep032.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep032_20260501_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 33: Oil prices rise on Middle East conflict news while Berkshire Hathaway holds a record $397 billion in cash.</title>
       <description># Modern Investing Techniques
@@ -1037,7 +1037,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>33</itunes:episode>
       <itunes:title>Ep 33: Oil prices rise on Middle East conflict news while Berkshire Hathaway holds a record $397 billion in cash.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep033.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep033_20260504_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 34: US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities amid geopolitical cross-currents.</title>
       <description># Modern Investing Techniques
@@ -1064,7 +1064,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>34</itunes:episode>
       <itunes:title>Ep 34: US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities amid geopolitical cross-currents.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/modern_investing/chapters_ep034.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/modern_investing/Modern_Investing_Ep034_20260505_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 35: AMD's 15% surge after data center revenue and guidance beat shows AI infrastructure demand remains a powerful driver worth watching for tech allocation.</title>
       <link>https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep035_20260506.mp3</link>

--- a/omni_view_podcast.rss
+++ b/omni_view_podcast.rss
@@ -516,7 +516,7 @@
       <itunes:episode>8</itunes:episode>
       <itunes:title>Ep 8: Iran's drone attack on Dubai airport escalates Middle East conflict as Israel strikes Tehran.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep008.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 9: US and Israeli strikes ignite oil depots in Tehran, escalating the Middle East war into its second week.</title>
       <description># Omni View — Omni‑View Briefing
@@ -593,7 +593,7 @@
       <itunes:episode>9</itunes:episode>
       <itunes:title>Ep 9: US and Israeli strikes ignite oil depots in Tehran, escalating the Middle East war into its second week.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep009.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 10: Iran's new supreme leader vows escalated attacks as oil surges past $120 amid Gulf strikes.</title>
       <description># Omni View — Omni‑View Briefing
@@ -664,7 +664,7 @@
       <itunes:episode>10</itunes:episode>
       <itunes:title>Ep 10: Iran's new supreme leader vows escalated attacks as oil surges past $120 amid Gulf strikes.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep010.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 11: Trump claims Iran war could end soon but threatens escalation if oil supplies are disrupted.</title>
       <description># Omni View — Omni‑View Briefing
@@ -733,7 +733,7 @@
       <itunes:episode>11</itunes:episode>
       <itunes:title>Ep 11: Trump claims Iran war could end soon but threatens escalation if oil supplies are disrupted.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep011.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 12: Ships attacked in Strait of Hormuz amid US-Israel-Iran war, escalating global oil supply fears.</title>
       <description># Omni View — Omni‑View Briefing
@@ -802,7 +802,7 @@
       <itunes:episode>12</itunes:episode>
       <itunes:title>Ep 12: Ships attacked in Strait of Hormuz amid US-Israel-Iran war, escalating global oil supply fears.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep012.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 13: Iran strikes oil tankers in the Gulf, surging prices to $100 a barrel amid escalating US-Israel conflict.</title>
       <description># Omni View — Omni‑View Briefing
@@ -883,7 +883,7 @@
       <itunes:episode>13</itunes:episode>
       <itunes:title>Ep 13: Iran strikes oil tankers in the Gulf, surging prices to $100 a barrel amid escalating US-Israel conflict.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep013.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 14: Four US service members killed in Iraq plane crash as Middle East war escalates with Iranian drone strikes.</title>
       <description># Omni View — Omni‑View Briefing
@@ -964,7 +964,7 @@
       <itunes:episode>14</itunes:episode>
       <itunes:title>Ep 14: Four US service members killed in Iraq plane crash as Middle East war escalates with Iranian drone strikes.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep014.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 15: US bombs Iran's Kharg Island oil hub as Middle East conflict escalates.</title>
       <description># Omni View — Omni‑View Briefing
@@ -1045,7 +1045,7 @@
       <itunes:episode>15</itunes:episode>
       <itunes:title>Ep 15: US bombs Iran's Kharg Island oil hub as Middle East conflict escalates.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep015.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 16: Iran denies its supreme leader's death amid escalating US-Israel strikes and global oil disruptions.</title>
       <description># Omni View — Omni‑View Briefing
@@ -1134,7 +1134,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>16</itunes:episode>
       <itunes:title>Ep 16: Iran denies its supreme leader's death amid escalating US-Israel strikes and global oil disruptions.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep016.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 17: Iran war escalates with US embassy attack in Baghdad and global inflation fears prompting rate hikes.</title>
       <description># Omni View — Omni‑View Briefing
@@ -1167,7 +1167,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>17</itunes:episode>
       <itunes:title>Ep 17: Iran war escalates with US embassy attack in Baghdad and global inflation fears prompting rate hikes.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep017.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep017_20260317_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 18: Oil prices fall as U.S. considers releasing sanctioned Iranian crude while Israel-Iran conflict disrupts global energy markets.</title>
       <description>**# Omni View — Omni‑View Briefing**  
@@ -1202,7 +1202,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>18</itunes:episode>
       <itunes:title>Ep 18: Oil prices fall as U.S. considers releasing sanctioned Iranian crude while Israel-Iran conflict disrupts global energy markets.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep018.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep018_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Omni View - Episode 19 - March 20, 2026</title>
       <description>**OMNI VIEW**  
@@ -1231,7 +1231,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>19</itunes:episode>
       <itunes:title>Omni View - Episode 19 - March 20, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep019.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep019_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 20: Trump considers winding down Iran war while easing sanctions on Iranian oil as Israel strikes Tehran targets and global energy prices surge.</title>
       <description>**HOOK:** Trump considers winding down Iran war while easing sanctions on Iranian oil as Israel strikes Tehran targets and global energy prices surge.
@@ -1260,7 +1260,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>20</itunes:episode>
       <itunes:title>Ep 20: Trump considers winding down Iran war while easing sanctions on Iranian oil as Israel strikes Tehran targets and global energy prices surge.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep020.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep020_20260321_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 21: Escalating Iran conflict triggers global energy crisis warnings, market turmoil, and emergency government meetings.</title>
       <description>**# Omni View — Omni‑View Briefing**  
@@ -1295,7 +1295,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>21</itunes:episode>
       <itunes:title>Ep 21: Escalating Iran conflict triggers global energy crisis warnings, market turmoil, and emergency government meetings.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep021.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep021_20260323_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 22: Trump administration shares 15-point plan to end Iran war as Tehran launches new strikes on US and Israeli targets.</title>
       <description>**# Omni View — Omni‑View Briefing**
@@ -1330,7 +1330,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>22</itunes:episode>
       <itunes:title>Ep 22: Trump administration shares 15-point plan to end Iran war as Tehran launches new strikes on US and Israeli targets.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep022.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep022_20260325_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 23: Iran has rejected President Trump’s proposed peace plan as a pretext for invasion, while Israel claims it killed Iran’s naval chief amid escalating Middle East conflict.</title>
       <description>**# Omni View — Omni‑View Briefing**  
@@ -1363,7 +1363,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>23</itunes:episode>
       <itunes:title>Ep 23: Iran has rejected President Trump’s proposed peace plan as a pretext for invasion, while Israel claims it killed Iran’s naval chief amid escalating Middle East conflict.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep023.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep023_20260326_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 24: Trump extends deadline for Iran to reopen Strait of Hormuz to April 6, pausing strikes on energy sites as oil markets fluctuate.</title>
       <description>**# Omni View — Omni‑View Briefing**  
@@ -1396,7 +1396,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>24</itunes:episode>
       <itunes:title>Ep 24: Trump extends deadline for Iran to reopen Strait of Hormuz to April 6, pausing strikes on energy sites as oil markets fluctuate.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep024.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep024_20260327_transcript.json" type="application/json" /></item>
     <item>
       <title>Omni View - Episode 25 - March 29, 2026</title>
       <description>**OMNI VIEW SPECIAL EDUCATIONAL EPISODE**
@@ -1431,7 +1431,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>25</itunes:episode>
       <itunes:title>Omni View - Episode 25 - March 29, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep025.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep025_20260329_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 26: Oil prices fell after reports President Trump is willing to end the Iran conflict even if the Strait of Hormuz stays largely closed.</title>
       <description>**# Omni View — Omni‑View Briefing**
@@ -1464,7 +1464,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>26</itunes:episode>
       <itunes:title>Ep 26: Oil prices fell after reports President Trump is willing to end the Iran conflict even if the Strait of Hormuz stays largely closed.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep026.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep026_20260331_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 27: Trump warns Iran of further strikes after US-Israeli attack destroys Iran's largest bridge, as Tehran vows continued resistance.</title>
       <description>**# Omni View — Omni‑View Briefing**
@@ -1499,7 +1499,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>27</itunes:episode>
       <itunes:title>Ep 27: Trump warns Iran of further strikes after US-Israeli attack destroys Iran's largest bridge, as Tehran vows continued resistance.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep027.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep027_20260403_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 28: U.S. forces rescue both crew members of an F-15E fighter jet shot down over Iran, with President Trump calling it one of the most daring search-and-rescue operations in American history.</title>
       <description>**# Omni View — Omni‑View Briefing**  
@@ -1534,7 +1534,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>28</itunes:episode>
       <itunes:title>Ep 28: U.S. forces rescue both crew members of an F-15E fighter jet shot down over Iran, with President Trump calling it one of the most daring search-and-rescue operations in American history.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep028.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep028_20260405_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 29: Trump issues Tuesday deadline threatening to strike Iranian infrastructure if the Strait of Hormuz remains closed, driving up oil prices and rattling markets.</title>
       <description>**# Omni View — Omni‑View Briefing**  
@@ -1569,7 +1569,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>29</itunes:episode>
       <itunes:title>Ep 29: Trump issues Tuesday deadline threatening to strike Iranian infrastructure if the Strait of Hormuz remains closed, driving up oil prices and rattling markets.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep029.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep029_20260407_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 30: Fragile US-Iran ceasefire faces immediate test as Israel strikes Lebanon, Iran halts tankers in the Strait of Hormuz, and both sides dispute what was actually agreed.</title>
       <description>**HOOK:** Fragile US-Iran ceasefire faces immediate test as Israel strikes Lebanon, Iran halts tankers in the Strait of Hormuz, and both sides dispute what was actually agreed.
@@ -1598,7 +1598,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>30</itunes:episode>
       <itunes:title>Ep 30: Fragile US-Iran ceasefire faces immediate test as Israel strikes Lebanon, Iran halts tankers in the Strait of Hormuz, and both sides dispute what was actually agreed.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep030.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep030_20260409_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 31: US and Iranian officials begin highest-level direct talks in 40 years in Pakistan as Trump warns of military buildup if diplomacy fails.</title>
       <description>**# Omni View — Omni‑View Briefing**  
@@ -1633,7 +1633,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>31</itunes:episode>
       <itunes:title>Ep 31: US and Iranian officials begin highest-level direct talks in 40 years in Pakistan as Trump warns of military buildup if diplomacy fails.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep031.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep031_20260411_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 32: Rory McIlroy wins back-to-back Masters in thrilling Augusta finale as Trump announces Strait of Hormuz blockade sending oil above $100.</title>
       <description>**HOOK:** Rory McIlroy wins back-to-back Masters in thrilling Augusta finale as Trump announces Strait of Hormuz blockade sending oil above $100.
@@ -1660,7 +1660,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>32</itunes:episode>
       <itunes:title>Ep 32: Rory McIlroy wins back-to-back Masters in thrilling Augusta finale as Trump announces Strait of Hormuz blockade sending oil above $100.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep032.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep032_20260413_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 33: US military claims Iran blockade has completely halted economic trade as Trump criticizes Pope Leo over the conflict.</title>
       <description>**HOOK:** US military claims Iran blockade has completely halted economic trade as Trump criticizes Pope Leo over the conflict.
@@ -1687,7 +1687,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>33</itunes:episode>
       <itunes:title>Ep 33: US military claims Iran blockade has completely halted economic trade as Trump criticizes Pope Leo over the conflict.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep033.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep033_20260415_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 34: Israel and Lebanon ceasefire takes effect as Trump hails 'historic' peace effort amid ongoing Iran war tensions.</title>
       <description>**HOOK:** Israel and Lebanon ceasefire takes effect as Trump hails 'historic' peace effort amid ongoing Iran war tensions.
@@ -1716,7 +1716,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>34</itunes:episode>
       <itunes:title>Ep 34: Israel and Lebanon ceasefire takes effect as Trump hails 'historic' peace effort amid ongoing Iran war tensions.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep034.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep034_20260417_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 35: US-Iran ceasefire deadline looms with JD Vance poised to lead Pakistan talks as both sides issue fresh threats.</title>
       <description>**HOOK:** US-Iran ceasefire deadline looms with JD Vance poised to lead Pakistan talks as both sides issue fresh threats.
@@ -1743,7 +1743,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>35</itunes:episode>
       <itunes:title>Ep 35: US-Iran ceasefire deadline looms with JD Vance poised to lead Pakistan talks as both sides issue fresh threats.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep035.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep035_20260421_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 36: UK Prime Minister Keir Starmer faces open revolt as a Labour MP calls for his resignation amid a growing Cabinet rift.</title>
       <description>**HOOK:** UK Prime Minister Keir Starmer faces open revolt as a Labour MP calls for his resignation amid a growing Cabinet rift.
@@ -1772,7 +1772,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>36</itunes:episode>
       <itunes:title>Ep 36: UK Prime Minister Keir Starmer faces open revolt as a Labour MP calls for his resignation amid a growing Cabinet rift.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep036.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep036_20260423_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 37: King Charles faces US pressure over Falklands sovereignty as Trump envoys head to Iran peace talks in Pakistan.</title>
       <description>**HOOK:** King Charles faces US pressure over Falklands sovereignty as Trump envoys head to Iran peace talks in Pakistan.
@@ -1801,7 +1801,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>37</itunes:episode>
       <itunes:title>Ep 37: King Charles faces US pressure over Falklands sovereignty as Trump envoys head to Iran peace talks in Pakistan.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep037.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep037_20260425_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 38: King Charles begins US state visit amid heightened security fears following the White House Correspondents' Dinner shooting.</title>
       <description>**HOOK:** King Charles begins US state visit amid heightened security fears following the White House Correspondents' Dinner shooting.
@@ -1830,7 +1830,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>38</itunes:episode>
       <itunes:title>Ep 38: King Charles begins US state visit amid heightened security fears following the White House Correspondents' Dinner shooting.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep038.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep038_20260427_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 39: King Charles addresses Congress and shares laughs with Trump at White House state dinner during historic royal visit.</title>
       <description>**HOOK:** King Charles addresses Congress and shares laughs with Trump at White House state dinner during historic royal visit.
@@ -1859,7 +1859,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>39</itunes:episode>
       <itunes:title>Ep 39: King Charles addresses Congress and shares laughs with Trump at White House state dinner during historic royal visit.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep039.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep039_20260429_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 40: UK raises terror threat level to 'severe' after stabbings of two Jewish men in Golders Green.</title>
       <description># Omni View — Omni‑View Briefing
@@ -1894,7 +1894,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>40</itunes:episode>
       <itunes:title>Ep 40: UK raises terror threat level to 'severe' after stabbings of two Jewish men in Golders Green.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep040.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep040_20260501_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 41: President Trump is reviewing a new peace proposal from Iran but doubts it will be acceptable since Tehran has not paid a big enough price.</title>
       <description># Omni View — Omni‑View Briefing
@@ -1923,7 +1923,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>41</itunes:episode>
       <itunes:title>Ep 41: President Trump is reviewing a new peace proposal from Iran but doubts it will be acceptable since Tehran has not paid a big enough price.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep041.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep041_20260503_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 42: Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</title>
       <description># Omni View — Omni‑View Briefing
@@ -1952,7 +1952,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>42</itunes:episode>
       <itunes:title>Ep 42: Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/omni_view/chapters_ep042.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/omni_view/Omni_View_Ep042_20260505_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 43: Novo Nordisk raised its 2026 outlook after strong sales of its new Wegovy pill sent shares up 6%.</title>
       <link>https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep043_20260506.mp3</link>

--- a/planetterrian_podcast.rss
+++ b/planetterrian_podcast.rss
@@ -559,7 +559,7 @@
       <itunes:episode>27</itunes:episode>
       <itunes:title>Ep 27: Mayo Clinic identified a rare MET gene mutation directly causing fatty liver disease without common risk factors.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep027.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 29: European trial finds sulthiame drug cuts sleep apnea breathing pauses by up to 47%, improving oxygen levels.</title>
       <description># Planetterrian Daily
@@ -672,7 +672,7 @@
       <itunes:episode>29</itunes:episode>
       <itunes:title>Ep 29: European trial finds sulthiame drug cuts sleep apnea breathing pauses by up to 47%, improving oxygen levels.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep029.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 30: Researchers found that combining two colon polyp types raises bowel cancer risk up to fivefold.</title>
       <description># Planetterrian Daily
@@ -769,7 +769,7 @@
       <itunes:episode>30</itunes:episode>
       <itunes:title>Ep 30: Researchers found that combining two colon polyp types raises bowel cancer risk up to fivefold.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep030.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 31: Scientists uncovered evidence of ancient underground water on Mars that may have sustained microbial life longer than expected.</title>
       <description># Planetterrian Daily
@@ -872,7 +872,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>31</itunes:episode>
       <itunes:title>Ep 31: Scientists uncovered evidence of ancient underground water on Mars that may have sustained microbial life longer than expected.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep031.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 32: Ravens in Yellowstone navigate directly to likely wolf kill sites using memorized landscape patterns rather than following the predators.</title>
       <description># Planetterrian Daily
@@ -907,7 +907,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>32</itunes:episode>
       <itunes:title>Ep 32: Ravens in Yellowstone navigate directly to likely wolf kill sites using memorized landscape patterns rather than following the predators.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep032_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 33: South African raptors have declined sharply over 16 years, with half the studied species dropping more than 50%.</title>
       <description>**HOOK:** South African raptors have declined sharply over 16 years, with half the studied species dropping more than 50%.
@@ -936,7 +936,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>33</itunes:episode>
       <itunes:title>Ep 33: South African raptors have declined sharply over 16 years, with half the studied species dropping more than 50%.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep033_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 34: Engineered probiotic bacteria infiltrated tumors in mice and produced cancer drugs on site, potentially improving precision while cutting side effects.</title>
       <description># Planetterrian Daily
@@ -971,7 +971,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>34</itunes:episode>
       <itunes:title>Ep 34: Engineered probiotic bacteria infiltrated tumors in mice and produced cancer drugs on site, potentially improving precision while cutting side effects.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep034.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep034_20260321_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 35: [Slow News Edition] Light-activated nanoparticles trigger copper overload to kill cancer cells 100 times more effectively than existing chemotherapy.</title>
       <description># Planetterrian Daily
@@ -1006,7 +1006,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>35</itunes:episode>
       <itunes:title>Ep 35: [Slow News Edition] Light-activated nanoparticles trigger copper overload to kill cancer cells 100 times more effectively than existing chemotherapy.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep035.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep035_20260326_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 36: [Slow News Edition] Excess belly fat combined with low muscle mass raises death risk by 83% through accelerated inflammation and muscle loss.</title>
       <description>**HOOK:** Excess belly fat combined with low muscle mass raises death risk by 83% through accelerated inflammation and muscle loss.
@@ -1035,7 +1035,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>36</itunes:episode>
       <itunes:title>Ep 36: [Slow News Edition] Excess belly fat combined with low muscle mass raises death risk by 83% through accelerated inflammation and muscle loss.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep036.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep036_20260327_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 37: [Slow News Edition] Supercomputer simulations have mapped the full motions of the spliceosome inside a two-million-atom model of the human cell.</title>
       <description>**HOOK:** Supercomputer simulations have mapped the full motions of the spliceosome inside a two-million-atom model of the human cell.
@@ -1062,7 +1062,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>37</itunes:episode>
       <itunes:title>Ep 37: [Slow News Edition] Supercomputer simulations have mapped the full motions of the spliceosome inside a two-million-atom model of the human cell.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep037.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep037_20260329_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 38: Deep sleep activates a brain-driven feedback loop that releases growth hormone to build muscle, burn fat, and sharpen cognition.</title>
       <description># Planetterrian Daily
@@ -1097,7 +1097,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>38</itunes:episode>
       <itunes:title>Ep 38: Deep sleep activates a brain-driven feedback loop that releases growth hormone to build muscle, burn fat, and sharpen cognition.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep038.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep038_20260331_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 39: Squid genomes reveal they retreated to deep-sea oxygen refuges over 100 million years ago to survive Earth's largest extinction.</title>
       <description>**HOOK:** Squid genomes reveal they retreated to deep-sea oxygen refuges over 100 million years ago to survive Earth's largest extinction.
@@ -1124,7 +1124,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>39</itunes:episode>
       <itunes:title>Ep 39: Squid genomes reveal they retreated to deep-sea oxygen refuges over 100 million years ago to survive Earth's largest extinction.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep039.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep039_20260401_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 40: New research shows BMI misclassifies more than one third of adults when compared to precise DXA body-fat scans.</title>
       <description>**Planetterrian Daily**
@@ -1159,7 +1159,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>40</itunes:episode>
       <itunes:title>Ep 40: New research shows BMI misclassifies more than one third of adults when compared to precise DXA body-fat scans.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep040.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep040_20260403_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 41: Sugarcane-derived protein creates artificial saliva that shields teeth from acid far better than current options, especially when combined with fluoride.</title>
       <description>**# Planetterrian Daily**  
@@ -1194,7 +1194,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>41</itunes:episode>
       <itunes:title>Ep 41: Sugarcane-derived protein creates artificial saliva that shields teeth from acid far better than current options, especially when combined with fluoride.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep041.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep041_20260405_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 42: A new high-temperature memory chip keeps functioning at 700°C, potentially transforming electronics and AI in extreme environments.</title>
       <description>**# Planetterrian Daily**  
@@ -1229,7 +1229,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>42</itunes:episode>
       <itunes:title>Ep 42: A new high-temperature memory chip keeps functioning at 700°C, potentially transforming electronics and AI in extreme environments.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep042.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep042_20260407_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 43: New genetic markers now identify seedless self-pollinating muscadine grapes years before fruit appears, accelerating breeding of better varieties.</title>
       <description>**HOOK:** New genetic markers now identify seedless self-pollinating muscadine grapes years before fruit appears, accelerating breeding of better varieties.
@@ -1258,7 +1258,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>43</itunes:episode>
       <itunes:title>Ep 43: New genetic markers now identify seedless self-pollinating muscadine grapes years before fruit appears, accelerating breeding of better varieties.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep043.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep043_20260409_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 44: Marine heat waves are now measurably supercharging global hurricane damage according to a major new study.</title>
       <description>**Planetterrian Daily**  
@@ -1293,7 +1293,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>44</itunes:episode>
       <itunes:title>Ep 44: Marine heat waves are now measurably supercharging global hurricane damage according to a major new study.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep044.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep044_20260411_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 45: A single CAR-T cell therapy has driven three distinct autoimmune diseases into remission in one patient for the first time.</title>
       <description>**HOOK:** A single CAR-T cell therapy has driven three distinct autoimmune diseases into remission in one patient for the first time.
@@ -1322,7 +1322,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>45</itunes:episode>
       <itunes:title>Ep 45: A single CAR-T cell therapy has driven three distinct autoimmune diseases into remission in one patient for the first time.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep045.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep045_20260413_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 46: Ideaya’s eye cancer drug met its phase 2/3 primary endpoint, clearing a path to accelerated FDA filing later this year.</title>
       <description>**HOOK:** Ideaya’s eye cancer drug met its phase 2/3 primary endpoint, clearing a path to accelerated FDA filing later this year.
@@ -1351,7 +1351,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>46</itunes:episode>
       <itunes:title>Ep 46: Ideaya’s eye cancer drug met its phase 2/3 primary endpoint, clearing a path to accelerated FDA filing later this year.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep046.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep046_20260415_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 47: Protein engineers created over 10 million data points in three days, dramatically accelerating AI-guided design of custom molecules.</title>
       <description># Planetterrian Daily
@@ -1386,7 +1386,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>47</itunes:episode>
       <itunes:title>Ep 47: Protein engineers created over 10 million data points in three days, dramatically accelerating AI-guided design of custom molecules.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep047.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep047_20260419_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 48: California hybrid honeybees resist Varroa mites from the larval stage, carrying far fewer parasites without heavy chemical use.</title>
       <description># Planetterrian Daily
@@ -1421,7 +1421,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>48</itunes:episode>
       <itunes:title>Ep 48: California hybrid honeybees resist Varroa mites from the larval stage, carrying far fewer parasites without heavy chemical use.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep048.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep048_20260421_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 49: Supplementing a specific polyunsaturated fatty acid restored visual function and reversed cellular aging signs in the retinas of older mice.</title>
       <description># Planetterrian Daily
@@ -1456,7 +1456,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>49</itunes:episode>
       <itunes:title>Ep 49: Supplementing a specific polyunsaturated fatty acid restored visual function and reversed cellular aging signs in the retinas of older mice.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep049.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep049_20260423_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 50: Higher education levels strongly predict longer lifespans across global populations, even where health records are incomplete.</title>
       <description># Planetterrian Daily
@@ -1491,7 +1491,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>50</itunes:episode>
       <itunes:title>Ep 50: Higher education levels strongly predict longer lifespans across global populations, even where health records are incomplete.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep050.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep050_20260425_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 51: Mixing workout types over decades lowers mortality risk more effectively than repeating the same activity.</title>
       <description># Planetterrian Daily
@@ -1526,7 +1526,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>51</itunes:episode>
       <itunes:title>Ep 51: Mixing workout types over decades lowers mortality risk more effectively than repeating the same activity.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep051.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep051_20260427_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 52: A blood test using AI models is showing early promise for monitoring a rare childhood bone and soft tissue cancer.</title>
       <description># Planetterrian Daily
@@ -1561,7 +1561,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>52</itunes:episode>
       <itunes:title>Ep 52: A blood test using AI models is showing early promise for monitoring a rare childhood bone and soft tissue cancer.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep052.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep052_20260429_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 53: A blood test for p-tau217 can predict Alzheimer's risk years before any symptoms appear.</title>
       <description># Planetterrian Daily
@@ -1598,7 +1598,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>53</itunes:episode>
       <itunes:title>Ep 53: A blood test for p-tau217 can predict Alzheimer's risk years before any symptoms appear.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep053.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep053_20260501_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 54: Researchers have identified a blood-based DNA marker that tracks arsenic exposure and may predict toxicity risks for those affected by contaminated water.</title>
       <description># Planetterrian Daily
@@ -1629,7 +1629,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>54</itunes:episode>
       <itunes:title>Ep 54: Researchers have identified a blood-based DNA marker that tracks arsenic exposure and may predict toxicity risks for those affected by contaminated water.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep054.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep054_20260503_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 55: Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</title>
       <description># Planetterrian Daily
@@ -1660,7 +1660,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>55</itunes:episode>
       <itunes:title>Ep 55: Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/planetterrian/chapters_ep055.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/planetterrian/Planetterrian_Daily_Ep055_20260505_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 56: A single 25 mg dose of psilocybin produced measurable brain structural changes in healthy adults that persisted for at least one month.</title>
       <link>https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep056_20260506.mp3</link>

--- a/podcast.rss
+++ b/podcast.rss
@@ -1172,7 +1172,7 @@
       <itunes:episode>398</itunes:episode>
       <itunes:title>Ep 398: Automakers are exiting Tesla's EU carbon credit pool, which could squeeze a key revenue stream worth billions.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep398.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 399: Tesla's Giga Berlin workers elect 'Giga United' majority, signaling a shift away from union influence.</title>
       <description># Tesla Shorts Time
@@ -1237,7 +1237,7 @@
       <itunes:episode>399</itunes:episode>
       <itunes:title>Ep 399: Tesla's Giga Berlin workers elect 'Giga United' majority, signaling a shift away from union influence.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep399.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 400: Tesla's patent for a one-piece composite seat signals the next-gen Roadster is nearing its debut.</title>
       <description># Tesla Shorts Time
@@ -1300,7 +1300,7 @@
       <itunes:episode>400</itunes:episode>
       <itunes:title>Ep 400: Tesla's patent for a one-piece composite seat signals the next-gen Roadster is nearing its debut.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep400.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 401: Tesla patents breakthrough dry electrode process for cheaper, cleaner battery production.</title>
       <description># Tesla Shorts Time
@@ -1373,7 +1373,7 @@
       <itunes:episode>401</itunes:episode>
       <itunes:title>Ep 401: Tesla patents breakthrough dry electrode process for cheaper, cleaner battery production.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep401.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 402: Tesla's FSD tech is now called more revolutionary than the iPhone by experts, sparking major buzz.</title>
       <description># Tesla Shorts Time
@@ -1444,7 +1444,7 @@
       <itunes:episode>402</itunes:episode>
       <itunes:title>Ep 402: Tesla's FSD tech is now called more revolutionary than the iPhone by experts, sparking major buzz.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep402.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 403: Tesla loses two long-time executives, including finance VP Sendil Palani after 17 years and OTA director Thomas Dmytryk after 11 years.</title>
       <description># Tesla Shorts Time
@@ -1507,7 +1507,7 @@
       <itunes:episode>403</itunes:episode>
       <itunes:title>Ep 403: Tesla loses two long-time executives, including finance VP Sendil Palani after 17 years and OTA director Thomas Dmytryk after 11 years.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep403.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 404: Tesla ramps up Cybercab testing on public roads as it queues for mass production.</title>
       <description># Tesla Shorts Time
@@ -1582,7 +1582,7 @@
       <itunes:episode>404</itunes:episode>
       <itunes:title>Ep 404: Tesla ramps up Cybercab testing on public roads as it queues for mass production.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep404.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 405: Tesla is ramping up Cybercab production to hundreds weekly at its Austin factory ahead of launch.</title>
       <description># Tesla Shorts Time
@@ -1655,7 +1655,7 @@
       <itunes:episode>405</itunes:episode>
       <itunes:title>Ep 405: Tesla is ramping up Cybercab production to hundreds weekly at its Austin factory ahead of launch.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep405.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 406: Tesla gains a stake in SpaceX by converting its $2B xAI investment, deepening ties between Musk's companies.</title>
       <description># Tesla Shorts Time
@@ -1716,7 +1716,7 @@
       <itunes:episode>406</itunes:episode>
       <itunes:title>Ep 406: Tesla gains a stake in SpaceX by converting its $2B xAI investment, deepening ties between Musk's companies.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep406.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 407: Tesla's latest software update brings Comfort Braking to Model Y, enhancing smoother stops for owners.</title>
       <description># Tesla Shorts Time
@@ -1789,7 +1789,7 @@
       <itunes:episode>407</itunes:episode>
       <itunes:title>Ep 407: Tesla's latest software update brings Comfort Braking to Model Y, enhancing smoother stops for owners.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep407.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 408: Elon Musk confirms Tesla's Terafab AI chip plant starts production in just seven days.</title>
       <description># Tesla Shorts Time
@@ -1874,7 +1874,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>408</itunes:episode>
       <itunes:title>Ep 408: Elon Musk confirms Tesla's Terafab AI chip plant starts production in just seven days.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep408.json" type="application/json+chapters" /></item>
     <item>
       <title>Ep 411: Canada is investing $200 million in its own Spaceport Nova Scotia to cut reliance on SpaceX for future launches.</title>
       <description># Tesla Shorts Time
@@ -1909,7 +1909,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>411</itunes:episode>
       <itunes:title>Ep 411: Canada is investing $200 million in its own Spaceport Nova Scotia to cut reliance on SpaceX for future launches.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep411.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep411_20260318_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 413: Tesla and SpaceX launched the Terafab project to build vertically integrated AI chip production on a massive scale.</title>
       <description># Tesla Shorts Time
@@ -1944,7 +1944,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>413</itunes:episode>
       <itunes:title>Ep 413: Tesla and SpaceX launched the Terafab project to build vertically integrated AI chip production on a massive scale.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep413.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep413_20260322_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 414: NHTSA has escalated its investigation into Tesla's Full Self-Driving software to the engineering analysis phase.</title>
       <description># Tesla Shorts Time
@@ -1981,7 +1981,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>414</itunes:episode>
       <itunes:title>Ep 414: NHTSA has escalated its investigation into Tesla's Full Self-Driving software to the engineering analysis phase.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep414_20260322_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 415: Cybertruck earns IIHS Top Safety Pick+ while Tesla patents a fresh trailer-style range extender.</title>
       <description># Tesla Shorts Time
@@ -2016,7 +2016,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>415</itunes:episode>
       <itunes:title>Ep 415: Cybertruck earns IIHS Top Safety Pick+ while Tesla patents a fresh trailer-style range extender.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep415.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep415_20260324_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 416: [Slow News Edition] Tesla is developing a new family vehicle that Elon Musk calls way cooler than a minivan as the company begins phasing out the Model S and X.</title>
       <description># Tesla Shorts Time
@@ -2051,7 +2051,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>416</itunes:episode>
       <itunes:title>Ep 416: [Slow News Edition] Tesla is developing a new family vehicle that Elon Musk calls way cooler than a minivan as the company begins phasing out the Model S and X.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep416.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep416_20260325_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 417: [Slow News Edition] Tesla makes Fortune’s 2026 Most Innovative Companies list thanks to the Cybercab as production begins this year.</title>
       <description># Tesla Shorts Time
@@ -2088,7 +2088,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>417</itunes:episode>
       <itunes:title>Ep 417: [Slow News Edition] Tesla makes Fortune’s 2026 Most Innovative Companies list thanks to the Cybercab as production begins this year.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep417.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep417_20260327_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 418: A Tesla on FSD Supervised avoided a potential collision with a school bus that nearly ran a red light, with the viral video showing the system braking sharply to protect its occupants.</title>
       <description># Tesla Shorts Time
@@ -2123,7 +2123,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>418</itunes:episode>
       <itunes:title>Ep 418: A Tesla on FSD Supervised avoided a potential collision with a school bus that nearly ran a red light, with the viral video showing the system braking sharply to protect its occupants.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep418.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep418_20260328_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 419: [Slow News Edition] Tesla has started delivering the refreshed Model Y Performance and RWD in British Columbia after weeks of shifting timelines.</title>
       <description># Tesla Shorts Time
@@ -2158,7 +2158,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>419</itunes:episode>
       <itunes:title>Ep 419: [Slow News Edition] Tesla has started delivering the refreshed Model Y Performance and RWD in British Columbia after weeks of shifting timelines.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep419.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep419_20260329_transcript.json" type="application/json" /></item>
     <item>
       <title>Tesla Shorts Time - Episode 420 - March 31, 2026</title>
       <description>**Tesla Shorts Time – Special Educational Episode**
@@ -2181,7 +2181,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>420</itunes:episode>
       <itunes:title>Tesla Shorts Time - Episode 420 - March 31, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep420.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep420_20260331_transcript.json" type="application/json" /></item>
     <item>
       <title>Tesla Shorts Time - Episode 421 - March 31, 2026</title>
       <description>**Tesla Shorts Time – Special Educational Episode**
@@ -2208,7 +2208,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>421</itunes:episode>
       <itunes:title>Tesla Shorts Time - Episode 421 - March 31, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep421.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep421_20260331_transcript.json" type="application/json" /></item>
     <item>
       <title>Tesla Shorts Time - Episode 422 - April 01, 2026</title>
       <description>**Tesla Shorts Time – Special Educational Episode**
@@ -2231,7 +2231,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>422</itunes:episode>
       <itunes:title>Tesla Shorts Time - Episode 422 - April 01, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep422.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep422_20260401_transcript.json" type="application/json" /></item>
     <item>
       <title>Tesla Shorts Time - Episode 423 - April 01, 2026</title>
       <description>**Tesla Shorts Time – Special Educational Episode**
@@ -2258,7 +2258,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>423</itunes:episode>
       <itunes:title>Tesla Shorts Time - Episode 423 - April 01, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep423.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep423_20260401_transcript.json" type="application/json" /></item>
     <item>
       <title>Tesla Shorts Time - Episode 424 - April 02, 2026</title>
       <description>**Tesla Shorts Time – Special Educational Episode**
@@ -2281,7 +2281,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>424</itunes:episode>
       <itunes:title>Tesla Shorts Time - Episode 424 - April 02, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep424.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep424_20260402_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 425: Tesla regained the top spot in global pure EV sales by outpacing BYD while expanding the long-wheelbase Model Y across Asia.</title>
       <description># Tesla Shorts Time
@@ -2316,7 +2316,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>425</itunes:episode>
       <itunes:title>Ep 425: Tesla regained the top spot in global pure EV sales by outpacing BYD while expanding the long-wheelbase Model Y across Asia.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep425.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep425_20260403_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 426: A Tesla in Israel took a direct hit from Iranian missile debris yet its glass roof held firm, while the company also overtook BYD in global EV sales for Q1.</title>
       <description>**# Tesla Shorts Time**  
@@ -2351,7 +2351,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>426</itunes:episode>
       <itunes:title>Ep 426: A Tesla in Israel took a direct hit from Iranian missile debris yet its glass roof held firm, while the company also overtook BYD in global EV sales for Q1.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep426.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep426_20260404_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 427: BYD has now outsold Tesla for the second straight month as the Chinese EV maker continues gaining ground in global markets.</title>
       <description># Tesla Shorts Time
@@ -2386,7 +2386,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>427</itunes:episode>
       <itunes:title>Ep 427: BYD has now outsold Tesla for the second straight month as the Chinese EV maker continues gaining ground in global markets.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep427.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep427_20260405_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 428: US regulator closes its investigation into Tesla's Actually Smart Summon after the company rolled out software fixes.</title>
       <description># Tesla Shorts Time
@@ -2421,7 +2421,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>428</itunes:episode>
       <itunes:title>Ep 428: US regulator closes its investigation into Tesla's Actually Smart Summon after the company rolled out software fixes.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep428.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep428_20260406_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 429: Tesla reclaims the global EV sales crown in Q1 by overtaking BYD despite a modest 6% vehicle delivery increase and softer energy growth.</title>
       <description># Tesla Shorts Time
@@ -2458,7 +2458,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>429</itunes:episode>
       <itunes:title>Ep 429: Tesla reclaims the global EV sales crown in Q1 by overtaking BYD despite a modest 6% vehicle delivery increase and softer energy growth.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep429.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep429_20260407_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 430: Tesla's European registrations more than quadrupled in Germany last month, signalling a sharp rebound in one of its key markets.</title>
       <description># Tesla Shorts Time
@@ -2493,7 +2493,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>430</itunes:episode>
       <itunes:title>Ep 430: Tesla's European registrations more than quadrupled in Germany last month, signalling a sharp rebound in one of its key markets.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep430.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep430_20260408_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 431: Tesla's Supercharger-for-Business tool reveals massive ROI differences between prime and poor locations while Polestar launches direct discounts targeting its owners.</title>
       <description># Tesla Shorts Time
@@ -2528,7 +2528,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>431</itunes:episode>
       <itunes:title>Ep 431: Tesla's Supercharger-for-Business tool reveals massive ROI differences between prime and poor locations while Polestar launches direct discounts targeting its owners.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep431.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep431_20260409_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 432: Tesla deliveries missed expectations again amid rising inventory while the company appears to be restarting work on affordable compact EVs.</title>
       <description># Tesla Shorts Time
@@ -2563,7 +2563,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>432</itunes:episode>
       <itunes:title>Ep 432: Tesla deliveries missed expectations again amid rising inventory while the company appears to be restarting work on affordable compact EVs.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep432.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep432_20260410_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 433: Tesla’s dedicated Semi factory in Nevada is now open and aiming for 50,000 trucks a year as fleet interest picks up.</title>
       <description># Tesla Shorts Time
@@ -2598,7 +2598,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>433</itunes:episode>
       <itunes:title>Ep 433: Tesla’s dedicated Semi factory in Nevada is now open and aiming for 50,000 trucks a year as fleet interest picks up.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep433.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep433_20260411_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 434: Tesla’s Full Self-Driving software just received its first European regulatory approval in the Netherlands, opening a key regulatory door but leaving broader EU rollout still ahead.</title>
       <description># Tesla Shorts Time
@@ -2633,7 +2633,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>434</itunes:episode>
       <itunes:title>Ep 434: Tesla’s Full Self-Driving software just received its first European regulatory approval in the Netherlands, opening a key regulatory door but leaving broader EU rollout still ahead.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep434.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep434_20260412_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 435: Tesla secured its first European approval for FSD Supervised in the Netherlands, four years after the initial push, though the system arrives with restrictions.</title>
       <description># Tesla Shorts Time
@@ -2668,7 +2668,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>435</itunes:episode>
       <itunes:title>Ep 435: Tesla secured its first European approval for FSD Supervised in the Netherlands, four years after the initial push, though the system arrives with restrictions.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep435.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep435_20260413_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 436: Tesla's Spring 2026 software update is rolling out with a voice-activated Grok assistant and a redesigned Self-Driving app for AI4 hardware.</title>
       <description># Tesla Shorts Time
@@ -2703,7 +2703,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>436</itunes:episode>
       <itunes:title>Ep 436: Tesla's Spring 2026 software update is rolling out with a voice-activated Grok assistant and a redesigned Self-Driving app for AI4 hardware.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep436.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep436_20260414_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 437: Netherlands has approved Tesla's Full Self-Driving software in a first for Europe, opening the door to wider AI regulatory progress.</title>
       <description># Tesla Shorts Time
@@ -2738,7 +2738,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>437</itunes:episode>
       <itunes:title>Ep 437: Netherlands has approved Tesla's Full Self-Driving software in a first for Europe, opening the door to wider AI regulatory progress.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep437.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep437_20260415_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 438: A Tesla owner's camera caught the moment a Mercedes EV owner escaped just before their vehicle caught fire.</title>
       <description>**# Tesla Shorts Time**  
@@ -2773,7 +2773,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>438</itunes:episode>
       <itunes:title>Ep 438: A Tesla owner's camera caught the moment a Mercedes EV owner escaped just before their vehicle caught fire.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep438.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep438_20260416_transcript.json" type="application/json" /></item>
     <item>
       <title>Tesla Shorts Time - Episode 439 - April 17, 2026</title>
       <description>**SECTION 1: NEWS**
@@ -2800,7 +2800,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>439</itunes:episode>
       <itunes:title>Tesla Shorts Time - Episode 439 - April 17, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep439.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep439_20260417_transcript.json" type="application/json" /></item>
     <item>
       <title>Tesla Shorts Time - Episode 440 - April 18, 2026</title>
       <description>**Hey, it's me catching you up on Tesla today.**
@@ -2823,7 +2823,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>440</itunes:episode>
       <itunes:title>Tesla Shorts Time - Episode 440 - April 18, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep440.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep440_20260418_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 441: Tesla has expanded its unsupervised Robotaxi service into Dallas and Houston right before earnings.</title>
       <description># Tesla Shorts Time
@@ -2860,7 +2860,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>441</itunes:episode>
       <itunes:title>Ep 441: Tesla has expanded its unsupervised Robotaxi service into Dallas and Houston right before earnings.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep441.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep441_20260419_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 442: Full Self-Driving is now live on Teslas in Europe, with first-hand test drives starting to surface.</title>
       <description># Tesla Shorts Time
@@ -2897,7 +2897,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>442</itunes:episode>
       <itunes:title>Ep 442: Full Self-Driving is now live on Teslas in Europe, with first-hand test drives starting to surface.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep442.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep442_20260420_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 443: Tesla is developing a smaller, cheaper electric SUV to reach more everyday buyers.</title>
       <description># Tesla Shorts Time
@@ -2934,7 +2934,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>443</itunes:episode>
       <itunes:title>Ep 443: Tesla is developing a smaller, cheaper electric SUV to reach more everyday buyers.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep443.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep443_20260421_transcript.json" type="application/json" /></item>
     <item>
       <title>Tesla Shorts Time - Episode 444 - April 22, 2026</title>
       <description>**Hey, how's it going?**
@@ -2965,7 +2965,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>444</itunes:episode>
       <itunes:title>Tesla Shorts Time - Episode 444 - April 22, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep444.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep444_20260422_transcript.json" type="application/json" /></item>
     <item>
       <title>Tesla Shorts Time - Episode 445 - April 23, 2026</title>
       <description>**Hey, it's April 23, 2026.**
@@ -2988,7 +2988,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>445</itunes:episode>
       <itunes:title>Tesla Shorts Time - Episode 445 - April 23, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep445.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep445_20260423_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 446: Tesla has started production of the Cybercab at Giga Texas.</title>
       <description># Tesla Shorts Time
@@ -3025,7 +3025,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>446</itunes:episode>
       <itunes:title>Ep 446: Tesla has started production of the Cybercab at Giga Texas.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep446.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep446_20260423_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 447: Tesla patented a Lane Language Model that predicts road geometry like a chatbot predicts the next word.</title>
       <description># Tesla Shorts Time
@@ -3062,7 +3062,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>447</itunes:episode>
       <itunes:title>Ep 447: Tesla patented a Lane Language Model that predicts road geometry like a chatbot predicts the next word.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep447.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep447_20260424_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 448: Tesla patented an acid-free lithium extraction method that yields ultra-pure liquid while locking waste in dry clay.</title>
       <description># Tesla Shorts Time
@@ -3099,7 +3099,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>448</itunes:episode>
       <itunes:title>Ep 448: Tesla patented an acid-free lithium extraction method that yields ultra-pure liquid while locking waste in dry clay.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep448.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep448_20260425_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 449: Giga Berlin is ramping up output by 20% and adding 1,000 new hires after a record first quarter.</title>
       <description># Tesla Shorts Time
@@ -3134,7 +3134,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>449</itunes:episode>
       <itunes:title>Ep 449: Giga Berlin is ramping up output by 20% and adding 1,000 new hires after a record first quarter.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep449.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep449_20260426_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 450: Tesla has begun production of its CyberCab robotaxi in Texas, with revenue targeted after 2027.</title>
       <description># Tesla Shorts Time
@@ -3171,7 +3171,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>450</itunes:episode>
       <itunes:title>Ep 450: Tesla has begun production of its CyberCab robotaxi in Texas, with revenue targeted after 2027.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep450.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep450_20260427_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 451: Tesla filed an S-8 registering shares for Musk’s 2018 performance award, lifting his stake back over 20%.</title>
       <description># Tesla Shorts Time
@@ -3206,7 +3206,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>451</itunes:episode>
       <itunes:title>Ep 451: Tesla filed an S-8 registering shares for Musk’s 2018 performance award, lifting his stake back over 20%.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep451.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep451_20260427_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 452: Tesla is rolling out a Virtual Queue for Superchargers to end the fights over who charges next.</title>
       <description># Tesla Shorts Time
@@ -3243,7 +3243,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>452</itunes:episode>
       <itunes:title>Ep 452: Tesla is rolling out a Virtual Queue for Superchargers to end the fights over who charges next.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep452.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep452_20260427_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 453: Tesla is hiring engineers to build a wireless Battery Management System for Cybercab that removes heavy wiring harnesses across its vehicles.</title>
       <description># Tesla Shorts Time
@@ -3278,7 +3278,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>453</itunes:episode>
       <itunes:title>Ep 453: Tesla is hiring engineers to build a wireless Battery Management System for Cybercab that removes heavy wiring harnesses across its vehicles.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep453.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep453_20260428_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 454: Tesla has filed to begin vehicle sales and service in Bulgaria, expanding its footprint into Eastern Europe.</title>
       <description># Tesla Shorts Time
@@ -3315,7 +3315,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>454</itunes:episode>
       <itunes:title>Ep 454: Tesla has filed to begin vehicle sales and service in Bulgaria, expanding its footprint into Eastern Europe.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep454.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep454_20260429_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 455: Tesla has started mass production of the Semi in Nevada.</title>
       <description># Tesla Shorts Time
@@ -3356,7 +3356,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>455</itunes:episode>
       <itunes:title>Ep 455: Tesla has started mass production of the Semi in Nevada.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep455.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep455_20260430_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 456: The first production Tesla Cybercab has rolled off the line with a VIN assigned.</title>
       <description># Tesla Shorts Time
@@ -3397,7 +3397,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>456</itunes:episode>
       <itunes:title>Ep 456: The first production Tesla Cybercab has rolled off the line with a VIN assigned.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep456.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep456_20260501_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 457: Tesla has introduced its cheapest Model 3 in Canada at a record low while planning a Roadster unveil this month.</title>
       <description># Tesla Shorts Time
@@ -3438,7 +3438,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>457</itunes:episode>
       <itunes:title>Ep 457: Tesla has introduced its cheapest Model 3 in Canada at a record low while planning a Roadster unveil this month.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep457.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep457_20260502_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 458: California has closed a loophole that blocked permits for driverless vehicles under new autonomous legislation.</title>
       <description># Tesla Shorts Time
@@ -3479,7 +3479,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>458</itunes:episode>
       <itunes:title>Ep 458: California has closed a loophole that blocked permits for driverless vehicles under new autonomous legislation.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep458.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep458_20260502_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 459: The final Model X to roll off the line carries a hidden tribute with factory signatures under its Garnet Red paint.</title>
       <description># Tesla Shorts Time
@@ -3500,7 +3500,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>459</itunes:episode>
       <itunes:title>Ep 459: The final Model X to roll off the line carries a hidden tribute with factory signatures under its Garnet Red paint.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep459.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep459_20260502_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 460: Tesla has started high-volume production of the Semi with the first unit off the line at its giant factory.</title>
       <description># Tesla Shorts Time
@@ -3531,7 +3531,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>460</itunes:episode>
       <itunes:title>Ep 460: Tesla has started high-volume production of the Semi with the first unit off the line at its giant factory.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep460.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep460_20260502_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 461: A new Tesla Semi with three cameras per side mirror was spotted at the Las Vegas Convention Center ahead of the ACT Expo.</title>
       <description># Tesla Shorts Time
@@ -3560,7 +3560,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>461</itunes:episode>
       <itunes:title>Ep 461: A new Tesla Semi with three cameras per side mirror was spotted at the Las Vegas Convention Center ahead of the ACT Expo.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep461.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep461_20260503_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 462: Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</title>
       <description># Tesla Shorts Time
@@ -3591,7 +3591,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>462</itunes:episode>
       <itunes:title>Ep 462: Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep462.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep462_20260504_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 463: Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</title>
       <description># Tesla Shorts Time
@@ -3622,7 +3622,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>463</itunes:episode>
       <itunes:title>Ep 463: Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/tesla_shorts_time/chapters_ep463.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep463_20260505_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 464: WattEV ordered 370 Tesla Semis in a roughly $100 million deal, the largest yet for the electric truck.</title>
       <link>https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep464_20260506.mp3</link>

--- a/privet_russian_podcast.rss
+++ b/privet_russian_podcast.rss
@@ -201,7 +201,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>1</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 1 - March 14, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep001.json" type="application/json+chapters" /></item>
     <item>
       <title>Привет, Русский! - Episode 2 - March 20, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -240,7 +240,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>2</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 2 - March 20, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep002.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep002_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 3 - March 20, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -279,7 +279,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>3</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 3 - March 20, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep003.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep003_20260320_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 4 - March 24, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -318,7 +318,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>4</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 4 - March 24, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep004.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep004_20260324_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 5 - March 26, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -357,7 +357,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>5</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 5 - March 26, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep005.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep005_20260326_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 6 - March 26, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -396,7 +396,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>6</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 6 - March 26, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep006.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep006_20260326_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 7 - March 28, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -443,7 +443,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>7</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 7 - March 28, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep007.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep007_20260328_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 8 - March 30, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -482,7 +482,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>8</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 8 - March 30, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep008.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep008_20260330_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 9 - April 08, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -521,7 +521,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>9</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 9 - April 08, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep009.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep009_20260408_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 10 - April 10, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -560,7 +560,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>10</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 10 - April 10, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep010.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep010_20260410_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 11 - April 20, 2026</title>
       <description># Привет, Русский! — Episode Plan
@@ -597,7 +597,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>11</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 11 - April 20, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep011.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep011_20260420_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 12 - April 22, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -634,7 +634,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>12</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 12 - April 22, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep012.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep012_20260422_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 13 - April 24, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -681,7 +681,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>13</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 13 - April 24, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep013.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep013_20260424_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 14 - April 26, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -720,7 +720,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>14</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 14 - April 26, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep014.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep014_20260426_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 15 - April 28, 2026</title>
       <description>**# Привет, Русский! — Episode Plan**  
@@ -767,7 +767,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>15</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 15 - April 28, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep015.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep015_20260428_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 16 - April 30, 2026</title>
       <description>**Привет, Русский! — Episode Plan**  
@@ -818,7 +818,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>16</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 16 - April 30, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep016.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep016_20260430_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 17 - May 02, 2026</title>
       <description># Привет, Русский! — Episode Plan
@@ -871,7 +871,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>17</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 17 - May 02, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep017.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep017_20260502_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 18 - May 02, 2026</title>
       <description># Привет, Русский! — Episode Plan
@@ -920,7 +920,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>18</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 18 - May 02, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep018.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep018_20260502_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 19 - May 04, 2026</title>
       <description># Привет, Русский! — Episode Plan
@@ -965,7 +965,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>19</itunes:episode>
       <itunes:title>Привет, Русский! - Episode 19 - May 04, 2026</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/privet_russian/chapters_ep019.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/privet_russian/PR_Ep019_20260504_transcript.json" type="application/json" /></item>
     <item>
       <title>Привет, Русский! - Episode 20 - May 06, 2026</title>
       <link>https://op3.dev/e/audio.nerranetwork.com/privet_russian/PR_Ep020_20260506.mp3</link>

--- a/run_show.py
+++ b/run_show.py
@@ -1869,6 +1869,9 @@ def run(args: argparse.Namespace) -> None:
                         voice_intro_delay=config.audio.voice_intro_delay,
                         background_music_path=bg_music_path,
                         outro_crossfade=config.audio.outro_crossfade,
+                        outro_fade_out_duration=getattr(
+                            config.audio, "outro_fade_out_duration", 6.0,
+                        ),
                     )
                 else:
                     logger.warning("Music file not found: %s — using voice only", music_path)

--- a/scripts/backfill_podcast_tags.py
+++ b/scripts/backfill_podcast_tags.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""One-shot: re-inject Podcasting 2.0 chapters / transcript URLs onto
+historical RSS items.
+
+Why this is needed
+==================
+``feedgen`` doesn't support the ``podcast:`` namespace, so the RSS
+regen path in ``engine/publisher.py:update_rss_feed`` rebuilt every
+feed from parsed itunes-namespace data only — silently dropping any
+``<podcast:chapters>`` / ``<podcast:transcript>`` tag that earlier
+runs had injected. The fix in ``engine.publisher`` now preserves
+those tags going forward; this script does the one-time backfill so
+historical episodes get them back.
+
+For each ``*_podcast.rss`` (and ``podcast.rss`` for Tesla), walk every
+``<item>``, derive the ``chapters_url`` / ``transcript_url`` from the
+enclosure MP3 filename, check that the file exists locally, and
+inject the matching ``<podcast:chapters>`` / ``<podcast:transcript>``
+element if missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+REPO = Path(__file__).resolve().parent.parent
+PODCAST_NS = "https://podcastindex.org/namespace/1.0"
+ITUNES_NS = "http://www.itunes.com/dtds/podcast-1.0.dtd"
+BASE_URL = "https://nerranetwork.com"
+
+
+# Map RSS path -> (digest_subdir, ep-num pattern in filename).
+# Tesla uses ``podcast.rss`` (legacy); every other show uses
+# ``<slug>_podcast.rss``.
+SHOW_FEEDS: Dict[str, str] = {
+    "podcast.rss": "tesla_shorts_time",
+    "omni_view_podcast.rss": "omni_view",
+    "fascinating_frontiers_podcast.rss": "fascinating_frontiers",
+    "planetterrian_podcast.rss": "planetterrian",
+    "env_intel_podcast.rss": "env_intel",
+    "models_agents_podcast.rss": "models_agents",
+    "models_agents_beginners_podcast.rss": "models_agents_beginners",
+    "modern_investing_podcast.rss": "modern_investing",
+    "finansy_prosto_podcast.rss": "finansy_prosto",
+    "privet_russian_podcast.rss": "privet_russian",
+    "unintended_consequences_podcast.rss": "unintended_consequences",
+}
+
+
+_EP_NUM_RE = re.compile(r"Ep(\d{3,4})", re.IGNORECASE)
+
+
+def _enclosure_filename(item: ET.Element) -> Optional[str]:
+    enc = item.find("enclosure")
+    if enc is None:
+        return None
+    url = enc.get("url", "")
+    if not url:
+        return None
+    return url.rsplit("/", 1)[-1]
+
+
+def _derive_urls(
+    enclosure_filename: str, digest_subdir: str
+) -> Tuple[Optional[str], Optional[str]]:
+    """Given an enclosure filename like ``Tesla_Shorts_Time_Pod_Ep464_20260506.mp3``
+    and the digest subdirectory name, return ``(chapters_url, transcript_url)``
+    if the files exist on disk. ``None`` for either side if the matching
+    file isn't present.
+    """
+    if not enclosure_filename.endswith(".mp3"):
+        return None, None
+    base = enclosure_filename[:-4]  # strip `.mp3`
+
+    # Episode number for the chapters_ep{NNN}.json file.
+    m = _EP_NUM_RE.search(base)
+    chapters_url: Optional[str] = None
+    if m:
+        ep_num = int(m.group(1))
+        chapters_path = REPO / "digests" / digest_subdir / f"chapters_ep{ep_num:03d}.json"
+        if chapters_path.exists():
+            chapters_url = (
+                f"{BASE_URL}/digests/{digest_subdir}/chapters_ep{ep_num:03d}.json"
+            )
+
+    # Transcript file shares the enclosure stem.
+    transcript_path = REPO / "digests" / digest_subdir / f"{base}_transcript.json"
+    transcript_url: Optional[str] = None
+    if transcript_path.exists():
+        transcript_url = (
+            f"{BASE_URL}/digests/{digest_subdir}/{base}_transcript.json"
+        )
+
+    return chapters_url, transcript_url
+
+
+def _backfill_feed(rss_path: Path, digest_subdir: str, dry_run: bool) -> dict:
+    """Add missing podcast 2.0 tags to *rss_path* in place. Returns
+    a stats dict for the caller to print."""
+    stats = {"feed": rss_path.name, "items": 0, "chapters_added": 0, "transcripts_added": 0}
+    if not rss_path.exists():
+        stats["error"] = "missing"
+        return stats
+
+    ET.register_namespace("podcast", PODCAST_NS)
+    ET.register_namespace("itunes", ITUNES_NS)
+    ET.register_namespace("atom", "http://www.w3.org/2005/Atom")
+
+    tree = ET.parse(str(rss_path))
+    root = tree.getroot()
+
+    # Strip any duplicate xmlns:podcast attribute so the output stays clean.
+    for attr in list(root.attrib):
+        if attr == "xmlns:podcast" or (
+            attr.startswith("xmlns:") and root.attrib[attr] == PODCAST_NS
+        ):
+            del root.attrib[attr]
+
+    channel = root.find("channel")
+    if channel is None:
+        stats["error"] = "no <channel>"
+        return stats
+
+    for item in channel.findall("item"):
+        stats["items"] += 1
+        filename = _enclosure_filename(item)
+        if not filename:
+            continue
+        chapters_url, transcript_url = _derive_urls(filename, digest_subdir)
+
+        if (
+            chapters_url
+            and item.find(f"{{{PODCAST_NS}}}chapters") is None
+        ):
+            el = ET.SubElement(item, f"{{{PODCAST_NS}}}chapters")
+            el.set("url", chapters_url)
+            el.set("type", "application/json+chapters")
+            stats["chapters_added"] += 1
+
+        if (
+            transcript_url
+            and item.find(f"{{{PODCAST_NS}}}transcript") is None
+        ):
+            el = ET.SubElement(item, f"{{{PODCAST_NS}}}transcript")
+            el.set("url", transcript_url)
+            el.set("type", "application/json")
+            stats["transcripts_added"] += 1
+
+    if not dry_run:
+        tree.write(str(rss_path), xml_declaration=True, encoding="UTF-8")
+    return stats
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dry-run", action="store_true",
+                   help="Print what would change without writing.")
+    p.add_argument("--feed", default=None,
+                   help="Limit backfill to a specific RSS filename.")
+    args = p.parse_args()
+
+    targets: Dict[str, str] = SHOW_FEEDS
+    if args.feed:
+        targets = {args.feed: SHOW_FEEDS.get(args.feed, "")}
+        if not targets[args.feed]:
+            print(f"Unknown feed: {args.feed}", file=sys.stderr)
+            return 2
+
+    total = {"items": 0, "chapters_added": 0, "transcripts_added": 0}
+    for feed_name, digest_subdir in targets.items():
+        rss_path = REPO / feed_name
+        s = _backfill_feed(rss_path, digest_subdir, args.dry_run)
+        if s.get("error"):
+            print(f"  ⚠️  {feed_name}: {s['error']}")
+            continue
+        print(
+            f"  {feed_name}: {s['items']} items "
+            f"(+{s['chapters_added']} chapters, +{s['transcripts_added']} transcripts)"
+        )
+        for k in ("items", "chapters_added", "transcripts_added"):
+            total[k] += s.get(k, 0)
+
+    mode = "dry-run" if args.dry_run else "applied"
+    print(
+        f"\nTotals ({mode}): {total['items']} items scanned, "
+        f"{total['chapters_added']} chapters added, "
+        f"{total['transcripts_added']} transcripts added."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -79,20 +79,20 @@ tts:
 audio:
   min_audio_duration: 180
   transition_sting: assets/music/transition_sting.mp3
-  # Music timing — bumped May 2026 so the intro and outro feel like a
-  # real podcast (NPR / Hard Fork / The Daily) instead of cutting off
-  # after a few seconds. Total intro music presence = intro_duration
-  # (alone) + overlap_duration (with voice) + fade_duration (gentle
-  # tail-out under voice) = 15 + 10 + 15 = 40s. Outro = 40s after
-  # voice ends. ``voice_intro_delay`` MUST stay >= ``intro_duration``
-  # so the voice doesn't start before the music intro alone-period
-  # finishes.
-  voice_intro_delay: 15.0
-  intro_duration: 15.0
+  # Music timing — bumped *again* in May 2026 after the operator
+  # reported that the intro and outro still cut off too quickly on
+  # TST and MAB. Total intro music presence is now 55s
+  # (25 alone + 10 overlap + 20 fade-tail) and the outro runs 60s
+  # after voice ends with a 6s graceful close. ``voice_intro_delay``
+  # MUST stay >= ``intro_duration`` so the voice doesn't enter while
+  # the music intro is still in its alone-period.
+  voice_intro_delay: 25.0
+  intro_duration: 25.0
   overlap_duration: 10.0
-  fade_duration: 15.0
-  outro_duration: 40.0
+  fade_duration: 20.0
+  outro_duration: 60.0
   outro_crossfade: 20.0
+  outro_fade_out_duration: 6.0
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -187,11 +187,11 @@ tts:
 audio:
   music_file: assets/music/EnvIntel.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 15.0
-  intro_duration: 15.0
+  voice_intro_delay: 25.0
+  intro_duration: 25.0
   overlap_duration: 10.0
-  fade_duration: 15.0
-  outro_duration: 40.0
+  fade_duration: 20.0
+  outro_duration: 60.0
   outro_crossfade: 20.0
   intro_volume: 0.4
   overlap_volume: 0.3

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -167,11 +167,11 @@ audio:
   # for emergency rollback.
   music_file: assets/music/fascinatingfrontiers_bg.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 15.0
-  intro_duration: 15.0
+  voice_intro_delay: 25.0
+  intro_duration: 25.0
   overlap_duration: 10.0
   fade_duration: 27.0
-  outro_duration: 40.0
+  outro_duration: 60.0
   outro_crossfade: 20.0
   intro_volume: 0.6
   overlap_volume: 0.5

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -184,11 +184,11 @@ tts:
 audio:
   music_file: "assets/music/Финансы Просто.mp3"
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 15.0
-  intro_duration: 15.0
+  voice_intro_delay: 25.0
+  intro_duration: 25.0
   overlap_duration: 10.0
-  fade_duration: 15.0
-  outro_duration: 40.0
+  fade_duration: 20.0
+  outro_duration: 60.0
   outro_crossfade: 20.0
   intro_volume: 0.6
   overlap_volume: 0.5

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -177,11 +177,11 @@ tts:
 audio:
   music_file: assets/music/ModelsAgents.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 15.0
-  intro_duration: 15.0
+  voice_intro_delay: 25.0
+  intro_duration: 25.0
   overlap_duration: 10.0
-  fade_duration: 15.0
-  outro_duration: 40.0
+  fade_duration: 20.0
+  outro_duration: 60.0
   outro_crossfade: 20.0
   intro_volume: 0.6
   overlap_volume: 0.5

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -155,11 +155,11 @@ tts:
 audio:
   music_file: assets/music/ModelsAgents.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 15.0
-  intro_duration: 15.0
+  voice_intro_delay: 25.0
+  intro_duration: 25.0
   overlap_duration: 10.0
-  fade_duration: 15.0
-  outro_duration: 40.0
+  fade_duration: 20.0
+  outro_duration: 60.0
   outro_crossfade: 20.0
   intro_volume: 0.6
   overlap_volume: 0.5

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -155,11 +155,11 @@ audio:
   # TODO: Generate dedicated music file — see assets/music/README.md for prompt.
   # Falling back to TST theme until modern_investing.mp3 is created.
   music_file: assets/music/ModernInvesting.mp3
-  voice_intro_delay: 15.0
-  intro_duration: 15.0
+  voice_intro_delay: 25.0
+  intro_duration: 25.0
   overlap_duration: 10.0
-  fade_duration: 15.0
-  outro_duration: 40.0
+  fade_duration: 20.0
+  outro_duration: 60.0
   outro_crossfade: 20.0
   intro_volume: 0.5
   overlap_volume: 0.4

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -164,11 +164,11 @@ tts:
 audio:
   music_file: assets/music/OmniView.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 15.0
-  intro_duration: 15.0
+  voice_intro_delay: 25.0
+  intro_duration: 25.0
   overlap_duration: 10.0
-  fade_duration: 15.0
-  outro_duration: 40.0
+  fade_duration: 20.0
+  outro_duration: 60.0
   outro_crossfade: 20.0
   intro_volume: 0.5
   overlap_volume: 0.4

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -202,11 +202,11 @@ tts:
 audio:
   music_file: assets/music/oilers-pride.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 15.0
-  intro_duration: 15.0
+  voice_intro_delay: 25.0
+  intro_duration: 25.0
   overlap_duration: 10.0
-  fade_duration: 15.0
-  outro_duration: 40.0
+  fade_duration: 20.0
+  outro_duration: 60.0
   outro_crossfade: 20.0
   intro_volume: 0.6
   overlap_volume: 0.5

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -130,11 +130,11 @@ tts:
 
 audio:
   music_file: "assets/music/ПриветРусский.mp3"
-  voice_intro_delay: 15.0
-  intro_duration: 15.0
+  voice_intro_delay: 25.0
+  intro_duration: 25.0
   overlap_duration: 10.0
-  fade_duration: 15.0
-  outro_duration: 40.0
+  fade_duration: 20.0
+  outro_duration: 60.0
   outro_crossfade: 20.0
   intro_volume: 0.6
   overlap_volume: 0.5

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -138,11 +138,11 @@ tts:
 audio:
   music_file: assets/music/tesla_shorts_time.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 15.0
-  intro_duration: 15.0
+  voice_intro_delay: 25.0
+  intro_duration: 25.0
   overlap_duration: 10.0
-  fade_duration: 15.0
-  outro_duration: 40.0
+  fade_duration: 20.0
+  outro_duration: 60.0
   outro_crossfade: 20.0
   intro_volume: 0.6
   overlap_volume: 0.5

--- a/shows/unintended_consequences.yaml
+++ b/shows/unintended_consequences.yaml
@@ -43,11 +43,11 @@ audio:
   # leaving this empty cleanly skips the mix step. Once a track exists,
   # add `music_file: assets/music/unintended_consequences.mp3` here.
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 15.0
-  intro_duration: 15.0
+  voice_intro_delay: 25.0
+  intro_duration: 25.0
   overlap_duration: 10.0
-  fade_duration: 15.0
-  outro_duration: 40.0
+  fade_duration: 20.0
+  outro_duration: 60.0
   outro_crossfade: 20.0
   intro_volume: 0.5
   overlap_volume: 0.4

--- a/tests/test_audio_commands.py
+++ b/tests/test_audio_commands.py
@@ -555,7 +555,7 @@ class TestAudioConfigDefaults:
         ``intro_duration`` so a no-YAML show still behaves correctly."""
         from engine.config import AudioConfig
         cfg = AudioConfig()
-        assert cfg.voice_intro_delay == 15.0
+        assert cfg.voice_intro_delay == 25.0
         assert cfg.voice_intro_delay >= cfg.intro_duration
 
     def test_background_music_file_default(self):
@@ -570,10 +570,10 @@ class TestAudioConfigDefaults:
         >= 30s for a real-podcast close."""
         from engine.config import AudioConfig
         cfg = AudioConfig()
-        assert cfg.intro_duration == 15.0
+        assert cfg.intro_duration == 25.0
         assert cfg.overlap_duration == 10.0
-        assert cfg.fade_duration == 15.0
-        assert cfg.outro_duration == 40.0
+        assert cfg.fade_duration == 20.0
+        assert cfg.outro_duration == 60.0
         assert cfg.intro_volume == 0.6
         assert cfg.overlap_volume == 0.5
         assert cfg.fade_volume == 0.4
@@ -597,7 +597,7 @@ class TestShowMusicConfigs:
         cfg = load_config("shows/tesla.yaml")
         assert cfg.audio.music_file == "assets/music/tesla_shorts_time.mp3"
         # May 2026 podcast-feel bump — see landmine in AudioConfig.
-        assert cfg.audio.voice_intro_delay == 15.0
+        assert cfg.audio.voice_intro_delay == 25.0
         assert cfg.audio.outro_crossfade == 20.0
 
     def test_ff_has_unified_music(self, load_config):
@@ -611,7 +611,7 @@ class TestShowMusicConfigs:
         # Dual-music override removed — the runner now uses the same
         # track for intro / overlap / fadeout / outro.
         assert cfg.audio.background_music_file is None
-        assert cfg.audio.voice_intro_delay == 15.0
+        assert cfg.audio.voice_intro_delay == 25.0
         # FF intentionally pins fade_duration at 27s (longer than the
         # network's 15s baseline) — preserved across the May 2026 bump.
         assert cfg.audio.fade_duration == 27.0
@@ -637,7 +637,7 @@ class TestShowMusicConfigs:
         (15s intro alone / 40s outro) but pins lower volumes for the
         briefing format."""
         cfg = load_config("shows/env_intel.yaml")
-        assert cfg.audio.intro_duration == 15.0
-        assert cfg.audio.outro_duration == 40.0
+        assert cfg.audio.intro_duration == 25.0
+        assert cfg.audio.outro_duration == 60.0
         assert cfg.audio.outro_crossfade == 20.0
         assert cfg.audio.intro_volume <= 0.5

--- a/tests/test_chapters.py
+++ b/tests/test_chapters.py
@@ -568,3 +568,88 @@ class TestPreambleBehavior:
         for s in sections:
             section_words.update(s.split())
         assert original_words == section_words
+
+
+# ---------------------------------------------------------------------------
+# Auto-segmentation fallback (May 2026 fix — TST chapter quality)
+# ---------------------------------------------------------------------------
+
+class TestAutoSegmentFallback:
+    """Operator caught a regression where TST episodes ship with only
+    ``Introduction`` + ``Closing`` chapters because the per-show regex
+    don't tolerate Whisper transcription variations. The auto-segment
+    fallback splits the head chapter into roughly-90-second segments
+    when the matched chapter count is below the floor."""
+
+    def _long_script(self, paragraphs: int) -> str:
+        # Each paragraph has ~50 words → ~18s of speech at 165wpm.
+        # Five paragraphs ≈ 90s, the auto-segment target.
+        para = (
+            "This is a fairly long paragraph that contains roughly fifty "
+            "words spread across several sentences. The intent is to give "
+            "the auto-segmenter enough material to choose paragraph "
+            "breaks at sensible boundaries inside the head chapter, "
+            "without exceeding the configured words-per-segment threshold."
+        )
+        return "Welcome back to the show. " + (
+            "\n\n".join([para] * paragraphs)
+        ) + "\n\nThanks for listening."
+
+    def test_auto_segment_fires_when_marker_count_below_min(self):
+        from engine.chapters import parse_chapters
+        # Only the Welcome marker matches — should yield 1 chapter
+        # without auto-segmentation. Auto-segment lifts that to >=4.
+        markers = [{"pattern": "Welcome", "title": "Introduction"}]
+        chapters = parse_chapters(
+            self._long_script(paragraphs=20),
+            markers,
+            show_name="test_show",
+            min_chapters=4,
+            auto_segment_target_seconds=90.0,
+        )
+        assert len(chapters) >= 4, (
+            f"Auto-segment fallback should produce >=4 chapters, got "
+            f"{len(chapters)} — titles: {[c.title for c in chapters]}"
+        )
+        # First chapter keeps the operator-supplied title; later ones
+        # are generic.
+        assert chapters[0].title == "Introduction"
+        assert chapters[1].title.startswith("Segment ")
+
+    def test_auto_segment_skips_when_enough_chapters_already(self):
+        from engine.chapters import parse_chapters
+        # Three markers all match — three chapters, above min. No auto
+        # segments should be added.
+        markers = [
+            {"pattern": "Welcome", "title": "Introduction"},
+            {"pattern": "fifty", "title": "Body"},
+            {"pattern": "Thanks for listening", "title": "Closing"},
+        ]
+        chapters = parse_chapters(
+            "Welcome to the show.\n\nThis paragraph has the word fifty.\n\nThanks for listening to the show.",
+            markers,
+            show_name="test_show",
+            min_chapters=2,
+        )
+        # Three matched chapters, no auto-segmentation.
+        assert len(chapters) == 3
+        assert all(not c.title.startswith("Segment ") for c in chapters)
+
+    def test_auto_segment_word_boundaries_remain_consistent(self):
+        """Word boundaries on the rebuilt chapter list must still cover
+        the entire script — no gaps, no overlaps."""
+        from engine.chapters import parse_chapters
+
+        markers = [{"pattern": "Welcome", "title": "Introduction"}]
+        chapters = parse_chapters(
+            self._long_script(paragraphs=12),
+            markers,
+            show_name="test_show",
+            min_chapters=4,
+            auto_segment_target_seconds=60.0,
+        )
+        for i in range(len(chapters) - 1):
+            assert chapters[i].word_end == chapters[i + 1].word_start, (
+                f"Gap or overlap between chapter {i} ({chapters[i].title}) "
+                f"and {i+1} ({chapters[i+1].title})"
+            )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,17 +205,17 @@ class TestDefaultValues:
         c = AudioConfig()
         assert c.music_file is None
         assert c.background_music_file is None
-        assert c.intro_duration == 15.0
+        assert c.intro_duration == 25.0
         assert c.overlap_duration == 10.0
-        assert c.fade_duration == 15.0
-        assert c.outro_duration == 40.0
+        assert c.fade_duration == 20.0
+        assert c.outro_duration == 60.0
         assert c.intro_volume == 0.6
         assert c.overlap_volume == 0.5
         assert c.fade_volume == 0.4
         assert c.outro_volume == 0.4
         # voice_intro_delay must be >= intro_duration so the voice
         # doesn't start before the music intro alone-period finishes.
-        assert c.voice_intro_delay == 15.0
+        assert c.voice_intro_delay == 25.0
         assert c.voice_intro_delay >= c.intro_duration
 
     def test_publishing_defaults(self):
@@ -441,7 +441,7 @@ class TestLoadConfigRealFiles:
         assert cfg.audio.music_file == "assets/music/fascinatingfrontiers_bg.mp3"
         assert cfg.audio.background_music_file is None
         # May 2026 podcast-feel bump — 15s music alone before voice.
-        assert cfg.audio.voice_intro_delay == 15.0
+        assert cfg.audio.voice_intro_delay == 25.0
         assert cfg.publishing.rss_category == "Science"
         assert cfg.publishing.x_env_prefix == "PLANETTERRIAN_X_"
         assert cfg.episode.prefix == "Fascinating_Frontiers"
@@ -456,7 +456,7 @@ class TestLoadConfigRealFiles:
         assert cfg.audio.music_file == "assets/music/oilers-pride.mp3"
         # May 2026 podcast-feel bump — outro is 40s of music after
         # voice ends so the close doesn't feel cut off.
-        assert cfg.audio.outro_duration == 40.0
+        assert cfg.audio.outro_duration == 60.0
         assert cfg.publishing.guid_prefix == "planetterrian-daily"
         assert cfg.episode.prefix == "Planetterrian_Daily"
         assert cfg.episode.output_dir == "digests/planetterrian"
@@ -556,8 +556,8 @@ class TestNestedConfigOverrides:
         # Network defaults inherited from shows/_defaults.yaml — see
         # the May 2026 podcast-feel bump (40s total intro music
         # presence, 40s outro after voice).
-        assert cfg.audio.intro_duration == 15.0
-        assert cfg.audio.outro_duration == 40.0
+        assert cfg.audio.intro_duration == 25.0
+        assert cfg.audio.outro_duration == 60.0
 
     def test_partial_publishing_override(self, tmp_path):
         data = {"publishing": {"rss_title": "Custom Title", "x_enabled": False}}

--- a/unintended_consequences_podcast.rss
+++ b/unintended_consequences_podcast.rss
@@ -43,7 +43,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>1</itunes:episode>
       <itunes:title>Ep 1: Delhi's British government paid for dead cobras to cut snake numbers, but the bounty led to breeding, and scrapping it released more snakes into the city.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/unintended_consequences/chapters_ep001.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/unintended_consequences/Unintended_Consequences_Ep001_20260504_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 2: In 1935, Australia brought 102 cane toads from Hawaii to battle sugarcane beetles — but the toads bred into the billions and killed native predators instead.</title>
       <description># Unintended Consequences — Episode Brief
@@ -72,7 +72,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>2</itunes:episode>
       <itunes:title>Ep 2: In 1935, Australia brought 102 cane toads from Hawaii to battle sugarcane beetles — but the toads bred into the billions and killed native predators instead.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/unintended_consequences/chapters_ep002.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/unintended_consequences/Unintended_Consequences_Ep002_20260504_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 3: In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would raise blood-lead levels in entire generations and measurably lower cognitive performance worldwide.</title>
       <description>&gt; **In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would raise blood-lead levels in entire generations and measurably lower cognitive performance worldwide.**
@@ -97,7 +97,7 @@ AI Disclosure: This podcast is curated by Patrick but uses AI-generated voice sy
       <itunes:episode>3</itunes:episode>
       <itunes:title>Ep 3: In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would raise blood-lead levels in entire generations and measurably lower cognitive performance worldwide.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
-    </item>
+    <podcast:chapters url="https://nerranetwork.com/digests/unintended_consequences/chapters_ep003.json" type="application/json+chapters" /><podcast:transcript url="https://nerranetwork.com/digests/unintended_consequences/Unintended_Consequences_Ep003_20260505_transcript.json" type="application/json" /></item>
     <item>
       <title>Ep 4: After Allied forces dusted civilians in Naples with DDT in 1944 to halt a typhus epidemic, the same persistent chemical that saved lives from insect-borne disease began thinning the eggshells of bald eagles and peregrine falcons across North America and Europe by the late 1950s.</title>
       <link>https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep004_20260506.mp3</link>


### PR DESCRIPTION
## Summary

Operator review of today's (May 6) episodes surfaced four issues. **Three are fixed here; the fourth (re-adding `<build-intensity>`) is declined with rationale.**

## 1. Music still cuts off too quickly (TST + MAB)

Bumped network audio defaults again so the open and close feel like a real podcast on every show:

| knob | old | new |
|------|-----|-----|
| `voice_intro_delay` | 15s | **25s** |
| `intro_duration` | 15s | **25s** |
| `fade_duration` | 15s | **20s** |
| `outro_duration` | 40s | **60s** |
| `outro_fade_out_duration` | 3s (hardcoded) | **6s** (operator-tunable) |

Total intro music presence: 25s alone + 10s overlap + 20s under-voice = **55s**. Outro: **60s** with a 6s graceful close. Updated all 11 per-show YAMLs in lockstep.

The previous 3s outro fade-out was abrupt; the new 6s taper is closer to broadcast-style podcast outros. Surfaced as a config knob so the operator can tune per show without touching `mix_with_music`.

## 2. TST transcripts not showing on Apple Podcasts

Real production regression — and it affects **every show**, not just TST.

Each RSS rebuild dropped `<podcast:chapters>` and `<podcast:transcript>` from prior episodes because the parser in `engine.publisher.update_rss_feed` only read itunes-namespace fields, leaving feedgen to silently omit the podcast: namespace tags. Across the 11 show feeds, only the latest episode of each had transcript metadata; **269 episodes had lost theirs**.

Fix:
- Parser now reads `podcast:chapters` + `podcast:transcript` URLs from existing items.
- New `_reinject_preserved_podcast_tags` re-emits them in a single XML pass after feedgen writes the new feed.
- One-shot `scripts/backfill_podcast_tags.py` derived chapter + transcript URLs from on-disk filenames and backfilled **+269 transcripts and +313 chapters across every feed**. Apple Podcasts will pick them up on next refresh.

## 3. Better chapter markers and headings

TST Ep464 shipped with only `Introduction` (30s → 469s, a 7-minute "chapter") + `Closing` because the per-show regex don't tolerate Whisper transcription variations.

Added an auto-segmentation fallback in `engine.chapters.parse_chapters`: when the matched chapter count is below `min_chapters` (default 4), the head chapter is auto-split at paragraph boundaries roughly every `auto_segment_target_seconds` (default 90s). Spliced chapters carry generic `Segment 2`, `Segment 3` … titles so they don't mislead about content. Operator-supplied section markers always take precedence; auto-segmentation only fills in when markers are too sparse.

Three new drift-guard tests pin the behaviour: auto-segment fires below the floor, skips above it, and word boundaries remain consistent (no gaps/overlaps).

## 4. Re-add `<build-intensity>` to all shows — **declined**

Operator asked to add `<fast>` AND `<build-intensity>` universally for more enthusiasm.

- **`<fast>` is already universal.** `shows/_defaults.yaml` and `engine.config.TTSConfig` both default to `speech_wrap_open: <fast>` / `speech_wrap_close: </fast>`. Every chunk sent to Grok TTS gets wrapped — confirmed by the drift guard `test_default_tts_config_has_fast_wrap_only`.
- **`<build-intensity>` will not be re-added.** [CLAUDE.md landmine #17](https://github.com/patricknovak/nerranetworks/blob/main/CLAUDE.md) documents transcript-level evidence (Whisper transcripts of UC Ep001 and Tesla Ep461) that Grok occasionally **spoke** the words "build intensity" out loud instead of consuming the tag — `<build-intensity>` is not in Grok's documented tag list. Two drift guards in `tests/test_tts_grok.py` explicitly prevent re-introduction.

If you want more audible energy, the recommended paths are: (a) push the per-show LLM podcast prompt toward more energetic narration; (b) use the documented `<emphasis>...</emphasis>` tag more aggressively per the show prompts. Both are reversible without TTS-level regressions.

## Test plan

- [x] pytest: **1577 passed** (+3 chapter auto-segment tests), 6 skipped, 2 pre-existing env-only deselected
- [x] `grep -c "podcast:transcript" *_podcast.rss podcast.rss` after backfill — every feed now has matching counts
- [x] WCAG / brand-color guards still pass
- [ ] Operator listens to next TST + MAB episode and confirms music feels right (the 25/10/20/60 timing applies starting tomorrow's run)
- [ ] Operator confirms Apple Podcasts now shows transcripts on prior TST episodes (may take 6–24h for Apple to refresh the feed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_