### PR TITLE
newsletter: hide long URLs in Source / Source/Post lines

### DIFF
--- a/engine/newsletter_body.py
+++ b/engine/newsletter_body.py
@@ -403,17 +403,79 @@ def transform_email_body(body: str, *, slug: str = "") -> str:
     contain raw HTML — Markdown viewers strip or escape it):
 
       1. Markdown ``---`` → styled ``<hr>`` (dark-mode aware)
-      2. Tesla ``**TSLA today:**`` line → styled stock-watch table
-      3. Privet vocab list → card-stack table
+      2. Source-line markdown links → inline HTML ``<a>`` so
+         Buttondown's markdown renderer doesn't choke on the long
+         Google-News redirect URLs (May 14 2026: operator caught
+         ``[Google News](https://news.google.com/...)`` rendering as
+         literal markdown source text instead of as a clickable
+         label, exposing the 600-char URL inline in the email body)
+      3. Tesla ``**TSLA today:**`` line → styled stock-watch table
+      4. Privet vocab list → card-stack table
 
     Idempotent — repeated runs produce the same HTML output.
     """
     body = upgrade_md_hr_to_html(body)
+    body = render_source_links_as_html(body)
     if slug == "tesla":
         body = render_tsla_price_block(body)
     if slug == "privet_russian":
         body = render_russian_vocab_cards(body)
     return body
+
+
+# ---------------------------------------------------------------------------
+# Source-line markdown → inline HTML (email-stage)
+# ---------------------------------------------------------------------------
+
+# Match the canonical ``<prefix>: [Label](URL)`` shape produced by
+# ``shorten_source_urls()``.  We re-find it at the email stage and
+# rewrite to inline HTML so Buttondown's markdown renderer doesn't get
+# a chance to mishandle the (sometimes 600-char) URL inside the
+# parentheses.  Restricting to the ``Source:`` / ``Source/Post:``
+# prefix avoids rewriting random ``[label](url)`` markdown links
+# elsewhere in the body.
+_SOURCE_HTML_LINK_RE = re.compile(
+    r"(Source/Post|Source):\s*\[([^\]]+)\]\((https?://[^)]+)\)",
+    flags=re.IGNORECASE,
+)
+
+
+def render_source_links_as_html(body: str) -> str:
+    """Convert ``Source: [label](url)`` markdown into inline ``<a>``.
+
+    Why this exists: Buttondown's markdown renderer (May 14 2026
+    audit) emits the LITERAL bracket/paren markdown when the URL
+    inside the parens is "too long" (the threshold isn't documented;
+    it consistently fails on 200-600-char Google News redirect URLs).
+    The reader sees ``Source: [Google News](https://news.google.com/
+    rss/articles/CBMi...?oc=5)`` as raw text with the URL spanning
+    multiple lines — the link IS clickable via Buttondown's bare-URL
+    autolink, but the markdown syntax bleeds through unrendered.
+
+    Inline HTML bypasses the markdown layer entirely.  Buttondown
+    passes through ``<a>`` tags untouched, so the reader sees
+    ``Source: Google News`` (no URL visible) with the link active.
+
+    Idempotent: re-running on already-HTMLified text is a no-op
+    because the regex requires markdown syntax (`[` `]` `(` `)`)
+    that isn't present after the first pass.
+    """
+    if not body or ("Source:" not in body and "Source/Post:" not in body):
+        return body
+
+    def _sub(match: re.Match) -> str:
+        prefix = match.group(1)
+        label = match.group(2)
+        url = match.group(3).rstrip(" ).,;")
+        # ``rel="noopener"`` for security; ``target="_blank"`` so the
+        # reader doesn't lose their place in the email when they click
+        # through to the source.
+        return (
+            f'{prefix}: <a href="{url}" target="_blank" '
+            f'rel="noopener">{label}</a>'
+        )
+
+    return _SOURCE_HTML_LINK_RE.sub(_sub, body)
 
 
 # ---------------------------------------------------------------------------
@@ -458,55 +520,104 @@ def linkify_x_handles(body: str) -> str:
 # "Source: <long-url>" shortening (post-fetch defense)
 # ---------------------------------------------------------------------------
 
-# Match "Source: <url>" emitted by the LLM at the end of a story. The URL
-# can be Google News (`news.google.com/rss/articles/CBMi...`) which is
-# 200-600 chars, or any other publisher URL with utm_*-style noise.
-# Captures (1) the URL itself; we replace the whole "Source: …" tail.
-_SOURCE_URL_RE = re.compile(
-    r"\s*Source:\s*(https?://[^\s)]+)",
+# Source-line URL patterns the LLM emits at the end of each story.
+# Two forms appear in production digests as of May 2026:
+#   * Bare URL:      ``Source: https://news.google.com/rss/articles/CBMi...``
+#                    ``Source/Post: https://news.google.com/rss/articles/CBMi...``
+#   * Markdown link: ``Source: [Google News](https://news.google.com/...)``
+#                    ``Source/Post: [insideevs.com](https://...)``
+#
+# Top 10 News items use the markdown form; Short Spot uses the bare form
+# (``Source/Post:`` because it doubles as a news source and a social
+# post link).  Either form can carry a 200-600-char Google News
+# redirect URL when the fetcher's ``resolve_google_news_url`` couldn't
+# resolve it at fetch time — both forms then bleed the redirect blob
+# into the rendered email (operator caught this on the May 12 Tesla
+# daily in Apple Mail).
+#
+# We canonicalize both forms to one compact shape:
+#   ``<prefix>: [domain](url)``
+#
+# ``<prefix>`` is preserved (Source vs Source/Post) so downstream
+# renderers that care about the distinction (e.g. the blog cite-pill
+# regex) keep working.
+
+# Match ``(Source|Source/Post): https://...`` (bare URL form).
+_SOURCE_BARE_URL_RE = re.compile(
+    r"\s*(Source/Post|Source):\s*(https?://[^\s)]+)",
+    flags=re.IGNORECASE,
+)
+# Match ``(Source|Source/Post): [Label](https://...)`` (markdown-link form).
+# Note: ``[^\)]+`` for the URL because the URL can contain anything
+# except the closing paren — including ``(`` if a publisher gets weird.
+_SOURCE_MD_LINK_RE = re.compile(
+    r"\s*(Source/Post|Source):\s*\[([^\]]+)\]\((https?://[^)]+)\)",
     flags=re.IGNORECASE,
 )
 
 
-def shorten_source_urls(body: str) -> str:
-    """Render long bare-URL "Source:" trailers as compact "Source: <domain>"
-    markdown links. Spec v2 follow-up after the May 2 Tesla daily showed
-    the literal Google News redirect blob `CBMiig...` in the body.
+def _domain_label_for(url: str) -> str:
+    """Pick a short, readable label for a publisher URL.
 
-    The fetcher's ``resolve_google_news_url`` canonicalizes URLs at fetch
-    time, but (a) cached articles from before that fix landed still have
-    the long URLs and (b) network failures during resolution leave the
-    original Google-News URL in the article record. This transform is a
-    final visual cleanup applied to the rendered body so the email never
-    shows the 600-char tracking blob even when the upstream resolver
-    bailed.
+    Strips ``www.``; collapses Google News redirect hosts to the literal
+    string "Google News" so a reader unfamiliar with the redirect format
+    sees what they're clicking on instead of a domain.
     """
