### PR TITLE
feat(prompts): stakes-first hook pattern for Tesla + Modern Investing (pilot)

### DIFF
--- a/shows/prompts/modern_investing_digest.txt
+++ b/shows/prompts/modern_investing_digest.txt
@@ -156,7 +156,7 @@ If the trade data above is empty, skip the Yesterday's Trade Review section. Oth
 **Date:** {today_str}
 💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence
 
-**HOOK:** [One factual, specific sentence about today's most actionable market development. Under 120 characters. No URLs, no emoji.]
+**HOOK:** [One sentence (under 120 characters) about today's most actionable market development. **Lead with the listener's stake — what does this mean for a Canadian investor TODAY** — then the underlying fact. Compare: WEAK ("U.S. sanctions on 11 entities and three individuals in Iran, China, Belarus and UAE.") vs STRONG ("Energy holdings could squeeze tighter as fresh sanctions hit 11 entities across four countries."). WEAK ("Bank of Canada holds rate at 2.75%.") vs STRONG ("Mortgage shoppers and dividend hunters got the same answer today: the Bank of Canada is staying put at 2.75%."). Specific, not hype. No URLs, no emoji.]
 
 **Market Pulse:** 3-4 sentences. Where are markets right now? Key index levels (S&P 500, NASDAQ, TSX Composite). What's driving sentiment today? What should investors be watching?
 

--- a/shows/prompts/tesla_digest.txt
+++ b/shows/prompts/tesla_digest.txt
@@ -75,7 +75,7 @@ If fewer than 5 quality articles are available today:
 **Date:** {today_str}
 **REAL-TIME TSLA price:** ${price} {change_str}
 
-**HOOK:** [One factual sentence that captures the single most important Tesla story today. Under 120 characters. Specific, not hype. No URLs, no dates, no emoji.]
+**HOOK:** [One sentence (under 120 characters) that captures today's most important Tesla story. **Lead with the consequence or stake, then the fact** — don't just state what happened. Compare these styles: WEAK ("Tesla unveils robotaxi service in three Texas cities.") vs STRONG ("Tesla's Texas robotaxi rollout is the first real-world test of FSD without a driver."). WEAK ("California regulators disclosed Tesla Semi battery sizes at 822 kWh and 548 kWh.") vs STRONG ("Tesla Semi's 822 kWh battery just settled the long-haul-electric-truck argument."). Specific, not hype. No URLs, no dates, no emoji.]
 
 ━━━━━━━━━━━━━━━━━━━━
 ### Top 10 News Items


### PR DESCRIPTION
## Why

Two parallel script audits across May 6-9 episodes (news cluster: Tesla / MIT / Omni View; education cluster: MAB / M&A / FF / PT) found a consistent pattern across the news shows: hooks lead with the **fact**, not the **stake**.

```
Tesla Ep467: "Tesla Vision now deploys airbags up to 70 milliseconds earlier."
MIT Ep037:  "U.S. sanctions on 11 entities and three individuals in Iran, China, Belarus and UAE…"
M&A Ep042:  "OpenAI released three purpose-built audio models…"
```

Listeners hear a specific number, mentally tag it as trivia, and tune out before the show explains why it matters.

## Root cause

Both Tesla and MIT digest prompts ask the LLM for "one factual sentence":

```
**HOOK:** [One factual, specific sentence about today's most actionable market development.]
```

The HOOK is interpolated verbatim into the podcast prompt and becomes the opening 30 seconds of every episode. Constraint produces accurate but emotionally inert hooks.

## Fix

Pilot on Tesla + MIT (largest audiences, clearest patterns) — replace "factual sentence" with "lead with the consequence/stake, then the fact" and provide concrete weak/strong comparison examples drawn from real recent episodes:

### Tesla
> WEAK: "Tesla unveils robotaxi service in three Texas cities."
> STRONG: "Tesla's Texas robotaxi rollout is the first real-world test of FSD without a driver."
>
> WEAK: "California regulators disclosed Tesla Semi battery sizes at 822 kWh and 548 kWh."
> STRONG: "Tesla Semi's 822 kWh battery just settled the long-haul-electric-truck argument."

### Modern Investing
> WEAK: "U.S. sanctions on 11 entities and three individuals in Iran, China, Belarus and UAE."
> STRONG: "Energy holdings could squeeze tighter as fresh sanctions hit 11 entities across four countries."
>
> WEAK: "Bank of Canada holds rate at 2.75%."
> STRONG: "Mortgage shoppers and dividend hunters got the same answer today: the Bank of Canada is staying put at 2.75%."

The 120-char cap, "specific not hype" guard, and no-URLs / no-emoji constraints all stay — only the framing instruction shifts.

## Why pilot, not network-wide

Same hook weakness exists on Omni View, Models & Agents, Fascinating Frontiers — but I want to see one day's runs land cleanly under the new instruction before rolling it across 5 shows. If tomorrow's hooks read like the STRONG examples without overshooting into hype, replicate; otherwise the comparison examples make the prompt easy to dial back.

## Shows deliberately untouched (already working per audit)

- **MAB** — teen-friendly framing lands ("not so scary, right?", relatable problem → solution)
- **Planetterrian** — best-in-class "Right now, as you listen…" device anchors the listener
- **Fascinating Frontiers** — has the wonder when it leads with it; the issue is structural reorder (lemon-sized world line gets buried), not a hook framing tweak

## Test plan

- [x] Full pytest suite: 1730 passing — no test churn (prompts aren't test-pinned beyond YAML wiring).
- [ ] **Tomorrow's runs** (May 10 onward): listen to Tesla + MIT openings. Should sound like "Tesla's [thing] is now [consequence]" rather than "Tesla [verb-ed] [object]".

## Audit findings deferred to follow-ups (no PR yet)

- **Listicle pacing**: stories listed without "why this matters" between them — needs podcast prompt edit, not digest prompt
- **TTS-vs-blog mismatch**: Omni View MD has 15 stories, TTS covers 5; either include in TTS or trim from MD
- **Modern Investing strategy abstraction**: "alcohol and camping stocks" with no ticker / no price — needs prompt-level "show, don't tell" rule
- **Models & Agents 15-second rule**: needs explicit "human hook before specs" instruction
- **Fascinating Frontiers cosmic spotlight**: structural reorder, not a hook tweak

These are all real and worth shipping — just not in THIS PR. Each is a separate prompt iteration that benefits from observing this PR's effect first.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_