### PR TITLE
fix: TSLA price multi-source fallback (Ep477+Ep478 shipped unavailable)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -673,62 +673,87 @@ decision); everything else has a live status card.
     show pulls from `shows/topic_queues/unintended_consequences.yaml`
     and never fetches news; raising it would block every episode.
 
-22. **TSLA price source: Yahoo Finance v8 chart API (May 2026)** —
-    `shows/hooks/tesla.py:_fetch_tsla_price()` calls
-    `https://query2.finance.yahoo.com/v8/finance/chart/TSLA` directly
-    via `requests.get` (no library wrapper, no third-party proxy).
-    Same authoritative endpoint `tesla.html` uses as its in-browser
-    fallback, so the website, podcasts, RSS, blog, and newsletter
-    all derive from one identical source of truth — and the
-    `api/tsla.json` cache the hook writes is the single source the
-    website's primary path reads.
+22. **TSLA price source: multi-source fallback chain (May 2026)** —
+    `shows/hooks/tesla.py:_fetch_tsla_price()` tries three sources
+    in priority order until one returns a quote that passes
+    validation:
 
-    Two prior fetchers failed and were retired:
+    1. **`yfinance.Ticker.history(period="5d")`** — primary.  Same
+       library + endpoint Modern Investing uses successfully every
+       weekday.  yfinance manages a cookie + crumb-token session
+       against Yahoo internally, which Yahoo's anti-bot trusts.
+    2. **`yfinance.Ticker.fast_info`** — secondary.  Adds the live
+       pre / post-market price when `history()` alone gives only
+       end-of-day closes.  Treats `0.0` as falsy (the historical
+       degraded-response failure mode) so it falls through cleanly.
+    3. **Direct HTTP to Yahoo v8 chart API** — last resort.  Works
+       locally and from some egress IPs but the bare `requests.get`
+       call (no session cookies / no crumb token) is observed to
+       return non-200s from GitHub Actions runner IPs at times.
 
-    - **yfinance (early 2026):** the library wraps this same Yahoo
-      endpoint but adds aggressive retry / parallel-fetch logic that
-      triggers Yahoo's rate-limit on the GitHub Actions runner's
-      egress IPs.  Repeatedly returned `$0.00 (price unavailable)`.
+    Each source returns `(price, prev_close, market_state)` or
+    `None`; the same validation (`$200–$1500` sanity band, 25%
+    deviation guard) gates every source, so a single bad source
+    can't ship a wrong number.
+
+    The `api/tsla.json` cache the hook writes is the single source
+    the website's primary path reads.  Cache file records
+    `"source": "yfinance_history"` / `"yfinance_fast_info"` /
+    `"yahoo_v8_chart"` so the management dashboard can tell at a
+    glance which path is winning — and notice if the primary has
+    been silently failing for days.
+
+    **Three prior fetchers failed and were superseded:**
+
+    - **yfinance `fast_info` only (early 2026):** operator caught
+      it repeatedly returning `$0.00 (price unavailable)`.  The
+      `or` chain treated `0.0` as falsy and fell through every
+      fallback to no data.  See git blame on commit `3247317`.
     - **Grok `x_search` (May 1–18 2026):** queried X for the latest
