### PR TITLE
newsletter: unblock OV / MIT / PR — bare-label header was hard-blocking sends

### DIFF
--- a/engine/newsletter_sanitizer.py
+++ b/engine/newsletter_sanitizer.py
@@ -218,12 +218,51 @@ def find_scaffold_leaks(text: str) -> List[str]:
                 sample = sample[:77] + "..."
             leaks.append(f"{name}: {sample!r}")
     # Generic catch-all: any line that's literally `**Anything Capitalized:**`
-    # at the start of a line is suspicious. We keep this *after* the
-    # specific-label pass so legit prose like "**Tesla:** A car company"
-    # mid-sentence doesn't trip — the start-of-line anchor + the rest of
-    # the line being *only* the label is the giveaway.
-    bare_label = re.compile(r"(?m)^\s*\*\*[A-Z][\w '-]{2,40}:\*\*\s*$")
+    # at the start of a line is suspicious — but ONLY when nothing
+    # follows on the next line.
+    #
+    # A bare `**Label:**` line followed by a bullet, a paragraph, a sub-
+    # header, or any other content is a legitimate Markdown section
+    # header — multiple show prompts define them deliberately:
+    #
+    #   Omni View    : ``**Questions to consider:**`` then ``- bullet``
+    #   Modern Inv.  : ``**AI Analysis:**`` then ``- **Catalyst:** ...``
+    #   Privet Rus.  : ``**Grammar Spotlight:**`` then prose paragraph
+    #
+    # The May 2026 send pipeline was hard-blocking those three shows
+    # ("haven't seen buttondown newsletters lately" — operator) because
+    # the regex didn't distinguish "header with content below" from
+    # "orphaned scaffold leak."
+    #
+    # New behaviour: only flag a label as scaffold when the next
+    # non-blank line is itself empty, another bare label, the end of the
+    # text, or another structural divider (i.e. nothing real underneath
+    # to render). A label with bullets / prose / a sub-header /
+    # blockquote / code on the next non-blank line is a legitimate
+    # section break and ships.
+    bare_label = re.compile(r"(?m)^[ \t]*\*\*[A-Z][\w '-]{2,40}:\*\*[ \t]*$")
+    lines = text.splitlines()
     for m in bare_label.finditer(text):
+        # Find which line the match starts on so we can inspect what
+        # comes after it. ``count`` is the line index of the label.
+        line_idx = text[:m.start()].count("\n")
+        # Scan forward for the next non-blank line.
+        follower: str | None = None
+        for nxt in lines[line_idx + 1:]:
+            stripped = nxt.strip()
+            if stripped:
+                follower = stripped
+                break
+        # No follower at all → label is truly orphaned at end of text.
+        is_orphan = follower is None
+        # Follower is also a bare label → cluster of scaffolding.
+        is_cluster = bool(
+            follower and bare_label.fullmatch(follower)
+        )
+        if not (is_orphan or is_cluster):
+            # A real follower (bullet, prose, sub-header) means this is
+            # a legitimate section header, not scaffold. Skip.
+            continue
         sample = m.group(0).strip()
         if len(sample) > 80:
             sample = sample[:77] + "..."

--- a/run_show.py
+++ b/run_show.py
@@ -2416,6 +2416,16 @@ def run(args: argparse.Namespace) -> None:
             email_id = None
             logger.exception("Newsletter send raised: %s", exc)
 
+        # Record the send outcome in metrics.json so the operator can
+        # spot a pipeline-wide silent-failure (e.g. May 2026 audit
+        # caught all three of OV / Modern Investing / Privet Russian
+        # being scaffold-blocked for weeks without a metric to flag
+        # it). ``newsletter_email_id`` is None on every blocked path;
+        # the bool counter is the easier-to-grep daily signal.
+        metrics.record("newsletter_sent", bool(email_id))
+        if email_id:
+            metrics.record("newsletter_email_id", email_id)
+
         if email_id:
             logger.info("Newsletter sent: %s", email_id)
         else:

--- a/tests/test_newsletter_sanitizer.py
+++ b/tests/test_newsletter_sanitizer.py
@@ -124,10 +124,69 @@ class TestFindScaffoldLeaks:
 
     def test_bare_label_line_is_caught_by_generic_rule(self):
         """A new label we forgot to add to the blocklist still trips
-        the generic ``^**Capitalized:**$`` catch-all."""
+        the generic ``^**Capitalized:**$`` catch-all when it stands
+        alone with no content under it."""
         text = "**Today's Insight:**"
         leaks = find_scaffold_leaks(text)
         assert any("bare-label line" in m for m in leaks)
+
+    def test_bare_label_with_bullets_below_is_not_scaffold(self):
+        """Multiple show prompts emit legitimate Markdown section
+        headers as bare labels followed by bullet content. Operator
+        report May 22 2026: "I haven't seen buttondown newsletters
+        lately" traced to Omni View / Modern Investing / Privet
+        Russian sending blocked because the old catch-all flagged
+        ``**Questions to consider:**`` as scaffold even though bullets
+        immediately followed. Real content under the label = real
+        section header = ship."""
+        text = (
+            "**Questions to consider:**\n"
+            "- What changes in shipping routes if oversight increases?\n"
+            "- Which countries have the strongest interest?\n"
+        )
+        leaks = find_scaffold_leaks(text)
+        assert not any("bare-label" in m for m in leaks), leaks
+
+    def test_bare_label_with_paragraph_below_is_not_scaffold(self):
+        """The Privet Russian ``**Grammar Spotlight:**`` shape — label
+        on its own line followed by a prose paragraph — must ship as
+        a section header, not block as scaffold."""
+        text = (
+            "**Grammar Spotlight:**\n"
+            "We are learning how to say \"it is\" with weather words.\n"
+        )
+        assert find_scaffold_leaks(text) == []
+
+    def test_bare_label_with_sub_label_below_is_not_scaffold(self):
+        """Modern Investing ``**AI Analysis:**`` is followed by a
+        bullet whose marker is another bold label (``- **Catalyst:**
+        ...``). The bullet's `-` prefix means it's content, not a
+        bare label, so the section header must ship."""
+        text = (
+            "**AI Analysis:**\n"
+            "- **Catalyst:** Policy announcement on quantum grants.\n"
+        )
+        assert find_scaffold_leaks(text) == []
+
+    def test_orphan_bare_label_at_end_of_text_still_flagged(self):
+        """A label with nothing under it (end of body or pre-truncation
+        scaffold) IS scaffold and must still block."""
+        text = "Some intro content.\n\n**Trailing Scaffold Label:**"
+        leaks = find_scaffold_leaks(text)
+        assert any("bare-label" in m for m in leaks)
+
+    def test_back_to_back_bare_labels_flagged_as_scaffold_cluster(self):
+        """When two bare labels follow each other with no content
+        between, it's a cluster of scaffolding the LLM mirrored from
+        the prompt, not a section header. Block both."""
+        text = (
+            "**Topic Selection:**\n"
+            "\n"
+            "**Topic Freshness:**\n"
+        )
+        leaks = find_scaffold_leaks(text)
+        # At least one of the two should fire; both are scaffolding.
+        assert any("bare-label" in m for m in leaks)
 
     def test_after_scrubbing_known_labels_clean(self):
         text = "**HOOK:** Body content.\n\n**Date:** May 02, 2026\n\nDone."


### PR DESCRIPTION
## Summary

Operator report: _"I haven't seen Buttondown newsletters lately."_

**Three shows have been silently scaffold-blocked, every send, for weeks.** Bug, not config. The bare-label catch-all in `engine.newsletter_sanitizer.find_scaffold_leaks` was flagging legitimate Markdown section headers as if they were prompt scaffolding the LLM had mirrored verbatim.

## Evidence — run scrubber + transforms + leak detector against latest digest of every enabled show

**Before this PR:**

```
tesla                          PASS
planetterrian                  PASS
fascinating_frontiers          PASS
omni_view                      BLOCK (13 leaks)   ← **Questions to consider:** × 13
models_agents                  PASS
models_agents_beginners        PASS
modern_investing               BLOCK (1 leak)     ← **AI Analysis:**
unintended_consequences        PASS
env_intel                      PASS
finansy_prosto                 PASS
privet_russian                 BLOCK (3 leaks)    ← **Grammar Spotlight:** / **Cultural Corner:** / **Practice Challenge:**
```

**After this PR:**

```
All 11 enabled shows           PASS
```

## Root cause

The catch-all regex `^\s*\*\*[A-Z][\w '-]{2,40}:\*\*\s*$` matches ANY line that's only a bold-and-colon label. The intent was to catch prompt labels the LLM mirrored verbatim into the output (`**TOPIC SELECTION:**`, `**TOPIC FRESHNESS:**`, etc.). It also matched legitimate Markdown section headers that were SUPPOSED to be there:

- **Omni View prompt** (line 55): `**Questions to consider:** 2–4 bullets`
- **Modern Investing prompt** (line 123): `**AI Analysis:**` + bullet list of catalyst/setup/risk
- **Privet Russian prompt** (lines 44, 74, 77): `**Grammar Spotlight:**` / `**Cultural Corner:**` / `**Practice Challenge:**`

The send pipeline hard-blocks on any non-empty leak list (`assert_clean` → `ScaffoldLeakError`), so the email never went out. The block was logged at ERROR level but no metric carried the outcome — the only evidence available to the operator was their inbox.

## Fix

1. **`engine/newsletter_sanitizer.py`** — bare-label detector now inspects the next non-blank line. A label is flagged ONLY when the follower is:
   - absent (orphan at end of text), or
   - another bare label (cluster of scaffolding)

   A follower with real content (bullet, prose, sub-header, blockquote) means the label is a legitimate section break — keep, ship.

   `scrub_scaffold` is **unchanged**; specific labels in `SCAFFOLD_PATTERNS` (`HOOK` / `Date` / `Theme` / `TOPIC SELECTION` / `LENGTH TARGET` / `WHAT TO SKIP` / etc.) still get stripped regardless of what follows. Only the generic "label-shape" detect layer narrowed.

2. **`run_show.py`** — send outcome now recorded in `metrics.json` (`newsletter_sent: bool`, `newsletter_email_id` on success). The silent-failure mode that hid this for weeks was the absence of any per-episode signal — only the operator's empty inbox.

3. **`tests/test_newsletter_sanitizer.py`** — 5 new behavioural tests pin the new logic both ways:

   ```
   test_bare_label_with_bullets_below_is_not_scaffold
   test_bare_label_with_paragraph_below_is_not_scaffold
   test_bare_label_with_sub_label_below_is_not_scaffold
   test_orphan_bare_label_at_end_of_text_still_flagged
   test_back_to_back_bare_labels_flagged_as_scaffold_cluster
   ```

## What does NOT change

- Specific known-scaffold patterns (`**HOOK:**`, `**TOPIC SELECTION:**`, etc.) still strip + still trigger `ScaffoldLeakError` if they survive scrubbing.
- The 20-hour same-day double-send guardrail.
- The WCAG contrast hard-block.
- The Buttondown API + slug + tag plumbing.
- Daily / weekly subject-line construction.

## Test plan

- [x] `pytest tests/test_newsletter_sanitizer.py` — 25 passed (5 new).
- [x] `pytest tests/` — 1874 passed.
- [x] End-to-end scrub + transform + leak-detect against the latest digest of every enabled show — all 11 pass.
- [ ] Next scheduled run produces newsletters for Omni View, Modern Investing, and Privet Russian (operator confirms in inbox).


---
_Generated by [Claude Code](https://claude.ai/code/session_013sWzi3YLLjJgckvarquWZS)_