### PR TITLE
fix: unblock daily build — surrogate scrub + commit-step hardening

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -434,7 +434,18 @@ jobs:
           "
 
       - name: Commit and push output
-        if: steps.pipeline.outputs.skipped != 'true'
+        # Run on `always()` so a failure in a *peripheral* later step
+        # (HTML regen, RSS regen, podcast-directory notify) doesn't
+        # block the commit. The actual episode artifacts — digest .md,
+        # transcripts, metrics — were produced by the pipeline step
+        # and must reach git regardless. Operator caught (May 7 2026)
+        # an entire day of episodes lost from the repo because
+        # generate_html.py --blogs hit a UnicodeEncodeError on a lone
+        # surrogate; GitHub Actions' implicit `success()` guard then
+        # skipped this commit step, the runner shut down, and the
+        # work was gone. Gate on `pipeline.outcome == 'success'` so
+        # we only commit when the pipeline itself succeeded.
+        if: always() && steps.pipeline.outcome == 'success' && steps.pipeline.outputs.skipped != 'true'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"

--- a/generate_html.py
+++ b/generate_html.py
@@ -15,6 +15,7 @@ Usage:
 
 import argparse
 import os
+import re
 import sys
 from pathlib import Path
 from urllib.parse import quote
@@ -25,6 +26,18 @@ ROOT = Path(__file__).resolve().parent
 TEMPLATES_DIR = ROOT / "templates"
 SHOWS_DIR = ROOT / "shows"
 GITHUB_RAW = "https://nerranetwork.com"
+
+# Operator caught (UC + Tesla, May 7 2026) blog generation aborting on
+# `UnicodeEncodeError: surrogates not allowed` because an LLM-rendered
+# string carried an unpaired UTF-16 surrogate (U+D800–U+DFFF). Python's
+# UTF-8 encoder rejects them, and a single bad code point would kill the
+# whole site rebuild — losing every blog post for every show in the run.
+# Scrub lone surrogates at the boundary of every HTML/XML file write.
+_LONE_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
+
+def _strip_lone_surrogates(text: str) -> str:
+    return _LONE_SURROGATE_RE.sub("", text)
 
 # Channel handles for the YouTube CTA on show pages. The handle is
 # determined per-show by youtube.channel in the YAML (en → @NerraNetwork,
@@ -1434,7 +1447,7 @@ def generate_summaries_page(slug, *, dry_run=False):
         print(f"[dry-run] Would write {out_path} ({len(html):,} bytes)")
         return None
 
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path} ({len(html):,} bytes)")
     return out_path
 
@@ -1579,7 +1592,7 @@ def generate_show_page(slug, *, dry_run=False):
         print(f"[dry-run] Would write {out_path} ({len(html):,} bytes)")
         return None
 
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path} ({len(html):,} bytes)")
     return out_path
 
@@ -1735,7 +1748,7 @@ def generate_network_page(*, dry_run=False):
         print(f"[dry-run] Would write {out_path} ({len(html):,} bytes)")
         return None
 
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path} ({len(html):,} bytes)")
     return out_path
 
@@ -1847,7 +1860,7 @@ def generate_blog_posts(slug, *, dry_run=False, cross_show_posts=None):
             print(f"[dry-run] Would write {out_path} ({len(html):,} bytes)")
         else:
             blog_dir.mkdir(parents=True, exist_ok=True)
-            out_path.write_text(html, encoding="utf-8")
+            out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
             print(f"Wrote {out_path}")
 
         results.append((meta, out_path))
@@ -1897,7 +1910,7 @@ def generate_blog_index(slug, *, dry_run=False, posts=None):
         return None
 
     blog_dir.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path}")
     return out_path
 
@@ -1946,7 +1959,7 @@ def generate_network_blog_index(*, dry_run=False, all_posts=None):
         return None
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path}")
     return out_path
 
@@ -2091,7 +2104,7 @@ def generate_sitemap(*, dry_run=False):
         print(f"[dry-run] Would write {out_path} ({len(urls)} URLs)")
         return None
 
-    out_path.write_text(xml, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(xml), encoding="utf-8")
     print(f"Wrote {out_path} ({len(urls)} URLs)")
     return out_path
 
@@ -2125,7 +2138,7 @@ def generate_404_page(*, dry_run=False):
         print(f"[dry-run] Would write {out_path}")
         return None
 
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path}")
     return out_path
 
