### PR TITLE
tesla: persist TSLA cache + reject hallucinated prices via deviation guard

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -456,6 +456,14 @@ jobs:
           git add *.html || true
           git add -A blog/ || true
           git add sitemap.xml || true
+          # Tesla cached price for the public website widget. Written
+          # by ``shows/hooks/tesla.py`` every Tesla run, consumed by
+          # ``tesla.html`` JS so the stock pill doesn't depend on
+          # Yahoo Finance CORS proxies.  Without committing this, the
+          # file gets wiped on every fresh runner checkout and the
+          # website shows "Market data unavailable" between runs
+          # (operator caught this May 15 2026, TST Ep473).
+          git add api/tsla.json || true
           # Topic queues — narrative-mode shows mark topics as produced
           # after each successful run. Without committing this, every
           # narrative-show run re-picks the same first-unproduced topic

--- a/shows/hooks/tesla.py
+++ b/shows/hooks/tesla.py
@@ -78,12 +78,27 @@ def pronunciation_overrides() -> dict:
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-# Sanity range for parsed prices. A real-time TSLA quote outside this
-# band almost certainly means Grok hallucinated or returned a stale /
-# malformed number; we'd rather ship ``(price unavailable)`` than a
-# garbage figure into the digest.
-_TSLA_PRICE_MIN = 50.0
-_TSLA_PRICE_MAX = 2000.0
+# Hard sanity range for parsed prices.  A real-time TSLA quote outside
+# this band almost certainly means Grok hallucinated or returned a
+# stale / malformed number; we'd rather ship ``(price unavailable)``
+# than a garbage figure into the digest.
+#
+# Updated May 15 2026: tightened from $50-$2000 to $200-$1500 after
+# operator caught Grok returning $250.35 for Ep473 when TSLA was
+# actually trading near $440.  TSLA hasn't traded below $200 in
+# over a year and is structurally unlikely to drop below $200 in the
+# near term given the post-2024 trading range.
+_TSLA_PRICE_MIN = 200.0
+_TSLA_PRICE_MAX = 1500.0
+
+# Tighter dynamic validation: a new price more than this fraction
+# away from the LAST CACHED price (``api/tsla.json``) gets rejected as
+# a probable hallucination.  TSLA's largest single-day moves over
+# the past 2 years sit around 12-15%; setting the floor at 25% gives
+# a comfortable margin for an unusually volatile earnings day while
+# still catching the May 15 2026 "$444 → $250" hallucination
+# (a ~44% drop) that motivated this guard.
+_TSLA_MAX_PCT_DEVIATION = 0.25  # 25% from last known close
 
 
 def _fetch_tsla_price() -> tuple[float, str]:
@@ -152,7 +167,8 @@ def _fetch_tsla_price() -> tuple[float, str]:
         logger.error("TSLA fields missing/non-numeric: %r", data)
         return 0.0, "(price unavailable)"
 
-    # Sanity range — Grok hallucinations sometimes invent low/high numbers.
+    # Hard sanity range — Grok hallucinations sometimes invent low/high
+    # numbers; reject anything wildly outside TSLA's historical range.
     if not (_TSLA_PRICE_MIN <= price <= _TSLA_PRICE_MAX):
         logger.error("TSLA price %.2f outside sanity band [%.0f, %.0f]",
                      price, _TSLA_PRICE_MIN, _TSLA_PRICE_MAX)
@@ -160,6 +176,24 @@ def _fetch_tsla_price() -> tuple[float, str]:
     if not (_TSLA_PRICE_MIN <= prev_close <= _TSLA_PRICE_MAX):
         logger.error("TSLA prev_close %.2f outside sanity band", prev_close)
         return 0.0, "(price unavailable)"
