### PR TITLE
audio: fix intro garbling, voice-enters-at-10s, slow 20s outro fade

### DIFF
--- a/engine/audio.py
+++ b/engine/audio.py
@@ -775,6 +775,22 @@ def mix_with_music(
 
         fade_start = intro_duration + overlap_duration
 
+        # Acrossfade window between consecutive music segments. Each
+        # segment's source-time slice is shifted back by this amount
+        # (and its duration extended by the same) so the crossfade
+        # region plays *identical* source content from both segments —
+        # just at different volume curves. Before May 12 2026 the
+        # overlap segment started at source second ``intro_duration``
+        # and the fadeout at ``intro_duration + overlap_duration``,
+        # which made the crossfade region sum two TEMPORALLY ADJACENT
+        # but DIFFERENT source passages (e.g. seconds 23–25 against
+        # seconds 25–27 of the music). The two passages had unrelated
+        # drum hits / chord changes, so the crossfade window sounded
+        # like two songs playing on top of each other for 2 s —
+        # operator caught this as "music gets garbled right before
+        # speech starts" on TST Ep470.
+        _MUSIC_XFADE_S = 2.0
+
         def _run_segment(name: str, cmd: list) -> str:
             subprocess.run(cmd, check=True, capture_output=True)
             return name
@@ -804,17 +820,26 @@ def mix_with_music(
             outro_fade_in = 6
             outro_fade_out_start = max(outro_duration - outro_fade_out_dur, 0)
 
+        # Coherent acrossfade: overlap and fadeout source slices are
+        # shifted back by ``_MUSIC_XFADE_S`` and extended by the same
+        # amount so the crossfade window plays identical source
+        # content from both segments. See _MUSIC_XFADE_S docstring above.
+        overlap_src_start = max(intro_duration - _MUSIC_XFADE_S, 0)
+        overlap_src_duration = overlap_duration + _MUSIC_XFADE_S
+        fadeout_src_start = max(fade_start - _MUSIC_XFADE_S, 0)
+        fadeout_src_duration = fade_duration + _MUSIC_XFADE_S
+
         segment_cmds = [
             ("intro", _music_intro_cmd(
                 str(music_path), str(music_intro_f),
                 duration=intro_duration, volume=intro_volume)),
             ("overlap", _music_overlap_cmd(
                 str(music_path), str(music_overlap_f),
-                start=intro_duration, duration=overlap_duration,
+                start=overlap_src_start, duration=overlap_src_duration,
                 volume=overlap_volume)),
             ("fadeout", _music_fadeout_cmd(
                 str(music_path), str(music_fadeout_f),
-                start=fade_start, duration=fade_duration,
+                start=fadeout_src_start, duration=fadeout_src_duration,
                 volume=fade_volume)),
             ("outro", _music_outro_cmd(
                 str(outro_music), str(music_outro_f),

--- a/engine/config.py
+++ b/engine/config.py
@@ -112,26 +112,34 @@ class AudioConfig:
     music_file: Optional[str] = None
     background_music_file: Optional[str] = None
     transition_sting: Optional[str] = None
-    # Music timing — May 2026 podcast-feel bump (revised). Aligned with
-    # ``shows/_defaults.yaml`` so a show running with the dataclass
-    # defaults (no YAML) gets the same behaviour as a show inheriting
-    # from the network baseline. Total intro music presence =
-    # intro_duration (alone) + overlap_duration (with voice) +
-    # fade_duration (under-voice tail) = 25 + 10 + 20 = 55s. Outro =
-    # 60s after voice ends with a 6s graceful fade-out close.
+    # Music timing — May 12 2026 retune. Operator caught (TST Ep470)
+    # that the 25 s music-alone intro felt too long ("when's the host
+    # going to talk?") and the 60 s post-voice outro felt too long /
+    # ended abruptly. New shape:
+    #   * intro_duration 10 s — music plays alone for 10 s before voice
+    #   * overlap_duration 15 s — music sits with voice
+    #   * fade_duration 30 s — slow log-fade under voice (no abrupt
+    #     cut; total intro music presence = 10+15+30 = 55 s, same
+    #     total as before, just front-shifted so voice enters sooner)
+    #   * outro_duration 20 s — music plays for 20 s after voice ends
+    #   * outro_fade_out_duration 15 s — most of the 20 s post-voice
+    #     outro is a graceful fade (5 s sustain + 15 s log-fade-out)
+    #   * outro_crossfade 20 s preserved — music begins ramping under
+    #     the last 20 s of voice, so the transition into the outro is
+    #     graceful rather than the music popping in cold.
     # ``voice_intro_delay`` MUST stay >= ``intro_duration`` so the
     # voice doesn't enter while the music intro is still in its
-    # alone-period. Operator's stated minimum is >= 30s on both ends.
-    intro_duration: float = 25.0
-    overlap_duration: float = 10.0
-    fade_duration: float = 20.0
-    outro_duration: float = 60.0
-    outro_fade_out_duration: float = 6.0
+    # alone-period (10 >= 10 holds).
+    intro_duration: float = 10.0
+    overlap_duration: float = 15.0
+    fade_duration: float = 30.0
+    outro_duration: float = 20.0
+    outro_fade_out_duration: float = 15.0
     intro_volume: float = 0.6
     overlap_volume: float = 0.5
     fade_volume: float = 0.4
     outro_volume: float = 0.4
-    voice_intro_delay: float = 25.0
+    voice_intro_delay: float = 10.0
     outro_crossfade: float = 0.0
 
 

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -75,20 +75,33 @@ tts:
 audio:
   min_audio_duration: 180
   transition_sting: assets/music/transition_sting.mp3
-  # Music timing — bumped *again* in May 2026 after the operator
-  # reported that the intro and outro still cut off too quickly on
-  # TST and MAB. Total intro music presence is now 55s
-  # (25 alone + 10 overlap + 20 fade-tail) and the outro runs 60s
-  # after voice ends with a 6s graceful close. ``voice_intro_delay``
-  # MUST stay >= ``intro_duration`` so the voice doesn't enter while
-  # the music intro is still in its alone-period.
-  voice_intro_delay: 25.0
-  intro_duration: 25.0
-  overlap_duration: 10.0
-  fade_duration: 20.0
-  outro_duration: 60.0
+  # Music timing — retuned May 12 2026 after operator listened to
+  # TST Ep470 and called three issues:
+  #   1. music "got garbled" right before speech starts (fixed in
+  #      engine/audio.py: overlap and fadeout source slices now
+  #      overlap by the acrossfade window so the crossfade plays
+  #      identical source content from both segments)
+  #   2. voice should enter at 10 s, not 25 s, with music continuing
+  #      under voice and fading out rather than cutting
+  #   3. post-voice outro should run only 20 s and fade slowly out
+  #      (was 60 s with a 6 s tail-cut, felt abrupt)
+  # New shape: 10 s music alone + 15 s overlap with voice + 30 s
+  # log-fade under voice = 55 s total intro music presence (same
+  # total as before, just front-shifted). Outro = 20 s music after
+  # voice ends, with most of that being a slow 15 s fade-out.
+  # ``outro_crossfade`` stays at 20 s so music ramps into the close
+  # under the last 20 s of voice; combined with the 20 s post-voice
+  # outro that's a 40 s outro segment with 5 s sustain + 15 s fade.
+  # ``voice_intro_delay`` MUST stay >= ``intro_duration`` so the
+  # voice doesn't enter while the music intro is still in its
+  # alone-period (10 >= 10 holds).
+  voice_intro_delay: 10.0
+  intro_duration: 10.0
+  overlap_duration: 15.0
+  fade_duration: 30.0
+  outro_duration: 20.0
   outro_crossfade: 20.0
-  outro_fade_out_duration: 6.0
+  outro_fade_out_duration: 15.0
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -187,12 +187,14 @@ tts:
 audio:
   music_file: assets/music/EnvIntel.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 25.0
-  intro_duration: 25.0
-  overlap_duration: 10.0
-  fade_duration: 20.0
-  outro_duration: 60.0
+  # May 12 2026 retune (see shows/_defaults.yaml).
+  voice_intro_delay: 10.0
+  intro_duration: 10.0
+  overlap_duration: 15.0
+  fade_duration: 30.0
+  outro_duration: 20.0
   outro_crossfade: 20.0
+  outro_fade_out_duration: 15.0
   intro_volume: 0.4
   overlap_volume: 0.3
   fade_volume: 0.25

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -167,12 +167,17 @@ audio:
   # for emergency rollback.
   music_file: assets/music/fascinatingfrontiers_bg.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 25.0
-  intro_duration: 25.0
-  overlap_duration: 10.0
-  fade_duration: 27.0
-  outro_duration: 60.0
+  # May 12 2026 retune (see shows/_defaults.yaml). FF previously pinned
+  # fade_duration at 27 s (network baseline was 20 s, FF was +7); with
+  # the new 30 s baseline FF returns to the network default. Operator
+  # can re-tune up if FF specifically needs a longer under-voice tail.
+  voice_intro_delay: 10.0
+  intro_duration: 10.0
+  overlap_duration: 15.0
+  fade_duration: 30.0
+  outro_duration: 20.0
   outro_crossfade: 20.0
+  outro_fade_out_duration: 15.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -184,12 +184,14 @@ tts:
 audio:
   music_file: "assets/music/Финансы Просто.mp3"
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 25.0
-  intro_duration: 25.0
-  overlap_duration: 10.0
-  fade_duration: 20.0
-  outro_duration: 60.0
+  # May 12 2026 retune (see shows/_defaults.yaml).
+  voice_intro_delay: 10.0
+  intro_duration: 10.0
+  overlap_duration: 15.0
+  fade_duration: 30.0
+  outro_duration: 20.0
   outro_crossfade: 20.0
+  outro_fade_out_duration: 15.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -177,12 +177,14 @@ tts:
 audio:
   music_file: assets/music/ModelsAgents.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 25.0
-  intro_duration: 25.0
-  overlap_duration: 10.0
-  fade_duration: 20.0
-  outro_duration: 60.0
+  # May 12 2026 retune (see shows/_defaults.yaml).
+  voice_intro_delay: 10.0
+  intro_duration: 10.0
+  overlap_duration: 15.0
+  fade_duration: 30.0
+  outro_duration: 20.0
   outro_crossfade: 20.0
+  outro_fade_out_duration: 15.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -155,12 +155,14 @@ tts:
 audio:
   music_file: assets/music/ModelsAgents.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 25.0
-  intro_duration: 25.0
-  overlap_duration: 10.0
-  fade_duration: 20.0
-  outro_duration: 60.0
+  # May 12 2026 retune (see shows/_defaults.yaml).
+  voice_intro_delay: 10.0
+  intro_duration: 10.0
+  overlap_duration: 15.0
+  fade_duration: 30.0
+  outro_duration: 20.0
   outro_crossfade: 20.0
+  outro_fade_out_duration: 15.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -159,12 +159,14 @@ audio:
   # TODO: Generate dedicated music file — see assets/music/README.md for prompt.
   # Falling back to TST theme until modern_investing.mp3 is created.
   music_file: assets/music/ModernInvesting.mp3
-  voice_intro_delay: 25.0
-  intro_duration: 25.0
-  overlap_duration: 10.0
-  fade_duration: 20.0
-  outro_duration: 60.0
+  # May 12 2026 retune (see shows/_defaults.yaml).
+  voice_intro_delay: 10.0
+  intro_duration: 10.0
+  overlap_duration: 15.0
+  fade_duration: 30.0
+  outro_duration: 20.0
   outro_crossfade: 20.0
+  outro_fade_out_duration: 15.0
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -164,12 +164,14 @@ tts:
 audio:
   music_file: assets/music/OmniView.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 25.0
-  intro_duration: 25.0
-  overlap_duration: 10.0
-  fade_duration: 20.0
-  outro_duration: 60.0
+  # May 12 2026 retune (see shows/_defaults.yaml).
+  voice_intro_delay: 10.0
+  intro_duration: 10.0
+  overlap_duration: 15.0
+  fade_duration: 30.0
+  outro_duration: 20.0
   outro_crossfade: 20.0
+  outro_fade_out_duration: 15.0
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -202,12 +202,14 @@ tts:
 audio:
   music_file: assets/music/oilers-pride.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 25.0
-  intro_duration: 25.0
-  overlap_duration: 10.0
-  fade_duration: 20.0
-  outro_duration: 60.0
+  # May 12 2026 retune (see shows/_defaults.yaml).
+  voice_intro_delay: 10.0
+  intro_duration: 10.0
+  overlap_duration: 15.0
+  fade_duration: 30.0
+  outro_duration: 20.0
   outro_crossfade: 20.0
+  outro_fade_out_duration: 15.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -130,12 +130,14 @@ tts:
 
 audio:
   music_file: "assets/music/ПриветРусский.mp3"
-  voice_intro_delay: 25.0
-  intro_duration: 25.0
-  overlap_duration: 10.0
-  fade_duration: 20.0
-  outro_duration: 60.0
+  # May 12 2026 retune (see shows/_defaults.yaml).
+  voice_intro_delay: 10.0
+  intro_duration: 10.0
+  overlap_duration: 15.0
+  fade_duration: 30.0
+  outro_duration: 20.0
   outro_crossfade: 20.0
+  outro_fade_out_duration: 15.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -140,12 +140,16 @@ tts:
 audio:
   music_file: assets/music/tesla_shorts_time.mp3
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 25.0
-  intro_duration: 25.0
-  overlap_duration: 10.0
-  fade_duration: 20.0
-  outro_duration: 60.0
+  # May 12 2026 retune (see shows/_defaults.yaml). Voice enters at 10 s,
+  # music continues 45 s under voice with a 30 s log-fade, post-voice
+  # outro is 20 s with a slow 15 s fade-out.
+  voice_intro_delay: 10.0
+  intro_duration: 10.0
+  overlap_duration: 15.0
+  fade_duration: 30.0
+  outro_duration: 20.0
   outro_crossfade: 20.0
+  outro_fade_out_duration: 15.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/unintended_consequences.yaml
+++ b/shows/unintended_consequences.yaml
@@ -43,12 +43,14 @@ audio:
   # leaving this empty cleanly skips the mix step. Once a track exists,
   # add `music_file: assets/music/unintended_consequences.mp3` here.
   transition_sting: assets/music/transition_sting.mp3
-  voice_intro_delay: 25.0
-  intro_duration: 25.0
-  overlap_duration: 10.0
-  fade_duration: 20.0
-  outro_duration: 60.0
+  # May 12 2026 retune (see shows/_defaults.yaml).
+  voice_intro_delay: 10.0
+  intro_duration: 10.0
+  overlap_duration: 15.0
+  fade_duration: 30.0
+  outro_duration: 20.0
   outro_crossfade: 20.0
+  outro_fade_out_duration: 15.0
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3

--- a/tests/test_audio_commands.py
+++ b/tests/test_audio_commands.py
@@ -580,11 +580,13 @@ class TestAudioConfigDefaults:
     """Verify AudioConfig dataclass has the new fields with correct defaults."""
 
     def test_voice_intro_delay_default(self):
-        """May 2026: dataclass default matches the network baseline of
-        ``intro_duration`` so a no-YAML show still behaves correctly."""
+        """May 12 2026 retune: dataclass default matches the network
+        baseline (10 s music alone before voice). ``voice_intro_delay``
+        must stay >= ``intro_duration`` so the voice never enters
+        before the music intro's alone-period finishes."""
         from engine.config import AudioConfig
         cfg = AudioConfig()
-        assert cfg.voice_intro_delay == 25.0
+        assert cfg.voice_intro_delay == 10.0
         assert cfg.voice_intro_delay >= cfg.intro_duration
 
     def test_background_music_file_default(self):
@@ -593,25 +595,30 @@ class TestAudioConfigDefaults:
         assert cfg.background_music_file is None
 
     def test_all_timing_defaults(self):
-        """May 2026 podcast-feel bump — see AudioConfig docstring.
-        Total intro music presence (alone + overlap + fade) must be
-        >= 30s so the open doesn't feel cut off; outro must also be
-        >= 30s for a real-podcast close."""
+        """May 12 2026 retune — see AudioConfig docstring. Voice enters
+        at 10 s, total intro music presence remains 55 s (10 alone +
+        15 overlap + 30 fade), post-voice outro is 20 s with a slow
+        15 s fade-out. Operator invariant: ≥30 s total intro music
+        presence preserved."""
         from engine.config import AudioConfig
         cfg = AudioConfig()
-        assert cfg.intro_duration == 25.0
-        assert cfg.overlap_duration == 10.0
-        assert cfg.fade_duration == 20.0
-        assert cfg.outro_duration == 60.0
+        assert cfg.intro_duration == 10.0
+        assert cfg.overlap_duration == 15.0
+        assert cfg.fade_duration == 30.0
+        assert cfg.outro_duration == 20.0
+        assert cfg.outro_fade_out_duration == 15.0
         assert cfg.intro_volume == 0.6
         assert cfg.overlap_volume == 0.5
         assert cfg.fade_volume == 0.4
         assert cfg.outro_volume == 0.4
-        # Operator invariant: ≥30s total intro presence, ≥30s outro.
+        # Operator invariant: ≥30 s total intro music presence so the
+        # open doesn't feel cut off (now 55 s).
         assert (
             cfg.intro_duration + cfg.overlap_duration + cfg.fade_duration
         ) >= 30.0
-        assert cfg.outro_duration >= 30.0
+        # outro_duration is now 20 s post-voice (was 60 s); most of
+        # it is the slow fade-out, so the close still feels graceful.
+        assert cfg.outro_duration >= 20.0
 
 
 class TestShowMusicConfigs:
@@ -625,8 +632,8 @@ class TestShowMusicConfigs:
     def test_tesla_has_music(self, load_config):
         cfg = load_config("shows/tesla.yaml")
         assert cfg.audio.music_file == "assets/music/tesla_shorts_time.mp3"
-        # May 2026 podcast-feel bump — see landmine in AudioConfig.
-        assert cfg.audio.voice_intro_delay == 25.0
+        # May 12 2026 retune — see AudioConfig docstring.
+        assert cfg.audio.voice_intro_delay == 10.0
         assert cfg.audio.outro_crossfade == 20.0
 
     def test_ff_has_unified_music(self, load_config):
@@ -634,16 +641,17 @@ class TestShowMusicConfigs:
         ``fascinatingfrontiers.mp3`` intro jingle + long ``_bg`` outro)
         to a single track for both. Operator preferred the open and
         close to share the same musical identity. The short jingle
-        file is kept in the repo for emergency rollback."""
+        file is kept in the repo for emergency rollback. May 12 2026
+        retune folded FF's per-show ``fade_duration: 27`` override
+        back to the network baseline (now 30 s) — the +7 offset was
+        tuned against the old 20 s baseline and doesn't carry forward."""
         cfg = load_config("shows/fascinating_frontiers.yaml")
         assert cfg.audio.music_file == "assets/music/fascinatingfrontiers_bg.mp3"
         # Dual-music override removed — the runner now uses the same
         # track for intro / overlap / fadeout / outro.
         assert cfg.audio.background_music_file is None
-        assert cfg.audio.voice_intro_delay == 25.0
-        # FF intentionally pins fade_duration at 27s (longer than the
-        # network's 15s baseline) — preserved across the May 2026 bump.
-        assert cfg.audio.fade_duration == 27.0
+        assert cfg.audio.voice_intro_delay == 10.0
+        assert cfg.audio.fade_duration == 30.0
 
     def test_pt_has_music(self, load_config):
         cfg = load_config("shows/planetterrian.yaml")
@@ -662,12 +670,12 @@ class TestShowMusicConfigs:
         assert cfg.audio.music_file == "assets/music/EnvIntel.mp3"
 
     def test_ei_standard_timing(self, load_config):
-        """EI inherits the network's May 2026 podcast-feel timing
-        (15s intro alone / 40s outro) but pins lower volumes for the
-        briefing format."""
+        """EI inherits the network's May 12 2026 retune (10 s intro
+        alone, 20 s post-voice outro with a slow 15 s fade) but pins
+        lower volumes for the briefing format."""
         cfg = load_config("shows/env_intel.yaml")
-        assert cfg.audio.intro_duration == 25.0
-        assert cfg.audio.outro_duration == 60.0
+        assert cfg.audio.intro_duration == 10.0
+        assert cfg.audio.outro_duration == 20.0
         assert cfg.audio.outro_crossfade == 20.0
         assert cfg.audio.intro_volume <= 0.5
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -196,27 +196,33 @@ class TestDefaultValues:
         assert c.apply_text_normalization == "on"
 
     def test_audio_defaults(self):
-        """May 2026: AudioConfig defaults align with the network's
-        ``shows/_defaults.yaml`` baseline so a show running with no
-        YAML override behaves like a show that inherits the baseline.
-        Total intro music presence = intro + overlap + fade = 40s,
-        with voice_intro_delay matching intro_duration so the voice
-        enters exactly when the music intro alone-period ends."""
+        """May 12 2026 retune: AudioConfig defaults align with the
+        network's ``shows/_defaults.yaml`` baseline. Voice enters at
+        10 s (was 25 s), music continues 45 s under voice with a 30 s
+        log-fade (total intro music presence still 55 s, just
+        front-shifted), and the post-voice outro is 20 s with most of
+        that being a slow 15 s fade-out. ``voice_intro_delay`` must
+        equal ``intro_duration`` so voice enters exactly when the
+        music intro alone-period ends."""
         c = AudioConfig()
         assert c.music_file is None
         assert c.background_music_file is None
-        assert c.intro_duration == 25.0
-        assert c.overlap_duration == 10.0
-        assert c.fade_duration == 20.0
-        assert c.outro_duration == 60.0
+        assert c.intro_duration == 10.0
+        assert c.overlap_duration == 15.0
+        assert c.fade_duration == 30.0
+        assert c.outro_duration == 20.0
+        assert c.outro_fade_out_duration == 15.0
         assert c.intro_volume == 0.6
         assert c.overlap_volume == 0.5
         assert c.fade_volume == 0.4
         assert c.outro_volume == 0.4
         # voice_intro_delay must be >= intro_duration so the voice
         # doesn't start before the music intro alone-period finishes.
-        assert c.voice_intro_delay == 25.0
+        assert c.voice_intro_delay == 10.0
         assert c.voice_intro_delay >= c.intro_duration
+        # Total intro music presence (alone + overlap + fade) preserved
+        # at 55 s across the May 12 2026 retune.
+        assert c.intro_duration + c.overlap_duration + c.fade_duration == 55.0
 
     def test_publishing_defaults(self):
         c = PublishingConfig()
@@ -442,8 +448,8 @@ class TestLoadConfigRealFiles:
         # file kept in repo for emergency rollback.
         assert cfg.audio.music_file == "assets/music/fascinatingfrontiers_bg.mp3"
         assert cfg.audio.background_music_file is None
-        # May 2026 podcast-feel bump — 15s music alone before voice.
-        assert cfg.audio.voice_intro_delay == 25.0
+        # May 12 2026 retune — 10s music alone before voice.
+        assert cfg.audio.voice_intro_delay == 10.0
         assert cfg.publishing.rss_category == "Science"
         assert cfg.publishing.x_env_prefix == "PLANETTERRIAN_X_"
         assert cfg.episode.prefix == "Fascinating_Frontiers"
@@ -456,9 +462,9 @@ class TestLoadConfigRealFiles:
         assert cfg.sources[0].label == "Nature"
         assert "longevity" in cfg.keywords
         assert cfg.audio.music_file == "assets/music/oilers-pride.mp3"
-        # May 2026 podcast-feel bump — outro is 40s of music after
-        # voice ends so the close doesn't feel cut off.
-        assert cfg.audio.outro_duration == 60.0
+        # May 12 2026 retune — post-voice outro is 20s with a 15s
+        # graceful fade (was 60s, felt too long and ended abruptly).
+        assert cfg.audio.outro_duration == 20.0
         assert cfg.publishing.guid_prefix == "planetterrian-daily"
         assert cfg.episode.prefix == "Planetterrian_Daily"
         assert cfg.episode.output_dir == "digests/planetterrian"
@@ -555,11 +561,10 @@ class TestNestedConfigOverrides:
         assert cfg.audio.music_file == "custom.mp3"
         # Per-show override wins.
         assert cfg.audio.voice_intro_delay == 25.0
-        # Network defaults inherited from shows/_defaults.yaml — see
-        # the May 2026 podcast-feel bump (40s total intro music
-        # presence, 40s outro after voice).
-        assert cfg.audio.intro_duration == 25.0
-        assert cfg.audio.outro_duration == 60.0
+        # Network defaults inherited from shows/_defaults.yaml — May 12
+        # 2026 retune (10s intro alone, 20s post-voice outro).
+        assert cfg.audio.intro_duration == 10.0
+        assert cfg.audio.outro_duration == 20.0
 
     def test_partial_publishing_override(self, tmp_path):
         data = {"publishing": {"rss_title": "Custom Title", "x_enabled": False}}


### PR DESCRIPTION
## Summary

Audio mix fixes for the three issues you called from TST Ep470:

1. ✅ **Music garbling right before speech starts** — root-caused and fixed
2. ✅ **Speech should start at 10 s with music gradual-fading under voice** — defaults retuned
3. ✅ **Music should continue 20 s after speech then slowly fade out** — defaults retuned

Item 4 (voice tags for "enthusiastic / deeper / faster") **intentionally deferred** for an explicit call from you — details at the bottom.

## Issue #1 — Music garbling root cause

The intro / overlap / fadeout music segments were each generated as a SEPARATE temporal slice of the source music: intro played source 0–25 s, overlap played source 25–35 s, fadeout played source 35–55 s. The acrossfade between segments used a 2 s window where BOTH segments played simultaneously.

Because the segments were **temporally adjacent** in the source music — intro's last 2 s = source 23–25 s, overlap's first 2 s = source 25–27 s — the acrossfade window played **two different 2-second passages of the song on top of each other**. Different drum hits, different chord changes, overlapping in time. Listeners heard "two songs playing at once" for the 2 s right before voice entered. Same bug at the overlap→fadeout boundary.

**Fix** (`engine/audio.py:mix_with_music`): shift overlap and fadeout source slices BACK by the acrossfade duration and extend each segment's `-t` by the same amount. Now overlap plays source 8–25 s (with new 10 s intro) and the first 2 s of overlap = source 8–10 = IDENTICAL to intro's last 2 s. The acrossfade window sums the same source content from both segments at smoothly transitioning volumes → coherent fade, no garbling.

Side benefit: this also fixes a pre-existing off-by-4 in the timeline length math (music_bed was actually 51 s but the code's silence calculation assumed 55 s because acrossfade absorption wasn't accounted for; both now match at 55 s).

## Issues #2 + #3 — Timing retune

Defaults (network + every show YAML):

| Field | Was | Now | Effect |
|---|---|---|---|
| `voice_intro_delay` | 25 | **10** | Voice enters 15 s sooner |
| `intro_duration` | 25 | **10** | Music alone for 10 s |
| `overlap_duration` | 10 | **15** | Music with voice |
| `fade_duration` | 20 | **30** | Slow log-fade under voice |
| `outro_duration` | 60 | **20** | Post-voice music |
| `outro_fade_out_duration` | 6 | **15** | Slow graceful close |
| `outro_crossfade` | 20 | 20 (unchanged) | Music ramps in over last 20 s of voice |

**Total intro music presence stays 55 s** (10 + 15 + 30) — same total duration of intro music, just front-shifted so voice enters sooner and the music has 45 s under voice to taper out. Most of those 45 s are the log-fade so the music slides out gracefully rather than dropping in level steps.

**Total post-voice music drops from 60 s to 20 s**, with 15 of those 20 s being a slow fade-out — matches your "20 s then slowly fade" literally.

`outro_crossfade` stays at 20 s so music still ramps in graceful under the last 20 s of voice. Combined: 40 s outro segment overall, with 20 s under voice + 5 s sustain at full outro volume after voice ends + 15 s log-fade-out.

FF previously pinned `fade_duration: 27` (+7 over the old 20 s baseline). Folded back to the new 30 s baseline — the +7 offset didn't have a documented reason and you can re-tune up if FF specifically needs a longer tail.

## Issue #4 — Voice "more enthusiastic, deeper, faster" via tags — **need your call**

This one is a deliberate stop-and-check because re-introducing wrapper tags directly contradicts the policy you ratified in PR #364 ("pause all TTS modifications — run raw Grok TTS baseline"). The CLAUDE.md landmine #17 entry I helped you write reads:

> Re-introduce ANY phonetic respelling or programmatic tag injection ONLY with A/B listen-test evidence on the custom voice that the modified audio is measurably better than raw on at least 3 different show contexts. Theory-driven "this should sound better" changes have a 100% regression rate on this voice so far.

You asked for tags now, knowing about the prior leaks. Three things to call out before I implement:

**(a) The track record so far on tag-based modifications:**

| Modification | Outcome |
|---|---|
| `<fast>...</fast>` chunk wrap | Grok voiced "Fast." aloud at chunk boundaries (M&A Ep045) — dropped #362 |
| `<build-intensity>` chunk wrap | Voiced "build intensity" aloud (TST Ep461) — dropped May 4 |
| `<emphasis>` programmatic injector | Was a no-op on TST (LLM spelled out currency) — dropped #364 |
| Phonetic respellings (Planetterrian, tissue, neurodegenerative) | All sounded WORSE than raw — dropped #364 |

100% regression rate. Every "this should sound better" change has been worse on the custom voice `kdif6sqjcyiq`.

**(b) What's actually achievable with Grok TTS tags:**

| You asked for | Grok TTS support |
|---|---|
| Faster | `<fast>` wrap exists but leaked at chunk boundaries (the bug above). Could be retried with a "whole-text wrap before chunking" architecture — risky |
| More enthusiastic | No direct tag. Closest approach: have the LLM use `<emphasis>` and exclamation points selectively. Limited control |
| Deeper | **Not a tag knob.** Pitch is voice-clone dependent. Would require training a different voice clone (~hours of operator audio + xAI Studio retraining) |

So the literal request "use tags" can only deliver speed (with proven failure mode) + selective emphasis. Deeper voice requires a different `voice_id`, not tags.

**(c) Bleed prevention is already wired:**

`engine/utils.py:strip_speech_tags()` already strips wrapping tags `<emphasis>`, `<whisper>`, `<soft>`, `<loud>`, `<slow>`, `<fast>`, `<build-intensity>` and inline tags `[breath]`, `[pause]`, `[long-pause]`, `[sigh]`, `[laugh]` before publishing to blog markdown / RSS show notes / newsletter / YouTube metadata. Idempotent, tested. Tags do NOT bleed into transcripts/blogs.

The audio-bleed problem (Grok voicing the tag at chunk boundaries) is the only real risk left, and it specifically affects multi-chunk scripts — most TST/MAB/M&A episodes are 6–9k chars which falls into 1–2 chunks depending on the 15k limit. If we restrict the wrap to single-chunk scripts or treat the entire script as one wrap-then-chunk operation, we may be able to avoid the bleed — but it's untested on the new voice.

### Options

Pick one and reply, or propose your own:

**Option A — Skip voice tags entirely.** Audio mix fixes ship; voice stays raw. Cleanest from the policy standpoint.

**Option B — Implement `<fast>` wrap of the whole text** (one wrap before chunking, so chunk boundaries don't carry the tag). Adds risk: untested on multi-chunk scripts. Recommend listen-test on TST Ep471 (tomorrow) before sweeping the network. Doesn't address "deeper".

**Option C — Just prompt the LLM to use `<emphasis>` selectively** (hooks, key phrases). Lowest risk because the LLM already uses prose; `<emphasis>` is well-tested in Grok. Modest enthusiasm bump. Doesn't address "deeper" or "faster".

**Option D — Switch to a different (deeper) `voice_id`** and combine with selective `<emphasis>` for enthusiasm. Biggest change — requires a new voice clone trained on your audio (~30 min of clean studio audio uploaded to xAI Console). The deeper voice would need to be verified to sound like you before swapping the network.

My recommendation is **Option C now** (low-risk emphasis-only) **+ start the Option D voice clone process** for "deeper" since it's the only path to that specific request. But it's your call.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_youtube.py` — 1,771 pass, 6 skip (pre-existing env issue unrelated)
- [ ] **Listen test on next episode** (TST Ep471 tomorrow morning):
  - [ ] Verify voice enters at ~10 s mark
  - [ ] Verify no "garbled" two-songs-at-once mishmash before voice enters
  - [ ] Verify music fades gradually under voice rather than dropping in steps
  - [ ] Verify post-voice music plays ~20 s and fades slowly to silence
- [ ] If the new timing feels rushed at 10 s, easy re-tune target is `voice_intro_delay: 13`, `intro_duration: 13` (or similar)
- [ ] If post-voice 20 s feels too short, re-tune `outro_duration: 25` or `outro_duration: 30`

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_