### PR TITLE
TST Ep465 audit: contrast, LLM hallucinations, broken feed, log clarity, scope guidance

### DIFF
--- a/engine/generator.py
+++ b/engine/generator.py
@@ -757,7 +757,21 @@ def _sanitize_podcast_script(text: str) -> str:
     # (identically or near-identically) to open the next paragraph.
     cleaned = _dedup_transition_sentences(cleaned)
 
-    return "\n".join(cleaned)
+    # Strip ``Patrick:`` (or other speaker-prefix) leakage at the
+    # start of paragraphs. Operator caught this on TST Ep465 (May 6
+    # 2026): the script had ``Patrick: Tesla...`` opening 5 of the
+    # news segments — the LLM was treating the prompt's host name
+    # as a literal speaker tag. The TTS would then SAY "Patrick" out
+    # loud as a name. Stripping here keeps the host's voice
+    # consistent without forcing prompts to play whack-a-mole with
+    # the model's habit.
+    text_joined = "\n".join(cleaned)
+    text_joined = re.sub(
+        r"(?im)^\s*(?:host|patrick|оля|olya|olia)\s*[:：]\s+",
+        "",
+        text_joined,
+    )
+    return text_joined
 
 
 # ---------------------------------------------------------------------------
@@ -1124,6 +1138,15 @@ def generate_digest(
     # generator doesn't inherit them.
     text = _strip_duplicate_stories(text, show_name=config.name)
 
+    # Strip the LLM's hallucinated timestamp suffixes from headlines.
+    # Operator caught this on TST Ep465 (May 6 2026): the digest ended
+    # up with "Tesla Semi Incentives Available Across Multiple States:
+    # May 06, 2026, 9:04 AM PDT" repeating in 11 of the headlines.
+    # The repetition guard caught it and tried to retry, but the model
+    # kept appending the same stamp. Post-processing is the
+    # belt-and-braces fix.
+    text = _strip_hallucinated_timestamps(text)
+
     return text
 
 
@@ -1175,6 +1198,60 @@ def _strip_duplicate_stories(
 
     kept = [b for i, b in enumerate(blocks) if i not in drop_indices]
     return "\n\n".join(kept)
+
+
+# Match the LLM's hallucinated timestamp stamps that appear inside
+# headlines. Two shapes seen in production:
+#   ": May 06, 2026, 9:04 AM PDT"
+#   ": Friday, May 6, 2026 at 9:04 PM"
+# The leading ``: `` (or ``: ``-with-space) plus the date+time pattern
+# is what we want to strip — keep the headline body, drop the stamp.
+_TIMESTAMP_STAMP_RE = re.compile(
+    r"""
+    \s*[:\-—]\s*                # leading separator (colon, dash, em-dash)
+    (?:[A-Z][a-z]+,?\s+)?       # optional weekday like ``Monday,``
+    [A-Z][a-z]+\s+\d{1,2},?     # month + day-number
+    \s+\d{4}                    # year
+    (?:[,\s]+\s*\d{1,2}:\d{2}   # optional hh:mm
+       (?:\s*[AP]M)?            # optional AM/PM
+       (?:\s+[A-Z]{2,4})?       # optional timezone abbrev like PDT
+    )?
+    """,
+    re.VERBOSE,
+)
+
+
+def _strip_hallucinated_timestamps(text: str) -> str:
+    """Strip the LLM's hallucinated ``: May 06, 2026, 9:04 AM PDT``
+    suffixes from headlines.
+
+    Tesla's grok-4.3 occasionally pads every Top-N headline with a
+    "publication" timestamp it invents from the current date/time
+    (operator caught 11 occurrences in TST Ep465 — every Top-10
+    item plus the deep-dive). The repetition guard catches it and
+    triggers a retry, but the retry often produces the same stamp.
+    Post-processing strips the suffix at the end of the digest
+    pipeline so downstream consumers (podcast script generation,
+    blog rendering, RSS show notes) never see them.
+
+    Conservative — only matches headline-tail stamps, not legitimate
+    in-body date references like "On May 6, 2026, Tesla announced..."
+    """
+    if not text or "20" not in text:
+        return text
+    cleaned_lines = []
+    for line in text.splitlines():
+        # Only strip from headline-shaped lines: bullet, numbered,
+        # or markdown-bold lines. Leave body prose untouched.
+        is_headline = bool(re.match(r"^\s*([-*•]|\d+\.|\*\*)", line))
+        if is_headline:
+            stripped = _TIMESTAMP_STAMP_RE.sub("", line).rstrip()
+            # Don't strip if it'd leave the line empty or just punctuation.
+            if stripped and re.search(r"\w", stripped):
+                cleaned_lines.append(stripped)
+                continue
+        cleaned_lines.append(line)
+    return "\n".join(cleaned_lines)
 
 
 def _generate_podcast_outline(

--- a/engine/newsletter_body.py
+++ b/engine/newsletter_body.py
@@ -103,10 +103,15 @@ def render_tsla_price_block(body: str) -> str:
         arrow = match.group(2) or ""
         delta = match.group(3) or ""
         # Up = green, Down = red, no arrow = neutral slate.
+        # Operator caught (TST Ep465, May 6 2026) the prior #10b981
+        # / #ef4444 pair failing the newsletter contrast hard-block:
+        # both clear AA on white but fall to 2.32 / 3.44 on the
+        # cream `#fef2f2` price-block surface. Bumped to Tailwind
+        # emerald-700 / red-700 so the arrows clear AA on cream.
         if arrow == "▲":
-            delta_color = "#10b981"
+            delta_color = "#047857"  # emerald-700, 5.01:1 on cream
         elif arrow == "▼":
-            delta_color = "#ef4444"
+            delta_color = "#b91c1c"  # red-700, 5.91:1 on cream
         else:
             delta_color = "#475569"
         delta_html = ""

--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -754,6 +754,15 @@ def _build_featured_episode_html(
     if num is None or not hook:
         return ""
     brand = show["brand_color"]
+    # Eyebrow text uses the deeper ``brand_color_dark`` because the
+    # card background is ``#f8fafc`` (luminance 0.967), which makes
+    # several brand colors fall just below WCAG AA. Tesla red
+    # ``#E31937`` lands at exactly 4.4999:1 on `#f8fafc` (operator
+    # caught this in the TST Ep465 newsletter contrast hard-block,
+    # May 6 2026). The dark variants all clear ≥5.5:1 so this
+    # robustly fixes the boundary case for every show without
+    # touching the brand color used elsewhere.
+    eyebrow_color = show.get("brand_color_dark") or brand
     slug = featured.get("show_slug", "")
     listen = featured.get("listen_url") or (
         episode_blog_url(slug, int(num)) if slug else show["show_page"]
@@ -780,7 +789,7 @@ def _build_featured_episode_html(
         f'style="background:#f8fafc;border-left:3px solid {brand};'
         f'border-radius:8px;padding:18px 18px 16px;">'
         '<div style="font-size:11px;font-weight:700;'
-        f'color:{brand};letter-spacing:0.08em;'
+        f'color:{eyebrow_color};letter-spacing:0.08em;'
         'text-transform:uppercase;margin-bottom:6px;">'
         '🎧 If you only have 10 minutes this week'
         '</div>'

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -441,10 +441,30 @@ def upload_caption_track(
         ).execute()
     except HttpError as exc:
         status = getattr(getattr(exc, "resp", None), "status", "?")
-        logger.warning(
-            "Failed to upload caption track for %s (HTTP %s): %s",
-            video_id, status, exc,
-        )
+        # ``captions.insert`` requires the ``youtube.force-ssl`` OAuth
+        # scope — most existing channel tokens were issued with only
+        # ``youtube.upload`` and ``youtube`` (no force-ssl). Operator
+        # caught this on TST Ep465 (May 6 2026): every long-form
+        # upload logs HTTP 403 ``Insufficient Permission`` for the
+        # caption track. Fix is to re-run the OAuth consent flow with
+        # ``--scope https://www.googleapis.com/auth/youtube.force-ssl``
+        # added (typically ``scripts/auth_youtube.py``) and replace
+        # the channel refresh tokens in the GitHub Actions secrets.
+        # The video upload itself still succeeds; this is best-effort.
+        if status in (403, "403"):
+            logger.warning(
+                "Caption track upload rejected for %s (HTTP 403 — "
+                "OAuth missing youtube.force-ssl scope). Re-run the "
+                "channel auth flow with that scope added; the video "
+                "upload itself succeeded so this is non-blocking. "
+                "Underlying: %s",
+                video_id, exc,
+            )
+        else:
+            logger.warning(
+                "Failed to upload caption track for %s (HTTP %s): %s",
+                video_id, status, exc,
+            )
         return False
     except Exception as exc:  # noqa: BLE001 — never crash the run
         logger.warning(

--- a/review_episodes.py
+++ b/review_episodes.py
@@ -903,6 +903,48 @@ def check_pipeline_metrics(ep: EpisodeReview) -> None:
             f"Only {article_count} article(s) were available. Content may be thin.",
         ))
 
+    # Grok Imagine generated 0 images while the show was opted in.
+    # Operator caught (TST Ep465, May 6 2026) the slideshow silently
+    # falling back to the cover when the API rejected the ``size``
+    # parameter. The fix landed in PR #322; this check makes any
+    # future failure mode (auth lapse, rate limit, model retirement)
+    # surface as a daily-review warning instead of needing a manual
+    # log dive.
+    image_provider = (counters.get("image_provider") or "pexels").lower()
+    if image_provider in ("grok", "hybrid"):
+        gen_count = counters.get("grok_images_generated")
+        if isinstance(gen_count, int) and gen_count == 0:
+            failures = counters.get("grok_image_failures") or []
+            sample = failures[0] if failures else "(no failure detail)"
+            ep.issues.append(Issue(
+                ep.show_slug, ep.episode_num, "warning",
+                "Grok Imagine produced 0 images (slideshow fell back to cover)",
+                f"The show is configured with image_provider={image_provider!r} "
+                f"but the Grok Imagine API generated 0 images on this run, so "
+                f"the YouTube long-form / Shorts slideshow used only the show "
+                f"cover. First failure: {sample}. Check engine.grok_imagine "
+                f"logs and the API response shape.",
+            ))
+
+    # YouTube upload failures — long-form is the larger surface so a
+    # silent failure there matters. ``youtube_long_error`` / `_short_error`
+    # are surfaced into metrics by ``_publish_youtube`` so the operator
+    # gets daily visibility without log-diving. Operator caught the
+    # ``invalidDescription`` regression (May 2026) on a manual metrics
+    # check; this check makes it automatic.
+    for kind in ("long", "short"):
+        err = counters.get(f"youtube_{kind}_error")
+        if not err:
+            continue
+        msg = err.get("message", "")[:200] if isinstance(err, dict) else str(err)[:200]
+        ep.issues.append(Issue(
+            ep.show_slug, ep.episode_num, "warning",
+            f"YouTube {kind}-form upload failed",
+            f"The {kind}-form video upload failed: {msg}. Check the "
+            f"engine.youtube logs for the full stack trace and the YouTube "
+            f"Data API quota dashboard.",
+        ))
+
 
 def check_story_duplication(ep: EpisodeReview) -> None:
     """Detect the same story being told twice within a single episode.

--- a/run_show.py
+++ b/run_show.py
@@ -2182,11 +2182,17 @@ def run(args: argparse.Namespace) -> None:
             logger.info("Newsletter sent: %s", email_id)
         else:
             # send_show_newsletter returns None for several distinct
-            # reasons. Help the operator diagnose by surfacing which
-            # one applied on this run.
-            tag = (
-                getattr(config.newsletter, "tag", "") or ""
-            ).strip()
+            # reasons (api key missing, contrast hard-block, scaffold
+            # leak, same-day double-send guard, Buttondown rejection,
+            # tag filter matched zero subscribers). engine.newsletter
+            # logs the SPECIFIC reason at ERROR/WARNING level just
+            # above — pointing the operator there is more accurate
+            # than guessing here. Operator caught (TST Ep465, May 6
+            # 2026) the prior speculative ``tag filter matched zero
+            # subscribers OR Buttondown rejected the send`` warning
+            # being printed when the actual block was a contrast
+            # hard-block, which is plainly logged on the preceding
+            # line.
             api_key_env = getattr(
                 config.newsletter, "api_key_env", "BUTTONDOWN_API_KEY",
             )
@@ -2196,18 +2202,12 @@ def run(args: argparse.Namespace) -> None:
                     "Add the secret in GitHub Actions to enable "
                     "newsletters.", api_key_env,
                 )
-            elif tag:
-                logger.warning(
-                    "Newsletter not sent: tag filter %r matched zero "
-                    "Buttondown subscribers, OR Buttondown rejected "
-                    "the send. Check Buttondown subscriber tags + "
-                    "the previous log lines from engine.newsletter.",
-                    tag,
-                )
             else:
                 logger.warning(
-                    "Newsletter not sent: see preceding "
-                    "engine.newsletter log lines for the API response.",
+                    "Newsletter not sent — see the preceding "
+                    "engine.newsletter log line for the specific "
+                    "reason (contrast block, scaffold leak, send "
+                    "guardrail, or Buttondown response).",
                 )
 
     # 13. Post to X

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -485,6 +485,99 @@ def item_13_youtube_health(shows: List[Dict[str, Any]]) -> Dict[str, Any]:
     )
 
 
+def item_22_grok_imagine_health(
+    shows: List[Dict[str, Any]],
+    metrics: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Every show opted in to ``image_provider: grok|hybrid`` is
+    actually generating images. Operator caught (TST Ep465, May 6
+    2026) the Grok Imagine API rejecting the OpenAI-style ``size``
+    parameter — both Tesla and MAB were configured for grok but
+    silently fell back to the show cover for every long-form / Shorts
+    upload. Without this landmine the failure stayed invisible until
+    the operator looked at a video on YouTube.
+
+    Fail when an opted-in show's last 30 episodes show <50%
+    grok-image generation success. Warn at <90%. OK above.
+    """
+    opted_in: List[str] = []
+    for s in shows:
+        cfg = s.get("cfg")
+        if not cfg:
+            continue
+        yt = getattr(cfg, "youtube", None)
+        if not yt or not getattr(yt, "enabled", False):
+            continue
+        provider = (getattr(yt, "image_provider", "pexels") or "pexels").lower()
+        if provider in ("grok", "hybrid"):
+            opted_in.append(s["slug"])
+
+    if not opted_in:
+        return _mk(
+            "item_22_grok_imagine_health",
+            "Grok Imagine generates images for opted-in shows",
+            "ok",
+            "No show is on image_provider=grok|hybrid — nothing to validate.",
+        )
+
+    # ``aggregate_metrics`` returns the per-show dict directly (keyed by
+    # slug). It's NOT wrapped in a ``per_show`` layer.
+    per_show = metrics or {}
+    failing: List[Dict[str, Any]] = []
+    warning: List[Dict[str, Any]] = []
+    healthy_count = 0
+    for slug in opted_in:
+        show_metrics = per_show.get(slug) or {}
+        gi = show_metrics.get("grok_imagine") or {}
+        attempts = int(gi.get("attempts") or 0)
+        rate = float(gi.get("generation_success_rate") or 0.0)
+        if attempts == 0:
+            # Show is opted in but hasn't run yet (or no metrics history).
+            continue
+        sample = (gi.get("recent_failures") or [])[:1]
+        first_fail = sample[0]["first_failure"] if sample else ""
+        if rate < 0.5:
+            failing.append({
+                "slug": slug,
+                "attempts": attempts,
+                "success_rate": rate,
+                "first_failure": first_fail,
+            })
+        elif rate < 0.9:
+            warning.append({"slug": slug, "success_rate": rate})
+        else:
+            healthy_count += 1
+
+    if failing:
+        return _mk(
+            "item_22_grok_imagine_health",
+            "Grok Imagine generates images for opted-in shows",
+            "fail",
+            f"{len(failing)} of {len(opted_in)} opted-in show(s) are "
+            f"generating <50% of expected images. First failure for "
+            f"{failing[0]['slug']}: {failing[0].get('first_failure', '(no detail)')[:160]}",
+            {"failing": failing, "warning": warning, "opted_in": opted_in},
+        )
+    if warning:
+        return _mk(
+            "item_22_grok_imagine_health",
+            "Grok Imagine generates images for opted-in shows",
+            "warn",
+            f"{len(warning)} of {len(opted_in)} opted-in show(s) are "
+            f"generating between 50% and 90% of expected images. Spot-"
+            f"check the recent_failures samples in per_show.<slug>."
+            f"grok_imagine.recent_failures.",
+            {"warning": warning, "opted_in": opted_in},
+        )
+    return _mk(
+        "item_22_grok_imagine_health",
+        "Grok Imagine generates images for opted-in shows",
+        "ok",
+        f"All {len(opted_in)} opted-in show(s) are generating ≥90% of "
+        f"expected images.",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Item 2 — RSS integrity + R2 / LFS audit
 # ---------------------------------------------------------------------------
@@ -792,6 +885,15 @@ def aggregate_metrics(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]
         recap_attempts = 0  # Sundays where this show's runner ticked
         recap_synthesised = 0  # Sundays where the recap actually built
         tag_leak_episodes = 0  # episodes with tag_leaks > 0
+        # Grok Imagine health (May 2026 rollout). Tracks per-show:
+        #   - cost (USD spent generating images this 30-ep window)
+        #   - generation success rate (episodes where ≥1 image generated)
+        #   - failure samples for recent runs (operator can see WHY 0 imgs)
+        # Pexels-only shows have all-zero values here.
+        grok_image_cost_total = 0.0
+        grok_image_attempts = 0    # episodes whose provider was grok/hybrid
+        grok_image_success_eps = 0  # episodes that generated >=1 image
+        grok_image_fail_samples: List[Dict[str, Any]] = []
         tag_leak_total = 0  # sum of leak counts across recent episodes
         tag_leak_pattern_counts: Dict[str, int] = {}
         yt_long_errors: List[Dict[str, Any]] = []  # last few error payloads
@@ -840,6 +942,26 @@ def aggregate_metrics(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]
                             tag_leak_pattern_counts[_name] = (
                                 tag_leak_pattern_counts.get(_name, 0) + _cnt
                             )
+
+            # Grok Imagine roll-up. Only counts toward attempts/success
+            # rate when this episode actually used the grok / hybrid
+            # path; pexels-only episodes are excluded from the
+            # denominator so the rate doesn't get diluted.
+            _ip = (counters.get("image_provider") or "pexels").lower()
+            if _ip in ("grok", "hybrid"):
+                grok_image_attempts += 1
+                _gen = counters.get("grok_images_generated")
+                if isinstance(_gen, int) and _gen > 0:
+                    grok_image_success_eps += 1
+                _cost = counters.get("grok_image_cost_usd")
+                if isinstance(_cost, (int, float)):
+                    grok_image_cost_total += float(_cost)
+                _fails = counters.get("grok_image_failures")
+                if isinstance(_fails, list) and _fails and _gen == 0:
+                    grok_image_fail_samples.append({
+                        "episode_num": data.get("episode_num"),
+                        "first_failure": str(_fails[0])[:200],
+                    })
             recent_samples.append({
                 "episode_num": data.get("episode_num"),
                 "total_duration_s": total,
@@ -892,6 +1014,26 @@ def aggregate_metrics(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]
                     round(recap_synthesised / recap_attempts, 3)
                     if recap_attempts else 0.0
                 ),
+            },
+            # Grok Imagine roll-up (May 2026 rollout). Per-show:
+            #   - cost_usd_recent: USD spent on image gen in the
+            #     last-30-eps window
+            #   - generation_success_rate: episodes (of those opted in
+            #     to grok/hybrid) that actually got >=1 image. A drop
+            #     here usually means an API request-format change or
+            #     auth lapse — the recent_failures samples will
+            #     pinpoint why.
+            #   - recent_failures: first failure message from each of
+            #     the last 5 episodes that ran grok and got 0 imgs
+            "grok_imagine": {
+                "attempts": grok_image_attempts,
+                "successful_episodes": grok_image_success_eps,
+                "generation_success_rate": (
+                    round(grok_image_success_eps / grok_image_attempts, 3)
+                    if grok_image_attempts else 0.0
+                ),
+                "cost_usd_recent": round(grok_image_cost_total, 4),
+                "recent_failures": grok_image_fail_samples[-5:],
             },
             # Tag-leak rate (Phase 1.6 of the audit). Aggregates the
             # `tag_leaks` and `tag_leaks_by_pattern` per-episode
@@ -1225,6 +1367,9 @@ def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optiona
     rss = audit_rss_enclosures(root, offline=offline)
     voice = audit_voice_config(shows, root)
 
+    metrics = aggregate_metrics(root, shows)
+    costs = aggregate_costs(root, shows)
+
     landmines: List[Dict[str, Any]] = [
         item_1_repo_size(root),
         item_2_rss_integrity(rss),
@@ -1237,10 +1382,11 @@ def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optiona
         item_11_tts_provider(shows),
         item_12_summaries_location(shows),
         item_13_youtube_health(shows),
+        # item_22 depends on metrics, so it goes last (and metrics is
+        # computed above so the dependency holds).
+        item_22_grok_imagine_health(shows, metrics),
     ]
 
-    metrics = aggregate_metrics(root, shows)
-    costs = aggregate_costs(root, shows)
     network = build_network_rollup(shows, landmines, metrics, costs, rss)
 
     # Strip the ShowConfig object out of per-show entries before serialising.

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -12,8 +12,10 @@ sources:
     label: CleanTechnica
   - url: https://whatsuptesla.com/feed
     label: WhatsUpTesla
-  - url: https://driveteslacanada.ca/feed/
-    label: Drive Tesla Canada
+  # driveteslacanada.ca returns persistent HTTP 403 (anti-bot block)
+  # on the GitHub Actions runner — removed May 6 2026 after every
+  # TST run logged the same warning. Re-add if/when their CDN
+  # whitelists CI ranges or we move to a residential-proxy fetch.
   - url: https://carbuzz.com/feed
     label: CarBuzz
   - url: https://insideevs.com/rss/articles/all/

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -404,7 +404,7 @@ class TestLoadConfigRealFiles:
         cfg = load_config(SHOWS_DIR / "tesla.yaml")
         assert cfg.name == "Tesla Shorts Time"
         assert cfg.slug == "tesla"
-        assert len(cfg.sources) >= 17  # electrek.co removed (blocked source)
+        assert len(cfg.sources) >= 16  # electrek.co + driveteslacanada.ca removed (blocked sources)
         assert cfg.sources[0].label == "Teslarati"
         assert "tsla" in cfg.keywords
         assert len(cfg.web_search_queries) == 4

--- a/tests/test_generator_postprocess.py
+++ b/tests/test_generator_postprocess.py
@@ -1,0 +1,145 @@
+"""Tests for engine.generator post-processing helpers added during the
+TST Ep465 audit (May 6 2026).
+
+Two LLM-output cleanup helpers covered here:
+
+  1. ``_strip_hallucinated_timestamps`` — Tesla's grok-4.3 occasionally
+     pads every Top-N headline with an invented "publication" timestamp
+     like "May 06, 2026, 9:04 AM PDT". 11 of these landed in TST Ep465
+     and the repetition guard couldn't shake them on retry.
+  2. Speaker-prefix strip in ``_sanitize_podcast_script`` — same episode
+     had "Patrick: Tesla..." opening 5 paragraphs. The TTS would say
+     the host name out loud as a literal speaker tag.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _strip_hallucinated_timestamps
+# ---------------------------------------------------------------------------
+
+class TestStripHallucinatedTimestamps:
+
+    def test_strips_pdt_stamp_from_numbered_headline(self):
+        from engine.generator import _strip_hallucinated_timestamps
+        text = (
+            "1. Tesla Semi Incentives Available Across Multiple "
+            "States: May 06, 2026, 9:04 AM PDT\n"
+            "2. Tesla and bk World Open New Supercharger Lounge Near "
+            "Lyon: May 06, 2026, 9:04 AM PDT"
+        )
+        out = _strip_hallucinated_timestamps(text)
+        assert "May 06, 2026" not in out
+        assert "AM PDT" not in out
+        assert "Tesla Semi Incentives Available Across Multiple States" in out
+        assert "Tesla and bk World Open New Supercharger Lounge Near Lyon" in out
+
+    def test_strips_bullet_headlines_too(self):
+        from engine.generator import _strip_hallucinated_timestamps
+        text = (
+            "- Tesla announces Q4 results — May 06, 2026, 9:04 AM PDT\n"
+            "* Tesla recall affects 200K vehicles: May 6, 2026"
+        )
+        out = _strip_hallucinated_timestamps(text)
+        assert "9:04 AM PDT" not in out
+        assert "May 6, 2026" not in out
+        assert "Tesla announces Q4 results" in out
+        assert "Tesla recall affects 200K vehicles" in out
+
+    def test_strips_bold_headlines(self):
+        from engine.generator import _strip_hallucinated_timestamps
+        text = "**Tesla announces Q4 results: May 06, 2026, 9:04 AM PDT**"
+        out = _strip_hallucinated_timestamps(text)
+        assert "May 06" not in out
+        assert "Tesla announces Q4 results" in out
+
+    def test_leaves_body_prose_untouched(self):
+        """Don't strip legitimate in-body date references like
+        ``On May 6, 2026, Tesla announced...`` — only headline tails."""
+        from engine.generator import _strip_hallucinated_timestamps
+        text = (
+            "On May 6, 2026, Tesla announced its Q4 results.\n"
+            "The numbers exceeded expectations across every segment.\n"
+            "Tesla followed up on May 6, 2026 with a press release."
+        )
+        out = _strip_hallucinated_timestamps(text)
+        assert out == text  # unchanged — none of these are headline-shaped
+
+    def test_does_not_strip_when_only_word_remaining(self):
+        """If stripping would leave the line empty / punctuation-only,
+        keep the original — defensive against malformed input."""
+        from engine.generator import _strip_hallucinated_timestamps
+        text = "1. May 06, 2026, 9:04 AM PDT"
+        out = _strip_hallucinated_timestamps(text)
+        # Leaves the original since stripping would erase the line.
+        assert "May 06" in out
+
+    def test_empty_input(self):
+        from engine.generator import _strip_hallucinated_timestamps
+        assert _strip_hallucinated_timestamps("") == ""
+
+    def test_no_timestamp_returns_input_unchanged(self):
+        from engine.generator import _strip_hallucinated_timestamps
+        text = "1. Tesla announces results.\n2. Another headline."
+        assert _strip_hallucinated_timestamps(text) == text
+
+
+# ---------------------------------------------------------------------------
+# Speaker-prefix strip in _sanitize_podcast_script
+# ---------------------------------------------------------------------------
+
+class TestSpeakerPrefixStrip:
+
+    def test_strips_patrick_speaker_prefix_at_start_of_paragraph(self):
+        from engine.generator import _sanitize_podcast_script
+        script = (
+            "Patrick: Tesla announced strong Q4 results today.\n"
+            "Patrick: Tesla also unveiled a new charging network.\n"
+            "Patrick: That wraps up today's update.\n"
+        )
+        out = _sanitize_podcast_script(script)
+        for line in out.splitlines():
+            assert not line.lstrip().lower().startswith("patrick:")
+        assert "Tesla announced strong Q4 results today." in out
+        assert "Tesla also unveiled a new charging network." in out
+
+    def test_strips_olya_prefix_for_russian_shows(self):
+        from engine.generator import _sanitize_podcast_script
+        script = (
+            "Olya: Сегодня важные новости о ставке Bank of Canada.\n"
+            "Оля: Что это значит для ваших ипотек.\n"
+        )
+        out = _sanitize_podcast_script(script)
+        for line in out.splitlines():
+            stripped = line.lstrip().lower()
+            assert not stripped.startswith("olya:")
+            assert not stripped.startswith("оля:")
+        assert "Сегодня важные новости" in out
+        assert "Что это значит для ваших ипотек." in out
+
+    def test_strips_generic_host_prefix(self):
+        from engine.generator import _sanitize_podcast_script
+        script = "Host: Welcome back to the show."
+        out = _sanitize_podcast_script(script)
+        assert "Host:" not in out
+        assert "Welcome back to the show." in out
+
+    def test_does_not_strip_inline_references_to_patrick(self):
+        """Stripping must be anchored at line start — the host name
+        appearing mid-sentence (e.g. quoting the host) stays."""
+        from engine.generator import _sanitize_podcast_script
+        script = (
+            "The producer asked Patrick: did you see the news?\n"
+            "Patrick: Yes, I did.\n"
+        )
+        out = _sanitize_podcast_script(script)
+        # Mid-sentence reference preserved.
+        assert "asked Patrick: did you see the news?" in out
+        # Line-start prefix stripped.
+        assert "Yes, I did." in out
+        assert "Patrick: Yes" not in out

--- a/tests/test_newsletter_body.py
+++ b/tests/test_newsletter_body.py
@@ -68,17 +68,26 @@ class TestBoxRulesEmail:
 class TestTeslaPriceBlock:
 
     def test_renders_up_arrow_green(self):
+        """May 6 2026: bumped emerald-500 (#10b981, 2.32:1 on cream)
+        to emerald-700 (#047857, 5.01:1) so the up arrow clears WCAG
+        AA on the TSLA price block's cream background. The prior
+        color triggered the newsletter contrast hard-block on
+        TST Ep465."""
         text = "**REAL-TIME TSLA price:** $390.82 ▲ $9.44 (2.5%)"
         out = render_tsla_price_block(text)
         assert "TSLA today" in out
         assert "$390.82" in out
-        assert "#10b981" in out
+        assert "#047857" in out
+        assert "#10b981" not in out  # old color must not regress
 
     def test_renders_down_arrow_red(self):
+        """Same fix for the down arrow: red-500 (#ef4444, 3.44:1) →
+        red-700 (#b91c1c, 5.91:1)."""
         text = "**TSLA today:** $372.80 ▼ $5.20 (-1.4%)"
         out = render_tsla_price_block(text)
         assert "$372.80" in out
-        assert "#ef4444" in out
+        assert "#b91c1c" in out
+        assert "#ef4444" not in out  # old color must not regress
 
     def test_no_match_returns_unchanged(self):
         text = "Some prose, no TSLA price line here."
@@ -539,3 +548,55 @@ class TestCanonicalScrubIntegration:
         assert "California closed a loophole" in emailed
         assert "Story body." in emailed
         assert "Brand-New Cybertruck Crashed" in emailed
+
+
+# ---------------------------------------------------------------------------
+# TSLA-arrow contrast guard (May 6 2026 — operator caught hard-block fire)
+# ---------------------------------------------------------------------------
+
+class TestTeslaArrowAaGuard:
+    """Both arrow colors must clear WCAG AA (4.5:1) on the price
+    block's cream `#fef2f2` background so the newsletter contrast
+    hard-block doesn't fire on any future TST send. Pin the arrow
+    colors AND the AA result so a future palette tweak can't drop
+    below the threshold without CI flagging it."""
+
+    CREAM_BG = "#fef2f2"
+
+    def _ratio(self, fg, bg):
+        from engine.contrast_validator import contrast_ratio
+        def _rgb(h):
+            h = h.lstrip("#")
+            return tuple(int(h[i:i+2], 16) for i in (0, 2, 4))
+        return contrast_ratio(_rgb(fg), _rgb(bg))
+
+    def test_up_arrow_color_clears_aa_on_price_block(self):
+        text = "**TSLA today:** $390.82 ▲ $9.44 (2.5%)"
+        out = render_tsla_price_block(text)
+        import re
+        # Span surrounding the arrow carries the color. The render
+        # places the color span BEFORE the arrow text, so search
+        # backward from the ▲ for the nearest preceding ``color:#...``.
+        i = out.find("▲")
+        assert i >= 0, f"▲ not found: {out[:200]}"
+        m = re.search(r"color:(#[0-9a-fA-F]{6})[^>]*>[^<]*$", out[:i])
+        assert m, f"up arrow color not found near ▲: {out[max(0,i-200):i]!r}"
+        ratio = self._ratio(m.group(1), self.CREAM_BG)
+        assert ratio >= 4.5, (
+            f"Up arrow {m.group(1)} measures {ratio:.2f}:1 on cream — "
+            f"would trigger newsletter contrast hard-block."
+        )
+
+    def test_down_arrow_color_clears_aa_on_price_block(self):
+        text = "**TSLA today:** $372.80 ▼ $5.20 (-1.4%)"
+        out = render_tsla_price_block(text)
+        import re
+        i = out.find("▼")
+        assert i >= 0, f"▼ not found: {out[:200]}"
+        m = re.search(r"color:(#[0-9a-fA-F]{6})[^>]*>[^<]*$", out[:i])
+        assert m, f"down arrow color not found near ▼: {out[max(0,i-200):i]!r}"
+        ratio = self._ratio(m.group(1), self.CREAM_BG)
+        assert ratio >= 4.5, (
+            f"Down arrow {m.group(1)} measures {ratio:.2f}:1 on cream — "
+            f"would trigger newsletter contrast hard-block."
+        )


### PR DESCRIPTION
## Summary

Comprehensive review of the TST Ep465 production log surfaced **six issues** across three layers (newsletter, LLM output, RSS sources, OAuth) plus a misleading diagnostic. All resolved here. Most fixes are **network-wide** (every show benefits) — a few are TST-specific.

## Issue 1 — Newsletter contrast hard-block fired (network-wide)

Two distinct contrast failures blocked the TST Ep465 newsletter send:

| Element | Color | Background | Ratio | Status |
|---|---|---|---|---|
| TSLA price ▲ arrow | `#10b981` (emerald-500) | `#fef2f2` cream | **2.32:1** | ❌ |
| TSLA price ▼ arrow | `#ef4444` (red-500) | `#fef2f2` cream | **3.44:1** | ❌ |
| Featured-card eyebrow text | `#E31937` Tesla red | `#f8fafc` slate | **4.4999:1** | ❌ (boundary) |

Fixes:
- `newsletter_body.render_tsla_price_block`: ▲ → `#047857` (emerald-700, 5.01:1); ▼ → `#b91c1c` (red-700, 5.91:1)
- `newsletter_template._build_featured_episode_html`: eyebrow text uses `brand_color_dark` instead of `brand_color`. Every show's dark variant clears ≥5.5:1 on the slate card — fixes the boundary case for Tesla AND prevents future palette tweaks from re-tripping the validator for any show whose `brand_color` measures between 4.5 and 4.6 on white.

## Issue 2 — LLM hallucinated timestamps in 11 of 11 headlines

Tesla's grok-4.3 padded every Top-N item with an invented "publication" timestamp like `: May 06, 2026, 9:04 AM PDT`. The repetition guard fired and triggered a retry — the retry produced the SAME stamp on more headlines. Same trigram showed up in the slow-news regen too.

**Fix:** new `engine.generator._strip_hallucinated_timestamps` runs at the end of `generate_digest`. Strips `: <Month> <day>, <year>[, <hh:mm> [AM|PM] [TZ]]` from headline-shaped lines (bullets, numbered, bold). Body prose with legitimate dates ("On May 6, 2026, Tesla announced...") is preserved by the headline-shape gate.

**Affects every show on Grok 4.3.**

## Issue 3 — Speaker-prefix bleed in podcast script (TTS spoke "Patrick")

TST Ep465 podcast script had `Patrick: Tesla...` opening 5 news segments. The TTS spoke the host name out loud as a literal speaker tag.

**Fix:** `_sanitize_podcast_script` now strips `Host:`, `Patrick:`, `Olya:`, `Оля:` (Russian variants) at line start. Mid-sentence references stay (e.g. *"The producer asked Patrick: did you see the news?"*).

**Network-wide.**

## Issue 4 — Persistent broken Tesla RSS feed

`driveteslacanada.ca/feed/` returns HTTP 403 from the GitHub Actions runner — every TST run since at least May 4 logs the same warning. Removed from the Tesla source list.

## Issue 5 — Misleading "tag filter matched zero subscribers" log

When the contrast hard-block (or scaffold leak / send guardrail) fires, `send_show_newsletter` returns `None` after logging the **actual** reason at ERROR level. `run_show.py`'s diagnostic then guessed the cause was a Buttondown tag filter / API rejection — wrong and confusing on every blocked send.

**Fix:** drop the speculative branch. `run_show.py` now points the operator to the preceding `engine.newsletter` log line that carries the real reason.

## Issue 6 — YouTube caption-track HTTP 403

`captions.insert` requires the `youtube.force-ssl` OAuth scope but the existing channel tokens were issued with just `youtube` + `youtube.upload`. The video upload itself succeeds; the caption track fails on every run.

**Fix:** log message explicitly identifies the missing scope and tells the operator how to fix it (re-run OAuth flow with `youtube.force-ssl`). Caption track stays best-effort — video upload is unaffected.

## Tests

- `tests/test_generator_postprocess.py` (new, 11 tests) — timestamp stripping (preserves body prose, handles bullet/numbered/bold) + speaker-prefix stripping (Patrick/Olya/Оля/Host; mid-sentence refs preserved)
- `tests/test_newsletter_body.py` — 2 contrast drift guards (both arrows must clear AA on cream surface)
- `tests/test_config.py` — Tesla source-count assertion relaxed to ≥16 (was ≥17) reflecting driveteslacanada removal
- Full suite: **1615 passed** (+13 new), 6 skipped, 2 pre-existing env-only deselected.

## Test plan

- [x] Full pytest green
- [x] Manual contrast verification on cream + slate surfaces for the new colors
- [ ] Operator: next TST + MAB run will exercise everything. Expected:
  - Newsletter sends successfully (no contrast block)
  - Headlines have no `: May 06, 2026, 9:04 AM PDT` stamps
  - TTS does NOT speak "Patrick" as a name
  - `driveteslacanada` warning gone from logs
  - Caption-track 403 still appears but with a clearer log line — operator action item is to add the scope when convenient


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_