### PR TITLE
fix(dashboard): TTS-provider landmine expects grok, not elevenlabs

### DIFF
--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -15,7 +15,7 @@ Landmines covered (per CLAUDE.md "Known Landmines"):
   6  - *_formatted.md duplicate files absent
   8  - publishing.x_enabled is a boolean on every show
   9  - TTS voice settings consistency vs shows/_defaults.yaml
-  11 - every show resolves tts.provider == elevenlabs
+  11 - every show resolves tts.provider == grok (network default since May 2026)
   12 - every summaries JSON lives under digests/<slug>/
 
 Items 7 (NEWSAPI dead secret) and 10 (early-episode deletion) are deliberately
@@ -377,27 +377,37 @@ def item_8_feature_flags(shows: List[Dict[str, Any]]) -> Dict[str, Any]:
 
 
 def item_11_tts_provider(shows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Network-wide TTS provider invariant.
+
+    All 11 shows migrated to Grok TTS in the May 2026 full-network
+    flip (CLAUDE.md landmine #17). ElevenLabs is the rollback path,
+    not the live provider — accidental drift back to it would be a
+    cost regression (Grok is ~36× cheaper per character) and a voice-
+    consistency regression (the entire English network shares one
+    custom-trained Grok voice). Pin grok as the expected provider so
+    a copy-paste from old YAML lights up the dashboard.
+    """
     wrong = []
     for s in shows:
         cfg = s.get("cfg")
         if not cfg:
             continue
         prov = (cfg.tts.provider or "").lower()
-        if prov != "elevenlabs":
+        if prov != "grok":
             wrong.append({"slug": s["slug"], "provider": prov or "<unset>"})
     if wrong:
         return _mk(
             "item_11_tts_provider",
-            "All shows use ElevenLabs TTS",
+            "All shows use Grok TTS",
             "fail",
-            f"{len(wrong)} show(s) do not resolve to elevenlabs",
+            f"{len(wrong)} show(s) do not resolve to grok",
             {"wrong": wrong},
         )
     return _mk(
         "item_11_tts_provider",
-        "All shows use ElevenLabs TTS",
+        "All shows use Grok TTS",
         "ok",
-        f"All {len(shows)} shows resolve tts.provider == elevenlabs.",
+        f"All {len(shows)} shows resolve tts.provider == grok.",
     )
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -74,6 +74,31 @@ def test_landmine_items_7_and_10_excluded():
         assert forbidden not in ids, f"{forbidden} must not be emitted"
 
 
+def test_item_11_expects_grok_provider_post_may_2026():
+    """The May 2026 full-network migration moved every show to Grok TTS
+    (CLAUDE.md landmine #17). The dashboard's item_11 invariant flipped
+    from `provider == elevenlabs` (pre-migration) to `provider == grok`
+    (current). This test pins the post-migration state so a copy-paste
+    from the old YAML wouldn't silently revert the dashboard signal."""
+    data = gd.build_dashboard(ROOT, offline=True)
+    item_11 = next(
+        (lm for lm in data["landmines"] if lm["id"] == "item_11_tts_provider"),
+        None,
+    )
+    assert item_11 is not None, "item_11_tts_provider must be emitted"
+    # Title and details must reflect Grok, not the old ElevenLabs check.
+    assert "Grok" in item_11["title"], (
+        f"item_11 title still references the pre-May-2026 expectation: "
+        f"{item_11['title']!r}"
+    )
+    assert "grok" in item_11["details"].lower()
+    # All 11 shows currently resolve to grok → status is ok.
+    assert item_11["status"] == "ok", (
+        f"All shows should resolve tts.provider == grok post-May 2026; "
+        f"got status={item_11['status']!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Test 3 — item 1 passes on a clean-ish repo
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Audit found `scripts/generate_dashboard.py:item_11_tts_provider` has
been failing on every dashboard render since the May 2026 TTS
migration. The check is hardcoded against the pre-migration provider
(elevenlabs) but every show on the network migrated to Grok TTS in
the May 2026 full-network flip (CLAUDE.md landmine #17).

```python
prov = (cfg.tts.provider or "").lower()
if prov != "elevenlabs":   # <-- inverted: every show now grok!
    wrong.append(...)
```

The dashboard's TTS-provider invariant has therefore been a
permanent red signal that operators learned to ignore — defeating
its purpose as a drift detector.

## Fix

Flip the expected state so:

- `provider == "grok"` is the expected baseline (network default
  per `shows/_defaults.yaml`)
- Drift back to elevenlabs OR any other provider trips the dashboard
- ElevenLabs stays as a documented rollback option (per landmine
  #17) but appearing in production is now a real signal

Updated:

- `scripts/generate_dashboard.py:item_11_tts_provider` — flipped check
- `scripts/generate_dashboard.py` module docstring — landmine #11 line
- `tests/test_dashboard.py` — new
  `test_item_11_expects_grok_provider_post_may_2026` pins the
  post-migration state so a copy-paste from the old YAML re-fails
  the dashboard

The existing `test_mab_and_ma_are_separate` already pins
`cfg.tts.provider == "grok"` for the two M&A shows independently,
so the YAML-level invariant has a separate guard.

## Test plan

- [x] `python scripts/generate_dashboard.py --offline --dry-run` →
  `item_11_tts_provider` reports `status="ok"` with
  `details="All 11 shows resolve tts.provider == grok."`
- [x] `pytest tests/test_dashboard.py` — 7 passing (1 skip pre-existing).

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_