-      `$TSLA` cashtag post.  Failed in two distinct ways operator
-      caught within 48 h of each other.  TST Ep473 (May 15)
-      returned $250 vs a real ~$444 (Grok pulled from a stale post —
-      caught by the 25% deviation guard).  TST Ep474 (May 16)
-      returned `price == prev_close == $415.50` because the X post
-      Grok latched onto only quoted a single number (caught by the
-      operator, not by any code guard).  X posts are not an
-      authoritative quote source.
+      `$TSLA` cashtag post.  Failed twice within 48 h.  TST Ep473
+      (May 15) returned $250 vs a real ~$444 (Grok pulled from a
+      stale post — caught by the deviation guard).  TST Ep474 (May
+      16) returned `price == prev_close == $415.50` because the X
+      post Grok latched onto only quoted a single number (caught
+      by the operator).  X posts are not an authoritative quote
+      source.
+    - **Direct Yahoo HTTP only (PR #385, May 18 2026):** worked
+      locally but Ep477 (May 19) + Ep478 (May 20) both shipped
+      `(price unavailable)` on GitHub Actions.  Bare `requests.get`
+      doesn't carry the cookie + crumb session yfinance manages,
+      and Yahoo's anti-bot apparently treats GHA egress IPs
+      differently for unauthenticated v8 calls than for
+      session-managed yfinance calls to the same endpoint.
 
-    **Why direct HTTP works where yfinance didn't:** one call per
-    Tesla cron run (~once / day), no retry storm, no parallel
-    yfinance sub-requests. Well below any practical rate limit when
-    the call shape matches what `finance.yahoo.com` itself sends.
-    Requires a real-browser `User-Agent` header (Yahoo returns 401
-    without one) — a current Firefox UA is hard-coded in
-    `_YAHOO_UA`.
+    **Subtle previous-close bug fixed at the same time:** the
+    direct HTTP source originally read `meta.chartPreviousClose`
+    as previous close.  That field is the close BEFORE the chart's
+    range window (so for `range=5d` it's the close from 6 trading
+    days ago — `$445.27` on 2026-05-20 vs the correct
+    `$404.11` for yesterday).  The HTTP source now reads
+    `indicators.quote[0].close[-2]` (the bar immediately before
+    the latest), which mirrors what `yfinance.Ticker.history()`
+    returns.  Meta fields are only fallbacks for null bar data.
 
-    **Sanity band:** prices outside `$200 – $1500` are rejected and
-    the fetcher returns `(0.0, "(price unavailable)")` — graceful
-    degradation identical to the old paths.
+    **Sanity band:** prices outside `$200 – $1500` are rejected.
 
-    **Dynamic deviation guard:** new prices that swing more than 25%
-    from the last cached close (`api/tsla.json`) are rejected as
-    probable bad data.  Yahoo is unlikely to return a 25%+ off
-    price, but the guard was load-bearing under the previous Grok
-    fetcher and is cheap to keep as defence-in-depth.
+    **Dynamic deviation guard:** new prices that swing more than
+    25% from the last cached close are rejected.  Load-bearing
+    under the Grok fetcher; kept on the multi-source chain as
+    defence-in-depth (any single source's bad day still gets the
+    chain to fall through to the next).
 
-    **`yfinance` dependency is still required** because
-    `shows/hooks/modern_investing.py` uses it for trade-execution
-    pricing across many tickers (NVDA, MSFT, etc.).  Only the Tesla
-    code path is on direct HTTP.
+    **`yfinance` is now also the primary** — it remains required
+    for Modern Investing's trade-execution pricing across many
+    tickers, and now powers Tesla too.
 
-    **Drift guards:** 29 unit tests in `tests/test_tesla_hook.py`
-    pin every failure mode (network error, HTTP 401 / 429, missing
-    fields, out-of-band price, deviation guard) → graceful
-    placeholder, and every happy-path shape (regular session, pre-
-    market, after-hours, `marketState: null`, `marketState:
-    POSTPOST`, `chartPreviousClose: null` fallback to
-    `previousClose`).  The cache file records
-    `"source": "yahoo_finance_v8"` so the dashboard can tell at a
-    glance which fetcher produced the last value — a regression
-    back to Grok would change that string.
+    **Drift guards:** 31 unit tests in `tests/test_tesla_hook.py`
+    pin per-source happy paths, chain fall-through semantics
+    (source 1 fails → source 2 tries; source 1 + 2 fail → source
+    3 tries), validation rejection forcing fall-through to the
+    next source, `marketState: null` rendering as REGULAR (not
+    After-hours), and persistence (success writes, failure does
+    NOT overwrite the previous-good cache).  Plus the
+    `test_bar_close_array_is_authoritative` guard explicitly
+    pins the HTTP source on `indicators.quote[0].close[-2]` over
+    `meta.chartPreviousClose`.

--- a/api/tsla.json
+++ b/api/tsla.json
@@ -1,10 +1,10 @@
 {
-  "price": 409.99,
-  "prev_close": 445.0,
-  "change": -35.01,
-  "change_pct": -7.87,
-  "change_str": "\u25bc $35.01 (7.9%)",
+  "price": 411.35,
+  "prev_close": 404.11,
+  "change": 7.24,
+  "change_pct": 1.79,
+  "change_str": "\u25b2 $7.24 (1.8%)",
   "market_state": "REGULAR",
-  "fetched_at": "2026-05-19T00:39:36Z",
-  "source": "yahoo_finance_v8"
+  "fetched_at": "2026-05-20T15:41:50Z",
+  "source": "yfinance_history"
 }

--- a/shows/hooks/tesla.py
+++ b/shows/hooks/tesla.py
@@ -1,10 +1,11 @@
 """Tesla-specific pre-fetch hook.
 
 Provides extra context that the Tesla Shorts Time digest prompt needs:
-- TSLA stock price and change string via Yahoo Finance's v8 chart API
-  (direct HTTP, no library wrapper). Source of truth for the website,
-  podcasts, RSS, blog, and newsletter — all consume the value this
-  hook returns and the ``api/tsla.json`` cache it writes.
+- TSLA stock price and change string via a multi-source fallback chain
+  (yfinance ``history`` → yfinance ``fast_info`` → direct Yahoo HTTP).
+  Source of truth for the website, podcasts, RSS, blog, and newsletter
+  — all consume the value this hook returns and the ``api/tsla.json``
+  cache it writes.  See ``_fetch_tsla_price()`` and landmine #22.
 - X posts section placeholder (disabled by default)
 - Market movers section (Monday only)
 - Content tracking for freshness
@@ -104,9 +105,9 @@ _TSLA_MAX_PCT_DEVIATION = 0.25  # 25% from last known close
 
 # Yahoo Finance v8 chart API endpoint — same one tesla.html falls back
 # to via CORS proxies in the browser.  Server-side we call it directly
-# (no proxy, no library wrapper). ``range=5d`` is enough to guarantee
-# a non-null ``chartPreviousClose`` even across long weekends /
-# holidays — ``range=1d`` returns nulls outside RTH.
+# (no proxy). ``range=5d`` is enough to guarantee a non-null
+# ``chartPreviousClose`` even across long weekends / holidays —
+# ``range=1d`` returns nulls outside RTH.
 _YAHOO_CHART_URL = (
     "https://query2.finance.yahoo.com/v8/finance/chart/TSLA"
     "?interval=1d&range=5d"
@@ -120,153 +121,287 @@ _YAHOO_UA = (
     "Gecko/20100101 Firefox/121.0"
 )
 
-# Timeout for the Yahoo call.  GitHub Actions runner egress occasionally
-# stalls; 8 s is the website's own per-proxy timeout and well under the
-# cron-job wall clock budget.
-_YAHOO_TIMEOUT_S = 8.0
+# Timeout for any single HTTP call.  GitHub Actions runner egress
+# occasionally stalls; 10 s leaves plenty of headroom while staying
+# under the cron-job wall clock budget.
+_HTTP_TIMEOUT_S = 10.0
 
 
 def _fetch_tsla_price() -> tuple[float, str]:
-    """Get current TSLA price + change string via Yahoo Finance.
+    """Get current TSLA price + change string with multi-source fallback.
 
-    Calls the v8 chart API (``query2.finance.yahoo.com/v8/finance/chart/TSLA``)
-    directly with ``requests`` — no yfinance library, no CORS proxy,
-    no third-party stock service.  Same authoritative endpoint
-    ``tesla.html`` uses as its in-browser fallback, so the website,
-    podcasts, RSS, blog, and newsletter all derive from one identical
-    source of truth.
+    Tries sources in priority order until one returns a quote that
+    passes validation (sanity band + deviation guard).  Each source
+    is wrapped in its own try / except so a single failure cannot
+    take down the chain.
+
+    Sources (priority order):
+      1. ``yfinance`` ``Ticker.history(period="5d")`` — proven reliable
+         on GitHub Actions runners (the Modern Investing show uses
+         the same library + endpoint successfully every weekday).
+         yfinance manages its own cookie + crumb-token session, which
+         Yahoo's anti-bot apparently trusts more than a bare
+         ``requests.get``.
+      2. ``yfinance`` ``Ticker.fast_info`` — adds the live last_price
+         (intraday / pre-market / post-market) when history alone only
+         gives end-of-day closes.  Falls through if ``fast_info``
+         returns empty / None fields (its historical failure mode).
+      3. Direct HTTP to Yahoo v8 chart API — works locally and from
+         some egress IPs; useful as a third opinion if the yfinance
+         session can't be established.
+
+    Each source returns ``(price, prev_close, market_state)`` or
+    ``None``.  Validation is applied uniformly.
 
     History:
-      yfinance (early 2026): the library wrapped this same endpoint
-        but added aggressive retry / parallel-fetch logic that
-        triggered Yahoo's rate-limit on the GitHub Actions runner's
-        egress IPs.  Repeatedly returned ``$0.00 (price unavailable)``.
-      Grok x_search (May 2026): queried X for the latest ``$TSLA``
-        cashtag post.  Failed in two distinct ways operator caught
-        within 48 h of each other — Ep473 (May 15) returned $250 vs
-        a real ~$444 (pulled from a stale post), Ep474 (May 16)
-        returned price == prev_close (single-number post, no change).
-        X posts are not an authoritative quote source.
-      Direct Yahoo (May 18 2026, this fetcher): one HTTP call, real
-        ``regularMarketPrice`` + ``chartPreviousClose`` + ``marketState``
-        from the same data that powers finance.yahoo.com.  One call
-        per Tesla cron run (~once / day) is well below any practical
-        rate limit when we're not using the yfinance retry-storm
-        client.
+      yfinance ``fast_info`` only (early 2026): operator caught it
+        repeatedly returning ``$0.00 (price unavailable)``.  The
+        ``or`` chain treated a returned ``0.0`` as falsy and fell
+        through every fallback to no data.  See git blame on
+        commit ``3247317``.
+      Grok ``x_search`` (May 2026): queried X for the latest
+        ``$TSLA`` cashtag post.  Failed twice within 48 h — Ep473
+        (May 15) returned ``$250`` vs real ``~$444`` (stale post),
+        Ep474 (May 16) returned ``price == prev_close`` (single-number
+        post).  X posts are not an authoritative quote source.
+      Direct Yahoo HTTP only (PR #385, May 18 2026): worked locally
+        but Ep477 + Ep478 on GitHub Actions both came back
+        ``(price unavailable)``.  The bare ``requests.get`` call
+        doesn't carry Yahoo's session cookie / crumb, so Yahoo's
+        anti-bot apparently returns a non-200 response for the GHA
+        runner's egress IP range — even though yfinance's session-
+        managed call to the same endpoint works fine in the same
+        environment.  Multi-source chain (this fetcher, PR #386)
+        keeps direct HTTP as the third opinion but leads with
+        yfinance.
 
-    Returns ``(price, change_str)`` in the same shape as before so
-    every downstream consumer keeps working without changes.
-
-    Failure modes (network down, non-200 response, missing fields,
-    out-of-range price, deviation guard trip): returns
+    Returns ``(price, change_str)``.  Failure modes (every source
+    fails, every source returns out-of-band data): returns
     ``(0.0, "(price unavailable)")``.
     """
-    try:
-        import requests
-    except Exception as exc:  # pragma: no cover — requests is in requirements.txt
-        logger.error("Could not import requests for TSLA fetch: %s", exc)
-        return 0.0, "(price unavailable)"
-
-    try:
-        resp = requests.get(
-            _YAHOO_CHART_URL,
-            headers={"User-Agent": _YAHOO_UA, "Accept": "application/json"},
-            timeout=_YAHOO_TIMEOUT_S,
-        )
-    except Exception as exc:
-        logger.error("Yahoo Finance request for TSLA failed: %s", exc)
-        return 0.0, "(price unavailable)"
-
-    if resp.status_code != 200:
-        logger.error(
-            "Yahoo Finance returned HTTP %s for TSLA (body=%r)",
-            resp.status_code, resp.text[:200],
-        )
-        return 0.0, "(price unavailable)"
-
-    try:
-        data = resp.json()
-    except Exception as exc:
-        logger.error("TSLA Yahoo JSON parse error: %s", exc)
-        return 0.0, "(price unavailable)"
-
-    # Yahoo's chart response shape:
-    #   { "chart": { "result": [ { "meta": { "regularMarketPrice": ...,
-    #     "chartPreviousClose": ..., "previousClose": ...,
-    #     "marketState": "REGULAR"|"PRE"|"POST"|"CLOSED" } } ] } }
-    try:
-        meta = data["chart"]["result"][0]["meta"]
-        price = float(meta["regularMarketPrice"])
-        # Yahoo provides both fields; ``chartPreviousClose`` is the one
-        # the website's fallback path prefers because it's never null
-        # when ``range >= 5d``.  ``previousClose`` is the secondary.
-        prev_close = float(
-            meta.get("chartPreviousClose") or meta.get("previousClose")
-        )
-    except (KeyError, IndexError, TypeError, ValueError) as exc:
-        logger.error("TSLA meta fields missing/malformed: %s", exc)
-        return 0.0, "(price unavailable)"
-
-    # Hard sanity range — guards against Yahoo briefly returning a
-    # stale split-adjusted figure or a malformed payload.
-    if not (_TSLA_PRICE_MIN <= price <= _TSLA_PRICE_MAX):
-        logger.error("TSLA price %.2f outside sanity band [%.0f, %.0f]",
-                     price, _TSLA_PRICE_MIN, _TSLA_PRICE_MAX)
-        return 0.0, "(price unavailable)"
-    if not (_TSLA_PRICE_MIN <= prev_close <= _TSLA_PRICE_MAX):
-        logger.error("TSLA prev_close %.2f outside sanity band", prev_close)
-        return 0.0, "(price unavailable)"
-
-    # Dynamic deviation check — reject prices that swing more than
-    # 25% from the last cached close.  No cache → skip the check
-    # (first-ever run can't compare).  Yahoo is unlikely to return a
-    # 25%+ off price, but the guard is cheap defence-in-depth.
     last_cached = _load_last_cached_tsla_price()
+
+    sources = (
+        ("yfinance_history", _fetch_via_yfinance_history),
+        ("yfinance_fast_info", _fetch_via_yfinance_fast_info),
+        ("yahoo_v8_chart", _fetch_via_yahoo_v8_chart),
+    )
+
+    for source_name, source_fn in sources:
+        try:
+            quote = source_fn()
+        except Exception as exc:
+            logger.warning("TSLA source %s raised: %s", source_name, exc)
+            continue
+        if quote is None:
+            logger.warning("TSLA source %s returned no data", source_name)
+            continue
+
+        price, prev_close, market_state = quote
+        if not _validate_quote(price, prev_close, last_cached, source_name):
+            continue
+
+        market_status = _market_status_suffix(market_state)
+        change = price - prev_close
+        pct = (change / prev_close) * 100 if prev_close else 0.0
+        direction = "▲" if change >= 0 else "▼"
+        change_str = (
+            f"{direction} ${abs(change):.2f} ({abs(pct):.1f}%){market_status}"
+        )
+        logger.info("TSLA via %s: $%.2f %s", source_name, price, change_str)
+
+        # Persist the live price to ``api/tsla.json`` so the public
+        # website (tesla.html) can render it without depending on its
+        # own client-side Yahoo fetch (which is subject to browser
+        # CORS and public proxy availability — see landmine #22).
+        _persist_tsla_price_json(
+            price=price, prev_close=prev_close, change=change, pct=pct,
+            change_str=change_str, market_state=market_state,
+            source=source_name,
+        )
+        return price, change_str
+
+    logger.error("All TSLA price sources failed — returning placeholder")
+    return 0.0, "(price unavailable)"
+
+
+def _validate_quote(
+    price: float, prev_close: float, last_cached: float | None,
+    source_name: str,
+) -> bool:
+    """Run sanity band + dynamic deviation guard against a candidate
+    quote.  Returns True if the quote is trustworthy."""
+    if not (_TSLA_PRICE_MIN <= price <= _TSLA_PRICE_MAX):
+        logger.warning(
+            "TSLA via %s: price %.2f outside sanity band [%.0f, %.0f]",
+            source_name, price, _TSLA_PRICE_MIN, _TSLA_PRICE_MAX,
+        )
+        return False
+    if not (_TSLA_PRICE_MIN <= prev_close <= _TSLA_PRICE_MAX):
+        logger.warning(
+            "TSLA via %s: prev_close %.2f outside sanity band",
+            source_name, prev_close,
+        )
+        return False
     if last_cached is not None and last_cached > 0:
         deviation = abs(price - last_cached) / last_cached
         if deviation > _TSLA_MAX_PCT_DEVIATION:
-            logger.error(
-                "TSLA price %.2f deviates %.1f%% from last cached "
-                "$%.2f (cap %.0f%%) — rejecting.",
-                price, deviation * 100, last_cached,
+            logger.warning(
+                "TSLA via %s: price %.2f deviates %.1f%% from last "
+                "cached $%.2f (cap %.0f%%) — rejecting.",
+                source_name, price, deviation * 100, last_cached,
                 _TSLA_MAX_PCT_DEVIATION * 100,
             )
-            return 0.0, "(price unavailable)"
+            return False
+    return True
 
-    # Yahoo uses ``PRE`` / ``REGULAR`` / ``POST`` / ``CLOSED`` /
-    # ``POSTPOST``, and occasionally returns ``null`` mid-session.
-    # ``None`` and missing both default to REGULAR — that's the
-    # honest fallback for an unknown state (no misleading
-    # after-hours suffix).
-    raw_state_val = meta.get("marketState")
-    raw_state = str(raw_state_val).upper() if raw_state_val else "REGULAR"
-    if raw_state == "PRE":
-        market_state = "PRE"
-        market_status = " (Pre-market)"
-    elif raw_state == "REGULAR":
-        market_state = "REGULAR"
-        market_status = ""
-    else:
-        # POST, POSTPOST, CLOSED — all read as after-hours on a podcast
-        # that ships at 8 AM ET (the most common case).
-        market_state = "POST"
-        market_status = " (After-hours)"
 
-    change = price - prev_close
-    pct = (change / prev_close) * 100 if prev_close else 0.0
-    direction = "▲" if change >= 0 else "▼"
-    change_str = f"{direction} ${abs(change):.2f} ({abs(pct):.1f}%){market_status}"
-    logger.info("TSLA via Yahoo Finance: $%.2f %s", price, change_str)
+def _market_status_suffix(market_state: str) -> str:
+    """Render the ``(After-hours)`` / ``(Pre-market)`` suffix
+    appended to the change string."""
+    s = (market_state or "REGULAR").upper()
+    if s == "PRE":
+        return " (Pre-market)"
+    if s == "REGULAR":
+        return ""
+    # POST, POSTPOST, CLOSED, anything unknown → after-hours.
+    return " (After-hours)"
 
-    # Persist the live price to ``api/tsla.json`` so the public
-    # website (tesla.html) can render it without depending on its own
-    # client-side Yahoo fetch (which is subject to browser CORS and
-    # public proxy availability — see landmine #22).
-    _persist_tsla_price_json(
-        price=price, prev_close=prev_close, change=change, pct=pct,
-        change_str=change_str, market_state=market_state,
+
+def _normalize_market_state(raw: object) -> str:
+    """Bucket Yahoo's various ``marketState`` values into the three
+    states our renderers know about (PRE / REGULAR / POST).
+    ``None``, missing, or unknown values default to REGULAR (the
+    honest fallback — no misleading after-hours suffix on a real
+    regular-session quote)."""
+    if not raw:
+        return "REGULAR"
+    s = str(raw).upper()
+    if s == "PRE":
+        return "PRE"
+    if s == "REGULAR":
+        return "REGULAR"
+    return "POST"
+
+
+def _fetch_via_yfinance_history() -> tuple[float, float, str] | None:
+    """Pull TSLA price + previous close from
+    ``yfinance.Ticker.history(period="5d")``.
+
+    yfinance manages a cookie + crumb-token session against Yahoo
+    that the bare ``requests.get`` path doesn't, which is why this
+    works reliably on GitHub Actions egress IPs where direct HTTP
+    has been observed to fail.
+
+    Returns ``None`` on any failure or empty data; the dispatcher
+    then moves on to the next source.
+    """
+    import yfinance as yf
+
+    ticker = yf.Ticker("TSLA")
+    hist = ticker.history(period="5d", interval="1d")
+    if hist is None or hist.empty or len(hist) < 1:
+        return None
+
+    price = float(hist["Close"].iloc[-1])
+    # ``history()`` doesn't expose marketState; default to REGULAR
+    # (close-of-day is by definition a regular-session price).  The
+    # fast_info source below picks up pre/post-market when relevant.
+    prev_close = float(hist["Close"].iloc[-2]) if len(hist) >= 2 else price
+    return price, prev_close, "REGULAR"
+
+
+def _fetch_via_yfinance_fast_info() -> tuple[float, float, str] | None:
+    """Pull TSLA via ``yfinance.Ticker.fast_info``.
+
+    Historically flaky — operator caught it returning ``0.0`` for
+    ``last_price`` mid-2026.  Kept as a secondary source because
+    when it works it carries the live (pre / post-market) price
+    that ``history()`` alone doesn't expose.  Treats ``0.0`` as
+    falsy so a degraded response falls through to the next source.
+    """
+    import yfinance as yf
+
+    ticker = yf.Ticker("TSLA")
+    info = ticker.fast_info
+    price = (
+        getattr(info, "last_price", None)
+        or getattr(info, "regularMarketPrice", None)
+        or getattr(info, "postMarketPrice", None)
     )
-    return price, change_str
+    prev_close = (
+        getattr(info, "previous_close", None)
+        or getattr(info, "regular_market_previous_close", None)
+    )
+    if not price or not prev_close:
+        return None
+
+    raw_state = (
+        getattr(info, "market_state", None)
+        or getattr(info, "marketState", None)
+    )
+    return float(price), float(prev_close), _normalize_market_state(raw_state)
+
+
+def _fetch_via_yahoo_v8_chart() -> tuple[float, float, str] | None:
+    """Direct HTTP call to Yahoo Finance v8 chart API.
+
+    Last-resort source — same endpoint the in-browser fallback on
+    ``tesla.html`` uses.  Works locally and from some egress IPs;
+    on GitHub Actions Yahoo has been observed returning non-200
+    responses to the bare-``requests.get`` call (the yfinance
+    sources above carry a cookie + crumb session that Yahoo trusts
+    more).  Kept for environments where it does work, and as a
+    third opinion the validator can cross-check.
+    """
+    import requests
+
+    resp = requests.get(
+        _YAHOO_CHART_URL,
+        headers={"User-Agent": _YAHOO_UA, "Accept": "application/json"},
+        timeout=_HTTP_TIMEOUT_S,
+    )
+    if resp.status_code != 200:
+        logger.warning(
+            "Yahoo v8 chart returned HTTP %s for TSLA (body=%r)",
+            resp.status_code, resp.text[:200],
+        )
+        return None
+
+    data = resp.json()
+    result = data["chart"]["result"][0]
+    meta = result["meta"]
+    price = float(meta["regularMarketPrice"])
+
+    # Previous close = the close of the bar immediately BEFORE the
+    # latest bar.  ``meta.chartPreviousClose`` looks tempting but it
+    # refers to the close BEFORE the chart's range window starts
+    # (so for ``range=5d`` it's the close from 6 trading days ago) —
+    # not yesterday's close.  Pull the actual previous bar's close
+    # from the ``indicators.quote`` array instead, which mirrors what
+    # ``yfinance.Ticker.history()`` returns.
+    prev_close: float | None = None
+    try:
+        closes = result["indicators"]["quote"][0]["close"]
+        # Skip any trailing None bars (Yahoo sometimes returns a
+        # null placeholder for a not-yet-traded session).
+        valid = [c for c in closes if c is not None]
+        if len(valid) >= 2:
+            prev_close = float(valid[-2])
+    except (KeyError, IndexError, TypeError, ValueError):
+        prev_close = None
+
+    # Final fallback chain for prev_close: meta's previousClose
+    # (yesterday's regular-session close, when populated) → meta's
+    # chartPreviousClose (always populated but anchors before the
+    # range window — usable only when no better option exists).
+    if prev_close is None:
+        prev_close_raw = meta.get("previousClose") or meta.get("chartPreviousClose")
+        if prev_close_raw is None:
+            return None
+        prev_close = float(prev_close_raw)
+
+    return price, prev_close, _normalize_market_state(meta.get("marketState"))
 
 
 def _load_last_cached_tsla_price() -> float | None:
@@ -298,15 +433,21 @@ def _load_last_cached_tsla_price() -> float | None:
 
 def _persist_tsla_price_json(
     *, price: float, prev_close: float, change: float, pct: float,
-    change_str: str, market_state: str,
+    change_str: str, market_state: str, source: str = "unknown",
 ) -> None:
     """Write the latest TSLA price to ``api/tsla.json`` (best-effort).
 
     Same-origin file served by GitHub Pages.  Updated every Tesla
-    pipeline run (daily + the M&A / MIT shows that share this hook
-    in their own pre-fetch loops where applicable).  Failure is
-    non-fatal — the digest pipeline continues even if the write
-    fails, and the website falls back to its Yahoo Finance path.
+    pipeline run.  Failure is non-fatal — the digest pipeline
+    continues even if the write fails, and the website falls back to
+    its in-browser Yahoo Finance path.
+
+    The ``source`` field records which of the multi-source chain
+    actually produced the value (``yfinance_history`` /
+    ``yfinance_fast_info`` / ``yahoo_v8_chart``).  The management
+    dashboard surfaces this so the operator can tell at a glance
+    which path is winning — and notice if a particular source has
+    been silently failing for days.
     """
     import json
     import datetime as _dt
@@ -320,7 +461,7 @@ def _persist_tsla_price_json(
         "change_str": change_str,
         "market_state": market_state,
         "fetched_at": _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
-        "source": "yahoo_finance_v8",
+        "source": source,
     }
     try:
         api_dir = Path(__file__).resolve().parent.parent.parent / "api"

--- a/tests/test_tesla_hook.py
+++ b/tests/test_tesla_hook.py
@@ -1,21 +1,41 @@
 """Tests for ``shows/hooks/tesla.py:_fetch_tsla_price``.
 
-The fetcher was flipped from Grok ``x_search`` to a direct HTTP call
-against Yahoo Finance's v8 chart API in May 2026 after operator caught
-Grok returning bad data on two consecutive days (Ep473: $250 vs real
-$444; Ep474: price == prev_close).  X posts are not an authoritative
-quote source.
+The fetcher uses a multi-source fallback chain to survive any single
+upstream source failing:
+
+  1. ``yfinance.Ticker.history(period="5d")`` — proven reliable on
+     GitHub Actions runners (same library + endpoint Modern Investing
+     uses successfully every weekday).
+  2. ``yfinance.Ticker.fast_info`` — adds live pre/post-market price
+     when history only returns end-of-day closes.
+  3. Direct HTTP to Yahoo Finance v8 chart API — last-resort source
+     for environments where it does work.
+
+Each source is wrapped so a failure in one doesn't take down the chain.
+Validation (sanity band + deviation guard) is applied uniformly.
+
+History of why this is multi-source:
+
+  - yfinance fast_info only (early 2026): returned ``$0.00`` on bad
+    days because the ``or`` chain treated ``0.0`` as falsy and fell
+    through to no data.
+  - Grok x_search (May 2026): returned hallucinated prices from
+    stale X posts; rejected by 25% deviation guard but slow to recover.
+  - Direct Yahoo HTTP only (PR #385): worked locally but failed on
+    GitHub Actions egress IPs because the bare ``requests.get`` call
+    doesn't carry Yahoo's cookie + crumb session — both Ep477 and
+    Ep478 shipped ``(price unavailable)``.
 
 These tests pin the contract:
+* Each source independently produces a valid quote (with all field
+  shapes including ``marketState: None``).
+* The chain falls through gracefully — if source 1 fails, source 2
+  is tried; if 1 and 2 fail, source 3 is tried.
+* If ALL sources fail or every source returns out-of-band data the
+  fetcher returns ``(0.0, "(price unavailable)")``.
 
-* Happy-path Yahoo response produces the canonical ``▲ $X.XX (X.X%)``
-  change string the existing pipeline expects.
-* HTTP errors, non-200 status, missing fields, out-of-range or
-  deviated prices all fall back to ``(0.0, "(price unavailable)")``
-  so we never ship a wrong number to the digest.
-
-The ``requests.get`` call is monkey-patched out — these are pure-
-function tests, never hit the network.
+External calls (``yfinance.Ticker``, ``requests.get``) are monkey-
+patched out — these are pure-function tests, never hit the network.
 """
 
 from __future__ import annotations
@@ -32,10 +52,102 @@ sys.path.insert(0, str(PROJECT_ROOT / "shows" / "hooks"))
 import tesla as tesla_hook  # noqa: E402  (sys.path manipulation needed)
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeYfHistory:
+    """Stand-in for the DataFrame returned by ``Ticker.history()``.
+
+    Real yfinance returns a pandas DataFrame; the production code only
+    accesses ``.empty``, ``len()``, and ``["Close"].iloc[idx]``, so
+    this minimal shim is enough."""
+
+    def __init__(self, closes: list[float]):
+        self._closes = list(closes)
+
+    @property
+    def empty(self) -> bool:
+        return len(self._closes) == 0
+
+    def __len__(self) -> int:
+        return len(self._closes)
+
+    def __getitem__(self, key: str):
+        assert key == "Close"
+        closes = self._closes
+
+        class _ColumnAccessor:
+            class _Iloc:
+                def __getitem__(self, idx: int) -> float:
+                    return closes[idx]
+
+            iloc = _Iloc()
+
+        return _ColumnAccessor()
+
+
+class _FakeFastInfo:
+    """Stand-in for ``Ticker.fast_info``."""
+
+    def __init__(
+        self, *,
+        last_price=None, previous_close=None, market_state=None,
+        regular_market_previous_close=None,
+    ):
+        self.last_price = last_price
+        self.previous_close = previous_close
+        self.regular_market_previous_close = regular_market_previous_close
+        self.market_state = market_state
+
+
+class _FakeTicker:
+    """Stand-in for ``yfinance.Ticker(...)``."""
+
+    def __init__(self, *, history=None, fast_info=None,
+                 history_raises=None, fast_info_raises=None):
+        self._history = history
+        self._fast_info = fast_info
+        self._history_raises = history_raises
+        self._fast_info_raises = fast_info_raises
+
+    def history(self, **kwargs):
+        if self._history_raises is not None:
+            raise self._history_raises
+        return self._history if self._history is not None else _FakeYfHistory([])
+
+    @property
+    def fast_info(self):
+        if self._fast_info_raises is not None:
+            raise self._fast_info_raises
+        return self._fast_info or _FakeFastInfo()
+
+
+def _install_yfinance_stub(monkeypatch, ticker: _FakeTicker):
+    """Patch ``yfinance.Ticker`` so both yfinance sources see the same
+    fake ticker (the dispatcher creates a fresh ``Ticker("TSLA")``
+    inside each source function)."""
+    import yfinance as yf
+    monkeypatch.setattr(yf, "Ticker", lambda symbol: ticker)
+
+
+def _install_yfinance_broken(monkeypatch, exc: Exception | None = None):
+    """Patch ``yfinance.Ticker`` so BOTH yfinance sources fail.
+    Pass an exception to raise on call, or leave None for the
+    "empty data" failure mode."""
+    if exc is not None:
+        def _ctor(symbol):
+            raise exc
+    else:
+        def _ctor(symbol):
+            return _FakeTicker(history=_FakeYfHistory([]), fast_info=_FakeFastInfo())
+    import yfinance as yf
+    monkeypatch.setattr(yf, "Ticker", _ctor)
+
+
 class _FakeResponse:
-    """Minimal stand-in for ``requests.Response`` that the fetcher
-    needs: ``status_code``, ``.json()``, ``.text``.
-    """
+    """Minimal stand-in for ``requests.Response``."""
 
     def __init__(self, *, status_code: int = 200, payload: dict | None = None,
                  text: str = ""):
@@ -53,18 +165,41 @@ def _make_yahoo_payload(
     *,
     price: float = 444.57,
     prev_close: float = 445.00,
-    market_state: str = "REGULAR",
+    market_state: str | None = "REGULAR",
+    chart_previous_close: float | None = None,
 ) -> dict:
-    """Build a Yahoo-shaped chart response with the requested fields."""
+    """Build a Yahoo v8 chart response with the requested fields.
+
+    The fetcher prefers the bar before the latest from
+    ``indicators.quote[0].close`` (which mirrors what
+    ``yfinance.Ticker.history()`` returns).  The bar array here
+    contains [prev_close, price] so the dispatcher picks ``prev_close``
+    as the previous bar's close.
+
+    ``chart_previous_close`` defaults to a value WAY OFF from
+    ``prev_close`` (445.27 — the production bug we caught: the
+    close from BEFORE the 5-day window) so any test that
+    accidentally falls back to it produces an obviously wrong
+    answer instead of coincidentally matching.
+    """
     return {
         "chart": {
             "result": [
                 {
                     "meta": {
                         "regularMarketPrice": price,
-                        "chartPreviousClose": prev_close,
+                        "chartPreviousClose": (
+                            chart_previous_close
+                            if chart_previous_close is not None
+                            else 99999.0
+                        ),
                         "previousClose": prev_close,
                         "marketState": market_state,
+                    },
+                    "indicators": {
+                        "quote": [
+                            {"close": [prev_close, price]},
+                        ],
                     },
                 },
             ],
@@ -72,10 +207,11 @@ def _make_yahoo_payload(
     }
 
 
-def _patch_yahoo(monkeypatch, *, response: _FakeResponse | None = None,
-                 raises: Exception | None = None):
-    """Stub ``requests.get`` (as imported inside ``_fetch_tsla_price``)
-    so the test never touches the network."""
+def _install_yahoo_http(monkeypatch, *, response: _FakeResponse | None = None,
+                       raises: Exception | None = None):
+    """Patch ``requests.get`` (the third source).  By default the
+    direct HTTP source is NOT exercised — yfinance succeeds before
+    we get there — but tests that drop into it install a real response."""
     import requests
 
     def _fake_get(url, **kwargs):
@@ -86,231 +222,492 @@ def _patch_yahoo(monkeypatch, *, response: _FakeResponse | None = None,
     monkeypatch.setattr(requests, "get", _fake_get)
 
 
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
 @pytest.fixture(autouse=True)
-def _stub_persist(monkeypatch):
-    """Default-stub the api/tsla.json write so the test suite doesn't
-    pollute the repo's ``api/`` directory every run, AND default-stub
-    the cache LOAD so tests with no explicit deviation-guard setup
-    get a clean ``no cache`` state (deviation check skipped).  Tests
-    that need to exercise the real persistence or specific cache
-    values re-patch these in their own bodies."""
+def _stub_persist_and_cache(monkeypatch):
+    """Default stubs so each test starts clean:
+      - ``api/tsla.json`` write is a no-op (no repo pollution).
+      - Last-cached price is ``None`` (deviation guard skipped).
+      - Both yfinance sources fail by default — tests that exercise
+        them re-patch them in their own bodies.
+      - Direct HTTP raises ``RuntimeError`` by default — same reason.
+    """
     monkeypatch.setattr(
         tesla_hook, "_persist_tsla_price_json", lambda **kwargs: None,
     )
     monkeypatch.setattr(
         tesla_hook, "_load_last_cached_tsla_price", lambda: None,
     )
+    _install_yfinance_broken(monkeypatch, exc=RuntimeError("yfinance stubbed off"))
+    _install_yahoo_http(monkeypatch, raises=RuntimeError("requests stubbed off"))
 
 
-class TestHappyPath:
+# ---------------------------------------------------------------------------
+# Source 1: yfinance history
+# ---------------------------------------------------------------------------
 
-    def test_clean_response_regular_session(self, monkeypatch):
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=411.82, prev_close=402.38, market_state="REGULAR",
-            ),
+
+class TestYfinanceHistorySource:
+    """Source 1 is the primary path — proven reliable in GHA."""
+
+    def test_clean_history_response(self, monkeypatch):
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([400.0, 410.0, 405.0, 411.82]),
+            fast_info=_FakeFastInfo(),  # not consulted on history hit
         ))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 411.82
-        # Up $9.44, ~2.3% — direction triangle ▲, no after-hours marker.
+        # 411.82 vs prev 405.0 → up $6.82, 1.7%
         assert "▲" in change_str
-        assert "$9.44" in change_str
-        assert "2.3%" in change_str
-        assert "After-hours" not in change_str
-        assert "Pre-market" not in change_str
+        assert "$6.82" in change_str
 
-    def test_negative_change_uses_down_arrow(self, monkeypatch):
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=380.00, prev_close=400.00, market_state="REGULAR",
+    def test_history_with_single_bar_uses_price_as_prev(self, monkeypatch):
+        """``history(period='5d')`` can return a single row on the
+        first trading day after a long holiday.  The source treats
+        prev_close as equal to price in that case so the change line
+        renders as ``▲ $0.00`` rather than crashing."""
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([411.82]),
+            fast_info=_FakeFastInfo(),
+        ))
+        price, change_str = tesla_hook._fetch_tsla_price()
+        assert price == 411.82
+        assert "$0.00" in change_str
+
+    def test_empty_history_falls_through_to_fast_info(self, monkeypatch):
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([]),
+            fast_info=_FakeFastInfo(
+                last_price=411.82, previous_close=405.0,
+                market_state="REGULAR",
             ),
         ))
         price, change_str = tesla_hook._fetch_tsla_price()
