### PR TITLE
homepage: remove Find Your Show, lift Fresh/Blog/Why up; nav consistent site-wide

### DIFF
--- a/env-intel-summaries.html
+++ b/env-intel-summaries.html
@@ -236,6 +236,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="env-intel.html">Environmental Intelligence</a></li>
 <li><a href="blog/env_intel/index.html">Blog</a></li>
 <li><a href="env-intel-summaries.html">Summaries</a></li>
@@ -251,6 +255,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="env-intel.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Environmental Intelligence</a>
 <a href="blog/env_intel/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="env-intel-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/env-intel.html
+++ b/env-intel.html
@@ -272,6 +272,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="blog/env_intel/index.html">Blog</a></li>
 <li><a href="env-intel-summaries.html">Summaries</a></li>
 <li><a href="env_intel_podcast.rss">RSS</a></li>
@@ -286,6 +290,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="env-intel.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
 <a href="blog/env_intel/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="env-intel-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/fascinating-frontiers-summaries.html
+++ b/fascinating-frontiers-summaries.html
@@ -40,6 +40,20 @@
 
     
     
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
     
     
     <script defer src="assets/js/tracking.js"></script>
@@ -222,6 +236,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="fascinating-frontiers.html">Fascinating Frontiers</a></li>
 <li><a href="blog/fascinating_frontiers/index.html">Blog</a></li>
 <li><a href="fascinating-frontiers-summaries.html">Summaries</a></li>
@@ -237,6 +255,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="fascinating-frontiers.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Fascinating Frontiers</a>
 <a href="blog/fascinating_frontiers/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="fascinating-frontiers-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/fascinating-frontiers.html
+++ b/fascinating-frontiers.html
@@ -273,6 +273,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="blog/fascinating_frontiers/index.html">Blog</a></li>
 <li><a href="fascinating-frontiers-summaries.html">Summaries</a></li>
 <li><a href="fascinating_frontiers_podcast.rss">RSS</a></li>
@@ -287,6 +291,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="fascinating-frontiers.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
 <a href="blog/fascinating_frontiers/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="fascinating-frontiers-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/index.html
+++ b/index.html
@@ -44,6 +44,20 @@
 
     
     
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
     
     
     <script defer src="assets/js/tracking.js"></script>
@@ -369,6 +383,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="#latest">Latest</a></li>
 <li><a href="#subscribe">Subscribe</a></li>
 
@@ -381,6 +399,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="#latest" onclick="document.getElementById('mobileMenu').classList.remove('open')">Latest</a>
 <a href="#subscribe" onclick="document.getElementById('mobileMenu').classList.remove('open')">Subscribe</a>
 
@@ -697,52 +719,272 @@
         </div>
     </section>
 
-    <!-- Find Your Show — interactive picker -->
-    <section id="find-your-show" class="nn-section" style="background:var(--nn-bg-alt);">
+    
+
+    <!-- Latest Across the Network -->
+    <section id="latest" class="nn-section" style="background:var(--nn-bg-alt);">
         <div class="container">
             <div class="nn-section-header">
-                <div class="section-label">Find Your Show</div>
-                <h2>Tell us what you're into — we'll show you where to start</h2>
-                <p>Pick any filters and matching shows stay highlighted. Clear all to see everything.</p>
+                <div class="section-label">Fresh Episodes</div>
+                <h2>Latest Across the Network</h2>
+                <p>The most recent episodes from all shows.</p>
             </div>
-            <div class="picker">
-                <div class="picker-row">
-                    <span class="picker-label">Topic</span>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="tesla">🔋 Tesla / EV</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="world-news">📰 World news</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="space">🚀 Space &amp; astronomy</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="science">🧬 Science</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="longevity">⚕️ Longevity / biotech</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="environment">🌍 Environment / climate</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="ai">🤖 AI / ML</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="investing">📈 Investing</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="personal-finance">💰 Personal finance</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="language-learning">🗣️ Language learning</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="history">📜 History &amp; policy</button>
+        </div>
+        
+        <div class="latest-scroll-row">
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#E31937;">Tesla Shorts Time</div>
+                <div class="episode-card-title">Ep 481: Tesla’s new magnet patent cuts rare-earth content below one percent by weight while keeping the part structurally intact.</div>
+                <div class="episode-card-date">Sat, May 23, 2026</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep481_20260523.mp3" aria-label="Tesla Shorts Time episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#6B47FF;">Fascinating Frontiers</div>
+                <div class="episode-card-title">Ep 78: SpaceX just flew its largest Starship yet on a test that ended with a controlled splashdown halfway around the world.</div>
+                <div class="episode-card-date">Sat, May 23, 2026</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep078_20260523.mp3" aria-label="Fascinating Frontiers episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#017A99;">Planetterrian Daily</div>
+                <div class="episode-card-title">Ep 67: Ordinary WiFi signals can identify people with near-perfect accuracy even when phones are off.</div>
+                <div class="episode-card-date">Sat, May 23, 2026</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep067_20260523.mp3" aria-label="Planetterrian Daily episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#7C3AED;">Models & Agents</div>
+                <div class="episode-card-title">Ep 57: OpenAI just added goal mode and screen-aware context to Codex, letting agents work autonomously for hours on real tasks.</div>
+                <div class="episode-card-date">Sat, May 23, 2026</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep057_20260523.mp3" aria-label="Models & Agents episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#C2410C;">Models & Agents for Beginners</div>
+                <div class="episode-card-title">Ep 47: OpenAI just gave its coding AI the power to see whatever’s on your Mac screen with one click.</div>
+                <div class="episode-card-date">Sat, May 23, 2026</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep047_20260523.mp3" aria-label="Models & Agents for Beginners episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#047857;">Modern Investing Techniques</div>
+                <div class="episode-card-title">Ep 51: Bitcoin index options are coming to Nasdaq, giving Canadian investors in TFSA accounts a new listed vehicle to express views on crypto without holding the underlying coins directly.</div>
+                <div class="episode-card-date">Sat, May 23, 2026</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep051_20260523.mp3" aria-label="Modern Investing Techniques episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#0B6FD6;">Omni View</div>
+                <div class="episode-card-title">Ep 58: US-Iran talks show tentative progress toward ending conflict, yet disagreements over uranium stockpiles and Hormuz access keep energy markets and regional security on edge.</div>
+                <div class="episode-card-date">Fri, May 22, 2026</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep058_20260522.mp3" aria-label="Omni View episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#BE185D;">Финансы Просто</div>
+                <div class="episode-card-title">Финансы Просто - Episode 41 - May 22, 2026</div>
+                <div class="episode-card-date">Fri, May 22, 2026</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/finansy_prosto/FP_Ep041_20260522.mp3" aria-label="Финансы Просто episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#4F46E5;">Привет, Русский!</div>
+                <div class="episode-card-title">Привет, Русский! - Episode 29 - May 22, 2026</div>
+                <div class="episode-card-date">Fri, May 22, 2026</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/privet_russian/PR_Ep029_20260522.mp3" aria-label="Привет, Русский! episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#B45309;">Unintended Consequences</div>
+                <div class="episode-card-title">Ep 15: Ian Goodfellow designed GANs in 2014 to let machines create realistic images from scratch; five years later the same system was generating non-consensual pornography and fabricated political videos at scale.</div>
+                <div class="episode-card-date">Fri, May 22, 2026</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep015_20260522.mp3" aria-label="Unintended Consequences episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+        </div>
+        
+    </section>
+
+    <!-- Latest from the Blog -->
+    
+    <section class="nn-section">
+        <div class="container">
+            <div class="nn-section-header">
+                <div class="section-label">Blog</div>
+                <h2>Latest from the Blog</h2>
+                <p>In-depth articles from our latest episodes.</p>
+            </div>
+            <div class="blog-idx-grid" style="max-width:900px;margin:0 auto;padding-bottom:var(--sp-8)">
+                
+                <a href="blog/tesla/ep481.html"
+                   class="blog-idx-card"
+                   style="--card-show-color: #E31937">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #E31937 15%, transparent);color:#E31937">Tesla Shorts Time</span>
+                        <span class="blog-idx-date">May 23, 2026</span>
+                        <span class="blog-idx-ep">Ep 481</span>
+                        <span class="blog-idx-reading">7 min</span>
+                    </div>
+                    <h2>Tesla Shorts Time</h2>
+                    
+                    <p>Tesla’s new magnet patent cuts rare-earth content below one percent by weight while keeping the part structurally intact.</p>
+                    
+                    <span class="blog-idx-read-more" style="color:#E31937">Read article &rarr;</span>
+                </a>
+                
+                <a href="blog/fascinating_frontiers/ep078.html"
+                   class="blog-idx-card"
+                   style="--card-show-color: #6B47FF">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #6B47FF 15%, transparent);color:#6B47FF">Fascinating Frontiers</span>
+                        <span class="blog-idx-date">May 23, 2026</span>
+                        <span class="blog-idx-ep">Ep 78</span>
+                        <span class="blog-idx-reading">6 min</span>
+                    </div>
+                    <h2>Fascinating Frontiers</h2>
+                    
+                    <p>SpaceX just flew its largest Starship yet on a test that ended with a controlled splashdown halfway around the world.</p>
+                    
+                    <span class="blog-idx-read-more" style="color:#6B47FF">Read article &rarr;</span>
+                </a>
+                
+                <a href="blog/planetterrian/ep067.html"
+                   class="blog-idx-card"
+                   style="--card-show-color: #017A99">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #017A99 15%, transparent);color:#017A99">Planetterrian Daily</span>
+                        <span class="blog-idx-date">May 23, 2026</span>
+                        <span class="blog-idx-ep">Ep 67</span>
+                        <span class="blog-idx-reading">6 min</span>
+                    </div>
+                    <h2>Planetterrian Daily</h2>
+                    
+                    <p>Ordinary WiFi signals can identify people with near-perfect accuracy even when phones are off.</p>
+                    
+                    <span class="blog-idx-read-more" style="color:#017A99">Read article &rarr;</span>
+                </a>
+                
+                <a href="blog/models_agents/ep057.html"
+                   class="blog-idx-card"
+                   style="--card-show-color: #7C3AED">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #7C3AED 15%, transparent);color:#7C3AED">Models & Agents</span>
+                        <span class="blog-idx-date">May 23, 2026</span>
+                        <span class="blog-idx-ep">Ep 57</span>
+                        <span class="blog-idx-reading">6 min</span>
+                    </div>
+                    <h2>Models & Agents</h2>
+                    
+                    <p>OpenAI just added goal mode and screen-aware context to Codex, letting agents work autonomously for hours on real tasks.</p>
+                    
+                    <span class="blog-idx-read-more" style="color:#7C3AED">Read article &rarr;</span>
+                </a>
+                
+                <a href="blog/models_agents_beginners/ep047.html"
+                   class="blog-idx-card"
+                   style="--card-show-color: #C2410C">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #C2410C 15%, transparent);color:#C2410C">Models & Agents for Beginners</span>
+                        <span class="blog-idx-date">May 23, 2026</span>
+                        <span class="blog-idx-ep">Ep 47</span>
+                        <span class="blog-idx-reading">4 min</span>
+                    </div>
+                    <h2>Models & Agents for Beginners</h2>
+                    
+                    <p>OpenAI just gave its coding AI the power to see whatever’s on your Mac screen with one click.</p>
+                    
+                    <span class="blog-idx-read-more" style="color:#C2410C">Read article &rarr;</span>
+                </a>
+                
+                <a href="blog/modern_investing/ep051.html"
+                   class="blog-idx-card"
+                   style="--card-show-color: #047857">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #047857 15%, transparent);color:#047857">Modern Investing Techniques</span>
+                        <span class="blog-idx-date">May 23, 2026</span>
+                        <span class="blog-idx-ep">Ep 51</span>
+                        <span class="blog-idx-reading">5 min</span>
+                    </div>
+                    <h2>Modern Investing Techniques</h2>
+                    
+                    <p>Bitcoin index options are coming to Nasdaq, giving Canadian investors in TFSA accounts a new listed vehicle to express views on crypto witho&hellip;</p>
+                    
+                    <span class="blog-idx-read-more" style="color:#047857">Read article &rarr;</span>
+                </a>
+                
+            </div>
+            <div style="text-align:center">
+                <a href="blog/index.html" class="nn-btn nn-btn-primary" style="font-size:0.9rem;padding:var(--sp-3) var(--sp-8)">View all blog posts</a>
+            </div>
+        </div>
+    </section>
+    
+
+    <!-- Why Nerra -->
+    <section class="nn-section" style="background:var(--nn-bg-alt);">
+        <div class="container">
+            <div class="nn-section-header">
+                <div class="section-label">Why Nerra</div>
+                <h2>Built different</h2>
+            </div>
+            <div class="features-grid">
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#9889;</div>
+                    <h3>AI-Enhanced Research</h3>
+                    <p>Every episode is backed by real-time news analysis across dozens of sources, curated and verified by a human host.</p>
                 </div>
