### PR TITLE
chore: log raw podcast script word count + target to metrics

### DIFF
--- a/run_show.py
+++ b/run_show.py
@@ -1574,6 +1574,13 @@ def run(args: argparse.Namespace) -> None:
                 _script_word_count, _TARGET_WORDS,
             )
             metrics.record("script_below_target", True)
+        # Always log the raw word count + target so post-hoc audits can
+        # validate calibration without grepping workflow logs. The May
+        # 2026 Phase-3 recalibration was hard to validate post-merge
+        # because only the boolean was preserved; the raw counts now
+        # let us compute the actual/target ratio over time.
+        metrics.record("podcast_script_word_count", _script_word_count)
+        metrics.record("podcast_script_target_words", _TARGET_WORDS)
 
         # 8c. Pre-TTS duration estimate — skip obviously doomed episodes before
         #     burning TTS credits.  ~150 words/minute for podcast speech.


### PR DESCRIPTION
## Why

Audit caught (May 7 2026) that `metrics.record("script_below_target", True)` preserves the boolean but **not** the actual word count or the per-show target. That made the May 2026 Phase-3 recalibration of `min_podcast_words` (PR #327) impossible to validate from the committed metrics alone — to find out *how short* an episode actually was, you had to grep workflow logs (which roll off after 90 days).

Empirically: across recent metrics for 11 shows, `script_below_target: true` fires on:

| Show | Rate | Recalibrated target |
|---|---|---|
| Tesla | 5/5 | 1700 |
| FF | 5/5 | 1500 |
| PT | 5/5 | 1400 |
| MIT | 5/5 | 1500 |
| EI | 5/5 | 1300 |
| UC | 4/4 | 1300 |
| OV | 4/5 | 1300 |
| FP | 4/5 | 900 |
| M&A | 3/5 | 1500 |
| PR | 3/5 | 700 |
| MAB | 0/5 | 1100 |

But these files predate the Phase-3 calibration (today's runs didn't commit due to the surrogate bug). Whether the recalibrated targets land cleanly is therefore an open question — and one we can't answer without the raw counts.

## Change

`run_show.py` (one new block, no behaviour change):

```python
metrics.record("podcast_script_word_count", _script_word_count)
metrics.record("podcast_script_target_words", _TARGET_WORDS)
```

Both numbers now appear under `counters.*` in every `metrics_ep*.json`. The hard-floor and warning-floor gates are unchanged.

## Why this is the right level of intervention

I considered re-tuning the Phase-3 thresholds today based on the audit, but the visible firing-rate table is from **pre-recalibration** episodes. Tomorrow's runs will be the first post-recalibration data. Adding the raw counts now means:

1. Tomorrow's runs commit with both numbers visible.
2. Within a week we'll have empirical actual-vs-target ratios per show.
3. *Then* we can retune from data, not vibes.

Skip-running this PR risks merging a calibration change that's already obsolete.

## Test plan

- [x] Full pytest suite: 1654 passing (only `test_youtube` skipped due to pre-existing missing `google.oauth2`).
- [x] `metrics.record(key, value)` writes to `self.counters[key]` and is emitted by `to_dict()` — verified via `engine/metrics.py:82–84` and `:90+`.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_