### PR TITLE
fix: TSLA price via Yahoo Finance direct HTTP (replace Grok x_search)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -673,47 +673,62 @@ decision); everything else has a live status card.
     show pulls from `shows/topic_queues/unintended_consequences.yaml`
     and never fetches news; raising it would block every episode.
 
-22. **TSLA price source flipped from yfinance to xAI `x_search` (May 2026)**
-    — `shows/hooks/tesla.py:_fetch_tsla_price()` previously called
-    yfinance with three retries and a 5-day history fallback. Operator
-    caught it repeatedly returning `$0.00 (price unavailable)` —
-    yfinance throttles aggressively on the GitHub Actions runner's
-    egress IPs and falls back to empty `fast_info` payloads, which
-    bypassed every retry because the code checked for an exception,
-    not for a missing field.
+22. **TSLA price source: Yahoo Finance v8 chart API (May 2026)** —
+    `shows/hooks/tesla.py:_fetch_tsla_price()` calls
+    `https://query2.finance.yahoo.com/v8/finance/chart/TSLA` directly
+    via `requests.get` (no library wrapper, no third-party proxy).
+    Same authoritative endpoint `tesla.html` uses as its in-browser
+    fallback, so the website, podcasts, RSS, blog, and newsletter
+    all derive from one identical source of truth — and the
+    `api/tsla.json` cache the hook writes is the single source the
+    website's primary path reads.
 
-    Replacement: a single Grok Responses API call with
-    `enable_x_search=True` and a JSON-only prompt. xAI's `x_search`
-    queries X (Twitter) for the latest `$TSLA` cashtag post and
-    returns `{"price": <float>, "prev_close": <float>,
-    "market_state": "REGULAR"|"POST"|"PRE"}`. Reuses `GROK_API_KEY`
-    (already in env for digest generation). No new secret, no
-    additional rate-limit surface.
+    Two prior fetchers failed and were retired:
 
-    **Sanity band:** prices outside `$50 – $2000` are rejected and
-    the fetcher returns `(0.0, "(price unavailable)")` — identical
-    to the old degraded path. Grok occasionally hallucinates low
-    numbers from old historical posts; the band catches those before
-    they reach the digest. Re-tune the band only if TSLA's real price
-    legitimately exits it.
+    - **yfinance (early 2026):** the library wraps this same Yahoo
+      endpoint but adds aggressive retry / parallel-fetch logic that
+      triggers Yahoo's rate-limit on the GitHub Actions runner's
+      egress IPs.  Repeatedly returned `$0.00 (price unavailable)`.
+    - **Grok `x_search` (May 1–18 2026):** queried X for the latest
+      `$TSLA` cashtag post.  Failed in two distinct ways operator
+      caught within 48 h of each other.  TST Ep473 (May 15)
+      returned $250 vs a real ~$444 (Grok pulled from a stale post —
+      caught by the 25% deviation guard).  TST Ep474 (May 16)
+      returned `price == prev_close == $415.50` because the X post
+      Grok latched onto only quoted a single number (caught by the
+      operator, not by any code guard).  X posts are not an
+      authoritative quote source.
 
-    **No fallback to yfinance.** The May 2026 operator decision was
-    to drop yfinance entirely — adding a fallback would re-introduce
-    the rate-limit surface this PR was designed to remove. If Grok
-    fails, the digest gets `(price unavailable)` exactly the way it
-    did when yfinance failed. The downstream rendering layers
-    (`engine/newsletter_body.py:render_tsla_price_block`,
-    `engine/publisher.py:format_tst_digest_for_x`, blog markdown)
-    all treat this as a graceful placeholder; the rest of the
-    digest ships normally.
+    **Why direct HTTP works where yfinance didn't:** one call per
+    Tesla cron run (~once / day), no retry storm, no parallel
+    yfinance sub-requests. Well below any practical rate limit when
+    the call shape matches what `finance.yahoo.com` itself sends.
+    Requires a real-browser `User-Agent` header (Yahoo returns 401
+    without one) — a current Firefox UA is hard-coded in
+    `_YAHOO_UA`.
+
+    **Sanity band:** prices outside `$200 – $1500` are rejected and
+    the fetcher returns `(0.0, "(price unavailable)")` — graceful
+    degradation identical to the old paths.
+
+    **Dynamic deviation guard:** new prices that swing more than 25%
+    from the last cached close (`api/tsla.json`) are rejected as
+    probable bad data.  Yahoo is unlikely to return a 25%+ off
+    price, but the guard was load-bearing under the previous Grok
+    fetcher and is cheap to keep as defence-in-depth.
 
     **`yfinance` dependency is still required** because
     `shows/hooks/modern_investing.py` uses it for trade-execution
-    pricing across many tickers (NVDA, MSFT, etc.). Only the Tesla
-    code path was flipped. 15 unit tests in
-    `tests/test_tesla_hook.py` pin every failure mode (network
-    error, no JSON, malformed JSON, missing fields, non-numeric
-    fields, out-of-band price, out-of-band prev_close) → graceful
-    placeholder, and every happy-path shape (regular session, after-
-    hours, pre-market, negative change, JSON wrapped in code fence
-    / prose).
+    pricing across many tickers (NVDA, MSFT, etc.).  Only the Tesla
+    code path is on direct HTTP.
+
+    **Drift guards:** 29 unit tests in `tests/test_tesla_hook.py`
+    pin every failure mode (network error, HTTP 401 / 429, missing
+    fields, out-of-band price, deviation guard) → graceful
+    placeholder, and every happy-path shape (regular session, pre-
+    market, after-hours, `marketState: null`, `marketState:
+    POSTPOST`, `chartPreviousClose: null` fallback to
+    `previousClose`).  The cache file records
+    `"source": "yahoo_finance_v8"` so the dashboard can tell at a
+    glance which fetcher produced the last value — a regression
+    back to Grok would change that string.

