### PR TITLE
youtube: fix caption sync + drop captions/hook into bottom third

### DIFF
--- a/engine/captions.py
+++ b/engine/captions.py
@@ -76,7 +76,8 @@ def _wrap_caption_line(text: str, max_chars: int = 42) -> str:
 
 
 def transcript_to_srt(transcript_path: Path, srt_path: Path,
-                      *, min_segment_duration: float = 0.4) -> Path:
+                      *, min_segment_duration: float = 0.4,
+                      audio_offset_seconds: float = 0.0) -> Path:
     """Convert a faster-whisper transcript JSON into SRT subtitles.
 
     Parameters
@@ -89,6 +90,20 @@ def transcript_to_srt(transcript_path: Path, srt_path: Path,
         Skip cues shorter than this many seconds. Whisper sometimes
         emits sub-100ms artifacts for breath/punctuation that flicker
         on screen.
+    audio_offset_seconds:
+        Shift every cue right by this many seconds. Required when the
+        Whisper transcript was generated against a voice-only "raw"
+        MP3 but the video uses the post-mix final MP3 that prepends
+        a music intro. The pipeline transcribes the raw voice to get
+        clean word boundaries (music confuses Whisper), then offsets
+        the SRT by ``config.audio.voice_intro_delay`` so the cues
+        align with the speech inside the final mix. Without this
+        offset every caption on a show with a 25 s music intro
+        (Planetterrian, Unintended Consequences) appeared 25 s
+        earlier than the corresponding speech on the YouTube long-
+        form — operator reported the result as "terrible". Defaults
+        to ``0.0`` for back-compat with any caller that already
+        feeds an aligned transcript.
 
     Returns
     -------
@@ -97,6 +112,10 @@ def transcript_to_srt(transcript_path: Path, srt_path: Path,
     """
     if not transcript_path.exists():
         raise FileNotFoundError(f"transcript not found: {transcript_path}")
+    if audio_offset_seconds < 0:
+        raise ValueError(
+            f"audio_offset_seconds must be >= 0; got {audio_offset_seconds}"
+        )
 
     data = json.loads(transcript_path.read_text(encoding="utf-8"))
     segments = data.get("segments") or []