-    if not body or "Source:" not in body:
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(url).netloc
+    except Exception:  # noqa: BLE001
+        host = ""
+    if not host:
+        return url
+    host = host.lower()
+    if host.startswith("www."):
+        host = host[4:]
+    if host.startswith("news.google."):
+        return "Google News"
+    return host
+
+
+def shorten_source_urls(body: str) -> str:
+    """Render every ``Source:`` / ``Source/Post:`` line as a compact
+    ``<prefix>: [domain](url)`` markdown link, regardless of the
+    input form.
+
+    Two passes:
+      1. Markdown form ``Source: [Label](URL)`` → rewrite the label to
+         the URL's domain (idempotent when the label already IS the
+         domain).
+      2. Bare form ``Source: https://URL`` → wrap as a markdown link
+         with the URL's domain as the label.
+
+    Both passes preserve the leading prefix verb (Source vs
+    Source/Post).  No-op when neither pattern is present.
+
+    Spec v2 follow-up after the May 2 Tesla daily showed the literal
+    Google News redirect blob ``CBMiig...`` in the body; May 14 audit
+    extended the cover to (a) ``Source/Post:`` prefix and (b) markdown-
+    link form, both of which the prior regex missed.
+    """
+    if not body or ("Source:" not in body and "Source/Post:" not in body):
         return body
 