--- a/api/tsla.json
+++ b/api/tsla.json
@@ -1,10 +1,10 @@
 {
-  "price": 419.75,
-  "prev_close": 415.5,
-  "change": 4.25,
-  "change_pct": 1.02,
-  "change_str": "\u25b2 $4.25 (1.0%) (Pre-market)",
-  "market_state": "PRE",
-  "fetched_at": "2026-05-18T12:16:57Z",
-  "source": "grok_x_search"
+  "price": 409.99,
+  "prev_close": 445.0,
+  "change": -35.01,
+  "change_pct": -7.87,
+  "change_str": "\u25bc $35.01 (7.9%)",
+  "market_state": "REGULAR",
+  "fetched_at": "2026-05-19T00:39:36Z",
+  "source": "yahoo_finance_v8"
 }

--- a/shows/hooks/tesla.py
+++ b/shows/hooks/tesla.py
@@ -1,11 +1,10 @@
 """Tesla-specific pre-fetch hook.
 
 Provides extra context that the Tesla Shorts Time digest prompt needs:
-- TSLA stock price and change string via xAI's ``x_search`` built-in
-  tool against X (Twitter). Was yfinance; flipped May 2026 after
-  operator caught yfinance returning ``$0.00 (price unavailable)``
-  repeatedly. X has real-time cashtag data with no rate limits the
-  way Yahoo Finance does.
+- TSLA stock price and change string via Yahoo Finance's v8 chart API
+  (direct HTTP, no library wrapper). Source of truth for the website,
+  podcasts, RSS, blog, and newsletter — all consume the value this
+  hook returns and the ``api/tsla.json`` cache it writes.
 - X posts section placeholder (disabled by default)
 - Market movers section (Monday only)
 - Content tracking for freshness
@@ -30,7 +29,11 @@ def pre_fetch(config, *, episode_num: int | None = None, today_str: str | None =
     """
     context: dict = {}
 
-    # Stock price via xAI x_search (queries X for real-time $TSLA cashtag data)
+    # Stock price via Yahoo Finance v8 chart API (direct HTTP).
+    # Same endpoint the website (`tesla.html`) uses as its fallback —
+    # consolidating everything onto the authoritative real-time quote
+    # source so website / podcasts / RSS / blog / newsletter never
+    # diverge again.
     price, change_str = _fetch_tsla_price()
     context["price"] = f"{price:.2f}"
     context["change_str"] = change_str
@@ -79,96 +82,133 @@ def pronunciation_overrides() -> dict:
 # ---------------------------------------------------------------------------
 
 # Hard sanity range for parsed prices.  A real-time TSLA quote outside
-# this band almost certainly means Grok hallucinated or returned a
-# stale / malformed number; we'd rather ship ``(price unavailable)``
-# than a garbage figure into the digest.
+# this band almost certainly means the upstream API returned a stale /
+# malformed number; we'd rather ship ``(price unavailable)`` than a
+# garbage figure into the digest.
 #
-# Updated May 15 2026: tightened from $50-$2000 to $200-$1500 after
-# operator caught Grok returning $250.35 for Ep473 when TSLA was
-# actually trading near $440.  TSLA hasn't traded below $200 in
-# over a year and is structurally unlikely to drop below $200 in the
-# near term given the post-2024 trading range.
+# Updated May 15 2026: tightened from $50-$2000 to $200-$1500.
+# TSLA hasn't traded below $200 in over a year and is structurally
+# unlikely to drop below $200 in the near term given the post-2024
+# trading range.
 _TSLA_PRICE_MIN = 200.0
 _TSLA_PRICE_MAX = 1500.0
 
 # Tighter dynamic validation: a new price more than this fraction
 # away from the LAST CACHED price (``api/tsla.json``) gets rejected as
-# a probable hallucination.  TSLA's largest single-day moves over
-# the past 2 years sit around 12-15%; setting the floor at 25% gives
-# a comfortable margin for an unusually volatile earnings day while
-# still catching the May 15 2026 "$444 → $250" hallucination
+# a probable bad quote.  TSLA's largest single-day moves over the past
+# 2 years sit around 12-15%; setting the floor at 25% gives a
+# comfortable margin for an unusually volatile earnings day while
+# still catching the May 15 2026 "$444 → $250" regression
 # (a ~44% drop) that motivated this guard.
 _TSLA_MAX_PCT_DEVIATION = 0.25  # 25% from last known close
 
+# Yahoo Finance v8 chart API endpoint — same one tesla.html falls back
+# to via CORS proxies in the browser.  Server-side we call it directly
+# (no proxy, no library wrapper). ``range=5d`` is enough to guarantee
+# a non-null ``chartPreviousClose`` even across long weekends /
+# holidays — ``range=1d`` returns nulls outside RTH.
+_YAHOO_CHART_URL = (
+    "https://query2.finance.yahoo.com/v8/finance/chart/TSLA"
+    "?interval=1d&range=5d"
+)
+
+# Yahoo Finance rejects requests without a real-browser User-Agent
+# header (returns 401 ``Unauthorized``).  Mirror a current Firefox
+# UA so the endpoint treats us as a regular fetch.
+_YAHOO_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) "
+    "Gecko/20100101 Firefox/121.0"
+)
+
+# Timeout for the Yahoo call.  GitHub Actions runner egress occasionally
+# stalls; 8 s is the website's own per-proxy timeout and well under the
+# cron-job wall clock budget.
+_YAHOO_TIMEOUT_S = 8.0
+
 
 def _fetch_tsla_price() -> tuple[float, str]:
-    """Get current TSLA price + change string via Grok's ``x_search``.
+    """Get current TSLA price + change string via Yahoo Finance.
 
-    Replaces the previous yfinance path. Operator caught yfinance
-    repeatedly returning ``$0.00 (price unavailable)`` on Tesla
-    runs (May 2026). xAI's Responses API has a built-in ``x_search``
-    tool that queries X (Twitter) for the live ``$TSLA`` cashtag —
-    every cashtag X post carries the real-time quote inline.
+    Calls the v8 chart API (``query2.finance.yahoo.com/v8/finance/chart/TSLA``)
+    directly with ``requests`` — no yfinance library, no CORS proxy,
+    no third-party stock service.  Same authoritative endpoint
+    ``tesla.html`` uses as its in-browser fallback, so the website,
+    podcasts, RSS, blog, and newsletter all derive from one identical
+    source of truth.
 
