### PR TITLE
fix(video): escape real newlines in drawtext to fix Shorts ffmpeg parse

### DIFF
--- a/engine/video.py
+++ b/engine/video.py
@@ -86,12 +86,42 @@ def _find_font() -> str:
 
 
 def _drawtext_escape(value: str) -> str:
-    """Escape a string for ffmpeg ``drawtext text=`` value."""
+    """Escape a string for ffmpeg ``drawtext text=`` value.
+
+    The text= value gets embedded inside a single-quoted region of
+    a ``-filter_complex`` graph. ffmpeg's filter_complex parser:
+
+      * Treats ``\\`` as a literal backslash.
+      * Treats ``\\'`` as a literal apostrophe inside the quoted region.
+      * **Terminates the quoted region on a literal line feed** —
+        which means a real newline character in our wrapped Shorts
+        caption truncates the text= value mid-string and the rest of
+        the filter graph parses as garbage.
+
+    Operator caught (Tesla Ep466, May 8 2026): the Shorts ffmpeg
+    invocation failed because the wrapped 4-line hook contained real
+    ``\\n`` newlines inside ``text='...'``. ffmpeg saw the first
+    newline, closed the quoted region, then choked on what looked
+    like a stray filter argument. Resulting metric:
+    ``youtube_short_uploaded: false`` with a
+    ``CalledProcessError`` containing the broken command.
+
+    Fix: escape real newlines to the literal two-character sequence
+    ``\\n`` (backslash + n). ffmpeg's drawtext text-expansion phase
+    runs *after* filter_complex parsing and recognises ``\\n`` as a
+    line break — so the rendered caption still wraps to multiple
+    lines, but the parser no longer terminates the quoted region
+    prematurely.
+
+    Order matters: escape backslashes FIRST so the new escapes don't
+    get re-escaped on the way out.
+    """
     return (
         value.replace("\\", "\\\\")
              .replace(":", r"\:")
              .replace("'", r"\'")
              .replace("%", r"\%")
+             .replace("\n", r"\n")
     )
 
 

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -327,6 +327,58 @@ def test_drawtext_escape_handles_metacharacters():
     assert _drawtext_escape("path\\to") == "path\\\\to"
 
 