-        assert price == 380.00
-        assert "▼" in change_str
-        assert "$20.00" in change_str
-        assert "5.0%" in change_str
+        assert price == 411.82  # fast_info won
+        assert "▲" in change_str
 
-    def test_after_hours_marker(self, monkeypatch):
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=415.00, prev_close=411.82, market_state="POST",
+    def test_history_raise_falls_through_to_fast_info(self, monkeypatch):
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history_raises=RuntimeError("Yahoo session lost"),
+            fast_info=_FakeFastInfo(
+                last_price=420.00, previous_close=400.00,
+                market_state="POST",
             ),
         ))
-        _, change_str = tesla_hook._fetch_tsla_price()
+        price, change_str = tesla_hook._fetch_tsla_price()
+        assert price == 420.00
         assert "(After-hours)" in change_str
 
+
+# ---------------------------------------------------------------------------
+# Source 2: yfinance fast_info
+# ---------------------------------------------------------------------------
+
+
+class TestYfinanceFastInfoSource:
+    """Source 2 fills in pre/post-market live price when history
+    alone only gives day-level closes."""
+
     def test_pre_market_marker(self, monkeypatch):
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=405.00, prev_close=411.82, market_state="PRE",
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([]),  # force fallthrough
+            fast_info=_FakeFastInfo(
+                last_price=405.00, previous_close=411.82,
+                market_state="PRE",
             ),
         ))
         _, change_str = tesla_hook._fetch_tsla_price()
         assert "(Pre-market)" in change_str