-    Returns ``(price, change_str)`` in the same shape as the old
-    yfinance path so every downstream consumer (digest template, RSS,
-    blog, newsletter, X teaser) continues to work without changes.
+    History:
+      yfinance (early 2026): the library wrapped this same endpoint
+        but added aggressive retry / parallel-fetch logic that
+        triggered Yahoo's rate-limit on the GitHub Actions runner's
+        egress IPs.  Repeatedly returned ``$0.00 (price unavailable)``.
+      Grok x_search (May 2026): queried X for the latest ``$TSLA``
+        cashtag post.  Failed in two distinct ways operator caught
+        within 48 h of each other — Ep473 (May 15) returned $250 vs
+        a real ~$444 (pulled from a stale post), Ep474 (May 16)
+        returned price == prev_close (single-number post, no change).
+        X posts are not an authoritative quote source.
+      Direct Yahoo (May 18 2026, this fetcher): one HTTP call, real
+        ``regularMarketPrice`` + ``chartPreviousClose`` + ``marketState``
+        from the same data that powers finance.yahoo.com.  One call
+        per Tesla cron run (~once / day) is well below any practical
+        rate limit when we're not using the yfinance retry-storm
+        client.
 
-    Failure modes (network down, Grok parse error, out-of-range
-    price): returns ``(0.0, "(price unavailable)")`` — identical to
-    the old code's degraded path.
+    Returns ``(price, change_str)`` in the same shape as before so
+    every downstream consumer keeps working without changes.
+
+    Failure modes (network down, non-200 response, missing fields,
+    out-of-range price, deviation guard trip): returns
+    ``(0.0, "(price unavailable)")``.
     """
-    import json
-    import re
-
     try:
-        from digests.xai_grok import grok_generate_text
-    except Exception as exc:  # pragma: no cover — module path guard
-        logger.error("Could not import xai_grok helper: %s", exc)
+        import requests
+    except Exception as exc:  # pragma: no cover — requests is in requirements.txt
+        logger.error("Could not import requests for TSLA fetch: %s", exc)
         return 0.0, "(price unavailable)"
 
-    prompt = (
-        "Search X (Twitter) for the current real-time TSLA stock price "
-        "from the most recent $TSLA cashtag post. Return ONLY a single "
-        "JSON object (no prose, no code fences):\n"
-        '{"price": <float>, "prev_close": <float>, '
-        '"market_state": "REGULAR"|"POST"|"PRE"}'
-    )
-
     try:
-        text, _meta = grok_generate_text(
-            prompt=prompt,
-            enable_x_search=True,
-            max_tokens=200,
-            temperature=0.0,
+        resp = requests.get(
+            _YAHOO_CHART_URL,
+            headers={"User-Agent": _YAHOO_UA, "Accept": "application/json"},
+            timeout=_YAHOO_TIMEOUT_S,
         )
     except Exception as exc:
-        logger.error("Grok x_search call for TSLA failed: %s", exc)
+        logger.error("Yahoo Finance request for TSLA failed: %s", exc)
         return 0.0, "(price unavailable)"
 
-    # Grok occasionally wraps the JSON in a code fence or adds a
-    # leading "Here is the data:" sentence despite the prompt. Pull
-    # the first ``{...}`` block out before parsing.
-    m = re.search(r"\{[^{}]*\}", text or "")
-    if not m:
-        logger.error("Grok x_search returned no JSON for TSLA: %r", (text or "")[:200])
-        return 0.0, "(price unavailable)"
-
-    try:
-        data = json.loads(m.group(0))
-    except json.JSONDecodeError as exc:
-        logger.error("TSLA JSON parse error: %s — body=%r", exc, m.group(0))
+    if resp.status_code != 200:
+        logger.error(
+            "Yahoo Finance returned HTTP %s for TSLA (body=%r)",
+            resp.status_code, resp.text[:200],
+        )
         return 0.0, "(price unavailable)"
 
     try:
-        price = float(data.get("price"))
-        prev_close = float(data.get("prev_close"))
-    except (TypeError, ValueError):
-        logger.error("TSLA fields missing/non-numeric: %r", data)
+        data = resp.json()
+    except Exception as exc:
+        logger.error("TSLA Yahoo JSON parse error: %s", exc)
         return 0.0, "(price unavailable)"
 
-    # Hard sanity range — Grok hallucinations sometimes invent low/high
-    # numbers; reject anything wildly outside TSLA's historical range.
+    # Yahoo's chart response shape:
+    #   { "chart": { "result": [ { "meta": { "regularMarketPrice": ...,
+    #     "chartPreviousClose": ..., "previousClose": ...,
+    #     "marketState": "REGULAR"|"PRE"|"POST"|"CLOSED" } } ] } }
+    try:
+        meta = data["chart"]["result"][0]["meta"]
+        price = float(meta["regularMarketPrice"])
+        # Yahoo provides both fields; ``chartPreviousClose`` is the one
+        # the website's fallback path prefers because it's never null
+        # when ``range >= 5d``.  ``previousClose`` is the secondary.
+        prev_close = float(
+            meta.get("chartPreviousClose") or meta.get("previousClose")
+        )
+    except (KeyError, IndexError, TypeError, ValueError) as exc:
+        logger.error("TSLA meta fields missing/malformed: %s", exc)
+        return 0.0, "(price unavailable)"
+
+    # Hard sanity range — guards against Yahoo briefly returning a
+    # stale split-adjusted figure or a malformed payload.
     if not (_TSLA_PRICE_MIN <= price <= _TSLA_PRICE_MAX):
         logger.error("TSLA price %.2f outside sanity band [%.0f, %.0f]",
                      price, _TSLA_PRICE_MIN, _TSLA_PRICE_MAX)
@@ -178,44 +218,50 @@ def _fetch_tsla_price() -> tuple[float, str]:
         return 0.0, "(price unavailable)"
 
     # Dynamic deviation check — reject prices that swing more than
-    # 25% from the last cached close.  Catches stale / hallucinated
-    # quotes that pass the wide static band.  Operator caught
-    # ($250 vs real $444, May 15 2026 TST Ep473).  No cache → skip
-    # the check (first-ever run can't compare).
+    # 25% from the last cached close.  No cache → skip the check
+    # (first-ever run can't compare).  Yahoo is unlikely to return a
+    # 25%+ off price, but the guard is cheap defence-in-depth.
     last_cached = _load_last_cached_tsla_price()
     if last_cached is not None and last_cached > 0:
         deviation = abs(price - last_cached) / last_cached
         if deviation > _TSLA_MAX_PCT_DEVIATION:
             logger.error(
                 "TSLA price %.2f deviates %.1f%% from last cached "
-                "$%.2f (cap %.0f%%) — likely Grok hallucination; "
-                "rejecting.",
+                "$%.2f (cap %.0f%%) — rejecting.",
                 price, deviation * 100, last_cached,
                 _TSLA_MAX_PCT_DEVIATION * 100,
             )
             return 0.0, "(price unavailable)"
 
-    market_state = str(data.get("market_state", "REGULAR")).upper()
-    market_status = ""
-    if market_state == "POST":
-        market_status = " (After-hours)"
-    elif market_state == "PRE":
+    # Yahoo uses ``PRE`` / ``REGULAR`` / ``POST`` / ``CLOSED`` /
+    # ``POSTPOST``, and occasionally returns ``null`` mid-session.
+    # ``None`` and missing both default to REGULAR — that's the
+    # honest fallback for an unknown state (no misleading
+    # after-hours suffix).
+    raw_state_val = meta.get("marketState")
+    raw_state = str(raw_state_val).upper() if raw_state_val else "REGULAR"
+    if raw_state == "PRE":
+        market_state = "PRE"
         market_status = " (Pre-market)"
+    elif raw_state == "REGULAR":
+        market_state = "REGULAR"
+        market_status = ""
+    else:
+        # POST, POSTPOST, CLOSED — all read as after-hours on a podcast
+        # that ships at 8 AM ET (the most common case).
+        market_state = "POST"
+        market_status = " (After-hours)"
 
     change = price - prev_close
     pct = (change / prev_close) * 100 if prev_close else 0.0
     direction = "▲" if change >= 0 else "▼"
     change_str = f"{direction} ${abs(change):.2f} ({abs(pct):.1f}%){market_status}"
-    logger.info("TSLA via x_search: $%.2f %s", price, change_str)
+    logger.info("TSLA via Yahoo Finance: $%.2f %s", price, change_str)
 
-    # Persist the live price to ``api/tsla.json`` so the public website
-    # (tesla.html) can render it without depending on Yahoo Finance.
-    # Operator caught (May 14 2026) that the site's client-side fetch
-    # of ``query2.finance.yahoo.com`` had been failing through both
-    # CORS proxies, leaving "Market data unavailable" on the page even
-    # though the pipeline knew the live price.  Same-origin JSON
-    # avoids the CORS layer entirely; the JS falls back to Yahoo if
-    # this file is somehow missing.
+    # Persist the live price to ``api/tsla.json`` so the public
+    # website (tesla.html) can render it without depending on its own
+    # client-side Yahoo fetch (which is subject to browser CORS and
+    # public proxy availability — see landmine #22).
     _persist_tsla_price_json(
         price=price, prev_close=prev_close, change=change, pct=pct,
         change_str=change_str, market_state=market_state,
@@ -274,7 +320,7 @@ def _persist_tsla_price_json(
         "change_str": change_str,
         "market_state": market_state,
         "fetched_at": _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
-        "source": "grok_x_search",
+        "source": "yahoo_finance_v8",
     }
     try:
         api_dir = Path(__file__).resolve().parent.parent.parent / "api"

--- a/tests/test_tesla_hook.py
+++ b/tests/test_tesla_hook.py
@@ -1,17 +1,21 @@
 """Tests for ``shows/hooks/tesla.py:_fetch_tsla_price``.
 
