### PR TITLE
tts: re-enable &lt;fast&gt; wrap network-wide via single-call synthesis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -483,6 +483,58 @@ decision); everything else has a live status card.
     so far (Planetterrian, tissue, neurodegenerative, `<fast>` wrap,
     `<build-intensity>` wrap — every one made it worse).
 
+    **May 13 2026 update — `<fast>` wrap re-enabled via single-call
+    synthesis.** Operator listened to the May 13 episodes (post-#365
+    editorializing reduction + #366 audio retune + #367 streamline)
+    and asked for whole-script `<fast>` energy on every podcast
+    ("Option B for all podcasts please"). The historical chunk-wrap
+    leak (M&A Ep045 voicing "Fast." at section-TTS boundaries) was
+    a *multi-call* problem: section-TTS + chunked synthesis meant
+    every chunk got its own `<fast>...</fast>` wrap as an
+    independent Grok API call, and Grok occasionally voiced the
+    opening tag aloud at the boundary between calls.
+
+    Leak-safe implementation (the only safe path):
+    - Network default `shows/_defaults.yaml`: `speech_wrap_open:
+      "<fast>"`, `speech_wrap_close: "</fast>"`, `use_section_tts:
+      false`, `max_chars: 14000`.
+    - The four fields are a *coupled set* — flipping any one
+      without the others re-introduces the leak.
+    - `run_show.py:1714` gates section-TTS on `config.tts.use_section_tts`
+      so the network-wide flip is one YAML field.
+    - `engine/tts.py:_speak_with_grok` has a May 13 safety guard:
+      if a script overflows `max_chars` and splits into multiple
+      chunks, it DROPS the wrap (with a loud warning) rather than
+      apply it per-chunk. Episode loses the energy lift but ships
+      clean audio.
+
+    Trade-off: section-TTS off means **no transition stings between
+    chapter markers**. Chapter markers themselves still work in
+    podcast apps (Apple, Spotify, Pocket Casts) because they come
+    from `chapters.json` not from section-TTS. The brief musical
+    stings between chapters are gone — most listeners won't notice;
+    one-line revert (`use_section_tts: true` + drop the wrap) if
+    desired.
+
+    Drift guards in `tests/test_tts_grok.py`:
+    - `test_default_tts_config_dataclass_has_no_chunk_wrap` —
+      dataclass default stays empty (backwards compat for callers
+      that bypass YAML).
+    - `test_network_default_has_fast_wrap_and_single_call` — pins
+      the four coupled fields on the loaded Tesla YAML so a partial
+      revert (e.g. re-enabling section-TTS without dropping the
+      wrap) fails CI.
+    - `test_speak_with_grok_drops_wrap_on_multi_chunk` — verifies
+      the safety guard fires when a script overflows.
+    - `test_speak_with_grok_keeps_wrap_on_single_chunk` — verifies
+      the happy path applies the wrap as expected.
+
+    The policy above (no theory-driven tag changes) still stands
+    for any FUTURE additions. The May 13 `<fast>` re-enable was an
+    *operator override* with explicit awareness of the historical
+    risk; it ships as a single coherent infrastructure change
+    (single-call synthesis) rather than as a tag-injection retry.
+
 18. **Newsletter pipeline spec v2 (May 2026)** — multi-day refinement
     pass on the Buttondown send pipeline addressing contrast bugs,
     LLM scaffold leaks, and daily-vs-weekly template parity. Files:

--- a/engine/config.py
+++ b/engine/config.py
@@ -89,18 +89,29 @@ class TTSConfig:
     use_speaker_boost: bool = True
     speed: float = 1.0  # Speech speed (0.7–1.2); Flash v2.5 supports this range
     apply_text_normalization: str = "on"  # "auto", "on", or "off"; helps with number/date pronunciation
-    # No chunk-wrap. Earlier defaults wrapped every Grok TTS chunk in
-    # ``<fast>...</fast>`` for an energy lift. May 2026 audit caught
-    # Grok TTS occasionally **voicing** the opening ``<fast>`` aloud as
-    # "Fast." at section-TTS boundaries (M&A Ep045, May 11) — and
-    # ``<fast>`` isn't on Grok's documented tag list. Emphasis is now
-    # injected programmatically by ``engine.prosody.inject_prosody_tags``
-    # at script-save time, wrapping currency / percentage / cashtag
-    # tokens in the *documented* ``<emphasis>...</emphasis>`` tag.
-    # Re-introduce a chunk wrap only with transcript-level evidence
-    # that Grok consumes it silently at every section boundary.
+    # ---- Speech tag wrap (May 13 2026: re-enabled via single-call path) ----
+    # The chunk wrap previously got dropped because Grok TTS occasionally
+    # voiced "Fast." aloud at section-TTS boundaries (M&A Ep045, May 11).
+    # Re-enabled May 13 2026 via the network ``_defaults.yaml`` after the
+    # operator asked for whole-script ``<fast>`` energy on all podcasts.
+    # The leak-safe implementation pairs the wrap with
+    # ``use_section_tts: False`` and a larger ``max_chars`` so each
+    # episode synthesises in a single Grok API call — no boundaries, no
+    # leak surface. If ``use_section_tts`` is True AND the wrap is set,
+    # the wrap will be applied per-section per-chunk and CAN leak (the
+    # historical failure mode). The defaults below preserve backwards-
+    # compat at the dataclass level; the network-wide flip lives in
+    # ``shows/_defaults.yaml``.
     speech_wrap_open: str = ""
     speech_wrap_close: str = ""
+    # When True, the runner splits the script at chapter boundaries
+    # and synthesises each section as a separate Grok TTS call,
+    # stitching transition stings between. When False, the whole
+    # script goes through ``synthesize()`` as a single call (no
+    # stings, no boundaries — required for whole-script speech wrap
+    # to apply safely). The network default in ``_defaults.yaml`` is
+    # False as of May 13 2026.
+    use_section_tts: bool = True
     # Post-TTS transcription validation (opt-in)
     validate_transcription: bool = False
     whisper_model: str = "base"  # "tiny", "base", "small", "medium"

--- a/engine/tts.py
+++ b/engine/tts.py
@@ -760,6 +760,30 @@ def _speak_with_grok(
     effective_max = min(max_chars, GROK_MAX_CHARS_PER_REQUEST - wrap_overhead)
     chunks = chunk_text(text, max_chars=effective_max)
 
+    # Multi-chunk + speech wrap = the chunk-boundary leak that M&A
+    # Ep045 caught (May 11 2026: Grok voiced "Fast." aloud at each
+    # boundary because every chunk got its own ``<fast>...</fast>``
+    # wrap as an independent API call).  May 13 2026 safety: if a
+    # script overflows ``max_chars`` and gets split, DROP the wrap
+    # rather than re-introduce the boundary leak.  The episode loses
+    # the energy lift but ships clean audio.  Operator sees a loud
+    # warning so they can decide whether to shorten the script or
+    # accept the trade-off.
+    if len(chunks) > 1 and (speech_wrap_open or speech_wrap_close):
+        logger.warning(
+            "Grok TTS: script split into %d chunks (%d chars total > "
+            "%d effective_max) — DROPPING speech wrap to avoid the "
+            "chunk-boundary leak (Grok voicing the opening tag aloud "
+            "at section boundaries — landmine #17). Audio will be "
+            "raw without the ``%s%s`` wrap.  Shorten the script or "
+            "bump tts.max_chars (current cap is Grok's 15000) to "
+            "keep wrap active.",
+            len(chunks), len(text), effective_max,
+            speech_wrap_open, speech_wrap_close,
+        )
+        speech_wrap_open = ""
+        speech_wrap_close = ""
+
     def _wrap(s: str) -> str:
         if not (speech_wrap_open or speech_wrap_close):
             return s

--- a/run_show.py
+++ b/run_show.py
@@ -1711,8 +1711,16 @@ def run(args: argparse.Namespace) -> None:
             if config.audio.transition_sting:
                 sting_path = PROJECT_ROOT / config.audio.transition_sting
 
+            # ``config.tts.use_section_tts`` is the network-wide opt-in.
+            # As of May 13 2026 the default is False — episodes are
+            # synthesised as a single Grok TTS call so the network-wide
+            # ``<fast>...</fast>`` wrap from ``_defaults.yaml`` is
+            # applied exactly once per episode (no chunk/section
+            # boundaries that could leak the tag aloud). See landmine
+            # #17 + the TTSConfig docstring.
             use_section_tts = (
-                episode_chapters
+                getattr(config.tts, "use_section_tts", True)
+                and episode_chapters
                 and len(episode_chapters) >= 2
                 and sting_path
             )

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -49,17 +49,34 @@ tts:
   provider: grok
   voice_id: kdif6sqjcyiq
   language_code: en
-  max_chars: 10000
-  # No chunk-wrap. Earlier defaults wrapped every chunk in
-  # ``<fast>...</fast>``; May 2026 audit caught Grok voicing the
-  # opening tag aloud as "Fast." at section-TTS boundaries (M&A
-  # Ep045, May 11). ``<fast>`` is also NOT on Grok's documented
-  # tag list (only ``[breath]``, ``[pause]``, ``[long-pause]``,
-  # ``<emphasis>``, ``<whisper>``, ``<slow>``, ``<soft>`` are).
-  # News-anchor emphasis is now injected at script-save time by
-  # ``engine.prosody.inject_prosody_tags`` using ``<emphasis>``.
-  speech_wrap_open: ""
-  speech_wrap_close: ""
+  # Bumped from 10000 → 14000 (May 13 2026) so the typical 6-12k-char
+  # podcast script fits in a single Grok TTS API call. With
+  # ``use_section_tts: false`` (below) and a network-wide ``<fast>``
+  # wrap, single-chunk synthesis is the leak-safe path: one wrap, one
+  # API call, zero internal boundaries that could voice the tag aloud.
+  # Grok's hard per-request cap is 15000 so 14000 leaves room for the
+  # wrap overhead.
+  max_chars: 14000
+  # ---- Speech-tag wrap (re-enabled May 13 2026) ----
+  # Operator chose Option B from the May 13 TST review: whole-script
+  # ``<fast>`` wrap on every podcast to lift voice energy.  Previous
+  # chunk-wrap experiments leaked "Fast." aloud at section-TTS
+  # boundaries (M&A Ep045, May 11); the leak-safe implementation is
+  # pairing the wrap with ``use_section_tts: false`` so each episode
+  # is one Grok API call.  Tag-leak detector still scans Whisper
+  # transcripts for any audible "fast" / "</fast>" recurrence and
+  # records the count in metrics.
+  speech_wrap_open: "<fast>"
+  speech_wrap_close: "</fast>"
+  # Force single-call synthesis network-wide so the ``<fast>`` wrap
+  # above is applied exactly once per episode.  Trade-off: the brief
+  # musical "stings" between chapter markers (transition_sting) no
+  # longer play, because their insertion point was BETWEEN section-
+  # TTS calls.  Listener-facing change is small; chapter markers in
+  # podcast apps (Apple, Spotify, Pocket Casts) still work because
+  # they come from the chapters.json sidecar, not from section-TTS.
+  # To re-enable section-TTS + drop the wrap, flip both fields here.
+  use_section_tts: false
   # ---- Legacy ElevenLabs baseline ----
   # No show currently overrides `provider: elevenlabs`. Kept here so
   # an emergency rollback (e.g. Grok TTS outage) is a one-line YAML

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -507,7 +507,11 @@ class TestLoadConfigRealFiles:
         assert cfg.tts.voice_id == "kdif6sqjcyiq"
         assert cfg.tts.stability == 0.5  # Inherited from legacy ElevenLabs baseline
         assert cfg.tts.style == 0.0
-        assert cfg.tts.max_chars == 10000
+        # max_chars bumped to 14000 (May 13 2026) so the typical
+        # 6-12k podcast script fits in a single Grok TTS call —
+        # required for the network-wide ``<fast>`` wrap to apply
+        # safely without leaking at chunk boundaries.
+        assert cfg.tts.max_chars == 14000
         # EI got its own dedicated theme in May 2026
         # (replaced the shared tesla_shorts_time.mp3).
         assert cfg.audio.music_file == "assets/music/EnvIntel.mp3"

--- a/tests/test_tts_grok.py
+++ b/tests/test_tts_grok.py
@@ -569,21 +569,134 @@ def test_grok_path_wrap_is_empty_string_safe(tmp_path: Path, monkeypatch):
     assert sent == "Bare sentence."
 
 
-def test_default_tts_config_has_no_chunk_wrap():
-    """The network default is **no chunk wrap** — drift guard.
+def test_default_tts_config_dataclass_has_no_chunk_wrap():
+    """The ``TTSConfig`` dataclass default (no YAML) keeps the wrap
+    empty for backwards compat — any caller that constructs
+    ``TTSConfig()`` directly gets the safe legacy behaviour. The
+    network-wide wrap is set in ``shows/_defaults.yaml`` (see
+    ``test_network_default_has_fast_wrap_and_single_call`` below)
+    so the dataclass default and the network default deliberately
+    diverge as of May 13 2026.
 
-    History: paired with ``<build-intensity>`` in PR #293 (May 3 2026),
-    simplified to ``<fast>`` alone May 4, then dropped entirely May 11
-    after M&A Ep045 caught Grok voicing the ``<fast>`` open tag aloud
-    as "Fast." at section-TTS boundaries (transcript lines 18 + 42).
-    Emphasis is now programmatic via ``engine.prosody.inject_prosody_tags``.
-    Re-introduce a chunk wrap ONLY with transcript-level evidence that
-    Grok consumes it silently at every section boundary.
+    History: chunk wrap paired with ``<build-intensity>`` in PR #293
+    (May 3 2026), simplified to ``<fast>`` alone May 4, dropped
+    entirely May 11 after M&A Ep045 caught Grok voicing the
+    ``<fast>`` open tag aloud as "Fast." at section-TTS boundaries
+    (transcript lines 18 + 42). Re-enabled May 13 2026 via the
+    network default paired with ``use_section_tts: False`` so each
+    episode synthesises in a single Grok API call — no chunk/section
+    boundaries that could leak the tag aloud.
     """
     from engine.config import TTSConfig
     cfg = TTSConfig()
     assert cfg.speech_wrap_open == ""
     assert cfg.speech_wrap_close == ""
+    # use_section_tts also defaults True at the dataclass level
+    # (matches pre-May-13 behaviour for callers that bypass YAML).
+    assert cfg.use_section_tts is True
+
+
+def test_network_default_has_fast_wrap_and_single_call():
+    """The network ``shows/_defaults.yaml`` baseline (loaded by every
+    show that doesn't override) MUST carry the May 13 2026 retune:
+
+      * ``speech_wrap_open: "<fast>"`` and matching close — operator-
+        requested Option B from the May 13 listen-test review.
+      * ``use_section_tts: false`` — required for the wrap to apply
+        safely (single Grok API call, no chunk/section boundaries).
+      * ``max_chars: 14000`` — headroom for the typical 6-12k podcast
+        script to fit in one Grok request (cap is 15000).
+
+    If any one of these drifts away from the others, the wrap can
+    leak at chunk boundaries (the historical M&A Ep045 failure).
+    Pinning them as a triple here so a partial revert (e.g.
+    re-enabling section-TTS without dropping the wrap) is caught
+    in CI."""
+    from engine.config import load_config
+
+    cfg = load_config("shows/tesla.yaml")
+    assert cfg.tts.speech_wrap_open == "<fast>"
+    assert cfg.tts.speech_wrap_close == "</fast>"
+    assert cfg.tts.use_section_tts is False
+    assert cfg.tts.max_chars == 14000
+
+
+def test_speak_with_grok_drops_wrap_on_multi_chunk(tmp_path: Path, monkeypatch):
+    """Safety guard: if a script overflows ``max_chars`` and splits
+    into multiple chunks, ``_speak_with_grok`` MUST drop the wrap
+    rather than apply it per-chunk (the historical leak).
+
+    This is the May 13 2026 defence-in-depth against the chunk-
+    boundary leak. The network default pairs the wrap with
+    ``use_section_tts: false`` + ``max_chars: 14000`` so single-chunk
+    is the normal path; this guard catches the rare case where a
+    script grows past the cap."""
+    captured_texts: list[str] = []
+
+    def fake_chunk(text, voice_id, out_path, **kwargs):
+        captured_texts.append(text)
+        Path(out_path).write_bytes(b"\xff\xfb\x90")
+
+    monkeypatch.setattr(tts, "grok_speak_chunk", fake_chunk)
+    monkeypatch.setattr(
+        tts.subprocess, "run",
+        lambda *a, **kw: MagicMock(returncode=0),
+    )
+
+    # Force a 2-chunk script: 6000 chars at max_chars=3000.
+    long_text = "Sentence one. " * 500  # ~7000 chars
+    tts._speak_with_grok(
+        long_text,
+        voice_id="kdif6sqjcyiq",
+        filename=str(tmp_path / "out.mp3"),
+        api_key="k",
+        max_chars=3000,
+        language_code="en",
+        speech_wrap_open="<fast>",
+        speech_wrap_close="</fast>",
+    )
+
+    # At least 2 chunks were sent; NONE carry the wrap.
+    assert len(captured_texts) >= 2
+    for sent in captured_texts:
+        assert "<fast>" not in sent, (
+            "Multi-chunk path leaked the wrap — the May 13 safety "
+            "guard should drop the wrap when len(chunks) > 1."
+        )
+        assert "</fast>" not in sent
+
+
+def test_speak_with_grok_keeps_wrap_on_single_chunk(tmp_path: Path, monkeypatch):
+    """Counterpart to the multi-chunk guard: when the script fits in
+    one chunk, the wrap MUST be applied (single API call, no leak
+    surface). This is the happy-path that delivers Option B."""
+    captured_texts: list[str] = []
+
+    def fake_chunk(text, voice_id, out_path, **kwargs):
+        captured_texts.append(text)
+        Path(out_path).write_bytes(b"\xff\xfb\x90")
+
+    monkeypatch.setattr(tts, "grok_speak_chunk", fake_chunk)
+    monkeypatch.setattr(
+        tts.subprocess, "run",
+        lambda *a, **kw: MagicMock(returncode=0),
+    )
+
+    tts._speak_with_grok(
+        "Short script that fits in one chunk.",
+        voice_id="kdif6sqjcyiq",
+        filename=str(tmp_path / "out.mp3"),
+        api_key="k",
+        max_chars=14000,
+        language_code="en",
+        speech_wrap_open="<fast>",
+        speech_wrap_close="</fast>",
+    )
+
+    assert len(captured_texts) == 1
+    sent = captured_texts[0]
+    assert sent.startswith("<fast>")
+    assert sent.endswith("</fast>")
 
 
 def test_synthesize_sections_passes_wrap_through(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary

Per your "Option B for all podcasts" direction. **But first, a heads-up on what I learned while implementing.**

### What I found before flipping the switch

When I dug into the actual TTS pipeline, the naive "set `speech_wrap_open: <fast>`" approach is **exactly the bug we paused in PR #364**:

- The pipeline runs `synthesize_sections()` by default (one separate Grok TTS API call per chapter — typically 3-5 sections per episode)
- `_speak_with_grok()` chunks long sections further (~1-3 chunks each)
- A wrap config setting applies the wrap to **every chunk in every section** — up to 15 independent API calls per episode, each with its own `<fast>...</fast>`
- That's exactly the chunk-boundary failure mode where Grok voiced "Fast." aloud at section transitions in M&A Ep045

So **naive Option B re-introduces the historical bug.** The safe way is single-call synthesis: one Grok API call per episode, wrapping the whole script once, with no internal boundaries.

## What this PR ships

**Four coupled fields flipped together in `shows/_defaults.yaml`:**

| Field | Was | Now |
|---|---|---|
| `speech_wrap_open` | `""` | `"<fast>"` |
| `speech_wrap_close` | `""` | `"</fast>"` |
| `use_section_tts` | (new field) | `false` |
| `max_chars` | `10000` | `14000` |

These four are a **coupled set** — flipping any one without the others re-introduces the leak. Drift-guard test pins them all together so a partial revert fails CI.

**Code changes:**
- `engine/config.py` — added `use_section_tts: bool = True` field to TTSConfig (dataclass default preserved for no-YAML callers; network YAML sets it to false)
- `run_show.py:1714` — section-TTS gate now reads `config.tts.use_section_tts`. When false, the whole script flows through `synthesize()` as one Grok call.
- `engine/tts.py:_speak_with_grok` — **defence-in-depth safety guard**: if a script overflows `max_chars` and splits into multiple chunks, DROP the wrap (with a loud warning) rather than apply it per-chunk. Episode loses the energy lift but ships clean audio.

## Trade-off you should know about

`use_section_tts: false` means **no transition stings between chapter markers.** These were brief musical separators (~0.5s) that played between chapters during section-TTS concatenation. Most listeners won't notice — chapter markers themselves still work in podcast apps (Apple, Spotify, Pocket Casts) because those come from `chapters.json`, not from the audio.

If you miss the stings, one-line revert: set `use_section_tts: true` in `_defaults.yaml` AND drop the speech wrap. Coupled fields, intentionally.

## Drift guards (4 new tests)

1. `test_default_tts_config_dataclass_has_no_chunk_wrap` — dataclass default stays empty for backwards compat
2. `test_network_default_has_fast_wrap_and_single_call` — pins all 4 coupled YAML fields; **partial revert fails CI**
3. `test_speak_with_grok_drops_wrap_on_multi_chunk` — verifies the safety guard fires on overflow
4. `test_speak_with_grok_keeps_wrap_on_single_chunk` — verifies the happy path applies the wrap once

## Sizing — will all shows fit in one chunk?

Recent script char counts from metrics:

| Show | TTS chars | Fits in 14000? |
|---|---|---|
| Tesla 471 | 4538 | ✅ |
| Omni View 49 | ~9700 | ✅ |
| Fascinating Frontiers 69 | ~8000 | ✅ |
| Models & Agents 47 | 8754 | ✅ |
| MAB 37 | ~6300 | ✅ |
| Modern Investing 41 | 8540 | ✅ |
| Planetterrian 62 | ~6000 | ✅ |
| Env Intel 33 | ~8000 | ✅ |
| Unintended Consequences 8 | 6427 | ✅ |
| Финансы Просто 35 | ~5400 | ✅ |
| Привет, Русский! 23 | ~3700 | ✅ |

Every show comfortably under 14000. Hardest overflow scenario: a 15-min TST episode could approach 12k. Still single-chunk. If a future episode genuinely hits 14k+, the safety guard kicks in (raw audio + warning) and you can decide whether to shorten the script or bump `max_chars` to Grok's 15000 cap.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_youtube.py` — 1,784 pass, 6 skip
- [ ] **First TST episode after merge:** listen for energy lift on the host's delivery — should feel ~10-15% faster / more enthusiastic
- [ ] **Whisper transcript check:** verify no "fast" or "</fast>" appears as text in any transcript (tag-leak detector will scan automatically)
- [ ] **Audio sanity:** verify no audible glitch where transition stings used to be (between chapters)
- [ ] If energy feels off (too rushed, breath issues, weird pacing), revert is one YAML PR away

## Rollback

Single revert path:
```yaml
# shows/_defaults.yaml
speech_wrap_open: ""
speech_wrap_close: ""
use_section_tts: true
max_chars: 10000
```

Or partial revert (keep single-call, drop the energy lift):
```yaml
speech_wrap_open: ""
speech_wrap_close: ""
# keep use_section_tts: false, keep max_chars: 14000
```

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_