### PR TITLE
youtube: full transcript shown, flush-bottom long-form, synced Shorts captions

### DIFF
--- a/engine/captions.py
+++ b/engine/captions.py
@@ -42,12 +42,28 @@ def _format_srt_timestamp(seconds: float) -> str:
     return f"{hours:02d}:{minutes:02d}:{secs:02d},{ms:03d}"
 
 
-def _wrap_caption_line(text: str, max_chars: int = 42) -> str:
-    """Greedy word-wrap so each caption stays at ≤2 lines.
+def _wrap_caption_line(text: str, max_chars: int = 55,
+                       max_lines: int = 3) -> str:
+    """Greedy word-wrap so each caption stays within *max_lines*.
+
+    May 2026 operator report: "transcript appears to not be the full
+    script shown." Root cause was the previous 2-line cap with
+    ``lines[-1] = " ".join(rest)`` — when text overflowed the
+    second line, the code OVERWROTE line 2's already-committed
+    content with the remainder, losing whatever words had been
+    placed in line 2 before the cutoff. The right-side text of
+    every long cue was silently clipped.
+
+    Fix: wider per-line budget (55 chars at FontSize=22 still sits
+    well inside the 1920-wide long-form frame and the 1080-wide
+    Shorts frame; mobile players are the bottleneck) and a true
+    multi-line wrap. If a single Whisper segment is so long it
+    exceeds ``max_chars * max_lines``, the LAST line is allowed
+    to overflow horizontally (libass clips gracefully on the
+    right) — better than dropping committed earlier lines.
 
     SRT renders blank lines as cue terminators, so we use ``\\n``