-The fetcher was flipped from yfinance to Grok's ``x_search`` built-in
-tool in May 2026 after operator caught yfinance repeatedly returning
-``$0.00 (price unavailable)``. These tests pin the contract:
+The fetcher was flipped from Grok ``x_search`` to a direct HTTP call
+against Yahoo Finance's v8 chart API in May 2026 after operator caught
+Grok returning bad data on two consecutive days (Ep473: $250 vs real
+$444; Ep474: price == prev_close).  X posts are not an authoritative
+quote source.
 
-* Happy-path JSON from Grok produces the canonical
-  ``▲ $X.XX (X.X%)`` change string the existing pipeline expects.
-* Out-of-range / malformed / missing-field responses fall back to
-  ``(0.0, "(price unavailable)")`` so we never ship a hallucinated
-  number to the digest.
+These tests pin the contract:
 
-The Grok call itself is monkey-patched out — these are pure-function
-tests, never hit the network.
+* Happy-path Yahoo response produces the canonical ``▲ $X.XX (X.X%)``
+  change string the existing pipeline expects.
+* HTTP errors, non-200 status, missing fields, out-of-range or
+  deviated prices all fall back to ``(0.0, "(price unavailable)")``
+  so we never ship a wrong number to the digest.
+
+The ``requests.get`` call is monkey-patched out — these are pure-
+function tests, never hit the network.
 """
 
 from __future__ import annotations
@@ -28,14 +32,58 @@ sys.path.insert(0, str(PROJECT_ROOT / "shows" / "hooks"))
 import tesla as tesla_hook  # noqa: E402  (sys.path manipulation needed)
 
 
-def _patch_grok(monkeypatch, text: str):
-    """Stub ``digests.xai_grok.grok_generate_text`` to return ``text``."""
-    from digests import xai_grok
+class _FakeResponse:
+    """Minimal stand-in for ``requests.Response`` that the fetcher
+    needs: ``status_code``, ``.json()``, ``.text``.
+    """
 
-    def _fake(prompt, **kwargs):
-        return text, {"provider": "stub"}
+    def __init__(self, *, status_code: int = 200, payload: dict | None = None,
+                 text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
 
-    monkeypatch.setattr(xai_grok, "grok_generate_text", _fake)
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no payload")
+        return self._payload
+
+
+def _make_yahoo_payload(
+    *,
+    price: float = 444.57,
+    prev_close: float = 445.00,
+    market_state: str = "REGULAR",
+) -> dict:
+    """Build a Yahoo-shaped chart response with the requested fields."""
+    return {
+        "chart": {
+            "result": [
+                {
+                    "meta": {
+                        "regularMarketPrice": price,
+                        "chartPreviousClose": prev_close,
+                        "previousClose": prev_close,
+                        "marketState": market_state,
+                    },
+                },
+            ],
+        },
+    }
+
+
+def _patch_yahoo(monkeypatch, *, response: _FakeResponse | None = None,
+                 raises: Exception | None = None):
+    """Stub ``requests.get`` (as imported inside ``_fetch_tsla_price``)
+    so the test never touches the network."""
+    import requests
+
+    def _fake_get(url, **kwargs):
+        if raises is not None:
+            raise raises
+        return response
+
+    monkeypatch.setattr(requests, "get", _fake_get)
 
 
 @pytest.fixture(autouse=True)
@@ -56,8 +104,12 @@ def _stub_persist(monkeypatch):
 
 class TestHappyPath:
 
-    def test_clean_json_regular_session(self, monkeypatch):
-        _patch_grok(monkeypatch, '{"price": 411.82, "prev_close": 402.38, "market_state": "REGULAR"}')
+    def test_clean_response_regular_session(self, monkeypatch):
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=411.82, prev_close=402.38, market_state="REGULAR",
+            ),
+        ))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 411.82
         # Up $9.44, ~2.3% — direction triangle ▲, no after-hours marker.
@@ -68,7 +120,11 @@ class TestHappyPath:
         assert "Pre-market" not in change_str
 
     def test_negative_change_uses_down_arrow(self, monkeypatch):
-        _patch_grok(monkeypatch, '{"price": 380.00, "prev_close": 400.00, "market_state": "REGULAR"}')
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=380.00, prev_close=400.00, market_state="REGULAR",
+            ),
+        ))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 380.00
         assert "▼" in change_str
@@ -76,80 +132,124 @@ class TestHappyPath:
         assert "5.0%" in change_str
 
     def test_after_hours_marker(self, monkeypatch):
-        _patch_grok(monkeypatch, '{"price": 415.00, "prev_close": 411.82, "market_state": "POST"}')
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=415.00, prev_close=411.82, market_state="POST",
+            ),
+        ))
         _, change_str = tesla_hook._fetch_tsla_price()
         assert "(After-hours)" in change_str
 
     def test_pre_market_marker(self, monkeypatch):
-        _patch_grok(monkeypatch, '{"price": 405.00, "prev_close": 411.82, "market_state": "PRE"}')
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=405.00, prev_close=411.82, market_state="PRE",
+            ),
+        ))
         _, change_str = tesla_hook._fetch_tsla_price()
         assert "(Pre-market)" in change_str
 
-    def test_extracts_json_when_grok_adds_prose(self, monkeypatch):
-        """Grok occasionally wraps the JSON in code fences or adds
-        a 'Here is the data:' preamble despite the prompt. The
-        first-``{...}``-block regex must still parse it cleanly."""
-        _patch_grok(
-            monkeypatch,
-            'Here is the latest:\n```json\n{"price": 400.00, "prev_close": 400.00, "market_state": "REGULAR"}\n```\nThat\'s from $TSLA on X.',
+    def test_closed_state_renders_as_after_hours(self, monkeypatch):
+        """Yahoo uses ``CLOSED`` outside trading hours on
+        weekends/holidays.  The downstream rendering doesn't have a
+        dedicated 'closed' visual treatment so we collapse it into
+        the after-hours bucket (which is what the operator sees on
+        an 8 AM ET podcast publish anyway)."""
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=415.00, prev_close=411.82, market_state="CLOSED",
+            ),
+        ))
+        _, change_str = tesla_hook._fetch_tsla_price()
+        assert "(After-hours)" in change_str
+
+    def test_falls_back_to_previous_close_when_chart_close_missing(self, monkeypatch):
+        """``chartPreviousClose`` is the primary close field but Yahoo
+        occasionally returns null for it (early pre-market on a fresh
+        trading day); fall back to ``previousClose`` so we don't
+        unnecessarily ship a price-unavailable."""
+        payload = _make_yahoo_payload(
+            price=400.00, prev_close=400.00, market_state="REGULAR",
         )
+        payload["chart"]["result"][0]["meta"]["chartPreviousClose"] = None
+        payload["chart"]["result"][0]["meta"]["previousClose"] = 395.00
+        _patch_yahoo(monkeypatch, response=_FakeResponse(payload=payload))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 400.00
         assert "▲" in change_str
-        assert "$0.00" in change_str
+        assert "$5.00" in change_str
 
 
 class TestFailureModes:
     """Every path that can't yield a trustworthy quote must return
     ``(0.0, "(price unavailable)")`` so the digest template renders
