### PR TITLE
fix(recap): skip daily validator on Sunday weekly-recap to stop digest overwrite

### DIFF
--- a/run_show.py
+++ b/run_show.py
@@ -954,10 +954,24 @@ def run(args: argparse.Namespace) -> None:
     # 7b. Post-generation digest validation — catch structure issues before TTS.
     #      If critical sections are missing, retry digest generation once with an
     #      explicit instruction to include them.
+    #
+    # Skip entirely when in Sunday weekly-recap mode. Operator caught
+    # (May 10 2026) the recap digest produced by ``build_weekly_recap_digest``
+    # being silently OVERWRITTEN here: the daily-format validator
+    # rejected the recap (missing "Top 10 News Items", "Tesla First
+    # Principles", etc. — sections that don't apply on a recap day),
+    # the retry path called ``generate_digest`` with the live news
+    # template, and the synthesised recap content got replaced by a
+    # daily digest from TODAY's news. Six of seven recap-eligible
+    # shows shipped daily content on May 10 with the metric still
+    # claiming ``weekly_recap_mode: True``. M&A survived only because
+    # its validator config didn't enforce conflicting sections. Recaps
+    # have their own fixed shape ("This Week's Top Stories") and
+    # don't need the daily-format validator's protection.
     from engine.validation import validate_digest as _validate_digest, SHOW_VALIDATION_CONFIGS
     _val_factory = SHOW_VALIDATION_CONFIGS.get(config.slug)
     _exact_dups: list = []  # Populated by validate_digest for 100% cross-episode matches
