### PR TITLE
fix: pad voice so music outro plays full duration (network-wide regression)

### DIFF
--- a/engine/audio.py
+++ b/engine/audio.py
@@ -597,21 +597,36 @@ def _music_acrossfade_cmd(
     return cmd
 
 
-def _final_mix_cmd(voice_in: str, music_in: str, final_out: str) -> list:
+def _final_mix_cmd(
+    voice_in: str, music_in: str, final_out: str,
+    *, voice_pad_seconds: float = 30.0,
+) -> list:
     """Voice + music final mix with sidechain ducking + EBU R128 loudnorm.
 
     Filter graph stages:
 
-      1. ``asplit`` — duplicate the voice signal so it can drive both the
-         sidechain compressor (as the trigger) and the final amix (as audio).
-      2. ``sidechaincompress`` — when voice is present, music is pulled
-         down 8 dB; when voice pauses, music rises smoothly. ``threshold=-30 dB``
-         and ``ratio=8`` mean even modest voice levels duck the music; the
-         ``attack=50 ms`` / ``release=600 ms`` pair gives broadcast feel
-         (slow enough not to clamp mid-syllable, long enough to hold
-         through natural pauses without "pumping" back in).
-         ``level_sc=2`` doubles the trigger sensitivity so quieter narration
-         still ducks the bed reliably.
+      1. ``apad`` — pad the voice input with ``voice_pad_seconds`` of
+         trailing silence so it remains the same length as music_full.
+         Without this pad, ``sidechaincompress`` truncates the output
+         when the voice (sidechain trigger) ends, causing the music
+         outro to be cut short.  Operator caught this network-wide
+         on May 16 2026 (TST Ep474 + every other show that day) —
+         every episode had ~10s of post-voice content instead of the
+         intended ``outro_duration`` (30s).  The pad should equal the
+         configured ``outro_duration`` so the voice "ends" at the
+         same timeline position the music outro ends.
+      2. ``asplit`` — duplicate the (padded) voice signal so it can
+         drive both the sidechain compressor (as the trigger) and
+         the final amix (as audio).
+      3. ``sidechaincompress`` — when voice is present, music is
+         pulled down 8 dB; when voice pauses (or after the pad
+         starts), music rises smoothly. ``threshold=-30 dB`` and
+         ``ratio=8`` mean even modest voice levels duck the music; the
+         ``attack=50 ms`` / ``release=600 ms`` pair gives broadcast
+         feel (slow enough not to clamp mid-syllable, long enough to
+         hold through natural pauses without "pumping" back in).
+         ``level_sc=2`` doubles the trigger sensitivity so quieter
+         narration still ducks the bed reliably.
 
          May 8 2026 retune: was ``attack=20 / release=300``. The 20 ms
          attack ducked music DURING vowel onsets so listeners heard
@@ -620,22 +635,25 @@ def _final_mix_cmd(voice_in: str, music_in: str, final_out: str) -> list:
          instead of transient. 600 ms release holds ducking through
          pauses between sentences, eliminating the "music comes back
          then dips again" cycle that broke immersion.
-      3. ``amix`` — sums voice + ducked music with longest-duration semantics.
-      4. ``loudnorm I=-16`` — final integrated-loudness target. Apple
-         Podcasts and Spotify both auto-normalize listener-side, so episodes
-         well under -16 LUFS get attenuated and feel quiet next to NPR-mastered
-         shows. ``TP=-1.5`` keeps headroom to absorb true-peak intersample
-         peaks without clipping. ``LRA=11`` preserves natural dynamics
-         (a denser LRA flatlines the audio).
+      4. ``amix`` — sums (padded) voice + ducked music. Both inputs
+         now have the same length, so ``duration=longest`` produces
+         the expected full music_full duration.
+      5. ``loudnorm I=-16`` — final integrated-loudness target. Apple
+         Podcasts and Spotify both auto-normalize listener-side, so
+         episodes well under -16 LUFS get attenuated and feel quiet
+         next to NPR-mastered shows. ``TP=-1.5`` keeps headroom to
+         absorb true-peak intersample peaks without clipping.
+         ``LRA=11`` preserves natural dynamics (a denser LRA
+         flatlines the audio).
 
-    Final encode is libmp3lame -q:a 0 (~245 kbps VBR — archival quality
-    spoken-word + music; ~6.5 MB per 30-min episode).
+    Final encode is libmp3lame -q:a 0 (~245 kbps VBR — archival
+    quality spoken-word + music; ~6.5 MB per 30-min episode).
     """
     return [
         "ffmpeg", "-y", "-threads", "0",
         "-i", voice_in, "-i", music_in,
         "-filter_complex",
-        "[0:a]asplit=2[voice_mix][voice_sc];"
+        f"[0:a]apad=pad_dur={voice_pad_seconds},asplit=2[voice_mix][voice_sc];"
         "[1:a][voice_sc]sidechaincompress="
         "threshold=-30dB:ratio=8:attack=50:release=600:level_sc=2"
         "[music_ducked];"
@@ -934,7 +952,13 @@ def mix_with_music(
         subprocess.run(cmd, check=True, capture_output=True)
 
         # --- Final mix: voice + music ---
-        cmd = _final_mix_cmd(str(voice_mix), str(music_full), str(output_path))
+        # Pad voice with trailing silence equal to ``outro_duration`` so
+        # ``sidechaincompress`` + ``amix duration=longest`` produce the
+        # full music_full length (see _final_mix_cmd docstring).
+        cmd = _final_mix_cmd(
+            str(voice_mix), str(music_full), str(output_path),
+            voice_pad_seconds=float(outro_duration),
+        )
         subprocess.run(cmd, check=True, capture_output=True, timeout=timeout_seconds)
 
     logger.info("Final mix complete: %s", output_path)

--- a/tests/test_audio_commands.py
+++ b/tests/test_audio_commands.py
@@ -124,14 +124,22 @@ def music_concat(concat_list: str, music_full_out: str) -> list:
     ]
 
 
-def final_mix(voice_in: str, music_in: str, final_out: str) -> list:
+def final_mix(
+    voice_in: str, music_in: str, final_out: str,
+    *, voice_pad_seconds: float = 30.0,
+) -> list:
     """Mix voice and music tracks together with sidechain ducking +
-    EBU R128 loudnorm (May 2026 broadcast-quality upgrade)."""
+    EBU R128 loudnorm (May 2026 broadcast-quality upgrade).
+
+    May 16 2026: voice is padded with ``voice_pad_seconds`` of trailing
+    silence so ``sidechaincompress`` + ``amix duration=longest`` produce
+    the full music_full length instead of truncating at voice-end.
+    """
     return [
         "ffmpeg", "-y", "-threads", "0",
         "-i", voice_in, "-i", music_in,
         "-filter_complex",
-        "[0:a]asplit=2[voice_mix][voice_sc];"
+        f"[0:a]apad=pad_dur={voice_pad_seconds},asplit=2[voice_mix][voice_sc];"
         "[1:a][voice_sc]sidechaincompress="
         "threshold=-30dB:ratio=8:attack=50:release=600:level_sc=2"
         "[music_ducked];"
@@ -272,10 +280,23 @@ class TestFinalMix:
     def test_filter_complex_has_sidechain_ducking(self):
         cmd = final_mix("/voice.mp3", "/music.mp3", "/final.mp3")
         fc = cmd[cmd.index("-filter_complex") + 1]
+        # Voice is padded with trailing silence (May 16 2026 fix) so
+        # amix=duration=longest produces the full music_full length
+        # instead of truncating at voice-end.
+        assert "apad=pad_dur=" in fc
         # Voice is split so it can both drive the sidechain compressor AND
         # be summed back into the mix.
         assert "asplit=2" in fc
         assert "[voice_mix]" in fc and "[voice_sc]" in fc
+
+    def test_voice_apad_matches_outro_duration(self):
+        """Voice padding must equal outro_duration so the music outro
+        plays through its full length. Operator caught this network-wide
+        on May 16 2026 — ALL episodes had ~10s post-voice content instead
+        of 30s because sidechaincompress truncated when voice ended."""
+        cmd = final_mix("/v.mp3", "/m.mp3", "/f.mp3", voice_pad_seconds=30.0)
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        assert "apad=pad_dur=30" in fc
         # Music is ducked under voice presence.
         assert "sidechaincompress=" in fc
         assert "threshold=-30dB" in fc


### PR DESCRIPTION
## Summary

Network-wide outro regression caught by the operator on May 16 2026 — TST Ep474 and every other show that day had only ~10 s of post-voice content instead of the configured 30 s outro_duration. The music outro was being truncated at voice-end.

## Root cause

`_final_mix_cmd` runs `sidechaincompress` on music keyed by voice, then sums them with `amix=duration=longest`. When the voice (the sidechain trigger) ends, ffmpeg appears to stop pulling samples from the music branch through the compressor, so the output ends near voice-end rather than music_full's end — regardless of `duration=longest`.

Whisper transcript of TST Ep474:
- Voice ends at **419.4 s**
- Final MP3 is **429.87 s**
- Expected music_full is **449.4 s** (419.4 + 30 outro)
- Off by **19.5 s** of missing post-voice music

Same gap pattern across all 7 shows that ran today — this is structural, not show-specific.

## Fix

Prepend `apad=pad_dur=<outro_duration>` to the voice input before `asplit`. Both `amix` inputs now have equal length, so `duration=longest` produces music_full's full duration. The pad is silent and only extends past speech, so the listener hears the full 30 s music outro.

```diff
- "[0:a]asplit=2[voice_mix][voice_sc];"
+ f"[0:a]apad=pad_dur={voice_pad_seconds},asplit=2[voice_mix][voice_sc];"
```

The call site in `mix_with_music()` passes `voice_pad_seconds=float(outro_duration)` so the pad stays in lockstep with the configured outro length.

## Drift guards

- `test_voice_apad_matches_outro_duration` — asserts `apad=pad_dur=30` appears in the filter graph for the default outro_duration
- `test_filter_complex_has_sidechain_ducking` — bumped to assert `apad=pad_dur=` is present

## Test plan

- [x] `pytest tests/ -q --ignore=tests/test_youtube.py` — **1815 passed, 6 skipped**
- [ ] Tomorrow's cron runs produce final MP3s whose duration matches `voice_duration + 30 s` (verify by ffprobe on TST/OV/PT/FF/MAA/MAB/MIT episodes)
- [ ] Listen test: confirm the 30 s music outro is audible to its full fade-out close

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_