+        assert "▼" in change_str
 
-    def test_closed_state_renders_as_after_hours(self, monkeypatch):
-        """Yahoo uses ``CLOSED`` outside trading hours on
-        weekends/holidays.  The downstream rendering doesn't have a
-        dedicated 'closed' visual treatment so we collapse it into
-        the after-hours bucket (which is what the operator sees on
-        an 8 AM ET podcast publish anyway)."""
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=415.00, prev_close=411.82, market_state="CLOSED",
+    def test_after_hours_marker(self, monkeypatch):
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([]),
+            fast_info=_FakeFastInfo(
+                last_price=415.00, previous_close=411.82,
+                market_state="POST",
             ),
         ))
         _, change_str = tesla_hook._fetch_tsla_price()
         assert "(After-hours)" in change_str
 
-    def test_falls_back_to_previous_close_when_chart_close_missing(self, monkeypatch):
-        """``chartPreviousClose`` is the primary close field but Yahoo
-        occasionally returns null for it (early pre-market on a fresh
-        trading day); fall back to ``previousClose`` so we don't
-        unnecessarily ship a price-unavailable."""
-        payload = _make_yahoo_payload(
-            price=400.00, prev_close=400.00, market_state="REGULAR",
-        )
-        payload["chart"]["result"][0]["meta"]["chartPreviousClose"] = None
-        payload["chart"]["result"][0]["meta"]["previousClose"] = 395.00
-        _patch_yahoo(monkeypatch, response=_FakeResponse(payload=payload))
-        price, change_str = tesla_hook._fetch_tsla_price()
-        assert price == 400.00
-        assert "▲" in change_str
-        assert "$5.00" in change_str
+    def test_fast_info_zero_falls_through_to_http(self, monkeypatch):
+        """Historical fast_info bug: ``last_price`` comes back as
+        ``0.0`` on a degraded response.  The ``or`` chain must treat
+        ``0.0`` as falsy so the source returns None and the dispatcher
+        moves on (rather than reporting ``$0.00`` as a real price)."""
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([]),
+            fast_info=_FakeFastInfo(
+                last_price=0.0, previous_close=411.82,
+                market_state="REGULAR",
+            ),
+        ))
+        # And source 3 (direct HTTP) succeeds.
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=411.19, prev_close=445.27, market_state="REGULAR",
+            ),
+        ))
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 411.19  # source 3 won
+
+    def test_fast_info_missing_prev_falls_through(self, monkeypatch):
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([]),
+            fast_info=_FakeFastInfo(
+                last_price=411.82, previous_close=None,
+                market_state="REGULAR",
+            ),
+        ))
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=412.00, prev_close=410.00, market_state="REGULAR",
+            ),
+        ))
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 412.00
 
 
-class TestFailureModes:
-    """Every path that can't yield a trustworthy quote must return
-    ``(0.0, "(price unavailable)")`` so the digest template renders
-    a graceful placeholder rather than a wrong number."""
+# ---------------------------------------------------------------------------
+# Source 3: direct HTTP to Yahoo v8 chart
+# ---------------------------------------------------------------------------
 