-    between lines within a single cue. 42 chars per line at ~30pt
-    sits inside a 1920-wide frame with margins.
+    between lines within a single cue.
     """
     text = " ".join(text.split())
     if len(text) <= max_chars:
@@ -55,21 +71,27 @@ def _wrap_caption_line(text: str, max_chars: int = 42) -> str:
     words = text.split()
     lines: List[str] = []
     current = ""
-    for word in words:
+    i = 0
+    while i < len(words):
+        word = words[i]
         candidate = f"{current} {word}".strip()
+        # Fits on the current line — accept and continue.
         if len(candidate) <= max_chars or not current:
             current = candidate
-        else:
-            lines.append(current)
-            current = word
-            if len(lines) >= 2:
-                # Trailing words go in the second line — let it overflow
-                # rather than truncate; the caption renderer can clip
-                # gracefully but a missing word reads as a transcription
-                # error.
-                rest = [current] + [w for w in words[words.index(word) + 1:]]
-                lines[-1] = " ".join(rest)
-                return "\n".join(lines)
+            i += 1
+            continue
+        # Doesn't fit: commit ``current`` and start a new line.
+        lines.append(current)
+        current = ""
+        if len(lines) >= max_lines:
+            # Already filled all ``max_lines`` complete lines.
+            # Tack the remaining words onto the LAST committed
+            # line and let libass clip on the right. The earlier
+            # lines stay intact (no overwrite — that was the bug).
+            rest = " ".join(words[i:])
+            lines[-1] = (lines[-1] + " " + rest).strip()
+            return "\n".join(lines)
+        # Try this word on the new line in the next iteration.
     if current:
         lines.append(current)
     return "\n".join(lines)
@@ -169,6 +191,137 @@ def transcript_to_srt(transcript_path: Path, srt_path: Path,
         )
         raise
     logger.info("Wrote %d caption cues → %s", len(cues), srt_path.name)
+    return srt_path
+
+
+def transcript_to_srt_window(
+    transcript_path: Path,
+    srt_path: Path,
+    *,
+    window_start_seconds: float,
+    window_duration_seconds: float,
+    audio_offset_seconds: float = 0.0,
+    min_segment_duration: float = 0.4,
+    wrap_max_chars: int = 32,
+    wrap_max_lines: int = 3,
+) -> Path:
+    """Emit a SRT containing only the cues that fall inside a time
+    window of the FINAL audio, with their timestamps shifted so the
+    SRT starts at t=0 relative to the window.
+
+    Used by the YouTube Shorts pipeline: the Shorts MP4 plays the
+    audio slice ``[window_start_seconds, window_start_seconds +
+    window_duration_seconds]`` of the final episode MP3, so the
+    cues that originally landed within that slice need their
+    timestamps rebased to the Shorts clip's own timeline.
+
+    The wrap is tighter (32 chars / 3 lines) than the long-form
+    default because vertical Shorts have a 1080-px wide frame
+    versus 1920 long-form; wider line lengths spill past the visible
+    edge on phones.
+
+    Parameters
+    ----------
+    transcript_path, srt_path, audio_offset_seconds, min_segment_duration:
+        Same as ``transcript_to_srt``.
+    window_start_seconds, window_duration_seconds:
+        The slice of the FINAL audio (after the music intro offset
+        has already been applied via ``audio_offset_seconds``) that
+        the Shorts MP4 plays. Both in seconds, ``start`` >= 0.
+    wrap_max_chars, wrap_max_lines:
+        Per-line and per-cue limits — tighter than the long-form
+        defaults to fit the vertical Shorts frame.
+
+    Returns
+    -------
+    Path
+        ``srt_path`` on success. The file may be empty if no cues
+        fall inside the window (caller should treat that as
+        "skip burn-in captions for this Shorts run").
+    """
+    if not transcript_path.exists():
+        raise FileNotFoundError(f"transcript not found: {transcript_path}")
+    if audio_offset_seconds < 0:
+        raise ValueError(
+            f"audio_offset_seconds must be >= 0; got {audio_offset_seconds}"
+        )
+    if window_start_seconds < 0:
+        raise ValueError(
+            f"window_start_seconds must be >= 0; got {window_start_seconds}"
+        )
+    if window_duration_seconds <= 0:
+        raise ValueError(
+            f"window_duration_seconds must be > 0; got {window_duration_seconds}"
+        )
+
+    data = json.loads(transcript_path.read_text(encoding="utf-8"))
+    segments = data.get("segments") or []
+    if not isinstance(segments, list):
+        raise ValueError(
+            f"transcript JSON {transcript_path} has no 'segments' list"
+        )
+
+    window_end = window_start_seconds + window_duration_seconds
+    srt_path.parent.mkdir(parents=True, exist_ok=True)
+    cues: List[str] = []
+    cue_index = 1
+    for seg in segments:
+        if not isinstance(seg, dict):
+            continue
+        start = seg.get("start")
+        end = seg.get("end")
+        text = (seg.get("text") or "").strip()
+        if start is None or end is None or not text:
+            continue
+        try:
+            # Shift to final-audio timeline first, then check window.
+            start_f = float(start) + audio_offset_seconds
+            end_f = float(end) + audio_offset_seconds
+        except (TypeError, ValueError):
+            continue
+        # Skip cues that don't overlap the Shorts window at all.
+        if end_f <= window_start_seconds or start_f >= window_end:
+            continue
+        # Clip cues that straddle a window boundary so they don't
+        # spill into negative-time or past-end territory.
+        clipped_start = max(start_f, window_start_seconds)
+        clipped_end = min(end_f, window_end)
+        if clipped_end - clipped_start < min_segment_duration:
+            continue
+        # Rebase onto the Shorts clip's t=0 origin.
+        rel_start = clipped_start - window_start_seconds
+        rel_end = clipped_end - window_start_seconds
+        wrapped = _wrap_caption_line(
+            text, max_chars=wrap_max_chars, max_lines=wrap_max_lines,
+        )
+        cues.append(
+            f"{cue_index}\n"
+            f"{_format_srt_timestamp(rel_start)} --> "
+            f"{_format_srt_timestamp(rel_end)}\n"
+            f"{wrapped}\n"
+        )
+        cue_index += 1
+
+    if not cues:
+        logger.info(
+            "Shorts window [%.2fs, %.2fs] (offset=%.2fs) contained no "
+            "transcript cues — caption file will be empty",
+            window_start_seconds, window_end, audio_offset_seconds,
+        )
+
+    try:
+        srt_path.write_text("\n".join(cues), encoding="utf-8")
+    except OSError as exc:
+        logger.error(
+            "Failed to write Shorts SRT to %s (%s): %s",
+            srt_path, type(exc).__name__, exc,
+        )
+        raise
+    logger.info(
+        "Wrote %d Shorts caption cues → %s (window=[%.1fs, %.1fs])",
+        len(cues), srt_path.name,
+        window_start_seconds, window_end,
+    )
     return srt_path
 
 

--- a/engine/video.py
+++ b/engine/video.py
@@ -387,28 +387,31 @@ def _render_slideshow(scene_paths: Sequence[Path], output: Path,
 # Long-form filter graph (stage 2)
 # ---------------------------------------------------------------------------
 
-# Force-style for the burn-in subtitles. ASS color format is &HAABBGGRR
-# (alpha is "amount of transparency" — 0x00 is opaque, 0xFF is
-# transparent). The May 2026 operator review of the long-form YouTube
-# output asked for two changes:
+# Force-style for the long-form burn-in subtitles. ASS color format
+# is &HAABBGGRR (alpha is "amount of transparency" — 0x00 is opaque,
+# 0xFF is transparent).
 #
-#   1. Position firmly in the bottom third of the 1920x1080 frame
-#      rather than the previous "near the bottom edge" baseline.
-#      ``MarginV=120`` lifts the baseline ~120 px above the bottom
-#      edge, placing the caption text roughly y≈940 — comfortably
-#      inside the bottom-third zone (y > 720) but still high enough
-#      not to overlap the YouTube progress-bar HUD on mobile.
-#   2. "Not as prominent." Drop the opaque box behind the text
-#      (``BorderStyle=3`` → ``BorderStyle=1`` outline-only with a
-#      strong outline + soft shadow) so the slideshow imagery stays
-#      visible behind the words. Smaller font (22 → 18) reads less
-#      as "burned-in subtitle bar" and more as "auto-caption hint."
-#      White text + black 3 px outline + 1 px shadow remains
-#      readable against bright backgrounds (matches YouTube's own
-#      auto-caption styling).
+# May 2026 history (operator-driven iteration):
+#   * First pass: ``MarginV=120`` was meant to put text in the bottom
+#     third (y > 720). With Alignment=2 + a 2-line cue, the bottom of
+#     the text sat at y≈960 — technically inside the bottom third but
+#     still looked "mid-frame" on a YouTube player whose chrome
+#     overlays the lower 80 px. ``FontSize=18`` also read as too small
+#     in side-by-side reviews.
+#   * Second pass (this comment block): drop the baseline to
+#     ``MarginV=50`` so the text sits flush with the bottom area of
+#     the video (text bottom ≈ y=1030, comfortably above YouTube's
+#     auto-fading progress-bar HUD), and bump ``FontSize`` 18 → 22
+#     for readability on phones and tablets. Operator caught the
+#     long-form cues being too small + too high to read as a proper
+#     burned-in transcript.
+#
+# Outline-only (``BorderStyle=1`` + ``Outline=3`` + ``Shadow=1``) is
+# unchanged from the first pass — keeps the slideshow imagery
+# visible behind the words.
 _SUBTITLES_FORCE_STYLE = (
     "FontName=DejaVu Sans,"
-    "FontSize=18,"
+    "FontSize=22,"
     "PrimaryColour=&H00FFFFFF,"
     "OutlineColour=&H00000000,"
     "BackColour=&H00000000,"
@@ -416,7 +419,37 @@ _SUBTITLES_FORCE_STYLE = (
     "Outline=3,"
     "Shadow=1,"
     "Alignment=2,"
-    "MarginV=120"
+    "MarginV=50"
+)
+
+
+# Force-style for the Shorts (1080x1920 vertical) burn-in subtitles.
+# Three reasons this can't reuse ``_SUBTITLES_FORCE_STYLE``:
+#   1. Vertical frame is narrower (1080 vs 1920) so per-line char
+#      budgets that work on long-form spill past the visible edge.
+#      The matching wrap in ``captions.transcript_to_srt_window``
+#      uses ``wrap_max_chars=32`` — fits inside 1080 px at
+#      FontSize=34 with comfortable side margins.
+#   2. Shorts are watched on phones held close — the FontSize must
+#      step up (22 → 34) so cues are readable at 5–10 cm viewing.
+#   3. Position has to clear both the static hook caption (at
+#      ``y=h*0.70`` ≈ 1344) and the URL pill (at ``y=H-h-100`` ≈
+#      1820), AND sit firmly in the bottom third. ``MarginV=300``
+#      places the cue baseline at y≈1620 — between the hook
+#      (which fades after 3 s) and the URL pill, with enough
+#      vertical clearance for a 3-line cue at FontSize=34 not to
+#      overlap either.
+_SHORTS_SUBTITLES_FORCE_STYLE = (
+    "FontName=DejaVu Sans,"
+    "FontSize=34,"
+    "PrimaryColour=&H00FFFFFF,"
+    "OutlineColour=&H00000000,"
+    "BackColour=&H00000000,"
+    "BorderStyle=1,"
+    "Outline=4,"
+    "Shadow=2,"
+    "Alignment=2,"
+    "MarginV=300"
 )
 
 
@@ -500,7 +533,8 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
                              fps: int = 30,
                              hook: Optional[str] = None,
                              bg_is_video: bool = False,
-                             with_url_pill: bool = False) -> str:
+                             with_url_pill: bool = False,
+                             subtitles_path: Optional[str] = None) -> str:
     """filter_complex for the 1080x1920 Shorts build.
 
     Inputs:
@@ -544,38 +578,57 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
     else:
         post_brand_label = "[branded]"
 
+    # Anchor for any post-brand overlay (hook caption + burn-in
+    # subtitles + the final ``[v]`` rename). We chain by reassigning
+    # ``post_brand_label`` after each step so the order is:
+    #   brand pill → URL pill → hook (0-3s) → burn-in subtitles → [v]
+    chain = base
     if hook:
         wrapped = _wrap_caption(hook)
         escaped = _drawtext_escape(wrapped)
-        # May 2026 operator review: move the hook out of the top
-        # half (was y=240) into the bottom third of the 1080x1920
-        # frame and reduce visual weight to match the long-form
-        # caption treatment.
-        #   * ``y=h*0.70`` puts the text baseline at y≈1344, which
-        #     centres the wrapped caption inside the bottom third
-        #     (y > 1280) while leaving room above the
-        #     ``H-h-100`` URL pill that sits at y≈1820 when
-        #     ``with_url_pill=True``.
-        #   * ``fontsize=44`` (was 64) is still readable on a
-        #     phone but no longer dominates the slideshow.
+        # May 2026 operator review: hook is the static 0-3 s
+        # opening title — separate from the burn-in transcript
+        # that follows. Position lifted ABOVE the burn-in zone
+        # so the two overlays don't visually collide during the
+        # first 3 s. ``y=h*0.55`` puts the hook around y≈1056 —
+        # inside the lower half but well above the subtitle
+        # baseline at y≈1620 (MarginV=300 in
+        # ``_SHORTS_SUBTITLES_FORCE_STYLE``).
+        #   * ``fontsize=44`` is still readable on a phone but
+        #     no longer dominates the slideshow.
         #   * Outline-only (no ``box=1`` solid fill) keeps the
         #     imagery visible behind the words. A 4 px black
         #     outline + 2 px shadow stays readable on bright
