### PR TITLE
fix(youtube): strip URLs from long-form description to fix invalidDescription on Tesla

### DIFF
--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -62,8 +62,26 @@ def _strip_markdown(text: str) -> str:
     text = re.sub(r"__(.*?)__", r"\1", text)
     # Inline code
     text = re.sub(r"`([^`]+)`", r"\1", text)
-    # Markdown links → plain URL
-    text = re.sub(r"\[([^\]]+)\]\((https?://[^\)]+)\)", r"\1: \2", text)
+    # Markdown links → keep the LABEL only, drop the URL.
+    #
+    # Operator caught (Tesla Ep459-465 long-form, May 2-5 2026)
+    # YouTube rejecting every Tesla long-form upload with
+    # ``invalidDescription``. Tesla digests embed Google News redirect
+    # URLs of the form
+    # ``https://news.google.com/rss/articles/CBMimgFBVV95cUx...?oc=5``
+    # — 200+ char base64-encoded paths. Five such URLs in the body
+    # paragraphs trips YouTube's "looks-like-spam" classifier on
+    # ``body.snippet.description``. Shorts uploads (which use a
+    # separate metadata path with no body content) were unaffected.
+    #
+    # The chapters block + subscribe link + audio URL still ship
+    # clean URLs to listeners; readers don't lose navigation. The
+    # source citations remain in the digest .md / blog post / RSS,
+    # which is where readers actually click them.
+    text = re.sub(r"\[([^\]]+)\]\(https?://[^\)]+\)", r"\1", text)
+    # Belt-and-braces: strip any bare URL longer than 80 chars that
+    # survived (e.g. a non-markdown raw URL pasted into the digest).
+    text = re.sub(r"https?://[^\s)]{80,}", "", text)
     # Final defense-in-depth: drop any remaining ``<`` / ``>`` so
     # YouTube doesn't 400 on stray angle-bracket content (math like
     # ``<2030``, escaped speech tags that survived earlier passes,