-    def test_network_error_raises(self, monkeypatch):
-        _patch_yahoo(monkeypatch, raises=RuntimeError("network down"))
-        price, change_str = tesla_hook._fetch_tsla_price()
-        assert price == 0.0
-        assert change_str == "(price unavailable)"
 
-    def test_http_non_200(self, monkeypatch):
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            status_code=429, text="Rate limited",
+class TestYahooHttpSource:
+
+    def test_drops_in_when_both_yfinance_sources_fail(self, monkeypatch):
+        """Both yfinance sources empty/failing — direct HTTP picks up."""
+        # Default fixture already breaks yfinance; only install Yahoo HTTP.
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(
+                price=411.19, prev_close=445.27, market_state="REGULAR",
+            ),
         ))
         price, change_str = tesla_hook._fetch_tsla_price()
-        assert price == 0.0
-        assert change_str == "(price unavailable)"
+        assert price == 411.19
+        assert "▼" in change_str
+        assert "$34.08" in change_str
 
-    def test_yahoo_401_unauthorized(self, monkeypatch):
-        """If Yahoo starts rejecting our User-Agent the call returns
-        401; fall back gracefully rather than ship garbage."""
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
+    def test_null_market_state_renders_as_regular(self, monkeypatch):
+        """Yahoo returns ``marketState: null`` mid-session at times
+        (observed live 2026-05-18).  Must render as a regular session
+        rather than mislabel as After-hours."""
+        payload = _make_yahoo_payload(
+            price=411.19, prev_close=445.27, market_state=None,
+        )
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(payload=payload))
+        _, change_str = tesla_hook._fetch_tsla_price()
+        assert "(After-hours)" not in change_str
+        assert "(Pre-market)" not in change_str
+
+    def test_unknown_market_state_collapses_to_post(self, monkeypatch):
+        """``POSTPOST`` is a real Yahoo state; renders as After-hours
+        rather than crashing."""
+        payload = _make_yahoo_payload(
+            price=411.19, prev_close=445.27, market_state="POSTPOST",
+        )
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(payload=payload))
+        _, change_str = tesla_hook._fetch_tsla_price()
+        assert "(After-hours)" in change_str
+
+    def test_http_non_200_falls_through(self, monkeypatch):
+        """When direct HTTP returns 401/429 (Yahoo blocking GHA egress
+        IP) the chain returns unavailable rather than ship garbage."""
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(
             status_code=401, text="Unauthorized",
         ))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 0.0
         assert change_str == "(price unavailable)"
 