-    if _val_factory:
+    if _val_factory and not is_weekly_recap:
         _val_config = _val_factory()
         _recent = content_tracker.get_recent_headlines(days=7)
         _val_passed, _val_issues, _exact_dups = _validate_digest(

--- a/tests/test_weekly_recap_validator_gate.py
+++ b/tests/test_weekly_recap_validator_gate.py
@@ -1,0 +1,93 @@
+"""Drift guard for the May 10 2026 weekly-recap-overwrite bug.
+
+Operator caught (Sunday May 10) six of seven recap-eligible shows
+shipping daily-format episodes despite their metrics correctly
+reporting ``weekly_recap_mode: True``. Root cause:
+
+  1. ``run_show.py`` built the recap digest via ``build_weekly_recap_digest``.
+  2. It then ran the daily-format validator
+     (``engine.validation.validate_digest``) against the recap content.
+  3. The daily validator rejected the recap because it expected
+     daily-format sections like ``Top 10 News Items``,
+     ``Tesla First Principles``, etc. — sections the recap shape
+     doesn't carry.
+  4. The retry path called ``generate_digest`` which fetched TODAY's
+     news and wrote a daily digest, OVERWRITING the synthesised recap.
+  5. The metric ``weekly_recap_mode: True`` stayed set from before
+     the overwrite, so observability lied about what shipped.
+
+Fix: gate the validator on ``not is_weekly_recap``. Recaps have
+their own fixed shape (``This Week's Top Stories``) and shouldn't be
+shape-checked by the daily validator.
+
+This test pins the gate in ``run_show.py`` source. A future "let's
+revalidate everything" refactor that drops the gate will trip this
+test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+_ROOT = Path(__file__).resolve().parent.parent
+_RUN_SHOW = _ROOT / "run_show.py"
+
+
+def test_validator_block_gated_on_not_weekly_recap():
+    """The daily-format validator must be skipped in recap mode.
+
+    Without the gate, ``build_weekly_recap_digest`` output was being
+    overwritten by ``generate_digest`` on Sundays — six of seven
+    recap-eligible shows shipped daily content on May 10 2026.
+    """
+    source = _RUN_SHOW.read_text(encoding="utf-8")
+    # The gate must reference both the validator factory AND the
+    # ``is_weekly_recap`` flag so a daily-format check doesn't fire
+    # on a recap digest.
+    assert "if _val_factory and not is_weekly_recap:" in source, (
+        "Daily-format validator block in run_show.py must be gated on "
+        "``not is_weekly_recap``. Without the gate, recap digests get "
+        "overwritten with daily content on Sundays. See May 10 2026 "
+        "incident comment in run_show.py:7b."
+    )
+
+
+def test_recap_digest_has_recap_shape_not_daily():
+    """The synthesised recap digest must have the ``Weekly Recap``
+    title heading and ``This Week's Top Stories`` section — those
+    are the markers the daily validator would flag as missing
+    daily sections, which is why the gate is necessary."""
+    from unittest.mock import patch
+    from datetime import date
+    from engine import weekly_recap
+
+    fake_episodes = [
+        {
+            "episode_num": 100,
+            "date": "2026-05-04",
+            "hook": "Lead story from earlier in the week.",
+            "digest_md": "# Some Show\n\nBody paragraph one.\n\nBody paragraph two.",
+        },
+        {
+            "episode_num": 101,
+            "date": "2026-05-05",
+            "hook": "Second story from mid-week.",
+            "digest_md": "# Some Show\n\nMid-week analysis.\n\nMore mid-week analysis.",
+        },
+    ]
+
+    with patch("engine.content_lake.query_show_range", return_value=fake_episodes):
+        out = weekly_recap.build_weekly_recap_digest(
+            "tesla", "Tesla Shorts Time", date(2026, 5, 10),
+        )
+
+    assert out is not None
+    # Recap-shaped header — distinct from daily.
+    assert "— Weekly Recap" in out
+    # Recap-shaped section — distinct from "Top 10 News Items".
+    assert "This Week's Top Stories" in out
+    # Hook explicitly references the look-back framing.
+    assert "Looking back at" in out


### PR DESCRIPTION
## Why

Operator caught (Sunday May 10 2026) **six of seven** recap-eligible shows shipping **daily-format episodes** despite metrics reporting `weekly_recap_mode: True`:

| Show | Today's digest header | Was it actually a recap? |
|---|---|---|
| tesla_shorts_time | `# Tesla Shorts Time` | ❌ |
| omni_view | `# Omni View — Omni‑View Briefing` | ❌ |
| planetterrian | `# Planetterrian Daily` | ❌ |
| fascinating_frontiers | `# Fascinating Frontiers` | ❌ |
| **models_agents** | `# Models & Agents — Weekly Recap` | ✅ |
| models_agents_beginners | `# Models & Agents for Beginners` | ❌ |
| modern_investing | `# Modern Investing Techniques` | ❌ |

## Root cause

`run_show.py:7b` runs `engine.validation.validate_digest` against **every** digest — including the recap synthesised by `engine.weekly_recap.build_weekly_recap_digest`. The daily-format validator rejects the recap because it expects daily-only sections (`Top 10 News Items`, `Tesla First Principles`, etc.).

The retry path then calls `generate_digest` which fetches TODAY's news and writes a fresh DAILY digest, **overwriting the recap**. The `weekly_recap_mode: True` metric was already recorded by the time the overwrite happened, so observability falsely claimed recap mode shipped.

M&A survived only because its `SHOW_VALIDATION_CONFIGS` entry doesn't enforce sections that conflict with the recap shape — the six others have stricter validators that all rejected and triggered the retry.

## Fix

Gate the validator block on `not is_weekly_recap`:

```diff
- if _val_factory:
+ if _val_factory and not is_weekly_recap:
```

Recaps have their own fixed shape (`# <Show> — Weekly Recap` / `This Week's Top Stories` / `Looking back at N episodes…`) and don't need the daily-format validator's protection — they ARE structured, just structured differently.

## Test plan

- [x] **New** `test_validator_block_gated_on_not_weekly_recap` — pins the `and not is_weekly_recap` clause in `run_show.py` source so a future refactor can't drop it silently.
- [x] **New** `test_recap_digest_has_recap_shape_not_daily` — confirms the recap output uses recap-only markers (`Weekly Recap` title, `This Week's Top Stories`, `Looking back at` hook) that the daily validator would have flagged as missing daily sections (which is exactly the failure mode this PR fixes).
- [x] Full pytest suite: 1732 passing (was 1730; +2).
- [ ] **Next Sunday's runs (May 17)**: all 7 recap-eligible shows should ship "Looking back at the past week"-framed episodes, not "Let's get into what's moving in the Tesla world today".

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_