### PR TITLE
fix(content-tracker): prose-section fallback + suppress pre-flight LLM ping warning

### DIFF
--- a/engine/content_tracker.py
+++ b/engine/content_tracker.py
@@ -383,6 +383,27 @@ def _extract_bold_headlines(text: str, max_items: int = 20) -> List[str]:
             if len(headlines) >= max_items:
                 return headlines
 
+    # Fallback 3: pure prose sections (e.g. MAB's "The Big Story" — no
+    # bold, no numbered list, no sub-headers, just a paragraph). Use
+    # the first substantive sentence as a topic signature so cross-
+    # episode dedup catches "we covered this story yesterday" via
+    # proper-noun overlap. Operator caught (MAB Ep031, May 7 2026)
+    # the LLM retelling the Perplexity Personal Computer story in
+    # blocks 2 AND 4 of the same episode — cross-episode dedup
+    # silently missed yesterday's mention because The Big Story
+    # extracts to zero headlines.
+    if not headlines:
+        # Strip leading list markers / metadata lines that aren't real
+        # prose; first sentence ending in . ! ? wins.
+        cleaned = re.sub(r"^\s*(\d+\.\s+|[-*]\s+)", "", text, flags=re.MULTILINE)
+        sentence_match = re.search(r"([A-ZА-Я][^.!?\n]{30,200}[.!?])", cleaned)
+        if sentence_match:
+            t = sentence_match.group(1).strip()
+            # Strip inline markdown that survived (bold, italic, code).
+            t = re.sub(r"[*_`]+", "", t).strip()
+            if t and t not in headlines:
+                headlines.append(t)
+
     if not headlines:
         logger.warning(
             "Could not extract any headlines from digest section (%d chars). "

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -122,7 +122,13 @@ def _call_grok(
     meta: Dict[str, Any] = {"provider": "openai_compat", "model": model}
     finish_reason = getattr(resp.choices[0], "finish_reason", None)
     meta["finish_reason"] = finish_reason
-    if finish_reason == "length":
+    # Only warn on length-truncation when the caller is actually trying
+    # to produce content. Pre-flight LLM ping uses max_tokens=10 by
+    # design — "truncated" is the expected outcome, not a regression.
+    # Threshold of 200 is well below any legitimate digest/podcast
+    # completion (smallest digest path uses >= 4000) but above every
+    # health-check / classifier call we make today.
+    if finish_reason == "length" and max_tokens >= 200:
         logger.warning(
             "LLM response truncated (finish_reason=length, max_tokens=%d) — "
             "output may end mid-sentence",

--- a/tests/test_content_tracker.py
+++ b/tests/test_content_tracker.py
@@ -114,6 +114,54 @@ class TestExtractBoldHeadlines:
         headlines = _extract_bold_headlines(text)
         assert len(headlines) == 1
 
+    def test_prose_section_falls_back_to_first_sentence(self):
+        """Operator caught (MAB Ep031, May 7 2026) ``The Big Story``
+        section emitting zero headlines because it's pure prose — no
+        bold, no numbered list, no sub-headers. Cross-episode dedup
+        then missed yesterday's mention and the LLM retold the same
+        story (Perplexity Personal Computer) in two blocks of one
+        episode. The prose-fallback captures the topic via the first
+        substantive sentence."""
+        text = (
+            "Google DeepMind just unveiled Aletheia, an AI agent that "
+            "moves from competition-style math problems to professional "
+            "research-level discoveries. It iterates on proofs in plain "
+            "language and verifies them against known facts."
+        )
+        headlines = _extract_bold_headlines(text)
+        assert len(headlines) == 1
+        assert "Google DeepMind" in headlines[0]
+        assert "Aletheia" in headlines[0]
+
+    def test_prose_fallback_strips_inline_markdown(self):
+        """First-sentence fallback must clean up residual inline bold /
+        italic / code so the dedup signature is plain text."""
+        text = (
+            "OpenAI announced **Codex** today, a new *coding* assistant "
+            "that integrates with `vscode`. It runs locally."
+        )
+        headlines = _extract_bold_headlines(text)
+        # Either the bold ``Codex`` is captured by the bold pass (if the
+        # 10-char min still matches) OR the prose fallback fires. Either
+        # way the topic gets a signature; the test pins SOMETHING is
+        # extracted so cross-episode dedup never silently sees zero.
+        assert len(headlines) >= 1
+        # No inline markdown leaks through the prose path.
+        for h in headlines:
+            assert "*" not in h
+            assert "`" not in h
+
+    def test_prose_fallback_handles_cyrillic(self):
+        """Russian shows (FP, PR) might also benefit from the fallback —
+        confirm the regex anchors on Cyrillic capitals too."""
+        text = (
+            "Канадский фондовый рынок открылся ростом сегодня утром, "
+            "несмотря на падение технологического сектора в США."
+        )
+        headlines = _extract_bold_headlines(text)
+        assert len(headlines) == 1
+        assert "Канадский" in headlines[0]
+
 
 class TestExtractQuoteAuthor:
     def test_standard_format(self):

--- a/tests/test_llm_truncation_gate.py
+++ b/tests/test_llm_truncation_gate.py
@@ -1,0 +1,157 @@
+"""Drift guard for the May 7 2026 fix to the LLM truncation warning.
+
+Operator caught the pre-flight LLM ping (10-token completion against
+the configured model, used as a connectivity / API-key health check)
+firing a WARNING-level log message every single run::
+
+    LLM response truncated (finish_reason=length, max_tokens=10) —
+    output may end mid-sentence
+
+That's expected behaviour — the caller asked for 10 tokens and got 10.
+The warning was fully informative on a 4000-token digest call but
+pure noise on the 10-token ping. Suppressing tiny-budget calls keeps
+the noise out of CI logs without losing the legitimate signal.
+
+The fix in ``engine.generator._call_grok`` gates the WARN on
+``max_tokens >= 200`` — well below any digest / podcast call (smallest
+takes 4000+) but above every health-check / classifier path.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _build_fake_response(*, content: str, finish_reason: str):
+    """Build a stand-in for OpenAI's chat.completions response shape."""
+    choice = SimpleNamespace(
+        message=SimpleNamespace(content=content),
+        finish_reason=finish_reason,
+    )
+    return SimpleNamespace(choices=[choice], usage=None)
+
+
+def _call_with(max_tokens: int, finish_reason: str, caplog):
+    """Drive ``_call_grok`` with a stubbed OpenAI client and capture logs."""
+    from engine import generator as g
+
+    fake_response = _build_fake_response(
+        content="ok", finish_reason=finish_reason,
+    )
+
+    class _FakeCompletions:
+        def create(self, **kwargs):
+            return fake_response
+
+    class _FakeChat:
+        def __init__(self):
+            self.completions = _FakeCompletions()
+
+    class _FakeClient:
+        def __init__(self, *_, **__):
+            self.chat = _FakeChat()
+
+    # ``openai`` is a runtime dependency the test env doesn't install
+    # (``pip install -r requirements.txt`` is skipped during pytest).
+    # Inject a fake module into sys.modules so the lazy
+    # ``from openai import OpenAI`` inside _call_grok succeeds.
+    fake_module = types.ModuleType("openai")
+    fake_module.OpenAI = _FakeClient
+    with patch.dict(sys.modules, {"openai": fake_module}), \
+         patch.object(g, "_get_api_key", return_value="test-key"):
+        caplog.set_level(logging.WARNING, logger="engine.generator")
+        text, meta = g._call_grok(
+            prompt="ping",
+            model="grok-4.3",
+            temperature=0.0,
+            max_tokens=max_tokens,
+        )
+    # Snapshot the records list — caplog.records is a live reference
+    # that gets shared across calls inside one test (caplog.clear()
+    # mutates the same list object).
+    return text, meta, list(caplog.records)
+
+
+class TestTruncationWarningGate:
+
+    def test_preflight_ping_does_not_warn(self, caplog):
+        """max_tokens=10 (pre-flight ping) → no WARN even when the
+        response trips finish_reason=length."""
+        _, _, records = _call_with(
+            max_tokens=10, finish_reason="length", caplog=caplog,
+        )
+        truncation_warns = [
+            r for r in records
+            if r.levelno == logging.WARNING
+            and "LLM response truncated" in r.getMessage()
+        ]
+        assert truncation_warns == [], (
+            f"Pre-flight ping should be silent on truncation, got: "
+            f"{[r.getMessage() for r in truncation_warns]}"
+        )
+
+    def test_real_completion_still_warns(self, caplog):
+        """A genuine digest-sized call (max_tokens=4000) MUST still
+        WARN when finish_reason=length — that signals real content
+        loss the operator needs to see."""
+        _, _, records = _call_with(
+            max_tokens=4000, finish_reason="length", caplog=caplog,
+        )
+        truncation_warns = [
+            r for r in records
+            if r.levelno == logging.WARNING
+            and "LLM response truncated" in r.getMessage()
+        ]
+        assert len(truncation_warns) == 1, (
+            f"Real completion should warn on truncation; got "
+            f"{len(truncation_warns)} warning(s)."
+        )
+
+    def test_threshold_boundary_at_200(self, caplog):
+        """The gate is ``max_tokens >= 200``. Confirm 200 warns and 199
+        doesn't, so a future ``> 200`` typo doesn't break the loud
+        path silently."""
+        from engine import generator as g
+
+        # 199 → silent
+        _, _, records_199 = _call_with(
+            max_tokens=199, finish_reason="length", caplog=caplog,
+        )
+        # Need to clear caplog between calls.
+        caplog.clear()
+        # 200 → warns
+        _, _, records_200 = _call_with(
+            max_tokens=200, finish_reason="length", caplog=caplog,
+        )
+        warns_199 = [
+            r for r in records_199
+            if r.levelno == logging.WARNING
+            and "LLM response truncated" in r.getMessage()
+        ]
+        warns_200 = [
+            r for r in records_200
+            if r.levelno == logging.WARNING
+            and "LLM response truncated" in r.getMessage()
+        ]
+        assert warns_199 == []
+        assert len(warns_200) == 1
+
+    def test_normal_finish_reason_never_warns(self, caplog):
+        """``finish_reason='stop'`` is the happy path — no warning
+        regardless of max_tokens. Pin the gate doesn't accidentally
+        warn on completed responses."""
+        _, _, records = _call_with(
+            max_tokens=4000, finish_reason="stop", caplog=caplog,
+        )
+        truncation_warns = [
+            r for r in records
+            if r.levelno == logging.WARNING
+            and "LLM response truncated" in r.getMessage()
+        ]
+        assert truncation_warns == []


### PR DESCRIPTION
## Why

Two findings from the MAB Ep031 production log (May 7 2026, post-PR-#337):

### Finding 1: MAB's "The Big Story" never gets dedup signature

`engine.content_tracker._extract_bold_headlines` runs three patterns (`**bold**`, `1. numbered`, `### header`). MAB's `The Big Story` section is pure prose — none of the three match. Result:

```
WARNING engine.content_tracker: Could not extract any headlines from
digest section (1281 chars). Cross-episode dedup may miss repeated stories.
```

Visible downstream consequence in the same Ep031 run:

```
WARNING engine.generator: Story duplication in podcast script for
'Models & Agents for Beginners': blocks 2 and 4 share 2/2 proper-noun
signals (100%) — likely the same story retold. Shared: perplexity,
personal computer
```

The LLM retold the same Perplexity Personal Computer story twice in one episode because cross-episode dedup never built a signature for the prior day's coverage.

### Finding 2: Pre-flight LLM ping warns every run

```
WARNING engine.generator: LLM response truncated (finish_reason=length,
max_tokens=10) — output may end mid-sentence
```

The pre-flight ping intentionally uses `max_tokens=10` as a connectivity / API-key check. "Truncated" is the expected outcome. The warning fires every single run, training operators to ignore truncation alerts.

## Fix

### Content tracker — 4th fallback

```python
# Fallback 3: pure prose sections (e.g. MAB's "The Big Story" — no
# bold, no numbered list, no sub-headers, just a paragraph). Use
# the first substantive sentence as a topic signature so cross-
# episode dedup catches "we covered this story yesterday" via
# proper-noun overlap.
if not headlines:
    cleaned = re.sub(r"^\s*(\d+\.\s+|[-*]\s+)", "", text, flags=re.MULTILINE)
    sentence_match = re.search(r"([A-ZА-Я][^.!?\n]{30,200}[.!?])", cleaned)
    if sentence_match:
        t = sentence_match.group(1).strip()
        t = re.sub(r"[*_`]+", "", t).strip()  # strip residual markdown
        if t and t not in headlines:
            headlines.append(t)
```

Anchors on `[A-ZА-Я]` so Russian shows benefit if they ever take this branch (FP / PR currently extract via numbered/bold patterns).

### Truncation warning — gate on max_tokens

```python
if finish_reason == "length" and max_tokens >= 200:
    logger.warning(...)
```

Threshold of 200 is well below any digest / podcast call (smallest takes 4000+) and above every health-check / classifier path.

## Test plan

- [x] 4 new tests in `tests/test_content_tracker.py`:
  - `test_prose_section_falls_back_to_first_sentence` — the MAB Ep031 case
  - `test_prose_fallback_strips_inline_markdown`
  - `test_prose_fallback_handles_cyrillic`
- [x] 4 new tests in `tests/test_llm_truncation_gate.py`:
  - Pre-flight ping (max_tokens=10) → silent
  - Real completion (max_tokens=4000) → warns
  - Threshold boundary at 199/200
  - `finish_reason='stop'` → silent regardless of max_tokens
- [x] Full pytest suite: 1682 passing (was 1675; +7 net counting one threshold-boundary test).

## Audit findings deliberately deferred

- **`min_podcast_words` recalibration.** Today's MAB Ep031 came in at 963 words against target 1100 (12% short). Now have one post-Phase-3 datapoint with PR #335's metric. Want 3+ days of data before retuning.
- **Digest validator false positive on "The Big Story" item count.** Same root cause as Finding 1 (validator looks for numbered items in a prose section). Fix is bigger — needs per-section validator config — and deferring until the cross-episode dedup change has a day to bake.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_