-    def _sub(match: re.Match) -> str:
-        url = match.group(1).rstrip(" ).,;")
-        # Extract a human-readable domain.
-        try:
-            from urllib.parse import urlparse
-            host = urlparse(url).netloc
-        except Exception:  # noqa: BLE001
-            host = ""
-        if not host:
-            return match.group(0)
-        # Strip leading "www."; if it's still Google News after our
-        # fetch-time resolver bailed, label it that way explicitly so
-        # the reader at least sees what they're getting.
-        host = host.lower()
-        if host.startswith("www."):
-            host = host[4:]
-        if host.startswith("news.google."):
-            label = "Google News"
-        else:
-            label = host
-        return f" Source: [{label}]({url})"
+    def _md_sub(match: re.Match) -> str:
+        prefix = match.group(1)
+        url = match.group(3).rstrip(" ).,;")
+        label = _domain_label_for(url)
+        return f" {prefix}: [{label}]({url})"
 
-    return _SOURCE_URL_RE.sub(_sub, body)
+    def _bare_sub(match: re.Match) -> str:
+        prefix = match.group(1)
+        url = match.group(2).rstrip(" ).,;")
+        label = _domain_label_for(url)
+        return f" {prefix}: [{label}]({url})"
+
+    # Markdown form first — otherwise the bare-URL regex would also
+    # match the URL inside the markdown link and corrupt it.
+    body = _SOURCE_MD_LINK_RE.sub(_md_sub, body)
+    body = _SOURCE_BARE_URL_RE.sub(_bare_sub, body)
+    return body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_newsletter_body.py
+++ b/tests/test_newsletter_body.py
@@ -418,6 +418,123 @@ class TestShortenSourceUrls:
         twice = shorten_source_urls(once)
         assert once == twice
 
