### PR TITLE
planetterrian: bump digest max_tokens 3500 → 5000

### DIFF
--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -188,7 +188,17 @@ llm:
   podcast_prompt_file: shows/prompts/planetterrian_podcast.txt
   digest_temperature: 0.5
   podcast_temperature: 0.70
-  max_tokens: 3500
+  # May 16 2026: bumped 3500 → 5000 after Ep064 / Ep065 aborted at the
+  # 600-word podcast hard floor. Root cause: grok-4.3 reasoning tokens
+  # consumed a growing share of the 3500-token completion budget
+  # (Ep063 digest used 1204 completion tokens; the failed Ep064 used
+  # ~2500), squeezing the visible output down to ~4 stories instead of
+  # the prompt's 12-15 target. The thin digest then had all four
+  # surviving items stripped as 100% cross-episode duplicates, leaving
+  # the podcast LLM with nothing to expand. 5000 matches Tesla; MIT and
+  # Omni View sit at 4000. Re-tune downward only with evidence that the
+  # full digest fits in fewer tokens than grok-4.3 burns on reasoning.
+  max_tokens: 5000
   podcast_max_tokens: 8000
   min_podcast_words: 950
   podcast_chain: true


### PR DESCRIPTION
## Summary

PT Ep064 (and the May 15 Ep063-after attempt) both aborted at the
podcast hard floor:

```
ERROR run_show: Podcast script is clearly broken (541 words, hard floor 600) — aborting episode.
```

Pipeline-level root cause is the **digest**, not the podcast prompt.

### Evidence

| Run | digest completion tokens | digest chars | Top-15 items | outcome |
|---|---:|---:|---:|---|
| Ep063 (2026-05-14, ok)  | 1204  | 6301 | 10 | ships |
| Ep064 (2026-05-16, fail) | ~2500 | 3582 | **4** | abort |

(Ep064 completion derived from `total_tokens=9511` minus ~7000-token prompt.)

The completion-token jump without a matching content jump points at
**grok-4.3 reasoning consuming the extra budget**. At `max_tokens: 3500`
the model has roughly 1000–1500 tokens of visible output left after
reasoning — not enough for the 12-15 stories plus Planetterrian
Spotlight plus Science Deep Dive that the prompt asks for.

With only 4 items in the digest and all four matching recent headlines
at 100% similarity, `_strip_exact_duplicate_stories` removed every one
before podcast generation. The podcast LLM was then handed an
essentially empty story list and produced a 541-word script.

### Fix

Bump `max_tokens` from the network default 3500 to 5000, matching
Tesla's per-show override (MIT and Omni View sit at 4000). Inline
comment documents the reasoning-budget rationale so future tuning
has the math.

### Out of scope

Fascinating Frontiers showed the same 4-item collapse on Ep071 today
with the same root cause. Branch name scopes this PR to PT — FF needs
the same bump on a separate branch.

### What does NOT change

- Cross-episode 100% strip — still removes verbatim repeats.
- Podcast hard-floor abort (600 words) — still fires for genuine garbage.

If the next run still ships a thin digest the abort fires as before —
but the LLM finally has headroom to fill the section.

## Test plan

- [x] `pytest tests/test_validation.py tests/test_schedule.py` (37 passed)
- [x] `engine.config.load_config('shows/planetterrian.yaml')` resolves `max_tokens=5000`
- [ ] Next scheduled PT run produces a digest with 12-15 items and a podcast script above the 600-word floor.


---
_Generated by [Claude Code](https://claude.ai/code/session_013sWzi3YLLjJgckvarquWZS)_