### PR TITLE
fix(calibration): retune min_podcast_words to ~1.05× actual median delivery

### DIFF
--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -148,7 +148,7 @@ llm:
   podcast_temperature: 0.75
   max_tokens: 3500
   podcast_max_tokens: 8000
-  min_podcast_words: 1500
+  min_podcast_words: 1050
   podcast_chain: true
 
 tts:

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -144,7 +144,7 @@ llm:
   podcast_temperature: 0.75
   max_tokens: 5000
   podcast_max_tokens: 6000
-  min_podcast_words: 1100
+  min_podcast_words: 900
 
 tts:
   # Inherits provider=grok, voice_id=sal, language_code=en, max_chars=10000

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -146,7 +146,7 @@ llm:
   podcast_temperature: 0.7
   max_tokens: 4000
   podcast_max_tokens: 8000
-  min_podcast_words: 1500
+  min_podcast_words: 1300
   podcast_chain: true
 
 tts:

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -153,7 +153,7 @@ llm:
   podcast_temperature: 0.7
   max_tokens: 4000
   podcast_max_tokens: 8000
-  min_podcast_words: 1300
+  min_podcast_words: 900
 
 tts:
   # Inherits provider=grok, voice_id=sal, language_code=en, max_chars=10000

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -190,7 +190,7 @@ llm:
   podcast_temperature: 0.70
   max_tokens: 3500
   podcast_max_tokens: 8000
-  min_podcast_words: 1400
+  min_podcast_words: 950
   podcast_chain: true
 
 tts:

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -114,7 +114,7 @@ llm:
   podcast_temperature: 0.75
   max_tokens: 4000
   podcast_max_tokens: 5000
-  min_podcast_words: 700
+  min_podcast_words: 650
 
 tts:
   # Olya — Russian voice. Migrated from ElevenLabs (`gedzfqL7OGdPbwm0ynTP`)

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -126,7 +126,7 @@ llm:
   podcast_temperature: 0.7
   max_tokens: 5000
   podcast_max_tokens: 8000
-  min_podcast_words: 1700
+  min_podcast_words: 1200
   podcast_chain: true
 
 tts:

--- a/tests/test_phase3_calibration.py
+++ b/tests/test_phase3_calibration.py
@@ -25,21 +25,42 @@ import pytest
 # ---------------------------------------------------------------------------
 
 class TestRecalibratedMinPodcastWords:
-    """Operator caught (May 6 2026 audit) ``script_below_target: true``
-    firing on 9 of 11 shows because the per-show ``min_podcast_words``
-    was set ~40 % above what the LLM actually delivered. New values
-    are roughly 1.1× rolling-7-day median, so the flag becomes a real
-    alarm again."""
+    """Operator caught (May 6 2026 Phase-3 audit) ``script_below_target:
+    true`` firing on 9 of 11 shows because the per-show
+    ``min_podcast_words`` was set ~40 % above what the LLM actually
+    delivered. Phase-3 dropped the targets to ~1.1× rolling-7-day
+    median.
+
+    May 9 2026 follow-up retune: with PR #335's raw-word-count metric
+    now feeding actual delivery data into the audit, the Phase-3
+    targets STILL fired ``script_below_target`` on every show every
+    day — Phase 3 estimated median delivery from logs but the actual
+    median (now visible in metrics_ep*.json) was lower. Targets
+    dropped a second time to ~1.05× empirical median:
+
+      tesla            : 1700 → 1200  (median 1129)
+      omni_view        : 1300 → 900   (median  867)
+      planetterrian    : 1400 → 950   (median  887)
+      fascinating_fron : 1500 → 1050  (median  985)
+      modern_investing : 1500 → 1300  (median 1224)
+      models_agents_b… : 1100 → 900   (median  878)
+      privet_russian   : 700  → 650   (median  601)
+
+    ``models_agents`` and ``unintended_consequences`` retain their
+    Phase-3 values until at least 5 post-Phase-3 episodes have
+    committed (insufficient data to retune confidently). FP keeps
+    its 900 target because the median 836 is close enough that the
+    flag should fire occasionally, which is the desired behaviour."""
 
     EXPECTED = {
-        "tesla":                   1700,
-        "fascinating_frontiers":   1500,
-        "planetterrian":           1400,
-        "modern_investing":        1500,
-        "omni_view":               1300,
+        "tesla":                   1200,
+        "fascinating_frontiers":   1050,
+        "planetterrian":           950,
+        "modern_investing":        1300,
+        "omni_view":               900,
         "unintended_consequences": 1300,
         "finansy_prosto":          900,
-        "privet_russian":          700,
+        "privet_russian":          650,
     }
 
     @pytest.mark.parametrize("slug,expected", list(EXPECTED.items()))


