### PR TITLE
fix(pronunciation): Time-Daily blend + Planetterrian + tissue + neurodegenerative + hook rollout

### DIFF
--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -118,7 +118,13 @@ def clean_social_handles(text: str) -> str:
 _HANDLE_EXPANSIONS: Dict[str, str] = {
     "teslashortstime": "tesla shorts time",
     "omniviewnews": "omni view news",
-    "planetterrian": "planet terry an",
+    # @planetterrian X handle — same pronunciation as the show name
+    # (see WORD_PRONUNCIATIONS below). Tail is "uhn" not "un" because
+    # "UN" is in COMMON_ACRONYMS and gets re-substituted to "U N" by
+    # the case-insensitive acronym pass that runs after handle
+    # expansion — "uhn" reads identically as the schwa /ən/ but
+    # doesn't trigger the acronym match.
+    "planetterrian": "plan it tair ee uhn",
 }
 
 
@@ -332,8 +338,19 @@ COMMON_ACRONYMS: Dict[str, str] = {
 # Proper names and terms that TTS commonly mispronounces
 WORD_PRONUNCIATIONS: Dict[str, str] = {
     # --- Show names ---
-    "Planetterrian": "Planet-terry-an",
-    "planetterrian": "planet-terry-an",
+    # Operator caught (PT Ep059, May 10 2026) "Planetterrian" being
+    # mispronounced — the previous respelling "Planet-terry-an"
+    # parsed the hyphens as word breaks and the TTS inserted "Terry"
+    # the personal name in the middle ("PLAN-it · TER-ee · an").
+    # Intended pronunciation rhymes with "vegetarian":
+    # /ˌplæn.ɪˈtɛr.i.ən/ → PLAN-it-TAIR-ee-uhn. Spaces (no hyphens)
+    # let Grok TTS read the syllables as a single word with natural
+    # stress on the third syllable. Tail is "uhn" not "un" because
+    # "UN" is in COMMON_ACRONYMS and would be re-substituted to
+    # "U N" by the case-insensitive acronym pass that runs after
+    # this dict.
+    "Planetterrian": "plan it TAIR ee uhn",
+    "planetterrian": "plan it tair ee uhn",
 
     # --- Tesla product names ---
     "Robotaxis": "Robo-taxis",
@@ -401,6 +418,27 @@ WORD_PRONUNCIATIONS: Dict[str, str] = {
     "inflammaging": "inflamma-aging",
     "epigenetic": "epi-genetic",
     "epigenetics": "epi-genetics",
+
+    # Operator caught (PT Ep059, May 10 2026) Grok TTS mispronouncing
+    # both of these on a science-heavy episode:
+    #
+    #   "tissue" — Grok renders the /ʃ/ ("sh") incorrectly, producing
+    #     something like "TISS-yoo" or "TYE-soo" instead of "TISH-oo".
+    #     Standard pronunciation: /ˈtɪʃ.uː/.
+    #
+    #   "neurodegenerative" — long compound; Grok places stress
+    #     incorrectly and the middle "degen" gets glided. Standard:
+    #     /ˌnʊr.oʊ.dɪˈdʒɛn.ər.ə.tɪv/ → "NEW-row-de-JEN-er-uh-tiv".
+    #     The capitalised JEN hints stress to Grok; the explicit
+    #     hyphenation matches the syllable break.
+    "tissue": "tish-oo",
+    "tissues": "tish-ooz",
+    "Tissue": "Tish-oo",
+    "Tissues": "Tish-ooz",
+    "neurodegenerative": "newro-de-JEN-er-uh-tiv",
+    "Neurodegenerative": "Newro-de-JEN-er-uh-tiv",
+    "neurodegeneration": "newro-de-JEN-er-ay-shun",
+    "Neurodegeneration": "Newro-de-JEN-er-ay-shun",
 
     # --- AI model names ---
     "Qwen": "Chwen",

--- a/shows/prompts/fascinating_frontiers_digest.txt
+++ b/shows/prompts/fascinating_frontiers_digest.txt
@@ -28,7 +28,7 @@ If fewer than 5 quality articles are available today:
 **Date:** {today_str}
 🚀 **Fascinating Frontiers** - Space & Astronomy News
 
-**HOOK:** [One factual sentence that captures the single most important space or astronomy story today. Under 120 characters. Specific, not hype. No URLs, no dates, no emoji.]
+**HOOK:** [One sentence (under 120 characters) that captures today's most important space or astronomy story. **Lead with the mystery, scale, or stake — then the fact.** Compare: WEAK ("ESA and JAXA announced a joint Apophis flyby mission.") vs STRONG ("Two space agencies just teamed up to chase an asteroid that'll skim Earth in 2029."). WEAK ("Researchers detected an atmosphere on a distant Kuiper Belt object.") vs STRONG ("A lemon-sized world far past Neptune is somehow holding an atmosphere — gravity this weak shouldn't allow it."). Specific, not hype. No URLs, no dates, no emoji.]
 
 ━━━━━━━━━━━━━━━━━━━━
 ### Top 15 Space & Astronomy Stories

--- a/shows/prompts/models_agents_digest.txt
+++ b/shows/prompts/models_agents_digest.txt
@@ -60,7 +60,7 @@ If fewer than 5 quality articles are available today, cover what is available wi
 # Models & Agents
 **Date:** {today_str}
 
-**HOOK:** [One factual sentence that captures the single most exciting AI development today. Under 120 characters. Specific and concrete. No URLs, no dates, no emoji.]
+**HOOK:** [One sentence (under 120 characters) that captures today's most significant AI development. **Lead with what changes for builders or users — then the technical fact.** A professional audience still tunes out cold lists of model names; give them a 1-sentence "why care" before specs. Compare: WEAK ("OpenAI released three purpose-built audio models through the Realtime API.") vs STRONG ("Real-time voice agents just got cheaper and smarter — OpenAI split audio into three specialized models."). WEAK ("Anthropic donated Petri to Meridian Labs.") vs STRONG ("Anthropic's open-source alignment tool now lives outside its walls, free for any lab to extend."). Specific and concrete, not hype. No URLs, no dates, no emoji.]
 
 **What You Need to Know:** 2-3 sentences. Lead with the most significant development. Be specific — name the model, the framework, the version, the capability. End with what readers should pay attention to this week.
 

--- a/shows/prompts/omni_view_digest.txt
+++ b/shows/prompts/omni_view_digest.txt
@@ -20,7 +20,7 @@ Write a single website-friendly markdown briefing with this exact structure and 
 # Omni View — Omni‑View Briefing
 **Date:** {date_human}
 
-**HOOK:** [One factual sentence that captures the single most important or widely discussed story today. Under 120 characters. Specific and engaging. No URLs, no dates, no emoji.]
+**HOOK:** [One sentence (under 120 characters) that captures today's most important or widely discussed story. **Lead with the stake — what it means for ordinary people, regional stability, or the global outlook — then the fact.** Compare: WEAK ("UK local elections deliver heavy losses for Labour while Reform UK and pro-independence parties advance.") vs STRONG ("Britain's two-party stability just fractured: Labour bled councils to Reform UK and the SNP in a result not seen since the 1980s."). WEAK ("Pakistan launches airstrikes on Afghanistan.") vs STRONG ("Pakistan and Afghanistan are now openly at war on the border, with both sides reporting heavy casualties."). Specific and engaging, not hype. No URLs, no dates, no emoji.]
 
 ## Top stories (5)
 ## Top world stories (5)

--- a/shows/pronunciation_map.yaml
+++ b/shows/pronunciation_map.yaml
@@ -48,6 +48,16 @@ corrections:
   HW5: "H W five"
   AI5: "A I five"
 
+  # Operator caught (Tesla Ep468, May 10 2026) the show name
+  # "Tesla Shorts Time Daily" being mispronounced — Grok TTS glides
+  # the /m/ at the end of "Time" into the /d/ of "Daily" and the
+  # word comes out as "Time-aily" / "Timely" instead of two clearly
+  # separated words. Inserting a comma forces a brief pause that
+  # resets prosody at the junction. The text-only surfaces (digest,
+  # blog, RSS) read the standard form because this map only applies
+  # to the TTS copy of the script.
+  Tesla Shorts Time Daily: "Tesla Shorts Time, Daily"
+
   # ---------------- AI / tech ----------------
   # LLM and MCP are universally said as letter-by-letter; without this
   # entry Grok occasionally tries "lum" / "mick-pee".

--- a/tests/test_pronunciation.py
+++ b/tests/test_pronunciation.py
@@ -457,8 +457,20 @@ class TestApplyPronunciationFixes:
         assert "Cyber-truck" in result
 
     def test_planetterrian(self):
+        """Operator caught (PT Ep059, May 10 2026) the previous
+        respelling ``Planet-terry-an`` being mispronounced — Grok TTS
+        parsed the hyphens as word breaks and the personal name
+        "Terry" got inserted ("PLAN-it · TER-ee · an"). New respelling
+        matches the intended "vegetarian" cadence:
+        PLAN-it-TAIR-ee-uhn. Tail is "uhn" (not "un") because "UN" is
+        in COMMON_ACRONYMS — the case-insensitive acronym pass would
+        otherwise re-substitute "un" → "U N" and break the read."""
         result = apply_pronunciation_fixes("Welcome to Planetterrian")
-        assert "Planet-terry-an" in result
+        assert "plan it TAIR ee uhn" in result
+        # The old hyphenated form must NOT survive.
+        assert "Planet-terry-an" not in result
+        # The acronym-collision side-effect must NOT trigger.
+        assert "U N" not in result
 
     def test_teslarati(self):
         result = apply_pronunciation_fixes("According to Teslarati")


### PR DESCRIPTION
## Why

Operator caught **four** production mispronunciations across May 10 episodes. All fixed here plus the hook-pattern rollout from earlier in this PR.

## Fixes (all in `assets/pronunciation.py` + `shows/pronunciation_map.yaml`)

### 1. Tesla "Time Daily" blend (Ep468)

`Tesla Shorts Time Daily` rendered with the `/m/` end of "Time" gliding into the `/d/` onset of "Daily" → "Time-aily". The `/m/` requires lip closure that doesn't fully release before the alveolar `/d/`, so the `/d/` onset gets swallowed.

**Fix**: TTS-only respelling inserts a comma to reset prosody at the consonant junction:
```yaml
Tesla Shorts Time Daily: "Tesla Shorts Time, Daily"
```
Text-only surfaces (digest, blog, RSS, X teaser) keep the standard form.

### 2. Planetterrian respelling (Ep059)

Legacy `WORD_PRONUNCIATIONS["Planetterrian"] = "Planet-terry-an"` had Grok TTS treating the hyphens as word breaks and inserting "Terry" the name in the middle (`PLAN-it · TER-ee · an`). Confirmed intent is the "vegetarian" cadence: `PLAN-it-TAIR-ee-uhn`.

**Fix**: drop hyphens entirely, use spaces with stress-hint capitals:
```python
"Planetterrian": "plan it TAIR ee uhn"
```
Tail is `uhn` (not `un`) because `UN` is in `COMMON_ACRONYMS` and would be re-substituted to `U N` otherwise.

### 3. "tissue" (Ep059)

Grok TTS rendered `/ʃ/` wrong, producing "TISS-yoo" or "TYE-soo" instead of "TISH-oo".

**Fix**: pin standard `/ˈtɪʃ.uː/`:
```python
"tissue": "tish-oo"
```

### 4. "neurodegenerative" (Ep059)

Long compound; Grok stressed it incorrectly and "degen" got glided.

**Fix**: pin standard `/ˌnʊr.oʊ.dɪˈdʒɛn.ər.ə.tɪv/`:
```python
"neurodegenerative": "newro-de-JEN-er-uh-tiv"
```
Capitalised `JEN` hints stress; explicit hyphenation matches the syllable break. Sister word `neurodegeneration` added the same way.

## Listen-test candidates (surfaced by audit, NOT fixed in this PR)

The same audit pattern that found Planetterrian's bug flags three more entries with similar shape — but I'm **not** fixing them blindly because the cost of getting the respelling wrong twice is another mispronunciation in tomorrow's broadcast. Operator should listen-test these next time they appear in production:

| Entry | Current respelling | Suspected issue |
|---|---|---|
| Alnylam | `Al-nye-lam` | "Al" is a personal name + the standard pronunciation is /ælˈniː.ləm/ (al-NEE-lum), but the current respelling produces /æl naɪ læm/ (AL · NIGH · LAM) |
| Roscosmos | `Ross-cosmos` | "Ross" is a personal name; may render as "Ross's cosmos" |
| Teslarati | `Tesla-rah-tee` | "rah" might be read as cheering exclamation |

If you confirm any of these are wrong tomorrow, the same fix pattern (no hyphens, spaces, stress hint via capitals) applies.

## Hook-pattern rollout (unchanged from earlier draft)

PR #353's pilot landed cleanly today (Tesla Ep468 + MIT Ep038 both wrote stake-then-fact hooks). Replicating to OV / M&A / FF with show-specific weak/strong examples.

## Test plan

- [x] `test_planetterrian` updated to assert new respelling AND that legacy "Planet-terry-an" does NOT survive AND that "U N" collision does NOT fire.
- [x] End-to-end verification of all four substitutions through the actual `prepare_text_for_tts` pipeline.
- [x] Full pytest suite: 1730 passing.
- [ ] **Tomorrow's runs (May 11)**: listen-tests for all four corrected pronunciations.

## Why not a broader pre-emptive fix

Pronunciation respellings are subjective; getting one wrong is itself a mispronunciation for the audience. Confirmed reports get fixed; hypothesized risks get listen-tested first. This is the same caution that drove the corrected approach on the "Time Daily" fix earlier in this PR — the first attempt removed "Daily" entirely, which wasn't the right fix.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26