### PR TITLE
Grok Imagine images for Tesla + MAB long-form + Shorts (Option C)

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -286,6 +286,26 @@ class YouTubeConfig:
         "silhouette-of-woman", "woman-in-spotlight",
         "model-in", "topless-model",
     ])
+    # ---- Image provider (May 2026 rollout) ----
+    # ``pexels``  — free Pexels search (default; safe / well-tested).
+    # ``grok``    — fresh per-episode images via Grok Imagine for both
+    #               long-form AND Shorts, with separate prompt sets so
+    #               the two formats no longer share imagery (operator's
+    #               complaint May 6 2026). Costs ~$0.32 / episode at
+    #               the standard ``grok-imagine-image`` model rate.
+    # ``hybrid``  — Pexels for long-form, Grok for Shorts. Halfway
+    #               option for shows that want unique Shorts content
+    #               without paying for long-form re-rendering.
+    image_provider: str = "pexels"
+    # ``grok-imagine-image`` ($0.02/image, 300 req/min) is the safe
+    # default. ``grok-imagine-image-pro`` ($0.07/image, 30 req/min)
+    # is the higher-quality tier — use only on a show flagged for
+    # quality emphasis since it's 3.5× the cost.
+    grok_image_model: str = "grok-imagine-image"
+    # Optional one-line tone descriptor injected into every Grok prompt.
+    # Defaults to a generic photojournalism cue; shows can override
+    # (e.g. UC's narrative tone might want "documentary archival photo").
+    grok_image_descriptor: str = "photorealistic news photo"
 
 
 @dataclass

