### PR TITLE
YouTube pipeline P0–P2: quality, quota, resume-youtube

### DIFF
--- a/docs/env_var_inventory.md
+++ b/docs/env_var_inventory.md
@@ -60,7 +60,8 @@ Run:
 
 ```bash
 python run_show.py tesla --test          # digest only
-python run_show.py tesla --resume-publish  # publish-only retry
+python run_show.py tesla --resume-publish  # publish-only retry (skips YouTube)
+python run_show.py tesla --resume-youtube   # YouTube-only retry
 ```
 
 ---
@@ -86,5 +87,7 @@ python run_show.py tesla --resume-publish  # publish-only retry
 | `--skip-newsletter` | No Buttondown send |
 | `--skip-youtube` | No YouTube upload |
 | `--resume-publish` | Publish from existing MP3 + digest (skips fetch/TTS/YouTube) |
+| `--resume-youtube` | Rebuild/upload YouTube only (skips fetch/TTS/X/newsletter) |
 
 Auto `--resume-publish` when today's MP3 exists but `.published_YYYYMMDD.json` is missing.
+Use `--resume-youtube` when the rest of the pipeline succeeded but YouTube failed.

--- a/docs/youtube_setup.md
+++ b/docs/youtube_setup.md
@@ -1,146 +1,112 @@
 # YouTube Publishing — Setup & Operator Runbook
 
-The pipeline can publish each episode as a long-form 1920x1080 video and
-a 1080x1920 Shorts teaser, automatically disclosed as AI-narrated and
-monetization-eligible. This document covers the one-time setup work an
-operator (you) does outside the repo: GCP project, OAuth, channels,
-quota.
-
-For day-to-day code locations see:
+The pipeline publishes each enabled episode as a long-form 1920×1080 video and
+a 1080×1920 Shorts teaser, with AI disclosure on every upload. Code paths:
 
 - `engine/video.py` — ffmpeg long-form + Shorts builders
 - `engine/youtube.py` — Google API upload wrapper
-- `engine/video_metadata.py` — title / description / tag construction
-- `run_show.py` — `_publish_youtube()` stage runs after RSS, before X
+- `engine/video_metadata.py` — title / description / tags
+- `engine/youtube_shorts.py` — Shorts start offset + quota stagger
+- `run_show.py` — `_publish_youtube()` at step **10d** (before RSS, so the watch URL can land in show notes)
+
+## Production rollout (May 2026)
+
+| Show | `youtube.enabled` | Notes |
+|------|-------------------|--------|
+| `tesla` | `true` | Grok Imagine imagery |
+| `models_agents_beginners` | `true` | Pexels imagery (A/B month vs Tesla) |
+| All others | `false` | Ready to flip after quota increase |
+
+CI guard: `tests/test_schedule.py::test_only_tst_and_mab_enable_youtube`.
 
 ## Channel topology
 
-We use two channels:
+| Channel | Shows | Refresh-token secret |
+|---------|-------|----------------------|
+| English `@NerraNetwork` | English shows | `YOUTUBE_REFRESH_TOKEN_EN` |
+| Russian `@NerraRU` | `finansy_prosto`, `privet_russian` | `YOUTUBE_REFRESH_TOKEN_RU` |
 
-| Channel | Audience | Shows | Refresh-token secret |
-|---------|----------|-------|----------------------|
-| English Nerra Network | Default | tesla, omni_view, fascinating_frontiers, planetterrian, env_intel, models_agents, models_agents_beginners, modern_investing | `YOUTUBE_REFRESH_TOKEN_EN` |
-| Russian Nerra Network | Russian-speaking | finansy_prosto, privet_russian | `YOUTUBE_REFRESH_TOKEN_RU` |
-
-Per-show YAMLs select the channel via `youtube.channel: en` or
-`youtube.channel: ru`. The channel handle and display names are
-configured in YouTube Studio — the code only needs the OAuth refresh
-token belonging to that channel's account.
+Per-show YAML: `youtube.channel: en` or `ru`.
 
 ## One-time GCP + OAuth setup
 
-1. **Create a Google Cloud project** at <https://console.cloud.google.com/>.
-   Name it something like `nerra-network-youtube`.
-2. **Enable the YouTube Data API v3** under `APIs & Services → Library`.
-3. **Configure the OAuth consent screen** (`APIs & Services → OAuth consent screen`):
-   - User type: External.
-   - Add yourself as a test user (until the screen is verified, only test users can authorize).
-   - Scopes: `youtube.upload`, `youtube`.
-4. **Create OAuth credentials** (`APIs & Services → Credentials → Create Credentials → OAuth client ID`):
-   - Application type: **Desktop app**.
-   - Download the JSON file. Keep it local — never commit it.
-5. **Mint refresh tokens** (one per channel) by running the bootstrap
-   script locally:
+1. Create a Google Cloud project and enable **YouTube Data API v3**.
+2. OAuth consent screen: External, add yourself as test user until verified.
+3. Create **Desktop** OAuth credentials; download JSON (never commit).
+4. Mint refresh tokens locally:
 
    ```bash
    python scripts/youtube_oauth_bootstrap.py ~/Downloads/client_secrets.json
    ```
 
-   The script opens a browser. Sign into the Google account that owns
-   the **English channel** first, then re-run for the **Russian channel**.
-   Each run prints the refresh token; paste it into the matching GitHub
-   secret:
+   Run once per channel (English account, then Russian). The bootstrap script
+   requests `youtube.upload`, `youtube`, and **`youtube.force-ssl`** (required
+   for `captions.insert` / CC track upload).
 
-   - English run → `YOUTUBE_REFRESH_TOKEN_EN`
-   - Russian run → `YOUTUBE_REFRESH_TOKEN_RU`
+5. Paste tokens into GitHub secrets:
 
