### PR TITLE
fix(video): stretch slideshow scenes to span full audio (no more visible loops)

### DIFF
--- a/engine/video.py
+++ b/engine/video.py
@@ -567,8 +567,28 @@ def build_long_form_video(
     bg_is_video = False
     if scene_paths and len(scene_paths) >= 2:
         slideshow_path = work_dir / f"{output_path.stem}_slides.mp4"
+        # Stretch each scene so the slideshow naturally spans the full
+        # audio duration. Operator caught (May 8 2026) the previous
+        # fixed 12 s/scene behaviour producing a 96 s slideshow that
+        # ``-stream_loop -1`` cycled 3-6× across a typical 5-10 min
+        # episode — listeners noticed the same eight photos on repeat.
+        # Floor at 8 s so a very short episode doesn't whip through
+        # scenes; no upper cap (long-form episodes get longer holds
+        # which the Ken Burns zoom keeps watchable).
+        from engine.audio import get_audio_duration as _get_duration
         try:
-            _render_slideshow(scene_paths, slideshow_path, fps=fps)
+            audio_duration_s = _get_duration(str(audio_path)) or 0.0
+        except Exception:
+            audio_duration_s = 0.0
+        if audio_duration_s > 0:
+            scene_duration_s = max(8.0, audio_duration_s / len(scene_paths))
+        else:
+            scene_duration_s = _SCENE_DURATION_SECONDS  # legacy 12 s
+        try:
+            _render_slideshow(
+                scene_paths, slideshow_path,
+                scene_duration=scene_duration_s, fps=fps,
+            )
             bg_path = slideshow_path
             bg_is_video = True
         except subprocess.CalledProcessError as exc:

--- a/tests/test_slideshow_scene_cadence.py
+++ b/tests/test_slideshow_scene_cadence.py
@@ -1,0 +1,119 @@
+"""Drift guard for the May 8 2026 slideshow scene-cadence fix.
+
+Operator caught the long-form video using a fixed 12 s/scene cadence:
+8 scenes × 12 s = 96 s slideshow, then ``-stream_loop -1`` cycled
+that 96-second clip across the full 5-10 minute audio. Result:
+listeners saw the same eight photos on repeat 3-6 times per episode.
+
+Fix: ``build_long_form_video`` now computes
+``scene_duration = max(8.0, audio_duration / len(scene_paths))`` so
+the slideshow naturally spans the full audio without visible loops.
+A 6-minute episode → 8 scenes × ~45 s each. A 30 s teaser →
+8 scenes × ~8 s (floor). A 30-minute deep-dive → 8 scenes × ~225 s
+(Ken Burns zoom keeps long holds watchable).
+
+These tests pin the math directly by mocking the slideshow render
+and audio-duration probe.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def stub_paths(tmp_path):
+    audio = tmp_path / "ep.mp3"
+    audio.write_bytes(b"\x00" * 1024)
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\x00" * 1024)
+    out = tmp_path / "ep.mp4"
+    scenes = []
+    for i in range(8):
+        p = tmp_path / f"scene_{i}.jpg"
+        p.write_bytes(b"\x00")
+        scenes.append(p)
+    return {"audio": audio, "cover": cover, "out": out, "scenes": scenes}
+
+
+def _capture_scene_duration(stub_paths, audio_duration_s, num_scenes=8):
+    """Run build_long_form_video with mocks and return the
+    scene_duration argument that was passed to _render_slideshow.
+
+    Mocks bypass the actual ffmpeg invocation so the test is fast
+    and deterministic.
+    """
+    from engine import video
+
+    captured = {}
+
+    def _fake_render_slideshow(scene_paths, output, *,
+                               scene_duration=None, **kwargs):
+        captured["scene_duration"] = scene_duration
+        # Pretend the render produced an output the caller can chain on.
+        Path(output).write_bytes(b"\x00")
+        return Path(output)
+
+    def _fake_long_form_cmd(*args, **kwargs):
+        return ["true"]  # noop
+
+    def _fake_subprocess_run(cmd, **kwargs):
+        class _R:
+            returncode = 0
+            stderr = b""
+        # Touch the expected output so the caller doesn't 404 it.
+        if "out" in kwargs:
+            pass
+        return _R()
+
+    with patch.object(video, "_render_slideshow", _fake_render_slideshow), \
+         patch.object(video, "_long_form_cmd", _fake_long_form_cmd), \
+         patch("subprocess.run", _fake_subprocess_run), \
+         patch("engine.audio.get_audio_duration", return_value=audio_duration_s):
+        scenes = stub_paths["scenes"][:num_scenes]
+        video.build_long_form_video(
+            stub_paths["audio"], stub_paths["cover"], stub_paths["out"],
+            scene_paths=scenes,
+        )
+    return captured.get("scene_duration")
+
+
+class TestSceneCadenceMatchesAudio:
+
+    def test_six_minute_episode_eight_scenes_44s_each(self, stub_paths):
+        """Typical Tesla / MAB episode: 360 s audio, 8 scenes →
+        45 s/scene (one cycle, no loops)."""
+        dur = _capture_scene_duration(stub_paths, audio_duration_s=360.0)
+        assert dur == pytest.approx(45.0, rel=0.01), (
+            f"Expected ~45 s/scene for 360 s/8, got {dur}"
+        )
+
+    def test_ten_minute_episode_eight_scenes_75s_each(self, stub_paths):
+        """Long-form episode: 600 s audio, 8 scenes → 75 s/scene."""
+        dur = _capture_scene_duration(stub_paths, audio_duration_s=600.0)
+        assert dur == pytest.approx(75.0, rel=0.01)
+
+    def test_thirty_second_teaser_clamps_to_floor(self, stub_paths):
+        """Very short audio gets clamped to the 8 s floor so scenes
+        don't whip past faster than the eye can register."""
+        dur = _capture_scene_duration(stub_paths, audio_duration_s=30.0)
+        assert dur == 8.0, f"Floor should clamp short episodes; got {dur}"
+
+    def test_zero_or_unknown_audio_falls_back_to_legacy_12s(self, stub_paths):
+        """If ``get_audio_duration`` can't read the file (returns 0),
+        keep the legacy 12 s default rather than producing a 0-second
+        slideshow that would crash the slideshow render."""
+        from engine.video import _SCENE_DURATION_SECONDS
+        dur = _capture_scene_duration(stub_paths, audio_duration_s=0.0)
+        assert dur == _SCENE_DURATION_SECONDS
+
+    def test_three_scenes_for_short_episode_still_floors(self, stub_paths):
+        """Short audio + small scene count: 30 s / 3 = 10 s per scene
+        (above floor); floor doesn't kick in here, no clamping needed."""
+        dur = _capture_scene_duration(
+            stub_paths, audio_duration_s=30.0, num_scenes=3,
+        )
+        assert dur == pytest.approx(10.0, rel=0.01)

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -557,6 +557,13 @@ def test_build_long_form_video_renders_slideshow_for_multi_scene(tmp_path,
         return type("R", (), {"returncode": 0})()
 
     monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    # ``build_long_form_video`` now probes audio duration via
+    # ``engine.audio.get_audio_duration`` (May 8 2026 — stretches scene
+    # duration to span audio). Stub it so the ffprobe subprocess that
+    # function would otherwise spawn doesn't show up in ``captured_cmds``.
+    monkeypatch.setattr(
+        "engine.audio.get_audio_duration", lambda _path: 360.0,
+    )
     build_long_form_video(audio, cover, out, scene_paths=scenes)
 
     # Two ffmpeg invocations: stage-1 slideshow, stage-2 composite.


### PR DESCRIPTION
## Why

Operator caught (May 8 2026) the long-form YouTube videos cycling the same eight photos 3-6 times across each episode.

## Root cause

`_render_slideshow` rendered 8 scenes × fixed 12 s = 96 s slideshow MP4, then `-stream_loop -1` cycled that 96-second clip across the full audio (typical 5-10 minute = 300-600 s episode). Listeners saw the loop boundary every minute and a half.

## Fix

`build_long_form_video` now probes the actual audio duration and computes:

```python
scene_duration = max(8.0, audio_duration / scene_count)
```

So the slideshow naturally lasts the full episode without visible loops. The Ken Burns 1.00 → 1.12 zoom over each scene's window keeps long holds watchable.

## Examples (with the standard 8-scene budget)

| Audio duration | Scene duration | Note |
|---|---|---|
| 60 s teaser | 8 s/scene | Floor — don't whip past viewers |
| 360 s typical | 45 s/scene | One cycle, no loops |
| 600 s deep dive | 75 s/scene | One cycle |
| 1800 s long-form | 225 s/scene | One cycle, longer holds |

Floor at 8 s prevents pathological short-episode behaviour. **No upper cap** — the Ken Burns zoom + careful Grok Imagine compositions make long static holds tolerable, and avoiding visible loops matters more than micro-pacing.

Falls back to the legacy 12 s if `get_audio_duration` can't read the file (rare; usually only happens in test stubs that mock `subprocess.run`).

## Test plan

- [x] 5 new tests in `tests/test_slideshow_scene_cadence.py` covering short / typical / long episodes + the 0-duration fallback + 3-scene small-budget case.
- [x] Existing `test_build_long_form_video_renders_slideshow_for_multi_scene` updated to stub `get_audio_duration` so the new ffprobe probe doesn't show up in its ffmpeg-invocation count.
- [x] Full pytest suite: 1712 passing (was 1707; +5).

## Companion PRs (today's audit cycle)

- #343 (merged): voice compressor + sidechain ducking retune
- #344 (merged): chapter auto-segment titles from content
- #345 (merged): Shorts caption wrap defaults fit realistic hooks

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_