+
+    # Dynamic deviation check — reject prices that swing more than
+    # 25% from the last cached close.  Catches stale / hallucinated
+    # quotes that pass the wide static band.  Operator caught
+    # ($250 vs real $444, May 15 2026 TST Ep473).  No cache → skip
+    # the check (first-ever run can't compare).
+    last_cached = _load_last_cached_tsla_price()
+    if last_cached is not None and last_cached > 0:
+        deviation = abs(price - last_cached) / last_cached
+        if deviation > _TSLA_MAX_PCT_DEVIATION:
+            logger.error(
+                "TSLA price %.2f deviates %.1f%% from last cached "
+                "$%.2f (cap %.0f%%) — likely Grok hallucination; "
+                "rejecting.",
+                price, deviation * 100, last_cached,
+                _TSLA_MAX_PCT_DEVIATION * 100,
+            )
+            return 0.0, "(price unavailable)"
 
     market_state = str(data.get("market_state", "REGULAR")).upper()
     market_status = ""
@@ -187,6 +221,33 @@ def _fetch_tsla_price() -> tuple[float, str]:
         change_str=change_str, market_state=market_state,
     )
     return price, change_str
+
+
+def _load_last_cached_tsla_price() -> float | None:
+    """Read the last cached TSLA price from ``api/tsla.json``.
+
+    Returns ``None`` if the file doesn't exist, can't be parsed, or
+    has a missing/invalid ``price`` field.  Used by
+    :func:`_fetch_tsla_price` as the baseline for the dynamic
+    deviation guard (rejects new prices that swing > 25% from the
+    last known close).
+
+    First-ever run has no cache; the check is skipped on ``None`` so
+    the very first persist after a deploy isn't blocked.
+    """
+    import json
+    from pathlib import Path
+
+    try:
+        path = Path(__file__).resolve().parent.parent.parent / "api" / "tsla.json"
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        price = float(data.get("price", 0))
+        return price if price > 0 else None
+    except Exception as exc:  # pragma: no cover — best-effort
+        logger.warning("Could not read last cached tsla.json: %s", exc)
+        return None
 
 
 def _persist_tsla_price_json(

--- a/tests/test_tesla_hook.py
+++ b/tests/test_tesla_hook.py
@@ -41,11 +41,16 @@ def _patch_grok(monkeypatch, text: str):
 @pytest.fixture(autouse=True)
 def _stub_persist(monkeypatch):
     """Default-stub the api/tsla.json write so the test suite doesn't
-    pollute the repo's ``api/`` directory every run. Tests that need
-    to exercise the real persistence (or its failure modes) re-patch
-    this in their own bodies."""
+    pollute the repo's ``api/`` directory every run, AND default-stub
+    the cache LOAD so tests with no explicit deviation-guard setup
+    get a clean ``no cache`` state (deviation check skipped).  Tests
+    that need to exercise the real persistence or specific cache
+    values re-patch these in their own bodies."""
     monkeypatch.setattr(
         tesla_hook, "_persist_tsla_price_json", lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        tesla_hook, "_load_last_cached_tsla_price", lambda: None,
     )
 
 
@@ -240,6 +245,126 @@ class TestTslaJsonCache:
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 400.00
         assert change_str.startswith("▲")
+
+
+class TestDeviationGuard:
+    """Operator caught (TST Ep473, May 15 2026) Grok returning
+    ``$250.35`` for TSLA when the real price was ~$444 — a 44%
+    deviation that passed the wide ($200-$1500) hard sanity band.
+    The dynamic deviation guard rejects new prices that swing more
+    than 25% from the LAST CACHED price in ``api/tsla.json``."""
+
+    def test_rejects_price_more_than_25pct_below_cached(self, monkeypatch):
+        """Cached at $444, new price $250 = 44% drop → reject."""
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: 444.57,
+        )
+        _patch_grok(
+            monkeypatch,
+            '{"price": 250.35, "prev_close": 248.12, "market_state": "PRE"}',
+        )
+        price, change_str = tesla_hook._fetch_tsla_price()
+        assert price == 0.0
+        assert change_str == "(price unavailable)"
+
+    def test_rejects_price_more_than_25pct_above_cached(self, monkeypatch):
+        """Cached at $400, new price $600 = 50% spike → reject."""
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: 400.00,
+        )
+        _patch_grok(
+            monkeypatch,
+            '{"price": 600.00, "prev_close": 595.00, "market_state": "REGULAR"}',
+        )
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 0.0
+
+    def test_accepts_price_within_25pct_band(self, monkeypatch):
+        """Cached at $440, new price $420 = 4.5% drop → accept."""
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: 440.00,
+        )
+        _patch_grok(
+            monkeypatch,
+            '{"price": 420.00, "prev_close": 425.00, "market_state": "REGULAR"}',
+        )
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 420.00
+
+    def test_accepts_price_at_exactly_25pct_boundary(self, monkeypatch):
+        """At exactly 25% deviation the check is inclusive ( ``> cap``
+        rejects, ``== cap`` accepts) so a 12.5%-up / 12.5%-down day
+        with subsequent volatility doesn't trip the guard on a
+        recovery candle."""
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: 400.00,
+        )
+        # 400 * 1.25 = 500 — exactly at the upper boundary
+        _patch_grok(
+            monkeypatch,
+            '{"price": 500.00, "prev_close": 498.00, "market_state": "REGULAR"}',
+        )
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 500.00
+
+    def test_no_cache_skips_deviation_check(self, monkeypatch):
+        """First-ever run has no cached price — the deviation guard
+        is skipped (would otherwise block the network's first
+        Tesla run after deploy).  Hard sanity band still applies."""
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: None,
+        )
+        _patch_grok(
+            monkeypatch,
+            '{"price": 444.57, "prev_close": 445.00, "market_state": "REGULAR"}',
+        )
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 444.57
+
+    def test_zero_cache_treated_as_no_cache(self, monkeypatch):
+        """A degraded cache (``price: 0.0``) is treated as missing —
+        deviation check skipped."""
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: 0.0,
+        )
+        _patch_grok(
+            monkeypatch,
+            '{"price": 444.57, "prev_close": 445.00, "market_state": "REGULAR"}',
+        )
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 444.57
+
+
+class TestHardSanityBand:
+    """The dynamic deviation guard only fires when a cache exists.
+    The hard sanity band ($200-$1500) catches first-run hallucinations
+    and any price wildly outside TSLA's historical range."""
+
+    def test_rejects_price_below_hard_floor(self, monkeypatch):
+        """May 15 2026: floor raised from $50 to $200.  TSLA hasn't
+        traded below $200 in over a year and is structurally unlikely
+        to in the near term."""
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: None,
+        )
+        _patch_grok(
+            monkeypatch,
+            '{"price": 150.00, "prev_close": 152.00, "market_state": "REGULAR"}',
+        )
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 0.0
+
+    def test_rejects_price_above_hard_ceiling(self, monkeypatch):
+        """Ceiling lowered from $2000 to $1500."""
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: None,
+        )
+        _patch_grok(
+            monkeypatch,
+            '{"price": 1600.00, "prev_close": 1580.00, "market_state": "REGULAR"}',
+        )
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 0.0
 
 
 class TestMarketStateDefaulting:


