### PR TITLE
audio: outro fade-in 1s→0s + outro_volume bumped to match intro

### DIFF
--- a/editorial.html
+++ b/editorial.html
@@ -735,12 +735,15 @@
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>
-                    <div class="nn-subscribe-tags">
-                        <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                    <div class="nn-subscribe-tags"><label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                        <label><input type="checkbox" name="tag" value="Omni View"> Omni View</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
-                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models & Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Planetterrian Daily"> Planetterrian Daily</label>
                         <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
-                        <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label><label><input type="checkbox" name="tag" value="Finansy Prosto"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents"> Models &amp; Agents</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models &amp; Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
+                        <label><input type="checkbox" name="tag" value="Unintended Consequences"> Unintended Consequences</label><label><input type="checkbox" name="tag" value="Finansy Prosto"> Финансы Просто</label>
                         <label><input type="checkbox" name="tag" value="Privet Russian"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">

--- a/engine/audio.py
+++ b/engine/audio.py
@@ -471,13 +471,23 @@ def _music_outro_cmd(music_in: str, outro_out: str,
                      fade_in_duration: int = 2,
                      fade_out_start: int = 27,
                      fade_out_duration: int = 3) -> list:
+    # ``afade=d=0`` is undefined behaviour in ffmpeg; skip the fade-in
+    # filter entirely when ``fade_in_duration <= 0`` so the outro
+    # plays at full ``volume`` from t=0.  Operator preference, May
+    # 15 2026 — any fade-in let listeners interpret the post-voice
+    # silence as "audio ended" before the music ramped up.
+    af_parts = [f"volume={volume}"]
+    if fade_in_duration > 0:
+        af_parts.append(
+            f"afade=t=in:curve=log:st=0:d={fade_in_duration}"
+        )
+    af_parts.append(
+        f"afade=t=out:curve=log:st={fade_out_start}:d={fade_out_duration}"
+    )
     return [
         "ffmpeg", "-y", "-threads", "0",
         "-stream_loop", "-1", "-i", music_in, "-t", str(duration),
-        "-af",
-        f"volume={volume},"
-        f"afade=t=in:curve=log:st=0:d={fade_in_duration},"
-        f"afade=t=out:curve=log:st={fade_out_start}:d={fade_out_duration}",
+        "-af", ",".join(af_parts),
         "-ar", "44100", "-ac", "2",
         "-c:a", "libmp3lame", "-b:a", "192k", "-preset", "fast",
         outro_out,
@@ -812,15 +822,28 @@ def mix_with_music(
                 outro_fade_in, outro_fade_out_dur,
             )
         else:
-            # Music starts AFTER voice ends.  Quick 1 s fade-in so the
-            # music doesn't pop in cold but listener hears full outro
-            # volume by ~1 s post-voice.  Previous default was 6 s,
-            # which combined with sidechain-release timing made the
-            # post-voice music feel slow and tentative — operator
-            # caught this on TST Ep472 (May 14 2026: "ended abruptly
-            # as soon as the transcript stopped").
+            # Music starts AFTER voice ends — NO fade-in.  Music plays
+            # at full ``outro_volume`` from the instant voice ends so
+            # the listener perceives an unambiguous "music outro is
+            # here" cue.
+            #
+            # History:
+            #   May 6 2026 — 6 s fade-in (operator wanted "graceful")
+            #   May 14 2026 — dropped to 1 s (operator caught Ep472:
+            #     post-voice music felt "tentative / ended abruptly")
+            #   May 15 2026 — dropped to 0 s (operator caught Ep473:
+            #     "no music outro at all").
+            #
+            # Root cause of the lingering issue: even with a 1 s
+            # ``afade curve=log`` ramp, the audio is < 50 % of full
+            # volume until t ≈ 0.7 s.  Combined with the sidechain
+            # compressor's 600 ms release time after voice goes silent,
+            # the listener experienced ~1.5 s of near-silence before
+            # the outro became clearly audible.  Many listeners had
+            # already concluded "audio ended" by then.  Starting at
+            # full volume eliminates the perceptual gap.
             total_outro_duration = outro_duration
-            outro_fade_in = 1
+            outro_fade_in = 0
             outro_fade_out_start = max(outro_duration - outro_fade_out_dur, 0)
 
         # Coherent acrossfade: overlap and fadeout source slices are

--- a/engine/config.py
+++ b/engine/config.py
@@ -156,7 +156,15 @@ class AudioConfig:
     intro_volume: float = 0.6
     overlap_volume: float = 0.5
     fade_volume: float = 0.4
-    outro_volume: float = 0.4
+    # ``outro_volume`` matches ``intro_volume`` (May 15 2026) so the
+    # post-voice outro stands out clearly from the ducked-and-fading
+    # music that was playing during voice. Setting it equal to
+    # ``fade_volume`` (the prior default) created the perceptual
+    # equivalence operator caught on TST Ep473: "no music outro at
+    # all" — the music WAS playing, but at the same level the
+    # listener had been hearing it under-voice for the prior 30 s,
+    # so they registered no "music is back" transition.
+    outro_volume: float = 0.6
     voice_intro_delay: float = 10.0
     outro_crossfade: float = 0.0
 

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -125,7 +125,7 @@ audio:
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3
-  outro_volume: 0.3
+  outro_volume: 0.5
 
 storage:
   provider: r2

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -198,7 +198,7 @@ audio:
   intro_volume: 0.4
   overlap_volume: 0.3
   fade_volume: 0.25
-  outro_volume: 0.3
+  outro_volume: 0.4
 
 publishing:
   rss_file: env_intel_podcast.rss

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -181,7 +181,7 @@ audio:
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4
-  outro_volume: 0.4
+  outro_volume: 0.6
 
 publishing:
   rss_file: fascinating_frontiers_podcast.rss

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -195,7 +195,7 @@ audio:
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4
-  outro_volume: 0.4
+  outro_volume: 0.6
 
 publishing:
   host_name: "Оля"

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -188,7 +188,7 @@ audio:
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4
-  outro_volume: 0.4
+  outro_volume: 0.6
 
 publishing:
   rss_file: models_agents_podcast.rss

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -166,7 +166,7 @@ audio:
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4
-  outro_volume: 0.4
+  outro_volume: 0.6
 
 publishing:
   rss_file: models_agents_beginners_podcast.rss

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -170,7 +170,7 @@ audio:
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3
-  outro_volume: 0.3
+  outro_volume: 0.5
 
 publishing:
   rss_file: modern_investing_podcast.rss

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -175,7 +175,7 @@ audio:
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3
-  outro_volume: 0.3
+  outro_volume: 0.5
 
 publishing:
   rss_file: omni_view_podcast.rss

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -213,7 +213,7 @@ audio:
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4
-  outro_volume: 0.4
+  outro_volume: 0.6
 
 publishing:
   rss_file: planetterrian_podcast.rss

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -141,7 +141,7 @@ audio:
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4
-  outro_volume: 0.4
+  outro_volume: 0.6
 
 publishing:
   host_name: "Оля"

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -153,7 +153,7 @@ audio:
   intro_volume: 0.6
   overlap_volume: 0.5
   fade_volume: 0.4
-  outro_volume: 0.4
+  outro_volume: 0.6
 
 publishing:
   rss_file: podcast.rss

--- a/shows/unintended_consequences.yaml
+++ b/shows/unintended_consequences.yaml
@@ -54,7 +54,7 @@ audio:
   intro_volume: 0.5
   overlap_volume: 0.4
   fade_volume: 0.3
-  outro_volume: 0.3
+  outro_volume: 0.5
 
 publishing:
   rss_file: unintended_consequences_podcast.rss

--- a/tests/test_audio_commands.py
+++ b/tests/test_audio_commands.py
@@ -645,7 +645,7 @@ class TestAudioConfigDefaults:
         assert cfg.intro_volume == 0.6
         assert cfg.overlap_volume == 0.5
         assert cfg.fade_volume == 0.4
-        assert cfg.outro_volume == 0.4
+        assert cfg.outro_volume == 0.6  # May 15 2026: matches intro_volume for clear post-voice cue
         # Operator invariant: ≥30 s total intro music presence so the
         # open doesn't feel cut off (now 55 s).
         assert (
@@ -782,18 +782,22 @@ class TestOutroFadeInBumpForNonCrossfadeShows:
         """May 14 2026: outro_fade_in for the non-crossfade branch
         dropped from 6 s → 1 s so the music starts audible
         immediately after voice instead of slowly ramping over 6 s
-        (which combined with sidechain-release timing made the
-        post-voice music feel "tentative" / "ended abruptly" on TST
-        Ep472). 1 s is the minimum needed to avoid an audible pop;
-        any shorter and the music starts as a hard transient."""
+        (history: 6 s → 1 s → 0 s as operator caught successive
+        regressions of "music outro starts too late" — TST Ep471
+        → Ep472 → Ep473). At 0 s the outro plays at full
+        ``outro_volume`` from the instant voice ends, giving the
+        listener an unambiguous "music is back" cue."""
         import inspect
         from engine import audio
         src = inspect.getsource(audio.mix_with_music)
-        assert "outro_fade_in = 1" in src, (
-            "outro_fade_in default for non-crossfade shows must be 1s "
-            "(May 14 2026 retune). The previous 6s value made the "
-            "post-voice music feel tentative — operator-caught on "
-            "TST Ep472."
+        assert "outro_fade_in = 0" in src, (
+            "outro_fade_in default for non-crossfade shows must be 0s "
+            "(May 15 2026 retune). Any non-zero fade-in combined with "
+            "the sidechain compressor's 600 ms release time made the "
+            "post-voice music feel 'absent' to the operator on TST "
+            "Ep473 — full-volume start eliminates the perceptual gap."
         )
-        # Ensure the old 6s default isn't re-introduced silently.
+        # Ensure the prior 6 s and 1 s defaults aren't re-introduced
+        # silently.
         assert "outro_fade_in = 6" not in src
+        assert "outro_fade_in = 1" not in src

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -218,7 +218,7 @@ class TestDefaultValues:
         assert c.intro_volume == 0.6
         assert c.overlap_volume == 0.5
         assert c.fade_volume == 0.4
-        assert c.outro_volume == 0.4
+        assert c.outro_volume == 0.6  # May 15 2026: matches intro_volume for clear post-voice cue
         # voice_intro_delay must be >= intro_duration so the voice
         # doesn't start before the music intro alone-period finishes.
         assert c.voice_intro_delay == 10.0


### PR DESCRIPTION
## Summary

TST Ep473 had **"no music outro at all"** per operator — the third iteration on the same underlying issue (Ep471 "felt tentative", Ep472 "ended abruptly", Ep473 "no music").

## Root cause

Two stacking effects created a ~1.5-second perceptual gap between voice-end and clearly-audible music:

| Effect | Mechanism |
|---|---|
| `outro_fade_in = 1` with `curve=log` | Log fade reaches only ~10% gain at t=0.5; full only at t=1. First half is barely audible. |
| Sidechain compressor `release=600ms` | After voice silent, music takes 600 ms to spring back to full un-ducked level. |

The two don't compound (sidechain release runs in parallel with the fade-in), but listeners perceive ~1.5s of near-silence → conclude "audio ended" → miss the actual 28+ seconds of outro music that follows.

**Plus** — `outro_volume` was set EQUAL to `fade_volume` on every show. Listeners had been hearing "music ducked + fading under voice" at that level for 30s. When voice ended and music returned at the SAME level, there was no perceptual cue to register "outro section is here." Music felt unchanged — just less ducked.

## Fix

### 1. `outro_fade_in = 0` (was 1, was 6 originally)

`engine/audio.py:mix_with_music` non-crossfade branch uses `outro_fade_in = 0`. Music plays at full `outro_volume` from the instant voice ends.

The 0-second case is handled in `_music_outro_cmd`: when `fade_in_duration <= 0` the `afade t=in` filter is skipped entirely (`afade d=0` is undefined behaviour in ffmpeg). The outro segment ffmpeg command becomes:

```
volume=<outro_volume>,afade=t=out:curve=log:st=<start>:d=<dur>
```

No fade-in filter. Music starts at full volume, sustains, fades out at the end.

### 2. `outro_volume` bumped to match `intro_volume` per show

Listeners ALREADY know what the intro volume sounds like (they heard 10s of music alone at that level at episode start). Matching outro to intro cues "we're closing out the same way we opened."

| Show | Old outro_vol | New outro_vol (= intro_vol) |
|---|---|---|
| Tesla, FF, PT, M&A, MAB, FP, PR | 0.4 | **0.6** |
| Omni View, MIT, UC | 0.3 | **0.5** |
| Env Intel | 0.3 | **0.4** |
| `_defaults.yaml` | 0.3 | **0.5** |
| `engine/config.py` dataclass | 0.4 | **0.6** |

### Net listener experience after merge

```
[voice plays under fade music]
voice ends
→ music IMMEDIATELY at full intro-equivalent volume (no fade-in, no perceptual gap)
→ sustain for ~20 s
→ gentle log fade-out over last 10 s
→ silence
```

## Drift guards

`test_default_outro_fade_in_for_non_crossfade` updated:
- Now pins `outro_fade_in = 0` (the new value)
- Asserts both `outro_fade_in = 6` AND `outro_fade_in = 1` are ABSENT (so neither prior default can sneak back in via regression)

`test_audio_defaults` and `test_all_timing_defaults` updated to pin `outro_volume == 0.6`.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_youtube.py` — **1,806 pass, 6 skip**
- [ ] **Tomorrow's TST Ep474:** listen for clear, full-volume music starting AT voice-end (no perceptual gap), sustaining ~20s, fading over last 10s
- [ ] Spot-check OV, FF, M&A, MIT for the same pattern
- [ ] Confirm no sidechain "pumping" artifact during voice (it shouldn't — sidechain settings unchanged)

## Rollback

| Change | Revert |
|---|---|
| `outro_fade_in = 0` | Change back to `= 1` in `engine/audio.py` |
| outro volumes | `sed -i 's/outro_volume: 0.6/outro_volume: 0.4/' shows/*.yaml` (and 0.5→0.3 for OV/MIT/UC) |

Both changes are independent — partial revert is fine.

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_