-    a graceful placeholder rather than a hallucinated number."""
+    a graceful placeholder rather than a wrong number."""
 
-    def test_grok_call_raises(self, monkeypatch):
-        from digests import xai_grok
-
-        def _boom(prompt, **kwargs):
-            raise RuntimeError("network down")
-
-        monkeypatch.setattr(xai_grok, "grok_generate_text", _boom)
+    def test_network_error_raises(self, monkeypatch):
+        _patch_yahoo(monkeypatch, raises=RuntimeError("network down"))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 0.0
         assert change_str == "(price unavailable)"
 
-    def test_no_json_in_response(self, monkeypatch):
-        _patch_grok(monkeypatch, "I'm sorry, I can't find that data on X right now.")
+    def test_http_non_200(self, monkeypatch):
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            status_code=429, text="Rate limited",
+        ))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 0.0
         assert change_str == "(price unavailable)"
 
-    def test_malformed_json(self, monkeypatch):
-        _patch_grok(monkeypatch, '{"price": 411.82 "prev_close": 402.38}')  # missing comma
+    def test_yahoo_401_unauthorized(self, monkeypatch):
+        """If Yahoo starts rejecting our User-Agent the call returns
+        401; fall back gracefully rather than ship garbage."""
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            status_code=401, text="Unauthorized",
+        ))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 0.0
         assert change_str == "(price unavailable)"
 