-        #     backgrounds without painting a black rectangle
-        #     across the frame.
-        caption = (
+        #     backgrounds without painting a black rectangle.
+        hook_label = "[hooked]" if subtitles_path else "[v]"
+        hook_filter = (
             f";{post_brand_label}drawtext=fontfile='{font_path}':"
             f"text='{escaped}':"
             f"fontsize=44:fontcolor=white:"
-            f"x=(w-text_w)/2:y=h*0.70:"
+            f"x=(w-text_w)/2:y=h*0.55:"
             f"borderw=4:bordercolor=black:"
             f"shadowx=2:shadowy=2:shadowcolor=black@0.7:"
             f"line_spacing=10:"
             f"enable='between(t,0,3)'"
-            f"[v]"
+            f"{hook_label}"
         )
-        return base + caption
-    return base + f";{post_brand_label}null[v]"
+        chain += hook_filter
+        post_brand_label = hook_label
+
+    if subtitles_path:
+        escaped_sub = _subtitles_path_escape(subtitles_path)
+        # Use the dedicated Shorts force-style so font + position
+        # are tuned for the 1080x1920 vertical frame and don't
+        # overlap the hook (above) or the URL pill (below).
+        chain += (
+            f";{post_brand_label}subtitles='{escaped_sub}'"
+            f":force_style='{_SHORTS_SUBTITLES_FORCE_STYLE}'[v]"
+        )
+        return chain
+    if hook:
+        # Hook was the last filter — already terminated at [v].
+        return chain
+    return chain + f";{post_brand_label}null[v]"
 
 
 # ---------------------------------------------------------------------------
@@ -639,7 +692,8 @@ def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
                     fps: int = 30,
                     hook: Optional[str] = None,
                     bg_is_video: bool = False,
-                    url_pill_in: Optional[str] = None) -> List[str]:
+                    url_pill_in: Optional[str] = None,
+                    subtitles_path: Optional[str] = None) -> List[str]:
     """ffmpeg command for the 1080x1920 Shorts build.
 
     When *bg_is_video* is True, *bg_in* is a pre-rendered vertical
@@ -649,6 +703,14 @@ def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
 
     When *url_pill_in* is provided, a 4th input is added (the
     ``nerranetwork.com`` URL pill PNG) and overlaid at bottom-center.
+
+    When *subtitles_path* is provided (May 2026), ffmpeg's
+    ``subtitles`` filter burns the cues from a Shorts-windowed SRT
+    onto the video using the dedicated
+    ``_SHORTS_SUBTITLES_FORCE_STYLE`` (FontSize=34, MarginV=300) —
+    tuned for the 1080x1920 frame and positioned so it doesn't
+    collide with the static hook (0-3 s, y≈1056) or the URL pill
+    (y≈1820).
     """
     if bg_is_video:
         bg_input = ["-stream_loop", "-1", "-i", bg_in]
@@ -672,7 +734,8 @@ def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
         "-filter_complex",
         _short_form_filter_graph(1080, 1920, fps, hook,
                                  bg_is_video=bg_is_video,
-                                 with_url_pill=bool(url_pill_in)),
+                                 with_url_pill=bool(url_pill_in),
+                                 subtitles_path=subtitles_path),
         "-map", "[v]", "-map", "1:a",
         *_VIDEO_ENCODE,
         "-r", str(fps),
