### PR TITLE
fix: close remaining surrogate write sites + push daily review + pin MIT skip

### DIFF
--- a/.github/workflows/daily-review.yml
+++ b/.github/workflows/daily-review.yml
@@ -2,8 +2,12 @@ name: Daily Episode Review
 
 on:
   schedule:
-    # Run at 12:00 UTC — after all shows have finished (last show: TST at 9:30 UTC + 45min pipeline)
-    - cron: '0 12 * * *'
+    # Run at 12:15 UTC — after all shows have finished. May 2026 schedule
+    # overhaul moved the last show (UC) to 11:30 UTC + ~30 min pipeline ≈
+    # 12:00 UTC; an earlier 12:00 trigger left no buffer for GitHub Actions
+    # cron jitter and was racing UC every weekday. 15 extra minutes of
+    # slack stops the review from declaring UC "missed" on a normal day.
+    - cron: '15 12 * * *'
 
   workflow_dispatch:
     inputs:

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -1616,6 +1616,10 @@ def update_blog_rss(
 """
 
     rss_path.parent.mkdir(parents=True, exist_ok=True)
-    rss_path.write_text(rss_xml, encoding="utf-8")
+    # Scrub lone UTF-16 surrogates the LLM occasionally emits — see
+    # engine.utils.strip_lone_surrogates. Without this, a single bad
+    # code point in a blog hook would abort RSS feed regeneration.
+    from engine.utils import strip_lone_surrogates as _scrub
+    rss_path.write_text(_scrub(rss_xml), encoding="utf-8")
     logger.info("Blog RSS written: %s (%d entries)", rss_path, len(entries))
     return rss_path

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -558,3 +558,31 @@ def strip_speech_tags(text: str) -> str:
     # which leave a stray double-newline-with-space artifact.
     out = re.sub(r"\n[ \t]+\n", "\n\n", out)
     return out
+
+
+# ---------------------------------------------------------------------------
+# Lone-surrogate scrubbing
+# ---------------------------------------------------------------------------
+#
+# Operator caught (UC + Tesla blog generation, May 7 2026) the daily site
+# rebuild aborting with ``UnicodeEncodeError: surrogates not allowed``
+# inside ``Path.write_text(encoding="utf-8")``. An LLM-rendered string
+# carried a lone UTF-16 surrogate code point (U+D800–U+DFFF), the UTF-8
+# encoder refuses them, and a single bad code point then aborted the
+# entire blog regeneration — losing every other show's blog post in the
+# same run.
+#
+# The scrubber is the same regex used at every HTML/XML write boundary
+# in ``generate_html.py``. Promoted here from that module so every
+# component that writes LLM-touched text to disk (digest .md, TTS
+# script, blog post HTML, blog RSS feeds) can scrub at the boundary.
+_LONE_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
+
+def strip_lone_surrogates(text: str) -> str:
+    """Remove unpaired UTF-16 surrogate code points (U+D800–U+DFFF).
+
+    Properly paired emoji are unaffected — they're a single non-BMP
+    code point in Python strings, not two separate surrogates.
+    """
+    return _LONE_SURROGATE_RE.sub("", text)

--- a/generate_html.py
+++ b/generate_html.py
@@ -15,29 +15,22 @@ Usage:
 
 import argparse
 import os
-import re
 import sys
 from pathlib import Path
 from urllib.parse import quote
 
 from jinja2 import Environment, FileSystemLoader
 
+# Lone-surrogate scrubber lives in engine.utils so every component that
+# writes LLM-touched text to disk (digests, TTS scripts, blog posts,
+# RSS feeds, network HTML) scrubs at the same boundary. See utils.py
+# for the May 7 2026 operator-caught regression that prompted this.
+from engine.utils import strip_lone_surrogates as _strip_lone_surrogates
+
 ROOT = Path(__file__).resolve().parent
 TEMPLATES_DIR = ROOT / "templates"
 SHOWS_DIR = ROOT / "shows"
 GITHUB_RAW = "https://nerranetwork.com"
-
-# Operator caught (UC + Tesla, May 7 2026) blog generation aborting on
-# `UnicodeEncodeError: surrogates not allowed` because an LLM-rendered
-# string carried an unpaired UTF-16 surrogate (U+D800–U+DFFF). Python's
-# UTF-8 encoder rejects them, and a single bad code point would kill the
-# whole site rebuild — losing every blog post for every show in the run.
-# Scrub lone surrogates at the boundary of every HTML/XML file write.
-_LONE_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
-
-
-def _strip_lone_surrogates(text: str) -> str:
-    return _LONE_SURROGATE_RE.sub("", text)
 
 # Channel handles for the YouTube CTA on show pages. The handle is
 # determined per-show by youtube.channel in the YAML (en → @NerraNetwork,

--- a/run_show.py
+++ b/run_show.py
@@ -1337,9 +1337,12 @@ def run(args: argparse.Namespace) -> None:
     x_thread = scrub_scaffold(x_thread)
     x_thread = transform_daily_body(x_thread, slug=getattr(config, "slug", ""))
 
-    # Save digest to file
+    # Save digest to file. Strip lone UTF-16 surrogates (the LLM
+    # occasionally emits one); ``write_text`` would otherwise abort the
+    # whole pipeline on ``UnicodeEncodeError``. See engine.utils.
+    from engine.utils import strip_lone_surrogates as _scrub
     digest_md = digests_dir / f"{config.episode.prefix}_Ep{episode_num:03d}_{today:%Y%m%d}.md"
-    digest_md.write_text(x_thread, encoding="utf-8")
+    digest_md.write_text(_scrub(x_thread), encoding="utf-8")
     logger.info("Digest saved: %s", digest_md)
 
     # Narrative-mode shows: mark the topic as produced in the queue so
@@ -1641,8 +1644,9 @@ def run(args: argparse.Namespace) -> None:
         podcast_script = _re.sub(r"\n{3,}", "\n\n", podcast_script).strip()
 
         # Save TTS-ready script for debugging pronunciation/intro issues
+        from engine.utils import strip_lone_surrogates as _scrub
         tts_script_path = digests_dir / f"{config.episode.prefix}_Ep{episode_num:03d}_{today:%Y%m%d}_tts.txt"
-        tts_script_path.write_text(podcast_script, encoding="utf-8")
+        tts_script_path.write_text(_scrub(podcast_script), encoding="utf-8")
         logger.info("TTS script saved: %s", tts_script_path)
 
         # 9. TTS — provider-aware (ElevenLabs default; Grok for Russian shows)
@@ -2186,7 +2190,8 @@ def run(args: argparse.Namespace) -> None:
             _blog_dir = PROJECT_ROOT / "blog" / config.slug
             _blog_dir.mkdir(parents=True, exist_ok=True)
             _blog_path = _blog_dir / f"ep{episode_num:03d}.html"
-            _blog_path.write_text(_blog_html, encoding="utf-8")
+            from engine.utils import strip_lone_surrogates as _scrub
+            _blog_path.write_text(_scrub(_blog_html), encoding="utf-8")
             logger.info("Blog post written: %s", _blog_path)
 
             # Regenerate blog index (per-show + network)

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -95,6 +95,10 @@ x_accounts:
     max_posts: 3
 
 min_articles: 6
+# Explicit per-show pin (CLAUDE.md landmine #21). Markets always
+# produce 3+ stories on a weekday; if the network default ever
+# changes, this stays at 3 unless deliberately edited.
+min_articles_skip: 3
 
 keywords:
   - AI investing

--- a/tests/test_generate_html_surrogates.py
+++ b/tests/test_generate_html_surrogates.py
@@ -1,4 +1,4 @@
-"""Drift guard for the lone-surrogate scrubber in ``generate_html``.
+"""Drift guard for the lone-surrogate scrubber.
 
 Operator caught (UC + Tesla blog generation, May 7 2026) the daily site
 rebuild aborting with::
@@ -6,14 +6,16 @@ rebuild aborting with::
     UnicodeEncodeError: 'utf-8' codec can't encode characters in position
     73685-73686: surrogates not allowed
 
-at ``generate_html.py:1850`` (``out_path.write_text(html, encoding="utf-8")``).
+at ``generate_html.py`` (``out_path.write_text(html, encoding="utf-8")``).
 A single LLM-emitted lone UTF-16 surrogate killed the whole blog
 regeneration — losing every other show's blog post in the same run.
 
-The fix scrubs lone surrogates (U+D800–U+DFFF) at every HTML/XML write
-boundary in ``generate_html``. These tests pin that the scrubber exists
-and is correct; if the regex is removed or weakened, daily builds break
-silently the next time an LLM emits a malformed surrogate.
+The fix scrubs lone surrogates (U+D800–U+DFFF) at every text-write
+boundary across the pipeline. The canonical helper lives in
+``engine.utils.strip_lone_surrogates`` so every component that writes
+LLM-touched text (digests, TTS scripts, blog posts, RSS feeds, HTML)
+scrubs at the same boundary. ``generate_html._strip_lone_surrogates``
+is the legacy alias.
 """
 
 from __future__ import annotations
@@ -21,9 +23,22 @@ from __future__ import annotations
 
 class TestStripLoneSurrogates:
 
+    def test_helper_exists_in_engine_utils(self):
+        from engine.utils import strip_lone_surrogates
+        assert callable(strip_lone_surrogates)
+
     def test_helper_exists(self):
         from generate_html import _strip_lone_surrogates
         assert callable(_strip_lone_surrogates)
+
+    def test_engine_utils_and_generate_html_helpers_agree(self):
+        """generate_html re-exports engine.utils' helper, not a parallel
+        implementation. If a future refactor accidentally fork them, the
+        two scrubbers could drift and one of them would silently let
+        surrogates through."""
+        from engine.utils import strip_lone_surrogates as canonical
+        from generate_html import _strip_lone_surrogates as alias
+        assert alias is canonical
 
     def test_strips_high_surrogate(self):
         from generate_html import _strip_lone_surrogates


### PR DESCRIPTION
## Summary

Audit follow-up to PRs #331 + #332. Three independent improvements
bundled together because they all surfaced from the post-incident
audit and each is a small, ship-ready change.

## 1. Close remaining LLM-touched write sites (defence-in-depth)

PR #331 added `_strip_lone_surrogates` to every write site in
`generate_html.py` (16 sites) but left four others untouched. Each one
writes LLM-generated content directly to disk and would crash the
pipeline on a lone UTF-16 surrogate exactly like the original bug:

| File | Line | What it writes |
|---|---|---|
| `run_show.py` | digest_md.write_text(x_thread) | **Episode source-of-truth markdown** |
| `run_show.py` | tts_script_path.write_text(podcast_script) | TTS-ready debug script |
| `run_show.py` | _blog_path.write_text(_blog_html) | Per-episode blog post (inline path) |
| `engine/publisher.py` | rss_path.write_text(rss_xml) | Blog RSS feed |

The first one is the most painful: if the digest .md write crashed,
nothing downstream (RSS, newsletter, blog, X) could regenerate from
disk after the run.

**Refactor:** promoted the helper from `generate_html._strip_lone_surrogates`
(private) to `engine.utils.strip_lone_surrogates` (public) so every
component scrubs at the same boundary. `generate_html` keeps the
legacy `_strip_lone_surrogates` name as an alias. New drift-guard
test pins that the two names resolve to the **same function object**.

## 2. Daily-review cron: 12:00 UTC → 12:15 UTC

The May 2026 schedule overhaul moved Unintended Consequences to
11:30 UTC + ~30 min pipeline ≈ 12:00 UTC finish. Reviewing at exactly
12:00 left zero buffer for GitHub Actions cron jitter and would race
UC every weekday. 15 minutes of slack stops false "missed episode"
alarms. Issue #330 was a real instance of this race today.

## 3. Pin Modern Investing `min_articles_skip: 3` explicitly

Per CLAUDE.md landmine #21, every show should pin its own
`min_articles_skip` so the network default can be retuned without
silently shifting any one show. MIT was the only show inheriting
the default — now it's explicit.

## Test plan

- [x] Full pytest suite: 1654 passing (only `test_youtube` skipped due
  to pre-existing missing `google.oauth2` dependency).
- [x] New `test_engine_utils_and_generate_html_helpers_agree` pins the
  alias is the canonical helper, not a copy.
- [x] `engine.config.load_config('shows/modern_investing.yaml')` reads
  `min_articles_skip == 3` cleanly.
- [x] `yaml.safe_load` clean on both modified workflow YAMLs.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_