### PR TITLE
feat(youtube): direct show-page link at top of long-form + Shorts descriptions

### DIFF
--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -254,10 +254,20 @@ def build_long_form_metadata(
     subscribe_line = (
         f"🎧 Subscribe to {show_label} on the Nerra Network: {utm_link}"
     )
+    # Direct, no-frills show-page line at the top of the description.
+    # YouTube auto-hyperlinks the URL; keeps the show page one click away
+    # for any viewer who scrolls into "Show more". The bare URL (no UTM)
+    # is the canonical identity of the show on the network — operators
+    # use this URL on flyers, podcast directories, and so on, so it
+    # should match exactly when listeners cross-reference. The
+    # ``subscribe_line`` below carries the UTM-tracked variant for
+    # attribution.
+    show_page_line = f"🌐 Show page: {rss_link}"
 
     pieces: List[str] = []
     if hook:
         pieces.append(hook.strip())
+    pieces.append(show_page_line)
     pieces.append(subscribe_line)
     if body:
         pieces.append(body)
@@ -328,6 +338,10 @@ def build_short_metadata(
         f"{rss_link}{'&' if '?' in rss_link else '?'}"
         f"utm_source=youtube&utm_medium=shorts&utm_campaign=ep{episode_num}"
     )
+    # Show page link near the top — YouTube Shorts descriptions are
+    # short by design, so listeners who tap the title or "more" want
+    # the show page one click away.
+    pieces.append(f"🌐 Show page: {rss_link}")
     pieces.append(f"Subscribe to the podcast: {utm_link}")
     disclosure = (config.youtube.synthetic_disclosure or "").strip()
     if disclosure:

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -250,6 +250,53 @@ def test_build_long_form_metadata_includes_disclosure_and_utm():
     assert meta["default_language"] == "en"
 
 
+def test_build_long_form_metadata_includes_show_page_link_above_fold():
+    """Operator (May 8 2026) asked for a direct link to the show
+    webpage in every YouTube description so listeners can click
+    through to nerranetwork.com from the video. The link must appear
+    BEFORE the body paragraphs so it's visible above YouTube's
+    "Show more" fold (~150 chars on mobile).
+    """
+    config = _make_config()
+    meta = vm.build_long_form_metadata(
+        config,
+        episode_num=42,
+        today_str="2026-04-26",
+        hook="Robotaxi expands to Vancouver",
+        digest_text="Tesla announced robotaxi expansion today...",
+        audio_url="https://audio.nerranetwork.com/tesla/ep042.mp3",
+    )
+    desc = meta["description"]
+    # A visible "Show page:" line carries the bare canonical URL.
+    assert "Show page:" in desc
+    # The link itself (no UTM — that's the subscribe line below).
+    assert "https://nerranetwork.com/tesla.html" in desc
+    # Above-the-fold ordering: show page line appears before the body.
+    sp_idx = desc.index("Show page:")
+    body_idx = desc.index("robotaxi expansion")
+    assert sp_idx < body_idx, (
+        "Show page link must come before body paragraphs to stay above "
+        "YouTube's 'Show more' fold."
+    )
+
+
+def test_build_short_metadata_includes_show_page_link():
+    """Shorts descriptions are brief; the show page link must still
+    appear so a listener tapping into the description can reach the
+    show webpage."""
+    config = _make_config()
+    meta = vm.build_short_metadata(
+        config,
+        episode_num=42,
+        today_str="2026-04-26",
+        hook="Robotaxi expands to Vancouver",
+        long_form_url="https://www.youtube.com/watch?v=abcd1234",
+    )
+    desc = meta["description"]
+    assert "Show page:" in desc
+    assert "https://nerranetwork.com/tesla.html" in desc
+
+
 def test_build_long_form_metadata_strips_angle_brackets_from_hook():
     """Defense-in-depth final strip — even if the hook contains
     ``<`` / ``>`` (a chapter title quoting math, an unfortunate


### PR DESCRIPTION
## Why

Operator (May 8 2026) asked for a direct link to the show webpage in every YouTube video description so listeners can click through to nerranetwork.com from the video player.

The existing description had a UTM-tracked "Subscribe to <Show>" link, but it was framed as an action ("subscribe") rather than a destination. Many viewers don't recognize that the underlying URL is the show webpage.

## What

Add a dedicated `🌐 Show page: <bare URL>` line at the top of both long-form and Shorts descriptions — placed BEFORE the body paragraphs so it stays visible above YouTube's "Show more" fold (~150 chars on mobile).

### Long-form description order (top → bottom)

1. Hook _(above the fold)_
2. **🌐 Show page: https://nerranetwork.com/tesla.html** ← NEW
3. 🎧 Subscribe to Tesla Shorts Time on the Nerra Network: `<UTM-tagged URL>`
4. Body paragraphs (4 paragraphs of digest)
5. Chapters
6. Direct audio link
7. Photo attribution
8. AI disclosure footer

The bare URL is the canonical show identity (matches what's on flyers / podcast directories / cross-references). The UTM-tracked subscribe link sits one line below for attribution analytics — both URLs target the same page; the bare form is for the listener, the tracked form is for the operator.

### Shorts description order

1. Hook
2. Full episode link (when present)
3. **🌐 Show page: https://nerranetwork.com/tesla.html** ← NEW
4. Subscribe link (UTM)
5. AI disclosure
6. `#Shorts #podcast`

Tighter because Shorts descriptions are brief by design.

## Test plan

- [x] **New** `test_build_long_form_metadata_includes_show_page_link_above_fold` — asserts the line appears AND that it's positioned BEFORE the body paragraphs.
- [x] **New** `test_build_short_metadata_includes_show_page_link` — asserts the line appears in Shorts descriptions.
- [x] All other description tests (UTM, disclosure, angle-bracket strip, chapters block) pass unchanged.
- [x] Full pytest suite: 1715 passing (was 1713; +2).

## Companion PRs

- **#348** (open): TST Shorts ffmpeg parse fix — root cause why TST didn't have a Short today (real newlines in `text='…'`)
- **Coming next** (separate larger PR): video corner-overlay branding with per-show name pill + nerranetwork.com pill

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_