### PR TITLE
unintended_consequences: restore episode title hook

### DIFF
--- a/run_show.py
+++ b/run_show.py
@@ -2500,6 +2500,13 @@ def _extract_hook(digest: str) -> str | None:
     The digest prompts instruct the LLM to include a line like:
         **HOOK:** Scientists just discovered a new way to...
 
+    Falls back to the first top-of-digest blockquote (``> **<text>**``)
+    that appears before any ``###`` section heading. Narrative shows
+    (Unintended Consequences) occasionally drop the ``**HOOK:**`` label
+    and emit the hook as a leading blockquote instead; without this
+    fallback every UC episode after Ep 4 shipped with a generic
+    "Episode N — Month DD, YYYY" title in podcast apps.
+
     Returns the hook text (without the prefix) or *None* if not found.
     """
     import re
@@ -2510,6 +2517,19 @@ def _extract_hook(digest: str) -> str | None:
             hook = m.group(1).strip()
             # Strip leftover markdown/brackets the LLM sometimes wraps
             hook = re.sub(r"^\[|\]$", "", hook).strip()
+            if hook:
+                return hook
+
+    # Fallback: leading blockquote before the first ### heading.
+    # Matches `> **<text>**` on its own line. Only the first one wins;
+    # blockquotes that appear AFTER a section heading are scene-setting
+    # narration, not the title.
+    for line in digest.splitlines():
+        if line.lstrip().startswith("###"):
+            break
+        m = re.match(r"^\s*>\s*\*{1,3}([^*]{10,300})\*{1,3}\s*$", line)
+        if m:
+            hook = m.group(1).strip()
             if hook:
                 return hook
     return None

--- a/shows/prompts/unintended_consequences_episode.txt
+++ b/shows/prompts/unintended_consequences_episode.txt
@@ -7,9 +7,15 @@ This stage produces the EPISODE BRIEF that the podcast prompt will turn into spo
 **Date:** {today_str}
 **Topic:** {topic_title}
 
-**HOOK:** [One sentence that captures the irony and the surprise. Specific. Under 130 characters. Example: "Britain offered a bounty for every dead cobra in Delhi — and discovered the limits of incentive design the hard way."]
+**HOOK:** [One sentence under 130 characters that captures the irony and the surprise. Example: "Britain offered a bounty for every dead cobra in Delhi — and discovered the limits of incentive design the hard way."]
 
 ━━━━━━━━━━━━━━━━━━━━
+
+ABOUT THE HOOK LINE (CRITICAL — read before writing anything):
+The ``**HOOK:**`` line above is the RSS / Apple Podcasts / Spotify episode title. It is a SEPARATE FIELD from Segment 1 below. Both must appear in your output:
+  • ``**HOOK:**`` — one sentence, under 130 characters, plain prose, no blockquote markers. Sits on its own line BEFORE the ━━━ divider. Becomes the episode title in podcast apps.
+  • ``### Segment 1 — The Cold Open`` — 2–3 sentences of narrative scene-setting. Becomes the SPOKEN opening of the episode. May be longer and more atmospheric than the HOOK.
+Do NOT merge them. Do NOT replace ``**HOOK:**`` with a blockquote inside Segment 1. Do NOT omit the ``**HOOK:**`` label. An episode without an extractable ``**HOOK:**`` line ships with a generic "Episode N — May DD, 2026" title in podcast apps — bad for discovery.
 
 You are writing today's episode brief for "Unintended Consequences." Use ONLY the topic information provided below as your starting point and expand it with verifiable historical detail, names, dates, and numbers.
 
@@ -19,8 +25,8 @@ TOPIC CATEGORY: {topic_category}
 
 Produce a written essay-style brief covering all six segments below. The downstream podcast prompt will turn this into flowing narration — keep the tone narrative, not bullet-pointed. Each segment should read like prose paragraphs, not lists.
 
-### Segment 1 — The Hook
-2–3 sentences. Open with a vivid, specific detail or anecdote that immediately reveals the irony. State the core tension: "This was designed to [X]. Instead, it caused [Y]." No generic intros.
+### Segment 1 — The Cold Open
+2–3 sentences. Open with a vivid, specific detail or anecdote that immediately reveals the irony. State the core tension: "This was designed to [X]. Instead, it caused [Y]." No generic intros. This is the spoken opening of the episode — separate from the ``**HOOK:**`` title line above.
 
 ### Segment 2 — The Good Intention
 4–6 sentences. Who created or championed this? What problem were they trying to solve? What was the historical context — what made this seem like a great idea at the time? Establish empathy: rational people, reasonable decisions, the information they had.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -924,6 +924,57 @@ class TestHookExtraction:
         digest = "**HOOK:** \n\n### News"
         assert _extract_hook(digest) is None
 
+    def test_fallback_extracts_leading_blockquote(self):
+        """When the LLM drops the **HOOK:** label but writes a leading
+        ``> **<text>**`` blockquote before the first ``###`` heading,
+        the fallback should pick it up as the episode title. This is
+        the post-scrub shape of every show's saved .md file."""
+        from run_show import _extract_hook
+        digest = (
+            "# Unintended Consequences\n"
+            "> **Britain offered a bounty for every dead cobra in Delhi — "
+            "and discovered the limits of incentive design the hard way.**\n"
+            "\n"
+            "### Segment 1 — The Cold Open\n"
+            "In the narrow lanes of colonial Delhi...\n"
+        )
+        assert _extract_hook(digest) == (
+            "Britain offered a bounty for every dead cobra in Delhi — "
+            "and discovered the limits of incentive design the hard way."
+        )
+
+    def test_fallback_ignores_blockquote_after_section_heading(self):
+        """A blockquote that sits INSIDE the first segment is scene-
+        setting narration, not the title. The fallback must stop at the
+        first ``###`` heading so it doesn't promote a multi-sentence
+        opening paragraph to be the RSS title (the UC Ep5–10 failure
+        mode this fallback was added for)."""
+        from run_show import _extract_hook
+        digest = (
+            "### Segment 1 — The Cold Open\n"
+            "> **In January 1920, the day after the 18th Amendment banned "
+            "the manufacture and sale of intoxicating liquor, Chicago "
+            "police reported that saloons had simply shuttered their "
+            "front doors.**\n"
+            "\n"
+            "### Segment 2 — The Good Intention\n"
+        )
+        assert _extract_hook(digest) is None
+
+    def test_label_wins_over_fallback(self):
+        """When both ``**HOOK:**`` and a leading blockquote are present
+        the explicit label wins — the blockquote is just the visual
+        rendering of the same line, not a competing field."""
+        from run_show import _extract_hook
+        digest = (
+            "# Tesla Shorts Time\n"
+            "**HOOK:** Cybertruck just broke a sales record.\n"
+            "> **Cybertruck just broke a sales record.**\n"
+            "\n"
+            "### Top 10 News Items\n"
+        )
+        assert _extract_hook(digest) == "Cybertruck just broke a sales record."
+
     def test_clean_digest_strips_hook_line(self):
         """_clean_digest_for_podcast removes the HOOK line so it doesn't leak into the script."""
         from run_show import _clean_digest_for_podcast