+    def test_handles_source_post_prefix_bare_url(self):
+        """May 14 2026: Short Spot lines use ``Source/Post:`` (not
+        ``Source:``). Before the fix, those passed through unchanged
+        and the 600-char Google News blob bled into the email body."""
+        long_url = (
+            "https://news.google.com/rss/articles/CBMivg" + "x" * 400
+            + "?oc=5"
+        )
+        text = f"Short Spot body. Source/Post: {long_url}"
+        out = shorten_source_urls(text)
+        assert "Source/Post: [Google News]" in out
+        # Prefix preserved (not silently rewritten to "Source:") so
+        # downstream blog cite-pill rendering still distinguishes.
+        assert "Source/Post:" in out
+        # Original bare URL is no longer dangling after the prefix.
+        assert f"Source/Post: {long_url}" not in out
+
+    def test_handles_markdown_link_form(self):
+        """Top 10 News items already arrive as ``Source: [Label](URL)``
+        markdown. The label should be normalised to the URL's domain
+        so the canonical form is the same as the bare-URL path."""
+        long_url = (
+            "https://news.google.com/rss/articles/CBMivg" + "x" * 400
+            + "?oc=5"
+        )
+        text = f"Story body. Source: [Google News]({long_url})"
+        out = shorten_source_urls(text)
+        # Still labelled "Google News" (we collapse news.google.* to
+        # the literal label).
+        assert "[Google News]" in out
+        # No raw bracketed-link with the long URL leaking through.
+        # The output's markdown link still contains the URL but no
+        # additional ``[Label]`` outside the link.
+        assert out.count("[Google News]") == 1
+
+    def test_handles_source_post_markdown_form(self):
+        """Combined: ``Source/Post: [Label](URL)`` rare but possible."""
+        text = (
+            "Body. Source/Post: [insideevs.com]"
+            "(https://insideevs.com/news/12345/story-path/)"
+        )
+        out = shorten_source_urls(text)
+        assert "Source/Post: [insideevs.com]" in out
+        assert "(https://insideevs.com/news/12345/story-path/)" in out
+
+    def test_rewrites_markdown_label_to_domain(self):
+        """A markdown-form Source with a verbose label (not a domain)
+        gets the label rewritten to the URL's domain for consistency."""
+        text = (
+            "Body. Source: [Read more at this article]"
+            "(https://insideevs.com/foo)"
+        )
+        out = shorten_source_urls(text)
+        # Label collapses to the domain.
+        assert "[insideevs.com]" in out
+        assert "Read more at this article" not in out
+
+
+class TestRenderSourceLinksAsHtml:
+    """Email-stage: convert canonical ``Source: [label](url)``
+    markdown into inline HTML ``<a>`` so Buttondown's markdown
+    renderer doesn't choke on long Google News redirect URLs
+    (operator caught May 14 2026: the markdown source rendered as
+    visible text in Apple Mail, exposing the 600-char URL)."""
+
+    def setup_method(self):
+        from engine.newsletter_body import render_source_links_as_html
+        self._html = render_source_links_as_html
+
+    def test_converts_source_markdown_to_anchor(self):
+        text = "Body. Source: [Google News](https://news.google.com/foo?oc=5)"
+        out = self._html(text)
+        assert 'href="https://news.google.com/foo?oc=5"' in out
+        assert ">Google News</a>" in out
+        # Original markdown syntax is gone.
+        assert "[Google News]" not in out
+        assert "](https://" not in out
+
+    def test_converts_source_post_markdown_to_anchor(self):
+        text = "Body. Source/Post: [news.google.com](https://news.google.com/x)"
+        out = self._html(text)
+        assert "Source/Post:" in out
+        assert 'href="https://news.google.com/x"' in out
+        assert ">news.google.com</a>" in out
+
+    def test_includes_security_attributes(self):
+        """Every Source link must open in a new tab without leaking
+        the referrer (rel=noopener)."""
+        text = "Source: [insideevs.com](https://insideevs.com/foo)"
+        out = self._html(text)
+        assert 'target="_blank"' in out
+        assert 'rel="noopener"' in out
+
+    def test_idempotent(self):
+        text = "Source: [example.com](https://example.com/foo)"
+        once = self._html(text)
+        twice = self._html(once)
+        assert once == twice
+
+    def test_no_match_returns_unchanged(self):
+        text = "Body with no source line at all."
+        assert self._html(text) == text
+
+    def test_leaves_other_markdown_links_alone(self):
+        """The regex anchors on ``Source:`` / ``Source/Post:`` —
+        random markdown links elsewhere in the body must pass
+        through untouched."""
+        text = (
+            "See the [latest update](https://example.com/x) for details. "
+            "Source: [news.google.com](https://news.google.com/y)"
+        )
+        out = self._html(text)
+        # Source line converted.
+        assert 'href="https://news.google.com/y"' in out
+        # Random markdown link still in markdown form.
+        assert "[latest update](https://example.com/x)" in out
+
 
 # ---------------------------------------------------------------------------
 # X handle linkification


### PR DESCRIPTION
## Summary

Operator caught (May 14 2026 Apple Mail screenshot) the Tesla daily newsletter rendering 600-character Google News redirect URLs as raw text in the body. This PR ships a two-layer fix for that AND flags the separate "very light heading color" issue for further investigation.

### Issue A — long URLs visible (fixed in this PR)

Two compounding causes:

**(a) Coverage gap in `shorten_source_urls`** — the canonical transform only matched `Source:` prefix (not `Source/Post:` which Short Spot uses) and only the BARE-URL form (`Source: https://...`). Top 10 News items arrive from the LLM as markdown links (`Source: [Google News](URL)`) and **bypassed the shortener entirely**.