+def test_drawtext_escape_escapes_real_newlines():
+    """Operator caught (Tesla Ep466, May 8 2026) the Shorts ffmpeg
+    invocation failing because the wrapped 4-line hook contained
+    real ``\\n`` characters inside ``text='...'``. ffmpeg's
+    filter_complex parser terminates a single-quoted region on a
+    real line feed, which truncated the text= value mid-string.
+
+    The fix escapes real newlines to the literal two-char sequence
+    ``\\n``. ffmpeg's drawtext text-expansion (which runs *after*
+    filter_complex parsing) recognises ``\\n`` as a line break, so
+    the caption still wraps visually."""
+    # Real newline → literal \n (backslash + n)
+    assert _drawtext_escape("line one\nline two") == r"line one\nline two"
+    # Multi-line with apostrophe — the actual Tesla Ep466 case
+    out = _drawtext_escape("Tesla Semi's\nbattery sizes")
+    assert "\n" not in out, (
+        f"Real newlines must be escaped to literal \\n; got {out!r}"
+    )
+    assert r"\n" in out
+    assert r"\'" in out
+
+
+def test_short_form_filter_graph_caption_has_no_real_newlines():
+    """End-to-end pin: the rendered Shorts filter graph for a
+    realistic multi-line hook MUST NOT contain real newline
+    characters inside the drawtext text= region. A real newline
+    there terminates ffmpeg's single-quoted parsing region and
+    breaks the entire filter graph — exactly what failed Tesla
+    Ep466's Shorts upload on May 8 2026."""
+    hook = (
+        "California regulators just disclosed the Tesla Semi's "
+        "battery sizes at 822 kWh and 548 kWh."
+    )
+    graph = _short_form_filter_graph(hook=hook)
+    # Find the drawtext text= region.
+    import re as _re
+    m = _re.search(r"text='([^']*(?:\\'[^']*)*)'", graph)
+    assert m is not None, "drawtext text= region not found in graph"
+    text_value = m.group(1)
+    # No real newlines may appear inside the quoted region.
+    assert "\n" not in text_value, (
+        f"Real newline survived into drawtext text= value (would break "
+        f"ffmpeg parsing): {text_value!r}"
+    )
+    # But the literal escape sequence \n MUST be present so the rendered
+    # caption still wraps to multiple lines.
+    assert r"\n" in text_value, (
+        f"Multi-line hook should produce literal \\n breaks; got "
+        f"{text_value!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Caption wrapping for Shorts
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Operator caught (Tesla Ep466, May 8 2026) the Shorts ffmpeg invocation failing with `CalledProcessError`, leaving Tesla without a Shorts upload today while the long-form succeeded.

```
youtube_long_form_uploaded: True
youtube_short_uploaded:    False
youtube_short_error: {'type': 'CalledProcessError', 'message': "Command '['ffmpeg', ...
  -filter_complex ...drawtext=...text='California regulators\njust disclosed the\nTesla Semi\\'s batter...'..."
```

## Root cause

`_wrap_caption` returns multi-line text joined with **real `\n` newline characters**. `_drawtext_escape` did NOT escape those, so the wrapped hook embedded into:

```
-filter_complex "...drawtext=...:text='line1<NL>line2<NL>...'..."
```

carried literal line-feed bytes inside the single-quoted region.

**ffmpeg's filter_complex parser terminates a single-quoted region on a literal line feed.** The first newline closed the `text=` value mid-string, then the rest of the filter graph parsed as garbage → fail.

Tesla Ep466's 91-char hook wrapped to 4 lines (4 newlines in the value) — but **any** Shorts hook ≥ 23 chars wraps to ≥ 2 lines. Tesla was just the noisy one because it had an apostrophe that made the broken-parse error look like an apostrophe issue. The actual silent-failure surface is much wider — most shows likely had broken Shorts ffmpeg commands today; Tesla's just made it into the metric file because its long-form succeeded enough for the run to complete.

## Fix

`_drawtext_escape` now also escapes real newlines to the literal two-character sequence `\n` (backslash + n):

```python
return (
    value.replace("\\", "\\\\")    # backslashes first
         .replace(":", r"\:")
         .replace("'", r"\'")
         .replace("%", r"\%")
         .replace("\n", r"\n")     # NEW: real newline → literal \n
)
```

ffmpeg's drawtext text-expansion phase runs **after** filter_complex parsing, and recognises `\n` (the literal 2-char sequence) as a line break. So the rendered caption still wraps to multiple visual lines, but the parser no longer terminates the quoted region prematurely.

## Test plan

- [x] **New** `test_drawtext_escape_escapes_real_newlines` — pure-function test of the escape rule (real `\n` → literal `\n`).
- [x] **New** `test_short_form_filter_graph_caption_has_no_real_newlines` — end-to-end pin: the rendered Shorts filter graph for a multi-line hook contains **NO** real newlines inside `text='…'` AND **DOES** contain literal `\n` for line breaks.
- [x] Existing tests at long-form + Shorts call sites pass unchanged (single-line text values weren't affected by the bug, aren't affected by the fix).
- [x] Full pytest suite: 1717 passing (was 1715; +2).

## Why no other show flagged this

Their long-form succeeded → `youtube_long_form_uploaded: true` made the run pass overall → no error visible at the run level. The Shorts failure was masked by the surrounding success. This PR also makes other shows' Shorts succeed tomorrow.

## Companion follow-ups

You also asked for show-name + nerranetwork.com branding overlays and a direct show-page link in the YouTube description. That's a larger change (per-show logo asset, description template, corner overlays) — shipping that as a separate PR right after this one for review clarity.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_