--- a/run_show.py
+++ b/run_show.py
@@ -2989,7 +2989,11 @@ def _publish_youtube(
             # ``reason`` (quotaExceeded / authError / etc.) — capture
             # both that and the generic str fallback.
             err_type = type(exc).__name__
-            err_msg = str(exc)[:300]
+            # 1000 chars (was 300) — YouTube's invalidDescription
+            # carries a ``locationType`` and the offending location at
+            # the END of the message; the prior cap was truncating
+            # exactly that detail when post-mortem debugging.
+            err_msg = str(exc)[:1000]
             err_status = getattr(exc, "status_code", None) or getattr(
                 getattr(exc, "resp", None), "status", None
             )
@@ -3050,9 +3054,11 @@ def _publish_youtube(
         except Exception as exc:
             logger.exception("YouTube Shorts publish failed: %s", exc)
             # Mirror the long-form error capture so metrics.json
-            # carries actionable context for the operator.
+            # carries actionable context for the operator. 1000 chars
+            # (was 300) — YouTube errors include the offending
+            # location at the END of the message.
             err_type = type(exc).__name__
-            err_msg = str(exc)[:300]
+            err_msg = str(exc)[:1000]
             err_status = getattr(exc, "status_code", None) or getattr(
                 getattr(exc, "resp", None), "status", None
             )

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -60,6 +60,18 @@ def _make_config(**overrides):
 # ---------------------------------------------------------------------------
 
 def test_strip_markdown_removes_headers_bold_and_links():
+    """Markdown links are stripped to their LABEL ONLY (the URL is dropped).
+
+    Tesla Ep459-465 (May 2-5 2026) — every long-form upload failed with
+    ``invalidDescription`` because Tesla digests embed Google News
+    redirect URLs of the form
+    ``https://news.google.com/rss/articles/CBMimgFB...?oc=5`` (200+
+    char base64-encoded paths). YouTube's spam classifier flagged the
+    description, and Shorts (which use a separate metadata path
+    without body content) were unaffected. Drop the URL portion of
+    every markdown link so the description stays clean — readers
+    still get citation links via the .md / blog post / RSS, all of
+    which are unchanged."""
     raw = (
         "# Big news\n"
         "**Tesla** delivers on Q3.\n"
@@ -68,7 +80,43 @@ def test_strip_markdown_removes_headers_bold_and_links():
     out = vm._strip_markdown(raw)
     assert "**" not in out
     assert "#" not in out.split("\n")[0]
-    assert "https://example.com/post" in out
+    # Label survives, URL gone.
+    assert "the announcement" in out
+    assert "https://example.com" not in out
+
+
+def test_strip_markdown_drops_long_google_news_redirect_urls():
+    """Tesla Ep459-465 specific — the actual production trigger for the
+    May 2026 invalidDescription regression. Confirms a realistic
+    Google News redirect URL is removed from the body."""
+    raw = (
+        "1. **California Opens Roads to Autonomous Semi Trucks**: "
+        "Source: [Google News](https://news.google.com/rss/articles/"
+        "CBMimgFBVV95cUxNRWRNMzJUNTVYWURwdjh2ckxST2dpelFHSzBycFBsQXFD"
+        "eHI0S0RjREUza0I2TU5VNW9KWGhnVWJBOC1OX0VLXzBGZkVocFhiYzFyNmVp"
+        "TlRtSjBsUFlOMlloQ0lob2c4RlZYaHBLaUJCaTN3Z3dNakNDdy13TEU4TF80"
+        "eUJ0aTlOLVhnSHNxaGVXTWNCSktMQ013?oc=5)"
+    )
+    out = vm._strip_markdown(raw)
+    # The base64-looking redirect path must be gone.
+    assert "CBMimgFBVV95" not in out
+    # And the prose around it survives.
+    assert "California Opens Roads" in out
+    assert "Source: Google News" in out
+
+
+def test_strip_markdown_strips_bare_long_urls():
+    """Belt-and-braces: any non-markdown raw URL longer than 80 chars
+    also gets dropped, so a hand-written digest with a bare redirect
+    URL doesn't sneak past."""
+    raw = (
+        "See https://news.google.com/rss/articles/" + "x" * 200 + "?oc=5 "
+        "for context, but the short link https://x.com/y stays."
+    )
+    out = vm._strip_markdown(raw)
+    # Long URL gone; short URL survives.
+    assert "x" * 200 not in out
+    assert "https://x.com/y" in out
 
 
 def test_strip_markdown_drops_code_fences():


### PR DESCRIPTION
## Problem

Audit found Tesla long-form YouTube uploads have been failing 5/7 times for the past week with HTTP 400 `invalidDescription`. Shorts succeed every time.

```
"youtube_long_error": {
  "type": "ResumableUploadError",
  "status": 400,
  "message": "<HttpError 400 when requesting None returned \"The request metadata specifies an invalid video description.\". Details: \"[{'message': 'The request metadata specifies an invalid video description.', 'domain': 'youtube.video', 'reason': 'invalidDescription', 'location': 'body.snippet.description', 'loca..."
}
```

(message truncated mid-`'locationType'` — separate fix in this PR.)

Per-show recent failure rate (long-form):

| Show | Long success | Recent runs |
|---|---|---|
| Tesla | 2/7 (29%) | NNNNNYY |
| FF | 1/2 (50%) | YN |
| MAB | 2/4 (50%) | YNNY |

## Root cause

`engine.video_metadata._strip_markdown` rewrites markdown links to `label: url` — keeping the URL inline. Tesla / FF / MIT digests embed Google News redirect URLs:

```
https://news.google.com/rss/articles/CBMimgFBVV95cUxNRWRNMzJUNTVYWURwdjh2ckxST2dpelFHSzBycFBsQXFDeHI0S0RjREUza0I2TU5VNW9KWGhnVWJBOC1OX0VLXzBGZkVocFhiYzFyNmVpTlRtSjBsUFlOMlloQ0lob2c4RlZYaHBLaUJCaTN3Z3dNakNDdy13TEU4TF80eUJ0aTlOLVhnSHNxaGVXTWNCSktMQ013?oc=5
```

200+ chars of base64-encoded redirect data per URL, 5+ stories per digest → 1000+ chars of base64-looking URLs in the description body. YouTube's spam classifier flags this and 400s the request.

Shorts uploads use a separate metadata builder (`build_short_metadata`) that doesn't include digest body content, so they were unaffected.

## Fix

Two layered defences in `_strip_markdown`:

1. Markdown link rewrite changes from `label: url` to `label` (drop URL entirely). Citations stay in the digest .md / blog post / RSS where readers actually click them. The YouTube description still ships clean URLs via subscribe link, audio link, and chapters block.

2. Belt-and-braces: any *bare* URL longer than 80 chars that survives step 1 also gets stripped. Catches a hand-written digest with a non-markdown redirect URL.

Plus a debuggability win in `run_show.py`: bumped the YouTube error-message truncation from 300 to 1000 chars on both long-form and short error paths. The next `invalidDescription` (if any) will expose its `locationType` field instead of losing actionable detail to truncation.

## Test plan

- [x] 3 new tests in `tests/test_youtube.py`:
  - `test_strip_markdown_removes_headers_bold_and_links` updated to assert URL-stripped output (label-only).
  - `test_strip_markdown_drops_long_google_news_redirect_urls` — the realistic production trigger.
  - `test_strip_markdown_strips_bare_long_urls` — bare-URL fallback.
- [x] Full pytest suite: 1655 passing, 0 failures (only `test_youtube`'s pre-existing `google.oauth2` test still skipped).
- [x] Hand-verified the regex: applied to Tesla Ep465 digest, no Google News URL survives in the body output.

## Why this is high-leverage

Tesla is the network's largest property and the only show approved for full YouTube upload (English channel quota — landmine #20). 71% of its long-form uploads have been silently failing for a week.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_