### PR TITLE
Phase 4: Listener-journey + retention surfaces (newsletter hero, per-episode feedback, next-episode placeholder, WhatsApp/Telegram share)

### DIFF
--- a/templates/blog_post.html.j2
+++ b/templates/blog_post.html.j2
@@ -610,6 +610,10 @@
     </style>
 {% endblock %}
 
+{# Page-language flag — Russian shows render localized chrome
+   (Phase 1 audit + Phase 4 retention surfaces). #}
+{%- set _is_ru = (page_lang | default('en')) == 'ru' -%}
+
 {% block content %}
     <!-- Breadcrumb -->
     <nav aria-label="Breadcrumb" style="max-width:900px;margin:calc(72px + var(--sp-4)) auto 0;padding:0 var(--sp-6);font-family:var(--font-ui);font-size:0.82rem;">
@@ -719,12 +723,26 @@
                 <span>Share:</span>
                 <a href="https://twitter.com/intent/tweet?url={{ canonical_url }}&text={{ page_title | urlencode }}" target="_blank" rel="noopener" aria-label="Share on Twitter">&#120143; Post</a>
                 <a href="https://www.linkedin.com/sharing/share-offsite/?url={{ canonical_url }}" target="_blank" rel="noopener" aria-label="Share on LinkedIn">in LinkedIn</a>
+                <a href="https://wa.me/?text={{ (page_title ~ ' \u2014 ' ~ canonical_url) | urlencode }}" target="_blank" rel="noopener" aria-label="Share on WhatsApp">WhatsApp</a>
+                <a href="https://t.me/share/url?url={{ canonical_url }}&amp;text={{ page_title | urlencode }}" target="_blank" rel="noopener" aria-label="Share on Telegram">Telegram</a>
                 <button onclick="navigator.clipboard.writeText(window.location.href).then(function(){this.textContent='\u2713 Copied'}.bind(this))" aria-label="Copy link">&#128279; Copy link</button>
+            </div>
+
+            {#- Per-episode feedback surface (Phase 4 of May 2026 audit).
+                The strategic review found NO per-episode listener-voice
+                affordance \u2014 no thumbs-up, no comments, no community.
+                Mailto with prefilled subject/body is dependency-free,
+                privacy-respecting, and gives Patrick a real signal of
+                what episodes resonate. -#}
+            <div class="episode-feedback" style="display:flex;gap:var(--sp-3);align-items:center;justify-content:center;flex-wrap:wrap;margin:var(--sp-6) 0;padding:var(--sp-4);border-top:1px solid var(--nn-border);border-bottom:1px solid var(--nn-border);font-family:var(--font-ui);font-size:0.95rem;color:var(--nn-text-muted);">
+                <span>{{ '\ud83d\udc4b ' if not _is_ru else '\ud83d\udc4b ' }}{% if _is_ru %}\u041f\u043e\u043d\u0440\u0430\u0432\u0438\u043b\u0441\u044f \u0432\u044b\u043f\u0443\u0441\u043a?{% else %}Did this episode land?{% endif %}</span>
+                <a href="mailto:patrick@planetterrian.com?subject={{ ('I liked ' ~ show_name ~ ' Ep' ~ episode_num) | urlencode }}&body={{ ('Re: ' ~ canonical_url ~ '%0A%0A') }}" style="padding:6px 14px;border:1px solid var(--show-color);border-radius:100px;color:var(--show-color-text, var(--show-color));text-decoration:none;font-weight:600;">{% if _is_ru %}\ud83d\udc4d \u041e\u0442\u0437\u044b\u0432{% else %}\ud83d\udc4d Tell Patrick{% endif %}</a>
+                <a href="mailto:patrick@planetterrian.com?subject={{ ('Suggestion for ' ~ show_name) | urlencode }}&body={{ ('Re: ' ~ canonical_url ~ '%0A%0A') }}" style="padding:6px 14px;border:1px solid var(--nn-border);border-radius:100px;color:var(--nn-text-muted);text-decoration:none;font-weight:600;">{% if _is_ru %}\ud83d\udca1 \u0418\u0434\u0435\u044f{% else %}\ud83d\udca1 Suggest a story{% endif %}</a>
             </div>
 
             <!-- Subscribe CTA -->
             {% if newsletter_tag %}
-            <div class="show-subscribe-inline" style="margin-top:var(--sp-6);margin-bottom:var(--sp-6);">
+            <div id="subscribe-cta" class="show-subscribe-inline" style="margin-top:var(--sp-6);margin-bottom:var(--sp-6);">
                 <h3>Enjoy this episode? Get {{ show_name }} in your inbox</h3>
                 <p>New episode alerts — no spam, unsubscribe anytime.</p>
                 <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow"
@@ -755,6 +773,20 @@
                     <span class="nav-label">Next &rarr;</span>
                     <span class="nav-title">Episode {{ next_post.episode_num }}</span>
                 </a>
+                {% else %}
+                {#- Phase 4 of May 2026 audit: when this is the latest
+                    episode, ``next_post`` is None and the listener
+                    dead-ends. Show a "next episode tomorrow" placeholder
+                    that captures email instead of a blank space. -#}
+                {% if newsletter_tag %}
+                <div class="next nav-next-placeholder" style="text-align:right;color:var(--nn-text-muted);font-family:var(--font-ui);font-size:0.92rem;">
+                    <span class="nav-label">{% if _is_ru %}Завтра →{% else %}Tomorrow &rarr;{% endif %}</span>
+                    <span class="nav-title">{% if _is_ru %}Новый выпуск утром{% else %}New episode tomorrow{% endif %}</span>
+                    <a href="#subscribe-cta" style="font-size:0.82rem;color:var(--show-color-text, var(--show-color));text-decoration:none;display:block;margin-top:4px;">{% if _is_ru %}Подписаться, чтобы не пропустить →{% else %}Subscribe so you don't miss it &rarr;{% endif %}</a>
+                </div>
+                {% else %}
+                <div></div>
+                {% endif %}
                 {% endif %}
             </nav>
             {% endif %}

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -122,6 +122,26 @@
         </div>
     </section>
 
+    {#- Compact above-fold newsletter capture (May 2026 audit). The
+        full multi-show form lives in the footer; this single-input row
+        reaches scroll-and-bail visitors who never make it past the
+        latest-episode card. Tag pre-filled to this show. -#}
+    {% if newsletter_tag %}
+    <section style="padding:var(--sp-3) var(--sp-6);background:var(--nn-card);border-bottom:1px solid var(--nn-border);">
+        <div class="container" style="max-width:760px;display:flex;flex-wrap:wrap;align-items:center;gap:var(--sp-3);justify-content:center;">
+            <span style="font-family:var(--font-ui);font-size:0.92rem;color:var(--nn-text);">
+                {% if _is_ru %}📬 Получайте новые выпуски на почту:{% else %}📬 Get tomorrow's episode in your inbox:{% endif %}
+            </span>
+            <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" style="display:flex;gap:var(--sp-2);flex-wrap:wrap;">
+                <input type="hidden" name="tag" value="{{ newsletter_tag }}">
+                <input type="hidden" value="1" name="embed">
+                <input type="email" name="email" placeholder="{% if _is_ru %}ваш@email.ru{% else %}your@email.com{% endif %}" required aria-label="{% if _is_ru %}Адрес электронной почты{% else %}Email address{% endif %}" style="padding:6px 12px;border-radius:6px;border:1px solid var(--nn-border);background:var(--nn-bg);color:var(--nn-text);font-size:0.92rem;min-width:200px;">
+                <button type="submit" style="padding:6px 14px;border-radius:6px;background:var(--show-color);color:#ffffff;border:none;font-size:0.92rem;font-weight:600;cursor:pointer;">{% if _is_ru %}Подписаться{% else %}Subscribe{% endif %}</button>
+            </form>
+        </div>
+    </section>
+    {% endif %}
+
     <!-- Latest Episode -->
     <section class="nn-section" style="padding-top: var(--sp-8);">
         <div class="container">


### PR DESCRIPTION
## Summary — Phase 4 of the strategic improvement plan

Closes the biggest listener-retention gaps identified in the May 6 audit. Pure template / static-render changes — no engine logic.

| # | Bug | Fix |
|---|---|---|
| 1 | Newsletter signup buried 8 sections deep on every show page | Compact above-fold capture row directly under hero (single email input + button, tag pre-filled to the show) |
| 2 | NO per-episode listener-voice surface anywhere — no thumbs-up, no comments, no community link | Per-episode feedback row on every blog post with `mailto:` "👍 Tell Patrick" + "💡 Suggest a story" |
| 3 | Tesla blog posts dead-end on the day they're published (`next_post is None`) | "Tomorrow → New episode tomorrow / Subscribe so you don't miss it" placeholder card |
| 4 | Share row offered Twitter/LinkedIn/Copy only — no WhatsApp/Telegram for non-US audience | Added WhatsApp + Telegram intents |
| 5 | `_is_ru` not defined in blog post template | Defined at top of `{% block content %}` so retention surfaces render Russian copy on RU pages |

## Tests

No new unit tests — these are template surfaces. The full suite still passes (1654).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_