### PR TITLE
prompts: raise story coverage on FF, PT, M&A to hit word targets

### DIFF
--- a/shows/prompts/fascinating_frontiers_podcast.txt
+++ b/shows/prompts/fascinating_frontiers_podcast.txt
@@ -21,11 +21,11 @@ You are writing a 10–13 minute solo podcast script for "Fascinating Frontiers"
 HOST: Patrick in Vancouver — Canadian, space enthusiast, newscaster. Knowledgeable and genuinely curious about space.
 
 STRUCTURAL REQUIREMENTS (these determine episode length):
-- Cover 7-9 stories from the digest
+- Cover 9-11 stories from the digest
 - Each story: 4-6 sentences focused on facts — opening discovery/fact, 2-3 sentences with concrete source details (instrument names, measurements, distances, methodology, researcher quotes), 1 transition. Reserve commentary/significance for AT MOST ONE sentence per story, and only when it adds something the facts don't.
-- That is 50-70 sentences of story content alone
+- That is 55-75 sentences of story content alone
 - Add intro (2-3 sentences), hook (1 sentence), Cosmic Spotlight (5-7 sentences), tomorrow teaser (2 sentences), closing
-- Total: 60-80+ sentences, producing a 10-13 minute episode
+- Total: 70-90+ sentences, producing a 10-13 minute episode
 - This is a science NEWS show, not an editorial show. Wonder comes from the facts themselves (the actual distances, masses, mechanisms), not from added "this matters because" sentences.
 
 RULES:
@@ -71,7 +71,7 @@ TTS FORMATTING (critical for audio quality):
 PACING AND DEPTH:
 - Spend 45-75 seconds on each story. That means 4-6 sentences per story, with concrete science details in every sentence (distances, masses, instrument names, methodology, quotes).
 - For each story: state the discovery/event, then add the specific source details. Commentary is the exception, not the rule: at most ONE sentence per story, and only when it adds something the facts don't.
-- Cover the 7-9 most important stories from the digest. If a digest item is thin, move on rather than padding with significance sentences.
+- Cover the 9-11 most important stories from the digest. If a digest item is thin, move on rather than padding with significance sentences.
 - Use natural transitions between stories ("Now, shifting to..." or "On a different note..." or simply "Next up...")
 - NEVER retell or revisit a story you already covered, even from a different angle. Each news item gets ONE treatment. Once you have covered a story, it is done — move on to the next topic.
 - Do NOT repeat transition sentences. When you write a transition at the end of one story, start the next story with NEW content — do not repeat the transition line.

--- a/shows/prompts/models_agents_digest.txt
+++ b/shows/prompts/models_agents_digest.txt
@@ -77,21 +77,21 @@ Source: [EXACT URL FROM PRE-FETCHED — no modifications]
 
 ━━━━━━━━━━━━━━━━━━━━
 ### Model Updates
-2-4 items tracking new model releases, updates, benchmarks, or capability changes. For each:
+3-5 items tracking new model releases, updates, benchmarks, or capability changes. For each:
 **Title: Source Name**
 2-3 sentences: What's new (be specific — model name, version, capabilities, pricing). How it compares. Why it matters for your work.
 Source: [EXACT URL]
 
 ━━━━━━━━━━━━━━━━━━━━
 ### Agent & Tool Developments
-2-3 items covering agent frameworks, autonomous tools, computer use, MCP servers, or agentic capabilities. For each:
+3-4 items covering agent frameworks, autonomous tools, computer use, MCP servers, or agentic capabilities. For each:
 **Title: Source Name**
 2-3 sentences: What the tool/framework does. What's new or improved. How you can try it today.
 Source: [EXACT URL]
 
 ━━━━━━━━━━━━━━━━━━━━
 ### Practical & Community
-2-3 items highlighting open-source projects, tutorials, API changes, or developer tools. For each:
+3-4 items highlighting open-source projects, tutorials, API changes, or developer tools. For each:
 **Title: Source**
 2-3 sentences: What it is and what problem it solves. How to get started. Any notable limitations or requirements.
 Source: [EXACT URL]

--- a/shows/prompts/models_agents_podcast.txt
+++ b/shows/prompts/models_agents_podcast.txt
@@ -23,9 +23,9 @@ HOST: A tech-savvy AI practitioner and journalist who lives and breathes the AI 
 AUDIENCE: A mix of developers building with AI, professionals adopting AI tools, and curious people who want to stay informed about the most transformative technology of our generation. They range from hands-on builders to people who just want to know what's new and what to try. They are excited but also overwhelmed by the pace of change. They want a trusted guide.
 
 STRUCTURAL REQUIREMENTS (these determine episode length):
-- Cover the Top Story (5-7 sentences focused on facts: what shipped, specific capabilities, benchmark numbers, pricing, availability), Model Updates (3-5 sentences each for 2-4 items), Agent/Tool items (3-5 sentences each for 2-3 items), Practical/Community (3-5 sentences each for 2-3 items), Things to Try (1-2 sentences each), On the Horizon (1 sentence each)
+- Cover the Top Story (5-7 sentences focused on facts: what shipped, specific capabilities, benchmark numbers, pricing, availability), Model Updates (4-5 sentences each for 3-5 items), Agent/Tool items (4-5 sentences each for 3-4 items), Practical/Community (4-5 sentences each for 3-4 items), Things to Try (1-2 sentences each for 3-4 items), On the Horizon (1 sentence each for 2-3 items)
 - Reserve commentary/significance for AT MOST ONE sentence per item, and only when it adds something the facts don't. AI news is fascinating because of what the systems actually do — concrete capabilities, numbers, comparisons — not because of "this could change how developers work" framing.