### PR DESCRIPTION
## Why

May 9 production review (7 episodes shipped) showed `script_below_target` firing on **every** episode of every show. Phase-3 (PR #327, May 6) had retuned targets to "1.1× rolling median" — but the medians were estimated from log-grepped word counts, not measured. PR #335 then started logging the actual word count to `metrics_ep*.json`, and today's data reveals that actual deliveries are systematically lower than Phase 3 assumed.

The flag is meant to fire ~10-20% of episodes when content is genuinely thin. Firing 100% of the time means operators tune it out — defeating the whole purpose of the alarm.

## Data (post-Phase-3 medians from `metrics_ep*.json`)

| Show | Phase-3 target | Actual median | Phase-3 ratio | New target | New ratio |
|---|---|---|---|---|---|
| tesla | 1700 | 1129 | 0.66 | **1200** | 1.06 |
| omni_view | 1300 | 867 | 0.67 | **900** | 1.04 |
| planetterrian | 1400 | 887 | 0.63 | **950** | 1.07 |
| fascinating_frontiers | 1500 | 985 | 0.66 | **1050** | 1.07 |
| modern_investing | 1500 | 1224 | 0.82 | **1300** | 1.06 |
| models_agents_beginners | 1100 | 878 | 0.80 | **900** | 1.03 |
| privet_russian | 700 | 601 | 0.86 | **650** | 1.08 |

## Held back (insufficient data or already-tuned)

- **models_agents** (1500): only 2 post-Phase-3 episodes; median 1106 suggests 1150 is the next step, but want 5+ samples first.
- **unintended_consequences** (1300): no post-Phase-3 episodes yet — weekday-only + topic-queue cadence.
- **finansy_prosto** (900): actual median 836 is close enough that the flag fires occasionally — that's the desired behaviour, leave it.

## Test plan

- [x] `tests/test_phase3_calibration.py:TestRecalibratedMinPodcastWords` updated with new pinned values + docstring explaining the May 9 retune.
- [x] All 13 Phase-3 tests pass.
- [x] Full pytest suite: 1730 passing.

## Verifying tomorrow's runs (May 10+)

The flag should now fire on ~1 in 10 episodes (when Grok happens to produce a notably short script) instead of every episode. If it still fires daily across multiple shows, the new targets are still too high; another data-driven retune is the right answer.

## What today's review also confirmed (no PR needed)

- ✅ TST + MAB **both** shipped Shorts today — PR #348 fix worked.
- ✅ YouTube long-form descriptions carry the `🌐 Show page:` line as the second line, well above the fold (verified by reproducing Tesla Ep467's metadata).
- ✅ Per-show pill PNGs generated (`_show_pill_tesla_shorts_time.png`) alongside the network URL pill (`_url_pill_v1.png`) — PR #350 producing the right artifacts.
- ✅ Audio mixing pipeline: 0 tag leaks, mix duration normal (~40 s on Tesla), no errors. With PRs #343 (compressor retune) + #347 (acrossfade boundaries) shipped before today's runs, the artifact concerns from May 8 should be substantially reduced.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_