### PR TITLE
generator: anti-repetition retry must not swap to a sub-floor script

### DIFF
--- a/engine/generator.py
+++ b/engine/generator.py
@@ -713,6 +713,32 @@ def _strip_metadata_from_script(script: str) -> str:
     return script.strip()
 
 
+def _retry_word_count_ok(orig_words: int, retry_words: int,
+                         show_floor: int) -> bool:
+    """Decide whether a podcast-script retry's word count is healthy
+    enough to swap in. Both repetition-retry paths use this gate.
+
+    Two failure modes the gate protects against:
+
+      1. ``Omni View Ep059 (2026-05-23)`` — anti-repetition retry
+         replaced an 883-word original with a 555-word "cleaner"
+         retry. The retry passed the char-length 0.5× check
+         (3870/6163 ≈ 0.63) but then tripped the runner's 600-word
+         hard floor and aborted the episode. Floor is enforced
+         AFTER the swap, so we have to gate it BEFORE.
+      2. Drastic shrinkage even above the floor. A retry that's
+         lost 20%+ of word count almost certainly lost real
+         content along with the repetition.
+
+    Returns True when ``retry_words`` clears BOTH:
+      * 80 % of the original word count, AND
+      * the per-show ``min_podcast_word_floor`` + 50-word margin
+        (so the downstream hard-floor check has headroom).
+    """
+    threshold = max(int(orig_words * 0.8), show_floor + 50)
+    return retry_words >= threshold
+
+
 def _sanitize_podcast_script(text: str) -> str:
     """Strip known LLM artifacts that break TTS quality.
 
@@ -1607,18 +1633,26 @@ def generate_podcast_script(
                 min_podcast_words=min_words,
             )
             if _rep_retry < _rep_count:
-                # Guard: don't swap to a drastically shorter retry — it's
-                # likely garbage even if it has fewer repetitions.
-                if len(text_retry) < len(text) * 0.5:
+                # See ``_retry_word_count_ok`` for the OV Ep059
+                # incident this guard protects against.
+                orig_words = len(text.split())
+                retry_words = len(text_retry.split())
+                show_floor = (
+                    getattr(config.llm, "min_podcast_word_floor", 600) or 600
+                )
+                if not _retry_word_count_ok(orig_words, retry_words, show_floor):
                     logger.warning(
-                        "Repetition retry for '%s' has fewer repetitions but is "
-                        "drastically shorter (%d → %d chars) — keeping original",
-                        config.name, len(text), len(text_retry),
+                        "Repetition retry for '%s' has fewer repetitions but "
+                        "would drop word count too far (%d → %d, show floor=%d) "
+                        "— keeping original",
+                        config.name, orig_words, retry_words, show_floor,
                     )
                 else:
                     logger.info(
-                        "Repetition retry improved script for '%s' (%d → %d suspicious phrases)",
+                        "Repetition retry improved script for '%s' (%d → %d "
+                        "suspicious phrases, %d → %d words)",
                         config.name, _rep_count, _rep_retry,
+                        orig_words, retry_words,
                     )
                     text = text_retry
             else:
@@ -1674,13 +1708,31 @@ def generate_podcast_script(
                         pass
                 reps_rr = detect_phrase_repetition(text_rr)
                 critical_rr = [r for r in reps_rr if r["severity"] == "critical"]
-                # Guard: don't swap if retry is drastically shorter (likely garbage)
-                if not critical_rr and len(text_rr) >= len(text) * 0.5:
+                orig_words = len(text.split())
+                retry_words = len(text_rr.split())
+                show_floor = (
+                    getattr(config.llm, "min_podcast_word_floor", 600) or 600
+                )
+                # See ``_retry_word_count_ok`` for the OV Ep059
+                # incident this guard protects against (anti-rep
+                # retry replaced 883-word original with 555-word
+                # retry that then tripped the 600-word hard floor).
+                if not critical_rr and _retry_word_count_ok(
+                    orig_words, retry_words, show_floor,
+                ):
                     logger.info(
-                        "Anti-repetition retry cleared critical loops for '%s'",
-                        config.name,
+                        "Anti-repetition retry cleared critical loops for '%s' "
+                        "(%d → %d words)",
+                        config.name, orig_words, retry_words,
                     )
                     text = text_rr
+                elif not critical_rr:
+                    logger.warning(
+                        "Anti-repetition retry for '%s' cleared loops but "
+                        "dropped word count too far (%d → %d, show floor=%d) — "
+                        "keeping original to avoid hard-floor abort downstream",
+                        config.name, orig_words, retry_words, show_floor,
+                    )
                 else:
                     logger.warning(
                         "Anti-repetition retry did not clear critical loops for "

--- a/tests/test_generator_postprocess.py
+++ b/tests/test_generator_postprocess.py
@@ -143,3 +143,77 @@ class TestSpeakerPrefixStrip:
         # Line-start prefix stripped.
         assert "Yes, I did." in out
         assert "Patrick: Yes" not in out
+
+
+# ---------------------------------------------------------------------------
+# _retry_word_count_ok — guard for repetition-retry word-count regression
+# ---------------------------------------------------------------------------
+
+class TestRetryWordCountOk:
+    """Operator caught (Omni View Ep059, 2026-05-23) the anti-repetition
+    retry replacing an 883-word original with a 555-word retry. The old
+    guard used ``len(text_retry) < len(text) * 0.5`` on CHAR length,
+    which passed (3870 / 6163 ≈ 0.63), the swap went through, and the
+    555-word script then tripped the runner's 600-word hard floor and
+    aborted the episode. The new ``_retry_word_count_ok`` helper gates
+    both repetition-retry paths on WORD count, with the per-show floor
+    + 50 as a hard minimum so the hard-floor check downstream has
+    headroom."""
+
+    def test_ov_ep059_scenario_rejects_retry(self):
+        """The exact OV Ep059 numbers: 883-word original, 555-word
+        retry, network default floor=600. Must reject so the runner
+        keeps the (repetitive but usable) 883-word original instead
+        of swapping in the (clean but too-short) 555-word retry."""
+        from engine.generator import _retry_word_count_ok
+        assert _retry_word_count_ok(
+            orig_words=883, retry_words=555, show_floor=600,
+        ) is False
+
+    def test_healthy_retry_accepted(self):
+        """Retry that keeps >=80% of original word count AND stays
+        well above the floor — the happy path. Accept."""
+        from engine.generator import _retry_word_count_ok
+        assert _retry_word_count_ok(
+            orig_words=1000, retry_words=900, show_floor=600,
+        ) is True
+
+    def test_retry_below_floor_plus_margin_rejected(self):
+        """Even when the retry keeps 80%+ of the word count, if it
+        would land within 50 words of the per-show floor we reject —
+        the runner's hard-floor check happens AFTER the swap, so we
+        leave a 50-word buffer for ``loudnorm`` / ``_sanitize`` /
+        anti-tag-strip rounding."""
+        from engine.generator import _retry_word_count_ok
+        # 80% of 800 = 640. Floor + 50 = 650. Retry of 640 fails
+        # the floor-margin guard.
+        assert _retry_word_count_ok(
+            orig_words=800, retry_words=640, show_floor=600,
+        ) is False
+        # 651 clears floor+50.
+        assert _retry_word_count_ok(
+            orig_words=800, retry_words=651, show_floor=600,
+        ) is True
+
+    def test_env_intel_low_floor_lets_short_shows_swap(self):
+        """env_intel has ``min_podcast_word_floor: 450`` (PR #395) so
+        retries that land at 500-600 words still pass when the show
+        deliberately ships shorter episodes. Show-specific floor is
+        honored end-to-end."""
+        from engine.generator import _retry_word_count_ok
+        # env_intel: orig 700 → retry 580. 80% = 560, floor+50 = 500.
+        # 580 >= max(560, 500) = 560 → ACCEPT.
+        assert _retry_word_count_ok(
+            orig_words=700, retry_words=580, show_floor=450,
+        ) is True
+
+    def test_uses_max_of_two_constraints(self):
+        """When the two constraints (80% and floor+50) disagree, the
+        STRICTER one wins. A short original (e.g. 500 words) with a
+        retry at 400 words clears 80%-of-original (400 >= 400) but
+        not floor+50 (400 < 650 for floor=600) → REJECT."""
+        from engine.generator import _retry_word_count_ok
+        assert _retry_word_count_ok(
+            orig_words=500, retry_words=400, show_floor=600,
+        ) is False
+


### PR DESCRIPTION
## Summary

Operator caught (Omni View Ep 059, 2026-05-23): the anti-repetition retry inside `generate_podcast_script` replaced an **883-word original** with a **555-word retry**. The runner's downstream **600-word hard floor** then aborted the episode — Omni View shipped no episode at all today.

## Log trace

```
[WARN]  Podcast script for 'Omni View' is too short (883 words, target >900)
[WARN]  High repetition in podcast script ... retrying with lower temperature
[WARN]  Podcast script for 'Omni View' is too short (841 words, target >900)
[WARN]  Repetition retry did not improve for 'Omni View' — keeping original
[WARN]  Repetition loop detected ... "host they differ" (7x) — regenerating once
[INFO]  Anti-repetition retry cleared critical loops for 'Omni View'
[ERROR] Podcast script is clearly broken (555 words, hard floor 600)
        — aborting episode
```

## Root cause

The retry was accepted because the old guard was:

```python
if not critical_rr and len(text_rr) >= len(text) * 0.5:
    text = text_rr  # accept retry
```

Two problems:
1. **Wrong metric.** Char-length: 3870/6163 ≈ 0.63 → passes. But the runner's hard floor is on WORDS, not chars.
2. **Doesn't know about the per-show floor at all.** Hard-floor abort happens AFTER the swap, so the swap had no idea it was about to send the episode off a cliff.

## Fix

New shared helper `engine.generator._retry_word_count_ok(orig_words, retry_words, show_floor)` gates BOTH repetition-retry sites on:

```python
retry_words >= max(int(orig_words * 0.8), show_floor + 50)
```

Two coupled constraints:

| Constraint | Why |
|---|---|
| ≥ 80% of original word count | Drastic shrinkage usually means lost content, not just lost repetition. |
| ≥ `min_podcast_word_floor + 50` | Hard-floor check happens AFTER the swap; leave a 50-word buffer for sanitize / speech-tag strip / loudnorm rounding. |

Applied to both retry paths:

1. Lower-temperature repetition retry (`_rep_count >= 3` trigger) — was already char-length-gated; switched to the new helper.
2. Anti-repetition-loop retry (critical-loop trigger) — the OV Ep 059 failure site.

## OV scenario under the new helper

```
orig=883, retry=555, show_floor=600
→ threshold = max(int(883 × 0.8), 600 + 50) = max(706, 650) = 706
→ 555 < 706 → REJECT, keep 883-word original
→ runner's hard-floor check at 883 passes → episode ships
```

## Drift guards

`tests/test_generator_postprocess.py::TestRetryWordCountOk` — 5 new cases:

```
test_ov_ep059_scenario_rejects_retry             — 883 → 555 (floor 600) rejected
test_healthy_retry_accepted                       — 1000 → 900 accepted
test_retry_below_floor_plus_margin_rejected       — 80% pass but floor-margin fails
test_env_intel_low_floor_lets_short_shows_swap   — env_intel floor=450 accepts 580
test_uses_max_of_two_constraints                  — stricter constraint wins
```

```
1889 passed, 6 skipped in 20.30s
```

## What does NOT change

- The repetition-detection heuristic itself.
- The runner's hard-floor abort (still fires on a truly broken script).
- The per-show `min_podcast_word_floor` config (env_intel 450, everyone else 600).
- TTS / audio / publishing.

## Not in this PR — operator follow-up worth knowing about

The OV digest log also showed 22+ trigram repetitions of `**What happened (neutral):**` / `**Questions to consider:**` / `**Read more (sources):**` — those are the OV digest prompt's intended per-story scaffold (added in PR #398 unblock) but they're now tripping the repetition detector as false positives. The detector then drives the retry loops that this PR is patching the safety on. Two reasonable follow-ups:

1. Whitelist the OV-shape labels in `engine.generator.detect_phrase_repetition` so they don't count as suspicious. ← my preferred path.
2. Reshape the OV digest prompt to NOT repeat the labels per story.

Either is a separate PR. Today's bug is the unsafe swap, which this PR fixes.

## Test plan

- [x] `pytest tests/test_generator_postprocess.py -v` — 16 passed (5 new).
- [x] `pytest tests/` — 1889 passed.
- [x] OV Ep 059 scenario verified — 555-word retry now correctly rejected.
- [ ] Next OV run ships (even if the digest prompt's per-story scaffold still trips the repetition detector — the safe swap means the original survives).


---
_Generated by [Claude Code](https://claude.ai/code/session_013sWzi3YLLjJgckvarquWZS)_