@@ -2156,7 +2169,7 @@ def generate_start_here_page(*, dry_run=False):
         print(f"[dry-run] Would write {out_path}")
         return None
 
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path}")
     return out_path
 
@@ -2218,7 +2231,7 @@ def generate_about_page(*, dry_run=False):
         print(f"[dry-run] Would write {out_path}")
         return None
 
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path}")
     return out_path
 
@@ -2251,7 +2264,7 @@ def generate_press_page(*, dry_run=False):
         print(f"[dry-run] Would write {out_path}")
         return None
 
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path}")
     return out_path
 
@@ -2287,7 +2300,7 @@ def generate_editorial_page(*, dry_run=False):
         print(f"[dry-run] Would write {out_path}")
         return None
 
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path}")
     return out_path
 
@@ -2318,7 +2331,7 @@ def generate_contact_page(*, dry_run=False):
         print(f"[dry-run] Would write {out_path}")
         return None
 
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path}")
     return out_path
 
@@ -2349,7 +2362,7 @@ def generate_faq_page(*, dry_run=False):
         print(f"[dry-run] Would write {out_path}")
         return None
 
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path}")
     return out_path
 
@@ -2380,7 +2393,7 @@ def generate_how_to_listen_page(*, dry_run=False):
         print(f"[dry-run] Would write {out_path}")
         return None
 
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path}")
     return out_path
 
@@ -2423,7 +2436,7 @@ def generate_player_page(*, dry_run=False):
         print(f"[dry-run] Would write {out_path}")
         return None
 
-    out_path.write_text(html, encoding="utf-8")
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote {out_path}")
     return out_path
 

--- a/tests/test_generate_html_surrogates.py
+++ b/tests/test_generate_html_surrogates.py
@@ -1,0 +1,78 @@
+"""Drift guard for the lone-surrogate scrubber in ``generate_html``.
+
+Operator caught (UC + Tesla blog generation, May 7 2026) the daily site
+rebuild aborting with::
+
+    UnicodeEncodeError: 'utf-8' codec can't encode characters in position
+    73685-73686: surrogates not allowed
+
+at ``generate_html.py:1850`` (``out_path.write_text(html, encoding="utf-8")``).
+A single LLM-emitted lone UTF-16 surrogate killed the whole blog
+regeneration — losing every other show's blog post in the same run.
+
+The fix scrubs lone surrogates (U+D800–U+DFFF) at every HTML/XML write
+boundary in ``generate_html``. These tests pin that the scrubber exists
+and is correct; if the regex is removed or weakened, daily builds break
+silently the next time an LLM emits a malformed surrogate.
+"""
+
+from __future__ import annotations
+
+
+class TestStripLoneSurrogates:
+
+    def test_helper_exists(self):
+        from generate_html import _strip_lone_surrogates
+        assert callable(_strip_lone_surrogates)
+
+    def test_strips_high_surrogate(self):
+        from generate_html import _strip_lone_surrogates
+        # U+D83D in isolation — a high surrogate without a paired low
+        # surrogate. Common when an LLM truncates an emoji code unit.
+        bad = "Hello \ud83d world"
+        assert _strip_lone_surrogates(bad) == "Hello  world"
+
+    def test_strips_low_surrogate(self):
+        from generate_html import _strip_lone_surrogates
+        bad = "Quote \udc00 mark"
+        assert _strip_lone_surrogates(bad) == "Quote  mark"
+
+    def test_preserves_legitimate_emoji(self):
+        """A properly-paired emoji (U+D83D U+DE80 = 🚀) is a SINGLE
+        non-BMP code point in Python strings; the regex matches actual
+        surrogate code points, not the encoded form, so emoji survive."""
+        from generate_html import _strip_lone_surrogates
+        text = "Tesla 🚀 launches in three cities."
+        assert _strip_lone_surrogates(text) == text
+
+    def test_preserves_cyrillic(self):
+        from generate_html import _strip_lone_surrogates
+        text = "Финансы Просто, выпуск 32, шестое мая."
+        assert _strip_lone_surrogates(text) == text
+
+    def test_empty_input(self):
+        from generate_html import _strip_lone_surrogates
+        assert _strip_lone_surrogates("") == ""
+
+    def test_idempotent(self):
+        from generate_html import _strip_lone_surrogates
+        bad = "a\ud800b🚭c"  # lone D800, then a paired emoji
+        once = _strip_lone_surrogates(bad)
+        twice = _strip_lone_surrogates(once)
+        assert once == twice
+
+    def test_round_trips_through_utf8(self):
+        """The scrubbed output must encode cleanly to UTF-8 — that's the
+        whole point of the helper. Pre-fix, ``write_text`` raised
+        ``UnicodeEncodeError`` on this exact input."""
+        from generate_html import _strip_lone_surrogates
+        bad = "<html>contents 𐀀 plus lone \ud83d end</html>"
+        # ``"𐀀"`` is a high+low surrogate PAIR, but Python
+        # strings are UCS-4 so this is two separate surrogate code points
+        # (NOT a single non-BMP code point). The scrubber strips both.
+        scrubbed = _strip_lone_surrogates(bad)
+        # Must encode without raising.
+        scrubbed.encode("utf-8")
+        # No surrogate code points survive.
+        for ch in scrubbed:
+            assert not (0xD800 <= ord(ch) <= 0xDFFF)


