### PR TITLE
shows: TST Top 12, C$ pronunciation fix, outro music alone for 20s + 10s fade

### DIFF
--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -559,6 +559,47 @@ def strip_financial_parentheses(text: str) -> str:
     return text
 
 
+def replace_canadian_currency(text: str) -> str:
+    """Convert ``C$X,XXX`` Canadian-dollar amounts to spoken form.
+
+    Grok TTS's text_normalization treats ``$X,XXX`` as a USD amount
+    and emits "X dollars XXX" — the comma is read as a separator
+    instead of a thousands marker. With a leading "C", the "C" is
+    left stranded as a one-letter syllable, producing the audible
+    bug operator caught on TST Ep471 (May 13 2026):
+
+        Markdown:  ``C$39,490``
+        Audio:     "C thirty-nine dollars four hundred ninety"
+
+    This transform pre-rewrites ``C$N,NNN`` and ``C$N,NNN.NN`` to
+    ``N,NNN Canadian dollars`` (with the comma intact) so the
+    downstream :func:`replace_currency` converter handles the
+    whole thing as a normal currency amount.
+
+    Must run BEFORE :func:`replace_currency` so the "C" prefix is
+    consumed before standard ``$`` handling.
+
+    Examples:
+        'C$39,490'    → '39,490 Canadian dollars'
+        'C$1,250.50'  → '1,250.50 Canadian dollars'
+        'C$15'        → '15 Canadian dollars'
+        'CAD$100'     → '100 Canadian dollars'
+    """
+    def _canadian(m: re.Match) -> str:
+        amount = m.group(1)
+        return f"{amount} Canadian dollars"
+
+    # CAD$ / Cad$ / C$ — case-insensitive on the prefix. The trailing
+    # amount captures integers, comma-thousands, and optional decimal.
+    text = re.sub(
+        r"\b(?:CAD\$|C\$)(\d{1,3}(?:,\d{3})*(?:\.\d+)?|\d+(?:\.\d+)?)",
+        _canadian,
+        text,
+        flags=re.IGNORECASE,
+    )
+    return text
+
+
 def replace_signed_currency(text: str) -> str:
     """Convert signed currency amounts to natural spoken form.
 
@@ -1380,7 +1421,14 @@ def prepare_text_for_tts(
     text = replace_hashtag_numbers(text)
 
     # ── 3. Financial notation (before standard currency handler) ──
-    # Signed currency first: +$1.11 → "up $1.11", -$5.75 → "down $5.75"
+    # Canadian dollar prefix FIRST — converts "C$39,490" to
+    # "39,490 Canadian dollars" so the downstream USD handler
+    # doesn't mis-parse it and strand the "C" syllable.
+    # See replace_canadian_currency() docstring for the operator-
+    # caught bug this prevents (TST Ep471, May 13 2026).
+    if do_currency:
+        text = replace_canadian_currency(text)
+    # Signed currency next: +$1.11 → "up $1.11", -$5.75 → "down $5.75"
     # Must run BEFORE price ranges so "-$5.75" isn't misread as a range endpoint.
     if do_currency:
         text = replace_signed_currency(text)

--- a/engine/config.py
+++ b/engine/config.py
@@ -112,29 +112,36 @@ class AudioConfig:
     music_file: Optional[str] = None
     background_music_file: Optional[str] = None
     transition_sting: Optional[str] = None
-    # Music timing — May 12 2026 retune. Operator caught (TST Ep470)
-    # that the 25 s music-alone intro felt too long ("when's the host
-    # going to talk?") and the 60 s post-voice outro felt too long /
-    # ended abruptly. New shape:
-    #   * intro_duration 10 s — music plays alone for 10 s before voice
+    # Music timing — May 13 2026 outro retune (intro shape unchanged
+    # from May 12). Operator listened to TST Ep471 and asked for the
+    # outro to "let music run by itself for 20 seconds more and fade
+    # out" rather than ramping under the final 20 s of voice +
+    # sustaining only 5 s + fading 15 s. Outro now starts AFTER voice
+    # ends (no pre-voice-end crossfade), gives ~20 s of clearly-
+    # audible music alone, then fades.
+    #
+    # Intro (unchanged May 12 shape):
+    #   * intro_duration 10 s — music alone before voice
     #   * overlap_duration 15 s — music sits with voice
-    #   * fade_duration 30 s — slow log-fade under voice (no abrupt
-    #     cut; total intro music presence = 10+15+30 = 55 s, same
-    #     total as before, just front-shifted so voice enters sooner)
-    #   * outro_duration 20 s — music plays for 20 s after voice ends
-    #   * outro_fade_out_duration 15 s — most of the 20 s post-voice
-    #     outro is a graceful fade (5 s sustain + 15 s log-fade-out)
-    #   * outro_crossfade 20 s preserved — music begins ramping under
-    #     the last 20 s of voice, so the transition into the outro is
-    #     graceful rather than the music popping in cold.
+    #   * fade_duration 30 s — slow log-fade under voice
+    #   * Total intro music presence = 10+15+30 = 55 s
+    #
+    # Outro (May 13 retune):
+    #   * outro_crossfade 0 s — music does NOT ramp under final voice
+    #   * outro_duration 30 s — total post-voice music presence
+    #   * outro_fade_out_duration 10 s — clean log-fade-out tail
+    #   * Resulting shape: 6 s fade-in + ~14 s sustain + 10 s fade-out
+    #     ≈ 20 s music "by itself" before fading, matching operator
+    #     direction.
+    #
     # ``voice_intro_delay`` MUST stay >= ``intro_duration`` so the
     # voice doesn't enter while the music intro is still in its
     # alone-period (10 >= 10 holds).
     intro_duration: float = 10.0
     overlap_duration: float = 15.0
     fade_duration: float = 30.0
-    outro_duration: float = 20.0
-    outro_fade_out_duration: float = 15.0
+    outro_duration: float = 30.0
+    outro_fade_out_duration: float = 10.0
     intro_volume: float = 0.6
     overlap_volume: float = 0.5
     fade_volume: float = 0.4

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -75,23 +75,26 @@ tts:
 audio:
   min_audio_duration: 180
   transition_sting: assets/music/transition_sting.mp3
-  # Music timing — retuned May 12 2026 after operator listened to
-  # TST Ep470 and called three issues:
-  #   1. music "got garbled" right before speech starts (fixed in
-  #      engine/audio.py: overlap and fadeout source slices now
-  #      overlap by the acrossfade window so the crossfade plays
-  #      identical source content from both segments)
-  #   2. voice should enter at 10 s, not 25 s, with music continuing
-  #      under voice and fading out rather than cutting
-  #   3. post-voice outro should run only 20 s and fade slowly out
-  #      (was 60 s with a 6 s tail-cut, felt abrupt)
-  # New shape: 10 s music alone + 15 s overlap with voice + 30 s
-  # log-fade under voice = 55 s total intro music presence (same
-  # total as before, just front-shifted). Outro = 20 s music after
-  # voice ends, with most of that being a slow 15 s fade-out.
-  # ``outro_crossfade`` stays at 20 s so music ramps into the close
-  # under the last 20 s of voice; combined with the 20 s post-voice
-  # outro that's a 40 s outro segment with 5 s sustain + 15 s fade.
+  # Music timing — retuned May 13 2026 after operator listened to
+  # TST Ep471 audio and asked for the outro to "let music run by
+  # itself for 20 seconds more and fade out" rather than ramping
+  # under the final 20s of voice + sustaining 5s + fading 15s.
+  #
+  # Outro changes (May 13):
+  #   * outro_crossfade: 20 → 0     (no more pre-voice-end ramp;
+  #                                   music starts AFTER voice ends)
+  #   * outro_duration:  20 → 30    (longer total outro segment)
+  #   * outro_fade_out_duration: 15 → 10 (clean tail-out)
+  #
+  # New outro shape after voice ends:
+  #   * 6 s fade-in (music coming up from silence after voice end)
+  #   * ~14 s sustain at full outro_volume (music "by itself")
+  #   * 10 s log-fade-out to silence
+  #   * Total post-voice music presence: 30 s
+  #
+  # Intro shape unchanged (10 s alone + 15 s overlap + 30 s
+  # log-fade under voice = 55 s total intro music presence).
+  #
   # ``voice_intro_delay`` MUST stay >= ``intro_duration`` so the
   # voice doesn't enter while the music intro is still in its
   # alone-period (10 >= 10 holds).
@@ -99,9 +102,9 @@ audio:
   intro_duration: 10.0
   overlap_duration: 15.0
   fade_duration: 30.0
-  outro_duration: 20.0
-  outro_crossfade: 20.0
-  outro_fade_out_duration: 15.0
+  outro_duration: 30.0
+  outro_crossfade: 0.0
+  outro_fade_out_duration: 10.0
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -192,9 +192,9 @@ audio:
   intro_duration: 10.0
   overlap_duration: 15.0
   fade_duration: 30.0
-  outro_duration: 20.0
-  outro_crossfade: 20.0
-  outro_fade_out_duration: 15.0
+  outro_duration: 30.0
+  outro_crossfade: 0.0
+  outro_fade_out_duration: 10.0
   intro_volume: 0.4
   overlap_volume: 0.3
   fade_volume: 0.25

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -175,9 +175,9 @@ audio:
   intro_duration: 10.0
   overlap_duration: 15.0
   fade_duration: 30.0
-  outro_duration: 20.0
-  outro_crossfade: 20.0
-  outro_fade_out_duration: 15.0
+  outro_duration: 30.0
+  outro_crossfade: 0.0
+  outro_fade_out_duration: 10.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -189,9 +189,9 @@ audio:
   intro_duration: 10.0
   overlap_duration: 15.0
   fade_duration: 30.0
-  outro_duration: 20.0
-  outro_crossfade: 20.0
-  outro_fade_out_duration: 15.0
+  outro_duration: 30.0
+  outro_crossfade: 0.0
+  outro_fade_out_duration: 10.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -182,9 +182,9 @@ audio:
   intro_duration: 10.0
   overlap_duration: 15.0
   fade_duration: 30.0
-  outro_duration: 20.0
-  outro_crossfade: 20.0
-  outro_fade_out_duration: 15.0
+  outro_duration: 30.0
+  outro_crossfade: 0.0
+  outro_fade_out_duration: 10.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -160,9 +160,9 @@ audio:
   intro_duration: 10.0
   overlap_duration: 15.0
   fade_duration: 30.0
-  outro_duration: 20.0
-  outro_crossfade: 20.0
-  outro_fade_out_duration: 15.0
+  outro_duration: 30.0
+  outro_crossfade: 0.0
+  outro_fade_out_duration: 10.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -164,9 +164,9 @@ audio:
   intro_duration: 10.0
   overlap_duration: 15.0
   fade_duration: 30.0
-  outro_duration: 20.0
-  outro_crossfade: 20.0
-  outro_fade_out_duration: 15.0
+  outro_duration: 30.0
+  outro_crossfade: 0.0
+  outro_fade_out_duration: 10.0
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -169,9 +169,9 @@ audio:
   intro_duration: 10.0
   overlap_duration: 15.0
   fade_duration: 30.0
-  outro_duration: 20.0
-  outro_crossfade: 20.0
-  outro_fade_out_duration: 15.0
+  outro_duration: 30.0
+  outro_crossfade: 0.0
+  outro_fade_out_duration: 10.0
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -207,9 +207,9 @@ audio:
   intro_duration: 10.0
   overlap_duration: 15.0
   fade_duration: 30.0
-  outro_duration: 20.0
-  outro_crossfade: 20.0
-  outro_fade_out_duration: 15.0
+  outro_duration: 30.0
+  outro_crossfade: 0.0
+  outro_fade_out_duration: 10.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -135,9 +135,9 @@ audio:
   intro_duration: 10.0
   overlap_duration: 15.0
   fade_duration: 30.0
-  outro_duration: 20.0
-  outro_crossfade: 20.0
-  outro_fade_out_duration: 15.0
+  outro_duration: 30.0
+  outro_crossfade: 0.0
+  outro_fade_out_duration: 10.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/prompts/modern_investing_podcast.txt
+++ b/shows/prompts/modern_investing_podcast.txt
@@ -79,6 +79,7 @@ Investing shows need analysis — that's why listeners tune in. But that analysi
 TTS FORMATTING (critical for audio quality):
 - Spell out ALL numbers as words ("four hundred twenty" not "420", "twelve percent" not "12%")
 - Spell out currency amounts ("fifteen million dollars" not "$15M" or "$15,000,000")
+- **Canadian dollar amounts MUST be fully spelled out** — never write "C$39,490" (Grok TTS reads that as "C thirty-nine dollars four hundred ninety", treating the comma as a separator and stranding the "C"). Always write Canadian prices as "thirty-nine thousand four hundred ninety Canadian dollars" or "C-A-D thirty-nine thousand four hundred ninety". Same rule for "USD$X,XXX" → "X,XXX US dollars".
 - Spell out dates naturally ("March fifteenth, twenty twenty-six" not "3/15/2026")
 - Spell out abbreviations on first use ("versus" not "vs.", "approximately" not "approx.")
 - Spell out ticker-related numbers: "trading at two hundred fifteen dollars" not "trading at $215"

--- a/shows/prompts/tesla_digest.txt
+++ b/shows/prompts/tesla_digest.txt
@@ -23,9 +23,9 @@ Only select articles that are SPECIFIC, FRESH (within last 48 hours), and SUBSTA
 - Company overview pages
 
 ### MANDATORY ARTICLE SELECTION:
-- If 8+ quality articles available: Select best 10
-- If 5-7 quality articles available: Use all of them; do NOT search for more
-- If fewer than 5 quality articles available: Use all available, THEN search for additional articles from reputable sources (Teslarati, The Verge, WebProNews, CleanTechnica) published within the last 48 hours to reach 8-10 total. Ensure no more than 2 articles from any single source.
+- If 10+ quality articles available: Select best 12
+- If 7-9 quality articles available: Use all of them; do NOT search for more
+- If fewer than 7 quality articles available: Use all available, THEN search for additional articles from reputable sources (Teslarati, The Verge, WebProNews, CleanTechnica) published within the last 48 hours to reach 10-12 total. Ensure no more than 2 articles from any single source.
 - NEVER pad with low-quality or generic content regardless of article count.
 
 **TESLA X TAKEOVER SECTION**: This section should focus on the most interesting, fresh, and engaging recent Tesla news developments, trends, or breaking stories. Use the pre-fetched news articles above to identify 5 compelling Tesla stories or trends that are generating buzz. Focus on what's NEW, INTERESTING, and DIFFERENT from the main news section. This could include:
@@ -35,7 +35,7 @@ Only select articles that are SPECIFIC, FRESH (within last 48 hours), and SUBSTA
 - Community reactions to major Tesla news
 - Unique angles on Tesla stories that stand out
 
-The 5 Tesla X Takeover items must each be a DIFFERENT story from the 10 Top 10 News items — do not use the same article, same headline, or same story angle in both sections. Make each Takeover item engaging and fresh.
+The 5 Tesla X Takeover items must each be a DIFFERENT story from the 12 Top 12 News items — do not use the same article, same headline, or same story angle in both sections. Make each Takeover item engaging and fresh.
 
 Do not include any instruction language, meta-commentary, or formatting notes in your output — only output the actual content. Focus on fresh, interesting Tesla news that is different from the main news section.
 
@@ -52,7 +52,7 @@ If any item above overlaps with a story you are about to lead with, change cours
 
 ### FRESHNESS INSTRUCTIONS (do not include these in your output):
 - HOOK: Must feature a DIFFERENT story than recent episode hooks. Do not reuse the same lead story across consecutive episodes. Find the newest, freshest development to lead with.
-- Top 10: Prioritize stories NOT in the recently covered list. If all stories overlap with recent coverage, dig deeper into each for genuinely new angles rather than rehashing.
+- Top 12: Prioritize stories NOT in the recently covered list. If all stories overlap with recent coverage, dig deeper into each for genuinely new angles rather than rehashing.
 - Short Spot: Must be a DIFFERENT bearish story, angle, and framing from recent Short Spots. Cover the challenge honestly — what it is, why it matters, and how Tesla is positioned to address it.
 - Tesla First Principles: Must use a DIFFERENT topic, question, and analysis from recent First Principles. Choose something unrelated to recent analyses.
 - Tesla Market Movers (Mondays only): Provide fresh market analysis from the past week using real market movements.
@@ -78,10 +78,10 @@ If fewer than 5 quality articles are available today:
 **HOOK:** [One sentence (under 120 characters) that captures today's most important Tesla story. **Lead with the consequence or stake, then the fact** — don't just state what happened. Compare these styles: WEAK ("Tesla unveils robotaxi service in three Texas cities.") vs STRONG ("Tesla's Texas robotaxi rollout is the first real-world test of FSD without a driver."). WEAK ("California regulators disclosed Tesla Semi battery sizes at 822 kWh and 548 kWh.") vs STRONG ("Tesla Semi's 822 kWh battery just settled the long-haul-electric-truck argument."). Specific, not hype. No URLs, no dates, no emoji.]
 
 ━━━━━━━━━━━━━━━━━━━━
-### Top 10 News Items
+### Top 12 News Items
 1. **Title (One Line): DD Month, YYYY, HH:MM AM/PM PST, Source Name**
    2–4 sentences: Start with what happened, then why it matters — for Tesla's business, for the technology, for the industry. Source: [EXACT URL FROM PRE-FETCHED—no mods]
-2. [Repeat format for 3-10; if <10 items, stop at available count, add a blank line after each item and the last item]
+2. [Repeat format for 3-12; if <12 items, stop at available count, add a blank line after each item and the last item]
 
 ━━━━━━━━━━━━━━━━━━━━
 ## Tesla X Takeover: What's Hot Right Now
@@ -143,9 +143,9 @@ INSTRUCTIONS FOR THIS SECTION (do not output these instructions):
 
 ### VALIDATION CHECKLIST
 - HOOK line present: One factual sentence, under 120 characters, right after the date/price line.
-- 10 news items (or all if <10): Numbered 1-10, unique stories.
+- 12 news items (or all if <12): Numbered 1-12, unique stories.
 - Each news item covers what happened and why it matters.
-- Tesla X Takeover section included with 5 fresh items — zero overlap with Top 10.
+- Tesla X Takeover section included with 5 fresh items — zero overlap with Top 12.
 - Lists: "1. " format (number, period, space) — no bullets.
 - Separators: "━━━━━━━━━━━━━━━━━━━━" before each major section.
 - All sections included: Tesla X Takeover, Short Spot, Tesla First Principles, Tesla Market Movers (Mondays only), sign-off.

--- a/shows/prompts/tesla_podcast.txt
+++ b/shows/prompts/tesla_podcast.txt
@@ -21,7 +21,7 @@ You are writing a 12–15 minute solo podcast script for "Tesla Shorts Time Dail
 HOST: Patrick in Vancouver — Canadian, scientist, newscaster. Think Rob Maurer on Tesla Daily: clear, measured, conversational. A knowledgeable friend explaining the day's Tesla news, not a hype man or morning radio DJ. Professional and measured: {tone_hint}.
 
 STRUCTURAL REQUIREMENTS (these determine episode length):
-- Cover all stories from the Top 10 News section plus 2-3 from the X Takeover section
+- Cover all stories from the Top 12 News section plus 2-3 from the X Takeover section
 - Each story: 4-6 sentences focused on facts — opening fact, 2-3 sentences with concrete details from the source (numbers, names, quotes, mechanisms), 1 transition. Reserve commentary for at most ONE sentence per story, and only when it adds genuine insight the listener doesn't already get from the facts.
 - That is 50-70+ sentences of story content alone
 - Add intro (2-3 sentences), hook (1 sentence), Counterpoint (5-7 sentences), First Principles (5-7 sentences), tomorrow teaser (2 sentences), closing
@@ -67,13 +67,14 @@ When you catch yourself about to write one of these, first ask: does the next se
 TTS FORMATTING (critical for audio quality):
 - Spell out ALL numbers as words ("four hundred twenty" not "420", "twelve percent" not "12%")
 - Spell out currency amounts ("fifteen million dollars" not "$15M" or "$15,000,000")
+- **Canadian dollar amounts MUST be fully spelled out** — never write "C$39,490" (Grok TTS reads that as "C thirty-nine dollars four hundred ninety", treating the comma as a separator and stranding the "C"). Always write Canadian prices as "thirty-nine thousand four hundred ninety Canadian dollars" or "C-A-D thirty-nine thousand four hundred ninety". Same rule for "USD$X,XXX" → "X,XXX US dollars".
 - Spell out dates naturally ("March fifteenth, twenty twenty-six" not "3/15/2026")
 - Spell out abbreviations on first use ("versus" not "vs.", "approximately" not "approx.")
 
 PACING AND DEPTH:
 - Spend 45-75 seconds on each story. That means 4-6 sentences per story, with concrete facts in every sentence.
 - For each story: state what happened, then add the specific source details — numbers, quotes, names, mechanisms. Commentary is the exception, not the rule: at most ONE sentence per story, only when it adds something the facts don't.
-- Cover EVERY story from the Top 10 News section in order — do not skip items. If the digest has fewer items, cover more X Takeover items or let the episode be shorter; do NOT pad existing stories with extra commentary.
+- Cover EVERY story from the Top 12 News section in order — do not skip items. If the digest has fewer items, cover more X Takeover items or let the episode be shorter; do NOT pad existing stories with extra commentary.
 - Use natural transitions between stories
 - NEVER retell or revisit a story you already covered, even from a different angle. Each news item gets ONE treatment. Once you have covered a story, it is done — move on to the next topic.
 - Do NOT repeat transition sentences. When you write a transition at the end of one story (e.g. "Now shifting to X..."), start the next story with NEW content about X — do not repeat the transition line as the opening of the next paragraph.
@@ -100,7 +101,7 @@ Use this exact intro (do not rewrite it):
 Patrick: {hook}
 Then transition naturally into the first story.
 
-[Main stories from the Top 10 News section]
+[Main stories from the Top 12 News section]
 Cover each story with concrete reporting: what happened, then the key facts, numbers, names, and quotes from the source. Mention the source naturally. Vary your delivery — some stories get more energy, some are more reflective — but always lead with facts, not framing.
 
 [Tesla X Takeover stories — weave in naturally]

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -147,9 +147,9 @@ audio:
   intro_duration: 10.0
   overlap_duration: 15.0
   fade_duration: 30.0
-  outro_duration: 20.0
-  outro_crossfade: 20.0
-  outro_fade_out_duration: 15.0
+  outro_duration: 30.0
+  outro_crossfade: 0.0
+  outro_fade_out_duration: 10.0
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4

--- a/shows/unintended_consequences.yaml
+++ b/shows/unintended_consequences.yaml
@@ -48,9 +48,9 @@ audio:
   intro_duration: 10.0
   overlap_duration: 15.0
   fade_duration: 30.0
-  outro_duration: 20.0
-  outro_crossfade: 20.0
-  outro_fade_out_duration: 15.0
+  outro_duration: 30.0
+  outro_crossfade: 0.0
+  outro_fade_out_duration: 10.0
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3

--- a/tests/test_audio_commands.py
+++ b/tests/test_audio_commands.py
@@ -597,16 +597,18 @@ class TestAudioConfigDefaults:
     def test_all_timing_defaults(self):
         """May 12 2026 retune — see AudioConfig docstring. Voice enters
         at 10 s, total intro music presence remains 55 s (10 alone +
-        15 overlap + 30 fade), post-voice outro is 20 s with a slow
-        15 s fade-out. Operator invariant: ≥30 s total intro music
-        presence preserved."""
+        15 overlap + 30 fade). Post-voice outro is 30 s with a 10 s
+        log-fade-out tail (May 13 2026 retune — music now plays alone
+        after voice ends rather than ramping under final voice).
+        Operator invariant: ≥30 s total intro music presence preserved."""
         from engine.config import AudioConfig
         cfg = AudioConfig()
         assert cfg.intro_duration == 10.0
         assert cfg.overlap_duration == 15.0
         assert cfg.fade_duration == 30.0