-    def test_unparseable_body(self, monkeypatch):
-        _patch_yahoo(monkeypatch, response=_FakeResponse(payload=None))
+    def test_http_network_error_falls_through(self, monkeypatch):
+        _install_yahoo_http(monkeypatch, raises=RuntimeError("network down"))
         price, change_str = tesla_hook._fetch_tsla_price()
         assert price == 0.0
         assert change_str == "(price unavailable)"
 
-    def test_missing_meta(self, monkeypatch):
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload={"chart": {"result": []}},
+    def test_bar_close_array_is_authoritative(self, monkeypatch):
+        """The fetcher uses ``indicators.quote[0].close[-2]`` for
+        previous close — NOT the meta ``chartPreviousClose`` field,
+        which anchors before the chart's range window (the production
+        bug caught after PR #385 shipped, where ``chartPreviousClose``
+        was 445.27 = May 13 close instead of 404.11 = yesterday).
+
+        This payload deliberately puts ``chart_previous_close=99999``
+        (the default in the test helper); if the fetcher fell back to
+        it, the deviation guard or sanity band would catch it.  The
+        ``indicators.quote`` close array is the source of truth."""
+        payload = _make_yahoo_payload(
+            price=412.01, prev_close=404.11,
+            chart_previous_close=445.27,  # tempting but WRONG
+            market_state="REGULAR",
+        )
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(payload=payload))
+        price, change_str = tesla_hook._fetch_tsla_price()
+        assert price == 412.01
+        # If we'd used chartPreviousClose the change would be ~-$33.
+        # With the bar close array we get the correct +$7.90.
+        assert "▲" in change_str
+        assert "$7.90" in change_str
+
+    def test_null_bar_close_falls_back_to_meta_previous_close(self, monkeypatch):
+        """If the close-bar array contains nulls (early pre-market on
+        a fresh trading day), fall back to ``meta.previousClose``."""
+        payload = _make_yahoo_payload(price=400.00, prev_close=395.00)
+        # Break the bar array so the fallback fires.
+        payload["chart"]["result"][0]["indicators"]["quote"][0]["close"] = [None, None]
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(payload=payload))
+        price, change_str = tesla_hook._fetch_tsla_price()
+        assert price == 400.00
+        assert "$5.00" in change_str
+
+    def test_all_prev_close_sources_null_returns_unavailable(self, monkeypatch):
+        """If every previous-close source is null, the chain returns
+        unavailable — we don't make up a change."""
+        payload = _make_yahoo_payload(price=400.00, prev_close=395.00)
+        payload["chart"]["result"][0]["indicators"]["quote"][0]["close"] = [None, None]
+        payload["chart"]["result"][0]["meta"]["chartPreviousClose"] = None
+        payload["chart"]["result"][0]["meta"]["previousClose"] = None
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(payload=payload))
+        price, change_str = tesla_hook._fetch_tsla_price()
+        assert price == 0.0
+        assert change_str == "(price unavailable)"
+
+
+# ---------------------------------------------------------------------------
+# Chain semantics
+# ---------------------------------------------------------------------------
+
+
+class TestChainFallthrough:
+
+    def test_all_sources_fail_returns_unavailable(self, monkeypatch):
+        # Default fixture already breaks all 3 sources.
+        price, change_str = tesla_hook._fetch_tsla_price()
+        assert price == 0.0
+        assert change_str == "(price unavailable)"
+
+    def test_first_source_wins_skips_rest(self, monkeypatch):
+        """Source 1 succeeds → source 2 + 3 are not consulted."""
+        history_calls = {"n": 0}
+
+        def _counting_history(**kwargs):
+            history_calls["n"] += 1
+            return _FakeYfHistory([400.0, 410.0, 411.82])
+
+        ticker = _FakeTicker(fast_info=_FakeFastInfo(last_price=999.99))
+        ticker.history = _counting_history
+        import yfinance as yf
+        monkeypatch.setattr(yf, "Ticker", lambda symbol: ticker)
+
+        # Source 3 would return a totally different price if reached.
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(price=300.00, prev_close=300.00),
         ))
-        price, change_str = tesla_hook._fetch_tsla_price()
-        assert price == 0.0
-        assert change_str == "(price unavailable)"
 
-    def test_missing_price_field(self, monkeypatch):
-        payload = _make_yahoo_payload()
-        del payload["chart"]["result"][0]["meta"]["regularMarketPrice"]
-        _patch_yahoo(monkeypatch, response=_FakeResponse(payload=payload))
-        price, change_str = tesla_hook._fetch_tsla_price()
-        assert price == 0.0
-        assert change_str == "(price unavailable)"
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 411.82  # source 1's price
+        assert history_calls["n"] == 1
 
-    def test_price_below_sanity_band(self, monkeypatch):
-        """``$5`` is impossible for TSLA — likely a malformed payload
-        or a stale split-adjusted figure. Fall back gracefully."""
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=5.00, prev_close=400.00, market_state="REGULAR",
+    def test_out_of_band_source_1_falls_through(self, monkeypatch):
+        """If source 1 returns a price outside the sanity band (e.g.
+        a stale split-adjusted figure), the validator rejects it and
+        source 2 / 3 get a chance."""
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([5.0, 5.0, 5.0]),  # bad data
+            fast_info=_FakeFastInfo(
+                last_price=411.82, previous_close=405.0,
+                market_state="REGULAR",
             ),
         ))
-        price, change_str = tesla_hook._fetch_tsla_price()
-        assert price == 0.0
-        assert change_str == "(price unavailable)"
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 411.82  # source 2 won after source 1 was rejected
 
-    def test_price_above_sanity_band(self, monkeypatch):
-        """``$5000`` is impossibly high; fall back."""
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=5000.00, prev_close=400.00, market_state="REGULAR",
-            ),
+
+# ---------------------------------------------------------------------------
+# Validation: sanity band + deviation guard
+# ---------------------------------------------------------------------------
+
+
+class TestSanityBand:
+
+    def test_rejects_price_below_floor(self, monkeypatch):
+        """May 15 2026: floor raised from $50 to $200."""
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([150.0, 150.0]),
+            fast_info=_FakeFastInfo(last_price=150.0, previous_close=150.0,
+                                    market_state="REGULAR"),
+        ))
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(price=150.0, prev_close=150.0),
         ))
         price, change_str = tesla_hook._fetch_tsla_price()
-        assert price == 0.0
-        assert change_str == "(price unavailable)"
+        assert price == 0.0  # every source rejected by sanity band
 
-    def test_prev_close_out_of_band_fails(self, monkeypatch):
-        """A plausible price with an impossible prev_close would compute
-        a misleading change %; reject the whole response."""
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=400.00, prev_close=0.05, market_state="REGULAR",
-            ),
+    def test_rejects_price_above_ceiling(self, monkeypatch):
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([1600.0, 1600.0]),
+            fast_info=_FakeFastInfo(last_price=1600.0, previous_close=1600.0,
+                                    market_state="REGULAR"),
         ))
-        price, change_str = tesla_hook._fetch_tsla_price()
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(price=1600.0, prev_close=1600.0),
+        ))
+        price, _ = tesla_hook._fetch_tsla_price()
         assert price == 0.0
