### PR TITLE
Phase 1: Russian-show parity (cross-network, adjacency, tag, RSS lang, dates)

### DIFF
--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -578,6 +578,9 @@ def _transliterate_cyrillic(text: str) -> str:
 # Adjacent-shows lookup (cross-network module data)
 # ---------------------------------------------------------------------------
 
+_RU_SHOW_SLUGS = frozenset({"finansy_prosto", "privet_russian"})
+
+
 def _adjacent_shows_for(
     slug: str, today_str: str,
 ) -> Optional[List[Dict[str, str]]]:
@@ -587,6 +590,14 @@ def _adjacent_shows_for(
     Best-effort: reads ``shows/_defaults.yaml``'s
     ``newsletter.network_adjacencies`` map. Returns None if the lookup
     fails or finds nothing.
+
+    Language filtering (May 2026 audit): Russian-language shows
+    (Финансы Просто, Привет Русский!) only ever recommend each other
+    — never an English show their subscribers can't consume.
+    Conversely English shows skip Russian sisters. This drops the
+    ``finansy_prosto → modern_investing`` adjacency from the map's
+    behaviour without forcing the operator to maintain two separate
+    YAML maps.
     """
     try:
         import yaml as _yaml
@@ -597,9 +608,24 @@ def _adjacent_shows_for(
         data = _yaml.safe_load(defaults_path.read_text(encoding="utf-8")) or {}
         nl = data.get("newsletter") or {}
         adj_map = (nl.get("network_adjacencies") or {})
-        sister_slugs = list(adj_map.get(slug) or [])[:2]
+        sister_slugs = list(adj_map.get(slug) or [])[:6]  # take more, filter
         if not sister_slugs:
             return None
+        # Language filter: Russian shows recommend Russian shows only,
+        # English shows recommend English shows only.
+        is_ru = slug in _RU_SHOW_SLUGS
+        sister_slugs = [
+            s for s in sister_slugs
+            if (s in _RU_SHOW_SLUGS) == is_ru and s != slug
+        ][:2]
+        if not sister_slugs:
+            # Fall back to the other Russian show for FP/PR if the YAML
+            # map doesn't have a same-language sister.
+            if is_ru:
+                fallback = "privet_russian" if slug == "finansy_prosto" else "finansy_prosto"
+                sister_slugs = [fallback]
+            else:
+                return None
         out: List[Dict[str, str]] = []
         for sister_slug in sister_slugs:
             sister = _last_episode_for_show(sister_slug)

--- a/engine/russian_text.py
+++ b/engine/russian_text.py
@@ -1,0 +1,183 @@
+"""Russian-language post-processing for podcast TTS scripts.
+
+The LLM produces partially-Russian scripts that occasionally leave
+English month/year/date strings inline ("May sixth, twenty twenty-six"
+inside an otherwise-Russian sentence). Grok TTS reads those English
+strings literally with the Russian voice, which sounds awful.
+
+This module ships a single helper, ``russify_english_dates(text)``,
+that finds English-form dates and replaces them with Russian
+equivalents (genitive case, suitable for "сегодня шестое мая…" style
+sentences). Operator caught (Финансы Просто Ep32, May 6 2026
+production audit) the LLM emitting "May sixth, twenty twenty-six"
+inside a Russian sentence.
+
+Scope is deliberately narrow:
+
+  - Only matches English month names (``January`` … ``December``).
+    Russian months bypass without change.
+  - Handles two ordinal forms: numeric (``May 6``) and worded
+    (``May sixth``).
+  - Handles two year forms: numeric (``2026``) and worded
+    (``twenty twenty-six``).
+
+Pipeline integration: called once on the Russian-show podcast
+script just before TTS. Idempotent — running it twice produces
+the same output as running once.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict
+
+
+_MONTHS_EN_TO_RU: Dict[str, str] = {
+    "january": "января",
+    "february": "февраля",
+    "march": "марта",
+    "april": "апреля",
+    "may": "мая",
+    "june": "июня",
+    "july": "июля",
+    "august": "августа",
+    "september": "сентября",
+    "october": "октября",
+    "november": "ноября",
+    "december": "декабря",
+}
+
+
+_ORDINAL_NUM_TO_RU: Dict[int, str] = {
+    1: "первое",  2: "второе",  3: "третье",  4: "четвёртое",
+    5: "пятое",   6: "шестое",  7: "седьмое", 8: "восьмое",
+    9: "девятое", 10: "десятое",
+    11: "одиннадцатое", 12: "двенадцатое", 13: "тринадцатое",
+    14: "четырнадцатое", 15: "пятнадцатое", 16: "шестнадцатое",
+    17: "семнадцатое", 18: "восемнадцатое", 19: "девятнадцатое",
+    20: "двадцатое",
+    21: "двадцать первое", 22: "двадцать второе", 23: "двадцать третье",
+    24: "двадцать четвёртое", 25: "двадцать пятое", 26: "двадцать шестое",
+    27: "двадцать седьмое", 28: "двадцать восьмое", 29: "двадцать девятое",
+    30: "тридцатое", 31: "тридцать первое",
+}
+
+
+# Worded English ordinals → number (so we can route through the
+# numeric → Russian table above). Covers 1-31.
+_ORDINAL_WORD_TO_NUM: Dict[str, int] = {
+    "first": 1, "second": 2, "third": 3, "fourth": 4, "fifth": 5,
+    "sixth": 6, "seventh": 7, "eighth": 8, "ninth": 9, "tenth": 10,
+    "eleventh": 11, "twelfth": 12, "thirteenth": 13, "fourteenth": 14,
+    "fifteenth": 15, "sixteenth": 16, "seventeenth": 17, "eighteenth": 18,
+    "nineteenth": 19, "twentieth": 20,
+    "twenty-first": 21, "twenty first": 21,
+    "twenty-second": 22, "twenty second": 22,
+    "twenty-third": 23, "twenty third": 23,
+    "twenty-fourth": 24, "twenty fourth": 24,
+    "twenty-fifth": 25, "twenty fifth": 25,
+    "twenty-sixth": 26, "twenty sixth": 26,
+    "twenty-seventh": 27, "twenty seventh": 27,
+    "twenty-eighth": 28, "twenty eighth": 28,
+    "twenty-ninth": 29, "twenty ninth": 29,
+    "thirtieth": 30,
+    "thirty-first": 31, "thirty first": 31,
+}
+
+
+def _russify_year(year: int) -> str:
+    """Spell out 2020-2030 in genitive case. Operator's catalogue
+    only ships in this window (and historic episodes pre-2020 don't
+    show up in TTS scripts). Years outside the table fall back to
+    the digits — better than silently corrupting."""
+    catalogue: Dict[int, str] = {
+        2020: "две тысячи двадцатого года",
+        2021: "две тысячи двадцать первого года",
+        2022: "две тысячи двадцать второго года",
+        2023: "две тысячи двадцать третьего года",
+        2024: "две тысячи двадцать четвёртого года",
+        2025: "две тысячи двадцать пятого года",
+        2026: "две тысячи двадцать шестого года",
+        2027: "две тысячи двадцать седьмого года",
+        2028: "две тысячи двадцать восьмого года",
+        2029: "две тысячи двадцать девятого года",
+        2030: "две тысячи тридцатого года",
+    }
+    return catalogue.get(year, str(year))
+
+
+_WORDED_YEAR_TO_NUM: Dict[str, int] = {
+    "twenty twenty": 2020,
+    "twenty twenty-one": 2021, "twenty twenty one": 2021,
+    "twenty twenty-two": 2022, "twenty twenty two": 2022,
+    "twenty twenty-three": 2023, "twenty twenty three": 2023,
+    "twenty twenty-four": 2024, "twenty twenty four": 2024,
+    "twenty twenty-five": 2025, "twenty twenty five": 2025,
+    "twenty twenty-six": 2026, "twenty twenty six": 2026,
+    "twenty twenty-seven": 2027, "twenty twenty seven": 2027,
+    "twenty twenty-eight": 2028, "twenty twenty eight": 2028,
+    "twenty twenty-nine": 2029, "twenty twenty nine": 2029,
+    "twenty thirty": 2030,
+}
+
+
+# ``May 6, 2026`` and ``May 6 2026`` — numeric day, numeric year.
+_NUMERIC_DATE_RE = re.compile(
+    r"\b(January|February|March|April|May|June|July|August|September|October|November|December)"
+    r"\s+(\d{1,2})(?:st|nd|rd|th)?"
+    r",?\s+(\d{4})\b",
+    re.IGNORECASE,
+)
+
+# ``May sixth, twenty twenty-six`` — worded day, worded year.
+_WORDED_DATE_RE = re.compile(
+    r"\b(January|February|March|April|May|June|July|August|September|October|November|December)"
+    r"\s+(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth|"
+    r"eleventh|twelfth|thirteenth|fourteenth|fifteenth|sixteenth|seventeenth|"
+    r"eighteenth|nineteenth|twentieth|"
+    r"twenty[\s-](?:first|second|third|fourth|fifth|sixth|seventh|eighth|ninth)|"
+    r"thirtieth|thirty[\s-]first)"
+    r",?\s+"
+    r"(twenty\s+(?:twenty|thirty)(?:[\s-](?:one|two|three|four|five|six|seven|eight|nine))?)",
+    re.IGNORECASE,
+)
+
+
+def russify_english_dates(text: str) -> str:
+    """Replace English-form date expressions with Russian equivalents.
+
+    Idempotent: running this on already-Russified text is a no-op
+    (Russian month names don't match the English regex).
+    """
+    if not text:
+        return text
+
+    def _numeric_sub(match: re.Match) -> str:
+        month_en = match.group(1).lower()
+        day = int(match.group(2))
+        year = int(match.group(3))
+        ru_month = _MONTHS_EN_TO_RU.get(month_en, match.group(1))
+        ru_day = _ORDINAL_NUM_TO_RU.get(day, str(day))
+        ru_year = _russify_year(year)
+        return f"{ru_day} {ru_month} {ru_year}"
+
+    def _worded_sub(match: re.Match) -> str:
+        month_en = match.group(1).lower()
+        day_word = match.group(2).lower().strip()
+        year_word = match.group(3).lower().strip()
+        ru_month = _MONTHS_EN_TO_RU.get(month_en, match.group(1))
+        # Normalize ``twenty-first`` and ``twenty first`` to a single
+        # form before lookup. The dict has both spellings.
+        day_num = _ORDINAL_WORD_TO_NUM.get(day_word)
+        if day_num is None:
+            return match.group(0)  # punt — unknown ordinal
+        year_num = _WORDED_YEAR_TO_NUM.get(year_word)
+        if year_num is None:
+            return match.group(0)  # punt — unknown year phrasing
+        ru_day = _ORDINAL_NUM_TO_RU.get(day_num, str(day_num))
+        ru_year = _russify_year(year_num)
+        return f"{ru_day} {ru_month} {ru_year}"
+
+    text = _WORDED_DATE_RE.sub(_worded_sub, text)
+    text = _NUMERIC_DATE_RE.sub(_numeric_sub, text)
+    return text

--- a/run_show.py
+++ b/run_show.py
@@ -1593,6 +1593,16 @@ def run(args: argparse.Namespace) -> None:
         # number-to-words conversion made it invisible to earlier regex passes)
         podcast_script = _strip_post_pronunciation_artifacts(podcast_script)
 
+        # Russian-show date Russification — operator caught (Финансы
+        # Просто Ep32, May 6 2026) the LLM emitting English-form dates
+        # like "May sixth, twenty twenty-six" inside otherwise-Russian
+        # sentences. Grok TTS reads the English literally with the
+        # Russian voice, which sounds awful. Helper is idempotent and
+        # narrowly targeted so it's safe to run on every Russian script.
+        if args.show in ("finansy_prosto", "privet_russian"):
+            from engine.russian_text import russify_english_dates
+            podcast_script = russify_english_dates(podcast_script)
+
         # Append AI disclosure at the end of the episode
         podcast_script = podcast_script.rstrip() + "\n\n" + _AI_DISCLOSURE
 

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -143,7 +143,14 @@ audio:
 
 publishing:
   host_name: "Оля"
-  # rss_language defaults to en-us — primary audience is English speakers learning Russian
+  # rss_language is ``ru`` so the show appears in Apple Podcasts'
+  # Russian-language directory. The audience is English speakers
+  # *learning* Russian, but the show title and content are Russian
+  # — Apple's "Education > Language Learning" category for Russian
+  # is where the discovery happens. Bilingual scaffolding is fine
+  # under a ``ru`` language tag (Apple itself flags the show as a
+  # Russian-language language-learning resource).
+  rss_language: ru
   rss_file: privet_russian_podcast.rss
   rss_title: "Привет, Русский!"
   rss_description: "Learn Russian with Olya! A bilingual podcast for English speakers — kids and adult beginners. Each episode teaches vocabulary, phrases, and culture through fun, themed lessons. Привет means hello. Let's learn together!"

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -327,8 +327,13 @@
                         <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models & Agents for Beginners</label>
                         <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
                         <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
-                        <label><input type="checkbox" name="tag" value="Финансы Просто"> Финансы Просто</label>
-                        <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
+                        {#- Use ASCII tags here so they match the per-show YAML
+                            ``newsletter.tag`` values exactly. Buttondown rejects
+                            non-ASCII tags; mismatches between this footer form
+                            and the YAML split subscribers across two never-merged
+                            tags (operator caught this on FP, May 2026 audit). -#}
+                        <label><input type="checkbox" name="tag" value="Finansy Prosto"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Privet Russian"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="{{ t.subscribe_email_placeholder }}" required aria-label="{{ t.subscribe_email_aria }}">

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -638,14 +638,26 @@
     {% endif %}
 
     <!-- More from Nerra Network -->
+    {#- Filter cross-network grid by page language so Russian readers
+        don't get recommendations they can't consume. Russian-language
+        shows are finansy_prosto + privet_russian; everything else is
+        English. Operator caught (May 2026 audit) the prior grid listing
+        9 English shows on every Russian show page. -#}
+    {%- set _ru_show_slugs = ['finansy_prosto', 'privet_russian'] -%}
+    {%- set _is_ru_page = (page_lang | default('en')) == 'ru' -%}
+    {%- if _is_ru_page -%}
+        {%- set _network_shows = all_shows | selectattr('slug', 'in', _ru_show_slugs) | list -%}
+    {%- else -%}
+        {%- set _network_shows = all_shows | rejectattr('slug', 'in', _ru_show_slugs) | list -%}
+    {%- endif -%}
     <section class="cross-network nn-section">
         <div class="container">
             <div class="nn-section-header">
-                <h2>More from Nerra Network</h2>
-                <p>Ten daily shows keeping you informed.</p>
+                <h2>{% if _is_ru_page %}Другие подкасты Nerra Network{% else %}More from Nerra Network{% endif %}</h2>
+                <p>{% if _is_ru_page %}Подкасты на русском языке.{% else %}{{ _network_shows | length }} shows keeping you informed.{% endif %}</p>
             </div>
             <div class="cross-network-grid">
-                {% for s in all_shows %}
+                {% for s in _network_shows %}
                 {% if s.slug != show_slug %}
                 <div class="cross-network-card" style="display:flex;flex-direction:column;">
                     <a href="{{ path_prefix }}{{ s.show_page }}" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
@@ -658,7 +670,7 @@
                             <div class="cross-network-card-tagline">{{ s.tagline }}</div>
                         </div>
                     </a>
-                    <a href="{{ path_prefix }}{{ s.blog_page }}" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
+                    <a href="{{ path_prefix }}{{ s.blog_page }}" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">{% if _is_ru_page %}Читать блог{% else %}Read blog{% endif %} &rarr;</a>
                 </div>
                 {% endif %}
                 {% endfor %}

--- a/tests/test_russian_text.py
+++ b/tests/test_russian_text.py
@@ -1,0 +1,135 @@
+"""Tests for engine.russian_text — date Russification for FP / Привет.
+
+Operator caught (Финансы Просто Ep32, May 6 2026) the LLM emitting
+``May sixth, twenty twenty-six`` and ``May 6, 2026`` inside Russian
+sentences. Grok TTS reads English literally with the Russian voice,
+which sounds awful.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.russian_text import russify_english_dates
+
+
+class TestNumericDates:
+
+    def test_full_date(self):
+        out = russify_english_dates("Сегодня May 6, 2026, и у нас новости.")
+        assert "May" not in out
+        assert "шестое мая" in out
+        assert "две тысячи двадцать шестого года" in out
+
+    def test_ordinal_suffix_stripped(self):
+        out = russify_english_dates("News from January 1st, 2026.")
+        assert "первое января" in out
+        assert "1st" not in out
+
+    def test_no_comma(self):
+        out = russify_english_dates("July 4 2026 is a holiday.")
+        assert "четвёртое июля" in out
+
+    def test_two_digit_day(self):
+        out = russify_english_dates("December 25, 2025.")
+        assert "двадцать пятое декабря" in out
+
+
+class TestWordedDates:
+
+    def test_worded_full(self):
+        """Production-caught case: ``May sixth, twenty twenty-six``."""
+        out = russify_english_dates(
+            "Финансы Просто, выпуск 32, May sixth, twenty twenty-six.",
+        )
+        assert "May" not in out
+        assert "twenty" not in out
+        assert "шестое мая" in out
+        assert "две тысячи двадцать шестого года" in out
+
+    def test_hyphenated_ordinal(self):
+        out = russify_english_dates("Born on April twenty-first, twenty twenty-five.")
+        assert "двадцать первое апреля" in out
+        assert "две тысячи двадцать пятого года" in out
+
+    def test_space_separated_ordinal(self):
+        out = russify_english_dates("Born on April twenty first, twenty twenty five.")
+        assert "двадцать первое апреля" in out
+
+
+class TestNonMatchingInput:
+
+    def test_already_russian_unchanged(self):
+        text = "Сегодня шестое мая две тысячи двадцать шестого года."
+        assert russify_english_dates(text) == text
+
+    def test_no_date_unchanged(self):
+        text = "Это просто предложение без даты."
+        assert russify_english_dates(text) == text
+
+    def test_idempotent(self):
+        text = "Today is May 6, 2026, и это важный день."
+        once = russify_english_dates(text)
+        twice = russify_english_dates(once)
+        assert once == twice
+
+    def test_unknown_year_passes_through(self):
+        # 1999 isn't in the genitive table — should leave as digits
+        out = russify_english_dates("On May 6, 1999, something happened.")
+        assert "шестое мая" in out
+        assert "1999" in out  # year falls through
+
+    def test_empty_input(self):
+        assert russify_english_dates("") == ""
+
+
+class TestRussianShowAdjacencyFilter:
+    """The newsletter ``_adjacent_shows_for`` helper must NOT recommend
+    English shows to Russian-language subscribers (operator caught FP
+    being told to listen to Modern Investing in Russian-language
+    newsletters)."""
+
+    def test_finansy_recommends_only_privet(self, monkeypatch):
+        """FP's same-language sister is Привет Русский — that's the
+        only show a Russian subscriber can fully consume."""
+        from engine import newsletter
+
+        def _fake_last_episode(slug):
+            return {"slug": slug, "name": slug, "hook": "x", "url": "u"}
+
+        monkeypatch.setattr(
+            newsletter, "_last_episode_for_show", _fake_last_episode,
+        )
+
+        # Stub the YAML lookup to a known map that includes both
+        # English and Russian sisters for FP.
+        import yaml as _yaml
+        original_safe_load = _yaml.safe_load
+        def _fake_safe_load(text):
+            return {
+                "newsletter": {
+                    "network_adjacencies": {
+                        "finansy_prosto": [
+                            "modern_investing", "privet_russian", "tesla",
+                        ],
+                    },
+                },
+            }
+        monkeypatch.setattr(_yaml, "safe_load", _fake_safe_load)
+
+        # Make the existence check pass
+        from pathlib import Path as _P
+        monkeypatch.setattr(_P, "exists", lambda self: True)
+        monkeypatch.setattr(
+            _P, "read_text", lambda self, encoding="utf-8": "stub",
+        )
+
+        adj = newsletter._adjacent_shows_for("finansy_prosto", "2026-05-06")
+        assert adj is not None
+        slugs = [s["slug"] for s in adj]
+        assert "modern_investing" not in slugs, (
+            "English-only show recommended to Russian-language "
+            "subscriber — bug from May 2026 audit re-introduced"
+        )
+        assert "tesla" not in slugs
+        assert "privet_russian" in slugs


### PR DESCRIPTION
## Summary — Phase 1 of the strategic improvement plan

Fixes the biggest structural bugs affecting the two Russian-language shows (Финансы Просто, Привет Русский!) per the May 6 audit. Highest impact-per-hour of the 5-phase plan.

| # | Bug | Fix |
|---|---|---|
| 1 | Cross-network grid on Russian show pages listed 9 English shows readers can't consume | `templates/show_page.html.j2` filters by `page_lang`; Russian pages show only Russian shows + Russian header copy |
| 2 | Newsletter adjacency recommended Modern Investing / Tesla to FP (Russian) subscribers | `_adjacent_shows_for` filters sisters by same-language constraint; falls back to the other Russian show |
| 3 | FP Buttondown tag split: footer posted `Финансы Просто` (Cyrillic), YAML used `Finansy Prosto` (ASCII). Subscribers split across two never-merged tags | Footer now uses ASCII canonical form matching YAML for both FP and Привет |
| 4 | `privet_russian_podcast.rss <language>` was `en-us` — show invisible in Russian Apple directory | Explicit `rss_language: ru` |
| 5 | Russian shows TTS read English dates literally ("May sixth, twenty twenty-six" in a Russian sentence) | New `engine/russian_text.py:russify_english_dates` post-processes Russian-show scripts to genitive Russian ("шестое мая две тысячи двадцать шестого года"); idempotent, narrow scope |

## Tests

- New `tests/test_russian_text.py` (13 tests) covering numeric + worded date forms, non-matching cases, idempotency, plus a newsletter adjacency filter guard.
- Full suite: **1630 passed** (+13 new), 6 skipped, 2 pre-existing env-only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_