@@ -117,8 +136,8 @@ def transcript_to_srt(transcript_path: Path, srt_path: Path,
         if start is None or end is None or not text:
             continue
         try:
-            start_f = float(start)
-            end_f = float(end)
+            start_f = float(start) + audio_offset_seconds
+            end_f = float(end) + audio_offset_seconds
         except (TypeError, ValueError):
             continue
         if end_f - start_f < min_segment_duration:

--- a/engine/video.py
+++ b/engine/video.py
@@ -388,22 +388,35 @@ def _render_slideshow(scene_paths: Sequence[Path], output: Path,
 # ---------------------------------------------------------------------------
 
 # Force-style for the burn-in subtitles. ASS color format is &HAABBGGRR
-# (alpha is "100 minus opacity" — 0 is opaque, 255 is transparent).
-# BorderStyle=3 = opaque box behind the text. MarginV=80 sits the
-# subtitle baseline near the bottom edge — without the spectrum band
-# we used to lift captions above, this is the standard subtitle
-# position.
+# (alpha is "amount of transparency" — 0x00 is opaque, 0xFF is
+# transparent). The May 2026 operator review of the long-form YouTube
+# output asked for two changes:
+#
+#   1. Position firmly in the bottom third of the 1920x1080 frame
+#      rather than the previous "near the bottom edge" baseline.
+#      ``MarginV=120`` lifts the baseline ~120 px above the bottom
+#      edge, placing the caption text roughly y≈940 — comfortably
+#      inside the bottom-third zone (y > 720) but still high enough
+#      not to overlap the YouTube progress-bar HUD on mobile.
+#   2. "Not as prominent." Drop the opaque box behind the text
+#      (``BorderStyle=3`` → ``BorderStyle=1`` outline-only with a
+#      strong outline + soft shadow) so the slideshow imagery stays
+#      visible behind the words. Smaller font (22 → 18) reads less
+#      as "burned-in subtitle bar" and more as "auto-caption hint."
+#      White text + black 3 px outline + 1 px shadow remains
+#      readable against bright backgrounds (matches YouTube's own
+#      auto-caption styling).
 _SUBTITLES_FORCE_STYLE = (
     "FontName=DejaVu Sans,"
-    "FontSize=22,"
+    "FontSize=18,"
     "PrimaryColour=&H00FFFFFF,"
     "OutlineColour=&H00000000,"
-    "BackColour=&HA0000000,"
-    "BorderStyle=3,"
-    "Outline=4,"
-    "Shadow=0,"
+    "BackColour=&H00000000,"
+    "BorderStyle=1,"
+    "Outline=3,"
+    "Shadow=1,"
     "Alignment=2,"
-    "MarginV=80"
+    "MarginV=120"
 )
 
 
@@ -534,13 +547,30 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
     if hook:
         wrapped = _wrap_caption(hook)
         escaped = _drawtext_escape(wrapped)
+        # May 2026 operator review: move the hook out of the top
+        # half (was y=240) into the bottom third of the 1080x1920
+        # frame and reduce visual weight to match the long-form
+        # caption treatment.
+        #   * ``y=h*0.70`` puts the text baseline at y≈1344, which
+        #     centres the wrapped caption inside the bottom third
+        #     (y > 1280) while leaving room above the
+        #     ``H-h-100`` URL pill that sits at y≈1820 when
+        #     ``with_url_pill=True``.
+        #   * ``fontsize=44`` (was 64) is still readable on a
+        #     phone but no longer dominates the slideshow.
+        #   * Outline-only (no ``box=1`` solid fill) keeps the
+        #     imagery visible behind the words. A 4 px black
+        #     outline + 2 px shadow stays readable on bright
+        #     backgrounds without painting a black rectangle
+        #     across the frame.
         caption = (
             f";{post_brand_label}drawtext=fontfile='{font_path}':"
             f"text='{escaped}':"
-            f"fontsize=64:fontcolor=white:"
-            f"x=(w-text_w)/2:y=240:"
-            f"box=1:boxcolor=black@0.6:boxborderw=24:"
-            f"line_spacing=14:"
+            f"fontsize=44:fontcolor=white:"
+            f"x=(w-text_w)/2:y=h*0.70:"
+            f"borderw=4:bordercolor=black:"
+            f"shadowx=2:shadowy=2:shadowcolor=black@0.7:"
+            f"line_spacing=10:"
             f"enable='between(t,0,3)'"
             f"[v]"
         )

--- a/run_show.py
+++ b/run_show.py
@@ -3018,7 +3018,21 @@ def _publish_youtube(
     if transcript_path is not None:
         try:
             srt_candidate = work_dir / f"{base_name}.srt"
-            transcript_to_srt(transcript_path, srt_candidate)
+            # Whisper transcribes the voice-only raw MP3 (music
+            # confuses the segment timestamps), but the long-form
+            # video uses the final MP3 that prepends
+            # ``voice_intro_delay`` seconds of music. Offset the SRT
+            # by exactly that delay so the burned-in captions land
+            # on the speech instead of the music intro. See the
+            # captions.transcript_to_srt docstring for context.
+            _caption_offset = float(
+                getattr(config.audio, "voice_intro_delay", 0.0) or 0.0
+            )
+            transcript_to_srt(
+                transcript_path,
+                srt_candidate,
+                audio_offset_seconds=_caption_offset,
+            )
             srt_path = srt_candidate
         except Exception as exc:  # pragma: no cover — best-effort
             logger.warning("Caption generation failed: %s", exc)

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -108,6 +108,67 @@ def test_transcript_to_srt_missing_file_raises(tmp_path: Path):
         transcript_to_srt(tmp_path / "missing.json", tmp_path / "out.srt")
 
 
+def test_transcript_to_srt_applies_audio_offset(tmp_path: Path):
+    """Whisper transcribes the voice-only raw MP3 (t=0 at first word)
+    but the long-form video uses the final MP3 with a music intro
+    prepended. ``audio_offset_seconds`` shifts every cue right by
+    the music-intro duration so the captions land on the speech
+    instead of the music. Without this offset PT/UC episodes (25 s
+    intro) ship with every caption 25 s ahead of the audio."""
+    transcript = {
+        "language": "en",
+        "duration": 30.0,
+        "segments": [
+            {"start": 0.0, "end": 2.5, "text": "First sentence"},
+            {"start": 3.0, "end": 6.5, "text": "Second sentence"},
+        ],
+    }
+    transcript_path = tmp_path / "ep_transcript.json"
+    transcript_path.write_text(json.dumps(transcript), encoding="utf-8")
+    srt_path = tmp_path / "ep.srt"
+    transcript_to_srt(transcript_path, srt_path, audio_offset_seconds=25.0)
+
+    content = srt_path.read_text(encoding="utf-8")
+    # First cue: 0.0 → 2.5 becomes 25.0 → 27.5
+    assert "00:00:25,000 --> 00:00:27,500" in content
+    # Second cue: 3.0 → 6.5 becomes 28.0 → 31.5
+    assert "00:00:28,000 --> 00:00:31,500" in content
+    # The pre-offset timestamps must NOT survive.
+    assert "00:00:00,000 --> 00:00:02,500" not in content
+
+
+def test_transcript_to_srt_zero_offset_matches_legacy(tmp_path: Path):
+    """``audio_offset_seconds=0`` is the back-compat default — must
+    produce exactly the same SRT as a caller that omits the arg."""
+    transcript = {
+        "segments": [
+            {"start": 0.0, "end": 2.0, "text": "Hello"},
+        ],
+    }
+    transcript_path = tmp_path / "t.json"
+    transcript_path.write_text(json.dumps(transcript), encoding="utf-8")
+    srt_a = tmp_path / "a.srt"
+    srt_b = tmp_path / "b.srt"
+    transcript_to_srt(transcript_path, srt_a)
+    transcript_to_srt(transcript_path, srt_b, audio_offset_seconds=0.0)
+    assert srt_a.read_text() == srt_b.read_text()
+
+
+def test_transcript_to_srt_negative_offset_raises(tmp_path: Path):
+    """Negative offsets would shift cues to before the audio starts
+    and clamp at 00:00:00,000 — visually indistinguishable from a
+    correctly-aligned SRT, which would mask a calibration bug. Fail
+    loudly instead."""
+    transcript = {"segments": [{"start": 1.0, "end": 2.0, "text": "x"}]}
+    transcript_path = tmp_path / "t.json"
+    transcript_path.write_text(json.dumps(transcript), encoding="utf-8")
+    with pytest.raises(ValueError, match="audio_offset_seconds"):
+        transcript_to_srt(
+            transcript_path, tmp_path / "out.srt",
+            audio_offset_seconds=-1.0,
+        )
+
+
 def test_find_transcript_for_episode(tmp_path: Path):
     digests = tmp_path / "digests"
     digests.mkdir()

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -124,6 +124,38 @@ def test_short_form_filter_graph_with_hook_burns_caption():
     assert graph.endswith("[v]")
 
 
+def test_short_form_filter_graph_hook_sits_in_bottom_third():
+    """May 2026 operator review: the shorts hook moved out of the
+    top half (was ``y=240``) into the bottom third of the
+    1080x1920 frame. ``y=h*0.70`` puts the baseline at y≈1344,
+    well inside the bottom-third zone (y > 1280) and above the
+    URL pill at y≈1820. Pin the new position so a future style
+    edit doesn't drift back to the top."""
+    graph = _short_form_filter_graph(hook="anything")
+    # New bottom-third position.
+    assert "y=h*0.70" in graph
+    # Old top-of-frame position must not return.
+    assert "y=240" not in graph
+
+
+def test_short_form_filter_graph_hook_is_not_prominent():
+    """May 2026 operator review: drop the opaque-box treatment
+    (was ``box=1:boxcolor=black@0.6``) and shrink the font (64
+    → 44) so the hook no longer dominates the slideshow during
+    its 3-second window. Outline + shadow keep it readable on
+    bright frames without painting a black rectangle."""
+    graph = _short_form_filter_graph(hook="anything")
+    # Smaller font.
+    assert "fontsize=44" in graph
+    assert "fontsize=64" not in graph
+    # No opaque box behind the text.
+    assert "box=1" not in graph
+    assert "boxcolor=" not in graph
+    # Outline + soft shadow for readability without prominence.
+    assert "borderw=4" in graph
+    assert "bordercolor=black" in graph
+
+
 def test_short_form_filter_graph_without_hook_omits_caption():
     graph = _short_form_filter_graph(hook=None)
     # No first-3s caption when hook isn't provided.
@@ -522,9 +554,12 @@ def test_long_form_filter_graph_with_subtitles_appends_filter():
     # ASS force-style is appended.
     assert "force_style=" in graph
     assert "Alignment=2" in graph
-    # Subtitles sit at standard bottom margin now (no spectrum band
-    # to lift them above).
-    assert "MarginV=80" in graph
+    # Subtitles sit in the bottom third of the 1920x1080 frame (May
+    # 2026 operator review). ``MarginV=120`` puts the baseline ~120
+    # px above the bottom edge — comfortably below y=720 (bottom
+    # third boundary) and high enough that the YouTube progress bar
+    # doesn't overlap on mobile.
+    assert "MarginV=120" in graph
     # Subtitles attach to the [branded] stage (was [disclosed] before
     # the centered burn-in was removed).
     assert "[branded]subtitles=" in graph
@@ -548,14 +583,21 @@ def test_subtitles_path_escape_handles_metacharacters():
 
 
 def test_subtitles_force_style_has_required_fields():
-    """Sanity check on the ASS force-style string."""
+    """Sanity check on the ASS force-style string. May 2026 retune:
+    pin the new "auto-caption-style" look so a future style edit
+    doesn't silently regress to the old opaque-box look the operator
+    asked to remove ("make it not as prominent")."""
     assert "FontName=DejaVu Sans" in _SUBTITLES_FORCE_STYLE
     assert "Alignment=2" in _SUBTITLES_FORCE_STYLE
-    # Standard bottom-edge subtitle position now that the spectrum
-    # band is gone.
-    assert "MarginV=80" in _SUBTITLES_FORCE_STYLE
-    # BorderStyle=3 = opaque box behind text (better readability than outline).
-    assert "BorderStyle=3" in _SUBTITLES_FORCE_STYLE
+    # Bottom-third position (May 2026 operator review).
+    assert "MarginV=120" in _SUBTITLES_FORCE_STYLE
+    # BorderStyle=1 = outline + soft shadow only (no opaque box).
+    # Keeps the slideshow imagery visible behind the words.
+    assert "BorderStyle=1" in _SUBTITLES_FORCE_STYLE
+    assert "BorderStyle=3" not in _SUBTITLES_FORCE_STYLE
+    # Smaller font reads less as "subtitle bar" and more as
+    # "auto-caption hint" — also matches YouTube auto-caption sizing.
+    assert "FontSize=18" in _SUBTITLES_FORCE_STYLE
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Operator reported the YouTube long-form captions were "terrible" — out of sync with the speech — and asked for both long-form captions AND the Shorts hook to sit in the bottom third of the frame with less visual weight. Three independent fixes wired together.

## 1. Sync bug (the "terrible" part)

**Root cause:** `engine.transcripts.generate_transcript` runs Whisper on `raw_mp3` (voice-only TTS output) at `run_show.py:1953`, but `build_long_form_video` plays `final_mp3` (which prepends `voice_intro_delay` seconds of music intro via `engine.audio.mix_with_music`).

| Show | `voice_intro_delay` | Captions appeared |
|---|---:|---|
| Tesla / FF | 10 s | 10 s ahead of speech |
| Planetterrian | 25 s | **25 s ahead of speech** |
| Unintended Consequences | 10 s | 10 s ahead of speech |

For PT/UC every line of dialogue showed up a quarter-minute before the corresponding audio — the operator-described "terrible."

**Fix:** new `transcript_to_srt(..., audio_offset_seconds=...)` kwarg that shifts every cue right by N seconds. The runner passes `config.audio.voice_intro_delay` so each show's offset matches its own mix. Whisper continues to transcribe the voice-only raw MP3 (more accurate than letting it process music) and the alignment happens at SRT-emission time. Negative offsets `ValueError` instead of silently clamping early cues to `00:00:00,000`.

## 2. Long-form caption styling

Pure visual changes in `_SUBTITLES_FORCE_STYLE`:

| Field | Was | Now | Rationale |
|---|---|---|---|
| `MarginV` | 80 | **120** | Baseline ~y=940 — firmly in bottom third (y>720), clear of YouTube mobile progress bar |
| `BorderStyle` | 3 (opaque box) | **1** (outline only) | Removes the black bar painting across slideshow imagery |
| `FontSize` | 22 | **18** | Reads as "auto-caption hint" not "subtitle bar"; matches YouTube auto-captions |
| `Outline` | 4 | **3** | Slightly thinner |
| `Shadow` | 0 | **1** | Soft drop-shadow for readability on bright frames |

## 3. Shorts hook position + styling

The Shorts hook drawtext was at `y=240` (top of the 1920-tall frame) with `fontsize=64` and a `box=1:boxcolor=black@0.6` opaque backdrop.

| Field | Was | Now |
|---|---|---|
| `y` | `240` | `h*0.70` (≈1344, bottom third) |
| `fontsize` | 64 | 44 |
| `box=1:boxcolor=black@0.6` | yes | **removed** |
| Outline + shadow | none | `borderw=4 bordercolor=black shadowx=2 shadowy=2 shadowcolor=black@0.7` |

0-3 s display window and centred horizontal positioning unchanged. URL pill at y≈1820 leaves ~480 px clearance above the new hook position.

## Drift guards

```
tests/test_captions.py
  ✓ test_transcript_to_srt_applies_audio_offset
  ✓ test_transcript_to_srt_zero_offset_matches_legacy
  ✓ test_transcript_to_srt_negative_offset_raises

tests/test_video_commands.py
  ✓ test_subtitles_force_style_has_required_fields (updated: MarginV=120, BorderStyle=1, FontSize=18)
  ✓ test_long_form_filter_graph_with_subtitles_appends_filter (updated: MarginV=120)
  ✓ test_short_form_filter_graph_hook_sits_in_bottom_third (new)
  ✓ test_short_form_filter_graph_hook_is_not_prominent (new)
```

`BorderStyle=3` is now explicitly forbidden in the style assertion so a future style edit can't silently revert to the opaque-box look.

## What does NOT change

- Existing uploads on YouTube are unchanged — only **future** runs pick up the new appearance.
- The Shorts hook still shows for the first 3 seconds only.
- Whisper still runs on the voice-only raw MP3 (no accuracy regression from forcing it to process music).
- Captions are still segment-level (~5-10 s per cue), matching YouTube's auto-caption pacing.

## Test plan

- [x] `pytest tests/test_captions.py tests/test_video_commands.py` — 62 passed.
- [x] `pytest tests/` — 1869 passed, 6 skipped.
- [x] Filter-graph output inspected manually — long-form subtitles + shorts hook render the expected ASS / drawtext strings.
- [ ] Next scheduled run produces a long-form with synced captions + low-prominence styling.
- [ ] Same run's Shorts shows the hook in the bottom third with no opaque box.

## Future work (out of scope)

Shorts currently show only the 3-second hook — they don't yet have synced burn-in captions for the rest of the clip. That would be a follow-up: filter the SRT to the `[start_offset, start_offset+duration]` window, subtract `start_offset` from each cue, and pass that trimmed SRT to `_short_form_filter_graph`.


---
_Generated by [Claude Code](https://claude.ai/code/session_013sWzi3YLLjJgckvarquWZS)_