-- Total: 45-65+ sentences, producing a 6-9 minute episode
+- Total: 65-85+ sentences, producing a 8-11 minute episode
 
 EXAMPLE OF IDEAL STORY COVERAGE (use this depth and style — note the ratio: 5 fact-bearing sentences, 0 commentary sentences, 1 transition):
 Host: Anthropic released Claude four today, scoring forty-nine percent on the SWE-bench coding evaluation — nearly double what Claude three point five managed six months ago.

--- a/shows/prompts/planetterrian_podcast.txt
+++ b/shows/prompts/planetterrian_podcast.txt
@@ -21,11 +21,11 @@ You are writing a 10–13 minute solo podcast script for "Planetterrian Daily" E
 HOST: Patrick in Vancouver — Canadian, scientist, newscaster. Knowledgeable about science, health, and longevity research.
 
 STRUCTURAL REQUIREMENTS (these determine episode length):
-- Cover 7-9 stories from the digest
+- Cover 9-11 stories from the digest
 - Each story: 4-6 sentences focused on facts — opening finding/fact, 2-3 sentences with concrete source details (study size, methodology, journal, mechanisms, researcher quotes, specific numbers), 1 transition. Reserve commentary/implications for AT MOST ONE sentence per story, and only when it adds something the facts don't.
-- That is 50-70 sentences of story content alone
+- That is 55-75 sentences of story content alone
 - Add intro (2-3 sentences), hook (1 sentence), Spotlight (5-7 sentences), tomorrow teaser (2 sentences), closing
-- Total: 60-80+ sentences, producing a 10-13 minute episode
+- Total: 70-90+ sentences, producing a 10-13 minute episode
 - This is a science NEWS show, not an analysis show. Lead with the actual research findings — sample sizes, mechanisms, p-values, specific molecules — not with "this could lead to" sentences.
 
 RULES:
@@ -72,7 +72,7 @@ TTS FORMATTING (critical for audio quality):
 PACING AND DEPTH:
 - Spend 45-75 seconds on each story. That means 4-6 sentences per story, with concrete research details in every sentence (sample sizes, mechanisms, journals, specific molecules, study designs).
 - For each story: state the finding, then add the specific source details. Commentary is the exception, not the rule: at most ONE sentence per story, only when it adds something the facts don't.
-- Cover the 7-9 most important stories from the digest. If a digest item is thin, move on rather than padding with "this could lead to" sentences.
+- Cover the 9-11 most important stories from the digest. If a digest item is thin, move on rather than padding with "this could lead to" sentences.
 - Use natural transitions between stories ("Now, shifting to..." or "On a different note..." or simply "Next up...")
 - NEVER retell or revisit a story you already covered, even from a different angle. Each news item gets ONE treatment. Once you have covered a story, it is done — move on to the next topic.
 - Do NOT repeat transition sentences. When you write a transition at the end of one story, start the next story with NEW content — do not repeat the transition line.


### PR DESCRIPTION
## Summary

Three small prompt bumps to close the word-target gap on FF, PT, and M&A. Mirrors the spirit of PR #369's Top 10→12 fix on Tesla, but applied to the right knob for each show (FF/PT already have Top 15 in digests — gap is in podcast prompt coverage).

## What changed

| Show | Bump | Before | After |
|---|---|---|---|
| FF podcast | `Cover 7-9 stories` | 7-9 | 9-11 |
| PT podcast | `Cover 7-9 stories` | 7-9 | 9-11 |
| M&A podcast | Model Updates items | 2-4 | **3-5** |
| M&A podcast | Agent/Tool items | 2-3 | **3-4** |
| M&A podcast | Practical/Community items | 2-3 | **3-4** |
| M&A digest | Same three sections | (matched bump so digest backs the podcast) | |

UC stayed put — narrative-essay show, lower target by design.

## Why FF/PT digests aren't the bottleneck

I initially recommended "Top N expansion" mirroring Tesla, but on closer inspection both FF and PT already have **Top 15** in their digest prompts (well above the 7-9 the podcast prompt was drawing from). The bottleneck is in the **podcast** prompt's story-coverage range, not the digest's item count.

After the PR #365 editorializing reduction, each story produces ~4-6 sentences instead of the prior 6-8. Same story count × fewer sentences = thinner script. Raising the story count from 7-9 → 9-11 makes the math work again without re-introducing commentary padding.

## Why M&A needs the digest bumped too

M&A's podcast prompt structurally asks for "X items per section." If I bump the podcast count without bumping the matching digest count, the LLM either has to **invent items** (drift risk) or the podcast script underfills. Bumped both in lock-step so the digest backs whatever the podcast asks for.

## Expected impact (back-of-envelope)

| Show | Today | After bump (est) | Target |
|---|---|---|---|
| FF | 749 (71%) | ~880 (84%) | 1050 |
| PT | 714 (75%) | ~840 (88%) | 950 |
| M&A | 1133 (76%) | ~1300 (87%) | 1500 |

Doesn't close the gap completely — but should bring all three back above 80%, which the operator's tolerance band. If still below target on tomorrow's run, the cleaner fix is lowering the word targets themselves (they were calibrated against PRE-editorializing scripts and may just be too aggressive for the new content density).

## Test plan

- [x] `pytest tests/ --ignore=tests/test_youtube.py` — 1,806 pass (no test changes needed; assertions don't pin the specific counts)
- [ ] **Tomorrow's FF / PT / M&A runs** — check `podcast_script_word_count` is ≥ 80% of target
- [ ] **Listen-test:** confirm tone still feels factual (not re-padded with commentary) — the editorializing reduction should still be in effect
- [ ] **Cross-episode repeats** on FF (was 9) and PT (was 10) — should not get worse; the broader item pool may even help

## Rollback

Revert each prompt's specific number back. No coupled fields, no test changes — single-file reverts.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_