-   The script also prints `YOUTUBE_CLIENT_ID` and `YOUTUBE_CLIENT_SECRET`
-   — set those once (they're shared across both channels).
+   | Secret | Source |
+   |--------|--------|
+   | `YOUTUBE_CLIENT_ID` | OAuth client JSON |
+   | `YOUTUBE_CLIENT_SECRET` | OAuth client JSON |
+   | `YOUTUBE_REFRESH_TOKEN_EN` | English channel run |
+   | `YOUTUBE_REFRESH_TOKEN_RU` | Russian channel run |
 
-## GitHub secrets
+If captions fail with HTTP 403 after upgrading scopes, **revoke** the app at
+https://myaccount.google.com/permissions and re-run the bootstrap script so
+Google issues a new refresh token with `force-ssl`.
 
-The pipeline reads four secrets:
+## Quota
 
-| Secret | Source |
-|--------|--------|
-| `YOUTUBE_CLIENT_ID` | OAuth client JSON |
-| `YOUTUBE_CLIENT_SECRET` | OAuth client JSON |
-| `YOUTUBE_REFRESH_TOKEN_EN` | Bootstrap script (English channel) |
-| `YOUTUBE_REFRESH_TOKEN_RU` | Bootstrap script (Russian channel) |
+Default project quota: **10,000 units/day**.
 
-If any are missing, the YouTube stage logs a "credentials missing" notice
-and skips the upload — the rest of the pipeline (audio, RSS, X, etc.)
-continues unaffected.
+| API call | Units |
+|----------|------:|
+| `videos.insert` | 1,600 |
+| `thumbnails.set` | 50 |
+| `playlistItems.insert` | 50 |
+| `captions.insert` | 400 |
 
-## Quota — the operational gotcha
+Roughly **~3,400–3,800 units per show per day** (long + Short + thumb + playlist + captions).
 
-The default Google Cloud quota is **10,000 units/day** per project.
-Each `videos.insert` costs **1,600 units**, so the default lets you
-upload roughly six videos per day. With 11 shows × (long-form + Shorts)
-that's 32,000 units — over budget by a factor of three.
+- **2 enabled shows (today):** ~7k units — fits default quota.
+- **7 daily shows × 2 videos:** ~22k+ units on inserts alone — **request quota increase** (~50k/day) or set `youtube.shorts_upload_schedule: alternate_episodes` on some shows (Shorts only on even episode numbers).
 
-Two paths forward:
+`engine/youtube_quota.py` logs a warning at preflight when enabled shows exceed 10k.
 
-1. **Phased rollout** (default in this repo): only `tesla`,
-   `fascinating_frontiers`, and `models_agents` have `youtube.enabled:
-   true` to start. That's 3 × (1,600 + 1,600) = **9,600 units/day** —
-   right under the cap.
-2. **Quota extension request** (file on day 1): in Cloud Console →
-   `APIs & Services → YouTube Data API v3 → Quotas`, request an increase
-   to ~50,000 units/day. Justify with:
-   - Original editorial pipeline (we're not aggregating other creators).
-   - Compliance with `containsSyntheticMedia` disclosure on every upload.
-   - 11 daily shows × 2 video formats × OAuth-authenticated uploads.
+## YouTube Podcasts playlist (manual, once per playlist)
 
-   Reviews typically take 1–2 weeks. Once granted, flip `youtube.enabled`
-   to `true` on the remaining shows.
+The API adds videos to `youtube.podcast_playlist_id`, but the playlist only
+appears under **YouTube Studio → Podcasts** after you choose **Set existing
+playlist as a podcast** for that playlist. One-time per playlist per channel.
 
 ## AI disclosure
 
-Every upload sets `status.containsSyntheticMedia=True` via the API. This
-is the field YouTube introduced in October 2024 specifically for AI/A&S
-disclosure; setting it via the API renders the same "Altered or
-synthetic content" label the Studio UI applies and is required for
-monetization-eligible AI audio uploads.
+Every upload sets `status.containsSyntheticMedia=True` plus the
+`youtube.synthetic_disclosure` footer in `_defaults.yaml` (Grok TTS wording).
 
-In addition, every video description ends with a plain-language
-disclosure (defined in `shows/_defaults.yaml` under
-`youtube.synthetic_disclosure`):
+## Shorts timing
 
-> AI Disclosure: This podcast is curated by Patrick but uses
-> AI-generated voice synthesis (ElevenLabs) for the narration. …
+Shorts audio starts at `audio.voice_intro_delay` (not `intro_duration + delay`).
+Override per show:
 
-Do not remove or weaken this. Both layers (API flag + description text)
-are needed to stay inside YouTube's monetization policy.
+- `youtube.shorts_start_offset: 90` — fixed seconds
+- `youtube.shorts_start_mode: first_chapter` — jump to 2nd chapter marker
 
-## YouTube Analytics vs. Google Analytics
+## Retry / resume
 
-YouTube Studio has its own analytics dashboard and **does not** stream
-data into GA4. What the pipeline does instead: every video description
-links to `nerranetwork.com/<show>.html` with
-`?utm_source=youtube&utm_medium=video&utm_campaign=ep<N>` so when a
-viewer clicks through, GA4 on `nerranetwork.com` attributes the traffic
-to YouTube. Shorts use `utm_medium=shorts` to separate the two
-funnels.
+- **Failed upload after MP3 exists:** `python run_show.py <slug> --resume-youtube`
+  (rebuilds ffmpeg assets and re-uploads; skips TTS/X/newsletter).
+- **Failed RSS but MP3 ok:** `python run_show.py <slug> --resume-publish`
 
-If you want a periodic dump of YouTube Analytics into GA4, that's a
-separate manual integration (third-party connector) — out of scope here.
+## Validation checklist (first uploads)
 
-## Validation steps for the first uploads
+1. Run: `python run_show.py tesla --skip-x --skip-newsletter`
+2. In Studio: title, description, chapters, thumbnail, synthetic label.
+3. Confirm CC track on long-form (if OAuth includes `force-ssl`).
+4. Confirm Shorts uses vertical thumbnail and starts on voice (not mid-sentence skip).
 
-1. Set `youtube.privacy_status: unlisted` in `shows/tesla.yaml` (already
-   the default for phase-1 shows in this repo).
-2. Run locally:
+## Analytics
 
-   ```bash
-   python run_show.py tesla --skip-x --skip-newsletter
-   ```
-
-3. In YouTube Studio, open the new video and confirm:
-   - Title, description, chapters, tags rendered correctly.
-   - Custom thumbnail rendered (1280x720, hook visible).
-   - Under `Details → Altered content`: "Altered or synthetic content"
-     label is visible.
-   - Privacy is "Unlisted".
-4. Flip `youtube.privacy_status: public` in the YAML, re-run.
-5. Once two or three episodes have landed cleanly, repeat for the Shorts.
+Descriptions include UTM links (`utm_source=youtube`, `utm_medium=video` or `shorts`).
+YouTube Analytics does not feed GA4; use site UTMs for cross-funnel attribution.

--- a/engine/config.py
+++ b/engine/config.py
@@ -305,6 +305,15 @@ class YouTubeConfig:
     publish_long_form: bool = True
     publish_shorts: bool = True
     short_duration_seconds: float = 55.0
+    # Seconds into the final mixed MP3 where the Shorts clip begins.
+    # When unset, ``shorts_start_mode`` picks the offset (default ``voice``
+    # = ``audio.voice_intro_delay`` only — not intro_duration + delay).
+    shorts_start_offset: Optional[float] = None
+    # ``voice`` | ``first_chapter`` — see engine.youtube_shorts.
+    shorts_start_mode: str = "voice"
+    # ``always`` | ``alternate_episodes`` — skip Shorts on odd episode
+    # numbers to halve upload quota during phased rollout.
+    shorts_upload_schedule: str = "always"
     tags: List[str] = field(default_factory=list)
     synthetic_disclosure: str = ""
     podcast_playlist_id: Optional[str] = None
@@ -354,6 +363,16 @@ class YouTubeConfig:
     # Defaults to a generic photojournalism cue; shows can override
     # (e.g. UC's narrative tone might want "documentary archival photo").
     grok_image_descriptor: str = "photorealistic news photo"
+    # Optional path (relative to repo root) to a text template for the
+    # long-form description body. Placeholders: {hook}, {episode_num},
+    # {show_name}, {today_str}. When empty, uses digest paragraphs.
+    description_prompt_file: str = ""
+    # Appended to the description as an operator copy-paste block (YouTube
+    # has no API for pinned comments without extra scopes).
+    pinned_comment_template: str = ""
+    # When true and vertical scene images exist, build a 1080×1920 Shorts
+    # thumbnail instead of reusing the 1280×720 long-form thumb.
+    shorts_thumbnail_from_scene: bool = True
 
 
 @dataclass

--- a/engine/pipeline_resume.py
+++ b/engine/pipeline_resume.py
@@ -102,6 +102,33 @@ def _marker_complete(marker_path: Path) -> bool:
 def apply_resume_args(args: argparse.Namespace) -> argparse.Namespace:
     """Return args with YouTube skipped on resume (avoid duplicate uploads)."""
     merged = dict(vars(args))
-    merged["skip_youtube"] = True
+    if not merged.get("resume_youtube"):
+        merged["skip_youtube"] = True
     merged["resume_publish"] = True
     return argparse.Namespace(**merged)
+
+
+def apply_resume_youtube_args(args: argparse.Namespace) -> argparse.Namespace:
+    """Publish-only retry: rebuild/upload YouTube without re-running TTS."""
+    merged = dict(vars(args))
+    merged["skip_youtube"] = False
+    merged["resume_youtube"] = True
+    merged["resume_publish"] = True
+    merged["skip_x"] = True
+    merged["skip_newsletter"] = True
+    return argparse.Namespace(**merged)
+
+
+def should_resume_youtube(
+    expected_mp3: Path,
+    digest_md: Path,
+    *,
+    test_mode: bool,
+    dry_run: bool,
+    force: bool = False,
+) -> bool:
+    if test_mode or dry_run:
+        return False
+    if force:
+        return expected_mp3.exists() and digest_md.exists()
+    return expected_mp3.exists() and digest_md.exists()

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -1236,6 +1236,27 @@ def generate_episode_thumbnail(
     return output_path
 
 
+def generate_shorts_thumbnail(
+    base_image_path: Path,
+    episode_num: int,
+    date_str: str,
+    output_path: Path,
+    *,
+    hook: str = "",
+    show_name: str = "",
+) -> Path:
+    """Render a 1080×1920 vertical thumbnail for YouTube Shorts."""
+    return generate_episode_thumbnail(
+        base_image_path,
+        episode_num,
+        date_str,
+        output_path,
+        hook=hook,
+        show_name=show_name,
+        size=(1080, 1920),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Digest formatting for X posting
 # ---------------------------------------------------------------------------

--- a/engine/video.py
+++ b/engine/video.py
@@ -40,6 +40,19 @@ from typing import List, Optional, Sequence
 logger = logging.getLogger(__name__)
 
 
+def _run_ffmpeg(cmd: List[str], *, label: str) -> None:
+    """Run ffmpeg and attach stderr to the raised error for CI debugging."""
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or exc.stdout or "").strip()
+        if len(stderr) > 2000:
+            stderr = stderr[-2000:]
+        raise RuntimeError(
+            f"{label} failed (exit {exc.returncode}): {stderr or '(no stderr)'}"
+        ) from exc
+
+
 # ---------------------------------------------------------------------------
 # Encoding profile
 # ---------------------------------------------------------------------------
@@ -366,7 +379,7 @@ def _render_slideshow(scene_paths: Sequence[Path], output: Path,
                          width=width, height=height, fps=fps)
     logger.info("Rendering slideshow (%d scenes, %dx%d) → %s",
                 len(scene_paths), width, height, output.name)
-    subprocess.run(cmd, check=True, capture_output=True)
+    _run_ffmpeg(cmd, label="slideshow render")
     return output
 
 
@@ -757,7 +770,7 @@ def build_long_form_video(
     )
     logger.info("Building long-form video → %s (slideshow=%s, captions=%s)",
                 output_path.name, bg_is_video, bool(subtitles_path))
-    subprocess.run(cmd, check=True, capture_output=True)
+    _run_ffmpeg(cmd, label="long-form video")
     return output_path
 
 
@@ -846,5 +859,5 @@ def build_short_video(audio_path: Path, cover_path: Path,
         "Building Shorts video (%.1fs from %.1fs) → %s",
         duration, start_offset, output_path.name,
     )
-    subprocess.run(cmd, check=True, capture_output=True)
+    _run_ffmpeg(cmd, label="shorts video")
     return output_path

--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -18,9 +18,12 @@ import json
 import logging
 import re
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+# Repo root — two levels up from engine/
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 YOUTUBE_TITLE_MAX = 100
@@ -171,6 +174,43 @@ def _format_chapter_block(chapters: List[Dict]) -> str:
 # Tag handling
 # ---------------------------------------------------------------------------
 
+def _load_description_body_from_template(
+    config: Any,
+    *,
+    episode_num: int,
+    today_str: str,
+    hook: str,
+) -> str:
+    """Optional YouTube-specific description intro from a prompt file."""
+    yt = getattr(config, "youtube", None)
+    rel = (getattr(yt, "description_prompt_file", None) or "").strip()
+    if not rel:
+        return ""
+    path = Path(rel)
+    if not path.is_file():
+        path = _REPO_ROOT / rel
+    if not path.exists():
+        logger.warning("youtube.description_prompt_file missing: %s", path)
+        return ""
+    template = path.read_text(encoding="utf-8").strip()
+    rss_title = (
+        getattr(config.publishing, "rss_title", "")
+        or getattr(config, "name", "")
+    )
+    try:
+        body = template.format(
+            hook=(hook or "").strip(),
+            episode_num=episode_num,
+            today_str=today_str,
+            show_name=rss_title,
+            rss_link=getattr(config.publishing, "rss_link", "") or "",
+        )
+    except KeyError as exc:
+        logger.warning("description template format error: %s", exc)
+        return ""
+    return _strip_markdown(body)
+
+
 def _build_tags(
     extra: List[str],
     keywords: List[str],
@@ -245,10 +285,18 @@ def build_long_form_metadata(
         f"utm_source=youtube&utm_medium=video&utm_campaign=ep{episode_num}"
     )
 
-    # First few paragraphs of the digest become the description body.
-    body_source = _strip_markdown(digest_text or "")
-    paragraphs = [p.strip() for p in body_source.split("\n\n") if p.strip()]
-    body = "\n\n".join(paragraphs[:4]).strip()
+    template_body = _load_description_body_from_template(
+        config,
+        episode_num=episode_num,
+        today_str=today_str,
+        hook=hook,
+    )
+    if template_body:
+        body = template_body
+    else:
+        body_source = _strip_markdown(digest_text or "")
+        paragraphs = [p.strip() for p in body_source.split("\n\n") if p.strip()]
+        body = "\n\n".join(paragraphs[:4]).strip()
 
     chapters_block = _format_chapter_block(_read_chapters(chapters_path))
 
@@ -288,6 +336,19 @@ def build_long_form_metadata(
     disclosure = (config.youtube.synthetic_disclosure or "").strip()
     if disclosure:
         pieces.append(disclosure)
+    pinned = (getattr(config.youtube, "pinned_comment_template", None) or "").strip()
+    if pinned:
+        try:
+            pinned = pinned.format(
+                hook=(hook or "").strip(),
+                episode_num=episode_num,
+                today_str=today_str,
+                show_page_url=rss_link,
+                full_episode_url=audio_url or "",
+            )
+        except KeyError:
+            pass
+        pieces.append("—\nSuggested pinned comment:\n" + pinned)
 
     # Final safety strip — YouTube rejects any description containing
     # ``<`` or ``>`` with HTTP 400 ``invalidDescription``. ``_strip_markdown``

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -37,7 +37,7 @@ from typing import List, Optional
 
 from tenacity import (
     retry,
-    retry_if_exception_type,
+    retry_if_exception,
     stop_after_attempt,
     wait_exponential,
 )
@@ -45,10 +45,12 @@ from tenacity import (
 logger = logging.getLogger(__name__)
 
 
-# OAuth scopes required for upload + thumbnail set + channel read.
+# OAuth scopes required for upload + thumbnail set + channel read +
+# caption track upload (``captions.insert`` needs force-ssl).
 YOUTUBE_SCOPES = [
     "https://www.googleapis.com/auth/youtube.upload",
     "https://www.googleapis.com/auth/youtube",
+    "https://www.googleapis.com/auth/youtube.force-ssl",
 ]
 
 # Google's OAuth token endpoint. Held as a constant rather than an env
@@ -171,8 +173,22 @@ def _build_video_body(
     }
 
 
+def _is_retryable_upload_error(exc: BaseException) -> bool:
+    """Retry transient failures only — not 400 invalidDescription / auth."""
+    if _is_retryable_http_error(exc):
+        return True
+    try:
+        from googleapiclient.errors import HttpError
+    except ImportError:  # pragma: no cover
+        return False
+    if isinstance(exc, HttpError):
+        status = getattr(getattr(exc, "resp", None), "status", 0)
+        return status in (429, 500, 502, 503, 504)
+    return False
+
+
 @retry(
-    retry=retry_if_exception_type(Exception) & retry_if_exception_type(Exception),
+    retry=retry_if_exception(_is_retryable_upload_error),
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=2, min=4, max=30),
     reraise=True,

--- a/engine/youtube_preflight.py
+++ b/engine/youtube_preflight.py
@@ -1,0 +1,83 @@
+"""Pre-flight checks for YouTube-enabled shows."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, List
+
+from engine.youtube_quota import format_quota_warning, estimate_network_daily_units
+
+
+def validate_youtube_show_ready(
+    config: Any,
+    project_root: Path,
+) -> List[str]:
+    """Return fatal misconfiguration issues for an enabled show."""
+    issues: List[str] = []
+    yt = getattr(config, "youtube", None)
+    if not yt or not getattr(yt, "enabled", False):
+        return issues
+
+    slug = getattr(config, "slug", "show")
+    for name in (
+        f"{slug.replace('_', '-')}.jpg",
+        f"{slug}.jpg",
+    ):
+        if (project_root / "assets" / "covers" / name).exists():
+            break
+    else:
+        issues.append(
+            f"YouTube enabled but no cover at assets/covers/ for slug={slug}"
+        )
+
+    channel = (getattr(yt, "channel", "en") or "en").lower()
+    suffix = "RU" if channel == "ru" else "EN"
+    cred_vars = (
+        "YOUTUBE_CLIENT_ID",
+        "YOUTUBE_CLIENT_SECRET",
+        f"YOUTUBE_REFRESH_TOKEN_{suffix}",
+    )
+    missing = [v for v in cred_vars if not os.getenv(v, "").strip()]
+    if missing:
+        issues.append(
+            f"YouTube enabled but missing env vars: {', '.join(missing)}"
+        )
+
+    privacy = (getattr(yt, "privacy_status", "public") or "").strip()
+    if privacy not in ("public", "unlisted", "private"):
+        issues.append(
+            f"youtube.privacy_status={privacy!r} must be public, unlisted, or private"
+        )
+
+    provider = (getattr(yt, "image_provider", "pexels") or "pexels").lower()
+    if provider in ("pexels", "hybrid") and not os.getenv("PEXELS_API_KEY", "").strip():
+        issues.append(
+            "YouTube image_provider uses Pexels but PEXELS_API_KEY is unset"
+        )
+
+    if provider in ("grok", "hybrid") and not (
+        os.getenv("GROK_API_KEY", "").strip()
+        or os.getenv("XAI_API_KEY", "").strip()
+    ):
+        issues.append(
+            "YouTube image_provider uses Grok Imagine but GROK_API_KEY is unset"
+        )
+
+    queries = list(getattr(yt, "image_queries", None) or [])
+    if not queries:
+        issues.append(
+            f"YouTube enabled for {slug} but youtube.image_queries is empty "
+            "(required for safe slideshow imagery)"
+        )
+
+    return issues
+
+
+def youtube_network_quota_warning(project_root: Path) -> str | None:
+    """Warning when all enabled shows exceed the default daily quota."""
+    shows_dir = project_root / "shows"
+    if not shows_dir.is_dir():
+        return None
+    summary = estimate_network_daily_units(shows_dir)
+    return format_quota_warning(summary)

--- a/engine/youtube_quota.py
+++ b/engine/youtube_quota.py
@@ -1,0 +1,126 @@
+"""YouTube Data API v3 quota estimation for rollout planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+
+# Documented costs (units per call) — keep in sync with engine/youtube.py.
+QUOTA_VIDEO_INSERT = 1600
+QUOTA_THUMBNAIL_SET = 50
+QUOTA_PLAYLIST_INSERT = 50
+QUOTA_CAPTION_INSERT = 400
+DEFAULT_DAILY_QUOTA = 10_000
+
+
+@dataclass
+class QuotaEstimate:
+    """Estimated quota for one show on one day."""
+    long_form: bool
+    shorts: bool
+    caption_track: bool
+    units: int
+
+    @property
+    def uploads(self) -> int:
+        n = 0
+        if self.long_form:
+            n += 1
+        if self.shorts:
+            n += 1
+        return n
+
+
+def estimate_episode_units(
+    *,
+    publish_long_form: bool = True,
+    publish_shorts: bool = True,
+    with_thumbnail: bool = True,
+    with_playlist: bool = True,
+    with_caption_track: bool = True,
+) -> QuotaEstimate:
+    """Return per-episode quota breakdown."""
+    units = 0
+    if publish_long_form:
+        units += QUOTA_VIDEO_INSERT
+        if with_thumbnail:
+            units += QUOTA_THUMBNAIL_SET
+        if with_playlist:
+            units += QUOTA_PLAYLIST_INSERT
+        if with_caption_track:
+            units += QUOTA_CAPTION_INSERT
+    if publish_shorts:
+        units += QUOTA_VIDEO_INSERT
+        if with_thumbnail:
+            units += QUOTA_THUMBNAIL_SET
+        if with_playlist:
+            units += QUOTA_PLAYLIST_INSERT
+    return QuotaEstimate(
+        long_form=publish_long_form,
+        shorts=publish_shorts,
+        caption_track=publish_long_form and with_caption_track,
+        units=units,
+    )
+
+
+def list_youtube_enabled_slugs(shows_dir: Path) -> List[str]:
+    """Return slugs with ``youtube.enabled: true``."""
+    enabled: List[str] = []
+    for path in sorted(shows_dir.glob("*.yaml")):
+        if path.name.startswith("_"):
+            continue
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        slug = raw.get("slug") or path.stem
+        yt = raw.get("youtube") or {}
+        if yt.get("enabled") is True:
+            enabled.append(slug)
+    return enabled
+
+
+def estimate_network_daily_units(
+    shows_dir: Path,
+    *,
+    daily_quota: int = DEFAULT_DAILY_QUOTA,
+) -> dict:
+    """Sum quota for all enabled shows (reads show YAML only)."""
+    total = 0
+    per_show: dict[str, int] = {}
+    for path in sorted(shows_dir.glob("*.yaml")):
+        if path.name.startswith("_"):
+            continue
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        slug = raw.get("slug") or path.stem
+        yt = raw.get("youtube") or {}
+        if yt.get("enabled") is not True:
+            continue
+        est = estimate_episode_units(
+            publish_long_form=bool(yt.get("publish_long_form", True)),
+            publish_shorts=bool(yt.get("publish_shorts", True)),
+        )
+        per_show[slug] = est.units
+        total += est.units
+    return {
+        "enabled_slugs": list(per_show.keys()),
+        "per_show_units": per_show,
+        "total_units": total,
+        "daily_quota": daily_quota,
+        "over_quota": total > daily_quota,
+        "headroom_units": daily_quota - total,
+    }
+
+
+def format_quota_warning(summary: dict) -> Optional[str]:
+    """Human-readable warning when enabled shows exceed default quota."""
+    if not summary.get("over_quota"):
+        return None
+    slugs = ", ".join(summary.get("enabled_slugs") or [])
+    return (
+        f"YouTube quota: estimated {summary['total_units']} units/day for "
+        f"enabled shows ({slugs}) exceeds default {summary['daily_quota']} "
+        f"(~{summary['daily_quota'] // QUOTA_VIDEO_INSERT} video inserts). "
+        "Request a quota increase or set youtube.shorts_upload_schedule: "
+        "alternate_episodes on some shows."
+    )

--- a/engine/youtube_shorts.py
+++ b/engine/youtube_shorts.py
@@ -1,0 +1,107 @@
+"""Shorts clip timing helpers for the YouTube pipeline."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _read_chapter_starts(chapters_path: Optional[Path]) -> list[float]:
+    """Return sorted chapter start times (seconds) from a chapters JSON file."""
+    if not chapters_path or not chapters_path.exists():
+        return []
+    try:
+        data = json.loads(chapters_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Could not read chapters for Shorts offset: %s", exc)
+        return []
+    chapters = data.get("chapters") if isinstance(data, dict) else data
+    if not isinstance(chapters, list):
+        return []
+    starts: list[float] = []
+    for ch in chapters:
+        if not isinstance(ch, dict):
+            continue
+        start = ch.get("startTime", ch.get("start_time", ch.get("start")))
+        if start is None:
+            continue
+        try:
+            starts.append(max(0.0, float(start)))
+        except (TypeError, ValueError):
+            continue
+    return sorted(set(starts))
+
+
+def resolve_shorts_start_offset(
+    config: Any,
+    chapters_path: Optional[Path] = None,
+    *,
+    audio_duration: float = 0.0,
+) -> float:
+    """Pick where the Shorts audio clip begins in the final mixed MP3.
+
+    The mixed MP3 places voice at ``voice_intro_delay`` seconds (music-only
+    intro before that). Summing ``intro_duration + voice_intro_delay`` was
+    wrong and skipped the first ~10s of narration.
+
+    Modes (``youtube.shorts_start_mode``):
+
+      ``voice`` (default) — start at ``voice_intro_delay``.
+      ``first_chapter`` — start at the first chapter marker after the cold
+          open (second chapter when ≥2 exist, else first chapter > 45s).
+    """
+    yt = getattr(config, "youtube", None)
+    explicit = getattr(yt, "shorts_start_offset", None) if yt else None
+    if explicit is not None:
+        return max(0.0, float(explicit))
+
+    mode = (
+        (getattr(yt, "shorts_start_mode", None) or "voice") if yt else "voice"
+    ).strip().lower()
+
+    if mode == "first_chapter":
+        starts = _read_chapter_starts(chapters_path)
+        if len(starts) >= 2:
+            offset = starts[1]
+        elif len(starts) == 1 and starts[0] > 45.0:
+            offset = starts[0]
+        else:
+            offset = float(getattr(config.audio, "voice_intro_delay", 0.0) or 0.0)
+        if audio_duration > 0:
+            short_dur = float(
+                getattr(yt, "short_duration_seconds", 55.0) or 55.0
+            )
+            max_start = max(0.0, audio_duration - short_dur - 1.0)
+            offset = min(offset, max_start)
+        logger.info(
+            "Shorts start offset (first_chapter): %.1fs", offset,
+        )
+        return offset
+
+    offset = float(getattr(config.audio, "voice_intro_delay", 0.0) or 0.0)
+    logger.info("Shorts start offset (voice): %.1fs", offset)
+    return offset
+
+
+def should_upload_shorts_today(config: Any, *, episode_num: int) -> bool:
+    """Honor ``youtube.shorts_upload_schedule`` quota-stagger knob."""
+    yt = getattr(config, "youtube", None)
+    if not yt or not getattr(yt, "publish_shorts", True):
+        return False
+    schedule = (
+        getattr(yt, "shorts_upload_schedule", None) or "always"
+    ).strip().lower()
+    if schedule == "alternate_episodes":
+        upload = episode_num % 2 == 0
+        if not upload:
+            logger.info(
+                "Shorts upload skipped (shorts_upload_schedule=alternate_episodes, "
+                "ep %d).",
+                episode_num,
+            )
+        return upload
+    return True

--- a/run_show.py
+++ b/run_show.py
@@ -137,6 +137,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Publish only: MP3 + digest on disk, skip fetch/TTS (for mid-publish retries)",
     )
+    parser.add_argument(
+        "--resume-youtube",
+        action="store_true",
+        help="YouTube only: MP3 + digest on disk, rebuild/upload videos (skips TTS/RSS/X)",
+    )
     return parser.parse_args()
 
 
@@ -262,9 +267,12 @@ def _preflight_checks(config, *, dry_run: bool = False) -> None:
             if env_name and not os.environ.get(env_name):
                 logger.warning("R2 env var %s (%s) is empty — upload may fail", env_name, env_attr)
 
-    # YouTube preflight — when publishing is enabled, surface common
-    # misconfigurations as warnings (not fatal — YouTube is non-blocking
-    # for the rest of the pipeline).
+    # YouTube preflight — fatal for enabled shows (catch before API spend).
+    from engine.youtube_preflight import (
+        validate_youtube_show_ready,
+        youtube_network_quota_warning,
+    )
+    issues.extend(validate_youtube_show_ready(config, PROJECT_ROOT))
     yt_cfg = getattr(config, "youtube", None)
     if yt_cfg and getattr(yt_cfg, "enabled", False):
         playlist_id = (
@@ -278,12 +286,9 @@ def _preflight_checks(config, *, dry_run: bool = False) -> None:
                 "in shows/%s.yaml after creating the playlist in Studio.",
                 config.slug, config.slug,
             )
-        privacy = (getattr(yt_cfg, "privacy_status", "public") or "").strip()
-        if privacy not in ("public", "unlisted", "private"):
-            issues.append(
-                f"youtube.privacy_status={privacy!r} is invalid — "
-                "must be public, unlisted, or private."
-            )
+        quota_warn = youtube_network_quota_warning(PROJECT_ROOT)
+        if quota_warn:
+            logger.warning(quota_warn)
 
     # Newsletter preflight — when enabled, validate the status enum
     # before we hit Buttondown with a guaranteed-400 request.
@@ -445,7 +450,12 @@ def run(args: argparse.Namespace) -> None:
     )
 
     publish_marker = publish_marker_path(digests_dir, today)
-    if is_publish_complete(publish_marker) and not args.test:
+    resume_youtube_requested = getattr(args, "resume_youtube", False)
+    if (
+        is_publish_complete(publish_marker)
+        and not args.test
+        and not resume_youtube_requested
+    ):
         logger.info(
             "Checkpoint: publish complete for %s (marker %s). Skipping.",
             today.isoformat(), publish_marker.name,
@@ -454,9 +464,29 @@ def run(args: argparse.Namespace) -> None:
 
     from engine.pipeline_resume import (
         apply_resume_args,
+        apply_resume_youtube_args,
         load_resume_publish_state,
         should_resume_publish,
+        should_resume_youtube,
     )
+
+    digest_md_path = digests_dir / (
+        f"{config.episode.prefix}_Ep{episode_num:03d}_{today:%Y%m%d}.md"
+    )
+    resume_youtube = should_resume_youtube(
+        expected_mp3,
+        digest_md_path,
+        test_mode=args.test,
+        dry_run=args.dry_run,
+        force=resume_youtube_requested,
+    )
+    if resume_youtube_requested and not resume_youtube:
+        logger.error(
+            "Resume YouTube requires MP3 and digest on disk (%s, %s).",
+            expected_mp3.name,
+            digest_md_path.name,
+        )
+        sys.exit(1)
 
     resume_publish = should_resume_publish(
         expected_mp3,
@@ -465,7 +495,14 @@ def run(args: argparse.Namespace) -> None:
         dry_run=args.dry_run,
         force=getattr(args, "resume_publish", False),
     )
-    if resume_publish and not getattr(args, "resume_publish", False):
+    if resume_youtube:
+        args = apply_resume_youtube_args(args)
+        resume_publish = True
+        logger.info(
+            "Resume YouTube: rebuilding/uploading videos for %s (skipping TTS).",
+            expected_mp3.name,
+        )
+    elif resume_publish and not getattr(args, "resume_publish", False):
         logger.warning(
             "MP3 %s exists but publish marker missing — resume publish only "
             "(skipping fetch/TTS; YouTube skipped to avoid duplicate uploads).",
@@ -2915,8 +2952,15 @@ def _publish_youtube(
         find_transcript_for_episode,
         transcript_to_srt,
     )
-    from engine.publisher import generate_episode_thumbnail
+    from engine.publisher import (
+        generate_episode_thumbnail,
+        generate_shorts_thumbnail,
+    )
     from engine.video import build_long_form_video, build_short_video
+    from engine.youtube_shorts import (
+        resolve_shorts_start_offset,
+        should_upload_shorts_today,
+    )
     from engine.video_metadata import (
         build_long_form_metadata,
         build_short_metadata,
@@ -2942,8 +2986,9 @@ def _publish_youtube(
     long_video_path = work_dir / f"{base_name}.mp4"
     short_video_path = work_dir / f"{base_name}_short.mp4"
     thumbnail_path = work_dir / f"{base_name}_thumb.jpg"
+    short_thumbnail_path = work_dir / f"{base_name}_short_thumb.jpg"
+    show_label = config.publishing.rss_title or config.name
 
-    # Thumbnail is shared between long-form and Shorts.
     try:
         generate_episode_thumbnail(
             cover_path,
@@ -2951,10 +2996,10 @@ def _publish_youtube(
             date_str=today_str,
             output_path=thumbnail_path,
             hook=hook,
-            show_name=config.publishing.rss_title or config.name,
+            show_name=show_label,
         )
     except Exception as exc:  # pragma: no cover - thumbnail rendering best-effort
-        logger.warning("Thumbnail generation failed: %s", exc)
+        logger.warning("Long-form thumbnail generation failed: %s", exc)
         thumbnail_path = None  # type: ignore[assignment]
 
     # ---- Build captions SRT (optional — falls back to no captions) ----
@@ -3080,6 +3125,29 @@ def _publish_youtube(
     else:  # pexels (default)
         _run_pexels_path(into_long=True, into_short=True)
 
+    # Shorts thumbnail: vertical crop from cover or first vertical scene.
+    shorts_thumb_base = cover_path
+    if getattr(yt, "shorts_thumbnail_from_scene", True) and len(short_scene_paths) >= 1:
+        shorts_thumb_base = short_scene_paths[0]
+    try:
+        generate_shorts_thumbnail(
+            shorts_thumb_base,
+            episode_num=episode_num,
+            date_str=today_str,
+            output_path=short_thumbnail_path,
+            hook=hook,
+            show_name=show_label,
+        )
+    except Exception as exc:  # pragma: no cover
+        logger.warning("Shorts thumbnail generation failed: %s", exc)
+        short_thumbnail_path = thumbnail_path  # fallback to long-form thumb
+
+    from engine.audio import get_audio_duration as _audio_dur
+    try:
+        _ep_duration = _audio_dur(str(final_mp3)) or 0.0
+    except Exception:
+        _ep_duration = 0.0
+
     # ---- Long-form ----
     long_url = ""
     if config.youtube.publish_long_form:
@@ -3169,12 +3237,14 @@ def _publish_youtube(
             }
 
     # ---- Shorts ----
-    if config.youtube.publish_shorts:
+    if config.youtube.publish_shorts and should_upload_shorts_today(
+        config, episode_num=episode_num,
+    ):
         try:
-            short_offset = float(
-                getattr(config.audio, "intro_duration", 0.0) or 0.0
-            ) + float(
-                getattr(config.audio, "voice_intro_delay", 0.0) or 0.0
+            short_offset = resolve_shorts_start_offset(
+                config,
+                chapters_path if chapters_path.exists() else None,
+                audio_duration=_ep_duration,
             )
             duration = float(config.youtube.short_duration_seconds or 55.0)
             build_short_video(
@@ -3192,6 +3262,11 @@ def _publish_youtube(
                 hook=hook,
                 long_form_url=long_url,
             )
+            short_thumb = (
+                short_thumbnail_path
+                if short_thumbnail_path and Path(short_thumbnail_path).exists()
+                else thumbnail_path
+            )
             short_upload = upload_video(
                 short_video_path,
                 credentials=credentials,
@@ -3201,7 +3276,7 @@ def _publish_youtube(
                 category_id=meta["category_id"],
                 default_language=meta["default_language"],
                 privacy_status=config.youtube.privacy_status,
-                thumbnail_path=thumbnail_path,
+                thumbnail_path=short_thumb,
             )
             result["short_url"] = short_upload.watch_url
             playlist_id = (

--- a/scripts/youtube_oauth_bootstrap.py
+++ b/scripts/youtube_oauth_bootstrap.py
@@ -31,6 +31,8 @@ from pathlib import Path
 SCOPES = [
     "https://www.googleapis.com/auth/youtube.upload",
     "https://www.googleapis.com/auth/youtube",
+    # Required for captions.insert (CC track upload after long-form).
+    "https://www.googleapis.com/auth/youtube.force-ssl",
 ]
 
 

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -220,9 +220,17 @@ youtube:
   # Per-episode rendering toggles.
   publish_long_form: true
   publish_shorts: true
-  # Shorts clip pulled from the voice track only (skips music intro);
-  # keep < 60s so YouTube treats it as a Short.
+  # Shorts clip starts at voice_intro_delay (skips music-only intro).
+  # Override with shorts_start_offset (seconds) or shorts_start_mode:
+  # first_chapter (jumps to 2nd chapter marker for a stronger hook).
+  shorts_start_mode: voice
+  shorts_upload_schedule: always   # alternate_episodes = Shorts on even ep nums only
   short_duration_seconds: 55
+  description_prompt_file: shows/prompts/youtube_description_intro.txt
+  pinned_comment_template: |
+    🎧 Full episode + show notes: {show_page_url}
+    Subscribe on your favourite podcast app — search "{show_name}" on the Nerra Network.
+  shorts_thumbnail_from_scene: true
   # Network-wide tags appended to per-show tags.
   tags:
     - nerra network

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -246,13 +246,9 @@ youtube:
     - teen with laptop
     - classroom technology
   image_query_prefix: ""
-  # May 2026 rollout — second of the two YouTube-enabled shows opting
-  # in to Grok Imagine. AI-illustrated friendly imagery tied to each
-  # day's hook fits the beginner / teen audience better than Pexels
-  # stock photos of generic kids-with-laptops. ~$0.32/episode.
-  image_provider: grok
-  grok_image_model: grok-imagine-image
-  grok_image_descriptor: "friendly approachable illustration for beginners and teens"
+  # May 2026 — Pexels for one month while comparing engagement vs Tesla
+  # (Grok Imagine). Flip back to grok after operator review.
+  image_provider: pexels
   tags:
     - ai for beginners
     - learn ai

--- a/shows/prompts/youtube_description_intro.txt
+++ b/shows/prompts/youtube_description_intro.txt
@@ -1,0 +1,3 @@
+{hook}
+
+Today's {show_name} episode (Ep {episode_num}, {today_str}) covers the stories above in full — listen on Spotify, Apple Podcasts, or any podcast app via the show page below.

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -42,6 +42,8 @@ def _make_config(**overrides):
         synthetic_disclosure=overrides.get(
             "synthetic_disclosure", "AI Disclosure: synthesized voice."
         ),
+        description_prompt_file=overrides.get("description_prompt_file", ""),
+        pinned_comment_template=overrides.get("pinned_comment_template", ""),
         enabled=True,
         channel="en",
     )
@@ -217,6 +219,32 @@ def test_build_tags_respects_500_char_cap():
 # ---------------------------------------------------------------------------
 # Metadata builders
 # ---------------------------------------------------------------------------
+
+def test_youtube_oauth_scopes_include_force_ssl():
+    from engine.youtube import YOUTUBE_SCOPES
+    assert "https://www.googleapis.com/auth/youtube.force-ssl" in YOUTUBE_SCOPES
+
+
+def test_build_long_form_metadata_uses_description_template(tmp_path):
+    prompt = tmp_path / "yt_intro.txt"
+    prompt.write_text(
+        "Ep {episode_num}: {hook}\nShow: {show_name}",
+        encoding="utf-8",
+    )
+    cfg = _make_config()
+    cfg.youtube.description_prompt_file = str(prompt)
+    meta = vm.build_long_form_metadata(
+        cfg,
+        episode_num=5,
+        today_str="2026-05-20",
+        hook="Cybertruck news",
+        digest_text="# Digest\n\n**Should not appear** in YouTube body.",
+        audio_url="",
+    )
+    assert "Ep 5" in meta["description"]
+    assert "Cybertruck news" in meta["description"]
+    assert "Should not appear" not in meta["description"]
+
 
 def test_build_long_form_metadata_truncates_title_to_100_chars():
     config = _make_config(rss_title="X" * 80)

--- a/tests/test_youtube_preflight.py
+++ b/tests/test_youtube_preflight.py
@@ -1,0 +1,27 @@
+"""Tests for YouTube preflight validation."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from engine.youtube_preflight import validate_youtube_show_ready
+
+
+def test_enabled_show_requires_cover_and_queries(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    (root / "shows").mkdir(parents=True)
+    cfg = SimpleNamespace(
+        slug="tesla",
+        youtube=SimpleNamespace(
+            enabled=True,
+            channel="en",
+            privacy_status="public",
+            image_provider="pexels",
+            image_queries=["tesla car"],
+        ),
+    )
+    monkeypatch.setenv("YOUTUBE_CLIENT_ID", "id")
+    monkeypatch.setenv("YOUTUBE_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("YOUTUBE_REFRESH_TOKEN_EN", "token")
+    monkeypatch.setenv("PEXELS_API_KEY", "pex")
+    issues = validate_youtube_show_ready(cfg, root)
+    assert any("cover" in i.lower() for i in issues)

--- a/tests/test_youtube_quota.py
+++ b/tests/test_youtube_quota.py
@@ -1,0 +1,43 @@
+"""Tests for YouTube quota estimation."""
+
+from engine.youtube_quota import (
+    DEFAULT_DAILY_QUOTA,
+    estimate_episode_units,
+    estimate_network_daily_units,
+    format_quota_warning,
+)
+
+
+def test_estimate_episode_units_long_and_short():
+    est = estimate_episode_units(
+        publish_long_form=True,
+        publish_shorts=True,
+        with_caption_track=True,
+    )
+    assert est.uploads == 2
+    assert est.units > 3000
+
+
+def test_format_quota_warning_when_over():
+    summary = {
+        "over_quota": True,
+        "total_units": 12000,
+        "daily_quota": DEFAULT_DAILY_QUOTA,
+        "enabled_slugs": ["tesla", "models_agents_beginners"],
+    }
+    msg = format_quota_warning(summary)
+    assert msg is not None
+    assert "tesla" in msg
+
+
+def test_network_estimate_two_enabled_shows(tmp_path):
+    shows = tmp_path / "shows"
+    shows.mkdir()
+    for slug, enabled in (("tesla", True), ("omni_view", False)):
+        (shows / f"{slug}.yaml").write_text(
+            f"name: X\nslug: {slug}\nyoutube:\n  enabled: {enabled}\n",
+            encoding="utf-8",
+        )
+    summary = estimate_network_daily_units(shows)
+    assert summary["enabled_slugs"] == ["tesla"]
+    assert summary["total_units"] > 0

--- a/tests/test_youtube_shorts.py
+++ b/tests/test_youtube_shorts.py
@@ -1,0 +1,64 @@
+"""Tests for Shorts timing and quota-stagger helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from engine.youtube_shorts import (
+    resolve_shorts_start_offset,
+    should_upload_shorts_today,
+)
+
+
+def _config(*, voice_delay=10.0, intro_duration=10.0, **yt_kw):
+    return SimpleNamespace(
+        audio=SimpleNamespace(
+            voice_intro_delay=voice_delay,
+            intro_duration=intro_duration,
+        ),
+        youtube=SimpleNamespace(
+            shorts_start_offset=yt_kw.pop("shorts_start_offset", None),
+            shorts_start_mode=yt_kw.pop("shorts_start_mode", "voice"),
+            shorts_duration_seconds=55.0,
+            short_duration_seconds=55.0,
+            publish_shorts=True,
+            shorts_upload_schedule=yt_kw.pop(
+                "shorts_upload_schedule", "always",
+            ),
+            **yt_kw,
+        ),
+    )
+
+
+def test_voice_mode_uses_voice_intro_delay_only():
+    cfg = _config(voice_delay=10.0, intro_duration=10.0)
+    assert resolve_shorts_start_offset(cfg, None) == 10.0
+
+
+def test_explicit_offset_wins():
+    cfg = _config(shorts_start_offset=42.0)
+    assert resolve_shorts_start_offset(cfg, None) == 42.0
+
+
+def test_first_chapter_mode_uses_second_marker(tmp_path):
+    chapters = tmp_path / "chapters_ep001.json"
+    chapters.write_text(
+        json.dumps({
+            "chapters": [
+                {"title": "Intro", "startTime": 0},
+                {"title": "Story A", "startTime": 120},
+                {"title": "Story B", "startTime": 300},
+            ],
+        }),
+        encoding="utf-8",
+    )
+    cfg = _config(shorts_start_mode="first_chapter")
+    assert resolve_shorts_start_offset(cfg, chapters) == 120.0
+
+
+def test_alternate_episodes_schedule():
+    cfg = _config(shorts_upload_schedule="alternate_episodes")
+    assert should_upload_shorts_today(cfg, episode_num=2) is True
+    assert should_upload_shorts_today(cfg, episode_num=3) is False


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the YouTube pipeline review recommendations (P0–P2) before expanding uploads beyond Tesla + MAB.

## P0 — Blockers

- **Shorts audio start:** Uses `voice_intro_delay` only (fixes skipping ~10s of narration). Optional `shorts_start_mode: first_chapter` and `shorts_start_offset` in YAML.
- **OAuth:** Adds `youtube.force-ssl` scope for `captions.insert` (CC tracks). Bootstrap script + runbook updated — **operator must re-run OAuth** and replace refresh tokens.
- **Docs:** `docs/youtube_setup.md` corrected (TST+MAB, pipeline order, Grok disclosure, quota math, Studio podcast step).

## P1 — Quality & ops

- **`--resume-youtube`:** Rebuild/upload videos from existing MP3+digest without TTS/X/newsletter.
- **Upload retries:** Only 429/5xx (not permanent 400 `invalidDescription`).
- **ffmpeg errors:** stderr included in failure messages/metrics.
- **MAB:** `image_provider: pexels` for one-month A/B vs Tesla Grok.

## P2 — Polish

- **1080×1920 Shorts thumbnails** (from first vertical scene when available).
- **Description template** (`shows/prompts/youtube_description_intro.txt`) + pinned-comment hint in description.
- **Preflight:** Cover, credentials, Pexels/Grok keys, `image_queries` for enabled shows; network quota warning.
- **`shorts_upload_schedule: alternate_episodes`** to halve Shorts quota during rollout.

## Tests

- `tests/test_youtube_shorts.py`, `test_youtube_quota.py`, `test_youtube_preflight.py`
- Extended `tests/test_youtube.py` (scopes, description template)

## Operator follow-up (not in repo)

1. Re-run `scripts/youtube_oauth_bootstrap.py` after revoking old consent (for `force-ssl`).
2. Request YouTube API quota increase before enabling more shows.
3. Flag playlists as podcasts in YouTube Studio (one-time per playlist).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1dbdf264-5d2f-4f12-8a28-2b8c3037db26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1dbdf264-5d2f-4f12-8a28-2b8c3037db26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