-        assert change_str == "(price unavailable)"
+
+
+class TestDeviationGuard:
+    """Caught the May 15 2026 ``$444 → $250`` Grok regression.  Still
+    a load-bearing guard on the multi-source chain — if any source
+    returns a wildly different price than the cache, reject it."""
+
+    def test_rejects_44pct_drop(self, monkeypatch):
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: 444.57,
+        )
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([250.0, 250.0]),
+            fast_info=_FakeFastInfo(last_price=250.0, previous_close=250.0,
+                                    market_state="REGULAR"),
+        ))
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(price=250.0, prev_close=250.0),
+        ))
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 0.0
+
+    def test_rejects_50pct_spike(self, monkeypatch):
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: 400.00,
+        )
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([600.0, 600.0]),
+            fast_info=_FakeFastInfo(last_price=600.0, previous_close=600.0,
+                                    market_state="REGULAR"),
+        ))
+        _install_yahoo_http(monkeypatch, response=_FakeResponse(
+            payload=_make_yahoo_payload(price=600.0, prev_close=600.0),
+        ))
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 0.0
+
+    def test_accepts_within_band(self, monkeypatch):
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: 440.00,
+        )
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([425.0, 420.0]),
+            fast_info=_FakeFastInfo(),
+        ))
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 420.00
+
+    def test_accepts_at_exact_boundary(self, monkeypatch):
+        """``> cap`` rejects, ``== cap`` accepts."""
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: 400.00,
+        )
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([498.0, 500.0]),  # exactly +25%
+            fast_info=_FakeFastInfo(),
+        ))
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 500.00
+
+    def test_no_cache_skips_check(self, monkeypatch):
+        """First-ever run has no cached price — deviation guard skipped."""
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: None,
+        )
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([400.0, 444.57]),
+            fast_info=_FakeFastInfo(),
+        ))
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 444.57
+
+    def test_zero_cache_treated_as_none(self, monkeypatch):
+        monkeypatch.setattr(
+            tesla_hook, "_load_last_cached_tsla_price", lambda: 0.0,
+        )
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([400.0, 444.57]),
+            fast_info=_FakeFastInfo(),
+        ))
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 444.57
+
+
+# ---------------------------------------------------------------------------
+# Persistence cache (api/tsla.json)
+# ---------------------------------------------------------------------------
 
 
 class TestTslaJsonCache:
-    """``_fetch_tsla_price`` persists each successful fetch to
-    ``api/tsla.json`` so the public website (tesla.html) can render
-    a same-origin price without depending on its own client-side
-    Yahoo fetch (which can fail behind browser CORS / public proxies)."""
+    """The cache file is the website's same-origin source of truth.
+    Every successful fetch persists it; failed fetches do NOT
+    overwrite the previous-good value."""
 
-    def test_writes_api_tsla_json_on_success(self, monkeypatch, tmp_path):
-        """Successful price fetch writes api/tsla.json with the
-        full payload."""
+    def test_writes_payload_on_success(self, monkeypatch, tmp_path):
         import json
         captured: dict = {}
 
         def fake_persist(**kwargs):
             captured.update(kwargs)
-            out = tmp_path / "tsla.json"
-            payload = {
-                "price": round(kwargs["price"], 2),
-                "prev_close": round(kwargs["prev_close"], 2),
-                "change": round(kwargs["change"], 2),
-                "change_pct": round(kwargs["pct"], 2),
-                "change_str": kwargs["change_str"],
-                "market_state": kwargs["market_state"],
-            }
-            out.write_text(json.dumps(payload), encoding="utf-8")
 
         monkeypatch.setattr(tesla_hook, "_persist_tsla_price_json", fake_persist)
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=444.57, prev_close=445.00, market_state="REGULAR",
-            ),
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([445.00, 444.57]),
+            fast_info=_FakeFastInfo(),
         ))
 
         price, change_str = tesla_hook._fetch_tsla_price()
-
         assert price == 444.57
         assert captured["price"] == 444.57
         assert captured["prev_close"] == 445.00
         assert captured["market_state"] == "REGULAR"
-        assert "$0.43" in captured["change_str"]
-        out_path = tmp_path / "tsla.json"
-        assert out_path.exists()
-        payload = json.loads(out_path.read_text())
-        assert payload["price"] == 444.57
-        assert payload["prev_close"] == 445.00
+        assert captured["source"] == "yfinance_history"
+
+    def test_failure_does_not_overwrite_cache(self, monkeypatch):
+        """If every source fails the persist helper is NOT called —
+        the previous-good cached value stays intact."""
+        called = {"n": 0}
+
+        def fake_persist(**kwargs):
+            called["n"] += 1
+
+        monkeypatch.setattr(tesla_hook, "_persist_tsla_price_json", fake_persist)
+        # All sources broken via the autouse fixture.
+        price, _ = tesla_hook._fetch_tsla_price()
+        assert price == 0.0
+        assert called["n"] == 0
+
+    def test_source_field_records_which_path_won(self, monkeypatch):
+        """The cached ``source`` string distinguishes which path in
+        the chain produced the value — the management dashboard
+        surfaces this so the operator can spot a degraded primary."""
+        captured: dict = {}
+
+        def fake_persist(**kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr(tesla_hook, "_persist_tsla_price_json", fake_persist)
+        # History empty → fast_info should win.
+        _install_yfinance_stub(monkeypatch, _FakeTicker(
+            history=_FakeYfHistory([]),
+            fast_info=_FakeFastInfo(
+                last_price=411.82, previous_close=405.00,
+                market_state="REGULAR",
+            ),
+        ))
+        tesla_hook._fetch_tsla_price()
+        assert captured["source"] == "yfinance_fast_info"
 
     def test_persistence_failure_is_non_fatal(self, monkeypatch):
         """If ``api/tsla.json`` can't be written (disk full, permission)
@@ -325,208 +722,20 @@ class TestTslaJsonCache:
             return original_write(self, *args, **kwargs)
 
         monkeypatch.setattr(_Path, "write_text", explosive_write)
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=400.00, prev_close=400.00, market_state="REGULAR",
-            ),
+        # Restore the REAL persistence helper (autouse stubbed it).
+        from shows.hooks import tesla as _tesla
+        import importlib
+        importlib.reload(_tesla)
+        # Re-stub the cache load since reload reset it
+        monkeypatch.setattr(
+            _tesla, "_load_last_cached_tsla_price", lambda: None,
+        )
+        import yfinance as yf
+        monkeypatch.setattr(yf, "Ticker", lambda symbol: _FakeTicker(
+            history=_FakeYfHistory([400.00, 400.00]),
+            fast_info=_FakeFastInfo(),
         ))
-
         # Must NOT raise — best-effort wraps the write in try/except.
-        price, change_str = tesla_hook._fetch_tsla_price()
+        price, change_str = _tesla._fetch_tsla_price()
         assert price == 400.00
         assert change_str.startswith("▲")
-
-    def test_persisted_source_field_is_yahoo(self, monkeypatch):
-        """The cache file records its provenance so the dashboard /
-        operator can tell at a glance which fetcher produced the
-        last value."""
-        captured: dict = {}
-
-        def fake_persist(**kwargs):
-            captured.update(kwargs)
-
-        monkeypatch.setattr(tesla_hook, "_persist_tsla_price_json", fake_persist)
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=444.57, prev_close=445.00, market_state="REGULAR",
-            ),
-        ))
-
-        price, _ = tesla_hook._fetch_tsla_price()
-        assert price == 444.57
-
-        # The persistence helper hard-codes ``source: "yahoo_finance_v8"``;
-        # the contract guard lives separately because the kwargs the
-        # fetcher passes don't include ``source``.
-        import inspect
-        from shows.hooks import tesla
-        src = inspect.getsource(tesla._persist_tsla_price_json)
-        assert '"source": "yahoo_finance_v8"' in src
-
-
-class TestDeviationGuard:
-    """Defence-in-depth: reject prices that swing more than 25% from
-    the last cached close.  Yahoo is unlikely to return a 25%+ off
-    price, but the guard was load-bearing under the previous Grok
-    fetcher (caught the May 15 2026 ``$444 → $250`` regression) and
-    is cheap to keep in place."""
-
-    def test_rejects_price_more_than_25pct_below_cached(self, monkeypatch):
-        """Cached at $444, new price $250 = 44% drop → reject."""
-        monkeypatch.setattr(
-            tesla_hook, "_load_last_cached_tsla_price", lambda: 444.57,
-        )
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=250.35, prev_close=248.12, market_state="PRE",
-            ),
-        ))
-        price, change_str = tesla_hook._fetch_tsla_price()
-        assert price == 0.0
-        assert change_str == "(price unavailable)"
-
-    def test_rejects_price_more_than_25pct_above_cached(self, monkeypatch):
-        """Cached at $400, new price $600 = 50% spike → reject."""
-        monkeypatch.setattr(
-            tesla_hook, "_load_last_cached_tsla_price", lambda: 400.00,
-        )
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=600.00, prev_close=595.00, market_state="REGULAR",
-            ),
-        ))
-        price, _ = tesla_hook._fetch_tsla_price()
-        assert price == 0.0
-
-    def test_accepts_price_within_25pct_band(self, monkeypatch):
-        """Cached at $440, new price $420 = 4.5% drop → accept."""
-        monkeypatch.setattr(
-            tesla_hook, "_load_last_cached_tsla_price", lambda: 440.00,
-        )
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=420.00, prev_close=425.00, market_state="REGULAR",
-            ),
-        ))
-        price, _ = tesla_hook._fetch_tsla_price()
-        assert price == 420.00
-
-    def test_accepts_price_at_exactly_25pct_boundary(self, monkeypatch):
-        """At exactly 25% deviation the check is inclusive ( ``> cap``
-        rejects, ``== cap`` accepts) so a 12.5%-up / 12.5%-down day
-        with subsequent volatility doesn't trip the guard on a
-        recovery candle."""
-        monkeypatch.setattr(
-            tesla_hook, "_load_last_cached_tsla_price", lambda: 400.00,
-        )
-        # 400 * 1.25 = 500 — exactly at the upper boundary
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=500.00, prev_close=498.00, market_state="REGULAR",
-            ),
-        ))
-        price, _ = tesla_hook._fetch_tsla_price()
-        assert price == 500.00
-
-    def test_no_cache_skips_deviation_check(self, monkeypatch):
-        """First-ever run has no cached price — the deviation guard
-        is skipped (would otherwise block the network's first
-        Tesla run after deploy).  Hard sanity band still applies."""
-        monkeypatch.setattr(
-            tesla_hook, "_load_last_cached_tsla_price", lambda: None,
-        )
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=444.57, prev_close=445.00, market_state="REGULAR",
-            ),
-        ))
-        price, _ = tesla_hook._fetch_tsla_price()
-        assert price == 444.57
-
-    def test_zero_cache_treated_as_no_cache(self, monkeypatch):
-        """A degraded cache (``price: 0.0``) is treated as missing —
-        deviation check skipped."""
-        monkeypatch.setattr(
-            tesla_hook, "_load_last_cached_tsla_price", lambda: 0.0,
-        )
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=444.57, prev_close=445.00, market_state="REGULAR",
-            ),
-        ))
-        price, _ = tesla_hook._fetch_tsla_price()
-        assert price == 444.57
-
-
-class TestHardSanityBand:
-    """The hard sanity band ($200-$1500) catches first-run bad data
-    and any price wildly outside TSLA's historical range."""
-
-    def test_rejects_price_below_hard_floor(self, monkeypatch):
-        """May 15 2026: floor raised from $50 to $200.  TSLA hasn't
-        traded below $200 in over a year and is structurally unlikely
-        to in the near term."""
-        monkeypatch.setattr(
-            tesla_hook, "_load_last_cached_tsla_price", lambda: None,
-        )
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=150.00, prev_close=152.00, market_state="REGULAR",
-            ),
-        ))
-        price, _ = tesla_hook._fetch_tsla_price()
-        assert price == 0.0
-
-    def test_rejects_price_above_hard_ceiling(self, monkeypatch):
-        """Ceiling lowered from $2000 to $1500."""
-        monkeypatch.setattr(
-            tesla_hook, "_load_last_cached_tsla_price", lambda: None,
-        )
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=1600.00, prev_close=1580.00, market_state="REGULAR",
-            ),
-        ))
-        price, _ = tesla_hook._fetch_tsla_price()
-        assert price == 0.0
-
-
-class TestMarketStateDefaulting:
-    """Yahoo's ``marketState`` values map onto the three states the
-    rendering layers know about (PRE / REGULAR / POST); unknown
-    values collapse to POST so we never crash on a new state Yahoo
-    adds (e.g. ``POSTPOST``)."""
-
-    def test_missing_market_state_defaults_to_regular(self, monkeypatch):
-        payload = _make_yahoo_payload(price=411.82, prev_close=411.82)
-        del payload["chart"]["result"][0]["meta"]["marketState"]
-        _patch_yahoo(monkeypatch, response=_FakeResponse(payload=payload))
-        price, change_str = tesla_hook._fetch_tsla_price()
-        assert price == 411.82
-        assert "(After-hours)" not in change_str
-        assert "(Pre-market)" not in change_str
-
-    def test_null_market_state_defaults_to_regular(self, monkeypatch):
-        """Yahoo occasionally returns ``marketState: null`` mid-session
-        (observed live on 2026-05-18 against TSLA at $409.99).  A
-        null value must NOT render as 'After-hours' on a real
-        regular-session quote — default to REGULAR (no suffix)."""
-        payload = _make_yahoo_payload(price=411.82, prev_close=411.82)
-        payload["chart"]["result"][0]["meta"]["marketState"] = None
-        _patch_yahoo(monkeypatch, response=_FakeResponse(payload=payload))
-        price, change_str = tesla_hook._fetch_tsla_price()
-        assert price == 411.82
-        assert "(After-hours)" not in change_str
-        assert "(Pre-market)" not in change_str
-
-    def test_unknown_market_state_collapses_to_post(self, monkeypatch):
-        """``POSTPOST`` is a real Yahoo state (late after-hours session);
-        any unknown state should render as 'After-hours' rather than
-        crash."""
-        _patch_yahoo(monkeypatch, response=_FakeResponse(
-            payload=_make_yahoo_payload(
-                price=411.82, prev_close=411.82, market_state="POSTPOST",
-            ),
-        ))
-        _, change_str = tesla_hook._fetch_tsla_price()
-        assert "(After-hours)" in change_str


