### PR TITLE
fix(audio): chain acrossfade between sections to eliminate boundary clicks

### DIFF
--- a/engine/audio.py
+++ b/engine/audio.py
@@ -355,18 +355,56 @@ def concatenate_with_stings(
             if i < len(section_files) - 1:
                 interleaved.append(padded_sting)
 
-        # Concatenate with re-encoding for seamless joins
-        concat_list = tmp_dir / "sting_concat.txt"
-        with open(concat_list, "w", encoding="utf-8") as f:
+        # Concatenate with chained acrossfades. Operator caught
+        # (May 8 2026) audible clicks/ticks at every section boundary
+        # — Grok TTS chunks frequently end at non-zero amplitude (no
+        # trailing fade-out), and the previous ``-f concat`` demuxer
+        # joined them straight into the silent leading edge of
+        # ``padded_sting`` with no smoothing. The amplitude
+        # discontinuity at each junction was the audible "click".
+        # Chained ``acrossfade`` operations crossfade every junction
+        # by 30 ms — long enough to mask the discontinuity, short
+        # enough to be imperceptible as content overlap.
+        #
+        # The total output is shorter than the naive sum by
+        # (n_inputs - 1) * 0.03 s. For a typical 5-section episode
+        # with 4 stings, that's 8 junctions × 30 ms = 240 ms ≈ 0.24 s
+        # off a 6-minute mix — well within natural pacing variance.
+        n_inputs = len(interleaved)
+        if n_inputs >= 2:
+            input_args: List[str] = []
             for fp in interleaved:
-                f.write(f"file '{_ffmpeg_escape(fp)}'\n")
-
-        cmd = [
-            "ffmpeg", "-y", "-threads", "0",
-            "-f", "concat", "-safe", "0", "-i", str(concat_list),
-            "-c:a", "libmp3lame", "-q:a", "2",
-            str(output_path),
-        ]
+                input_args.extend(["-i", str(fp)])
+            # Build the chained acrossfade filter graph.
+            # First pair: [0:a][1:a]acrossfade...[a1]
+            # Subsequent: [a{i}][{i+1}:a]acrossfade...[a{i+1}]
+            xfade = "acrossfade=d=0.03:c1=tri:c2=tri"
+            chain_parts: List[str] = [
+                f"[0:a][1:a]{xfade}[a1]"
+            ]
+            for i in range(2, n_inputs):
+                prev = f"[a{i - 1}]"
+                this = f"[{i}:a]"
+                label = "[out]" if i == n_inputs - 1 else f"[a{i}]"
+                chain_parts.append(f"{prev}{this}{xfade}{label}")
+            filter_complex = ";".join(chain_parts)
+            cmd = [
+                "ffmpeg", "-y", "-threads", "0",
+                *input_args,
+                "-filter_complex", filter_complex,
+                "-map", "[out]",
+                "-c:a", "libmp3lame", "-q:a", "2",
+                str(output_path),
+            ]
+        else:
+            # Single input — just re-encode (preserves prior behaviour
+            # for the n=1 corner case the outer guard mostly handles).
+            cmd = [
+                "ffmpeg", "-y", "-threads", "0",
+                "-i", str(interleaved[0]),
+                "-c:a", "libmp3lame", "-q:a", "2",
+                str(output_path),
+            ]
         subprocess.run(cmd, check=True, capture_output=True)
 
     logger.info(

--- a/tests/test_transition_stings.py
+++ b/tests/test_transition_stings.py
@@ -366,3 +366,153 @@ class TestEndToEndSectionPipeline:
 
         # Sting should be configured
         assert cfg.audio.transition_sting is not None
+
+
+# =========================================================================
+# 8. TestSectionConcatAcrossfade
+# =========================================================================
+
+class TestSectionConcatAcrossfade:
+    """Pin the May 8 2026 fix that replaced ``-f concat`` demuxer with
+    chained ``acrossfade`` operations on section boundaries.
+
+    Operator caught audible clicks/ticks at every section boundary —
+    Grok TTS chunks frequently end at non-zero amplitude (no trailing
+    fade-out), and the demuxer joined them straight into the silent
+    leading edge of ``padded_sting`` with no smoothing. The amplitude
+    discontinuity at each junction was the audible click.
+
+    These tests verify the new ffmpeg command structure carries the
+    acrossfade filter chain so a future "let's go back to demuxer for
+    speed" refactor surfaces with a specific error.
+    """
+
+    def test_uses_acrossfade_filter_complex_for_multi_section(self, tmp_path):
+        """The ffmpeg command MUST use ``-filter_complex`` with chained
+        ``acrossfade=...:c1=tri:c2=tri`` operations, not ``-f concat``."""
+        sections = [tmp_path / f"sec_{i}.mp3" for i in range(3)]
+        for s in sections:
+            s.write_bytes(b"fake mp3")
+        sting = tmp_path / "sting.mp3"
+        sting.write_bytes(b"fake sting")
+        output = tmp_path / "out.mp3"
+
+        captured_cmds: list[list[str]] = []
+
+        def _fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            # Make output file exist so the function returns cleanly.
+            for i, arg in enumerate(cmd):
+                if arg.endswith(".mp3") and i == len(cmd) - 1:
+                    Path(arg).parent.mkdir(parents=True, exist_ok=True)
+                    Path(arg).write_bytes(b"\x00")
+            class _R:
+                returncode = 0
+                stderr = b""
+                stdout = b""
+            return _R()
+
+        with patch("engine.audio.subprocess.run", _fake_run):
+            concatenate_with_stings(sections, output, sting_path=sting)
+
+        # The FINAL ffmpeg invocation (the section concat) must use
+        # acrossfade-based filter_complex, not the demuxer concat.
+        # Filter the captured commands to find the one that produced
+        # the output path.
+        section_concat = next(
+            c for c in captured_cmds
+            if any(arg.endswith(output.name) for arg in c)
+        )
+        assert "-filter_complex" in section_concat, (
+            "Section concat must use -filter_complex (acrossfade chain), "
+            "not -f concat demuxer. The demuxer joins at sample "
+            "boundaries with no smoothing — produces clicks at every "
+            "section boundary."
+        )
+        assert "-f" not in section_concat or "concat" not in section_concat, (
+            "Section concat must NOT use -f concat demuxer."
+        )
+        fc_idx = section_concat.index("-filter_complex")
+        graph = section_concat[fc_idx + 1]
+        # Acrossfade with tri/tri curves is the smoothing primitive.
+        assert "acrossfade" in graph
+        assert "c1=tri" in graph and "c2=tri" in graph
+
+    def test_acrossfade_duration_is_30ms(self, tmp_path):
+        """The crossfade duration is 30 ms — long enough to mask the
+        amplitude discontinuity, short enough to be imperceptible as
+        content overlap. Pinning so a future "smaller" tweak doesn't
+        regress to a value that re-introduces audible clicks."""
+        sections = [tmp_path / f"sec_{i}.mp3" for i in range(2)]
+        for s in sections:
+            s.write_bytes(b"fake mp3")
+        sting = tmp_path / "sting.mp3"
+        sting.write_bytes(b"fake sting")
+        output = tmp_path / "out.mp3"
+
+        captured: list[list[str]] = []
+
+        def _fake_run(cmd, **kwargs):
+            captured.append(list(cmd))
+            for arg in cmd:
+                if arg.endswith(output.name):
+                    Path(arg).parent.mkdir(parents=True, exist_ok=True)
+                    Path(arg).write_bytes(b"\x00")
+            class _R:
+                returncode = 0
+                stderr = b""
+                stdout = b""
+            return _R()
+
+        with patch("engine.audio.subprocess.run", _fake_run):
+            concatenate_with_stings(sections, output, sting_path=sting)
+
+        section_concat = next(
+            c for c in captured if any(arg.endswith(output.name) for arg in c)
+        )
+        graph = section_concat[section_concat.index("-filter_complex") + 1]
+        # 30 ms duration must be present.
+        assert "d=0.03" in graph, (
+            f"Acrossfade duration must be 0.03 s; filter graph: {graph}"
+        )
+
+    def test_chains_acrossfade_for_n_inputs(self, tmp_path):
+        """For N inputs (sections + interleaved padded stings), the
+        graph must chain N-1 acrossfade operations producing a single
+        ``[out]`` label."""
+        # 3 sections + 2 stings = 5 inputs interleaved → 4 acrossfades
+        sections = [tmp_path / f"sec_{i}.mp3" for i in range(3)]
+        for s in sections:
+            s.write_bytes(b"x")
+        sting = tmp_path / "sting.mp3"
+        sting.write_bytes(b"x")
+        output = tmp_path / "out.mp3"
+
+        captured: list[list[str]] = []
+
+        def _fake_run(cmd, **kwargs):
+            captured.append(list(cmd))
+            for arg in cmd:
+                if arg.endswith(output.name):
+                    Path(arg).parent.mkdir(parents=True, exist_ok=True)
+                    Path(arg).write_bytes(b"\x00")
+            class _R:
+                returncode = 0
+                stderr = b""
+                stdout = b""
+            return _R()
+
+        with patch("engine.audio.subprocess.run", _fake_run):
+            concatenate_with_stings(sections, output, sting_path=sting)
+
+        section_concat = next(
+            c for c in captured if any(arg.endswith(output.name) for arg in c)
+        )
+        graph = section_concat[section_concat.index("-filter_complex") + 1]
+        # Final label is [out].
+        assert "[out]" in graph
+        # 4 acrossfade operations for 5 inputs.
+        assert graph.count("acrossfade") == 4
+        # -map [out] used as output target.
+        assert "-map" in section_concat
+        assert section_concat[section_concat.index("-map") + 1] == "[out]"


### PR DESCRIPTION
## Why

Operator caught (May 8 2026): *"unappealing audio artifacts… hisses and ticks are produced in the mixing process of mixing music and speech audio"*. Specifically clicks at section boundaries.

## Root cause

`engine/audio.py:concatenate_with_stings` joined section MP3s + padded stings via the **`-f concat` demuxer**. The demuxer decodes each input to PCM and butts them together at sample boundaries with no smoothing.

Grok TTS chunks frequently end at non-zero amplitude (no trailing fade-out). When the next-up `padded_sting` starts with silence (zero amplitude), the listener hears a sharp amplitude discontinuity → audible **click**. Same issue at the silence-end → next-section-start junction.

With 5 sections + 4 stings per typical episode, that's **8 click sources per episode**, each one a sharp artifact against the otherwise smooth mix.

## Fix

Replace the demuxer concat with chained `acrossfade` in a single `-filter_complex` graph. Each junction crossfades by **30 ms** with equal-power triangular curves:

```
[0:a][1:a]acrossfade=d=0.03:c1=tri:c2=tri[a1];
[a1][2:a]acrossfade=d=0.03:c1=tri:c2=tri[a2];
...
[a{N-2}][{N-1}:a]acrossfade=d=0.03:c1=tri:c2=tri[out]
```

- **30 ms** is long enough to fully mask any amplitude discontinuity but short enough to be imperceptible as content overlap.
- **`c1=tri:c2=tri`** (triangular equal-power) keeps perceived loudness constant through the crossfade.
- Total length impact: `(N - 1) × 30 ms`. For a 9-input case (5 sections + 4 stings) that's 240 ms shorter than the naive sum — well within natural pacing variance for a 6-minute episode.
- n=1 corner case falls back to a single re-encode (matches prior behaviour).

## Test plan

- [x] 3 new tests in `TestSectionConcatAcrossfade`:
  - `test_uses_acrossfade_filter_complex_for_multi_section` — pins that we use `-filter_complex` with acrossfade, NOT the `-f concat` demuxer
  - `test_acrossfade_duration_is_30ms` — pins the 30 ms duration (so a future "smaller" tweak doesn't regress to a value that re-introduces clicks)
  - `test_chains_acrossfade_for_n_inputs` — pins N-1 acrossfade operations for N inputs producing a single `[out]` label
- [x] Existing fallback-path tests (single-file copy, no-sting fallback) unchanged.
- [x] Full pytest suite: 1710 passing (was 1707; +3).

## Companion PRs (today's audit cycle)

- #343 (merged): voice compressor + sidechain ducking retune (the "pumping" half of the artifact complaint)
- #344 (merged): chapter auto-segment titles from content
- #345 (merged): Shorts caption wrap defaults fit realistic hooks
- #346 (merged): slideshow scene cadence spans full audio (no visible loops)

## How to verify

Tomorrow's runs (May 9). Listen specifically at section boundaries — should be smooth crossfades instead of audible clicks. The 30 ms overlap is below human perception threshold for content changes, so the listener experience is "no more ticks" rather than "now I hear overlapping content".

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_