-    def test_missing_field(self, monkeypatch):
-        _patch_grok(monkeypatch, '{"price": 411.82}')
+    def test_unparseable_body(self, monkeypatch):
+        _patch_yahoo(monkeypatch, response=_FakeResponse(payload=None))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 0.0
         assert change_str == "(price unavailable)"
 
-    def test_non_numeric_field(self, monkeypatch):
-        _patch_grok(monkeypatch, '{"price": "FOUR HUNDRED", "prev_close": 402.38, "market_state": "REGULAR"}')
+    def test_missing_meta(self, monkeypatch):
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload={"chart": {"result": []}},
+        ))
+        price, change_str = tesla_hook._fetch_tsla_price()
+        assert price == 0.0
+        assert change_str == "(price unavailable)"
+
+    def test_missing_price_field(self, monkeypatch):
+        payload = _make_yahoo_payload()
+        del payload["chart"]["result"][0]["meta"]["regularMarketPrice"]
+        _patch_yahoo(monkeypatch, response=_FakeResponse(payload=payload))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 0.0
         assert change_str == "(price unavailable)"
 
     def test_price_below_sanity_band(self, monkeypatch):
-        """``$5`` is impossible for TSLA — likely a Grok hallucination
-        or a stale stub from a parallel universe. Fall back gracefully."""
-        _patch_grok(monkeypatch, '{"price": 5.00, "prev_close": 400.00, "market_state": "REGULAR"}')
+        """``$5`` is impossible for TSLA — likely a malformed payload
+        or a stale split-adjusted figure. Fall back gracefully."""
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=5.00, prev_close=400.00, market_state="REGULAR",
+            ),
+        ))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 0.0
         assert change_str == "(price unavailable)"
 
     def test_price_above_sanity_band(self, monkeypatch):
         """``$5000`` is impossibly high; fall back."""
-        _patch_grok(monkeypatch, '{"price": 5000.00, "prev_close": 400.00, "market_state": "REGULAR"}')
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=5000.00, prev_close=400.00, market_state="REGULAR",
+            ),
+        ))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 0.0
         assert change_str == "(price unavailable)"
@@ -157,30 +257,26 @@ class TestFailureModes:
     def test_prev_close_out_of_band_fails(self, monkeypatch):
         """A plausible price with an impossible prev_close would compute
         a misleading change %; reject the whole response."""
-        _patch_grok(monkeypatch, '{"price": 400.00, "prev_close": 0.05, "market_state": "REGULAR"}')
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=400.00, prev_close=0.05, market_state="REGULAR",
+            ),
+        ))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 0.0
         assert change_str == "(price unavailable)"
 
 
 class TestTslaJsonCache:
-    """Operator caught (May 14 2026) the tesla.html stock widget
-    showing "Market data unavailable" because every Yahoo Finance
-    CORS proxy was failing — even though the pipeline knew the live
-    price the whole time. ``_fetch_tsla_price`` now persists the
-    last successful fetch to ``api/tsla.json`` so the website can
-    serve a same-origin price without depending on Yahoo Finance.
-    """
+    """``_fetch_tsla_price`` persists each successful fetch to
+    ``api/tsla.json`` so the public website (tesla.html) can render
+    a same-origin price without depending on its own client-side
+    Yahoo fetch (which can fail behind browser CORS / public proxies)."""
 
     def test_writes_api_tsla_json_on_success(self, monkeypatch, tmp_path):
         """Successful price fetch writes api/tsla.json with the
-        full payload (price, prev_close, change, change_pct,
-        change_str, market_state, fetched_at, source)."""
+        full payload."""
         import json
-        # Redirect ``api/`` directory to a tmp path for isolation.
-        # tesla.py computes the path as
-        # ``Path(__file__).parent.parent.parent / "api"``; we monkey-
-        # patch the persistence helper to use tmp instead.
         captured: dict = {}
 
         def fake_persist(**kwargs):
@@ -197,20 +293,19 @@ class TestTslaJsonCache:
             out.write_text(json.dumps(payload), encoding="utf-8")
 
         monkeypatch.setattr(tesla_hook, "_persist_tsla_price_json", fake_persist)
-        _patch_grok(
-            monkeypatch,
-            '{"price": 444.57, "prev_close": 445.00, "market_state": "REGULAR"}',
-        )
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=444.57, prev_close=445.00, market_state="REGULAR",
+            ),
+        ))
 
         price, change_str = tesla_hook._fetch_tsla_price()
 
-        # _persist_tsla_price_json was called with the right kwargs.
         assert price == 444.57
         assert captured["price"] == 444.57
         assert captured["prev_close"] == 445.00
         assert captured["market_state"] == "REGULAR"
         assert "$0.43" in captured["change_str"]
-        # The JSON file was actually written and is parseable.
         out_path = tmp_path / "tsla.json"
         assert out_path.exists()
         payload = json.loads(out_path.read_text())
@@ -218,14 +313,8 @@ class TestTslaJsonCache:
         assert payload["prev_close"] == 445.00
 
     def test_persistence_failure_is_non_fatal(self, monkeypatch):
-        """If ``api/tsla.json`` can't be written (disk full,
-        permission, etc.) the pipeline still gets a usable
-        ``(price, change_str)``. The cache is strictly best-effort
-        — landmine-style failures must not block daily digest
-        generation."""
-        # Force Path.write_text to raise so the inner try/except in
-        # _persist_tsla_price_json fires. Don't monkeypatch the
-        # outer function — we want to exercise the real safety net.
+        """If ``api/tsla.json`` can't be written (disk full, permission)
+        the pipeline still gets a usable ``(price, change_str)``."""
         from pathlib import Path as _Path
 
         original_write = _Path.write_text
@@ -236,33 +325,62 @@ class TestTslaJsonCache:
             return original_write(self, *args, **kwargs)
 
         monkeypatch.setattr(_Path, "write_text", explosive_write)
-        _patch_grok(
-            monkeypatch,
-            '{"price": 400.00, "prev_close": 400.00, "market_state": "REGULAR"}',
-        )
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=400.00, prev_close=400.00, market_state="REGULAR",
+            ),
+        ))
 
         # Must NOT raise — best-effort wraps the write in try/except.
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 400.00
         assert change_str.startswith("▲")
 
+    def test_persisted_source_field_is_yahoo(self, monkeypatch):
+        """The cache file records its provenance so the dashboard /
+        operator can tell at a glance which fetcher produced the
+        last value."""
+        captured: dict = {}
+
+        def fake_persist(**kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr(tesla_hook, "_persist_tsla_price_json", fake_persist)
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=444.57, prev_close=445.00, market_state="REGULAR",
+            ),
+        ))
+
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 444.57
+
+        # The persistence helper hard-codes ``source: "yahoo_finance_v8"``;
+        # the contract guard lives separately because the kwargs the
+        # fetcher passes don't include ``source``.
+        import inspect
+        from shows.hooks import tesla
+        src = inspect.getsource(tesla._persist_tsla_price_json)
+        assert '"source": "yahoo_finance_v8"' in src
+
 
 class TestDeviationGuard:
-    """Operator caught (TST Ep473, May 15 2026) Grok returning
-    ``$250.35`` for TSLA when the real price was ~$444 — a 44%
-    deviation that passed the wide ($200-$1500) hard sanity band.
-    The dynamic deviation guard rejects new prices that swing more
-    than 25% from the LAST CACHED price in ``api/tsla.json``."""
+    """Defence-in-depth: reject prices that swing more than 25% from
+    the last cached close.  Yahoo is unlikely to return a 25%+ off
+    price, but the guard was load-bearing under the previous Grok
+    fetcher (caught the May 15 2026 ``$444 → $250`` regression) and
+    is cheap to keep in place."""
 
     def test_rejects_price_more_than_25pct_below_cached(self, monkeypatch):
         """Cached at $444, new price $250 = 44% drop → reject."""
         monkeypatch.setattr(
             tesla_hook, "_load_last_cached_tsla_price", lambda: 444.57,
         )
-        _patch_grok(
-            monkeypatch,
-            '{"price": 250.35, "prev_close": 248.12, "market_state": "PRE"}',
-        )
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=250.35, prev_close=248.12, market_state="PRE",
+            ),
+        ))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 0.0
         assert change_str == "(price unavailable)"
@@ -272,10 +390,11 @@ class TestDeviationGuard:
         monkeypatch.setattr(
             tesla_hook, "_load_last_cached_tsla_price", lambda: 400.00,
         )
-        _patch_grok(
-            monkeypatch,
-            '{"price": 600.00, "prev_close": 595.00, "market_state": "REGULAR"}',
-        )
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=600.00, prev_close=595.00, market_state="REGULAR",
+            ),
+        ))
         price, _ = tesla_hook._fetch_tsla_price()
         assert price == 0.0
 
@@ -284,10 +403,11 @@ class TestDeviationGuard:
         monkeypatch.setattr(
             tesla_hook, "_load_last_cached_tsla_price", lambda: 440.00,
         )
-        _patch_grok(
-            monkeypatch,
-            '{"price": 420.00, "prev_close": 425.00, "market_state": "REGULAR"}',
-        )
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=420.00, prev_close=425.00, market_state="REGULAR",
+            ),
+        ))
         price, _ = tesla_hook._fetch_tsla_price()
         assert price == 420.00
 
@@ -300,10 +420,11 @@ class TestDeviationGuard:
             tesla_hook, "_load_last_cached_tsla_price", lambda: 400.00,
         )
         # 400 * 1.25 = 500 — exactly at the upper boundary
-        _patch_grok(
-            monkeypatch,
-            '{"price": 500.00, "prev_close": 498.00, "market_state": "REGULAR"}',
-        )
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=500.00, prev_close=498.00, market_state="REGULAR",
+            ),
+        ))
         price, _ = tesla_hook._fetch_tsla_price()
         assert price == 500.00
 
@@ -314,10 +435,11 @@ class TestDeviationGuard:
         monkeypatch.setattr(
             tesla_hook, "_load_last_cached_tsla_price", lambda: None,
         )
-        _patch_grok(
-            monkeypatch,
-            '{"price": 444.57, "prev_close": 445.00, "market_state": "REGULAR"}',
-        )
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=444.57, prev_close=445.00, market_state="REGULAR",
+            ),
+        ))
         price, _ = tesla_hook._fetch_tsla_price()
         assert price == 444.57
 
@@ -327,17 +449,17 @@ class TestDeviationGuard:
         monkeypatch.setattr(
             tesla_hook, "_load_last_cached_tsla_price", lambda: 0.0,
         )
-        _patch_grok(
-            monkeypatch,
-            '{"price": 444.57, "prev_close": 445.00, "market_state": "REGULAR"}',
-        )
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=444.57, prev_close=445.00, market_state="REGULAR",
+            ),
+        ))
         price, _ = tesla_hook._fetch_tsla_price()
         assert price == 444.57
 
 
 class TestHardSanityBand:
-    """The dynamic deviation guard only fires when a cache exists.
-    The hard sanity band ($200-$1500) catches first-run hallucinations
+    """The hard sanity band ($200-$1500) catches first-run bad data
     and any price wildly outside TSLA's historical range."""
 
     def test_rejects_price_below_hard_floor(self, monkeypatch):
@@ -347,10 +469,11 @@ class TestHardSanityBand:
         monkeypatch.setattr(
             tesla_hook, "_load_last_cached_tsla_price", lambda: None,
         )
-        _patch_grok(
-            monkeypatch,
-            '{"price": 150.00, "prev_close": 152.00, "market_state": "REGULAR"}',
-        )
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=150.00, prev_close=152.00, market_state="REGULAR",
+            ),
+        ))
         price, _ = tesla_hook._fetch_tsla_price()
         assert price == 0.0
 
@@ -359,27 +482,51 @@ class TestHardSanityBand:
         monkeypatch.setattr(
             tesla_hook, "_load_last_cached_tsla_price", lambda: None,
         )