@@ -811,7 +874,8 @@ def build_short_video(audio_path: Path, cover_path: Path,
                       fps: int = 30,
                       hook: Optional[str] = None,
                       scene_paths: Optional[Sequence[Path]] = None,
-                      show_name: Optional[str] = None) -> Path:
+                      show_name: Optional[str] = None,
+                      subtitles_path: Optional[Path] = None) -> Path:
     """Render a 1080x1920 vertical YouTube Shorts video.
 
     Parameters
@@ -837,6 +901,15 @@ def build_short_video(audio_path: Path, cover_path: Path,
         renders the show name in the top-right pill and a
         ``nerranetwork.com`` pill at bottom-center. When ``None``:
         legacy "Nerra Network" single pill in the top-right.
+    subtitles_path:
+        Optional SRT (May 2026). Cues must already be windowed and
+        rebased to the Shorts clip's own t=0 timeline (see
+        ``engine.captions.transcript_to_srt_window``). When
+        provided, ffmpeg's ``subtitles`` filter burns the cues
+        onto the video with the dedicated
+        ``_SHORTS_SUBTITLES_FORCE_STYLE``. The cues sit between the
+        static hook (above) and the URL pill (below) so all three
+        overlays are visible together without overlap.
     """
     if duration >= 60:
         raise ValueError(
@@ -884,10 +957,13 @@ def build_short_video(audio_path: Path, cover_path: Path,
         duration=duration, fps=fps, hook=hook,
         bg_is_video=bg_is_video,
         url_pill_in=str(url_pill_path) if url_pill_path else None,
+        subtitles_path=str(subtitles_path) if subtitles_path else None,
     )
     logger.info(
-        "Building Shorts video (%.1fs from %.1fs) → %s",
+        "Building Shorts video (%.1fs from %.1fs) → %s "
+        "(subtitles=%s)",
         duration, start_offset, output_path.name,
+        bool(subtitles_path),
     )
     _run_ffmpeg(cmd, label="shorts video")
     return output_path

--- a/run_show.py
+++ b/run_show.py
@@ -2978,6 +2978,7 @@ def _publish_youtube(
     from engine.captions import (
         find_transcript_for_episode,
         transcript_to_srt,
+        transcript_to_srt_window,
     )
     from engine.publisher import (
         generate_episode_thumbnail,
@@ -3288,6 +3289,40 @@ def _publish_youtube(
                 audio_duration=_ep_duration,
             )
             duration = float(config.youtube.short_duration_seconds or 55.0)
+
+            # Build a Shorts-windowed SRT (May 2026 operator review:
+            # Shorts had no synced captions at all). Reuse the Whisper
+            # transcript that already powers the long-form SRT, slice
+            # it to the Shorts time window, and rebase timestamps to
+            # the Shorts clip's own t=0 timeline. Same
+            # ``voice_intro_delay`` offset the long-form SRT uses so
+            # the cues land on speech in the final audio.
+            short_srt_path = None
+            if transcript_path is not None:
+                try:
+                    short_srt_candidate = work_dir / f"{base_name}_short.srt"
+                    _caption_offset = float(
+                        getattr(config.audio, "voice_intro_delay", 0.0) or 0.0
+                    )
+                    transcript_to_srt_window(
+                        transcript_path,
+                        short_srt_candidate,
+                        window_start_seconds=short_offset,
+                        window_duration_seconds=duration,
+                        audio_offset_seconds=_caption_offset,
+                    )
+                    if short_srt_candidate.exists() and short_srt_candidate.stat().st_size > 0:
+                        short_srt_path = short_srt_candidate
+                    else:
+                        logger.info(
+                            "Shorts SRT empty — no cues fell inside the "
+                            "[%.1fs, %.1fs] window. Shorts ships without "
+                            "burned-in captions.",
+                            short_offset, short_offset + duration,
+                        )
+                except Exception as exc:  # pragma: no cover — best-effort
+                    logger.warning("Shorts caption generation failed: %s", exc)
+
             build_short_video(
                 final_mp3, cover_path, short_video_path,
                 start_offset=short_offset,
@@ -3295,6 +3330,7 @@ def _publish_youtube(
                 hook=hook or None,
                 scene_paths=short_scene_paths if len(short_scene_paths) >= 2 else None,
                 show_name=config.name,
+                subtitles_path=short_srt_path,
             )
             meta = build_short_metadata(
                 config,

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -11,6 +11,7 @@ from engine.captions import (
     _wrap_caption_line,
     find_transcript_for_episode,
     transcript_to_srt,
+    transcript_to_srt_window,
 )
 
 
@@ -38,6 +39,44 @@ def test_wrap_caption_line_breaks_at_word_boundary():
     # No line should split a word in the middle.
     for line in lines:
         assert " " in line or len(line) <= 20
+
+
+def test_wrap_caption_line_supports_three_lines():
+    """May 2026 fix: prior 2-line cap dumped overflow text into
+    line 2 (which silently clipped off the right edge in libass).
+    A 3-line wrap fits the long Whisper segments that sentences
+    rich with named entities + numbers produce, without losing
+    content."""
+    text = (
+        "Engineers at the Stanford Artificial Intelligence "
+        "Laboratory reported a forty seven percent improvement "
+        "on the benchmark this morning compared to last quarter."
+    )
+    out = _wrap_caption_line(text, max_chars=40, max_lines=3)
+    lines = out.split("\n")
+    assert 2 <= len(lines) <= 3, f"expected 2-3 lines, got {len(lines)}: {lines!r}"
+    # Every word from the source must survive.
+    src_words = set(text.split())
+    rendered_words = set(out.replace("\n", " ").split())
+    assert src_words == rendered_words, (
+        f"lost words during wrap: {src_words - rendered_words!r}"
+    )
+
+
+def test_wrap_caption_line_default_is_55_chars_3_lines():
+    """The default budget changed May 2026 from 42 chars / 2 lines
+    to 55 chars / 3 lines. 55-char lines fit comfortably in a
+    1920-wide frame at FontSize=22 with side margins; the third
+    line absorbs sentences that the previous 2-line cap was
+    truncating."""
+    # Sentence chosen to fit in two 55-char lines, which the old
+    # 42-char default would have spilled into a third (overflowed) line.
+    text = "Sentence with enough length to require multi-line wrap on a 42-char budget but fits in 55."
+    out = _wrap_caption_line(text)
+    lines = out.split("\n")
+    assert all(len(line) <= 55 or " " not in line for line in lines)
+    # No clipping — every word survives.
+    assert set(text.split()) == set(out.replace("\n", " ").split())
 
 
 def test_transcript_to_srt_basic(tmp_path: Path):
@@ -166,6 +205,111 @@ def test_transcript_to_srt_negative_offset_raises(tmp_path: Path):
         transcript_to_srt(
             transcript_path, tmp_path / "out.srt",
             audio_offset_seconds=-1.0,
+        )
+
+
+def test_transcript_to_srt_window_clips_to_range(tmp_path: Path):
+    """Shorts pipeline: only cues whose timeline overlaps the
+    Shorts window survive. Cues outside the window are dropped;
+    cues that straddle a boundary are clipped to fit. Timestamps
+    are rebased so the SRT starts at t=0 relative to the Shorts
+    clip."""
+    transcript = {
+        "language": "en",
+        "segments": [
+            # Before window — drop.
+            {"start": 0.0, "end": 4.0, "text": "Intro music"},
+            # Straddles the window start — clip + keep tail.
+            {"start": 9.0, "end": 12.0, "text": "Boundary cue at start"},
+            # Fully inside — keep verbatim.
+            {"start": 15.0, "end": 20.0, "text": "Middle of the clip"},
+            # Straddles the window end — clip + keep head.
+            {"start": 62.0, "end": 70.0, "text": "Boundary cue at end"},
+            # After window — drop.
+            {"start": 75.0, "end": 80.0, "text": "Outro music"},
+        ],
+    }
+    transcript_path = tmp_path / "ep.json"
+    transcript_path.write_text(json.dumps(transcript), encoding="utf-8")
+    srt_path = tmp_path / "short.srt"
+    # Window: final-audio [10s, 65s] (duration=55).
+    transcript_to_srt_window(
+        transcript_path, srt_path,
+        window_start_seconds=10.0,
+        window_duration_seconds=55.0,
+    )
+    content = srt_path.read_text(encoding="utf-8")
+    # Three surviving cues (the two boundary cues + the middle one).
+    assert content.count(" --> ") == 3
+    # Pre-window and post-window text must NOT appear.
+    assert "Intro music" not in content
+    assert "Outro music" not in content
+    # Rebased: first surviving cue starts at t=0 (10.0 - 10.0).
+    assert "00:00:00,000 -->" in content
+    # Middle cue runs from 15.0 → 20.0 in the source = 5.0 → 10.0 in
+    # the rebased SRT.
+    assert "00:00:05,000 --> 00:00:10,000" in content
+
+
+def test_transcript_to_srt_window_applies_audio_offset(tmp_path: Path):
+    """The audio_offset_seconds applies BEFORE windowing — same
+    semantics as the long-form SRT (so the Shorts cues land on
+    speech in the final mix, not on the music intro)."""
+    transcript = {
+        "segments": [
+            # In the raw transcript timeline.
+            {"start": 0.0, "end": 5.0, "text": "First speech"},
+        ],
+    }
+    transcript_path = tmp_path / "t.json"
+    transcript_path.write_text(json.dumps(transcript), encoding="utf-8")
+    srt_path = tmp_path / "short.srt"
+    # Music intro = 10 s. The Shorts window is [10s, 30s] of the
+    # final audio. After offset, the speech cue is at [10s, 15s] —
+    # rebased to [0s, 5s] in the Shorts clip.
+    transcript_to_srt_window(
+        transcript_path, srt_path,
+        window_start_seconds=10.0,
+        window_duration_seconds=20.0,
+        audio_offset_seconds=10.0,
+    )
+    content = srt_path.read_text(encoding="utf-8")
+    assert "00:00:00,000 --> 00:00:05,000" in content
+    assert "First speech" in content
+
+
+def test_transcript_to_srt_window_empty_when_no_overlap(tmp_path: Path):
+    """A window that contains no transcript cues produces an empty
+    SRT (rather than raising). Caller treats empty as 'skip
+    burn-in for this Shorts.'"""
+    transcript = {"segments": [{"start": 0.0, "end": 3.0, "text": "Intro"}]}
+    transcript_path = tmp_path / "t.json"
+    transcript_path.write_text(json.dumps(transcript), encoding="utf-8")
+    srt_path = tmp_path / "short.srt"
+    transcript_to_srt_window(
+        transcript_path, srt_path,
+        window_start_seconds=60.0,
+        window_duration_seconds=10.0,
+    )
+    assert srt_path.exists()
+    assert srt_path.read_text(encoding="utf-8") == ""
+
+
+def test_transcript_to_srt_window_rejects_invalid_args(tmp_path: Path):
+    transcript_path = tmp_path / "t.json"
+    transcript_path.write_text(json.dumps({"segments": []}), encoding="utf-8")
+    srt_path = tmp_path / "short.srt"
+    with pytest.raises(ValueError, match="window_start_seconds"):
+        transcript_to_srt_window(
+            transcript_path, srt_path,
+            window_start_seconds=-1.0,
+            window_duration_seconds=10.0,
+        )
+    with pytest.raises(ValueError, match="window_duration_seconds"):
+        transcript_to_srt_window(
+            transcript_path, srt_path,
+            window_start_seconds=0.0,
+            window_duration_seconds=0.0,
         )
 
 

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -124,16 +124,16 @@ def test_short_form_filter_graph_with_hook_burns_caption():
     assert graph.endswith("[v]")
 
 
-def test_short_form_filter_graph_hook_sits_in_bottom_third():
-    """May 2026 operator review: the shorts hook moved out of the
-    top half (was ``y=240``) into the bottom third of the
-    1080x1920 frame. ``y=h*0.70`` puts the baseline at y≈1344,
-    well inside the bottom-third zone (y > 1280) and above the
-    URL pill at y≈1820. Pin the new position so a future style
-    edit doesn't drift back to the top."""
+def test_short_form_filter_graph_hook_sits_in_bottom_half():
+    """May 2026 follow-up: the Shorts hook moved out of the top
+    half (was ``y=240``) and now sits at ``y=h*0.55`` (≈y=1056) —
+    inside the lower half of the 1080x1920 frame but above the
+    burn-in subtitle baseline (MarginV=300 → y≈1620) so the two
+    overlays don't collide during the first 3 s when both are
+    visible. The hook fades after 3 s; the subtitles continue."""
     graph = _short_form_filter_graph(hook="anything")
-    # New bottom-third position.
-    assert "y=h*0.70" in graph
+    # New mid-lower position that leaves room for burn-in subs below.
+    assert "y=h*0.55" in graph
     # Old top-of-frame position must not return.
     assert "y=240" not in graph
 
@@ -162,6 +162,55 @@ def test_short_form_filter_graph_without_hook_omits_caption():
     assert "between(t,0,3)" not in graph
     # But the brand pill + visualization still produce the [v] output.
     assert graph.endswith("[v]")
+
+
+def test_short_form_filter_graph_burns_subtitles_when_path_provided():
+    """May 2026 operator review: Shorts had no synced captions at
+    all — only the 3-second static hook. With the new
+    ``subtitles_path`` arg the Shorts MP4 burns in cues from a
+    Shorts-windowed SRT using the dedicated
+    ``_SHORTS_SUBTITLES_FORCE_STYLE`` (FontSize=34, MarginV=300)
+    so the transcript actually shows up on the vertical format."""
+    graph = _short_form_filter_graph(subtitles_path="/tmp/short.srt")
+    assert "subtitles=" in graph
+    assert "FontSize=34" in graph
+    assert "MarginV=300" in graph
+    assert graph.endswith("[v]")
+
+
+def test_short_form_filter_graph_subtitles_compose_with_hook():
+    """When BOTH the hook and subtitles are present, the filter
+    graph must end in a single ``[v]`` output. The hook renders at
+    ``y=h*0.55`` (≈y=1056); the subtitles render at MarginV=300
+    (baseline ≈y=1620). Both must be visible together for the
+    first 3 seconds without overlapping."""
+    graph = _short_form_filter_graph(
+        hook="Today's market.", subtitles_path="/tmp/short.srt",
+    )
+    # Hook is wired through with its 0-3s gate.
+    assert "between(t,0,3)" in graph
+    # Subtitles filter is wired through.
+    assert "subtitles=" in graph
+    # Single final [v] output (no double-terminated graph).
+    assert graph.endswith("[v]")
+    # Hook chains into the subtitle stage rather than terminating
+    # the graph early.
+    assert "[hooked]subtitles=" in graph
+
+
+def test_short_form_cmd_threads_subtitles_path():
+    """The Shorts MP4 builder must pass ``subtitles_path`` through
+    to the filter graph so the burn-in actually happens. May 2026
+    operator complaint traced to the path being available
+    (transcript exists) but unused in the Shorts command builder."""
+    from engine.video import _short_form_cmd
+    cmd = _short_form_cmd(
+        "/v.mp3", "/bg.jpg", "/brand.png", "/out.mp4",
+        subtitles_path="/tmp/short.srt",
+    )
+    fc = cmd[cmd.index("-filter_complex") + 1]
+    assert "subtitles=" in fc
+    assert "/tmp/short.srt" in fc
 
 
 # ---------------------------------------------------------------------------
@@ -554,12 +603,12 @@ def test_long_form_filter_graph_with_subtitles_appends_filter():
     # ASS force-style is appended.
     assert "force_style=" in graph
     assert "Alignment=2" in graph
-    # Subtitles sit in the bottom third of the 1920x1080 frame (May
-    # 2026 operator review). ``MarginV=120`` puts the baseline ~120
-    # px above the bottom edge — comfortably below y=720 (bottom
-    # third boundary) and high enough that the YouTube progress bar
-    # doesn't overlap on mobile.
-    assert "MarginV=120" in graph
+    # Subtitles sit FLUSH with the bottom area (May 2026 follow-up
+    # — operator caught that the previous ``MarginV=120`` still
+    # read as "central portion" rather than truly bottom). The new
+    # ``MarginV=50`` puts the text baseline ≈y=1030 — just above
+    # YouTube's auto-fading progress-bar HUD.
+    assert "MarginV=50" in graph
     # Subtitles attach to the [branded] stage (was [disclosed] before
     # the centered burn-in was removed).
     assert "[branded]subtitles=" in graph
@@ -586,18 +635,21 @@ def test_subtitles_force_style_has_required_fields():
     """Sanity check on the ASS force-style string. May 2026 retune:
     pin the new "auto-caption-style" look so a future style edit
     doesn't silently regress to the old opaque-box look the operator
-    asked to remove ("make it not as prominent")."""
+    asked to remove ("make it not as prominent"). May 22 follow-up:
+    operator caught the previous ``MarginV=120 / FontSize=18`` still
+    reading as central + too small — moved to ``MarginV=50`` (flush
+    bottom) + ``FontSize=22`` (readable on phones)."""
     assert "FontName=DejaVu Sans" in _SUBTITLES_FORCE_STYLE
     assert "Alignment=2" in _SUBTITLES_FORCE_STYLE
-    # Bottom-third position (May 2026 operator review).
-    assert "MarginV=120" in _SUBTITLES_FORCE_STYLE
+    # Flush-bottom position (May 22 2026 operator follow-up).
+    assert "MarginV=50" in _SUBTITLES_FORCE_STYLE
     # BorderStyle=1 = outline + soft shadow only (no opaque box).
     # Keeps the slideshow imagery visible behind the words.
     assert "BorderStyle=1" in _SUBTITLES_FORCE_STYLE
     assert "BorderStyle=3" not in _SUBTITLES_FORCE_STYLE
-    # Smaller font reads less as "subtitle bar" and more as
-    # "auto-caption hint" — also matches YouTube auto-caption sizing.
-    assert "FontSize=18" in _SUBTITLES_FORCE_STYLE
+    # FontSize=22 (was 18) — bigger reads better on phone screens
+    # without looking like a heavy "subtitle bar."
+    assert "FontSize=22" in _SUBTITLES_FORCE_STYLE
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Operator review of the post-#396 YouTube output identified three real bugs (sync from #396 is now correct; everything else either regressed or was never built).

## 1. Long-form transcript was being truncated

`engine.captions._wrap_caption_line` had a content-loss bug. When a cue overflowed the 2-line budget, the overflow handler did:

```python
lines[-1] = " ".join(rest)  # OVERWRITES line 2's committed text
```

The right-side of every long cue was silently lost — exactly what the operator saw ("appears to not be the full script shown").

**Fix:** append-to-tail strategy:

```python
lines[-1] = (lines[-1] + " " + rest).strip()
```

Earlier committed lines stay intact; only the LAST line is allowed to overflow horizontally (libass clips on the right when that happens, but words BEFORE the overflow boundary all survive).

Also bumped the default budget from **42 chars / 2 lines → 55 chars / 3 lines** so a 3-line wrap absorbs the long Whisper segments that PR #397's substance-rich digests produce (average script went from ~5 000 to ~7 500-10 000 chars) without spilling into the overflow line.

## 2. Long-form caption position + size

`_SUBTITLES_FORCE_STYLE`:

| Field | Was | Now | Effect |
|---|---|---|---|
| `MarginV` | 120 | **50** | Baseline drops from y≈960 (mid-frame feel) to y≈1030 (flush bottom, above YouTube's auto-fading progress bar) |
| `FontSize` | 18 | **22** | Readable on phones / tablets without looking like a heavy subtitle bar |

## 3. Shorts had no synced captions at all

Shorts previously rendered ONLY the static hook (0-3 seconds). The vertical aspect ratio means viewers couldn't follow the audio without burn-in.

**Full vertical caption pipeline added:**

| Piece | What |
|---|---|
| `engine.captions.transcript_to_srt_window` | New helper. Filters the Whisper transcript to the Shorts window `[start_offset, start_offset + duration]` of the final audio, applies the same `voice_intro_delay` offset the long-form SRT uses, clips cues that straddle window boundaries, and REBASES timestamps so the SRT starts at t=0 relative to the Shorts clip. |
| `_SHORTS_SUBTITLES_FORCE_STYLE` | `FontSize=34` (phone viewing distance), `MarginV=300` (baseline at y≈1620), `BorderStyle=1` (outline-only). |
| Hook position | Moved `y=h*0.70 → y=h*0.55` (y≈1344 → y≈1056) so the subtitle baseline below has clear vertical space and the two overlays don't collide during the first 3 s. |
| `build_short_video(..., subtitles_path=...)` | Accepts the Shorts-windowed SRT. |
| `run_show.py` Shorts branch | Builds the windowed SRT next to the Shorts MP4 and passes it through. Best-effort: failures log + Shorts still ship. |

Filter-graph chain becomes:

```
[bg] → brand pill → URL pill → hook drawtext (0-3 s) → subtitles → [v]
```

All three overlays render together during the first 3 s without overlap, then the hook fades and the subtitles continue solo.

## Drift guards

```
tests/test_captions.py            (7 new):
  test_wrap_caption_line_supports_three_lines
  test_wrap_caption_line_default_is_55_chars_3_lines
  test_transcript_to_srt_window_clips_to_range
  test_transcript_to_srt_window_applies_audio_offset
  test_transcript_to_srt_window_empty_when_no_overlap
  test_transcript_to_srt_window_rejects_invalid_args
  + existing wrap / SRT-offset tests still pass

tests/test_video_commands.py      (4 new / updated):
  test_subtitles_force_style_has_required_fields    [MarginV=50, FontSize=22]
  test_long_form_filter_graph_with_subtitles_appends_filter  [MarginV=50]
  test_short_form_filter_graph_hook_sits_in_bottom_half      [y=h*0.55]
  test_short_form_filter_graph_burns_subtitles_when_path_provided
  test_short_form_filter_graph_subtitles_compose_with_hook
  test_short_form_cmd_threads_subtitles_path

1884 passed, 6 skipped in 26.74s
```

## What does NOT change

- The Whisper transcript itself, the `voice_intro_delay` offset, or the SRT cue boundaries (PR #396).
- Long-form audio pipeline (PR #400).
- Newsletter / RSS / X posting.
- Per-show YAML configs.

## Test plan

- [x] `pytest tests/test_captions.py tests/test_video_commands.py` — 71 passed.
- [x] `pytest tests/` — 1884 passed.
- [x] Manually rendered filter strings for long-form + Shorts (with and without hook + subtitles) — all chain correctly.
- [x] Wrap stress test: 23-word sentence wraps to 3 lines without losing any words; last line overflows horizontally (60 chars at 40-char budget) instead of dropping content.
- [ ] Next scheduled run: long-form caption renders flush-bottom at FontSize 22 with the full transcript visible; Shorts ship with synced cues between the hook and URL pill.

## Out of scope

- The 600 character-per-line / 4+ line case for extremely-long Whisper segments. Whisper's segment chunking pages at 5-10 second boundaries; segments long enough to need 4 lines after the new 3-line wrap are rare in practice. If they show up, easy follow-up: bump `max_lines` to 4 in the wrap helper.


---
_Generated by [Claude Code](https://claude.ai/code/session_013sWzi3YLLjJgckvarquWZS)_