### PR DESCRIPTION
## What was broken

Both Tesla episodes since PR #385 shipped with `**REAL-TIME TSLA price:** $0.00 (price unavailable)`:

- **Ep477 (2026-05-19)**: price unavailable
- **Ep478 (2026-05-20)**: price unavailable

The unavailable string propagated to the audio too — listeners heard *"T S L A closed at zero dollars, price unavailable"*.

## Root cause

PR #385's direct HTTP path works locally but fails on GitHub Actions egress IPs. The bare `requests.get(query2.finance.yahoo.com/v8/finance/chart/TSLA)` call doesn't carry the cookie + crumb session that `yfinance` manages internally. Yahoo's anti-bot apparently treats those calls differently and returns a non-200 response (or empty payload) for unauthenticated v8 chart calls from GHA's egress IPs — even though the same endpoint works fine when called via `yfinance.Ticker.history()` from the same runner.

Evidence: Modern Investing's daily cron has been calling `yfinance.Ticker.history()` from the same GHA runners the entire time and never returned $0 — its 2026-05-20 episode shipped with real prices (NVDA, S&P 500, etc.).

## Fix

Rewrite `_fetch_tsla_price()` as a three-source fallback chain:

1. **`yfinance.Ticker.history(period="5d")`** — primary. Same library + endpoint Modern Investing uses successfully every weekday.
2. **`yfinance.Ticker.fast_info`** — secondary. Adds live pre/post-market price when `history()` only gives end-of-day closes. Treats `0.0` as falsy (the historical degraded-response failure mode).
3. **Direct HTTP to Yahoo v8 chart API** — last resort. Works locally and from some egress IPs.

Each source is wrapped in its own try/except so one failure doesn't kill the chain. Validation ($200–$1500 sanity band + 25% deviation guard) is applied **uniformly** so a single bad source can't ship wrong data — if source 1 returns an out-of-band number the chain still moves on to source 2.

## Bonus fix: direct HTTP source had wrong `prev_close`

The direct HTTP source was reading `meta.chartPreviousClose`, which is the close BEFORE the chart's range window starts. For `range=5d` that's the close from **6 trading days ago** — on 2026-05-20 it returned `$445.27` (= May 13's close), not `$404.11` (= May 19's close, the actual yesterday).

This would have computed change = $412 - $445 = **-7.4%** instead of the correct +$7/+1.8%. Caught it during live testing of the fallback path before merging. Fixed by reading `indicators.quote[0].close[-2]` (the bar immediately before the latest), which mirrors what `yfinance.history()` returns. Meta fields are kept as a final null-fallback chain.

## Live verification

All three sources verified working from this environment:

```
INFO TSLA via yfinance_history: $411.35 ▲ $7.24 (1.8%)
INFO TSLA price cached to /home/user/nerranetworks/api/tsla.json
```

Forcing yfinance to raise (simulating GHA's failure mode):

```
WARNING TSLA source yfinance_history raised: simulated yfinance broken
WARNING TSLA source yfinance_fast_info raised: simulated yfinance broken
INFO TSLA via yahoo_v8_chart: $411.26 ▲ $7.16 (1.8%)
```

Both paths now give consistent +1.8% change. Cache refreshed with the live quote so the website is correct immediately on merge.

## Cache file `source` field

`api/tsla.json` now records which source produced the value:
- `"source": "yfinance_history"` ← happy path
- `"source": "yfinance_fast_info"` ← if history empty
- `"source": "yahoo_v8_chart"` ← if both yfinance paths fail

The dashboard can surface this so the operator notices if the primary has been silently failing for days.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_youtube.py` → **1824 passed, 6 skipped**
- [x] Live yfinance call: returns `$412.01` (today's close)
- [x] Live direct HTTP call: returns `$411.26` (same range)
- [x] Forced fall-through (yfinance broken): direct HTTP picks up
- [ ] Tomorrow's (2026-05-21) Tesla cron — `api/tsla.json` should update with `"source": "yfinance_history"` and a real price

## Drift guards

31 tests in `tests/test_tesla_hook.py`:
- Per-source happy paths (history, fast_info, HTTP)
- Chain fall-through (source 1 fails → source 2 tries; source 1+2 fail → source 3 tries)
- Validation rejection forces fall-through to next source (not return-unavailable)
- `marketState: null` renders as REGULAR (not After-hours)
- Deviation guard rejects $444 → $250 swing (the May 15 Grok regression)
- Cache file persistence: success writes, failure does NOT overwrite previous-good
- `test_bar_close_array_is_authoritative` pins HTTP source on `indicators.quote[0].close[-2]` over `meta.chartPreviousClose`

## Files

- `shows/hooks/tesla.py` — multi-source dispatcher + three source functions
- `tests/test_tesla_hook.py` — full rewrite for new chain semantics
- `api/tsla.json` — refreshed with live quote so website is correct on merge
- `CLAUDE.md` — landmine #22 updated with the full lineage of failed sources and the new chain

https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1AGkLLqtWafPzAkikZq26)_