### PR TITLE
Gallery Phase 2: manifest builder, Jinja2 components, /gallery page

### DIFF
--- a/.github/workflows/build-gallery-manifest.yml
+++ b/.github/workflows/build-gallery-manifest.yml
@@ -1,0 +1,98 @@
+name: Build Gallery Manifest
+
+# Rebuilds site/data/gallery-manifest.json by walking every .json
+# sidecar in the nerra-gallery R2 bucket. See
+# docs/gallery_storage.md for the manifest schema and
+# scripts/build_gallery_manifest.py for the builder.
+#
+# The script gracefully writes an empty manifest when R2 credentials
+# are missing — the workflow will not fail in that case. It also
+# skips the write when only the timestamp would change, so the daily
+# commit step is a no-op when no new images have been uploaded.
+#
+# Triggers:
+#   * Nightly at 03:30 UTC — well after run-show.yml finishes its
+#     last slot (~12:00 UTC) and the dashboard refresh.
+#   * After every successful "Run Podcast Show" workflow run, so the
+#     gallery reflects new uploads within minutes of episode publish.
+#   * On push to main affecting the gallery code paths.
+#   * workflow_dispatch for manual runs.
+
+on:
+  schedule:
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Run Podcast Show"]
+    types: [completed]
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/build_gallery_manifest.py'
+      - 'engine/gallery_uploader.py'
+      - '.github/workflows/build-gallery-manifest.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: build-gallery-manifest
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Skip workflow_run firings where the upstream Run Podcast Show failed.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-gallery-${{ hashFiles('requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-gallery-
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build gallery manifest
+        env:
+          R2_GALLERY_BUCKET: ${{ secrets.R2_GALLERY_BUCKET }}
+          R2_GALLERY_PUBLIC_BASE_URL: ${{ secrets.R2_GALLERY_PUBLIC_BASE_URL }}
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: python scripts/build_gallery_manifest.py --out site/data/gallery-manifest.json
+
+      - name: Pull latest before committing
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git pull --rebase --autostash origin main || true
+
+      - name: Commit and push manifest
+        run: |
+          git add site/data/gallery-manifest.json
+          if git diff --cached --quiet; then
+            echo "No manifest changes to commit"
+            exit 0
+          fi
+          git commit -m "Update gallery manifest $(date -u +%Y-%m-%dT%H:%MZ)"
+          # Small retry in case two gallery runs raced.
+          for i in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            git pull --rebase --autostash origin main || true
+            sleep 2
+          done
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,23 +160,49 @@ All RSS `<enclosure>` URLs now use `audio.nerranetwork.com` (Cloudflare R2).
 MP3 files are uploaded to R2 during the pipeline and excluded from git commits.
 **Do NOT change R2 bucket paths — this breaks podcast subscribers.**
 
-### Image gallery (Phase 1 — May 2026)
+### Image gallery (Phases 1 + 2 — May 2026)
 
 Every Grok-Imagine scene generated for the YouTube long-form / Shorts
 slideshow is uploaded to a separate R2 bucket (`nerra-gallery`) with a
-JSON sidecar and a watermarked WebP thumbnail. Module:
+JSON sidecar and a watermarked WebP thumbnail.
+
+**Phase 1 — storage.** Module:
 [`engine/gallery_uploader.py`](engine/gallery_uploader.py). The hook
 into `run_show.py:_publish_youtube` is purely additive — gallery
-upload failure cannot block YouTube publish. Layout, schema,
-env vars, and Phase 2/3 roadmap live in
-[`docs/gallery_storage.md`](docs/gallery_storage.md). New env vars:
+upload failure cannot block YouTube publish. New env vars:
 `R2_GALLERY_BUCKET` (default `nerra-gallery`),
 `R2_GALLERY_PUBLIC_BASE_URL` (optional). License default: **CC BY-SA
-4.0** with attribution to Nerra Network. Unconfigured environments
-(env vars unset) are a clean no-op. Backfill:
+4.0** with attribution to Nerra Network. Backfill:
 [`scripts/backfill_gallery.py`](scripts/backfill_gallery.py) — note
 historical scene dirs are in `.gitignore` so there is nothing to
 backfill from on-repo state without an external archive.
+
+**Phase 2 — manifest + rendering.** A workflow
+([`.github/workflows/build-gallery-manifest.yml`](.github/workflows/build-gallery-manifest.yml))
+runs nightly + after every successful `Run Podcast Show` and rebuilds
+[`site/data/gallery-manifest.json`](site/data/gallery-manifest.json)
+from the R2 sidecars via
+[`scripts/build_gallery_manifest.py`](scripts/build_gallery_manifest.py).
+The frontend is **vanilla JS** ([`assets/js/gallery.js`](assets/js/gallery.js))
+— no build step — hydrating the mount point declared in
+[`templates/_gallery_section.html.j2`](templates/_gallery_section.html.j2).
+The network-wide page is
+[`templates/gallery_page.html.j2`](templates/gallery_page.html.j2)
+rendered to `/gallery.html` by `generate_gallery_page()` in
+`generate_html.py`. Per-show galleries are embedded on each show page
+when `gallery_enabled` is true (today: any show with
+`youtube.enabled: true`, currently Tesla + MAB — see landmine #20).
+Prompt visibility is a per-image **toggle** (hidden by default in the
+lightbox). The "Download full size" button opens a Phase-3 email-gate
+modal **stub** — submitting the email marks the visitor as subscribed
+in `localStorage` and proceeds; the real Buttondown subscription +
+signed R2 URL flow lands in Phase 3.
+
+Layout, schema, env vars, and the Phase 3 roadmap live in
+[`docs/gallery_storage.md`](docs/gallery_storage.md). Unconfigured
+environments (env vars unset) are a clean no-op: the manifest builder
+writes an empty manifest and the frontend renders a friendly empty
+state.
 
 ### Testing
 

--- a/assets/js/gallery.js
+++ b/assets/js/gallery.js
@@ -1,0 +1,619 @@
+/* Nerra Network image gallery (Phase 2 — client renderer).
+ *
+ * Loads the static manifest at MANIFEST_URL, renders a thumbnail grid
+ * (lazy-loaded), and wires up:
+ *   - search (free-text across caption + prompt + tags)
+ *   - show filter (single or multi-select; multi when on /gallery)
+ *   - sort (newest / oldest)
+ *   - lightbox with prev/next, caption, prompt toggle, download button
+ *   - email-gate modal STUB. Phase 3 wires this to a Cloudflare Worker
+ *     that POSTs to Buttondown + signs the R2 download URL. For now,
+ *     submitting the email logs a console message and the download
+ *     proceeds straight to the original_url (the bucket policy in
+ *     Phase 1 already keeps originals private — the public URL today
+ *     resolves to 403 until the Worker exists).
+ *
+ * Mount: a single root element with [data-nn-gallery]. Optional
+ * data attributes:
+ *   data-show-slug   — limit to one show (per-show embed)
+ *   data-page-size   — initial render size; defaults to 60
+ *   data-show-filter — "hide" suppresses the show filter pill row
+ *                      (used by per-show embeds — the show is fixed)
+ */
+(function () {
+    'use strict';
+
+    var MANIFEST_URL = (window.NN_GALLERY_MANIFEST_URL ||
+        '/site/data/gallery-manifest.json');
+    var PROMPT_PREFIX_RE = /^[^,]+,\s*photorealistic[^,]*,\s*/i;
+
+    function $(sel, root) { return (root || document).querySelector(sel); }
+    function $$(sel, root) {
+        return Array.prototype.slice.call((root || document).querySelectorAll(sel));
+    }
+
+    function escapeHtml(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function formatDate(s) {
+        if (!s) return '';
+        try {
+            var d = new Date(s.length === 10 ? s + 'T00:00:00Z' : s);
+            if (isNaN(d.getTime())) return s;
+            return d.toLocaleDateString(undefined, {
+                year: 'numeric', month: 'short', day: 'numeric',
+                timeZone: 'UTC',
+            });
+        } catch (_) { return s; }
+    }
+
+    function shortPrompt(p) {
+        if (!p) return '';
+        // The pipeline's prompts often start with the show's curated
+        // image query then a long descriptor / framing tail. Strip the
+        // boilerplate tail when present so the toggle reveals the
+        // human-meaningful subject, not the cookie-cutter cinematic
+        // framing instructions that repeat on every image.
+        var idx = p.indexOf(', clean photographic');
+        if (idx > 12) p = p.slice(0, idx);
+        return p;
+    }
+
+    // ---------- State ----------
+
+    function GalleryState(images, opts) {
+        this.all = images || [];
+        this.opts = opts || {};
+        this.filter = {
+            query: '',
+            shows: opts.fixedShowSlug ? [opts.fixedShowSlug] : [],
+            sort: 'newest',
+        };
+        this.visible = this.all.slice();
+        this.pageSize = opts.pageSize || 60;
+        this.rendered = 0;
+    }
+
+    GalleryState.prototype.applyFilter = function () {
+        var q = this.filter.query.trim().toLowerCase();
+        var shows = this.filter.shows;
+        var sort = this.filter.sort;
+        var visible = this.all.filter(function (img) {
+            if (shows.length && shows.indexOf(img.show_slug) === -1) {
+                return false;
+            }
+            if (!q) return true;
+            var hay = [
+                img.caption, img.prompt, img.show_name,
+                img.episode_title,
+                (img.tags || []).join(' '),
+            ].join(' ').toLowerCase();
+            return hay.indexOf(q) !== -1;
+        });
+        // The manifest arrives sorted newest-first. Only flip when the
+        // user selects oldest.
+        if (sort === 'oldest') visible.reverse();
+        this.visible = visible;
+        this.rendered = 0;
+    };
+
+    // ---------- Render ----------
+
+    function renderCard(img) {
+        // Per-image card — pure DOM string, hydrated into the grid.
+        // Use loading="lazy" on the <img> so off-screen thumbnails
+        // don't fetch until the viewer scrolls near them.
+        var meta = formatDate(img.episode_date) +
+            (img.show_name ? ' · ' + escapeHtml(img.show_name) : '');
+        var altText = img.caption || img.episode_title || (
+            (img.show_name || 'Nerra Network') + ' image'
+        );
+        return (
+            '<figure class="nn-gallery-card" tabindex="0" ' +
+                'data-image-id="' + escapeHtml(img.image_id) + '" ' +
+                'aria-label="' + escapeHtml(altText) + '">' +
+                '<div class="nn-gallery-card-thumb">' +
+                    '<img loading="lazy" decoding="async" ' +
+                        'src="' + escapeHtml(img.thumbnail_url) + '" ' +
+                        'alt="' + escapeHtml(altText) + '">' +
+                '</div>' +
+                '<figcaption class="nn-gallery-card-meta">' +
+                    '<span class="nn-gallery-card-show">' +
+                        escapeHtml(img.show_name || img.show_slug) +
+                    '</span>' +
+                    '<span class="nn-gallery-card-date">' +
+                        escapeHtml(formatDate(img.episode_date)) +
+                    '</span>' +
+                '</figcaption>' +
+            '</figure>'
+        );
+    }
+
+    function renderShowFilter(grid, state) {
+        if (state.opts.suppressShowFilter) return '';
+        if (state.opts.shows.length < 2) return '';
+        var pills = state.opts.shows.map(function (s) {
+            var active = state.filter.shows.indexOf(s.slug) !== -1
+                ? ' is-active' : '';
+            return (
+                '<button type="button" class="nn-gallery-pill' + active + '" ' +
+                    'data-show-slug="' + escapeHtml(s.slug) + '">' +
+                    escapeHtml(s.name) +
+                    ' <span class="nn-gallery-pill-count">' + s.image_count + '</span>' +
+                '</button>'
+            );
+        }).join('');
+        return (
+            '<div class="nn-gallery-filters-row" role="group" ' +
+                'aria-label="Filter by show">' +
+                '<button type="button" class="nn-gallery-pill' +
+                    (state.filter.shows.length === 0 ? ' is-active' : '') +
+                    '" data-show-slug="">All shows</button>' +
+                pills +
+            '</div>'
+        );
+    }
+
+    function renderControls(state) {
+        if (state.opts.suppressControls) return '';
+        return (
+            '<div class="nn-gallery-controls">' +
+                '<label class="nn-gallery-search">' +
+                    '<span class="nn-vh">Search images</span>' +
+                    '<input type="search" placeholder="Search captions, prompts, tags…" ' +
+                        'class="nn-gallery-search-input">' +
+                '</label>' +
+                '<label class="nn-gallery-sort">' +
+                    '<span class="nn-vh">Sort</span>' +
+                    '<select class="nn-gallery-sort-select">' +
+                        '<option value="newest">Newest first</option>' +
+                        '<option value="oldest">Oldest first</option>' +
+                    '</select>' +
+                '</label>' +
+            '</div>'
+        );
+    }
+
+    function renderEmptyState(state) {
+        if (state.all.length === 0) {
+            return (
+                '<p class="nn-gallery-empty">No gallery images have ' +
+                'been published yet. Check back after the next episode ' +
+                'with AI-generated visuals.</p>'
+            );
+        }
+        return (
+            '<p class="nn-gallery-empty">No images match the current ' +
+            'filters. Clear the search or try a different show.</p>'
+        );
+    }
+
+    function renderPage(grid, state) {
+        var end = Math.min(state.rendered + state.pageSize, state.visible.length);
+        var html = '';
+        for (var i = state.rendered; i < end; i++) {
+            html += renderCard(state.visible[i]);
+        }
+        if (html) grid.insertAdjacentHTML('beforeend', html);
+        state.rendered = end;
+    }
+
+    function render(host, state) {
+        var controls = renderControls(state);
+        var filters = renderShowFilter(null, state);
+        host.innerHTML = (
+            controls +
+            filters +
+            '<div class="nn-gallery-status" aria-live="polite"></div>' +
+            '<div class="nn-gallery-grid" role="list"></div>' +
+            '<div class="nn-gallery-more-wrap">' +
+                '<button type="button" class="nn-gallery-more nn-btn">Show more</button>' +
+            '</div>'
+        );
+        var grid = $('.nn-gallery-grid', host);
+        var status = $('.nn-gallery-status', host);
+        var moreBtn = $('.nn-gallery-more', host);
+
+        function refresh() {
+            state.applyFilter();
+            grid.innerHTML = '';
+            if (state.visible.length === 0) {
+                grid.innerHTML = renderEmptyState(state);
+                moreBtn.style.display = 'none';
+                status.textContent = '';
+                return;
+            }
+            renderPage(grid, state);
+            updateMoreButton();
+            status.textContent = (
+                'Showing ' + Math.min(state.rendered, state.visible.length) +
+                ' of ' + state.visible.length + ' image' +
+                (state.visible.length === 1 ? '' : 's')
+            );
+        }
+
+        function updateMoreButton() {
+            if (state.rendered >= state.visible.length) {
+                moreBtn.style.display = 'none';
+            } else {
+                moreBtn.style.display = '';
+                moreBtn.textContent = (
+                    'Show more (' + (state.visible.length - state.rendered) +
+                    ' remaining)'
+                );
+            }
+        }
+
+        moreBtn.addEventListener('click', function () {
+            renderPage(grid, state);
+            updateMoreButton();
+            status.textContent = (
+                'Showing ' + Math.min(state.rendered, state.visible.length) +
+                ' of ' + state.visible.length + ' images'
+            );
+        });
+
+        var searchInput = $('.nn-gallery-search-input', host);
+        if (searchInput) {
+            var searchTimer = null;
+            searchInput.addEventListener('input', function (e) {
+                clearTimeout(searchTimer);
+                searchTimer = setTimeout(function () {
+                    state.filter.query = e.target.value;
+                    refresh();
+                }, 120);
+            });
+        }
+
+        var sortSelect = $('.nn-gallery-sort-select', host);
+        if (sortSelect) {
+            sortSelect.addEventListener('change', function (e) {
+                state.filter.sort = e.target.value;
+                refresh();
+            });
+        }
+
+        host.addEventListener('click', function (e) {
+            var pill = e.target.closest && e.target.closest('.nn-gallery-pill');
+            if (pill) {
+                var slug = pill.getAttribute('data-show-slug');
+                if (slug) {
+                    var idx = state.filter.shows.indexOf(slug);
+                    if (idx === -1) state.filter.shows.push(slug);
+                    else state.filter.shows.splice(idx, 1);
+                } else {
+                    state.filter.shows = [];
+                }
+                $$('.nn-gallery-pill', host).forEach(function (el) {
+                    var elSlug = el.getAttribute('data-show-slug');
+                    var on = elSlug ? (state.filter.shows.indexOf(elSlug) !== -1)
+                                    : state.filter.shows.length === 0;
+                    el.classList.toggle('is-active', on);
+                });
+                refresh();
+                return;
+            }
+            var card = e.target.closest && e.target.closest('.nn-gallery-card');
+            if (card) {
+                openLightbox(state, card.getAttribute('data-image-id'));
+            }
+        });
+
+        host.addEventListener('keydown', function (e) {
+            if (e.key !== 'Enter' && e.key !== ' ') return;
+            var card = e.target.closest && e.target.closest('.nn-gallery-card');
+            if (card) {
+                e.preventDefault();
+                openLightbox(state, card.getAttribute('data-image-id'));
+            }
+        });
+
+        refresh();
+    }
+
+    // ---------- Lightbox ----------
+
+    function ensureLightbox() {
+        var lb = $('.nn-gallery-lightbox');
+        if (lb) return lb;
+        lb = document.createElement('div');
+        lb.className = 'nn-gallery-lightbox';
+        lb.setAttribute('aria-hidden', 'true');
+        lb.setAttribute('role', 'dialog');
+        lb.setAttribute('aria-modal', 'true');
+        lb.innerHTML = (
+            '<button type="button" class="nn-lb-close" aria-label="Close">×</button>' +
+            '<button type="button" class="nn-lb-prev" aria-label="Previous image">‹</button>' +
+            '<button type="button" class="nn-lb-next" aria-label="Next image">›</button>' +
+            '<figure class="nn-lb-figure">' +
+                '<div class="nn-lb-image-wrap"><img class="nn-lb-image" alt=""></div>' +
+                '<figcaption class="nn-lb-meta">' +
+                    '<div class="nn-lb-title"></div>' +
+                    '<div class="nn-lb-sub"></div>' +
+                    '<div class="nn-lb-actions">' +
+                        '<button type="button" class="nn-lb-prompt-toggle nn-btn nn-btn-ghost">Show prompt</button>' +
+                        '<button type="button" class="nn-lb-download nn-btn">Download full size</button>' +
+                    '</div>' +
+                    '<details class="nn-lb-prompt" hidden>' +
+                        '<summary class="nn-vh">Prompt</summary>' +
+                        '<pre class="nn-lb-prompt-text"></pre>' +
+                    '</details>' +
+                    '<div class="nn-lb-license"></div>' +
+                '</figcaption>' +
+            '</figure>'
+        );
+        document.body.appendChild(lb);
+
+        lb.addEventListener('click', function (e) {
+            if (e.target === lb || e.target.classList.contains('nn-lb-close')) {
+                closeLightbox();
+            } else if (e.target.classList.contains('nn-lb-prev')) {
+                navLightbox(-1);
+            } else if (e.target.classList.contains('nn-lb-next')) {
+                navLightbox(+1);
+            } else if (e.target.classList.contains('nn-lb-prompt-toggle')) {
+                var details = $('.nn-lb-prompt', lb);
+                var hidden = details.hasAttribute('hidden');
+                if (hidden) details.removeAttribute('hidden');
+                else details.setAttribute('hidden', '');
+                e.target.textContent = hidden ? 'Hide prompt' : 'Show prompt';
+            } else if (e.target.classList.contains('nn-lb-download')) {
+                handleDownload();
+            }
+        });
+        document.addEventListener('keydown', function (e) {
+            if (lb.getAttribute('aria-hidden') === 'true') return;
+            if (e.key === 'Escape') closeLightbox();
+            else if (e.key === 'ArrowLeft') navLightbox(-1);
+            else if (e.key === 'ArrowRight') navLightbox(+1);
+        });
+        return lb;
+    }
+
+    var _lbState = { state: null, index: -1 };
+
+    function openLightbox(state, imageId) {
+        var idx = -1;
+        for (var i = 0; i < state.visible.length; i++) {
+            if (state.visible[i].image_id === imageId) { idx = i; break; }
+        }
+        if (idx === -1) return;
+        _lbState.state = state;
+        _lbState.index = idx;
+        var lb = ensureLightbox();
+        lb.setAttribute('aria-hidden', 'false');
+        document.body.classList.add('nn-no-scroll');
+        paintLightbox();
+    }
+
+    function closeLightbox() {
+        var lb = $('.nn-gallery-lightbox');
+        if (!lb) return;
+        lb.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('nn-no-scroll');
+        _lbState.state = null;
+        _lbState.index = -1;
+    }
+
+    function navLightbox(delta) {
+        if (!_lbState.state) return;
+        var n = _lbState.state.visible.length;
+        _lbState.index = ((_lbState.index + delta) % n + n) % n;
+        paintLightbox();
+    }
+
+    function paintLightbox() {
+        var lb = $('.nn-gallery-lightbox');
+        if (!lb || !_lbState.state) return;
+        var img = _lbState.state.visible[_lbState.index];
+        var imgEl = $('.nn-lb-image', lb);
+        imgEl.src = img.thumbnail_url; // start with thumb for instant paint
+        imgEl.alt = img.caption || img.episode_title || (img.show_name || '') + ' image';
+        // Swap to the full original after a tick (preloading the
+        // higher-res image without blocking the first paint). The
+        // public_base_url points at the public R2 host today; Phase 3
+        // will route this through the Worker to a signed URL.
+        var hires = new Image();
+        hires.onload = function () {
+            if (lb.getAttribute('aria-hidden') === 'false' &&
+                _lbState.state.visible[_lbState.index] === img) {
+                imgEl.src = img.original_url;
+            }
+        };
+        hires.onerror = function () { /* stay on thumbnail */ };
+        hires.src = img.original_url;
+
+        $('.nn-lb-title', lb).textContent = img.episode_title || '';
+        $('.nn-lb-sub', lb).textContent = [
+            img.show_name, formatDate(img.episode_date),
+        ].filter(Boolean).join(' · ');
+
+        var promptDetails = $('.nn-lb-prompt', lb);
+        var promptToggle = $('.nn-lb-prompt-toggle', lb);
+        var promptText = $('.nn-lb-prompt-text', lb);
+        var p = shortPrompt(img.prompt);
+        if (p) {
+            promptText.textContent = p;
+            promptToggle.style.display = '';
+            promptToggle.textContent = 'Show prompt';
+            promptDetails.setAttribute('hidden', '');
+        } else {
+            promptToggle.style.display = 'none';
+            promptDetails.setAttribute('hidden', '');
+        }
+
+        var lic = (img.license || 'CC BY-SA 4.0') + ' · ' +
+                  (img.attribution || 'Nerra Network');
+        if (img.license_url) {
+            $('.nn-lb-license', lb).innerHTML = (
+                '<a href="' + escapeHtml(img.license_url) +
+                '" target="_blank" rel="noopener">' + escapeHtml(lic) + '</a>'
+            );
+        } else {
+            $('.nn-lb-license', lb).textContent = lic;
+        }
+    }
+
+    // ---------- Download gate (Phase 3 stub) ----------
+
+    function isSubscribed() {
+        try { return localStorage.getItem('nn_gallery_subscriber') === '1'; }
+        catch (_) { return false; }
+    }
+    function markSubscribed() {
+        try { localStorage.setItem('nn_gallery_subscriber', '1'); }
+        catch (_) {}
+    }
+
+    function handleDownload() {
+        if (!_lbState.state) return;
+        var img = _lbState.state.visible[_lbState.index];
+        if (!img) return;
+        if (isSubscribed()) {
+            window.open(img.original_url, '_blank', 'noopener');
+            return;
+        }
+        openGateModal(img);
+    }
+
+    function ensureGateModal() {
+        var m = $('.nn-gate-modal');
+        if (m) return m;
+        m = document.createElement('div');
+        m.className = 'nn-gate-modal';
+        m.setAttribute('aria-hidden', 'true');
+        m.setAttribute('role', 'dialog');
+        m.setAttribute('aria-modal', 'true');
+        m.innerHTML = (
+            '<div class="nn-gate-card">' +
+                '<button type="button" class="nn-gate-close" aria-label="Close">×</button>' +
+                '<h2 class="nn-gate-title">One-time email to download</h2>' +
+                '<p class="nn-gate-body">Originals are gated behind a ' +
+                    'free email subscription. We&rsquo;ll send you ' +
+                    'occasional Nerra Network updates and you can ' +
+                    'download any image at full resolution from then on.</p>' +
+                '<form class="nn-gate-form">' +
+                    '<label><span class="nn-vh">Email</span>' +
+                        '<input type="email" required placeholder="you@example.com" ' +
+                            'autocomplete="email" class="nn-gate-input">' +
+                    '</label>' +
+                    '<button type="submit" class="nn-btn">Subscribe &amp; download</button>' +
+                '</form>' +
+                '<p class="nn-gate-fineprint">By subscribing you agree to ' +
+                    'receive emails from Nerra Network. Unsubscribe any time.</p>' +
+                '<p class="nn-gate-error" hidden></p>' +
+            '</div>'
+        );
+        document.body.appendChild(m);
+        m.addEventListener('click', function (e) {
+            if (e.target === m || e.target.classList.contains('nn-gate-close')) {
+                closeGateModal();
+            }
+        });
+        m.addEventListener('submit', function (e) {
+            e.preventDefault();
+            var email = ($('.nn-gate-input', m).value || '').trim();
+            if (!email) return;
+            submitGate(email, m);
+        });
+        return m;
+    }
+
+    function openGateModal(_img) {
+        var m = ensureGateModal();
+        m.setAttribute('aria-hidden', 'false');
+        document.body.classList.add('nn-no-scroll');
+        var input = $('.nn-gate-input', m);
+        if (input) setTimeout(function () { input.focus(); }, 30);
+    }
+
+    function closeGateModal() {
+        var m = $('.nn-gate-modal');
+        if (!m) return;
+        m.setAttribute('aria-hidden', 'true');
+        if (!$('.nn-gallery-lightbox[aria-hidden="false"]')) {
+            document.body.classList.remove('nn-no-scroll');
+        }
+    }
+
+    function submitGate(email, modal) {
+        // Phase 3 hook: POST to /api/subscribe on the Worker. For now
+        // this is a stub — we log the event, mark the visitor as
+        // subscribed locally, close the gate, and surface the
+        // download.
+        var errEl = $('.nn-gate-error', modal);
+        errEl.setAttribute('hidden', '');
+        if (typeof console !== 'undefined') {
+            console.info('[gallery] gate stub: would subscribe', email,
+                '(Phase 3 wires this to the Cloudflare Worker)');
+        }
+        // Best-effort GA4 event if gtag is on the page.
+        if (typeof window.gtag === 'function') {
+            try { window.gtag('event', 'gallery_subscribe_stub', { email_domain: email.split('@')[1] || '' }); }
+            catch (_) {}
+        }
+        markSubscribed();
+        closeGateModal();
+        // Re-trigger the download now that the visitor is "subscribed".
+        if (_lbState.state) {
+            var img = _lbState.state.visible[_lbState.index];
+            if (img) window.open(img.original_url, '_blank', 'noopener');
+        }
+    }
+
+    // ---------- Bootstrap ----------
+
+    function init(host) {
+        var fixedShowSlug = host.getAttribute('data-show-slug') || '';
+        var pageSize = parseInt(host.getAttribute('data-page-size'), 10);
+        var suppressShowFilter = host.getAttribute('data-show-filter') === 'hide';
+        var suppressControls = host.getAttribute('data-controls') === 'hide';
+
+        host.classList.add('nn-gallery');
+        host.innerHTML = '<p class="nn-gallery-loading">Loading gallery…</p>';
+
+        fetch(MANIFEST_URL, { credentials: 'omit' })
+            .then(function (r) {
+                if (!r.ok) throw new Error('manifest HTTP ' + r.status);
+                return r.json();
+            })
+            .then(function (manifest) {
+                var images = manifest.images || [];
+                var shows = manifest.shows || [];
+                if (fixedShowSlug) {
+                    images = images.filter(function (i) {
+                        return i.show_slug === fixedShowSlug;
+                    });
+                }
+                var state = new GalleryState(images, {
+                    fixedShowSlug: fixedShowSlug,
+                    shows: shows,
+                    pageSize: pageSize > 0 ? pageSize : 60,
+                    suppressShowFilter: suppressShowFilter || !!fixedShowSlug,
+                    suppressControls: suppressControls,
+                });
+                render(host, state);
+            })
+            .catch(function (err) {
+                host.innerHTML = (
+                    '<p class="nn-gallery-empty">Gallery manifest ' +
+                    'unavailable: ' + escapeHtml(err.message || err) +
+                    '. Try refreshing in a moment.</p>'
+                );
+            });
+    }
+
+    function bootAll() {
+        $$('[data-nn-gallery]').forEach(init);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', bootAll);
+    } else {
+        bootAll();
+    }
+})();

--- a/docs/gallery_storage.md
+++ b/docs/gallery_storage.md
@@ -162,10 +162,111 @@ python scripts/backfill_gallery.py --from-dir /tmp/old_ci_runs --execute
 python scripts/backfill_gallery.py --shows tesla --execute
 ```
 
+## Phase 2 — manifest + rendering (shipped)
+
+### Manifest builder
+
+[`scripts/build_gallery_manifest.py`](../scripts/build_gallery_manifest.py)
+walks every `*.json` sidecar in the R2 bucket and aggregates them into
+[`site/data/gallery-manifest.json`](../site/data/gallery-manifest.json).
+The manifest schema is versioned via `schema_version` (currently 1)
+and looks like::
+
+    {
+      "schema_version": 1,
+      "generated_at": "2026-05-24T15:30:00+00:00",
+      "image_count": 124,
+      "show_counts": {"tesla": 84, "models_agents_beginners": 40},
+      "shows": [{"slug": "tesla", "name": "Tesla Shorts Time", "image_count": 84}, ...],
+      "images": [
+        { ...sidecar fields...,
+          "thumbnail_url": "https://gallery.../tesla/.../<id>.thumb.webp",
+          "original_url":  "https://gallery.../tesla/.../<id>.jpeg",
+          "sidecar_url":   "https://gallery.../tesla/.../<id>.json"
+        }, ...
+      ]
+    }
+
+Images are sorted newest-first by `generated_at` so the default UI
+sort matches the manifest's natural order.
+
+The builder is **safe to run anywhere**: if R2 isn't configured it
+writes an empty manifest; if a sidecar fails to parse it logs and
+skips; if only the timestamp would change it doesn't rewrite the
+file. The CI workflow's commit step is therefore a no-op when no new
+images have been uploaded.
+
+### CI workflow
+
+[`.github/workflows/build-gallery-manifest.yml`](../.github/workflows/build-gallery-manifest.yml)
+runs:
+
+* Nightly at 03:30 UTC.
+* After every successful `Run Podcast Show` workflow run.
+* On push to `main` affecting gallery code paths.
+* `workflow_dispatch` for manual runs.
+
+It commits the regenerated manifest back to `main` (no-op when
+unchanged). Reuses the same R2 credentials as the audio pipeline plus
+the gallery-specific bucket/base-URL env vars.
+
+### Frontend
+
+* [`templates/_gallery_section.html.j2`](../templates/_gallery_section.html.j2)
+  — reusable Jinja2 partial that renders an empty
+  `<div data-nn-gallery>` mount point + bootstrap script tags.
+* [`templates/gallery_page.html.j2`](../templates/gallery_page.html.j2)
+  — network-wide browse page, rendered to `/gallery.html` by
+  `generate_gallery_page()` in `generate_html.py`.
+* [`assets/js/gallery.js`](../assets/js/gallery.js) — vanilla JS
+  (no build step) that fetches the manifest, renders the grid (lazy
+  thumbnails via `loading="lazy"`), runs search + show filter + sort
+  client-side, and opens a lightbox with prev/next, prompt toggle,
+  and a download button.
+* CSS additions in [`styles/main.css`](../styles/main.css) use the
+  existing design tokens (`--nn-bg`, `--nn-card`, `--show-color`,
+  etc.) so per-show embeds pick up the show's brand colour
+  automatically.
+
+### Per-show vs network-wide
+
+| Surface | Filter | Controls | Page size |
+|---|---|---|---|
+| Per-show embed (Tesla, MAB) | Pinned to that show | Search + sort hidden | 24 newest |
+| `/gallery` | All shows; multi-select pill row | Search + sort visible | 60 newest |
+
+A show is opted in when its YAML's `youtube.enabled` is true (today:
+Tesla Shorts Time + Models & Agents for Beginners — see CLAUDE.md
+landmine #20). When a show migrates off YouTube the embed
+auto-disables.
+
+### Prompt visibility
+
+Hidden by default; the lightbox shows a "Show prompt" button that
+toggles a `<details>` block. Decision recorded in the project spec
+under "QUESTIONS TO RAISE BEFORE BUILDING" #3.
+
+### Download gate (Phase 3 stub)
+
+The "Download full size" button in the lightbox opens an email-gate
+modal that:
+
+* In Phase 2: marks the visitor as subscribed in `localStorage` on
+  email submit, fires a GA4 `gallery_subscribe_stub` event, and
+  opens `original_url` in a new tab.
+* In Phase 3: will POST to `/api/subscribe` on a Cloudflare Worker
+  that calls Buttondown with `tag=gallery-subscriber` and sets a JWT
+  cookie, then 302 to a signed R2 URL.
+
+Until Phase 3 ships, original URLs typically resolve to 403 because
+the R2 bucket policy keeps originals private. The Phase 2 stub
+exists so the UI is complete and reviewable end-to-end now, and so
+Phase 3 only has to swap the network calls — not the UX.
+
 ## Roadmap
 
 | Phase | Status | Scope |
 |---|---|---|
-| 1 | **Shipped (this PR)** | R2 layout + uploader + sidecar + pipeline hook + backfill |
-| 2 | TODO | `/site/data/gallery-manifest.json` rebuilder, Jinja2 gallery components, per-show + network-wide pages |
-| 3 | TODO | Cloudflare Worker, JWT cookie, Buttondown gate, magic-link login |
+| 1 | **Shipped** | R2 layout + uploader + sidecar + pipeline hook + backfill |
+| 2 | **Shipped (this PR)** | Manifest builder + nightly workflow + Jinja2 gallery components + per-show + `/gallery` page + email-gate UI stub |
+| 3 | TODO | Cloudflare Worker, JWT cookie, Buttondown subscription, magic-link login, signed R2 download URLs |

--- a/gallery.html
+++ b/gallery.html
@@ -1,0 +1,618 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Browse the Nerra Network image gallery — AI-generated thumbnails, segment cards, and Shorts art from every episode, filterable by show and date.">
+    
+    <meta name="keywords" content="Nerra Network gallery, AI generated images, podcast artwork, Grok Imagine, episode thumbnails">
+    <title>Gallery — Nerra Network</title>
+    <meta name="theme-color" content="#6B47FF">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Gallery — Nerra Network">
+    <meta property="og:description" content="Every AI-generated visual produced for Nerra Network episodes. Browse by show, search, and download under CC BY-SA 4.0.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="assets/og-preview.png">
+    <meta property="og:url" content="https://nerranetwork.com/gallery.html">
+    <meta property="og:site_name" content="Nerra Network">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Gallery — Nerra Network">
+    <meta name="twitter:description" content="Every AI-generated visual produced for Nerra Network episodes. Browse by show, search, and download under CC BY-SA 4.0.">
+    <meta name="twitter:image" content="assets/og-preview.png">
+
+    <link rel="canonical" href="https://nerranetwork.com/gallery.html">
+    
+    
+    
+
+    <!-- Google Fonts: DM Sans + Source Serif 4 -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&display=swap" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%236B47FF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/></svg>">
+
+    
+    
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
+    
+    
+    <script defer src="assets/js/tracking.js"></script>
+
+    <!-- Shared CSS -->
+    <link rel="stylesheet" href="styles/main.css">
+
+    
+    <link rel="stylesheet" href="styles/main.css">
+    <style>
+        .nn-gallery-hero {
+            padding: calc(var(--nav-height) + var(--sp-12)) var(--sp-6) var(--sp-8);
+            text-align: center;
+            position: relative;
+            overflow: hidden;
+        }
+        .nn-gallery-hero::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(ellipse at 50% 0%, rgba(124, 92, 255, 0.18), transparent 70%);
+            pointer-events: none;
+        }
+        .nn-gallery-hero h1 {
+            font-family: var(--font-heading);
+            font-size: clamp(2rem, 5vw, 3rem);
+            margin: 0 0 var(--sp-3);
+            background: var(--nn-gradient);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+        }
+        .nn-gallery-hero p {
+            font-family: var(--font-ui);
+            color: var(--nn-text-muted);
+            font-size: 1.05rem;
+            max-width: 640px;
+            margin: 0 auto;
+        }
+        .nn-gallery-wrap {
+            max-width: 1280px;
+            margin: 0 auto;
+            padding: 0 var(--sp-6) var(--sp-16);
+        }
+    </style>
+
+
+    
+    <style>
+        @media (max-width: 768px) {
+            .nn-footer-grid { grid-template-columns: 1fr; }
+            .nn-footer-col h4 {
+                cursor: pointer;
+                position: relative;
+                padding-right: 1.5rem;
+            }
+            .nn-footer-col h4::after {
+                content: '+';
+                position: absolute;
+                right: 0;
+                font-size: 1.2rem;
+                color: var(--nn-text-muted);
+            }
+            .nn-footer-col.expanded h4::after { content: '\2212'; }
+            .nn-footer-col > a,
+            .nn-footer-col > ul { display: none; }
+            .nn-footer-col.expanded > a,
+            .nn-footer-col.expanded > ul { display: block; }
+        }
+    </style>
+</head>
+<body><a href="#main-content" class="skip-link">Skip to content</a>
+    <!-- Navigation -->
+    <nav class="nn-nav" aria-label="Main navigation">
+        <div class="nn-nav-inner">
+            <a href="index.html" class="nn-nav-logo">
+                <img src="assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
+                <span class="gradient-text">Nerra</span> Network
+            </a>
+
+            <ul class="nn-nav-links">
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Shows
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu" role="menu">
+                        
+                        <a href="models-agents.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents
+                        </a>
+                        
+                        <a href="planetterrian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily
+                        </a>
+                        
+                        <a href="omni-view.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View
+                        </a>
+                        
+                        <a href="models-agents-beginners.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners
+                        </a>
+                        
+                        <a href="fascinating-frontiers.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers
+                        </a>
+                        
+                        <a href="modern-investing.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques
+                        </a>
+                        
+                        <a href="tesla.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time
+                        </a>
+                        
+                        <a href="env-intel.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence
+                        </a>
+                        
+                        <a href="ru/finansy-prosto.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто
+                        </a>
+                        
+                        <a href="ru/privet-russian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский!
+                        </a>
+                        
+                        <a href="unintended-consequences.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences
+                        </a>
+                        
+                    </div>
+                </li>
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Blog
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu">
+                        <a href="blog/index.html" style="font-weight:600;border-bottom:1px solid var(--nn-border);padding-bottom:8px;margin-bottom:4px">
+                            All Blog Posts
+                        </a>
+                        
+                        <a href="blog/models_agents/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents Blog
+                        </a>
+                        
+                        <a href="blog/planetterrian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily Blog
+                        </a>
+                        
+                        <a href="blog/omni_view/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View Blog
+                        </a>
+                        
+                        <a href="blog/models_agents_beginners/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners Blog
+                        </a>
+                        
+                        <a href="blog/fascinating_frontiers/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers Blog
+                        </a>
+                        
+                        <a href="blog/modern_investing/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques Blog
+                        </a>
+                        
+                        <a href="blog/tesla/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time Blog
+                        </a>
+                        
+                        <a href="blog/env_intel/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence Blog
+                        </a>
+                        
+                        <a href="blog/finansy_prosto/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто Blog
+                        </a>
+                        
+                        <a href="blog/privet_russian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский! Blog
+                        </a>
+                        
+                        <a href="blog/unintended_consequences/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences Blog
+                        </a>
+                        
+                    </div>
+                </li>
+                
+                <li><a href="start-here.html">Start Here</a></li>
+                <li><a href="how-to-listen.html">Listen</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="player.html">Player</a></li>
+                <li><a href="index.html">Home</a></li>
+                
+            </ul>
+
+            <button class="nn-hamburger" aria-label="Toggle menu" aria-expanded="false" onclick="var m=document.getElementById('mobileMenu');m.classList.toggle('open');this.setAttribute('aria-expanded',m.classList.contains('open'));document.body.classList.toggle('menu-open')">&#9776;</button>
+        </div>
+    </nav>
+
+    <!-- Mobile Menu -->
+    <div id="mobileMenu" class="nn-mobile-menu">
+        
+        <a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Start Here</a>
+        <a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">How to Listen</a>
+        <a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">About</a>
+        <a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Player</a>
+        <a href="index.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Home</a>
+        
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">All Shows</div>
+            
+            <a href="models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents
+            </a>
+            
+            <a href="planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily
+            </a>
+            
+            <a href="omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View
+            </a>
+            
+            <a href="models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners
+            </a>
+            
+            <a href="fascinating-frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers
+            </a>
+            
+            <a href="modern-investing.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques
+            </a>
+            
+            <a href="tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time
+            </a>
+            
+            <a href="env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence
+            </a>
+            
+            <a href="ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто
+            </a>
+            
+            <a href="ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский!
+            </a>
+            
+            <a href="unintended-consequences.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences
+            </a>
+            
+        </div>
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">Blogs</div>
+            <a href="blog/index.html" class="nn-mobile-show-link" style="font-weight:600" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                All Blog Posts
+            </a>
+            
+            <a href="blog/models_agents/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents Blog
+            </a>
+            
+            <a href="blog/planetterrian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily Blog
+            </a>
+            
+            <a href="blog/omni_view/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View Blog
+            </a>
+            
+            <a href="blog/models_agents_beginners/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners Blog
+            </a>
+            
+            <a href="blog/fascinating_frontiers/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers Blog
+            </a>
+            
+            <a href="blog/modern_investing/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques Blog
+            </a>
+            
+            <a href="blog/tesla/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time Blog
+            </a>
+            
+            <a href="blog/env_intel/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence Blog
+            </a>
+            
+            <a href="blog/finansy_prosto/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто Blog
+            </a>
+            
+            <a href="blog/privet_russian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский! Blog
+            </a>
+            
+            <a href="blog/unintended_consequences/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences Blog
+            </a>
+            
+        </div>
+    </div>
+
+    <main id="main-content">
+    
+<section class="nn-gallery-hero">
+    <h1>Gallery</h1>
+    <p>Every AI-generated visual produced for Nerra Network episodes — long-form thumbnails, segment cards, and Shorts art. Browse by show or search the catalogue.</p>
+</section>
+
+<div class="nn-gallery-wrap">
+    
+<section class="nn-section nn-gallery-section" id="gallery">
+    
+
+    <div data-nn-gallery
+         
+         data-page-size="60"
+         >
+        <p class="nn-gallery-loading">Loading gallery&hellip;</p>
+    </div>
+</section>
+
+<script>
+    window.NN_GALLERY_MANIFEST_URL = 'site/data/gallery-manifest.json';
+</script>
+<script defer src="assets/js/gallery.js"></script>
+
+</div>
+
+    </main>
+
+    <!-- Footer -->
+    <footer class="nn-footer">
+        <div class="container">
+            <div class="nn-footer-grid">
+                <div>
+                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
+                    <p class="nn-footer-desc">Eleven shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Shows</h4>
+                    
+                    <a href="models-agents.html">Models & Agents</a>
+                    
+                    <a href="planetterrian.html">Planetterrian Daily</a>
+                    
+                    <a href="omni-view.html">Omni View</a>
+                    
+                    <a href="models-agents-beginners.html">Models & Agents for Beginners</a>
+                    
+                    <a href="fascinating-frontiers.html">Fascinating Frontiers</a>
+                    
+                    <a href="modern-investing.html">Modern Investing Techniques</a>
+                    
+                    <a href="tesla.html">Tesla Shorts Time</a>
+                    
+                    <a href="env-intel.html">Environmental Intelligence</a>
+                    
+                    <a href="ru/finansy-prosto.html">Финансы Просто</a>
+                    
+                    <a href="ru/privet-russian.html">Привет, Русский!</a>
+                    
+                    <a href="unintended-consequences.html">Unintended Consequences</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Blog</h4>
+                    <a href="blog/index.html">All Blog Posts</a>
+                    
+                    <a href="blog/models_agents/index.html">Models & Agents</a>
+                    
+                    <a href="blog/planetterrian/index.html">Planetterrian Daily</a>
+                    
+                    <a href="blog/omni_view/index.html">Omni View</a>
+                    
+                    <a href="blog/models_agents_beginners/index.html">Models & Agents for Beginners</a>
+                    
+                    <a href="blog/fascinating_frontiers/index.html">Fascinating Frontiers</a>
+                    
+                    <a href="blog/modern_investing/index.html">Modern Investing Techniques</a>
+                    
+                    <a href="blog/tesla/index.html">Tesla Shorts Time</a>
+                    
+                    <a href="blog/env_intel/index.html">Environmental Intelligence</a>
+                    
+                    <a href="blog/finansy_prosto/index.html">Финансы Просто</a>
+                    
+                    <a href="blog/privet_russian/index.html">Привет, Русский!</a>
+                    
+                    <a href="blog/unintended_consequences/index.html">Unintended Consequences</a>
+                    
+                    <a href="blog.rss">Blog RSS (All Shows)</a>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Listen</h4>
+                    <a href="how-to-listen.html" style="font-weight:600">How to Listen</a>
+                    <a href="player.html" style="font-weight:600">Network Player</a>
+                    <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939?utm_source=nerranetwork&utm_medium=footer&utm_campaign=tesla" target="_blank" rel="noopener" data-show="tesla">Apple Podcasts</a>
+                    <a href="network.rss">Network RSS</a>
+                    
+                    <a href="models_agents_podcast.rss">Models & Agents RSS</a>
+                    
+                    <a href="planetterrian_podcast.rss">Planetterrian Daily RSS</a>
+                    
+                    <a href="omni_view_podcast.rss">Omni View RSS</a>
+                    
+                    <a href="models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
+                    
+                    <a href="fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
+                    
+                    <a href="modern_investing_podcast.rss">Modern Investing Techniques RSS</a>
+                    
+                    <a href="podcast.rss">Tesla Shorts Time RSS</a>
+                    
+                    <a href="env_intel_podcast.rss">Environmental Intelligence RSS</a>
+                    
+                    <a href="finansy_prosto_podcast.rss">Финансы Просто RSS</a>
+                    
+                    <a href="privet_russian_podcast.rss">Привет, Русский! RSS</a>
+                    
+                    <a href="unintended_consequences_podcast.rss">Unintended Consequences RSS</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Connect</h4>
+                    <a href="https://x.com/teslashortstime" target="_blank" rel="noopener">@teslashortstime</a>
+                    <a href="https://x.com/omniviewnews" target="_blank" rel="noopener">@omniviewnews</a>
+                    <a href="https://x.com/planetterrian" target="_blank" rel="noopener">@planetterrian</a>
+                </div>
+            </div>
+            <div class="nn-footer-col">
+                <h4>About</h4>
+                <a href="about.html">About Nerra Network</a>
+                <a href="start-here.html">Start Here</a>
+                <a href="how-to-listen.html">How to Listen</a>
+                <a href="faq.html">FAQ</a>
+                <a href="contact.html">Contact</a>
+                <a href="press.html">Press Kit</a>
+                <a href="privacy-policy.html">Privacy Policy</a>
+                <a href="terms-of-service.html">Terms of Service</a>
+                <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="editorial.html">Editorial Process</a>
+                <a href="management.html">Network Status</a>
+            </div>
+            <!-- Newsletter Subscribe -->
+            <div class="nn-footer-subscribe">
+                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                    <h4>Get Show Updates</h4>
+                    <p>Pick the shows you want in your inbox:</p>
+                    <div class="nn-subscribe-tags"><label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                        <label><input type="checkbox" name="tag" value="Omni View"> Omni View</label>
+                        <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
+                        <label><input type="checkbox" name="tag" value="Planetterrian Daily"> Planetterrian Daily</label>
+                        <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents"> Models &amp; Agents</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models &amp; Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
+                        <label><input type="checkbox" name="tag" value="Unintended Consequences"> Unintended Consequences</label><label><input type="checkbox" name="tag" value="Finansy Prosto"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Privet Russian"> Привет, Русский!</label>
+                    </div>
+                    <div class="nn-subscribe-row">
+                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="hidden" value="1" name="embed">
+                        <button type="submit">Subscribe</button>
+                    </div>
+                </form>
+            </div>
+            <div class="nn-footer-bottom">
+                <span>© 2026 Nerra Network. All shows independently produced.</span>
+                <a href="index.html">nerranetwork.com</a>
+            </div>
+            <div class="nn-footer-legal">
+                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
+                <div>
+                    <a href="privacy-policy.html">Privacy</a> &middot;
+                    <a href="terms-of-service.html">Terms</a> &middot;
+                    <a href="ai-disclosure.html">AI Disclosure</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    // Toggle aria-expanded on dropdown hover/focus
+    document.querySelectorAll('.nn-nav-dropdown').forEach(function(dd) {
+        var btn = dd.querySelector('.nn-nav-dropdown-btn');
+        if (!btn) return;
+        dd.addEventListener('mouseenter', function() { btn.setAttribute('aria-expanded', 'true'); });
+        dd.addEventListener('mouseleave', function() { btn.setAttribute('aria-expanded', 'false'); });
+        btn.addEventListener('focus', function() { btn.setAttribute('aria-expanded', 'true'); });
+        btn.addEventListener('blur', function() {
+            setTimeout(function() {
+                if (!dd.contains(document.activeElement)) btn.setAttribute('aria-expanded', 'false');
+            }, 100);
+        });
+    });
+    // Mobile footer accordions
+    if (window.innerWidth <= 768) {
+        document.querySelectorAll('.nn-footer-col h4').forEach(function(h4) {
+            h4.addEventListener('click', function() {
+                h4.parentElement.classList.toggle('expanded');
+            });
+        });
+    }
+    </script>
+    
+</body>
+</html>

--- a/generate_html.py
+++ b/generate_html.py
@@ -1588,6 +1588,13 @@ def generate_show_page(slug, *, dry_run=False):
 
     is_russian = slug in ("finansy_prosto", "privet_russian")
 
+    yt_meta = _read_show_youtube(slug)
+    # Phase 2 gallery: enable the embedded per-show gallery section on
+    # any show whose YouTube path is on, since those are the shows
+    # currently producing Grok Imagine artwork. When a show migrates
+    # off YouTube (or off Grok Imagine), the section auto-disables.
+    gallery_enabled = bool(yt_meta.get("youtube_enabled"))
+
     context = {
         **cfg,
         "path_prefix": prefix,
@@ -1612,7 +1619,18 @@ def generate_show_page(slug, *, dry_run=False):
         "performance_data": performance_data,
         "page_lang": "ru" if is_russian else "en",
         "hreflang_self": f"ru-{cfg['slug']}" if is_russian else "en",
-        **_read_show_youtube(slug),
+        # Per-show embedded gallery (Phase 2).
+        "gallery_enabled": gallery_enabled,
+        "section_id": "gallery",
+        "section_title": "Episode gallery",
+        "section_intro": (
+            f"AI-generated visuals from recent {cfg['name']} episodes. "
+            "Click any image for a larger view; “Show prompt” "
+            "reveals the text the image was generated from."
+        ),
+        "page_size": 24,
+        "hide_controls": True,
+        **yt_meta,
     }
 
     html = template.render(**context)
@@ -2110,6 +2128,7 @@ def generate_sitemap(*, dry_run=False):
     for extra in ["modern-investing-resources.html", "start-here.html",
                   "about.html", "how-to-listen.html", "faq.html",
                   "press.html", "contact.html", "editorial.html",
+                  "gallery.html",
                   "404.html"]:
         if (ROOT / extra).exists():
             urls.append((f"{base}/{extra}", "0.5", _file_lastmod(ROOT / extra)))
@@ -2237,6 +2256,62 @@ def _count_languages() -> int:
         else:
             langs.add("en")
     return len(langs)
+
+
+def generate_gallery_page(*, dry_run=False):
+    """Generate the network-wide /gallery.html browse page.
+
+    The page renders an empty mount-point that ``assets/js/gallery.js``
+    hydrates client-side from ``site/data/gallery-manifest.json`` (built
+    nightly by ``scripts/build_gallery_manifest.py``). All filtering,
+    sorting, and lightbox UX is client-side.
+    """
+    env = _get_jinja_env()
+    template = env.get_template("gallery_page.html.j2")
+
+    context = {
+        "path_prefix": "",
+        "page_title": "Gallery — Nerra Network",
+        "page_description": (
+            "Every AI-generated visual produced for Nerra Network "
+            "episodes. Browse by show, search, and download under "
+            "CC BY-SA 4.0."
+        ),
+        "meta_description": (
+            "Browse the Nerra Network image gallery — AI-generated "
+            "thumbnails, segment cards, and Shorts art from every "
+            "episode, filterable by show and date."
+        ),
+        "meta_keywords": (
+            "Nerra Network gallery, AI generated images, podcast "
+            "artwork, Grok Imagine, episode thumbnails"
+        ),
+        "theme_color": "#6B47FF",
+        "og_image": "",
+        "canonical_url": "https://nerranetwork.com/gallery.html",
+        "show_color": "",
+        "show_color_dark": "",
+        "all_shows": _build_all_shows_list(),
+        # Params for the _gallery_section.html.j2 partial. The hero
+        # already has a title so the section itself runs untitled.
+        "section_id": "gallery",
+        "section_title": "",
+        "section_intro": "",
+        "show_slug": "",
+        "page_size": 60,
+        "hide_controls": False,
+    }
+
+    html = template.render(**context)
+    out_path = ROOT / "gallery.html"
+
+    if dry_run:
+        print(f"[dry-run] Would write {out_path}")
+        return None
+
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
+    print(f"Wrote {out_path}")
+    return out_path
 
 
 def generate_about_page(*, dry_run=False):
@@ -2561,6 +2636,7 @@ def main():
         generate_player_page(dry_run=args.dry_run)
         generate_start_here_page(dry_run=args.dry_run)
         generate_about_page(dry_run=args.dry_run)
+        generate_gallery_page(dry_run=args.dry_run)
         generate_how_to_listen_page(dry_run=args.dry_run)
         generate_press_page(dry_run=args.dry_run)
         generate_contact_page(dry_run=args.dry_run)

--- a/scripts/build_gallery_manifest.py
+++ b/scripts/build_gallery_manifest.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Rebuild the gallery manifest from the R2 ``nerra-gallery`` bucket.
+
+Phase 2 of the gallery feature. Walks every ``*.json`` sidecar in the
+gallery bucket, downloads + parses each, and writes one aggregated
+manifest to ``site/data/gallery-manifest.json``. The gallery page (and
+each show's embedded gallery) consume the manifest client-side to
+render thumbnails, run filters / sort, and link to the gated download.
+
+Schema (versioned via ``schema_version``)::
+
+    {
+      "schema_version": 1,
+      "generated_at": "2026-05-24T15:30:00+00:00",
+      "image_count": 124,
+      "show_counts": {"tesla": 84, "models_agents_beginners": 40},
+      "shows": [
+        {"slug": "tesla", "name": "Tesla Shorts Time", "image_count": 84},
+        ...
+      ],
+      "images": [
+         {  ... sidecar fields ... ,
+           "original_url": "https://gallery.../.../<id>.jpeg",
+           "thumbnail_url": "https://gallery.../.../<id>.thumb.webp",
+           "sidecar_url": "https://gallery.../.../<id>.json"
+         },
+         ...
+      ]
+    }
+
+Images are sorted newest-first by ``generated_at`` (falling back to
+``episode_date``) so the gallery page's default "Newest" sort matches
+the manifest's natural ordering and the JS doesn't have to re-sort on
+load.
+
+The script is **idempotent** and **safe to run anywhere**:
+
+* When R2 isn't configured (env vars missing), it logs a warning and
+  writes an empty manifest. The HTML gallery handles the empty case.
+* When a sidecar fails to parse, the script logs and skips that
+  image — never crashes the whole build.
+* When the only change to the manifest is the ``generated_at``
+  timestamp, the script does **not** rewrite the file (so the CI
+  workflow's ``git diff --cached --quiet`` check stays clean and
+  avoids no-op commits).
+
+Run::
+
+    python scripts/build_gallery_manifest.py
+    python scripts/build_gallery_manifest.py --out site/data/gallery-manifest.json
+    python scripts/build_gallery_manifest.py --dry-run     # don't write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from engine.gallery_uploader import (  # noqa: E402
+    GalleryConfig,
+    gallery_config_from_env,
+)
+
+logger = logging.getLogger("build_gallery_manifest")
+
+SCHEMA_VERSION = 1
+DEFAULT_OUTPUT = PROJECT_ROOT / "site" / "data" / "gallery-manifest.json"
+
+
+# ---------------------------------------------------------------------------
+# R2 walk
+# ---------------------------------------------------------------------------
+
+
+def _make_s3_client(config: GalleryConfig):
+    """Build a boto3 S3 client pointing at the gallery bucket.
+
+    Imported lazily so this module can still be imported (and
+    unit-tested) on machines without boto3 installed.
+    """
+    import boto3
+    from botocore.config import Config as BotoConfig
+
+    return boto3.client(
+        "s3",
+        endpoint_url=config.endpoint_url,
+        aws_access_key_id=config.access_key,
+        aws_secret_access_key=config.secret_key,
+        config=BotoConfig(
+            signature_version="s3v4",
+            retries={"max_attempts": 3, "mode": "adaptive"},
+        ),
+    )
+
+
+def _iter_sidecar_keys(s3, bucket: str) -> Iterable[str]:
+    """Yield every ``*.json`` key in the bucket, paginated."""
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket):
+        for obj in page.get("Contents", []) or []:
+            key = obj.get("Key", "")
+            if key.endswith(".json"):
+                yield key
+
+
+def _fetch_sidecar(s3, bucket: str, key: str) -> Optional[Dict]:
+    """Download + parse one sidecar. Returns ``None`` on any failure."""
+    try:
+        resp = s3.get_object(Bucket=bucket, Key=key)
+        body = resp["Body"].read()
+        return json.loads(body.decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to read sidecar %s: %s", key, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Manifest assembly
+# ---------------------------------------------------------------------------
+
+
+REQUIRED_SIDECAR_FIELDS = (
+    "image_id", "show_slug", "show_name", "episode_id", "episode_title",
+    "episode_date", "format",
+)
+
+
+def _public_url(config: GalleryConfig, key: str) -> str:
+    if config.public_base_url:
+        base = config.public_base_url.rstrip("/")
+    else:
+        base = f"{config.endpoint_url.rstrip('/')}/{config.bucket}"
+    return f"{base}/{key}"
+
+
+def _build_object_keys(sidecar: Dict) -> Tuple[str, str, str]:
+    """Reconstruct the three R2 keys from sidecar fields.
+
+    Mirrors ``engine.gallery_uploader._build_keys`` — kept in sync so
+    that the manifest builder never has to round-trip through the
+    uploader module to learn the layout.
+    """
+    prefix = (
+        f"{sidecar['show_slug']}/{sidecar['episode_date']}/{sidecar['episode_id']}"
+    )
+    stem = sidecar["image_id"]
+    ext = (sidecar.get("format") or "jpeg").lower().lstrip(".")
+    if ext == "jpg":
+        ext = "jpeg"
+    return (
+        f"{prefix}/{stem}.{ext}",
+        f"{prefix}/{stem}.thumb.webp",
+        f"{prefix}/{stem}.json",
+    )
+
+
+def _validate_sidecar(sidecar: Dict, source_key: str) -> bool:
+    missing = [f for f in REQUIRED_SIDECAR_FIELDS if not sidecar.get(f)]
+    if missing:
+        logger.warning(
+            "Sidecar %s missing required field(s) %s — skipping",
+            source_key, missing,
+        )
+        return False
+    return True
+
+
+def _sort_key(image: Dict) -> str:
+    return (
+        str(image.get("generated_at") or "")
+        + "|"
+        + str(image.get("episode_date") or "")
+        + "|"
+        + str(image.get("image_id") or "")
+    )
+
+
+def build_manifest(
+    sidecars: Iterable[Dict],
+    *,
+    config: GalleryConfig,
+    generated_at: Optional[str] = None,
+) -> Dict:
+    """Build the manifest dict from an iterable of sidecar payloads.
+
+    Pure function — the network walk (``_iter_sidecar_keys`` +
+    ``_fetch_sidecar``) is the only side-effectful part of this module.
+    Splitting them lets the unit tests pass in a hand-rolled list of
+    sidecars instead of mocking the entire S3 layer.
+    """
+    images: List[Dict] = []
+    show_counts: Dict[str, int] = {}
+    show_names: Dict[str, str] = {}
+
+    for sidecar in sidecars:
+        if not isinstance(sidecar, dict):
+            continue
+        # _validate_sidecar already logs; just check the return.
+        if not _validate_sidecar(sidecar, sidecar.get("image_id", "?")):
+            continue
+
+        original_key, thumb_key, sidecar_key = _build_object_keys(sidecar)
+        record = dict(sidecar)
+        record["original_url"] = _public_url(config, original_key)
+        record["thumbnail_url"] = _public_url(config, thumb_key)
+        record["sidecar_url"] = _public_url(config, sidecar_key)
+        images.append(record)
+
+        slug = sidecar["show_slug"]
+        show_counts[slug] = show_counts.get(slug, 0) + 1
+        if slug not in show_names:
+            show_names[slug] = sidecar.get("show_name") or slug
+
+    # Newest first. Stable enough — ``generated_at`` is RFC 3339, sorts
+    # lexicographically; ``image_id`` tiebreaks for deterministic order.
+    images.sort(key=_sort_key, reverse=True)
+
+    shows = sorted(
+        (
+            {
+                "slug": slug,
+                "name": show_names[slug],
+                "image_count": show_counts[slug],
+            }
+            for slug in show_counts
+        ),
+        key=lambda s: s["name"].lower(),
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": (
+            generated_at
+            or datetime.now(timezone.utc).isoformat(timespec="seconds")
+        ),
+        "image_count": len(images),
+        "show_counts": show_counts,
+        "shows": shows,
+        "images": images,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Write / compare
+# ---------------------------------------------------------------------------
+
+
+def _without_timestamp(manifest: Dict) -> Dict:
+    """Return a copy with ``generated_at`` stripped, for diffing."""
+    return {k: v for k, v in manifest.items() if k != "generated_at"}
+
+
+def write_manifest_if_changed(manifest: Dict, out_path: Path) -> bool:
+    """Write ``manifest`` to ``out_path`` only if the content (excluding
+    ``generated_at``) differs from what's already on disk.
+
+    Returns ``True`` when the file was (re)written. This keeps the CI
+    workflow's commit step a no-op when only the timestamp would
+    change, avoiding a daily empty commit.
+    """
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    new_payload = _without_timestamp(manifest)
+    if out_path.exists():
+        try:
+            existing = json.loads(out_path.read_text(encoding="utf-8"))
+            if _without_timestamp(existing) == new_payload:
+                logger.info(
+                    "Manifest content unchanged (image_count=%d) — "
+                    "skipping write.", manifest["image_count"],
+                )
+                return False
+        except Exception:  # noqa: BLE001 — bad file → overwrite
+            logger.warning("Existing manifest unreadable — overwriting")
+
+    out_path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False, sort_keys=True),
+        encoding="utf-8",
+    )
+    logger.info(
+        "Wrote %s (image_count=%d, shows=%d)",
+        out_path, manifest["image_count"], len(manifest["shows"]),
+    )
+    return True
+
+
+def empty_manifest(config: GalleryConfig) -> Dict:
+    """Build the manifest representing zero images.
+
+    Returned both when R2 isn't configured and when the bucket is
+    actually empty. The HTML gallery handles the empty case ("No
+    images yet — check back after the first episode publish.").
+    """
+    return build_manifest([], config=config)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def walk_bucket(config: GalleryConfig) -> List[Dict]:
+    """Network walk: list every sidecar and fetch it."""
+    s3 = _make_s3_client(config)
+    sidecars: List[Dict] = []
+    keys = list(_iter_sidecar_keys(s3, config.bucket))
+    logger.info("Found %d sidecar(s) in bucket %s", len(keys), config.bucket)
+    for key in keys:
+        body = _fetch_sidecar(s3, config.bucket, key)
+        if body is not None:
+            sidecars.append(body)
+    return sidecars
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out", type=Path, default=DEFAULT_OUTPUT,
+        help=f"Output manifest path (default: {DEFAULT_OUTPUT.relative_to(PROJECT_ROOT)})",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Compute the manifest but don't write or commit.",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    config = gallery_config_from_env()
+    if not config.is_configured:
+        logger.warning(
+            "Gallery R2 not configured — writing empty manifest. Set "
+            "R2_GALLERY_BUCKET + R2_ENDPOINT_URL + R2_ACCESS_KEY_ID + "
+            "R2_SECRET_ACCESS_KEY to actually scan the bucket.",
+        )
+        manifest = empty_manifest(config)
+    else:
+        try:
+            sidecars = walk_bucket(config)
+        except Exception as exc:  # noqa: BLE001 — log + write empty rather than crash CI
+            logger.error(
+                "R2 bucket walk failed (%s): %s — writing empty manifest",
+                type(exc).__name__, exc,
+            )
+            sidecars = []
+        manifest = build_manifest(sidecars, config=config)
+
+    if args.dry_run:
+        logger.info(
+            "[dry-run] would write %d image(s) to %s", manifest["image_count"],
+            args.out,
+        )
+        # Print the head for inspection (no need to dump 10k images).
+        preview = dict(manifest)
+        preview["images"] = manifest["images"][:3]
+        print(json.dumps(preview, indent=2, ensure_ascii=False))
+        return 0
+
+    write_manifest_if_changed(manifest, args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/data/gallery-manifest.json
+++ b/site/data/gallery-manifest.json
@@ -1,0 +1,8 @@
+{
+  "generated_at": "2026-05-24T00:00:00+00:00",
+  "image_count": 0,
+  "images": [],
+  "schema_version": 1,
+  "show_counts": {},
+  "shows": []
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1932,3 +1932,346 @@ body.menu-open {
   #nn-consent-banner .nn-consent-actions { justify-content: stretch; }
   #nn-consent-banner .nn-consent-btn { flex: 1; }
 }
+
+/* ===================================================================
+ * Gallery — Phase 2 (May 2026)
+ * Network-wide /gallery page + per-show embedded gallery section.
+ * Uses the shared design tokens defined at the top of this file
+ * (--nn-bg, --nn-card, --nn-border, --show-color, etc.) so the
+ * gallery picks up the per-show brand colour automatically when
+ * embedded on a show page.
+ * =================================================================== */
+
+.nn-gallery { display: block; width: 100%; }
+.nn-gallery-loading,
+.nn-gallery-empty {
+  font-family: var(--font-ui);
+  font-size: 0.95rem;
+  color: var(--nn-text-muted);
+  text-align: center;
+  padding: var(--sp-10) var(--sp-4);
+  border: 1px dashed var(--nn-border);
+  border-radius: 12px;
+  background: var(--nn-card);
+}
+
+.nn-gallery-controls {
+  display: flex;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: var(--sp-4);
+}
+.nn-gallery-search {
+  flex: 1 1 260px;
+  position: relative;
+}
+.nn-gallery-search-input,
+.nn-gallery-sort-select {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--nn-border);
+  background: var(--nn-card);
+  color: var(--nn-text);
+  font-family: var(--font-ui);
+  font-size: 0.95rem;
+}
+.nn-gallery-sort { flex: 0 0 auto; min-width: 160px; }
+.nn-gallery-search-input:focus,
+.nn-gallery-sort-select:focus {
+  outline: none;
+  border-color: var(--show-color, var(--nn-purple));
+  box-shadow: 0 0 0 3px rgba(107, 71, 255, 0.15);
+}
+
+.nn-gallery-filters-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-4);
+}
+.nn-gallery-pill {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--nn-border);
+  background: var(--nn-card);
+  color: var(--nn-text);
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+.nn-gallery-pill:hover { border-color: var(--show-color, var(--nn-purple)); }
+.nn-gallery-pill.is-active {
+  background: var(--show-color, var(--nn-purple));
+  border-color: var(--show-color, var(--nn-purple));
+  color: #fff;
+}
+.nn-gallery-pill-count {
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.75;
+}
+
+.nn-gallery-status {
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  color: var(--nn-text-muted);
+  margin-bottom: var(--sp-3);
+  min-height: 1.2em;
+}
+
+.nn-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--sp-4);
+  margin: 0;
+  padding: 0;
+}
+.nn-gallery-card {
+  margin: 0;
+  background: var(--nn-card);
+  border: 1px solid var(--nn-border);
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: zoom-in;
+  transition: transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+  display: flex;
+  flex-direction: column;
+}
+.nn-gallery-card:hover,
+.nn-gallery-card:focus {
+  outline: none;
+  border-color: var(--show-color, var(--nn-purple));
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.25);
+}
+.nn-gallery-card-thumb {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: var(--nn-bg-alt);
+  overflow: hidden;
+}
+.nn-gallery-card-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.nn-gallery-card-meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  padding: 10px 12px 12px;
+  font-family: var(--font-ui);
+}
+.nn-gallery-card-show {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--nn-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.nn-gallery-card-date {
+  font-size: 0.75rem;
+  color: var(--nn-text-muted);
+  flex-shrink: 0;
+}
+
+.nn-gallery-more-wrap {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--sp-6);
+}
+.nn-gallery-more { min-width: 220px; }
+
+/* Visually-hidden utility (a11y) */
+.nn-vh {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0, 0, 0, 0);
+  white-space: nowrap; border: 0;
+}
+
+/* ---- Lightbox ---- */
+body.nn-no-scroll { overflow: hidden; }
+
+.nn-gallery-lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 15, 26, 0.92);
+  z-index: 9100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--sp-4);
+}
+.nn-gallery-lightbox[aria-hidden="true"] { display: none; }
+.nn-lb-close,
+.nn-lb-prev,
+.nn-lb-next {
+  position: absolute;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.nn-lb-close:hover,
+.nn-lb-prev:hover,
+.nn-lb-next:hover {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.32);
+}
+.nn-lb-close { top: 16px; right: 16px; }
+.nn-lb-prev { top: 50%; left: 16px; transform: translateY(-50%); }
+.nn-lb-next { top: 50%; right: 16px; transform: translateY(-50%); }
+.nn-lb-figure {
+  margin: 0;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  gap: var(--sp-3);
+  max-width: min(1200px, 92vw);
+  max-height: 92vh;
+  width: 100%;
+}
+.nn-lb-image-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+}
+.nn-lb-image {
+  max-width: 100%;
+  max-height: 70vh;
+  object-fit: contain;
+  border-radius: 8px;
+  background: var(--nn-bg-alt);
+}
+.nn-lb-meta {
+  color: var(--nn-text);
+  font-family: var(--font-ui);
+  text-align: center;
+}
+.nn-lb-title { font-size: 1rem; font-weight: 600; }
+.nn-lb-sub { font-size: 0.85rem; color: var(--nn-text-muted); margin-top: 2px; }
+.nn-lb-actions {
+  display: inline-flex;
+  gap: var(--sp-3);
+  margin-top: var(--sp-3);
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.nn-btn-ghost {
+  background: transparent;
+  border: 1px solid var(--nn-border);
+  color: var(--nn-text);
+}
+.nn-btn-ghost:hover { background: rgba(255, 255, 255, 0.05); }
+.nn-lb-prompt {
+  margin-top: var(--sp-3);
+  text-align: left;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--nn-border);
+  border-radius: 8px;
+  padding: var(--sp-3);
+}
+.nn-lb-prompt-text {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8rem;
+  color: var(--nn-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.nn-lb-license {
+  margin-top: var(--sp-3);
+  font-size: 0.75rem;
+  color: var(--nn-text-muted);
+}
+.nn-lb-license a { color: var(--nn-text-muted); }
+
+@media (max-width: 600px) {
+  .nn-lb-prev, .nn-lb-next { bottom: 16px; top: auto; transform: none; }
+  .nn-lb-prev { left: 16px; }
+  .nn-lb-next { right: 16px; }
+}
+
+/* ---- Email-gate modal (Phase 3 stub) ---- */
+.nn-gate-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 15, 26, 0.88);
+  z-index: 9200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--sp-4);
+}
+.nn-gate-modal[aria-hidden="true"] { display: none; }
+.nn-gate-card {
+  background: var(--nn-bg-alt);
+  border: 1px solid var(--nn-border);
+  border-radius: 14px;
+  padding: var(--sp-6);
+  width: 100%;
+  max-width: 420px;
+  position: relative;
+  font-family: var(--font-ui);
+  color: var(--nn-text);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+}
+.nn-gate-close {
+  position: absolute;
+  top: 10px; right: 10px;
+  background: transparent;
+  border: 0;
+  color: var(--nn-text-muted);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.nn-gate-title { margin: 0 0 var(--sp-3); font-size: 1.15rem; }
+.nn-gate-body { margin: 0 0 var(--sp-4); font-size: 0.9rem; color: var(--nn-text-muted); }
+.nn-gate-form { display: flex; flex-direction: column; gap: var(--sp-2); }
+.nn-gate-input {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--nn-border);
+  background: var(--nn-card);
+  color: var(--nn-text);
+  font-family: var(--font-ui);
+  font-size: 0.95rem;
+}
+.nn-gate-input:focus {
+  outline: none;
+  border-color: var(--show-color, var(--nn-purple));
+  box-shadow: 0 0 0 3px rgba(107, 71, 255, 0.15);
+}
+.nn-gate-fineprint {
+  margin: var(--sp-3) 0 0;
+  font-size: 0.72rem;
+  color: var(--nn-text-muted);
+}
+.nn-gate-error {
+  margin: var(--sp-3) 0 0;
+  font-size: 0.8rem;
+  color: #fda4af;
+}

--- a/templates/_gallery_section.html.j2
+++ b/templates/_gallery_section.html.j2
@@ -1,0 +1,41 @@
+{# Reusable gallery section. Caller controls layout/title via params.
+
+   Renders an empty root element with the manifest URL + a small
+   help bar. The hydration is done client-side by assets/js/gallery.js
+   reading the static manifest at site/data/gallery-manifest.json.
+
+   Params:
+     section_id        — DOM id for the root container
+     section_title     — h2 text above the gallery (omit to hide)
+     section_intro     — short paragraph under the title (optional)
+     show_slug         — when provided, gallery is filtered to one show
+                         and the show-filter pill row is suppressed
+     page_size         — initial render count (defaults to 60 client-side)
+     hide_controls     — when truthy, hides the search + sort row
+                         (used on per-show embeds where the row of
+                         60 newest pictures for that show is enough)
+     path_prefix       — usual prefix to repo root from the rendered page
+                         (sub-pages use this to climb back)
+#}
+<section class="nn-section nn-gallery-section" id="{{ section_id|default('gallery') }}">
+    {% if section_title %}
+    <header class="nn-section-header">
+        <h2 class="nn-section-title">{{ section_title }}</h2>
+        {% if section_intro %}
+        <p class="nn-section-intro">{{ section_intro }}</p>
+        {% endif %}
+    </header>
+    {% endif %}
+
+    <div data-nn-gallery
+         {% if show_slug %}data-show-slug="{{ show_slug }}"{% endif %}
+         {% if page_size %}data-page-size="{{ page_size }}"{% endif %}
+         {% if hide_controls %}data-controls="hide"{% endif %}>
+        <p class="nn-gallery-loading">Loading gallery&hellip;</p>
+    </div>
+</section>
+
+<script>
+    window.NN_GALLERY_MANIFEST_URL = '{{ path_prefix|default("") }}site/data/gallery-manifest.json';
+</script>
+<script defer src="{{ path_prefix|default('') }}assets/js/gallery.js"></script>

--- a/templates/gallery_page.html.j2
+++ b/templates/gallery_page.html.j2
@@ -1,0 +1,52 @@
+{% extends "base.html.j2" %}
+
+{% block head_extra %}
+    <link rel="stylesheet" href="{{ path_prefix }}styles/main.css">
+    <style>
+        .nn-gallery-hero {
+            padding: calc(var(--nav-height) + var(--sp-12)) var(--sp-6) var(--sp-8);
+            text-align: center;
+            position: relative;
+            overflow: hidden;
+        }
+        .nn-gallery-hero::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(ellipse at 50% 0%, rgba(124, 92, 255, 0.18), transparent 70%);
+            pointer-events: none;
+        }
+        .nn-gallery-hero h1 {
+            font-family: var(--font-heading);
+            font-size: clamp(2rem, 5vw, 3rem);
+            margin: 0 0 var(--sp-3);
+            background: var(--nn-gradient);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+        }
+        .nn-gallery-hero p {
+            font-family: var(--font-ui);
+            color: var(--nn-text-muted);
+            font-size: 1.05rem;
+            max-width: 640px;
+            margin: 0 auto;
+        }
+        .nn-gallery-wrap {
+            max-width: 1280px;
+            margin: 0 auto;
+            padding: 0 var(--sp-6) var(--sp-16);
+        }
+    </style>
+{% endblock %}
+
+{% block content %}
+<section class="nn-gallery-hero">
+    <h1>Gallery</h1>
+    <p>Every AI-generated visual produced for Nerra Network episodes — long-form thumbnails, segment cards, and Shorts art. Browse by show or search the catalogue.</p>
+</section>
+
+<div class="nn-gallery-wrap">
+    {% include "_gallery_section.html.j2" with context %}
+</div>
+{% endblock %}

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -671,6 +671,12 @@
     </section>
     {% endif %}
 
+    {%- if gallery_enabled -%}
+    <section class="nn-section nn-gallery-section-wrap container">
+        {% include "_gallery_section.html.j2" with context %}
+    </section>
+    {%- endif -%}
+
     <!-- More from Nerra Network -->
     {#- Filter cross-network grid by page language so Russian readers
         don't get recommendations they can't consume. Russian-language

--- a/tests/test_build_gallery_manifest.py
+++ b/tests/test_build_gallery_manifest.py
@@ -1,0 +1,283 @@
+"""Unit tests for ``scripts/build_gallery_manifest``.
+
+Covers the pure manifest assembly (URL construction, sort order, show
+counts) and the write-if-changed path (no-op when only timestamp
+differs). The network walk is tiny glue around boto3 paginators and is
+not unit-tested here — it'd require mocking three boto3 surfaces for
+little signal.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from engine.gallery_uploader import GalleryConfig  # noqa: E402
+from scripts import build_gallery_manifest as bgm  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def config() -> GalleryConfig:
+    return GalleryConfig(
+        bucket="nerra-gallery",
+        endpoint_url="https://acct.r2.cloudflarestorage.com",
+        access_key="fake",
+        secret_key="fake",
+        public_base_url="https://gallery.example.com",
+    )
+
+
+def _sidecar(
+    *, image_id, slug="tesla", name="Tesla Shorts Time",
+    episode_id="ep001", episode_title="Ep 1", episode_date="2026-05-24",
+    generated_at="2026-05-24T15:00:00+00:00", fmt="jpeg",
+    prompt="a tesla cybertruck",
+):
+    return {
+        "image_id": image_id,
+        "show_slug": slug,
+        "show_name": name,
+        "episode_id": episode_id,
+        "episode_title": episode_title,
+        "episode_date": episode_date,
+        "generated_at": generated_at,
+        "format": fmt,
+        "prompt": prompt,
+        "model": "grok-imagine-image",
+        "intended_use": "segment_card",
+        "width": 1792,
+        "height": 1024,
+        "file_size": 215000,
+        "caption": "",
+        "tags": [slug, "segment_card"],
+        "license": "CC BY-SA 4.0",
+        "license_url": "https://creativecommons.org/licenses/by-sa/4.0/",
+        "attribution": "Nerra Network",
+        "youtube_video_id": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# URL construction
+# ---------------------------------------------------------------------------
+
+
+def test_public_url_uses_public_base_when_set(config):
+    url = bgm._public_url(config, "tesla/2026-05-24/ep001/abc.jpeg")
+    assert url == "https://gallery.example.com/tesla/2026-05-24/ep001/abc.jpeg"
+
+
+def test_public_url_falls_back_to_endpoint(config):
+    config.public_base_url = ""
+    url = bgm._public_url(config, "tesla/2026-05-24/ep001/abc.jpeg")
+    assert url == (
+        "https://acct.r2.cloudflarestorage.com/nerra-gallery/"
+        "tesla/2026-05-24/ep001/abc.jpeg"
+    )
+
+
+def test_build_object_keys_matches_uploader_layout(config):
+    sidecar = _sidecar(image_id="abc123def456", fmt="jpeg")
+    original, thumb, sidecar_key = bgm._build_object_keys(sidecar)
+    assert original == "tesla/2026-05-24/ep001/abc123def456.jpeg"
+    assert thumb == "tesla/2026-05-24/ep001/abc123def456.thumb.webp"
+    assert sidecar_key == "tesla/2026-05-24/ep001/abc123def456.json"
+
+
+def test_build_object_keys_normalises_jpg_to_jpeg():
+    sidecar = _sidecar(image_id="x", fmt="jpg")
+    original, _, _ = bgm._build_object_keys(sidecar)
+    assert original.endswith(".jpeg")
+
+
+def test_build_object_keys_passes_png_through():
+    sidecar = _sidecar(image_id="x", fmt="png")
+    original, _, _ = bgm._build_object_keys(sidecar)
+    assert original.endswith(".png")
+
+
+# ---------------------------------------------------------------------------
+# build_manifest
+# ---------------------------------------------------------------------------
+
+
+def test_build_manifest_empty_input(config):
+    manifest = bgm.build_manifest([], config=config)
+    assert manifest["image_count"] == 0
+    assert manifest["images"] == []
+    assert manifest["show_counts"] == {}
+    assert manifest["shows"] == []
+    assert manifest["schema_version"] == bgm.SCHEMA_VERSION
+    assert "generated_at" in manifest
+
+
+def test_build_manifest_sorts_newest_first(config):
+    older = _sidecar(image_id="older", generated_at="2026-05-22T10:00:00+00:00")
+    newer = _sidecar(image_id="newer", generated_at="2026-05-24T10:00:00+00:00")
+    middle = _sidecar(image_id="middle", generated_at="2026-05-23T10:00:00+00:00")
+    manifest = bgm.build_manifest([older, newer, middle], config=config)
+    assert [img["image_id"] for img in manifest["images"]] == [
+        "newer", "middle", "older",
+    ]
+
+
+def test_build_manifest_aggregates_show_counts(config):
+    sidecars = [
+        _sidecar(image_id="t1", slug="tesla", name="Tesla Shorts Time"),
+        _sidecar(image_id="t2", slug="tesla", name="Tesla Shorts Time"),
+        _sidecar(
+            image_id="m1", slug="models_agents_beginners",
+            name="Models & Agents for Beginners",
+        ),
+    ]
+    manifest = bgm.build_manifest(sidecars, config=config)
+    assert manifest["show_counts"] == {"tesla": 2, "models_agents_beginners": 1}
+    show_slugs = {s["slug"]: s for s in manifest["shows"]}
+    assert show_slugs["tesla"]["name"] == "Tesla Shorts Time"
+    assert show_slugs["models_agents_beginners"]["image_count"] == 1
+
+
+def test_build_manifest_skips_invalid_sidecars(config, caplog):
+    bad = {"image_id": "missing_show_slug"}  # missing required fields
+    good = _sidecar(image_id="ok")
+    manifest = bgm.build_manifest([bad, good], config=config)
+    assert manifest["image_count"] == 1
+    assert manifest["images"][0]["image_id"] == "ok"
+
+
+def test_build_manifest_attaches_urls_to_every_image(config):
+    sidecar = _sidecar(image_id="abc")
+    manifest = bgm.build_manifest([sidecar], config=config)
+    img = manifest["images"][0]
+    assert img["thumbnail_url"].endswith("/abc.thumb.webp")
+    assert img["original_url"].endswith("/abc.jpeg")
+    assert img["sidecar_url"].endswith("/abc.json")
+    # Original sidecar fields are preserved.
+    assert img["prompt"] == "a tesla cybertruck"
+    assert img["license"] == "CC BY-SA 4.0"
+
+
+def test_build_manifest_ignores_non_dict_entries(config):
+    sidecar = _sidecar(image_id="ok")
+    manifest = bgm.build_manifest(
+        [sidecar, None, "not a dict", 42], config=config,
+    )
+    assert manifest["image_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# write_manifest_if_changed
+# ---------------------------------------------------------------------------
+
+
+def test_write_creates_file_when_missing(tmp_path, config):
+    out = tmp_path / "site" / "data" / "gallery-manifest.json"
+    manifest = bgm.build_manifest([_sidecar(image_id="a")], config=config)
+    written = bgm.write_manifest_if_changed(manifest, out)
+    assert written is True
+    assert out.exists()
+    on_disk = json.loads(out.read_text())
+    assert on_disk["image_count"] == 1
+
+
+def test_write_is_noop_when_only_timestamp_differs(tmp_path, config):
+    out = tmp_path / "manifest.json"
+    first = bgm.build_manifest(
+        [_sidecar(image_id="a")], config=config,
+        generated_at="2026-05-24T10:00:00+00:00",
+    )
+    bgm.write_manifest_if_changed(first, out)
+    first_mtime = out.stat().st_mtime
+
+    second = bgm.build_manifest(
+        [_sidecar(image_id="a")], config=config,
+        generated_at="2026-05-25T10:00:00+00:00",
+    )
+    written = bgm.write_manifest_if_changed(second, out)
+    assert written is False
+    assert out.stat().st_mtime == first_mtime
+    # File still holds the first timestamp.
+    on_disk = json.loads(out.read_text())
+    assert on_disk["generated_at"] == "2026-05-24T10:00:00+00:00"
+
+
+def test_write_rewrites_when_content_changes(tmp_path, config):
+    out = tmp_path / "manifest.json"
+    first = bgm.build_manifest(
+        [_sidecar(image_id="a")], config=config,
+        generated_at="2026-05-24T10:00:00+00:00",
+    )
+    bgm.write_manifest_if_changed(first, out)
+
+    second = bgm.build_manifest(
+        [_sidecar(image_id="a"), _sidecar(image_id="b", episode_id="ep002")],
+        config=config,
+        generated_at="2026-05-25T10:00:00+00:00",
+    )
+    written = bgm.write_manifest_if_changed(second, out)
+    assert written is True
+    on_disk = json.loads(out.read_text())
+    assert on_disk["image_count"] == 2
+
+
+def test_write_recovers_from_corrupt_existing_file(tmp_path, config):
+    out = tmp_path / "manifest.json"
+    out.write_text("{ not valid json ::")
+    manifest = bgm.build_manifest([_sidecar(image_id="a")], config=config)
+    written = bgm.write_manifest_if_changed(manifest, out)
+    assert written is True
+    assert json.loads(out.read_text())["image_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# empty_manifest
+# ---------------------------------------------------------------------------
+
+
+def test_empty_manifest_has_zero_images(config):
+    manifest = bgm.empty_manifest(config)
+    assert manifest["image_count"] == 0
+    assert manifest["images"] == []
+    assert manifest["schema_version"] == bgm.SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# main() — orchestration with R2 unconfigured
+# ---------------------------------------------------------------------------
+
+
+def test_main_writes_empty_manifest_when_r2_unconfigured(tmp_path, monkeypatch):
+    for var in ("R2_GALLERY_BUCKET", "R2_ENDPOINT_URL", "R2_ACCESS_KEY_ID",
+                "R2_SECRET_ACCESS_KEY", "R2_GALLERY_PUBLIC_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    out = tmp_path / "manifest.json"
+    rc = bgm.main(["--out", str(out)])
+    assert rc == 0
+    assert out.exists()
+    payload = json.loads(out.read_text())
+    assert payload["image_count"] == 0
+    assert payload["schema_version"] == bgm.SCHEMA_VERSION
+
+
+def test_main_dry_run_does_not_write(tmp_path, monkeypatch, capsys):
+    for var in ("R2_GALLERY_BUCKET", "R2_ENDPOINT_URL", "R2_ACCESS_KEY_ID",
+                "R2_SECRET_ACCESS_KEY", "R2_GALLERY_PUBLIC_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    out = tmp_path / "manifest.json"
+    rc = bgm.main(["--dry-run", "--out", str(out)])
+    assert rc == 0
+    assert not out.exists()
+    captured = capsys.readouterr().out
+    assert '"image_count": 0' in captured

--- a/tests/test_gallery_render.py
+++ b/tests/test_gallery_render.py
@@ -1,0 +1,154 @@
+"""Smoke tests for the Phase 2 gallery rendering pipeline.
+
+These don't exercise the JS — they just verify the template wiring
+produces the right HTML (mount-point present when gallery is enabled,
+absent when it isn't) and that the gallery_page template renders.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from jinja2 import ChoiceLoader, DictLoader, Environment, FileSystemLoader, select_autoescape
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES_DIR = PROJECT_ROOT / "templates"
+
+
+@pytest.fixture
+def env() -> Environment:
+    return Environment(
+        loader=FileSystemLoader(str(TEMPLATES_DIR)),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+
+
+@pytest.fixture
+def base_context() -> dict:
+    return {
+        "path_prefix": "",
+        "show_slug": "tesla",
+        "show_name": "Tesla Shorts Time",
+        "section_id": "gallery",
+        "section_title": "Episode gallery",
+        "section_intro": "AI-generated visuals from recent episodes.",
+        "page_size": 24,
+        "hide_controls": True,
+    }
+
+
+def test_gallery_section_partial_renders_mount_point(env, base_context):
+    template = env.get_template("_gallery_section.html.j2")
+    html = template.render(**base_context)
+    assert "data-nn-gallery" in html
+    assert 'data-show-slug="tesla"' in html
+    assert 'data-page-size="24"' in html
+    assert 'data-controls="hide"' in html
+    assert "assets/js/gallery.js" in html
+    assert "site/data/gallery-manifest.json" in html
+    assert "Episode gallery" in html
+
+
+def test_gallery_section_omits_show_slug_when_not_given(env, base_context):
+    ctx = dict(base_context)
+    ctx.pop("show_slug")
+    template = env.get_template("_gallery_section.html.j2")
+    html = template.render(**ctx)
+    assert "data-nn-gallery" in html
+    assert "data-show-slug=" not in html
+
+
+def test_gallery_section_hides_title_when_blank(env, base_context):
+    ctx = dict(base_context)
+    ctx["section_title"] = ""
+    template = env.get_template("_gallery_section.html.j2")
+    html = template.render(**ctx)
+    # No <h2> for the section header when title is empty.
+    assert "nn-section-title" not in html
+
+
+def test_show_page_includes_gallery_when_enabled():
+    """When ``gallery_enabled`` is True the show_page template must
+    emit the gallery mount point and the JS bootstrap."""
+    # Build a stub jinja env that overrides base + macros so we don't
+    # need to render the entire 958-line show_page template — only the
+    # gallery-relevant fragment.
+    env = Environment(
+        loader=ChoiceLoader([
+            DictLoader({
+                "fragment.html.j2": (
+                    "{% if gallery_enabled %}"
+                    '{% include "_gallery_section.html.j2" with context %}'
+                    "{% endif %}"
+                ),
+            }),
+            FileSystemLoader(str(TEMPLATES_DIR)),
+        ]),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+    ctx = {
+        "gallery_enabled": True,
+        "path_prefix": "",
+        "show_slug": "models_agents_beginners",
+        "section_id": "gallery",
+        "section_title": "Episode gallery",
+        "section_intro": "",
+        "page_size": 24,
+        "hide_controls": True,
+    }
+    html = env.get_template("fragment.html.j2").render(**ctx)
+    assert "data-nn-gallery" in html
+
+    ctx["gallery_enabled"] = False
+    html = env.get_template("fragment.html.j2").render(**ctx)
+    assert "data-nn-gallery" not in html
+
+
+def test_gallery_page_template_renders():
+    """End-to-end render of the gallery page template via the project's
+    real Jinja env (which registers custom filters like ``with_utm``)
+    — fails loudly if any block reference goes stale."""
+    import sys
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    from generate_html import _get_jinja_env
+
+    env = _get_jinja_env()
+    template = env.get_template("gallery_page.html.j2")
+    html = template.render(
+        path_prefix="",
+        page_title="Gallery — Nerra Network",
+        page_description="x",
+        meta_description="x",
+        meta_keywords="x",
+        theme_color="#6B47FF",
+        og_image="",
+        canonical_url="https://nerranetwork.com/gallery.html",
+        show_color="",
+        show_color_dark="",
+        all_shows=[],
+        section_id="gallery",
+        section_title="",
+        section_intro="",
+        show_slug="",
+        page_size=60,
+        hide_controls=False,
+    )
+    assert "<h1>Gallery</h1>" in html
+    assert "data-nn-gallery" in html
+    assert "gallery.js" in html
+
+
+def test_gallery_manifest_placeholder_is_valid_json():
+    """The committed placeholder manifest must always be parseable —
+    if a future edit corrupts it, the JS gallery fetch fails on every
+    page load."""
+    import json
+    manifest_path = PROJECT_ROOT / "site" / "data" / "gallery-manifest.json"
+    assert manifest_path.exists(), "placeholder manifest missing"
+    data = json.loads(manifest_path.read_text())
+    assert data["schema_version"] == 1
+    assert isinstance(data["images"], list)
+    assert isinstance(data["shows"], list)
+    assert "image_count" in data


### PR DESCRIPTION
## Summary

Phase 2 of the Nerra Network image gallery. Adds the client-facing
browse surface and the CI job that keeps it fresh — sitting cleanly on
top of Phase 1's R2 storage + sidecar metadata.

Three new surfaces:
- **Per-show embedded gallery** on each YouTube-enabled show page
  (today: Tesla Shorts Time + Models & Agents for Beginners). Pinned
  to that show, 24 newest, search/sort hidden.
- **`/gallery.html`** — network-wide browse page. All shows,
  multi-select show pills, free-text search across caption + prompt
  + tags, newest/oldest sort, 60 newest with a "Show more" button.
- **Email-gate modal** wired to the lightbox's "Download full size"
  button. Phase 2 ships this as a UI **stub** — submitting an email
  marks the visitor as subscribed in `localStorage`, fires a GA4
  event, and opens the original URL in a new tab. Phase 3 swaps the
  network calls for a real Cloudflare Worker hitting Buttondown +
  signing R2 download URLs — UX stays identical.

## What's in here

* **`scripts/build_gallery_manifest.py`** — walks every `*.json`
  sidecar in the `nerra-gallery` R2 bucket, reconstructs URLs from
  sidecar fields, sorts newest-first, and writes
  `site/data/gallery-manifest.json`. Handles three tricky cases
  cleanly:
  * R2 unconfigured → empty manifest written (frontend renders empty
    state, page still works).
  * Sidecar fails to parse → logs + skips, never crashes.
  * Only `generated_at` would change → file not rewritten, so the CI
    workflow's `git diff --cached --quiet` check is a no-op.
* **`.github/workflows/build-gallery-manifest.yml`** — nightly at
  03:30 UTC + after every successful `Run Podcast Show` + on push to
  `main` affecting gallery code paths. Same commit-back pattern the
  `Management Dashboard` workflow uses.
* **`templates/_gallery_section.html.j2`** — reusable Jinja2 partial.
  Single mount point with optional `data-show-slug` /
  `data-page-size` / `data-controls` data attributes.
* **`templates/gallery_page.html.j2`** + `generate_gallery_page()` in
  `generate_html.py` — render `/gallery.html`. Wired into
  `--all` and the sitemap.
* **`templates/show_page.html.j2`** — embed the partial near the
  bottom, gated on `gallery_enabled` (derived from
  `youtube.enabled`). Today: Tesla + MAB only; when a show enables
  YouTube the embed auto-activates.
* **`assets/js/gallery.js`** — vanilla JS, no build step. Fetches
  manifest, renders grid with `loading="lazy"` thumbnails, search +
  show filter + sort, lightbox with prev/next + prompt toggle
  (hidden by default per the spec's question #3) + download button.
  Email-gate modal stub.
* **`styles/main.css`** — `.nn-gallery-*` rules using existing
  design tokens (`--nn-bg`, `--nn-card`, `--show-color`, etc.) so
  per-show embeds pick up the show's brand colour automatically.
* **`site/data/gallery-manifest.json`** — empty placeholder so the
  page works before the first CI run.
* **`tests/test_build_gallery_manifest.py`** — 18 tests covering
  URL construction, sort order, show-count aggregation, schema
  validation, idempotent write, and "R2 unconfigured = empty
  manifest" contract.
* **`tests/test_gallery_render.py`** — 6 Jinja2 render smoke tests:
  per-show gating, show-slug attribute, gallery_page renders against
  the real Jinja env (which carries the project's custom filters).
* **`docs/gallery_storage.md`** + **`CLAUDE.md`** — Phase 2
  documentation, manifest schema, per-show vs network-wide table,
  Phase 3 plan.

## Decisions locked

The spec's "QUESTIONS TO RAISE BEFORE BUILDING" #3 was the only
outstanding one for Phase 2. Confirmed with operator:

| Question | Decision |
|---|---|
| Prompt visibility on the gallery | **Toggle** — hidden by default in the lightbox, "Show prompt" button reveals it. Keeps the grid clean while leaving the AI provenance one click away. |

## Test plan

- [x] `pytest tests/test_build_gallery_manifest.py` — 18 passed
- [x] `pytest tests/test_gallery_render.py` — 6 passed
- [x] `pytest tests/test_gallery_render.py tests/test_build_gallery_manifest.py tests/test_gallery_uploader.py tests/test_storage.py tests/test_config.py` — 111 passed (verifies no regressions on touched surfaces)
- [x] `node -c assets/js/gallery.js` — vanilla JS syntax-clean
- [x] Live render of `gallery.html` (39 KB) — mount point + hero + empty-state copy correct
- [x] Live render of `tesla.html` + `models-agents-beginners.html` — gallery section emitted with correct `data-show-slug` / `data-page-size` / `data-controls="hide"`
- [x] Live render of `omni-view.html` — gallery section NOT emitted (`gallery_enabled=false`)
- [ ] **Pending after merge:** the first nightly build-gallery-manifest run populates the manifest from the R2 bucket; visit `/gallery.html` to confirm the grid renders
- [ ] **Pending Phase 3:** the email-gate modal opens but the download flow today resolves to the public `original_url` (which the R2 bucket policy keeps private — so it'll 403 until the Worker is in place)

## Operator action items

1. Set the GitHub Actions secrets `R2_GALLERY_BUCKET` and
   `R2_GALLERY_PUBLIC_BASE_URL` (gallery-specific). The other R2
   creds are already wired from Phase 1.
2. After merge, manually trigger `Build Gallery Manifest` once
   (workflow_dispatch) to seed `site/data/gallery-manifest.json`
   from whatever the bucket already contains; the nightly + workflow_run
   triggers take over from there.
3. The two existing show HTML pages (`tesla.html`,
   `models-agents-beginners.html`) get the gallery section on their
   next daily `Run Podcast Show` render — no manual rebuild needed.
   This PR intentionally does NOT commit the regenerated show pages
   to avoid mixing in unrelated drift (Google consent script
   additions from another PR).

Phase 3 (Cloudflare Worker — JWT cookie, Buttondown subscription,
signed R2 URLs, magic-link login) follows in the next PR.

https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2)_