--- a/engine/grok_imagine.py
+++ b/engine/grok_imagine.py
@@ -1,0 +1,344 @@
+"""Grok Imagine API wrapper for the YouTube long-form / Shorts pipeline.
+
+Sibling to :mod:`engine.visual_assets` (the Pexels path). Operator-driven
+opt-in via each show's ``youtube.image_provider`` config knob:
+
+  ``pexels``  — existing free Pexels search (default)
+  ``grok``    — generate fresh images per episode for long-form AND
+                Shorts via Grok Imagine, prompted from the day's hook
+  ``hybrid``  — Pexels for long-form, Grok for Shorts (cheaper test)
+
+Pricing (verified May 2026, see CLAUDE.md landmine on this rollout):
+
+  ``grok-imagine-image``       $0.02 / image  (300 req/min)
+  ``grok-imagine-image-pro``   $0.07 / image  ( 30 req/min)
+
+At 8 images per format × 2 formats × ~52 episodes/month for Tesla + MAB
+(the only YouTube-enabled shows) the standard model lands at ~$17/mo.
+
+Endpoint: ``POST https://api.x.ai/v1/images/generations`` — OpenAI-
+compatible request shape. Reuses the existing ``GROK_API_KEY`` /
+``XAI_API_KEY`` env var (no new auth surface).
+
+Failure mode: best-effort. If the API call fails, the run-show pipeline
+falls back to the show cover as a single scene — same graceful
+behaviour as the Pexels path. The exception is logged and surfaced in
+metrics.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+# Re-export Scene / SceneSet so the runner can hold a single result type
+# regardless of which provider returned it.
+from engine.visual_assets import Scene, SceneSet  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+
+GROK_IMAGINE_ENDPOINT = "https://api.x.ai/v1/images/generations"
+DEFAULT_MODEL = "grok-imagine-image"
+DEFAULT_TIMEOUT_S = 60
+
+# Per-image USD cost. Keep in sync with the model identifier in
+# ``MODEL_COST_USD`` so cost tracking stays accurate when the operator
+# flips between standard and pro.
+MODEL_COST_USD = {
+    "grok-imagine-image": 0.02,
+    "grok-imagine-image-pro": 0.07,
+    # Aliases the operator might type in YAML.
+    "grok-imagine-standard": 0.02,
+    "grok-imagine-pro": 0.07,
+}
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+def build_image_prompts(
+    *,
+    hook: str,
+    image_queries: List[str],
+    aspect: str = "16:9",
+    count: int = 8,
+    show_descriptor: str = "",
+) -> List[str]:
+    """Build *count* image prompts that combine each query with the hook.
+
+    Image queries are the show's curated phrases (Tesla → "tesla
+    factory", "tesla cybertruck on highway", etc.). The hook makes each
+    episode's image set unique — same query shape, different content.
+
+    Aspect is encoded in the prompt as a hint; Grok Imagine's actual
+    output dimensions depend on the ``size`` parameter sent at the API
+    layer, but including ``vertical 9:16 framing`` in the prompt
+    nudges composition. ``show_descriptor`` is an optional one-liner
+    (e.g. "high-energy news photo") that the show's prompt template
+    may want to inject for tone consistency.
+    """
+    if not image_queries:
+        return []
+
+    is_vertical = aspect.startswith("9:") or aspect == "vertical"
+    framing_hint = (
+        "vertical 9:16 framing, single subject, mobile-first composition"
+        if is_vertical
+        else "wide cinematic 16:9 framing, photojournalism style"
+    )
+
+    prompts: List[str] = []
+    safe_hook = (hook or "").strip().rstrip(".")
+    descriptor = (show_descriptor or "photorealistic news photo").strip()
+
+    for i, raw_query in enumerate(image_queries):
+        if i >= count:
+            break
+        q = (raw_query or "").strip()
+        if not q:
+            continue
+        parts = [q, descriptor, framing_hint]
+        if safe_hook:
+            parts.append(f"contextually related to: {safe_hook}")
+        prompts.append(", ".join(parts))
+
+    # If the operator's image_queries list is shorter than count,
+    # cycle through it so we always hit ``count`` distinct prompts.
+    # The hook makes the recycled prompt produce a different image each
+    # episode, so this isn't pure duplication.
+    while 0 < len(prompts) < count:
+        idx = len(prompts) % len(image_queries)
+        q = (image_queries[idx] or "").strip()
+        if not q:
+            break
+        parts = [q, descriptor, framing_hint, f"variant {len(prompts) + 1}"]
+        if safe_hook:
+            parts.append(f"contextually related to: {safe_hook}")
+        prompts.append(", ".join(parts))
+
+    return prompts
+
+
+# ---------------------------------------------------------------------------
+# API client
+# ---------------------------------------------------------------------------
+
+
+class GrokImagineError(RuntimeError):
+    """Raised on a non-recoverable Grok Imagine API failure."""
+
+
+def _api_size_for_aspect(aspect: str) -> str:
+    """Translate a human aspect string to the API's ``size`` parameter.
+
+    xAI's ``/v1/images/generations`` expects an ``WIDTHxHEIGHT`` string
+    similar to OpenAI's image API. The endpoint supports up to 2K
+    resolution; we keep things modest at 1024×x for cost and speed
+    (the YouTube slideshow downscales these anyway). Vertical Shorts
+    use a portrait size matched to YouTube Shorts' 1080×1920 guidance.
+    """
+    if aspect.startswith("9:") or aspect == "vertical":
+        return "1024x1792"
+    if aspect == "1:1":
+        return "1024x1024"
+    return "1792x1024"
+
+
+@retry(
+    retry=retry_if_exception_type(requests.exceptions.RequestException),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=8),
+    reraise=True,
+)
+def _request_one_image(
+    prompt: str,
+    *,
+    api_key: str,
+    model: str,
+    size: str,
+    timeout_s: int = DEFAULT_TIMEOUT_S,
+) -> bytes:
+    """POST a single prompt to ``/v1/images/generations`` and return
+    the raw image bytes. Wrapped in tenacity retry for transient
+    network errors. Caller is responsible for swallowing
+    ``GrokImagineError`` if it wants to fall back to a different
+    provider."""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "n": 1,
+        "size": size,
+        "response_format": "b64_json",
+    }
+    resp = requests.post(
+        GROK_IMAGINE_ENDPOINT,
+        headers=headers,
+        json=payload,
+        timeout=timeout_s,
+    )
+    if resp.status_code >= 400:
+        # Surface the API error message; HTTP 4xx isn't retried by
+        # tenacity (only RequestException) so a bad prompt fails fast.
+        raise GrokImagineError(
+            f"Grok Imagine HTTP {resp.status_code}: {resp.text[:300]}"
+        )
+    body = resp.json()
+    try:
+        b64 = body["data"][0]["b64_json"]
+    except (KeyError, IndexError) as exc:
+        raise GrokImagineError(
+            f"Grok Imagine response missing b64_json: {body!r}"
+        ) from exc
+    return base64.b64decode(b64)
+
+
+# ---------------------------------------------------------------------------
+# Public fetch helper — mirrors visual_assets.fetch_scene_images
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GrokSceneResult:
+    """Wraps a SceneSet plus the cost it incurred — kept separate so
+    the runner can record cost into the metrics file without coupling
+    it to the visual_assets layer (which has no concept of cost)."""
+
+    scene_set: SceneSet
+    cost_usd: float = 0.0
+    images_generated: int = 0
+    failures: List[str] = field(default_factory=list)
+
+
+def fetch_scene_images_grok(
+    *,
+    work_dir: Path,
+    episode_num: int,
+    prompts: List[str],
+    fallback_cover: Path,
+    aspect: str = "16:9",
+    label_suffix: str = "",
+    model: str = DEFAULT_MODEL,
+    api_key: Optional[str] = None,
+) -> GrokSceneResult:
+    """Generate one image per prompt and persist to the per-episode
+    scenes directory.
+
+    ``label_suffix`` differentiates the cache directory between the
+    long-form set and the Shorts set so they don't clobber each other:
+    long-form goes to ``scenes_ep<NNN>/`` and Shorts to
+    ``scenes_ep<NNN>_short/``.
+
+    Returns a ``GrokSceneResult`` with a ``SceneSet`` (always at least
+    one scene — falls back to *fallback_cover* on failure) plus the
+    USD cost spent during generation. Per-image cost is taken from
+    ``MODEL_COST_USD``; if the model identifier isn't recognised,
+    cost is recorded as 0 and the operator should update the table.
+    """
+    if api_key is None:
+        api_key = (
+            os.getenv("GROK_API_KEY", "").strip()
+            or os.getenv("XAI_API_KEY", "").strip()
+        )
+
+    out_dir = work_dir / f"scenes_ep{episode_num:03d}{label_suffix}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if not api_key:
+        logger.info(
+            "GROK_API_KEY/XAI_API_KEY not set — Grok Imagine path "
+            "falling back to cover for ep%s%s",
+            episode_num, label_suffix,
+        )
+        return GrokSceneResult(
+            scene_set=SceneSet(
+                scenes=[Scene(path=fallback_cover)],
+                is_fallback=True,
+            ),
+        )
+
+    if not prompts:
+        logger.warning(
+            "Grok Imagine called with no prompts for ep%s — falling back",
+            episode_num,
+        )
+        return GrokSceneResult(
+            scene_set=SceneSet(
+                scenes=[Scene(path=fallback_cover)],
+                is_fallback=True,
+            ),
+        )
+
+    size = _api_size_for_aspect(aspect)
+    per_image_cost = MODEL_COST_USD.get(model, 0.0)
+
+    scenes: List[Scene] = []
+    failures: List[str] = []
+    images_generated = 0
+    cost_usd = 0.0
+
+    for idx, prompt in enumerate(prompts):
+        out_path = out_dir / f"grok_{idx:02d}.jpeg"
+        try:
+            img_bytes = _request_one_image(
+                prompt, api_key=api_key, model=model, size=size,
+            )
+            out_path.write_bytes(img_bytes)
+            scenes.append(Scene(
+                path=out_path,
+                photographer="Grok Imagine (xAI)",
+                photographer_url="https://x.ai/imagine",
+            ))
+            images_generated += 1
+            cost_usd += per_image_cost
+        except Exception as exc:
+            # Best-effort: log and continue. As long as we end up with
+            # at least 2 scenes the slideshow path stays useful.
+            failures.append(f"prompt[{idx}]: {exc}")
+            logger.warning(
+                "Grok Imagine generation failed for ep%s prompt %d: %s",
+                episode_num, idx, exc,
+            )
+
+    if not scenes:
+        logger.warning(
+            "Grok Imagine produced no images for ep%s%s — fallback to cover",
+            episode_num, label_suffix,
+        )
+        return GrokSceneResult(
+            scene_set=SceneSet(
+                scenes=[Scene(path=fallback_cover)],
+                is_fallback=True,
+            ),
+            cost_usd=round(cost_usd, 4),
+            images_generated=images_generated,
+            failures=failures,
+        )
+
+    logger.info(
+        "Grok Imagine generated %d images for ep%s%s (cost=$%.2f)",
+        images_generated, episode_num, label_suffix, cost_usd,
+    )
+    return GrokSceneResult(
+        scene_set=SceneSet(scenes=scenes, is_fallback=False),
+        cost_usd=round(cost_usd, 4),
+        images_generated=images_generated,
+        failures=failures,
+    )

--- a/run_show.py
+++ b/run_show.py
@@ -1994,6 +1994,21 @@ def run(args: argparse.Namespace) -> None:
         if youtube_urls.get("short_error"):
             metrics.record("youtube_short_error", youtube_urls["short_error"])
         metrics.record("pexels_photos_filtered", youtube_pexels_filtered)
+        # Grok Imagine cost tracking (May 2026). Always recorded so the
+        # dashboard can plot $0 for pexels-only runs and the actual
+        # spend for grok / hybrid runs.
+        metrics.record(
+            "grok_image_cost_usd",
+            float(youtube_urls.get("grok_image_cost_usd", 0.0) or 0.0),
+        )
+        metrics.record(
+            "grok_images_generated",
+            int(youtube_urls.get("grok_images_generated", 0) or 0),
+        )
+        metrics.record(
+            "image_provider",
+            youtube_urls.get("image_provider", "pexels"),
+        )
     except Exception:
         pass
 
@@ -2743,27 +2758,94 @@ def _publish_youtube(
         except Exception as exc:  # pragma: no cover — best-effort
             logger.warning("Caption generation failed: %s", exc)
 
-    # ---- Resolve scene slideshow (Pexels-backed; falls back to cover) ----
-    scene_paths = [cover_path]
+    # ---- Resolve scene slideshow ----
+    # ``image_provider`` selects between three paths (May 2026 rollout):
+    #   pexels  — free Pexels search; same set used for long-form + Shorts
+    #   grok    — Grok Imagine generates two distinct sets per episode
+    #             (long-form 16:9 + Shorts 9:16) prompted from the hook
+    #   hybrid  — Pexels for long-form, Grok for Shorts only
+    yt = config.youtube
+    image_provider = (getattr(yt, "image_provider", "pexels") or "pexels").lower()
+
+    long_scene_paths = [cover_path]
+    short_scene_paths = [cover_path]
     pexels_attribution: list = []
     pexels_filtered = 0
-    try:
-        yt = config.youtube
-        scene_set = fetch_scene_images(
-            work_dir=work_dir,
-            episode_num=episode_num,
-            keywords=list(getattr(config, "keywords", []) or []),
-            fallback_cover=cover_path,
-            image_queries=list(getattr(yt, "image_queries", []) or []),
-            image_query_prefix=getattr(yt, "image_query_prefix", "") or "",
-            safe_skip_terms=list(getattr(yt, "image_safe_skip_terms", []) or []),
+    grok_image_cost = 0.0
+    grok_images_generated = 0
+    grok_image_failures: list = []
+
+    def _run_pexels_path(into_long: bool, into_short: bool):
+        nonlocal pexels_attribution, pexels_filtered
+        try:
+            scene_set = fetch_scene_images(
+                work_dir=work_dir,
+                episode_num=episode_num,
+                keywords=list(getattr(config, "keywords", []) or []),
+                fallback_cover=cover_path,
+                image_queries=list(getattr(yt, "image_queries", []) or []),
+                image_query_prefix=getattr(yt, "image_query_prefix", "") or "",
+                safe_skip_terms=list(getattr(yt, "image_safe_skip_terms", []) or []),
+            )
+            if not scene_set.is_fallback and len(scene_set) >= 2:
+                if into_long:
+                    nonlocal_paths = scene_set.paths()
+                    long_scene_paths[:] = nonlocal_paths
+                if into_short:
+                    short_scene_paths[:] = scene_set.paths()
+                pexels_attribution = scene_set.attribution_lines()
+            pexels_filtered = int(getattr(scene_set, "photos_filtered", 0) or 0)
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.warning("Pexels scene fetch failed: %s", exc)
+
+    def _run_grok_path(*, aspect: str, label_suffix: str) -> "list[Path]":
+        from engine.grok_imagine import (
+            build_image_prompts,
+            fetch_scene_images_grok,
         )
-        if not scene_set.is_fallback and len(scene_set) >= 2:
-            scene_paths = scene_set.paths()
-            pexels_attribution = scene_set.attribution_lines()
-        pexels_filtered = int(getattr(scene_set, "photos_filtered", 0) or 0)
-    except Exception as exc:  # pragma: no cover — best-effort
-        logger.warning("Scene fetch failed (using cover only): %s", exc)
+        nonlocal grok_image_cost, grok_images_generated, grok_image_failures
+        try:
+            prompts = build_image_prompts(
+                hook=hook or "",
+                image_queries=list(getattr(yt, "image_queries", []) or []),
+                aspect=aspect,
+                count=8,
+                show_descriptor=getattr(
+                    yt, "grok_image_descriptor", "photorealistic news photo",
+                ),
+            )
+            result = fetch_scene_images_grok(
+                work_dir=work_dir,
+                episode_num=episode_num,
+                prompts=prompts,
+                fallback_cover=cover_path,
+                aspect=aspect,
+                label_suffix=label_suffix,
+                model=getattr(yt, "grok_image_model", "grok-imagine-image"),
+            )
+            grok_image_cost += result.cost_usd
+            grok_images_generated += result.images_generated
+            grok_image_failures.extend(result.failures)
+            if not result.scene_set.is_fallback and len(result.scene_set) >= 2:
+                # Grok-generated images are royalty-free under xAI's
+                # terms; we still credit the model in the description
+                # so listeners know it's AI-generated imagery.
+                pexels_attribution.append(
+                    "Imagery generated by Grok Imagine (xAI)."
+                )
+                return result.scene_set.paths()
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.warning("Grok Imagine scene fetch failed: %s", exc)
+        return [cover_path]
+
+    if image_provider == "grok":
+        long_scene_paths = _run_grok_path(aspect="16:9", label_suffix="")
+        short_scene_paths = _run_grok_path(aspect="9:16", label_suffix="_short")
+    elif image_provider == "hybrid":
+        _run_pexels_path(into_long=True, into_short=False)
+        short_scene_paths = _run_grok_path(aspect="9:16", label_suffix="_short")
+    else:  # pexels (default)
+        _run_pexels_path(into_long=True, into_short=True)
 
     # ---- Long-form ----
     long_url = ""
@@ -2771,7 +2853,7 @@ def _publish_youtube(
         try:
             build_long_form_video(
                 final_mp3, cover_path, long_video_path,
-                scene_paths=scene_paths if len(scene_paths) >= 2 else None,
+                scene_paths=long_scene_paths if len(long_scene_paths) >= 2 else None,
                 subtitles_path=srt_path,
             )
             meta = build_long_form_metadata(
@@ -2862,7 +2944,7 @@ def _publish_youtube(
                 start_offset=short_offset,
                 duration=duration,
                 hook=hook or None,
-                scene_paths=scene_paths if len(scene_paths) >= 2 else None,
+                scene_paths=short_scene_paths if len(short_scene_paths) >= 2 else None,
             )
             meta = build_short_metadata(
                 config,
@@ -2924,6 +3006,14 @@ def _publish_youtube(
     # it as a metric. A spike here is the operator's signal that the
     # show's image_queries / safe_skip_terms need tightening.
     result["pexels_photos_filtered"] = pexels_filtered
+    # Grok Imagine cost-tracking. Recorded as a metric so the
+    # management dashboard can surface monthly spend on per-episode
+    # image generation. Zero when image_provider != grok / hybrid.
+    result["grok_image_cost_usd"] = round(grok_image_cost, 4)
+    result["grok_images_generated"] = grok_images_generated
+    if grok_image_failures:
+        result["grok_image_failures"] = grok_image_failures[:5]
+    result["image_provider"] = image_provider
     return result
 
 

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -243,6 +243,13 @@ youtube:
     - teen with laptop
     - classroom technology
   image_query_prefix: ""
+  # May 2026 rollout — second of the two YouTube-enabled shows opting
+  # in to Grok Imagine. AI-illustrated friendly imagery tied to each
+  # day's hook fits the beginner / teen audience better than Pexels
+  # stock photos of generic kids-with-laptops. ~$0.32/episode.
+  image_provider: grok
+  grok_image_model: grok-imagine-image
+  grok_image_descriptor: "friendly approachable illustration for beginners and teens"
   tags:
     - ai for beginners
     - learn ai

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -238,6 +238,15 @@ youtube:
     - tesla model y
     - ev road trip
   image_query_prefix: "tesla "
+  # May 2026 rollout — Tesla is the larger of the two YouTube-enabled
+  # shows (Tesla + MAB only, per landmine #20 quota cap). Operator
+  # opted in to Grok Imagine for differentiated long-form / Shorts
+  # imagery tied to each day's hook. ~$0.32/episode at the standard
+  # ``grok-imagine-image`` rate (8 imgs × 2 formats × $0.02). Flip
+  # back to ``pexels`` if engagement metrics don't justify the spend.
+  image_provider: grok
+  grok_image_model: grok-imagine-image
+  grok_image_descriptor: "high-energy Tesla news photo"
   tags:
     - tesla
     - tsla

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -641,3 +641,56 @@ class TestNestedConfigOverrides:
         assert cfg.sources[1].url == "https://raw.com"
         assert cfg.name == ""
         assert cfg.llm == LLMConfig()
+
+
+# ---------------------------------------------------------------------------
+# YouTube image provider — May 2026 Grok Imagine rollout
+# ---------------------------------------------------------------------------
+
+class TestYouTubeImageProviderConfig:
+    """Phase 1 of the Grok Imagine rollout. The new fields default to
+    the old Pexels behaviour so any show that doesn't opt in keeps its
+    current pipeline; only Tesla + MAB are flipped to ``grok`` in this
+    PR (per CLAUDE.md landmine #20 those are the only YouTube-enabled
+    shows). Pin the defaults so a future YAML refactor doesn't
+    silently regress to a different provider."""
+
+    def test_default_image_provider_is_pexels(self):
+        from engine.config import YouTubeConfig
+        c = YouTubeConfig()
+        assert c.image_provider == "pexels"
+        # Per-show overrides are the only path to non-default providers.
+
+    def test_default_grok_image_model_is_standard(self):
+        """Standard model is $0.02/img; pro is $0.07/img. Default to
+        the cheaper one so a misconfigured show doesn't surprise-bill."""
+        from engine.config import YouTubeConfig
+        c = YouTubeConfig()
+        assert c.grok_image_model == "grok-imagine-image"
+        assert "pro" not in c.grok_image_model
+
+    def test_tesla_yaml_uses_grok_image_provider(self):
+        """Tesla is one of the two shows opting in to Grok Imagine in
+        this PR. If the YAML drifts back to ``pexels`` (or worse, the
+        field disappears) we want CI to flag it before next deploy."""
+        cfg = load_config(SHOWS_DIR / "tesla.yaml")
+        assert cfg.youtube.image_provider == "grok"
+
+    def test_mab_yaml_uses_grok_image_provider(self):
+        cfg = load_config(SHOWS_DIR / "models_agents_beginners.yaml")
+        assert cfg.youtube.image_provider == "grok"
+
+    def test_other_shows_remain_on_pexels(self):
+        """Every other show (the 9 that aren't YouTube-enabled today,
+        plus any future YouTube-enabled show) must stay on Pexels
+        until the operator explicitly flips them. Pexels is free;
+        Grok costs $0.32/episode."""
+        for slug in ("omni_view", "fascinating_frontiers", "planetterrian",
+                     "env_intel", "models_agents", "modern_investing",
+                     "finansy_prosto", "privet_russian",
+                     "unintended_consequences"):
+            cfg = load_config(SHOWS_DIR / f"{slug}.yaml")
+            assert cfg.youtube.image_provider == "pexels", (
+                f"{slug} drifted off pexels — would silently incur Grok "
+                f"Imagine cost"
+            )