### PR DESCRIPTION
## Summary

Today's daily build silently lost an entire day of episodes. Two
independent bugs combined to cause it; this PR fixes both.

### Bug 1 (proximate): `UnicodeEncodeError` in blog HTML write

```
File ".../generate_html.py", line 1850, in generate_blog_posts
  out_path.write_text(html, encoding="utf-8")
UnicodeEncodeError: 'utf-8' codec can't encode characters in position
73685-73686: surrogates not allowed
```

A single LLM-emitted lone UTF-16 surrogate (U+D800–U+DFFF) inside one
episode's content was killing the entire blog regeneration. Same root
cause hit Tesla and Unintended Consequences runs today.

**Fix:** add `_strip_lone_surrogates()` and apply it at every
HTML/XML write boundary in `generate_html.py` (16 sites). Properly
paired emoji are unaffected; only unpaired surrogate code points are
stripped.

### Bug 2 (structural): peripheral failure cascaded into total data loss

In `.github/workflows/run-show.yml`, each show's matrix job runs:

1. Run show pipeline → produces digest/audio/transcript/metrics, ships
   audio to R2 + YouTube, updates RSS, sends newsletter, posts X.
2. Validate output
3. Regenerate network RSS
4. **Regenerate show HTML pages** (`generate_html.py --blogs`) ← failed today
5. Notify podcast directories
6. Commit and push output

The "Commit and push output" step had `if: steps.pipeline.outputs.skipped != 'true'`.
GitHub Actions implicitly adds `success()` to every `if:` clause, so when
step 4 failed, step 6 was *also* skipped — the runner shut down with the
digest .md, transcript, and metrics still in tmpfs. The full day's
artifacts never reached git, even though the audio had already shipped
to listeners.

**Fix:** change the commit step's `if:` to
`always() && steps.pipeline.outcome == 'success' && steps.pipeline.outputs.skipped != 'true'`.
Now a peripheral regen failure can no longer skip the commit. Episode
artifacts survive whatever happens after the pipeline step itself
succeeded.

## Verification

- [x] 8 new regression tests in `tests/test_generate_html_surrogates.py`
  pin the helper exists, strips high + low surrogates, preserves
  legit emoji + Cyrillic, is idempotent, round-trips through UTF-8.
- [x] Full pytest suite: 1656 passing (only pre-existing failure is
  `google.oauth2` missing — unrelated).
- [x] `python generate_html.py --show unintended_consequences` — UC
  blog regeneration completes without error.
- [x] `python generate_html.py` (full rebuild) — 401 HTML files
  written, no surrogate errors anywhere in output.
- [x] Workflow YAML parses cleanly (`yaml.safe_load`).

## Why both fixes ship together

Either alone is incomplete:

- Surrogate scrubber alone: today's specific bug is fixed, but the next
  time *any* peripheral step fails (e.g. transient network blip in
  podcast-directory notify) the same data-loss pattern repeats.
- Workflow hardening alone: still loses today because the commit step
  needs the digest .md to actually pass. The pipeline succeeded, so
  the artifacts ARE there — but the surrogate scrub is what unblocks
  blog regen so the **operator's site** stays in sync with what
  shipped.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26