-        _patch_grok(
-            monkeypatch,
-            '{"price": 1600.00, "prev_close": 1580.00, "market_state": "REGULAR"}',
-        )
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=1600.00, prev_close=1580.00, market_state="REGULAR",
+            ),
+        ))
         price, _ = tesla_hook._fetch_tsla_price()
         assert price == 0.0
 
 
 class TestMarketStateDefaulting:
-    """If Grok omits ``market_state``, the fetcher should still return
-    a valid quote — just without an after-hours/pre-market suffix."""
+    """Yahoo's ``marketState`` values map onto the three states the
+    rendering layers know about (PRE / REGULAR / POST); unknown
+    values collapse to POST so we never crash on a new state Yahoo
+    adds (e.g. ``POSTPOST``)."""
 
     def test_missing_market_state_defaults_to_regular(self, monkeypatch):
-        _patch_grok(monkeypatch, '{"price": 411.82, "prev_close": 411.82}')
+        payload = _make_yahoo_payload(price=411.82, prev_close=411.82)
+        del payload["chart"]["result"][0]["meta"]["marketState"]
+        _patch_yahoo(monkeypatch, response=_FakeResponse(payload=payload))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 411.82
         assert "(After-hours)" not in change_str
         assert "(Pre-market)" not in change_str
 
-    def test_unknown_market_state_treated_as_regular(self, monkeypatch):
-        _patch_grok(monkeypatch, '{"price": 411.82, "prev_close": 411.82, "market_state": "WEIRD"}')
-        _, change_str = tesla_hook._fetch_tsla_price()
+    def test_null_market_state_defaults_to_regular(self, monkeypatch):
+        """Yahoo occasionally returns ``marketState: null`` mid-session
+        (observed live on 2026-05-18 against TSLA at $409.99).  A
+        null value must NOT render as 'After-hours' on a real
+        regular-session quote — default to REGULAR (no suffix)."""
+        payload = _make_yahoo_payload(price=411.82, prev_close=411.82)
+        payload["chart"]["result"][0]["meta"]["marketState"] = None
+        _patch_yahoo(monkeypatch, response=_FakeResponse(payload=payload))
+        price, change_str = tesla_hook._fetch_tsla_price()
+        assert price == 411.82
         assert "(After-hours)" not in change_str
         assert "(Pre-market)" not in change_str
+
+    def test_unknown_market_state_collapses_to_post(self, monkeypatch):
+        """``POSTPOST`` is a real Yahoo state (late after-hours session);
+        any unknown state should render as 'After-hours' rather than
+        crash."""
+        _patch_yahoo(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=411.82, prev_close=411.82, market_state="POSTPOST",
+            ),
+        ))
+        _, change_str = tesla_hook._fetch_tsla_price()
+        assert "(After-hours)" in change_str


### PR DESCRIPTION
## Summary

Operator caught TSLA quotes wrong across website, podcasts, and blogs. The architecture was already unified (one fetcher → `api/tsla.json` that every surface reads), but the underlying source — Grok `x_search` against X posts — was unreliable.

## Evidence

Last 5 Tesla episodes:

| Ep | Date | Price | Change | Issue |
|---|---|---|---|---|
| 470 | May 12 | $445.00 | ▲ $16.65 (3.9%) | OK |
| 471 | May 13 | $444.57 | ▼ $0.43 (0.1%) | OK |
| 472 | May 14 | $445.00 | ▲ $16.15 (3.8%) | identical to Ep470's ▲ — stale post |
| 473 | May 15 | $250.35 | ▲ $2.23 (Pre-market) | $250 vs real ~$444 — caught by deviation guard |
| 474 | May 16 | $415.50 | ▲ $0.00 (After-hours) | price == prev_close, single-number post |

X posts are not an authoritative quote source.

## Fix

Replace `shows/hooks/tesla.py:_fetch_tsla_price()` with a direct HTTP call to Yahoo Finance v8 chart API — the same endpoint `tesla.html` already uses as its in-browser fallback. One call per Tesla cron run (~once/day), no yfinance library retry storm, well under any practical rate limit. Requires a real-browser `User-Agent` (Yahoo returns 401 without one) — hard-coded as a current Firefox UA.

```
https://query2.finance.yahoo.com/v8/finance/chart/TSLA?interval=1d&range=5d
→ chart.result[0].meta.regularMarketPrice
→ chart.result[0].meta.chartPreviousClose (fallback: previousClose)
→ chart.result[0].meta.marketState (PRE / REGULAR / POST / CLOSED / POSTPOST / null)
```

Kept the $200-$1500 sanity band and the 25% deviation guard as defence-in-depth.

## Live verification

Called the endpoint directly from this environment:

```
status: 200
regularMarketPrice: 409.99
chartPreviousClose: 445.0
marketState: None  ← Yahoo sometimes returns null; handled
```

End-to-end fetcher returned `$409.99 ▼ $35.01 (7.9%)` and refreshed `api/tsla.json` so the website immediately picks up correct data.

## Drift guards

29 tests in `tests/test_tesla_hook.py` pin:
- Happy paths: regular session, pre-market, after-hours, `marketState: null` defaults to REGULAR, `marketState: POSTPOST` collapses to POST, `chartPreviousClose: null` falls back to `previousClose`
- Failure modes: network error, HTTP 401 / 429, unparseable body, missing fields, out-of-band price, deviation guard rejection
- Cache file records `"source": "yahoo_finance_v8"` — a regression back to Grok would change this string

## Test plan

- [x] `pytest tests/ -q --ignore=tests/test_youtube.py` — **1822 passed, 6 skipped**
- [x] Live HTTP call against `query2.finance.yahoo.com` from this environment returned 200 with valid data
- [x] End-to-end `_fetch_tsla_price()` returned correct `($409.99, '▼ $35.01 (7.9%)')` and refreshed `api/tsla.json`
- [ ] Tomorrow's Tesla cron run — verify `api/tsla.json` shows current price + correct change

## Files

- `shows/hooks/tesla.py` — fetcher replaced; persistence helper unchanged except `source` string
- `tests/test_tesla_hook.py` — full rewrite around `requests.get` stubbing
- `api/tsla.json` — refreshed with live data so the website is correct immediately on merge
- `CLAUDE.md` — landmine #22 updated to reflect the new authoritative source

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_