### PR DESCRIPTION
## Summary

Every Unintended Consequences episode since Ep 5 has shipped to RSS / Apple Podcasts / Spotify with the generic fallback title `Unintended Consequences - Episode N - May DD, 2026`. Ep 1–4 had proper one-sentence titles.

```
Ep 1: Delhi's British government paid for dead cobras to cut snake numbers, but the bounty led to breeding…
Ep 4: After Allied forces dusted civilians in Naples with DDT in 1944 to halt a typhus epidemic…
Ep 5: Unintended Consequences - Episode 5 - May 11, 2026   ← regression starts here
Ep 11: Unintended Consequences - Episode 11 - May 18, 2026
```

## Root cause

`shows/prompts/unintended_consequences_episode.txt` asks the LLM for two things that read like duplicates:

- `**HOOK:**` — one sentence above the `━━━` divider (becomes the RSS title)
- `### Segment 1 — The Hook` — 2-3 sentence spoken cold open

From Ep 5 onward the model collapsed the two: dropped the `**HOOK:**` label entirely and rendered Segment 1 as a 3-sentence blockquote. `run_show._extract_hook` only matches the `**HOOK:**` regex; with the label gone it returns None and `run_show.py:2220` falls back to the generic format.

## Fix (2 changes)

**Prompt (`shows/prompts/unintended_consequences_episode.txt`)**
- Rename `Segment 1 — The Hook` → `Segment 1 — The Cold Open` so the section name no longer collides with the field name.
- Add an `ABOUT THE HOOK LINE` callout right after the field telling the model that `**HOOK:**` and Segment 1 are separate fields, that the HOOK line becomes the podcast-app title, and that an episode without an extractable HOOK ships with a bad title.

**`run_show._extract_hook` defensive fallback**
When the `**HOOK:**` regex misses, scan for a leading `> **<text>**` blockquote BEFORE the first `###` heading and treat that as the title. Matches the post-scrub shape every other show's saved `.md` carries (via `promote_hook_to_blockquote` in `engine/newsletter_body.py`). Length-capped at 300 chars so a multi-sentence in-segment blockquote (the UC Ep 5–10 shape) is left alone rather than promoted to a too-long title.

## Tests

`tests/test_integration.py::TestHookExtraction` — 4 new cases, all 10 passing:

- `test_fallback_extracts_leading_blockquote` — post-scrub shape works.
- `test_fallback_ignores_blockquote_after_section_heading` — the UC Ep 5–10 failure mode is not mistakenly promoted to a title.
- `test_label_wins_over_fallback` — explicit `**HOOK:**` still takes precedence.
- Existing `test_returns_none_when_missing` still passes.

```
============================== 10 passed in 0.04s ==============================
```

## Out of scope

Ep 5–11 are stuck with their generic fallback titles unless re-rendered — their blockquote sits past the first `###` so the new fallback intentionally won't pick it up (a 600-char three-sentence title is worse than `Episode N - May DD`). If the operator wants to backfill, the cleanest path is to re-run those topic-queue entries (their `produced: true` flag would need flipping back to `false` first).

## Test plan

- [x] `pytest tests/test_integration.py::TestHookExtraction` — 10 passed.
- [x] Prompt placeholders still resolve (`today_str`, `topic_brief`, `topic_category`, `topic_title`).
- [x] Sanity-checked the fallback against every show's latest saved `.md` — all extract the right hook, no regressions.
- [ ] Next UC run (Ep 12) ships with a real one-sentence RSS title.


---
_Generated by [Claude Code](https://claude.ai/code/session_013sWzi3YLLjJgckvarquWZS)_