-                <div class="picker-row">
-                    <span class="picker-label">You are</span>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="investors">An investor</button>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="professionals">A pro in the field</button>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="builders">A builder / engineer</button>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="students">A student</button>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="beginners">A curious beginner</button>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="newcomers">A newcomer to Canada</button>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="enthusiasts">An enthusiast</button>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#127911;</div>
+                    <h3>Zero Ads. Zero Sponsors.</h3>
+                    <p>No ad reads, no sponsor segments, no paywalls. Just pure content, every single day. Free forever.</p>
                 </div>
-                <div class="picker-row">
-                    <span class="picker-label">Language</span>
-                    <button type="button" class="picker-chip" data-filter-group="language" data-filter-value="english">English</button>
-                    <button type="button" class="picker-chip" data-filter-group="language" data-filter-value="russian">Русский</button>
-                    <button type="button" class="picker-chip" data-filter-group="language" data-filter-value="bilingual">Bilingual (RU + EN)</button>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#127758;</div>
+                    <h3>Multi-Perspective Coverage</h3>
+                    <p>We pull from diverse sources to present balanced, nuanced takes — not echo chambers or clickbait.</p>
                 </div>
-                <div class="picker-row picker-row-actions">
-                    <button type="button" class="picker-clear nn-btn">Clear filters</button>
-                    <span class="picker-count" aria-live="polite">Showing all <strong id="picker-count-total">11</strong> shows</span>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#128197;</div>
+                    <h3>Daily Consistency</h3>
+                    <p>New episodes every day (or weekday), rain or shine. Build a daily learning habit you can rely on.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#127463;&#127464;</div>
+                    <h3>Made in Canada</h3>
+                    <p>Independently produced in Vancouver by Patrick. No corporate backing, no editorial interference.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#128266;</div>
+                    <h3>Multilingual</h3>
+                    <p>Shows in English and Russian, with more languages planned. Knowledge shouldn't have a language barrier.</p>
                 </div>
             </div>
         </div>
     </section>
+
+    
 
     <!-- Show Showcase -->
     <section id="shows" class="nn-section">
@@ -1176,267 +1418,6 @@
         </div>
     </section>
 