**(b) Buttondown markdown bug** — even when our transform DID emit compact `Source: [Google News](URL)` markdown, Buttondown's renderer rendered the brackets and parens as literal text when the URL inside was very long (no documented threshold; consistently fails on 200-600-char Google News redirect URLs). Reader saw the raw markdown syntax + the URL bleeding across multiple lines.

**Two-layer fix:**

1. **`shorten_source_urls`** (canonical stage) now handles all four input shapes uniformly:
   - `Source: https://URL` (bare)
   - `Source/Post: https://URL` (bare, Short Spot)
   - `Source: [Label](URL)` (markdown)
   - `Source/Post: [Label](URL)` (markdown)

   All normalise to `<prefix>: [domain](URL)` markdown. Prefix preserved so downstream consumers (blog cite-pill regex) still distinguish Source vs Source/Post.

2. **`render_source_links_as_html`** (email-only stage, NEW) runs *after* the canonical transform. Converts `<prefix>: [label](url)` markdown into inline HTML `<a href="url" target="_blank" rel="noopener">label</a>`. Bypasses Buttondown's markdown renderer entirely so long-URL links render reliably.

Anchored on `Source:` / `Source/Post:` prefix only — random markdown links elsewhere in the body are untouched.

### Issue B — "very light heading color" (NOT fixed in this PR, see below)

The screenshot shows the title "Tesla's robotaxi rollout in Texas is hitting long wait... · Tesla Shorts 🚀" appearing in light blue/gray text at the TOP of the email, before the red cover tile. That area is NOT in our HTML — it appears to be either:

- **Apple Mail's expanded-subject chrome.** Apple Mail iOS shows the email's subject line in a dedicated styled bar above the body. Apple controls that styling; we control only the subject text length/content.
- **Buttondown's auto-injected newsletter header.** Buttondown automatically inserts the email title + newsletter name + date + "Did someone forward you this?" subscribe link as a header above the body content we send. Styling comes from Buttondown's theme settings, not our HTML.

Either way, **neither path is reachable from our `transform_daily_body` / `transform_email_body` / `wrap_with_branding` pipeline.** A blind CSS injection could regress other clients.

**To diagnose properly I'd need either:**
1. The raw HTML Buttondown actually sent (downloadable from Buttondown's "Sent" view → "View HTML")
2. OR a check of Buttondown's brand-settings page → "Title color" / "Header background" / etc.

Happy to chase either if you can share. Most likely fix: tweak the Buttondown brand colors in the dashboard to use darker title text.

## Test plan

- [x] `pytest tests/test_newsletter_body.py` — 57 pass (11 new tests)
- [x] `pytest tests/ --ignore=tests/test_youtube.py` — 1,806 pass, 6 skip
- [ ] **Next daily newsletter send (any show with Source: lines):** verify in Apple Mail that "Source: Google News" renders as a single clickable link — no URL visible, no markdown brackets visible
- [ ] Spot-check Buttondown's web archive view of the newsletter: same — should show clean clickable links

## Tests added

**`TestShortenSourceUrls`** gains 4 cases:
- Source/Post: prefix with bare URL → compact markdown
- Source: markdown link form → label rewritten to domain
- Source/Post: markdown link form
- Verbose markdown label → collapsed to domain

**New `TestRenderSourceLinksAsHtml`** class (6 cases):
- Source markdown → `<a href>`
- Source/Post markdown → `<a href>` (prefix preserved)
- target/rel security attributes present
- Idempotent
- No-match no-op
- Random `[label](url)` elsewhere untouched

## Rollback

Both changes are scoped to `engine/newsletter_body.py`:
- Revert `shorten_source_urls` to the prior regex if a publisher format breaks (unlikely — broader regex is strictly more permissive)
- Remove the `render_source_links_as_html` call from `transform_email_body` if Buttondown ever fixes their markdown renderer or if the inline HTML causes issues in any client (Outlook desktop, etc.) — fallback is the pre-fix behavior

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_