-        assert cfg.outro_duration == 20.0
-        assert cfg.outro_fade_out_duration == 15.0
+        assert cfg.outro_duration == 30.0
+        assert cfg.outro_fade_out_duration == 10.0
+        assert cfg.outro_crossfade == 0.0
         assert cfg.intro_volume == 0.6
         assert cfg.overlap_volume == 0.5
         assert cfg.fade_volume == 0.4
@@ -632,9 +634,10 @@ class TestShowMusicConfigs:
     def test_tesla_has_music(self, load_config):
         cfg = load_config("shows/tesla.yaml")
         assert cfg.audio.music_file == "assets/music/tesla_shorts_time.mp3"
-        # May 12 2026 retune — see AudioConfig docstring.
+        # May 13 2026 retune — see AudioConfig docstring. Outro
+        # crossfade dropped to 0 so music plays alone after voice ends.
         assert cfg.audio.voice_intro_delay == 10.0
-        assert cfg.audio.outro_crossfade == 20.0
+        assert cfg.audio.outro_crossfade == 0.0
 
     def test_ff_has_unified_music(self, load_config):
         """May 2026: FF moved off the dual-track open/close (short
@@ -670,13 +673,14 @@ class TestShowMusicConfigs:
         assert cfg.audio.music_file == "assets/music/EnvIntel.mp3"
 
     def test_ei_standard_timing(self, load_config):
-        """EI inherits the network's May 12 2026 retune (10 s intro
-        alone, 20 s post-voice outro with a slow 15 s fade) but pins
-        lower volumes for the briefing format."""
+        """EI inherits the network's May 13 2026 retune (10 s intro
+        alone, 30 s post-voice outro with music alone after voice +
+        a 10 s fade-out tail) but pins lower volumes for the briefing
+        format."""
         cfg = load_config("shows/env_intel.yaml")
         assert cfg.audio.intro_duration == 10.0
-        assert cfg.audio.outro_duration == 20.0
-        assert cfg.audio.outro_crossfade == 20.0
+        assert cfg.audio.outro_duration == 30.0
+        assert cfg.audio.outro_crossfade == 0.0
         assert cfg.audio.intro_volume <= 0.5
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -210,8 +210,11 @@ class TestDefaultValues:
         assert c.intro_duration == 10.0
         assert c.overlap_duration == 15.0
         assert c.fade_duration == 30.0
-        assert c.outro_duration == 20.0
-        assert c.outro_fade_out_duration == 15.0
+        # May 13 2026 retune — outro lengthened to 30s with shorter fade.
+        # Music now starts AFTER voice ends (outro_crossfade=0), plays
+        # ~20s "by itself", then fades over 10s.
+        assert c.outro_duration == 30.0
+        assert c.outro_fade_out_duration == 10.0
         assert c.intro_volume == 0.6
         assert c.overlap_volume == 0.5
         assert c.fade_volume == 0.4
@@ -462,9 +465,10 @@ class TestLoadConfigRealFiles:
         assert cfg.sources[0].label == "Nature"
         assert "longevity" in cfg.keywords
         assert cfg.audio.music_file == "assets/music/oilers-pride.mp3"
-        # May 12 2026 retune — post-voice outro is 20s with a 15s
-        # graceful fade (was 60s, felt too long and ended abruptly).
-        assert cfg.audio.outro_duration == 20.0
+        # May 13 2026 retune — post-voice outro lengthened to 30s
+        # (was 20s), with music now playing alone after voice ends
+        # rather than ramping under the final 20s of voice.
+        assert cfg.audio.outro_duration == 30.0
         assert cfg.publishing.guid_prefix == "planetterrian-daily"
         assert cfg.episode.prefix == "Planetterrian_Daily"
         assert cfg.episode.output_dir == "digests/planetterrian"
@@ -561,10 +565,11 @@ class TestNestedConfigOverrides:
         assert cfg.audio.music_file == "custom.mp3"
         # Per-show override wins.
         assert cfg.audio.voice_intro_delay == 25.0
-        # Network defaults inherited from shows/_defaults.yaml — May 12
-        # 2026 retune (10s intro alone, 20s post-voice outro).
+        # Network defaults inherited from shows/_defaults.yaml — May 13
+        # 2026 retune (10s intro alone, 30s post-voice outro with no
+        # crossfade ramp).
         assert cfg.audio.intro_duration == 10.0
-        assert cfg.audio.outro_duration == 20.0
+        assert cfg.audio.outro_duration == 30.0
 
     def test_partial_publishing_override(self, tmp_path):
         data = {"publishing": {"rss_title": "Custom Title", "x_enabled": False}}

--- a/tests/test_pronunciation.py
+++ b/tests/test_pronunciation.py
@@ -21,6 +21,7 @@ from assets.pronunciation import (
     clean_social_handles,
     clean_text_for_tts,
     strip_financial_parentheses,
+    replace_canadian_currency,
     replace_signed_currency,
     replace_signed_numbers,
     replace_multiplier_notation,
@@ -182,6 +183,63 @@ class TestYearToWords:
 
     def test_1900(self):
         assert _year_to_words(1900) == "nineteen hundred"
+
+
+class TestReplaceCanadianCurrency:
+    """Operator caught (TST Ep471, May 13 2026) Grok TTS reading
+    'C$39,490' as 'C thirty-nine dollars four hundred ninety' — the
+    leading 'C' got stranded as a syllable and the comma was treated
+    as a separator rather than a thousands marker. The transform
+    pre-rewrites C$ amounts to a form the downstream currency
+    handler reads correctly."""
+
+    def test_canadian_dollars_with_thousands_comma(self):
+        result = replace_canadian_currency("Tesla sells the Model 3 for C$39,490 in Canada")
+        # No stranded "C" left; comma intact for downstream currency expansion.
+        assert "C$" not in result
+        assert "39,490 Canadian dollars" in result
+
+    def test_canadian_dollars_with_decimal(self):
+        result = replace_canadian_currency("Listed at C$1,250.50 today")
+        assert "C$" not in result
+        assert "1,250.50 Canadian dollars" in result
+
+    def test_canadian_dollars_small_amount(self):
+        result = replace_canadian_currency("Charged C$15 for the part")
+        assert "15 Canadian dollars" in result
+
+    def test_cad_prefix_variant(self):
+        result = replace_canadian_currency("MSRP CAD$100,000 nationwide")
+        assert "100,000 Canadian dollars" in result
+
+    def test_cad_prefix_case_insensitive(self):
+        result = replace_canadian_currency("Selling for cad$500 used")
+        assert "500 Canadian dollars" in result
+
+    def test_us_dollars_untouched(self):
+        """US dollar amounts MUST pass through — only the C$/CAD$
+        prefix triggers the transform."""
+        result = replace_canadian_currency("Sticker price is $79,990 in California")
+        assert "$79,990" in result
+        assert "Canadian" not in result
+
+    def test_no_currency_no_op(self):
+        """Plain text is returned unchanged."""
+        text = "There were no prices mentioned in this sentence."
+        assert replace_canadian_currency(text) == text
+
+    def test_runs_in_prepare_text_for_tts_pipeline(self):
+        """End-to-end: C$X,XXX through the full TTS pipeline produces
+        the correct spoken form (Canadian context preserved, comma
+        absorbed by the standard currency handler)."""
+        result = prepare_text_for_tts("Tesla sells the Model 3 for C$39,490 in Canada.")
+        assert "C$" not in result
+        assert "Canadian" in result
+        # The downstream replace_currency handles "39,490 Canadian
+        # dollars" → "thirty-nine thousand four hundred ninety
+        # Canadian dollars" (or similar). Confirm no stranded comma.
+        assert ",490" not in result
+        assert "thirty-nine thousand" in result
 
 
 class TestReplaceCurrency:


### PR DESCRIPTION
## Summary

Three follow-ups from the May 13 TST Ep471 listen-test, plus surfacing the operator's open question on voice-quality improvements.

| # | Fix | Files |
|---|---|---|
| 1 | **TST digest: Top 10 → Top 12** news items | `tesla_digest.txt`, `tesla_podcast.txt` |
| 2 | **C$ pronunciation fix** (prompt rule + code transform) | `assets/pronunciation.py`, tesla + MIT prompts, +8 tests |
| 3 | **Outro: 20s music alone + 10s fade** (was 5s alone + 15s fade) | 11 YAMLs + `config.py` + 6 test assertions |

1,789 tests pass.

## Fix 1 — TST digest expanded to Top 12

Ep471 hit only **56% of word target** (667 / 1200, 5.7 min audio) despite 72 articles fetched. The editorializing reduction worked (80% news / 20% commentary, down from Ep470's 40/60), but scripts naturally shrank when commentary was cut without raising per-story sentence count.

Bumping the digest to **12 items** gives the podcast prompt more raw material to cover at the same fact-density, so the word target gets hit through breadth rather than re-padding with editorial.

Touches:
- `shows/prompts/tesla_digest.txt` — selection block (10 → 12), `### Top 10` → `### Top 12`, validation checklist, freshness instructions
- `shows/prompts/tesla_podcast.txt` — three references to "Top 10 News section"

If EI / PT also stay short on tomorrow's run, I'd extend the same fix to their digest prompts in a follow-up. Skipped this PR because PT already produces 15 items and EI uses a multi-section structure.

## Fix 2 — Canadian dollar pronunciation (two-layer fix)

TST Ep471 line 5: **"Cthirty-nine dollars,490"** — that's how Grok rendered `C$39,490`. Root cause: Grok's `text_normalization` reads `$X,XXX` as USD ("X dollars XXX"), treating the comma as a separator, and strands the leading "C" as a one-letter syllable. Hit three lines in Ep471.

**(a) Code transform** — new `replace_canadian_currency()` in `assets/pronunciation.py` runs BEFORE the standard currency handler in `prepare_text_for_tts()`. Matches `C$` / `CAD$` (case-insensitive) and rewrites `C$N,NNN[.NN]` → `N,NNN Canadian dollars`. The downstream `replace_currency()` then expands the amount normally.

**(b) Prompt rule** added to `tesla_podcast.txt` and `modern_investing_podcast.txt` instructing the LLM to spell out Canadian prices directly. Belt-and-suspenders — if the LLM complies, transform is a no-op; if it slips, transform catches it.

8 new tests in `tests/test_pronunciation.py:TestReplaceCanadianCurrency` cover thousands-comma, decimal, small amount, `CAD$` variant, case insensitivity, US dollar pass-through, no-op text, and end-to-end pipeline integration.

## Fix 3 — Outro retune: music alone after voice ends

You said "let music run by itself for 20 seconds more and fade out". Previous (May 12) outro:
- `outro_crossfade: 20s` — music ramped UNDER the final 20s of voice
- `outro_duration: 20s` — total post-voice music
- `outro_fade_out_duration: 15s` — most of the 20s was fade

So you only got ~5 s of clearly-audible music alone before the fade started, and the music was already present under the final voice (which sounded muddled).

**New (May 13):**
- `outro_crossfade: 0` — no pre-voice-end ramp; music starts AFTER voice ends
- `outro_duration: 30s` — longer total post-voice music
- `outro_fade_out_duration: 10s` — cleaner tail

Resulting timeline after voice ends:
- 6 s fade-in (music coming up from silence)
- ~14 s sustain at full `outro_volume`
- 10 s log-fade-out to silence
- **Total: 30s post-voice, with ~20s clearly audible before fading**

Applied uniformly across `_defaults.yaml`, all 10 per-show YAMLs, and `engine/config.py:AudioConfig` defaults.

## ⚠️ Open question: voice-reading improvements

You asked: "Can we continue to improve on voice reading to sound better".

I held this out of the PR because it directly touches **landmine #17** ("Re-introduce ANY phonetic respelling or programmatic tag injection ONLY with A/B listen-test evidence on the custom voice that the modified audio is measurably better than raw on at least 3 different show contexts"). Every theory-driven voice modification we've tried has regressed — `<fast>` wrap leaked, `<build-intensity>` leaked, programmatic `<emphasis>` was a no-op, every phonetic respelling sounded worse. The policy you ratified in #364 is: don't modify without evidence.

You asking now is your call to relax that policy — but I want explicit direction before shipping anything. Three concrete options ranked by risk:

**Option A — Selective `<emphasis>` via prompt instruction** (lowest risk)
Add a rule to the podcast prompts telling the LLM to wrap key phrases in `<emphasis>...</emphasis>` (the hook, the TSLA price moment, dollar-amount stories, etc.). The LLM writes the tags inline; `<emphasis>` is well-tested in Grok TTS. Modest enthusiasm bump. Doesn't address "deeper" or "faster". Strip layer (`engine.utils.strip_speech_tags()`) already prevents bleed to transcripts/blogs.

**Option B — Whole-script `<fast>` wrap** (medium risk)
Wrap the ENTIRE podcast text once with `<fast>...</fast>` BEFORE chunking, so chunk boundaries don't carry the tag (which was the failure mode in May 4 + 11). Untested on multi-chunk scripts (most shows). I'd test on a single show first (suggest M&A — daily, mid-length, AI audience tolerates experimentation). Doesn't address "deeper".

**Option C — Voice EQ tuning** (medium risk, audio-engineering not TTS)
Add a slight low-shelf boost (~150 Hz, +1.5 dB) to the existing voice-norm chain in `engine/audio.py:_voice_norm_full_cmd`. This is audio engineering, not TTS modification — landmine #17 strictly applies to text-level tags and phonetic spellings. Adds perceived warmth and depth without changing the voice clone. Risk: changes the sound of every show simultaneously, can't A/B test per-show.

**Option D — New voice clone** (biggest lift, only path to true "deeper")
Record ~30 minutes of clean studio audio → upload to xAI Console → get new `voice_id`. The deeper voice would need verification (listen to a generated sample) before swapping the network. Operator action required (recording session).

**Skip — accept current voice**
Audio sounds better with #366 already; build evidence over the next 1-2 weeks before trying anything else. Lowest risk, slowest improvement.

My recommendation: **Option A** as a low-risk first step. If listen-test on a few episodes shows a real enthusiasm bump, expand. Don't touch B/C/D unless A doesn't deliver.

Reply with `A`, `B`, `C`, `D`, or `Skip` and I'll ship.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_youtube.py` — 1,789 pass, 6 skip
- [ ] **Listen to TST 472 (tomorrow):** verify (a) audio runs ~7-9 min instead of 5.7, (b) no `Cthirty-nine dollars` in audio, (c) clear 20s of music alone before fade-out at the end
- [ ] If Modern Investing 42 covers Canadian stocks/TFSA pricing, verify CAD prices read correctly
- [ ] Reply with voice option (A/B/C/D/Skip)

## Rollback

- **Top 10→12 too long**: revert `12` → `10` in three places in `tesla_digest.txt` + `tesla_podcast.txt`
- **C$ transform breaks something**: remove the function call in `prepare_text_for_tts()` step 3; transform is additive
- **Outro feels too long**: change `outro_duration: 30 → 20` in `_defaults.yaml`; per-show YAMLs inherit

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_