--- a/tests/test_grok_imagine.py
+++ b/tests/test_grok_imagine.py
@@ -1,0 +1,245 @@
+"""Tests for engine.grok_imagine — Grok Imagine API wrapper.
+
+Three layers:
+  1. Prompt construction — deterministic, no network. Pins how the
+     hook + show image_queries get woven into a generation prompt
+     so a future tweak doesn't silently regress prompt quality.
+  2. Cost-table sanity — pin the May 2026 published prices so a
+     copy-paste typo in MODEL_COST_USD trips a test instead of
+     billing the operator at the wrong rate.
+  3. Fallback behaviour — when the API returns an error or no API
+     key is set, the helper returns a SceneSet containing the show
+     cover, never crashes the pipeline.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import Path
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+class TestBuildImagePrompts:
+
+    def test_returns_count_prompts_when_queries_match(self):
+        from engine.grok_imagine import build_image_prompts
+        prompts = build_image_prompts(
+            hook="Tesla unveils Cybertruck price drop",
+            image_queries=["tesla car", "tesla factory", "cybertruck"],
+            count=3,
+            aspect="16:9",
+        )
+        assert len(prompts) == 3
+        # Hook is woven in to every prompt so episodes get unique imagery.
+        for p in prompts:
+            assert "Tesla unveils Cybertruck price drop" in p
+
+    def test_recycles_queries_when_count_exceeds_query_list(self):
+        """If the operator's image_queries list has 3 entries but we
+        want 8 prompts, the extra prompts cycle through the queries
+        with a ``variant`` marker so the model sees distinct strings."""
+        from engine.grok_imagine import build_image_prompts
+        prompts = build_image_prompts(
+            hook="Big news",
+            image_queries=["a", "b", "c"],
+            count=8,
+        )
+        assert len(prompts) == 8
+        # Distinct prompts even though queries recycle.
+        assert len(set(prompts)) == 8
+
+    def test_vertical_aspect_includes_9_16_framing_hint(self):
+        from engine.grok_imagine import build_image_prompts
+        v = build_image_prompts(
+            hook="x", image_queries=["q"], count=1, aspect="9:16",
+        )
+        assert "9:16" in v[0] or "vertical" in v[0].lower()
+        h = build_image_prompts(
+            hook="x", image_queries=["q"], count=1, aspect="16:9",
+        )
+        assert "16:9" in h[0] or "cinematic" in h[0].lower()
+
+    def test_show_descriptor_is_injected(self):
+        """``grok_image_descriptor`` is the per-show tone cue (e.g.
+        ``high-energy Tesla news photo``). Must appear in every prompt
+        so the model picks up the show's voice."""
+        from engine.grok_imagine import build_image_prompts
+        prompts = build_image_prompts(
+            hook="x",
+            image_queries=["a", "b"],
+            count=2,
+            show_descriptor="high-energy Tesla news photo",
+        )
+        for p in prompts:
+            assert "high-energy Tesla news photo" in p
+
+    def test_empty_queries_returns_empty_list(self):
+        from engine.grok_imagine import build_image_prompts
+        assert build_image_prompts(hook="x", image_queries=[], count=8) == []
+
+    def test_no_hook_still_yields_prompts(self):
+        """The pipeline runs even when the hook is empty (e.g. early
+        in fetch). The prompt builder shouldn't crash, and prompts
+        should still be deterministic."""
+        from engine.grok_imagine import build_image_prompts
+        prompts = build_image_prompts(
+            hook="", image_queries=["tesla car"], count=1,
+        )
+        assert prompts and "tesla car" in prompts[0]
+
+
+# ---------------------------------------------------------------------------
+# Cost table — pin the May 2026 published prices
+# ---------------------------------------------------------------------------
+
+class TestCostTable:
+
+    def test_standard_price_is_two_cents(self):
+        from engine.grok_imagine import MODEL_COST_USD
+        assert MODEL_COST_USD["grok-imagine-image"] == 0.02
+
+    def test_pro_price_is_seven_cents(self):
+        from engine.grok_imagine import MODEL_COST_USD
+        assert MODEL_COST_USD["grok-imagine-image-pro"] == 0.07
+
+    def test_aliases_map_to_same_prices(self):
+        """Operators sometimes type ``grok-imagine-standard`` /
+        ``grok-imagine-pro`` instead of the API IDs. The cost table
+        recognises both spellings so cost tracking stays accurate
+        regardless."""
+        from engine.grok_imagine import MODEL_COST_USD
+        assert MODEL_COST_USD["grok-imagine-standard"] == MODEL_COST_USD["grok-imagine-image"]
+        assert MODEL_COST_USD["grok-imagine-pro"] == MODEL_COST_USD["grok-imagine-image-pro"]
+
+
+# ---------------------------------------------------------------------------
+# Fallback behaviour — never crash the pipeline
+# ---------------------------------------------------------------------------
+
+class TestFetchSceneImagesGrokFallbacks:
+
+    def test_no_api_key_returns_fallback_scene_set(self, tmp_path: Path, monkeypatch):
+        from engine.grok_imagine import fetch_scene_images_grok
+        # Both env vars empty — the wrapper should fall back gracefully.
+        monkeypatch.delenv("GROK_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"\xff\xd8\xff\xd9")  # tiny valid-ish JPEG
+        result = fetch_scene_images_grok(
+            work_dir=tmp_path,
+            episode_num=1,
+            prompts=["tesla supercharger"],
+            fallback_cover=cover,
+        )
+        assert result.scene_set.is_fallback is True
+        assert len(result.scene_set) == 1
+        assert result.scene_set.scenes[0].path == cover
+        assert result.cost_usd == 0.0
+
+    def test_empty_prompts_returns_fallback(self, tmp_path: Path, monkeypatch):
+        from engine.grok_imagine import fetch_scene_images_grok
+        monkeypatch.setenv("GROK_API_KEY", "sk-test")
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"\xff\xd8\xff\xd9")
+        result = fetch_scene_images_grok(
+            work_dir=tmp_path,
+            episode_num=1,
+            prompts=[],
+            fallback_cover=cover,
+        )
+        assert result.scene_set.is_fallback is True
+
+    def test_api_error_falls_back_to_cover(self, tmp_path: Path, monkeypatch):
+        """The API endpoint returning a 500 should not blow up the
+        pipeline — every prompt fails, the wrapper returns the cover
+        as a single scene with cost 0 and the failures listed."""
+        from engine import grok_imagine
+
+        monkeypatch.setenv("GROK_API_KEY", "sk-test")
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"\xff\xd8\xff\xd9")
+
+        def _fake_request(*a, **kw):
+            raise grok_imagine.GrokImagineError("HTTP 500: server error")
+
+        monkeypatch.setattr(grok_imagine, "_request_one_image", _fake_request)
+
+        result = grok_imagine.fetch_scene_images_grok(
+            work_dir=tmp_path,
+            episode_num=42,
+            prompts=["a", "b"],
+            fallback_cover=cover,
+        )
+        assert result.scene_set.is_fallback is True
+        assert result.images_generated == 0
+        assert len(result.failures) == 2
+        assert result.cost_usd == 0.0
+
+    def test_partial_success_still_returns_real_scenes(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        """If 6 of 8 prompts succeed and 2 fail, the result has 6 real
+        scenes (not the fallback cover). Cost reflects only the
+        successful generations."""
+        from engine import grok_imagine
+
+        monkeypatch.setenv("GROK_API_KEY", "sk-test")
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"\xff\xd8\xff\xd9")
+
+        # Make the 4th call fail; the rest succeed with a tiny PNG.
+        tiny_png = base64.b64decode(
+            b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgAAIAAAUAAeImBZsAAAAASUVORK5CYII="
+        )
+        call_count = {"n": 0}
+
+        def _fake_request(prompt, *, api_key, model, size, **_kw):
+            call_count["n"] += 1
+            if call_count["n"] == 4:
+                raise grok_imagine.GrokImagineError("HTTP 400: prompt rejected")
+            return tiny_png
+
+        monkeypatch.setattr(grok_imagine, "_request_one_image", _fake_request)
+
+        result = grok_imagine.fetch_scene_images_grok(
+            work_dir=tmp_path,
+            episode_num=10,
+            prompts=[f"q{i}" for i in range(8)],
+            fallback_cover=cover,
+            model="grok-imagine-image",
+        )
+        assert result.scene_set.is_fallback is False
+        assert result.images_generated == 7
+        assert len(result.failures) == 1
+        # 7 successes × $0.02
+        assert result.cost_usd == pytest.approx(0.14, rel=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Aspect → API size mapping
+# ---------------------------------------------------------------------------
+
+class TestApiSizeForAspect:
+
+    def test_horizontal_returns_landscape_size(self):
+        from engine.grok_imagine import _api_size_for_aspect
+        assert _api_size_for_aspect("16:9") == "1792x1024"
+
+    def test_vertical_returns_portrait_size(self):
+        from engine.grok_imagine import _api_size_for_aspect
+        out = _api_size_for_aspect("9:16")
+        # Portrait — height > width.
+        w, h = (int(x) for x in out.split("x"))
+        assert h > w
+
+    def test_square_returns_square(self):
+        from engine.grok_imagine import _api_size_for_aspect
+        assert _api_size_for_aspect("1:1") == "1024x1024"


### PR DESCRIPTION
## Summary

Operator caught the same Pexels images appearing on long-form videos AND Shorts (line 2774 + 2865 in `run_show.py` were both passed the same `scene_paths`). Operator approved **Option C** from the cost analysis: Grok Imagine generates two distinct 8-image sets per episode — one 16:9 for long-form, one 9:16 for Shorts — both prompted from the day's hook.

## What ships

### New module — `engine/grok_imagine.py`
- `build_image_prompts(hook, image_queries, aspect, count, show_descriptor)` — weaves the hook into each curated query, injects a cinematic 16:9 / vertical 9:16 framing hint, recycles queries when the list is shorter than `count`.
- `fetch_scene_images_grok(...)` — generates one image per prompt via `POST https://api.x.ai/v1/images/generations`, persists to a per-format scenes cache (`scenes_ep<NNN>/` long-form, `scenes_ep<NNN>_short/` Shorts), tracks USD cost, returns a `SceneSet` matching the Pexels path's contract.
- Cost table pinned: `grok-imagine-image` $0.02/img, `grok-imagine-image-pro` $0.07/img (May 2026 published prices).
- Reuses existing `GROK_API_KEY` / `XAI_API_KEY` — no new auth surface.

### Config knobs — `YouTubeConfig`
| field | default |
|---|---|
| `image_provider` | `pexels` (existing behaviour) |
| `grok_image_model` | `grok-imagine-image` (cheaper $0.02/img tier) |
| `grok_image_descriptor` | `"photorealistic news photo"` |

Three modes: `pexels` (existing), `grok` (both formats unique), `hybrid` (Pexels long-form + Grok Shorts).

### Runner wiring — `_publish_youtube`
Replaced single shared `scene_paths` with `long_scene_paths` + `short_scene_paths` lists. Dispatches on `image_provider`. Failure mode: same as Pexels — falls back to show cover, never crashes the run.

New metrics in `metrics_ep<NNN>.json`:
- `grok_image_cost_usd` — USD spent (0 for pexels-only)
- `grok_images_generated`
- `image_provider`

### Per-show opt-ins
- **`shows/tesla.yaml`**: `image_provider: grok`, descriptor `"high-energy Tesla news photo"`
- **`shows/models_agents_beginners.yaml`**: `image_provider: grok`, descriptor `"friendly approachable illustration for beginners and teens"`

Every other show stays on `pexels` (the YAML default). Tesla + MAB are the only two YouTube-enabled shows per landmine #20 quota cap, so this enables the rollout exactly where it'll get measured.

## Cost expectation

8 imgs × 2 formats × $0.02 = **$0.32 / episode**. At Tesla daily + MAB daily cadence (~52 episodes/show/month each), the network spend is ~$17/mo. The $25 free-credit grant on the xAI account covers ~6 weeks of testing before any out-of-pocket cost.

## Tests

- `tests/test_grok_imagine.py` (new) — **16 tests**: prompt construction (hook injection, aspect framing, query recycling, show descriptor), cost-table sanity (May 2026 published prices pinned), graceful fallback (no API key, empty prompts, full API failure, partial success).
- `tests/test_config.py` (extended) — **5 drift guards**: pexels remains the default; Tesla + MAB use `grok`; the standard $0.02 model is the default (so a typo can't surprise-bill at the pro rate); every other show stays on `pexels`.
- Full suite: **1598 passed** (+21 new), 6 skipped, 2 pre-existing env-only deselected.

## Test plan

- [x] Full pytest suite green
- [x] WCAG / brand-color guards still pass
- [x] No new auth secrets required
- [ ] Operator: next Tesla + MAB run (cron tomorrow morning) will exercise the path. Expected metrics in `metrics_ep<NNN>.json`: `image_provider: grok`, `grok_images_generated: 16` (8 long + 8 short), `grok_image_cost_usd: ~0.32`.
- [ ] Operator: review YouTube uploads after first run. If imagery looks weak, flip back to `pexels` per-show in YAML; if good, leave it and check engagement metrics over the next 2–4 weeks before deciding to expand to other shows or upgrade to the pro model.

## Rollback

Single-line revert per show: change `image_provider: grok` back to `image_provider: pexels` (or delete the line — `pexels` is the dataclass default). No data migration needed; the next run uses the Pexels path again.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_