### PR TITLE
fix(video): Shorts caption wrap defaults fit 90+ char hooks without truncation

### DIFF
--- a/engine/video.py
+++ b/engine/video.py
@@ -110,9 +110,18 @@ def _subtitles_path_escape(p: str) -> str:
     )
 
 
-def _wrap_caption(text: str, max_chars_per_line: int = 22,
-                  max_lines: int = 3) -> str:
-    """Greedy word-wrap for a Shorts caption, capped at *max_lines*."""
+def _wrap_caption(text: str, max_chars_per_line: int = 26,
+                  max_lines: int = 4) -> str:
+    """Greedy word-wrap for a Shorts caption, capped at *max_lines*.
+
+    May 8 2026: bumped defaults from ``22 × 3`` (66-char budget) to
+    ``26 × 4`` (104-char budget). Operator caught Tesla Ep466's
+    91-char hook ("California regulators just disclosed the Tesla
+    Semi's battery sizes at 822 kWh and 548 kWh.") truncating to
+    "...batter…" mid-word. The 9:16 1920-pixel vertical Shorts
+    canvas has plenty of room for 4 lines at 64 px (≈ 304 px stack);
+    ``y=240`` start position still leaves the brand pill above and
+    plenty of clear space below."""
     if not text:
         return ""
     words = text.split()

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -349,6 +349,28 @@ def test_wrap_caption_empty_returns_empty():
     assert _wrap_caption("") == ""
 
 
+def test_wrap_caption_default_budget_fits_realistic_hook():
+    """Operator caught (Tesla Ep466, May 8 2026) the default ``22 × 3``
+    budget (66 chars) truncating realistic 90+ char hooks to
+    ``...batter…`` mid-word. The new ``26 × 4`` defaults give a
+    104-char budget — enough headroom for the longest hooks the LLM
+    actually produces. Pin so a future "tighter wrap" change doesn't
+    silently re-introduce the truncation."""
+    hook = (
+        "California regulators just disclosed the Tesla Semi's battery "
+        "sizes at 822 kWh and 548 kWh."
+    )
+    out = _wrap_caption(hook)  # use defaults
+    # No truncation marker.
+    assert "..." not in out, (
+        f"Realistic 90+ char hook truncated under default wrap "
+        f"budget: {out!r}"
+    )
+    # Every word from the original survived (case-preserving).
+    for word in hook.split():
+        assert word in out, f"Word {word!r} dropped during wrap: {out!r}"
+
+
 # ---------------------------------------------------------------------------
 # Slideshow (stage 1) — multi-scene Ken Burns + concat
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Operator caught (Tesla Ep466, May 8 2026) the Shorts caption truncating:

> "California regulators just disclosed the Tesla Semi's battery sizes at 822 kWh and 548 kWh." (91 chars)

→ to `"...batter…"` mid-word.

## Root cause

`engine/video.py:_wrap_caption` defaults: `max_chars_per_line=22`, `max_lines=3` → 66-char budget. Realistic hooks the LLM produces are routinely 80–100+ chars.

## Fix

Bump defaults to `26 × 4` → 104-char budget. At 64 px font on a 1080×1920 vertical Shorts canvas, four 26-character lines occupy ~304 px stacked — fits comfortably between the brand pill at the top (`y=24`) and the lower-third clear area. The previous 22-char width was overly conservative for the actual rendered font.

The `_wrap_caption` algorithm is unchanged — only the defaults shifted. Callers passing explicit `max_chars_per_line=` are unaffected.

## Test plan

- [x] **New** `test_wrap_caption_default_budget_fits_realistic_hook` — uses defaults to wrap the Tesla Ep466 hook verbatim and asserts no truncation marker + every word survives.
- [x] Existing tests use explicit `max_chars_per_line=22` so they continue to verify the algorithm at any width.
- [x] Full pytest suite: 1707 passing (was 1706; +1).

## Companion PRs (same audit cycle)

- #343 (merged): voice compressor + sidechain ducking retune for "pumping" artifacts
- #344 (open): chapter auto-segment titles from content (vs. generic "Segment N")

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_