### PR DESCRIPTION
## Summary

Operator caught (TST Ep473, May 15 2026) two compounding bugs that shipped **$250.35** as the TSLA price in the digest when the real price was ~$444, AND left "Market data unavailable" on tesla.html.

## Root causes

### Bug 1 — `api/tsla.json` was never committed by the workflow

`shows/hooks/tesla.py:_persist_tsla_price_json` (added in PR #372) writes the cache file correctly — verified locally. But the daily auto-commit step in `.github/workflows/run-show.yml` only stages `digests/`, `*.rss`, `*.html`, `blog/`, `sitemap.xml`, and `shows/topic_queues/`. **Not `api/`.** Each runner started with a fresh checkout, wrote the cache, then dropped it.

Result: the website's `fetch('/api/tsla.json')` always 404'd, fell back to Yahoo Finance via CORS proxies (which were failing) → "Market data unavailable."

### Bug 2 — Hard sanity band was too wide ($50–$2000)

Grok's x_search returned $250.35 for TSLA today when the real price was ~$444. $250 sat well inside the $50–$2000 band, so the bogus quote was accepted and propagated to the digest, blog markdown, podcast TTS, RSS show notes, X teaser, and newsletter.

## Fix

### 1. Workflow commits `api/tsla.json`

Added one line to the per-show commit step:

```yaml
git add api/tsla.json || true
```

Same pattern as `shows/topic_queues/` — a small persistent file (< 300 bytes) the pipeline needs across runs.

### 2. Tighter hard sanity band: $50-$2000 → **$200-$1500**

TSLA hasn't traded below $200 in over a year and is structurally unlikely to in the near term. Tightening the floor catches the May 15 hallucination AND any similar low-side stale quote. The $1500 ceiling preserves room for legitimate growth without leaving so much headroom that obvious hallucinations pass.

### 3. Dynamic deviation guard ±25% from last cached close

New `_TSLA_MAX_PCT_DEVIATION = 0.25` constant + `_load_last_cached_tsla_price()` helper. After the price passes the hard sanity band, a second check rejects anything > 25% away from the last cached close:

```python
cached = _load_last_cached_tsla_price()  # may be None
if cached and abs(price - cached) / cached > 0.25:
    return 0.0, "(price unavailable)"
```

**Why 25%:**
- TSLA's worst legitimate single-day moves over the past 2 years: 12-15%
- $444 → $250 (the May 15 hallucination) = 44% drop — caught
- A volatile earnings day with a ~12% pop wouldn't trip the guard
- `None` cache → skip the check so a fresh deploy isn't blocked

The cache will populate from the FIRST successful run after this PR merges (since Fix 1 makes it persist), so the guard goes live on day 2.

## Tests

**8 new tests** in `tests/test_tesla_hook.py`:

| Test | Verifies |
|---|---|
| `TestDeviationGuard::test_rejects_price_more_than_25pct_below_cached` | $444 cached, $250 returned → reject (the actual Ep473 scenario) |
| `test_rejects_price_more_than_25pct_above_cached` | $400 cached, $600 returned → reject (50% spike) |
| `test_accepts_price_within_25pct_band` | $440 cached, $420 returned → accept (4.5% drop, normal volatility) |
| `test_accepts_price_at_exactly_25pct_boundary` | $400 cached, $500 returned → accept (boundary inclusive) |
| `test_no_cache_skips_deviation_check` | First-ever run → guard skipped, hard sanity band only |
| `test_zero_cache_treated_as_no_cache` | Degraded cache (`price: 0`) → treated as missing |
| `TestHardSanityBand::test_rejects_price_below_hard_floor` | $150 returned → reject (tightened floor) |
| `test_rejects_price_above_hard_ceiling` | $1600 returned → reject (tightened ceiling) |

Autouse `_stub_persist` fixture extended to also stub `_load_last_cached_tsla_price` so existing tests don't accidentally read a stray local cache file.

**1,814 tests pass, 6 skipped** (8 added).

## Test plan

- [x] `pytest tests/ --ignore=tests/test_youtube.py` — 1,814 pass
- [ ] **Tomorrow's TST run:** verify `api/tsla.json` appears in the auto-commit and contains the actual current TSLA price (not $250)
- [ ] **Day after tomorrow:** verify the deviation guard is silent in metrics — if Grok hallucinates again, the digest should ship `(price unavailable)` rather than the bogus number
- [ ] Visit `nerranetwork.com/tesla.html` post-merge — TSLA pill should show real price, not "Market data unavailable"
- [ ] Visit any Tesla blog post — should show clean cite-pill links (#373 already shipped this; just sanity check)

## Rollback

Each fix is independent:

| Change | Revert |
|---|---|
| Workflow commit | Remove the `git add api/tsla.json` line |
| Sanity band | Revert constants in `shows/hooks/tesla.py` |
| Deviation guard | Remove `_load_last_cached_tsla_price` call + helper |

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_