-    <!-- Latest Across the Network -->
-    <section id="latest" class="nn-section" style="background:var(--nn-bg-alt);">
-        <div class="container">
-            <div class="nn-section-header">
-                <div class="section-label">Fresh Episodes</div>
-                <h2>Latest Across the Network</h2>
-                <p>The most recent episodes from all shows.</p>
-            </div>
-        </div>
-        
-        <div class="latest-scroll-row">
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#E31937;">Tesla Shorts Time</div>
-                <div class="episode-card-title">Ep 481: Tesla’s new magnet patent cuts rare-earth content below one percent by weight while keeping the part structurally intact.</div>
-                <div class="episode-card-date">Sat, May 23, 2026</div>
-                
-                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep481_20260523.mp3" aria-label="Tesla Shorts Time episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#6B47FF;">Fascinating Frontiers</div>
-                <div class="episode-card-title">Ep 78: SpaceX just flew its largest Starship yet on a test that ended with a controlled splashdown halfway around the world.</div>
-                <div class="episode-card-date">Sat, May 23, 2026</div>
-                
-                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep078_20260523.mp3" aria-label="Fascinating Frontiers episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#017A99;">Planetterrian Daily</div>
-                <div class="episode-card-title">Ep 67: Ordinary WiFi signals can identify people with near-perfect accuracy even when phones are off.</div>
-                <div class="episode-card-date">Sat, May 23, 2026</div>
-                
-                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep067_20260523.mp3" aria-label="Planetterrian Daily episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#7C3AED;">Models & Agents</div>
-                <div class="episode-card-title">Ep 57: OpenAI just added goal mode and screen-aware context to Codex, letting agents work autonomously for hours on real tasks.</div>
-                <div class="episode-card-date">Sat, May 23, 2026</div>
-                
-                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep057_20260523.mp3" aria-label="Models & Agents episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#C2410C;">Models & Agents for Beginners</div>
-                <div class="episode-card-title">Ep 47: OpenAI just gave its coding AI the power to see whatever’s on your Mac screen with one click.</div>
-                <div class="episode-card-date">Sat, May 23, 2026</div>
-                
-                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep047_20260523.mp3" aria-label="Models & Agents for Beginners episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#047857;">Modern Investing Techniques</div>
-                <div class="episode-card-title">Ep 51: Bitcoin index options are coming to Nasdaq, giving Canadian investors in TFSA accounts a new listed vehicle to express views on crypto without holding the underlying coins directly.</div>
-                <div class="episode-card-date">Sat, May 23, 2026</div>
-                
-                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep051_20260523.mp3" aria-label="Modern Investing Techniques episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#0B6FD6;">Omni View</div>
-                <div class="episode-card-title">Ep 58: US-Iran talks show tentative progress toward ending conflict, yet disagreements over uranium stockpiles and Hormuz access keep energy markets and regional security on edge.</div>
-                <div class="episode-card-date">Fri, May 22, 2026</div>
-                
-                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep058_20260522.mp3" aria-label="Omni View episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#BE185D;">Финансы Просто</div>
-                <div class="episode-card-title">Финансы Просто - Episode 41 - May 22, 2026</div>
-                <div class="episode-card-date">Fri, May 22, 2026</div>
-                
-                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/finansy_prosto/FP_Ep041_20260522.mp3" aria-label="Финансы Просто episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#4F46E5;">Привет, Русский!</div>
-                <div class="episode-card-title">Привет, Русский! - Episode 29 - May 22, 2026</div>
-                <div class="episode-card-date">Fri, May 22, 2026</div>
-                
-                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/privet_russian/PR_Ep029_20260522.mp3" aria-label="Привет, Русский! episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:#B45309;">Unintended Consequences</div>
-                <div class="episode-card-title">Ep 15: Ian Goodfellow designed GANs in 2014 to let machines create realistic images from scratch; five years later the same system was generating non-consensual pornography and fabricated political videos at scale.</div>
-                <div class="episode-card-date">Fri, May 22, 2026</div>
-                
-                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep015_20260522.mp3" aria-label="Unintended Consequences episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                
-            </div>
-            
-        </div>
-        
-    </section>
-
-    <!-- Why Nerra -->
-    <section class="nn-section">
-        <div class="container">
-            <div class="nn-section-header">
-                <div class="section-label">Why Nerra</div>
-                <h2>Built different</h2>
-            </div>
-            <div class="features-grid">
-                <div class="feature-card glass-card">
-                    <div class="feature-icon">&#9889;</div>
-                    <h3>AI-Enhanced Research</h3>
-                    <p>Every episode is backed by real-time news analysis across dozens of sources, curated and verified by a human host.</p>
-                </div>
-                <div class="feature-card glass-card">
-                    <div class="feature-icon">&#127911;</div>
-                    <h3>Zero Ads. Zero Sponsors.</h3>
-                    <p>No ad reads, no sponsor segments, no paywalls. Just pure content, every single day. Free forever.</p>
-                </div>
-                <div class="feature-card glass-card">
-                    <div class="feature-icon">&#127758;</div>
-                    <h3>Multi-Perspective Coverage</h3>
-                    <p>We pull from diverse sources to present balanced, nuanced takes — not echo chambers or clickbait.</p>
-                </div>
-                <div class="feature-card glass-card">
-                    <div class="feature-icon">&#128197;</div>
-                    <h3>Daily Consistency</h3>
-                    <p>New episodes every day (or weekday), rain or shine. Build a daily learning habit you can rely on.</p>
-                </div>
-                <div class="feature-card glass-card">
-                    <div class="feature-icon">&#127463;&#127464;</div>
-                    <h3>Made in Canada</h3>
-                    <p>Independently produced in Vancouver by Patrick. No corporate backing, no editorial interference.</p>
-                </div>
-                <div class="feature-card glass-card">
-                    <div class="feature-icon">&#128266;</div>
-                    <h3>Multilingual</h3>
-                    <p>Shows in English and Russian, with more languages planned. Knowledge shouldn't have a language barrier.</p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Latest from the Blog -->
-    
-    <section class="nn-section">
-        <div class="container">
-            <div class="nn-section-header">
-                <div class="section-label">Blog</div>
-                <h2>Latest from the Blog</h2>
-                <p>In-depth articles from our latest episodes.</p>
-            </div>
-            <div class="blog-idx-grid" style="max-width:900px;margin:0 auto;padding-bottom:var(--sp-8)">
-                
-                <a href="blog/tesla/ep481.html"
-                   class="blog-idx-card"
-                   style="--card-show-color: #E31937">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #E31937 15%, transparent);color:#E31937">Tesla Shorts Time</span>
-                        <span class="blog-idx-date">May 23, 2026</span>
-                        <span class="blog-idx-ep">Ep 481</span>
-                        <span class="blog-idx-reading">7 min</span>
-                    </div>
-                    <h2>Tesla Shorts Time</h2>
-                    
-                    <p>Tesla’s new magnet patent cuts rare-earth content below one percent by weight while keeping the part structurally intact.</p>
-                    
-                    <span class="blog-idx-read-more" style="color:#E31937">Read article &rarr;</span>
-                </a>
-                
-                <a href="blog/fascinating_frontiers/ep078.html"
-                   class="blog-idx-card"
-                   style="--card-show-color: #6B47FF">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #6B47FF 15%, transparent);color:#6B47FF">Fascinating Frontiers</span>
-                        <span class="blog-idx-date">May 23, 2026</span>
-                        <span class="blog-idx-ep">Ep 78</span>
-                        <span class="blog-idx-reading">6 min</span>
-                    </div>
-                    <h2>Fascinating Frontiers</h2>
-                    
-                    <p>SpaceX just flew its largest Starship yet on a test that ended with a controlled splashdown halfway around the world.</p>
-                    
-                    <span class="blog-idx-read-more" style="color:#6B47FF">Read article &rarr;</span>
-                </a>
-                
-                <a href="blog/planetterrian/ep067.html"
-                   class="blog-idx-card"
-                   style="--card-show-color: #017A99">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #017A99 15%, transparent);color:#017A99">Planetterrian Daily</span>
-                        <span class="blog-idx-date">May 23, 2026</span>
-                        <span class="blog-idx-ep">Ep 67</span>
-                        <span class="blog-idx-reading">6 min</span>
-                    </div>
-                    <h2>Planetterrian Daily</h2>
-                    
-                    <p>Ordinary WiFi signals can identify people with near-perfect accuracy even when phones are off.</p>
-                    
-                    <span class="blog-idx-read-more" style="color:#017A99">Read article &rarr;</span>
-                </a>
-                
-                <a href="blog/models_agents/ep057.html"
-                   class="blog-idx-card"
-                   style="--card-show-color: #7C3AED">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #7C3AED 15%, transparent);color:#7C3AED">Models & Agents</span>
-                        <span class="blog-idx-date">May 23, 2026</span>
-                        <span class="blog-idx-ep">Ep 57</span>
-                        <span class="blog-idx-reading">6 min</span>
-                    </div>
-                    <h2>Models & Agents</h2>
-                    
-                    <p>OpenAI just added goal mode and screen-aware context to Codex, letting agents work autonomously for hours on real tasks.</p>
-                    
-                    <span class="blog-idx-read-more" style="color:#7C3AED">Read article &rarr;</span>
-                </a>
-                
-                <a href="blog/models_agents_beginners/ep047.html"
-                   class="blog-idx-card"
-                   style="--card-show-color: #C2410C">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #C2410C 15%, transparent);color:#C2410C">Models & Agents for Beginners</span>
-                        <span class="blog-idx-date">May 23, 2026</span>
-                        <span class="blog-idx-ep">Ep 47</span>
-                        <span class="blog-idx-reading">4 min</span>
-                    </div>
-                    <h2>Models & Agents for Beginners</h2>
-                    
-                    <p>OpenAI just gave its coding AI the power to see whatever’s on your Mac screen with one click.</p>
-                    
-                    <span class="blog-idx-read-more" style="color:#C2410C">Read article &rarr;</span>
-                </a>
-                
-                <a href="blog/modern_investing/ep051.html"
-                   class="blog-idx-card"
-                   style="--card-show-color: #047857">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, #047857 15%, transparent);color:#047857">Modern Investing Techniques</span>
-                        <span class="blog-idx-date">May 23, 2026</span>
-                        <span class="blog-idx-ep">Ep 51</span>
-                        <span class="blog-idx-reading">5 min</span>
-                    </div>
-                    <h2>Modern Investing Techniques</h2>
-                    
-                    <p>Bitcoin index options are coming to Nasdaq, giving Canadian investors in TFSA accounts a new listed vehicle to express views on crypto witho&hellip;</p>
-                    
-                    <span class="blog-idx-read-more" style="color:#047857">Read article &rarr;</span>
-                </a>
-                
-            </div>
-            <div style="text-align:center">
-                <a href="blog/index.html" class="nn-btn nn-btn-primary" style="font-size:0.9rem;padding:var(--sp-3) var(--sp-8)">View all blog posts</a>
-            </div>
-        </div>
-    </section>
     
 
     <!-- About the Network -->
@@ -1766,37 +1747,8 @@
 
     
     <style>
-      .picker { max-width: 960px; margin: 0 auto; }
-      .picker-row {
-        display: flex; flex-wrap: wrap; align-items: center; gap: 10px;
-        padding: 10px 0;
-      }
-      .picker-label {
-        flex: 0 0 auto; min-width: 88px;
-        font-family: var(--font-ui); font-size: 0.85rem;
-        color: var(--nn-text-muted); text-transform: uppercase; letter-spacing: 0.05em;
-      }
-      .picker-chip {
-        background: transparent; border: 1px solid var(--nn-border);
-        color: var(--nn-text); border-radius: 999px;
-        min-height: 44px;
-        display: inline-flex; align-items: center;
-        padding: 8px 16px; font-size: 0.9rem; font-family: var(--font-ui);
-        cursor: pointer; transition: background 120ms, border-color 120ms, color 120ms;
-      }
-      .picker-chip:hover { border-color: #6B47FF; }
-      .picker-chip.is-active {
-        background: rgba(124, 92, 255, 0.18);
-        border-color: #6B47FF;
-        color: #fff;
-      }
-      .picker-row-actions { justify-content: space-between; padding-top: 18px; }
-      .picker-clear { font-size: 0.85rem; padding: 8px 16px; }
-      .picker-count { color: var(--nn-text-muted); font-size: 0.85rem; font-family: var(--font-ui); }
-      .picker-count strong { color: var(--nn-text); }
-
-      /* Cards that don't match the active filters fade out but stay in DOM
-         order so the grid layout doesn't jump around. */
+      /* Show-card filter states — used by future picker reinstatement
+         or any other selector that wants to dim non-matching cards. */
       .show-card-wrap.is-dimmed { opacity: 0.32; filter: grayscale(0.5); }
       .show-card-wrap.is-dimmed .show-card { pointer-events: none; }
       .show-card-wrap.is-match {
@@ -1809,6 +1761,7 @@
       }
       .show-card-audience strong { color: var(--nn-text); font-weight: 600; }
 
+      /* Subscribe-section per-show rows — independent of the picker. */
       .subscribe-show-list {
         display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
         gap: 12px; margin: 24px auto 0; max-width: 1100px;
@@ -1831,83 +1784,6 @@
       .subscribe-link-btn:hover { background: rgba(124,92,255,0.22); }
       .subscribe-link-rss { background: rgba(255,140,0,0.12); }
     </style>
-
-    <script>
-    (function () {
-      const grid = document.getElementById("show-showcase-grid");
-      if (!grid) return;
-      const cards = Array.from(grid.querySelectorAll(".show-card-wrap"));
-      const chips = Array.from(document.querySelectorAll(".picker-chip"));
-      const clearBtn = document.querySelector(".picker-clear");
-      const countEl = document.getElementById("picker-count-total");
-      const total = cards.length;
-
-      const active = { topics: new Set(), audience: new Set(), language: new Set() };
-
-      function tokensOf(card, group) {
-        const raw = card.getAttribute("data-" + group) || "";
-        return raw.split(/\s+/).filter(Boolean);
-      }
-
-      function cardMatches(card) {
-        for (const group of ["topics", "audience", "language"]) {
-          const wanted = active[group];
-          if (wanted.size === 0) continue;
-          const has = new Set(tokensOf(card, group));
-          let ok = false;
-          for (const w of wanted) {
-            if (has.has(w)) { ok = true; break; }
-          }
-          if (!ok) return false;
-        }
-        return true;
-      }
-
-      function applyFilters() {
-        const anyActive =
-          active.topics.size + active.audience.size + active.language.size > 0;
-        let matched = 0;
-        cards.forEach((card) => {
-          const m = cardMatches(card);
-          card.classList.toggle("is-dimmed", anyActive && !m);
-          card.classList.toggle("is-match", anyActive && m);
-          if (m) matched++;
-        });
-        if (!countEl) return;
-        if (!anyActive) {
-          countEl.textContent = total;
-          countEl.parentElement.firstChild.textContent = "Showing all ";
-        } else {
-          countEl.textContent = matched;
-          countEl.parentElement.firstChild.textContent = "Showing ";
-        }
-      }
-
-      chips.forEach((chip) => {
-        chip.addEventListener("click", () => {
-          const group = chip.getAttribute("data-filter-group");
-          const value = chip.getAttribute("data-filter-value");
-          if (!group || !value || !active[group]) return;
-          if (active[group].has(value)) {
-            active[group].delete(value);
-            chip.classList.remove("is-active");
-          } else {
-            active[group].add(value);
-            chip.classList.add("is-active");
-          }
-          applyFilters();
-        });
-      });
-
-      if (clearBtn) {
-        clearBtn.addEventListener("click", () => {
-          for (const k in active) active[k].clear();
-          chips.forEach((c) => c.classList.remove("is-active"));
-          applyFilters();
-        });
-      }
-    })();
-    </script>
 
     </main>
 

--- a/models-agents-beginners-summaries.html
+++ b/models-agents-beginners-summaries.html
@@ -40,6 +40,20 @@
 
     
     
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
     
     
     <script defer src="assets/js/tracking.js"></script>
@@ -222,6 +236,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="models-agents-beginners.html">Models & Agents for Beginners</a></li>
 <li><a href="blog/models_agents_beginners/index.html">Blog</a></li>
 <li><a href="models-agents-beginners-summaries.html">Summaries</a></li>
@@ -237,6 +255,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="models-agents-beginners.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Models & Agents for Beginners</a>
 <a href="blog/models_agents_beginners/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="models-agents-beginners-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/models-agents-beginners.html
+++ b/models-agents-beginners.html
@@ -273,6 +273,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="blog/models_agents_beginners/index.html">Blog</a></li>
 <li><a href="models-agents-beginners-summaries.html">Summaries</a></li>
 <li><a href="models_agents_beginners_podcast.rss">RSS</a></li>
@@ -287,6 +291,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="models-agents-beginners.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
 <a href="blog/models_agents_beginners/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="models-agents-beginners-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/models-agents-summaries.html
+++ b/models-agents-summaries.html
@@ -40,6 +40,20 @@
 
     
     
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
     
     
     <script defer src="assets/js/tracking.js"></script>
@@ -222,6 +236,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="models-agents.html">Models & Agents</a></li>
 <li><a href="blog/models_agents/index.html">Blog</a></li>
 <li><a href="models-agents-summaries.html">Summaries</a></li>
@@ -237,6 +255,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="models-agents.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Models & Agents</a>
 <a href="blog/models_agents/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="models-agents-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/models-agents.html
+++ b/models-agents.html
@@ -273,6 +273,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="blog/models_agents/index.html">Blog</a></li>
 <li><a href="models-agents-summaries.html">Summaries</a></li>
 <li><a href="models_agents_podcast.rss">RSS</a></li>
@@ -287,6 +291,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="models-agents.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
 <a href="blog/models_agents/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="models-agents-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/modern-investing-summaries.html
+++ b/modern-investing-summaries.html
@@ -40,6 +40,20 @@
 
     
     
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
     
     
     <script defer src="assets/js/tracking.js"></script>
@@ -222,6 +236,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="modern-investing.html">Modern Investing Techniques</a></li>
 <li><a href="blog/modern_investing/index.html">Blog</a></li>
 <li><a href="modern-investing-summaries.html">Summaries</a></li>
@@ -237,6 +255,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="modern-investing.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Modern Investing Techniques</a>
 <a href="blog/modern_investing/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="modern-investing-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/modern-investing.html
+++ b/modern-investing.html
@@ -273,6 +273,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="blog/modern_investing/index.html">Blog</a></li>
 <li><a href="modern-investing-summaries.html">Summaries</a></li>
 <li><a href="modern_investing_podcast.rss">RSS</a></li>
@@ -287,6 +291,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="modern-investing.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
 <a href="blog/modern_investing/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="modern-investing-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/omni-view-summaries.html
+++ b/omni-view-summaries.html
@@ -40,6 +40,20 @@
 
     
     
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
     
     
     <script defer src="assets/js/tracking.js"></script>
@@ -222,6 +236,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="omni-view.html">Omni View</a></li>
 <li><a href="blog/omni_view/index.html">Blog</a></li>
 <li><a href="omni-view-summaries.html">Summaries</a></li>
@@ -237,6 +255,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="omni-view.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Omni View</a>
 <a href="blog/omni_view/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="omni-view-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/omni-view.html
+++ b/omni-view.html
@@ -273,6 +273,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="blog/omni_view/index.html">Blog</a></li>
 <li><a href="omni-view-summaries.html">Summaries</a></li>
 <li><a href="omni_view_podcast.rss">RSS</a></li>
@@ -287,6 +291,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="omni-view.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
 <a href="blog/omni_view/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="omni-view-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/planetterrian-summaries.html
+++ b/planetterrian-summaries.html
@@ -40,6 +40,20 @@
 
     
     
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
     
     
     <script defer src="assets/js/tracking.js"></script>
@@ -222,6 +236,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="planetterrian.html">Planetterrian Daily</a></li>
 <li><a href="blog/planetterrian/index.html">Blog</a></li>
 <li><a href="planetterrian-summaries.html">Summaries</a></li>
@@ -237,6 +255,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="planetterrian.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Planetterrian Daily</a>
 <a href="blog/planetterrian/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="planetterrian-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/planetterrian.html
+++ b/planetterrian.html
@@ -273,6 +273,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="blog/planetterrian/index.html">Blog</a></li>
 <li><a href="planetterrian-summaries.html">Summaries</a></li>
 <li><a href="planetterrian_podcast.rss">RSS</a></li>
@@ -287,6 +291,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="planetterrian.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
 <a href="blog/planetterrian/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="planetterrian-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/ru/finansy-prosto-summaries.html
+++ b/ru/finansy-prosto-summaries.html
@@ -236,6 +236,10 @@
                     </div>
                 </li>
                 
+<li><a href="../start-here.html">Начало</a></li>
+<li><a href="../how-to-listen.html">Где слушать</a></li>
+<li><a href="../about.html">О нас</a></li>
+<li><a href="../player.html">Плеер</a></li>
 <li><a href="../ru/finansy-prosto.html">Финансы Просто</a></li>
 <li><a href="../blog/finansy_prosto/index.html">Blog</a></li>
 <li><a href="../ru/finansy-prosto-summaries.html">Summaries</a></li>
@@ -251,6 +255,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="../start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Начало</a>
+<a href="../how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Где слушать</a>
+<a href="../about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">О нас</a>
+<a href="../player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Плеер</a>
 <a href="../ru/finansy-prosto.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Финансы Просто</a>
 <a href="../blog/finansy_prosto/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="../ru/finansy-prosto-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
@@ -745,6 +753,7 @@
                 <a href="../privacy-policy.html">Политика конфиденциальности</a>
                 <a href="../terms-of-service.html">Условия использования</a>
                 <a href="../ai-disclosure.html">ИИ-раскрытие</a>
+                <a href="../editorial.html">Редакционная политика</a>
                 <a href="../management.html">Статус сети</a>
             </div>
             <!-- Newsletter Subscribe -->
@@ -753,14 +762,16 @@
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Подписка…";setTimeout(function(){btn.textContent="Проверьте почту ✓";btn.disabled=false;},500);">
                     <h4>Подписка на обновления</h4>
                     <p>Выберите подкасты, которые хотите получать на почту:</p>
-                    <div class="nn-subscribe-tags">
-                        <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                    <div class="nn-subscribe-tags"><label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                        <label><input type="checkbox" name="tag" value="Omni View"> Omni View</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
-                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models & Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Planetterrian Daily"> Planetterrian Daily</label>
                         <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents"> Models &amp; Agents</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models &amp; Agents for Beginners</label>
                         <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
-                        <label><input type="checkbox" name="tag" value="Финансы Просто"> Финансы Просто</label>
-                        <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
+                        <label><input type="checkbox" name="tag" value="Unintended Consequences"> Unintended Consequences</label><label><input type="checkbox" name="tag" value="Finansy Prosto"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Privet Russian"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">

--- a/ru/finansy-prosto.html
+++ b/ru/finansy-prosto.html
@@ -273,6 +273,10 @@
                     </div>
                 </li>
                 
+<li><a href="../start-here.html">Начало</a></li>
+<li><a href="../how-to-listen.html">Где слушать</a></li>
+<li><a href="../about.html">О нас</a></li>
+<li><a href="../player.html">Плеер</a></li>
 <li><a href="../blog/finansy_prosto/index.html">Блог</a></li>
 <li><a href="../ru/finansy-prosto-summaries.html">Выпуски</a></li>
 <li><a href="../finansy_prosto_podcast.rss">RSS</a></li>
@@ -287,6 +291,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="../start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Начало</a>
+<a href="../how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Где слушать</a>
+<a href="../about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">О нас</a>
+<a href="../player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Плеер</a>
 <a href="../ru/finansy-prosto.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Главная</a>
 <a href="../blog/finansy_prosto/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Блог</a>
 <a href="../ru/finansy-prosto-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Выпуски</a>

--- a/ru/privet-russian-summaries.html
+++ b/ru/privet-russian-summaries.html
@@ -236,6 +236,10 @@
                     </div>
                 </li>
                 
+<li><a href="../start-here.html">Начало</a></li>
+<li><a href="../how-to-listen.html">Где слушать</a></li>
+<li><a href="../about.html">О нас</a></li>
+<li><a href="../player.html">Плеер</a></li>
 <li><a href="../ru/privet-russian.html">Привет, Русский!</a></li>
 <li><a href="../blog/privet_russian/index.html">Blog</a></li>
 <li><a href="../ru/privet-russian-summaries.html">Summaries</a></li>
@@ -251,6 +255,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="../start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Начало</a>
+<a href="../how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Где слушать</a>
+<a href="../about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">О нас</a>
+<a href="../player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Плеер</a>
 <a href="../ru/privet-russian.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Привет, Русский!</a>
 <a href="../blog/privet_russian/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="../ru/privet-russian-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
@@ -745,6 +753,7 @@
                 <a href="../privacy-policy.html">Политика конфиденциальности</a>
                 <a href="../terms-of-service.html">Условия использования</a>
                 <a href="../ai-disclosure.html">ИИ-раскрытие</a>
+                <a href="../editorial.html">Редакционная политика</a>
                 <a href="../management.html">Статус сети</a>
             </div>
             <!-- Newsletter Subscribe -->
@@ -753,14 +762,16 @@
                       onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Подписка…";setTimeout(function(){btn.textContent="Проверьте почту ✓";btn.disabled=false;},500);">
                     <h4>Подписка на обновления</h4>
                     <p>Выберите подкасты, которые хотите получать на почту:</p>
-                    <div class="nn-subscribe-tags">
-                        <label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                    <div class="nn-subscribe-tags"><label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                        <label><input type="checkbox" name="tag" value="Omni View"> Omni View</label>
                         <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
-                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models & Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Planetterrian Daily"> Planetterrian Daily</label>
                         <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents"> Models &amp; Agents</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models &amp; Agents for Beginners</label>
                         <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
-                        <label><input type="checkbox" name="tag" value="Финансы Просто"> Финансы Просто</label>
-                        <label><input type="checkbox" name="tag" value="Привет, Русский!"> Привет, Русский!</label>
+                        <label><input type="checkbox" name="tag" value="Unintended Consequences"> Unintended Consequences</label><label><input type="checkbox" name="tag" value="Finansy Prosto"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Privet Russian"> Привет, Русский!</label>
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="ваш@email.ru" required aria-label="Адрес электронной почты">

--- a/ru/privet-russian.html
+++ b/ru/privet-russian.html
@@ -273,6 +273,10 @@
                     </div>
                 </li>
                 
+<li><a href="../start-here.html">Начало</a></li>
+<li><a href="../how-to-listen.html">Где слушать</a></li>
+<li><a href="../about.html">О нас</a></li>
+<li><a href="../player.html">Плеер</a></li>
 <li><a href="../blog/privet_russian/index.html">Блог</a></li>
 <li><a href="../ru/privet-russian-summaries.html">Выпуски</a></li>
 <li><a href="../privet_russian_podcast.rss">RSS</a></li>
@@ -287,6 +291,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="../start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Начало</a>
+<a href="../how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Где слушать</a>
+<a href="../about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">О нас</a>
+<a href="../player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Плеер</a>
 <a href="../ru/privet-russian.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Главная</a>
 <a href="../blog/privet_russian/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Блог</a>
 <a href="../ru/privet-russian-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Выпуски</a>

--- a/templates/network_page.html.j2
+++ b/templates/network_page.html.j2
@@ -1,11 +1,25 @@
 {% extends "base.html.j2" %}
 
+{# May 2026 operator request: homepage nav previously read just
+   ``Latest | Subscribe`` — inconsistent with the rest of the site
+   which carries ``Start Here | Listen | About | Player`` in the
+   top-right. Switched to that 4-link set + the in-page ``Latest``
+   and ``Subscribe`` anchors so the homepage matches every other
+   page while still exposing the homepage-specific jump links. #}
 {% block nav_links %}
+<li><a href="{{ path_prefix }}start-here.html">{{ t.nav_start_here }}</a></li>
+<li><a href="{{ path_prefix }}how-to-listen.html">{{ t.nav_listen }}</a></li>
+<li><a href="{{ path_prefix }}about.html">{{ t.nav_about }}</a></li>
+<li><a href="{{ path_prefix }}player.html">{{ t.nav_player }}</a></li>
 <li><a href="#latest">Latest</a></li>
 <li><a href="#subscribe">Subscribe</a></li>
 {% endblock %}
 
 {% block mobile_nav_links %}
+<a href="{{ path_prefix }}start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ t.nav_start_here }}</a>
+<a href="{{ path_prefix }}how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ t.nav_listen }}</a>
+<a href="{{ path_prefix }}about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ t.nav_about }}</a>
+<a href="{{ path_prefix }}player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ t.nav_player }}</a>
 <a href="#latest" onclick="document.getElementById('mobileMenu').classList.remove('open')">Latest</a>
 <a href="#subscribe" onclick="document.getElementById('mobileMenu').classList.remove('open')">Subscribe</a>
 {% endblock %}
@@ -181,52 +195,127 @@
         </div>
     </section>
 
-    <!-- Find Your Show — interactive picker -->
-    <section id="find-your-show" class="nn-section" style="background:var(--nn-bg-alt);">
+    {# May 2026 operator request: "Find Your Show" interactive picker
+       was removed and replaced by the Fresh Episodes / Blog / Why Nerra
+       triplet (in that order) — these three sections used to live
+       BELOW the Show Showcase grid; they now sit in the prime slot
+       between the stats bar and the show grid so the page leads with
+       what listeners actually came for (recent episodes + recent
+       writing + the network's pitch) before showing the full
+       show-grid catalogue. The old triplet positions below have been
+       removed in the same edit to avoid duplication. #}
+
+    <!-- Latest Across the Network -->
+    <section id="latest" class="nn-section" style="background:var(--nn-bg-alt);">
         <div class="container">
             <div class="nn-section-header">
-                <div class="section-label">Find Your Show</div>
-                <h2>Tell us what you're into — we'll show you where to start</h2>
-                <p>Pick any filters and matching shows stay highlighted. Clear all to see everything.</p>
+                <div class="section-label">Fresh Episodes</div>
+                <h2>Latest Across the Network</h2>
+                <p>The most recent episodes from all shows.</p>
             </div>
-            <div class="picker">
-                <div class="picker-row">
-                    <span class="picker-label">Topic</span>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="tesla">🔋 Tesla / EV</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="world-news">📰 World news</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="space">🚀 Space &amp; astronomy</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="science">🧬 Science</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="longevity">⚕️ Longevity / biotech</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="environment">🌍 Environment / climate</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="ai">🤖 AI / ML</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="investing">📈 Investing</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="personal-finance">💰 Personal finance</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="language-learning">🗣️ Language learning</button>
-                    <button type="button" class="picker-chip" data-filter-group="topics" data-filter-value="history">📜 History &amp; policy</button>
+        </div>
+        {% if latest_episodes %}
+        <div class="latest-scroll-row">
+            {% for ep in latest_episodes %}
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:{{ ep.brand_color }};">{{ ep.show_name }}</div>
+                <div class="episode-card-title">{{ ep.title }}</div>
+                <div class="episode-card-date">{{ ep.date_display }}</div>
+                {% if ep.audio_url %}
+                <audio controls preload="none" src="{{ ep.audio_url }}" aria-label="{{ ep.show_name }} episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                {% endif %}
+            </div>
+            {% endfor %}
+        </div>
+        {% else %}
+        <div class="latest-scroll-row">
+            <p style="color:var(--nn-text-muted);padding:2rem;text-align:center;width:100%;">Episodes will appear here once available.</p>
+        </div>
+        {% endif %}
+    </section>
+
+    <!-- Latest from the Blog -->
+    {% if latest_blog_posts %}
+    <section class="nn-section">
+        <div class="container">
+            <div class="nn-section-header">
+                <div class="section-label">Blog</div>
+                <h2>Latest from the Blog</h2>
+                <p>In-depth articles from our latest episodes.</p>
+            </div>
+            <div class="blog-idx-grid" style="max-width:900px;margin:0 auto;padding-bottom:var(--sp-8)">
+                {% for post in latest_blog_posts %}
+                <a href="blog/{{ post.show_slug }}/ep{{ '%03d' % post.episode_num }}.html"
+                   class="blog-idx-card"
+                   style="--card-show-color: {{ post.show_color }}">
+                    <div class="blog-idx-card-top">
+                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, {{ post.show_color }} 15%, transparent);color:{{ post.show_color }}">{{ post.show_name }}</span>
+                        <span class="blog-idx-date">{{ post.date }}</span>
+                        <span class="blog-idx-ep">Ep {{ post.episode_num }}</span>
+                        <span class="blog-idx-reading">{{ post.reading_time_min }} min</span>
+                    </div>
+                    <h2>{{ post.title }}</h2>
+                    {% if post.hook %}
+                    <p>{{ post.hook[:140] }}{% if post.hook|length > 140 %}&hellip;{% endif %}</p>
+                    {% endif %}
+                    <span class="blog-idx-read-more" style="color:{{ post.show_color }}">Read article &rarr;</span>
+                </a>
+                {% endfor %}
+            </div>
+            <div style="text-align:center">
+                <a href="blog/index.html" class="nn-btn nn-btn-primary" style="font-size:0.9rem;padding:var(--sp-3) var(--sp-8)">View all blog posts</a>
+            </div>
+        </div>
+    </section>
+    {% endif %}
+
+    <!-- Why Nerra -->
+    <section class="nn-section" style="background:var(--nn-bg-alt);">
+        <div class="container">
+            <div class="nn-section-header">
+                <div class="section-label">Why Nerra</div>
+                <h2>Built different</h2>
+            </div>
+            <div class="features-grid">
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#9889;</div>
+                    <h3>AI-Enhanced Research</h3>
+                    <p>Every episode is backed by real-time news analysis across dozens of sources, curated and verified by a human host.</p>
                 </div>
-                <div class="picker-row">
-                    <span class="picker-label">You are</span>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="investors">An investor</button>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="professionals">A pro in the field</button>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="builders">A builder / engineer</button>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="students">A student</button>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="beginners">A curious beginner</button>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="newcomers">A newcomer to Canada</button>
-                    <button type="button" class="picker-chip" data-filter-group="audience" data-filter-value="enthusiasts">An enthusiast</button>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#127911;</div>
+                    <h3>Zero Ads. Zero Sponsors.</h3>
+                    <p>No ad reads, no sponsor segments, no paywalls. Just pure content, every single day. Free forever.</p>
                 </div>
-                <div class="picker-row">
-                    <span class="picker-label">Language</span>
-                    <button type="button" class="picker-chip" data-filter-group="language" data-filter-value="english">English</button>
-                    <button type="button" class="picker-chip" data-filter-group="language" data-filter-value="russian">Русский</button>
-                    <button type="button" class="picker-chip" data-filter-group="language" data-filter-value="bilingual">Bilingual (RU + EN)</button>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#127758;</div>
+                    <h3>Multi-Perspective Coverage</h3>
+                    <p>We pull from diverse sources to present balanced, nuanced takes — not echo chambers or clickbait.</p>
                 </div>
-                <div class="picker-row picker-row-actions">
-                    <button type="button" class="picker-clear nn-btn">Clear filters</button>
-                    <span class="picker-count" aria-live="polite">Showing all <strong id="picker-count-total">{{ all_shows | length }}</strong> shows</span>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#128197;</div>
+                    <h3>Daily Consistency</h3>
+                    <p>New episodes every day (or weekday), rain or shine. Build a daily learning habit you can rely on.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#127463;&#127464;</div>
+                    <h3>Made in Canada</h3>
+                    <p>Independently produced in Vancouver by Patrick. No corporate backing, no editorial interference.</p>
+                </div>
+                <div class="feature-card glass-card">
+                    <div class="feature-icon">&#128266;</div>
+                    <h3>Multilingual</h3>
+                    <p>Shows in English and Russian, with more languages planned. Knowledge shouldn't have a language barrier.</p>
                 </div>
             </div>
         </div>
     </section>
+
+    {# --- Find Your Show picker REMOVED (May 2026) — original chip
+       set retained below as a comment for easy resurrection if the
+       operator changes their mind. ---
+       (chip list previously here — three rows of topic / audience /
+       language buttons + clear-filters action — all removed.) --- #}
 
     <!-- Show Showcase -->
     <section id="shows" class="nn-section">
@@ -280,111 +369,10 @@
         </div>
     </section>
 
-    <!-- Latest Across the Network -->
-    <section id="latest" class="nn-section" style="background:var(--nn-bg-alt);">
-        <div class="container">
-            <div class="nn-section-header">
-                <div class="section-label">Fresh Episodes</div>
-                <h2>Latest Across the Network</h2>
-                <p>The most recent episodes from all shows.</p>
-            </div>
-        </div>
-        {% if latest_episodes %}
-        <div class="latest-scroll-row">
-            {% for ep in latest_episodes %}
-            <div class="latest-scroll-card glass-card">
-                <div class="episode-card-show" style="background:{{ ep.brand_color }};">{{ ep.show_name }}</div>
-                <div class="episode-card-title">{{ ep.title }}</div>
-                <div class="episode-card-date">{{ ep.date_display }}</div>
-                {% if ep.audio_url %}
-                <audio controls preload="none" src="{{ ep.audio_url }}" aria-label="{{ ep.show_name }} episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
-                {% endif %}
-            </div>
-            {% endfor %}
-        </div>
-        {% else %}
-        <div class="latest-scroll-row">
-            <p style="color:var(--nn-text-muted);padding:2rem;text-align:center;width:100%;">Episodes will appear here once available.</p>
-        </div>
-        {% endif %}
-    </section>
-
-    <!-- Why Nerra -->
-    <section class="nn-section">
-        <div class="container">
-            <div class="nn-section-header">
-                <div class="section-label">Why Nerra</div>
-                <h2>Built different</h2>
-            </div>
-            <div class="features-grid">
-                <div class="feature-card glass-card">
-                    <div class="feature-icon">&#9889;</div>
-                    <h3>AI-Enhanced Research</h3>
-                    <p>Every episode is backed by real-time news analysis across dozens of sources, curated and verified by a human host.</p>
-                </div>
-                <div class="feature-card glass-card">
-                    <div class="feature-icon">&#127911;</div>
-                    <h3>Zero Ads. Zero Sponsors.</h3>
-                    <p>No ad reads, no sponsor segments, no paywalls. Just pure content, every single day. Free forever.</p>
-                </div>
-                <div class="feature-card glass-card">
-                    <div class="feature-icon">&#127758;</div>
-                    <h3>Multi-Perspective Coverage</h3>
-                    <p>We pull from diverse sources to present balanced, nuanced takes — not echo chambers or clickbait.</p>
-                </div>
-                <div class="feature-card glass-card">
-                    <div class="feature-icon">&#128197;</div>
-                    <h3>Daily Consistency</h3>
-                    <p>New episodes every day (or weekday), rain or shine. Build a daily learning habit you can rely on.</p>
-                </div>
-                <div class="feature-card glass-card">
-                    <div class="feature-icon">&#127463;&#127464;</div>
-                    <h3>Made in Canada</h3>
-                    <p>Independently produced in Vancouver by Patrick. No corporate backing, no editorial interference.</p>
-                </div>
-                <div class="feature-card glass-card">
-                    <div class="feature-icon">&#128266;</div>
-                    <h3>Multilingual</h3>
-                    <p>Shows in English and Russian, with more languages planned. Knowledge shouldn't have a language barrier.</p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Latest from the Blog -->
-    {% if latest_blog_posts %}
-    <section class="nn-section">
-        <div class="container">
-            <div class="nn-section-header">
-                <div class="section-label">Blog</div>
-                <h2>Latest from the Blog</h2>
-                <p>In-depth articles from our latest episodes.</p>
-            </div>
-            <div class="blog-idx-grid" style="max-width:900px;margin:0 auto;padding-bottom:var(--sp-8)">
-                {% for post in latest_blog_posts %}
-                <a href="blog/{{ post.show_slug }}/ep{{ '%03d' % post.episode_num }}.html"
-                   class="blog-idx-card"
-                   style="--card-show-color: {{ post.show_color }}">
-                    <div class="blog-idx-card-top">
-                        <span class="blog-idx-show-badge" style="background:color-mix(in srgb, {{ post.show_color }} 15%, transparent);color:{{ post.show_color }}">{{ post.show_name }}</span>
-                        <span class="blog-idx-date">{{ post.date }}</span>
-                        <span class="blog-idx-ep">Ep {{ post.episode_num }}</span>
-                        <span class="blog-idx-reading">{{ post.reading_time_min }} min</span>
-                    </div>
-                    <h2>{{ post.title }}</h2>
-                    {% if post.hook %}
-                    <p>{{ post.hook[:140] }}{% if post.hook|length > 140 %}&hellip;{% endif %}</p>
-                    {% endif %}
-                    <span class="blog-idx-read-more" style="color:{{ post.show_color }}">Read article &rarr;</span>
-                </a>
-                {% endfor %}
-            </div>
-            <div style="text-align:center">
-                <a href="blog/index.html" class="nn-btn nn-btn-primary" style="font-size:0.9rem;padding:var(--sp-3) var(--sp-8)">View all blog posts</a>
-            </div>
-        </div>
-    </section>
-    {% endif %}
+    {# Fresh Episodes / Blog / Why Nerra triplet was moved ABOVE the
+       Show Showcase as part of the May 2026 homepage restructure
+       (operator request). The original positions here are now empty
+       to avoid duplicating those sections on the page. #}
 
     <!-- About the Network -->
     <section class="nn-section" style="background:var(--nn-bg-alt);">
@@ -489,39 +477,14 @@
         </div>
     </section>
 
-    {# --- "Find Your Show" picker behaviour + styles --- #}
+    {# --- May 2026: "Find Your Show" picker styles + JS were
+       removed when the section came out. The non-picker styles
+       below (``.show-card-wrap`` filter classes, ``.show-card-audience``,
+       ``.subscribe-show-list``) are still referenced by other
+       sections so they stay. --- #}
     <style>
-      .picker { max-width: 960px; margin: 0 auto; }
-      .picker-row {
-        display: flex; flex-wrap: wrap; align-items: center; gap: 10px;
-        padding: 10px 0;
-      }
-      .picker-label {
-        flex: 0 0 auto; min-width: 88px;
-        font-family: var(--font-ui); font-size: 0.85rem;
-        color: var(--nn-text-muted); text-transform: uppercase; letter-spacing: 0.05em;
-      }
-      .picker-chip {
-        background: transparent; border: 1px solid var(--nn-border);
-        color: var(--nn-text); border-radius: 999px;
-        min-height: 44px;
-        display: inline-flex; align-items: center;
-        padding: 8px 16px; font-size: 0.9rem; font-family: var(--font-ui);
-        cursor: pointer; transition: background 120ms, border-color 120ms, color 120ms;
-      }
-      .picker-chip:hover { border-color: #6B47FF; }
-      .picker-chip.is-active {
-        background: rgba(124, 92, 255, 0.18);
-        border-color: #6B47FF;
-        color: #fff;
-      }
-      .picker-row-actions { justify-content: space-between; padding-top: 18px; }
-      .picker-clear { font-size: 0.85rem; padding: 8px 16px; }
-      .picker-count { color: var(--nn-text-muted); font-size: 0.85rem; font-family: var(--font-ui); }
-      .picker-count strong { color: var(--nn-text); }
-
-      /* Cards that don't match the active filters fade out but stay in DOM
-         order so the grid layout doesn't jump around. */
+      /* Show-card filter states — used by future picker reinstatement
+         or any other selector that wants to dim non-matching cards. */
       .show-card-wrap.is-dimmed { opacity: 0.32; filter: grayscale(0.5); }
       .show-card-wrap.is-dimmed .show-card { pointer-events: none; }
       .show-card-wrap.is-match {
@@ -534,6 +497,7 @@
       }
       .show-card-audience strong { color: var(--nn-text); font-weight: 600; }
 
+      /* Subscribe-section per-show rows — independent of the picker. */
       .subscribe-show-list {
         display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
         gap: 12px; margin: 24px auto 0; max-width: 1100px;
@@ -556,81 +520,4 @@
       .subscribe-link-btn:hover { background: rgba(124,92,255,0.22); }
       .subscribe-link-rss { background: rgba(255,140,0,0.12); }
     </style>
-
-    <script>
-    (function () {
-      const grid = document.getElementById("show-showcase-grid");
-      if (!grid) return;
-      const cards = Array.from(grid.querySelectorAll(".show-card-wrap"));
-      const chips = Array.from(document.querySelectorAll(".picker-chip"));
-      const clearBtn = document.querySelector(".picker-clear");
-      const countEl = document.getElementById("picker-count-total");
-      const total = cards.length;
-
-      const active = { topics: new Set(), audience: new Set(), language: new Set() };
-
-      function tokensOf(card, group) {
-        const raw = card.getAttribute("data-" + group) || "";
-        return raw.split(/\s+/).filter(Boolean);
-      }
-
-      function cardMatches(card) {
-        for (const group of ["topics", "audience", "language"]) {
-          const wanted = active[group];
-          if (wanted.size === 0) continue;
-          const has = new Set(tokensOf(card, group));
-          let ok = false;
-          for (const w of wanted) {
-            if (has.has(w)) { ok = true; break; }
-          }
-          if (!ok) return false;
-        }
-        return true;
-      }
-
-      function applyFilters() {
-        const anyActive =
-          active.topics.size + active.audience.size + active.language.size > 0;
-        let matched = 0;
-        cards.forEach((card) => {
-          const m = cardMatches(card);
-          card.classList.toggle("is-dimmed", anyActive && !m);
-          card.classList.toggle("is-match", anyActive && m);
-          if (m) matched++;
-        });
-        if (!countEl) return;
-        if (!anyActive) {
-          countEl.textContent = total;
-          countEl.parentElement.firstChild.textContent = "Showing all ";
-        } else {
-          countEl.textContent = matched;
-          countEl.parentElement.firstChild.textContent = "Showing ";
-        }
-      }
-
-      chips.forEach((chip) => {
-        chip.addEventListener("click", () => {
-          const group = chip.getAttribute("data-filter-group");
-          const value = chip.getAttribute("data-filter-value");
-          if (!group || !value || !active[group]) return;
-          if (active[group].has(value)) {
-            active[group].delete(value);
-            chip.classList.remove("is-active");
-          } else {
-            active[group].add(value);
-            chip.classList.add("is-active");
-          }
-          applyFilters();
-        });
-      });
-
-      if (clearBtn) {
-        clearBtn.addEventListener("click", () => {
-          for (const k in active) active[k].clear();
-          chips.forEach((c) => c.classList.remove("is-active"));
-          applyFilters();
-        });
-      }
-    })();
-    </script>
 {% endblock %}

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -45,7 +45,17 @@
    are the most reliable approach. #}
 {%- set _is_ru = (page_lang | default('en')) == 'ru' -%}
 
+{# May 2026 operator request: top-right nav must carry the
+   ``Start Here / Listen / About / Player`` quartet across the
+   whole site for consistency. Layered IN FRONT OF the per-show
+   navigation (Blog / Summaries / RSS / @handle) so listeners on
+   a show page can still jump to that show's secondary surfaces
+   directly while also seeing the network-wide quartet. #}
 {% block nav_links %}
+<li><a href="{{ path_prefix }}start-here.html">{{ t.nav_start_here }}</a></li>
+<li><a href="{{ path_prefix }}how-to-listen.html">{{ t.nav_listen }}</a></li>
+<li><a href="{{ path_prefix }}about.html">{{ t.nav_about }}</a></li>
+<li><a href="{{ path_prefix }}player.html">{{ t.nav_player }}</a></li>
 <li><a href="{{ path_prefix }}{{ blog_page }}">{% if _is_ru %}Блог{% else %}Blog{% endif %}</a></li>
 <li><a href="{{ path_prefix }}{{ summaries_page }}">{% if _is_ru %}Выпуски{% else %}Summaries{% endif %}</a></li>
 <li><a href="{{ path_prefix }}{{ rss_file }}">RSS</a></li>
@@ -53,6 +63,10 @@
 {% endblock %}
 
 {% block mobile_nav_links %}
+<a href="{{ path_prefix }}start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ t.nav_start_here }}</a>
+<a href="{{ path_prefix }}how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ t.nav_listen }}</a>
+<a href="{{ path_prefix }}about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ t.nav_about }}</a>
+<a href="{{ path_prefix }}player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ t.nav_player }}</a>
 <a href="{{ path_prefix }}{{ show_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">{% if _is_ru %}Главная{% else %}Home{% endif %}</a>
 <a href="{{ path_prefix }}{{ blog_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">{% if _is_ru %}Блог{% else %}Blog{% endif %}</a>
 <a href="{{ path_prefix }}{{ summaries_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">{% if _is_ru %}Выпуски{% else %}Summaries{% endif %}</a>

--- a/templates/summaries_page.html.j2
+++ b/templates/summaries_page.html.j2
@@ -1,6 +1,13 @@
 {% extends "base.html.j2" %}
 
+{# May 2026: site-wide nav consistency — Start Here / Listen /
+   About / Player quartet in front of the per-show secondary
+   links. Same pattern as ``show_page.html.j2``. #}
 {% block nav_links %}
+<li><a href="{{ path_prefix }}start-here.html">{{ t.nav_start_here }}</a></li>
+<li><a href="{{ path_prefix }}how-to-listen.html">{{ t.nav_listen }}</a></li>
+<li><a href="{{ path_prefix }}about.html">{{ t.nav_about }}</a></li>
+<li><a href="{{ path_prefix }}player.html">{{ t.nav_player }}</a></li>
 <li><a href="{{ path_prefix }}{{ show_page }}">{{ show_name }}</a></li>
 <li><a href="{{ path_prefix }}blog/{{ show_slug }}/index.html">Blog</a></li>
 <li><a href="{{ path_prefix }}{{ summaries_page }}">Summaries</a></li>
@@ -9,6 +16,10 @@
 {% endblock %}
 
 {% block mobile_nav_links %}
+<a href="{{ path_prefix }}start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ t.nav_start_here }}</a>
+<a href="{{ path_prefix }}how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ t.nav_listen }}</a>
+<a href="{{ path_prefix }}about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ t.nav_about }}</a>
+<a href="{{ path_prefix }}player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ t.nav_player }}</a>
 <a href="{{ path_prefix }}{{ show_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">{{ show_name }}</a>
 <a href="{{ path_prefix }}blog/{{ show_slug }}/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="{{ path_prefix }}{{ summaries_page }}" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/tesla-summaries.html
+++ b/tesla-summaries.html
@@ -40,6 +40,20 @@
 
     
     
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
     
     
     <script defer src="assets/js/tracking.js"></script>
@@ -222,6 +236,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="tesla.html">Tesla Shorts Time</a></li>
 <li><a href="blog/tesla/index.html">Blog</a></li>
 <li><a href="tesla-summaries.html">Summaries</a></li>
@@ -237,6 +255,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="tesla.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Tesla Shorts Time</a>
 <a href="blog/tesla/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="tesla-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/tesla.html
+++ b/tesla.html
@@ -273,6 +273,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="blog/tesla/index.html">Blog</a></li>
 <li><a href="tesla-summaries.html">Summaries</a></li>
 <li><a href="podcast.rss">RSS</a></li>
@@ -287,6 +291,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="tesla.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
 <a href="blog/tesla/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="tesla-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/unintended-consequences-summaries.html
+++ b/unintended-consequences-summaries.html
@@ -40,6 +40,20 @@
 
     
     
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
     
     
     <script defer src="assets/js/tracking.js"></script>
@@ -222,6 +236,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="unintended-consequences.html">Unintended Consequences</a></li>
 <li><a href="blog/unintended_consequences/index.html">Blog</a></li>
 <li><a href="unintended-consequences-summaries.html">Summaries</a></li>
@@ -237,6 +255,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="unintended-consequences.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Unintended Consequences</a>
 <a href="blog/unintended_consequences/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="unintended-consequences-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>

--- a/unintended-consequences.html
+++ b/unintended-consequences.html
@@ -272,6 +272,10 @@
                     </div>
                 </li>
                 
+<li><a href="start-here.html">Start Here</a></li>
+<li><a href="how-to-listen.html">Listen</a></li>
+<li><a href="about.html">About</a></li>
+<li><a href="player.html">Player</a></li>
 <li><a href="blog/unintended_consequences/index.html">Blog</a></li>
 <li><a href="unintended-consequences-summaries.html">Summaries</a></li>
 <li><a href="unintended_consequences_podcast.rss">RSS</a></li>
@@ -286,6 +290,10 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
+<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
+<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
+<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
+<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
 <a href="unintended-consequences.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
 <a href="blog/unintended_consequences/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
 <a href="unintended-consequences-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>


### PR DESCRIPTION
## Summary

Two coordinated operator requests addressed together.

## 1. Homepage section restructure

- **Removed** the "Find Your Show" interactive picker section.
- **Lifted** the three sections that previously sat below the Show Showcase grid into the slot the picker vacated.
- **Order** matches the request exactly: Fresh Episodes → Blog → Why Nerra.

New section flow:

```
Hero
Stats Bar
Fresh Episodes      ← lifted from below
Blog                ← lifted from below
Why Nerra           ← lifted from below
Show Showcase
About
Subscribe
Newsletter
```

The page now leads with what visitors actually come for (recent episodes, recent writing, the "why us" pitch) before showing the full show-grid catalogue. Picker-only styles + JS were also dropped; styles that other sections still use (`.show-card-wrap.is-dimmed`, `.subscribe-show-row`, etc.) stay.

## 2. Site-wide nav consistency

Before today the top-right nav came in three different shapes:

| Page class | Nav |
|---|---|
| Homepage | `Latest \| Subscribe` |
| Show pages | `Blog \| Summaries \| RSS \| @handle` |
| Static pages (about, faq, how-to-listen, contact, 404) | `Start Here \| Listen \| About \| Player \| Home` |

After this PR every page leads with the four-link "network quartet" (`Start Here | Listen | About | Player`), then keeps whatever page-specific links it needs:

| Page class | New nav |
|---|---|
| Homepage (`network_page.html.j2`) | `Start Here \| Listen \| About \| Player \| Latest \| Subscribe` |
| Show pages (`show_page.html.j2`) | `Start Here \| Listen \| About \| Player \| Blog \| Summaries \| RSS \| @handle` |
| Summaries pages (`summaries_page.html.j2`) | `Start Here \| Listen \| About \| Player \| <Show name> \| Blog \| Summaries \| RSS \| @handle` |
| Static pages | Unchanged — already had the quartet |

Mobile menu mirrors the desktop nav for each template. Russian shows pick up the quartet via the localized `t.nav_*` keys in `base.html.j2` (no separate handling needed).

## Files

- `templates/network_page.html.j2` — section restructure + nav override.
- `templates/show_page.html.j2` — nav override + mobile-nav override.
- `templates/summaries_page.html.j2` — nav override + mobile-nav override.
- All 11 show HTML pages, 11 summaries pages, and `index.html` regenerated.

## Test plan

- [x] `pytest tests/` — 1889 passed, 6 skipped.
- [x] HTMLParser sanity check across `index.html`, every show page, every summaries page — all parse cleanly.
- [x] Manual grep across all 22 regenerated pages — every one leads with `Start Here | Listen | About | Player`.
- [x] `grep -c "find-your-show\|picker-chip" index.html` → 0 — the picker is fully gone.
- [ ] Operator confirms the homepage now opens to Fresh Episodes / Blog / Why Nerra above the show grid.

## What does NOT change

- Hero / Stats Bar / Show Showcase / About / Subscribe / Newsletter sections (content unchanged).
- Per-show secondary nav (Blog / Summaries / RSS) still reachable on show pages.
- Static pages' nav (already correct).
- Schema.org / Open Graph metadata.


---
_Generated by [Claude Code](https://claude.ai/code/session_013sWzi3YLLjJgckvarquWZS)_