### PR TITLE
Gallery Phase 3: Cloudflare Worker — JWT cookie, Buttondown, magic-link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,9 @@ digests/*/youtube_tmp/*.srt
 !data/.gitkeep
 !outputs/.gitkeep
 
+
+# Cloudflare Worker (workers/gallery) build + local-dev artifacts.
+workers/**/node_modules/
+workers/**/.wrangler/
+workers/**/.dev.vars
+workers/**/dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ All RSS `<enclosure>` URLs now use `audio.nerranetwork.com` (Cloudflare R2).
 MP3 files are uploaded to R2 during the pipeline and excluded from git commits.
 **Do NOT change R2 bucket paths — this breaks podcast subscribers.**
 
-### Image gallery (Phases 1 + 2 — May 2026)
+### Image gallery (Phases 1 + 2 + 3 — May 2026)
 
 Every Grok-Imagine scene generated for the YouTube long-form / Shorts
 slideshow is uploaded to a separate R2 bucket (`nerra-gallery`) with a
@@ -193,16 +193,37 @@ rendered to `/gallery.html` by `generate_gallery_page()` in
 when `gallery_enabled` is true (today: any show with
 `youtube.enabled: true`, currently Tesla + MAB — see landmine #20).
 Prompt visibility is a per-image **toggle** (hidden by default in the
-lightbox). The "Download full size" button opens a Phase-3 email-gate
-modal **stub** — submitting the email marks the visitor as subscribed
-in `localStorage` and proceeds; the real Buttondown subscription +
-signed R2 URL flow lands in Phase 3.
+lightbox).
 
-Layout, schema, env vars, and the Phase 3 roadmap live in
-[`docs/gallery_storage.md`](docs/gallery_storage.md). Unconfigured
-environments (env vars unset) are a clean no-op: the manifest builder
-writes an empty manifest and the frontend renders a friendly empty
-state.
+**Phase 3 — email-gated downloads.** Cloudflare Worker at
+`api.nerranetwork.com` ([`workers/gallery/`](workers/gallery/)) with
+four endpoints: `POST /api/subscribe` (Buttondown subscribe + 90-day
+JWT cookie), `GET /api/login` (magic-link email via Resend, always
+200 so the address can't be enumerated), `GET /api/magic` (consume
+the magic JWT, set cookie, 302 to /gallery), `GET /api/download`
+(verify cookie, stream the R2 object via the bucket binding with
+`Content-Disposition: attachment`). JWT is HS256, hand-rolled in
+[`workers/gallery/src/jwt.ts`](workers/gallery/src/jwt.ts) — no
+third-party dep on the Worker. The download endpoint **proxies bytes
+through the Worker** instead of issuing signed R2 URLs (revocation
+works, no shareable URLs, no SigV4 plumbing — documented deviation
+from the spec). Frontend [`assets/js/gallery.js`](assets/js/gallery.js)
+calls these endpoints with `credentials:'include'`; gate modal
+supports both "Subscribe & download" and "Already subscribed? Sign
+in instead" paths. New secrets (set via `wrangler secret put` once):
+`JWT_SECRET`, `BUTTONDOWN_API_KEY`, `RESEND_API_KEY`,
+`RESEND_FROM_EMAIL`. The Worker doesn't need new R2 credentials —
+the bucket is wired declaratively as `GALLERY_BUCKET` in
+[`workers/gallery/wrangler.toml`](workers/gallery/wrangler.toml).
+
+Layout, schema, env vars, deployment steps, and the operator
+checklist live in
+[`docs/gallery_storage.md`](docs/gallery_storage.md) and
+[`workers/gallery/README.md`](workers/gallery/README.md).
+Unconfigured environments (env vars unset) are a clean no-op: the
+manifest builder writes an empty manifest, the frontend renders a
+friendly empty state, and the gate modal surfaces a network error if
+the Worker hostname isn't reachable yet.
 
 ### Testing
 

--- a/assets/js/gallery.js
+++ b/assets/js/gallery.js
@@ -25,6 +25,12 @@
 
     var MANIFEST_URL = (window.NN_GALLERY_MANIFEST_URL ||
         '/site/data/gallery-manifest.json');
+    // Worker base URL. Phase 3 deploys the Worker at
+    // api.nerranetwork.com; the override exists so local dev
+    // (python -m http.server 8080 + wrangler dev) can point at
+    // http://127.0.0.1:8787 without editing this file.
+    var API_BASE = (window.NN_GALLERY_API_BASE ||
+        'https://api.nerranetwork.com').replace(/\/+$/, '');
     var PROMPT_PREFIX_RE = /^[^,]+,\s*photorealistic[^,]*,\s*/i;
 
     function $(sel, root) { return (root || document).querySelector(sel); }
@@ -411,21 +417,13 @@
         if (!lb || !_lbState.state) return;
         var img = _lbState.state.visible[_lbState.index];
         var imgEl = $('.nn-lb-image', lb);
-        imgEl.src = img.thumbnail_url; // start with thumb for instant paint
+        imgEl.src = img.thumbnail_url;
         imgEl.alt = img.caption || img.episode_title || (img.show_name || '') + ' image';
-        // Swap to the full original after a tick (preloading the
-        // higher-res image without blocking the first paint). The
-        // public_base_url points at the public R2 host today; Phase 3
-        // will route this through the Worker to a signed URL.
-        var hires = new Image();
-        hires.onload = function () {
-            if (lb.getAttribute('aria-hidden') === 'false' &&
-                _lbState.state.visible[_lbState.index] === img) {
-                imgEl.src = img.original_url;
-            }
-        };
-        hires.onerror = function () { /* stay on thumbnail */ };
-        hires.src = img.original_url;
+        // Phase 3: originals are private (the Worker proxies them
+        // through /api/download). The lightbox stays on the 800-px
+        // watermarked thumbnail, which is the right size for a modal
+        // preview. The "Download full size" button takes the visitor
+        // through the email gate to fetch the original.
 
         $('.nn-lb-title', lb).textContent = img.episode_title || '';
         $('.nn-lb-sub', lb).textContent = [
@@ -458,26 +456,59 @@
         }
     }
 
-    // ---------- Download gate (Phase 3 stub) ----------
+    // ---------- Download gate (Phase 3 — wired to api.nerranetwork.com) ----------
 
-    function isSubscribed() {
-        try { return localStorage.getItem('nn_gallery_subscriber') === '1'; }
-        catch (_) { return false; }
+    function downloadEndpoint(key) {
+        return API_BASE + '/api/download?key=' + encodeURIComponent(key);
     }
-    function markSubscribed() {
-        try { localStorage.setItem('nn_gallery_subscriber', '1'); }
-        catch (_) {}
+    function subscribeEndpoint() { return API_BASE + '/api/subscribe'; }
+    function loginEndpoint(email) {
+        return API_BASE + '/api/login?email=' + encodeURIComponent(email);
     }
 
+    // Programmatic download: fetch the bytes through the Worker so
+    // we re-validate the JWT cookie on every download (revocation
+    // works) and the browser triggers a real save dialog via
+    // <a download>. If the Worker says 401 we open the gate; on any
+    // other error we surface a console warning and let the visitor
+    // retry. Note: cross-origin <a download> respects
+    // Content-Disposition from the Worker.
     function handleDownload() {
         if (!_lbState.state) return;
         var img = _lbState.state.visible[_lbState.index];
-        if (!img) return;
-        if (isSubscribed()) {
-            window.open(img.original_url, '_blank', 'noopener');
-            return;
-        }
-        openGateModal(img);
+        if (!img || !img.original_key) return;
+        fetch(downloadEndpoint(img.original_key), {
+            method: 'GET',
+            credentials: 'include',
+        }).then(function (resp) {
+            if (resp.status === 401) {
+                openGateModal();
+                return null;
+            }
+            if (!resp.ok) {
+                throw new Error('download HTTP ' + resp.status);
+            }
+            return resp.blob().then(function (blob) {
+                var url = URL.createObjectURL(blob);
+                var a = document.createElement('a');
+                a.href = url;
+                a.download = img.original_key.split('/').pop() || 'image';
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                setTimeout(function () { URL.revokeObjectURL(url); }, 30000);
+                if (typeof window.gtag === 'function') {
+                    try { window.gtag('event', 'gallery_download', { image_id: img.image_id }); }
+                    catch (_) {}
+                }
+            });
+        }).catch(function (err) {
+            if (typeof console !== 'undefined') {
+                console.warn('[gallery] download failed:', err);
+            }
+            // Fallback: open the gate so they can sign in / sign up.
+            openGateModal();
+        });
     }
 
     function ensureGateModal() {
@@ -496,34 +527,74 @@
                     'free email subscription. We&rsquo;ll send you ' +
                     'occasional Nerra Network updates and you can ' +
                     'download any image at full resolution from then on.</p>' +
-                '<form class="nn-gate-form">' +
+                '<form class="nn-gate-form" data-mode="subscribe">' +
                     '<label><span class="nn-vh">Email</span>' +
                         '<input type="email" required placeholder="you@example.com" ' +
                             'autocomplete="email" class="nn-gate-input">' +
                     '</label>' +
-                    '<button type="submit" class="nn-btn">Subscribe &amp; download</button>' +
+                    '<button type="submit" class="nn-btn nn-gate-submit">Subscribe &amp; download</button>' +
                 '</form>' +
                 '<p class="nn-gate-fineprint">By subscribing you agree to ' +
-                    'receive emails from Nerra Network. Unsubscribe any time.</p>' +
+                    'receive emails from Nerra Network. Unsubscribe any time. ' +
+                    '<a href="#" class="nn-gate-toggle">Already subscribed? Sign in instead.</a>' +
+                '</p>' +
                 '<p class="nn-gate-error" hidden></p>' +
+                '<p class="nn-gate-success" hidden></p>' +
             '</div>'
         );
         document.body.appendChild(m);
         m.addEventListener('click', function (e) {
             if (e.target === m || e.target.classList.contains('nn-gate-close')) {
                 closeGateModal();
+                return;
+            }
+            if (e.target.classList && e.target.classList.contains('nn-gate-toggle')) {
+                e.preventDefault();
+                toggleGateMode(m);
             }
         });
         m.addEventListener('submit', function (e) {
             e.preventDefault();
-            var email = ($('.nn-gate-input', m).value || '').trim();
+            var input = $('.nn-gate-input', m);
+            var email = (input && input.value || '').trim();
             if (!email) return;
-            submitGate(email, m);
+            var mode = $('.nn-gate-form', m).getAttribute('data-mode');
+            if (mode === 'login') submitLogin(email, m);
+            else submitSubscribe(email, m);
         });
         return m;
     }
 
-    function openGateModal(_img) {
+    function toggleGateMode(m) {
+        var form = $('.nn-gate-form', m);
+        var title = $('.nn-gate-title', m);
+        var body = $('.nn-gate-body', m);
+        var submit = $('.nn-gate-submit', m);
+        var toggle = $('.nn-gate-toggle', m);
+        var success = $('.nn-gate-success', m);
+        var error = $('.nn-gate-error', m);
+        if (success) success.setAttribute('hidden', '');
+        if (error) error.setAttribute('hidden', '');
+        if (form.getAttribute('data-mode') === 'subscribe') {
+            form.setAttribute('data-mode', 'login');
+            title.textContent = 'Sign in to download';
+            body.textContent = 'Enter the email you previously subscribed with. ' +
+                'We’ll send you a one-click sign-in link.';
+            submit.textContent = 'Send sign-in link';
+            toggle.textContent = 'Don’t have an account? Subscribe instead.';
+        } else {
+            form.setAttribute('data-mode', 'subscribe');
+            title.textContent = 'One-time email to download';
+            body.innerHTML = 'Originals are gated behind a ' +
+                'free email subscription. We’ll send you ' +
+                'occasional Nerra Network updates and you can ' +
+                'download any image at full resolution from then on.';
+            submit.textContent = 'Subscribe & download';
+            toggle.textContent = 'Already subscribed? Sign in instead.';
+        }
+    }
+
+    function openGateModal() {
         var m = ensureGateModal();
         m.setAttribute('aria-hidden', 'false');
         document.body.classList.add('nn-no-scroll');
@@ -540,29 +611,87 @@
         }
     }
 
-    function submitGate(email, modal) {
-        // Phase 3 hook: POST to /api/subscribe on the Worker. For now
-        // this is a stub — we log the event, mark the visitor as
-        // subscribed locally, close the gate, and surface the
-        // download.
+    function showGateError(modal, message) {
+        var el = $('.nn-gate-error', modal);
+        if (!el) return;
+        el.textContent = message;
+        el.removeAttribute('hidden');
+    }
+
+    function showGateSuccess(modal, message) {
+        var el = $('.nn-gate-success', modal);
+        if (!el) return;
+        el.textContent = message;
+        el.removeAttribute('hidden');
+    }
+
+    function setGateBusy(modal, busy) {
+        var submit = $('.nn-gate-submit', modal);
+        if (submit) submit.disabled = !!busy;
+    }
+
+    function submitSubscribe(email, modal) {
         var errEl = $('.nn-gate-error', modal);
-        errEl.setAttribute('hidden', '');
-        if (typeof console !== 'undefined') {
-            console.info('[gallery] gate stub: would subscribe', email,
-                '(Phase 3 wires this to the Cloudflare Worker)');
-        }
-        // Best-effort GA4 event if gtag is on the page.
-        if (typeof window.gtag === 'function') {
-            try { window.gtag('event', 'gallery_subscribe_stub', { email_domain: email.split('@')[1] || '' }); }
-            catch (_) {}
-        }
-        markSubscribed();
-        closeGateModal();
-        // Re-trigger the download now that the visitor is "subscribed".
-        if (_lbState.state) {
-            var img = _lbState.state.visible[_lbState.index];
-            if (img) window.open(img.original_url, '_blank', 'noopener');
-        }
+        var okEl = $('.nn-gate-success', modal);
+        if (errEl) errEl.setAttribute('hidden', '');
+        if (okEl) okEl.setAttribute('hidden', '');
+        setGateBusy(modal, true);
+        fetch(subscribeEndpoint(), {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email: email }),
+        }).then(function (resp) {
+            if (resp.ok) {
+                if (typeof window.gtag === 'function') {
+                    try { window.gtag('event', 'gallery_subscribe', { email_domain: email.split('@')[1] || '' }); }
+                    catch (_) {}
+                }
+                closeGateModal();
+                // Retry the download — the cookie is now set.
+                handleDownload();
+                return;
+            }
+            return resp.json().then(function (body) {
+                showGateError(modal,
+                    (body && body.error)
+                        ? ('Couldn’t subscribe: ' + body.error)
+                        : 'Couldn’t subscribe. Please try again in a moment.');
+            }, function () {
+                showGateError(modal, 'Couldn’t subscribe. Please try again in a moment.');
+            });
+        }).catch(function () {
+            showGateError(modal, 'Network error. Please check your connection and retry.');
+        }).then(function () { setGateBusy(modal, false); });
+    }
+
+    function submitLogin(email, modal) {
+        var errEl = $('.nn-gate-error', modal);
+        var okEl = $('.nn-gate-success', modal);
+        if (errEl) errEl.setAttribute('hidden', '');
+        if (okEl) okEl.setAttribute('hidden', '');
+        setGateBusy(modal, true);
+        fetch(loginEndpoint(email), {
+            method: 'GET',
+            credentials: 'include',
+        }).then(function (resp) {
+            // The API always returns 200 to avoid email enumeration —
+            // so we show the same success message regardless of
+            // whether the address is actually subscribed.
+            if (resp.ok) {
+                showGateSuccess(modal,
+                    'If that email is subscribed, a sign-in link is on the way. ' +
+                    'Check your inbox (and spam folder).');
+                if (typeof window.gtag === 'function') {
+                    try { window.gtag('event', 'gallery_login_requested'); }
+                    catch (_) {}
+                }
+            } else {
+                showGateError(modal, 'Couldn’t send the link. Please try again.');
+            }
+        }).catch(function () {
+            showGateError(modal, 'Network error. Please check your connection and retry.');
+        }).then(function () { setGateBusy(modal, false); });
     }
 
     // ---------- Bootstrap ----------

--- a/docs/gallery_storage.md
+++ b/docs/gallery_storage.md
@@ -263,10 +263,115 @@ the R2 bucket policy keeps originals private. The Phase 2 stub
 exists so the UI is complete and reviewable end-to-end now, and so
 Phase 3 only has to swap the network calls — not the UX.
 
+## Phase 3 — email-gated downloads (shipped)
+
+### Endpoints (Cloudflare Worker at `api.nerranetwork.com`)
+
+| Method | Path | Behaviour |
+|---|---|---|
+| POST | `/api/subscribe` | Body `{email}`. Subscribes via Buttondown with tag `gallery-subscriber`, sets a 90-day HttpOnly Secure SameSite=Lax JWT cookie, returns `200 {ok:true}`. Already-subscribed addresses are treated as success (so re-subscribing still issues the cookie). |
+| GET | `/api/login?email=...` | If the address is subscribed, sends a magic-link email via Resend (15-min TTL). **Always returns 200** regardless of whether the address exists — the response is identical on hit vs miss so the endpoint can't be used to enumerate subscribers. |
+| GET | `/api/magic?token=...` | Verifies the magic-login JWT (HS256 + exp + scope), issues the 90-day cookie, 302 to `/gallery.html`. |
+| GET | `/api/download?key=<r2_object_key>` | Verifies the cookie. Validates the key is well-formed (no traversal / no absolute paths). Fetches the R2 object via the bound bucket and streams it back with `Content-Disposition: attachment`. |
+| GET | `/api/health` | Liveness ping. |
+
+### Authentication model
+
+Two JWT scopes, both signed with HMAC-SHA256 using the `JWT_SECRET`
+the operator provisions once:
+
+| Scope | TTL | Carrier |
+|---|---|---|
+| `gallery-subscriber` | 90 days | Cookie `nn_gallery=<jwt>` (HttpOnly, Secure, SameSite=Lax) |
+| `magic-login` | 15 minutes | URL query parameter on the emailed magic link |
+
+The cookie is set by `/api/subscribe` and `/api/magic` and consumed
+by `/api/download`. There is no logout endpoint — Phase 3 ships a
+single-cookie subscriber model; the operator can revoke
+network-wide by rotating `JWT_SECRET` (all outstanding cookies
+become invalid on the next download attempt).
+
+### Download path — spec deviation
+
+The project spec called for `/api/download` to issue a **short-lived
+signed R2 URL and 302 redirect**. The Worker **proxies the bytes
+through** instead. Rationale:
+
+* Re-validates the JWT on every request, so revocation actually works
+  (signed URLs would remain valid for their full TTL even after the
+  visitor's cookie expires).
+* No signed URLs in browser history or share sheets — originals can't
+  leak via copy-paste of a working URL.
+* No SigV4 plumbing or third-party dependency in the Worker.
+
+For the gallery's traffic volume the Worker bandwidth cost is well
+under the free tier. If we hit Worker bandwidth limits we'll swap to
+signed URLs — the endpoint contract from the frontend's perspective
+is unchanged.
+
+### Frontend integration
+
+[`assets/js/gallery.js`](../assets/js/gallery.js) calls the Worker
+endpoints with `fetch(..., { credentials: 'include' })`. The base
+URL defaults to `https://api.nerranetwork.com` and is overridable
+via `window.NN_GALLERY_API_BASE` (used by `wrangler dev` against the
+local static site).
+
+The lightbox displays the watermarked 800-px thumbnail; the "Download
+full size" button fetches the original via `/api/download` and uses
+a programmatic `<a download>` click to trigger the browser save
+dialog. If the response is 401 (no cookie / expired cookie), the
+gate modal opens.
+
+The gate modal has two modes, toggleable via a single link:
+
+* **Subscribe & download** (default): POSTs to `/api/subscribe`,
+  then retries the download.
+* **Sign in instead**: GETs `/api/login?email=...`, shows the
+  enumeration-safe success message.
+
+### Worker layout
+
+```
+workers/gallery/
+├── README.md            # Operator deploy + smoke-test guide
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts
+├── wrangler.toml        # Worker config + R2 binding + route
+├── src/
+│   ├── index.ts         # Router (4 endpoints + /health)
+│   ├── handlers.ts      # Endpoint logic (pure functions of (req, env, deps))
+│   ├── jwt.ts           # HS256 sign/verify, hand-rolled, no deps
+│   ├── buttondown.ts    # Buttondown API client
+│   ├── resend.ts        # Resend API client
+│   ├── magic-email.ts   # HTML + plain-text magic-link email
+│   ├── cors.ts          # Origin allow-list + CORS headers
+│   └── types.ts         # Env + DI shape
+└── test/                # 45 vitest tests across the 3 modules
+```
+
+### Operator deployment
+
+See [`workers/gallery/README.md`](../workers/gallery/README.md) for
+the step-by-step deploy guide. Summary:
+
+1. Tighten R2 bucket policy: originals private, thumbnails + sidecars
+   public.
+2. Add a CNAME `api.nerranetwork.com` in the Cloudflare zone.
+3. Create a Resend account + verify the sending domain + grab an
+   API key.
+4. From `workers/gallery/`: `wrangler secret put` four secrets
+   (`JWT_SECRET`, `BUTTONDOWN_API_KEY`, `RESEND_API_KEY`,
+   `RESEND_FROM_EMAIL`).
+5. `npm install && npm test && npm run deploy`.
+6. Bind the custom domain `api.nerranetwork.com` to the Worker in
+   the Cloudflare dashboard.
+
 ## Roadmap
 
 | Phase | Status | Scope |
 |---|---|---|
 | 1 | **Shipped** | R2 layout + uploader + sidecar + pipeline hook + backfill |
-| 2 | **Shipped (this PR)** | Manifest builder + nightly workflow + Jinja2 gallery components + per-show + `/gallery` page + email-gate UI stub |
-| 3 | TODO | Cloudflare Worker, JWT cookie, Buttondown subscription, magic-link login, signed R2 download URLs |
+| 2 | **Shipped** | Manifest builder + nightly workflow + Jinja2 gallery components + per-show + `/gallery` page + email-gate UI stub |
+| 3 | **Shipped (this PR)** | Cloudflare Worker (subscribe / login / magic / download), JWT cookie, Buttondown subscription, magic-link email via Resend, frontend wired to real endpoints |

--- a/scripts/build_gallery_manifest.py
+++ b/scripts/build_gallery_manifest.py
@@ -214,6 +214,10 @@ def build_manifest(
         record["original_url"] = _public_url(config, original_key)
         record["thumbnail_url"] = _public_url(config, thumb_key)
         record["sidecar_url"] = _public_url(config, sidecar_key)
+        # Phase 3: the frontend passes this key to the Worker's
+        # /api/download endpoint. The Worker validates the JWT cookie
+        # then streams the R2 object from the bound bucket.
+        record["original_key"] = original_key
         images.append(record)
 
         slug = sidecar["show_slug"]

--- a/styles/main.css
+++ b/styles/main.css
@@ -2270,8 +2270,27 @@ body.nn-no-scroll { overflow: hidden; }
   font-size: 0.72rem;
   color: var(--nn-text-muted);
 }
+.nn-gate-fineprint a,
+.nn-gate-toggle {
+  color: var(--nn-text);
+  text-decoration: underline;
+  cursor: pointer;
+}
 .nn-gate-error {
   margin: var(--sp-3) 0 0;
   font-size: 0.8rem;
   color: #fda4af;
+}
+.nn-gate-success {
+  margin: var(--sp-3) 0 0;
+  font-size: 0.85rem;
+  color: #86efac;
+  background: rgba(34, 197, 94, 0.08);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+  border-radius: 8px;
+  padding: var(--sp-2) var(--sp-3);
+}
+.nn-gate-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }

--- a/tests/test_build_gallery_manifest.py
+++ b/tests/test_build_gallery_manifest.py
@@ -164,6 +164,8 @@ def test_build_manifest_attaches_urls_to_every_image(config):
     assert img["thumbnail_url"].endswith("/abc.thumb.webp")
     assert img["original_url"].endswith("/abc.jpeg")
     assert img["sidecar_url"].endswith("/abc.json")
+    # Phase 3: frontend passes this key to /api/download.
+    assert img["original_key"] == "tesla/2026-05-24/ep001/abc.jpeg"
     # Original sidecar fields are preserved.
     assert img["prompt"] == "a tesla cybertruck"
     assert img["license"] == "CC BY-SA 4.0"

--- a/workers/gallery/README.md
+++ b/workers/gallery/README.md
@@ -1,0 +1,156 @@
+# nerra-gallery-api
+
+Cloudflare Worker that backs the Nerra Network image gallery's
+email-gated download flow (Phase 3 of the gallery project). The
+Worker exposes four endpoints under `https://api.nerranetwork.com/api/`
+and is consumed by `assets/js/gallery.js` on the static site.
+
+## Endpoints
+
+| Method | Path | Auth | Behaviour |
+|---|---|---|---|
+| POST | `/api/subscribe` | none | Body `{email}`. Subscribes via Buttondown with tag `gallery-subscriber`, sets a 90-day HttpOnly Secure SameSite=Lax JWT cookie, returns `200 {ok:true}`. |
+| GET | `/api/login` | none | `?email=...`. If the address is subscribed in Buttondown, sends a magic-link email via Resend (15-min TTL). Always 200 (no enumeration). |
+| GET | `/api/magic` | none | `?token=...`. Verifies the magic-login JWT, issues the 90-day cookie, 302 to `/gallery.html`. |
+| GET | `/api/download` | cookie | `?key=<r2_object_key>`. Verifies the cookie, fetches the R2 object via the bound bucket, streams it back with `Content-Disposition: attachment`. |
+| GET | `/api/health` | none | Liveness ping. `200 {ok:true}`. |
+
+## Deviation from spec
+
+The project spec called for `/api/download` to issue a short-lived
+signed R2 URL and 302 redirect. The Worker **proxies the bytes
+through** instead. Each request re-validates the JWT (so revocation
+works), signed URLs can't leak / be shared / be cached in browser
+history, and there's no SigV4 plumbing or third-party dependency to
+maintain. For the gallery's traffic volume the Worker bandwidth cost
+is well under the free tier. If we ever hit Worker bandwidth limits
+we'll swap to signed URLs — the endpoint contract from the
+frontend's perspective is unchanged.
+
+## One-time operator setup
+
+### 1. R2 bucket policy
+
+In the Cloudflare dashboard, R2 → `nerra-gallery` → Settings:
+
+* **Thumbnails (`*.thumb.webp`) and sidecars (`*.json`):** public
+  read at `gallery.nerranetwork.com` (already configured in Phase 1).
+* **Originals (`*.jpeg`, `*.png`, etc.):** flip to private. The
+  Worker proxies them via the binding — they don't need to be
+  publicly reachable.
+
+A simple WAF rule that returns 403 for any path on
+`gallery.nerranetwork.com` not ending in `.thumb.webp` or `.json`
+achieves the split cleanly.
+
+### 2. DNS + custom domain
+
+In the Cloudflare dashboard for the `nerranetwork.com` zone:
+
+1. Add a CNAME: `api` → any target (Cloudflare will rewrite once the
+   Worker custom-domain binding takes over). Proxy ON.
+2. After deploying the Worker (step 5 below), bind the route
+   `api.nerranetwork.com/api/*` to the Worker via
+   Workers & Pages → `nerra-gallery-api` → Settings → Domains &
+   Routes → "Add Custom Domain".
+
+The `routes` entry in `wrangler.toml` declares the route; deploying
+with `wrangler deploy` activates it on the bound zone.
+
+### 3. Resend account + domain verification
+
+1. Sign up at https://resend.com (free tier: 3 000 / month, 100 / day).
+2. Add and verify the sending domain (typically `nerranetwork.com`
+   or a subdomain like `mail.nerranetwork.com`). Resend walks you
+   through the DNS records (SPF + DKIM).
+3. Create an API key from the dashboard.
+
+### 4. Worker secrets
+
+From `workers/gallery/`:
+
+```bash
+# Strong random secret for HMAC-SHA256 JWT signing (64 random bytes).
+openssl rand -base64 64 | wrangler secret put JWT_SECRET
+
+# Existing Buttondown API key — same one the newsletter pipeline uses.
+echo "$BUTTONDOWN_API_KEY" | wrangler secret put BUTTONDOWN_API_KEY
+
+# Resend API key from step 3.
+echo "$RESEND_API_KEY"     | wrangler secret put RESEND_API_KEY
+
+# A verified Resend sender — e.g. "Nerra Network <gallery@nerranetwork.com>".
+echo "Nerra Network <gallery@nerranetwork.com>" | wrangler secret put RESEND_FROM_EMAIL
+```
+
+The R2 binding is set declaratively in `wrangler.toml` (not via
+`wrangler secret`) — Cloudflare wires it up at deploy time.
+
+### 5. Deploy
+
+```bash
+cd workers/gallery
+npm install
+npm test          # 45 unit tests
+npm run typecheck
+npm run deploy    # = wrangler deploy
+```
+
+`wrangler deploy` reads `wrangler.toml`, uploads the bundled Worker,
+and binds the route. First deploy will require `wrangler login`.
+
+### 6. Smoke-test
+
+```bash
+# Health
+curl https://api.nerranetwork.com/api/health
+
+# Subscribe (sets cookie)
+curl -i -c jar -b jar -H 'Origin: https://nerranetwork.com' \
+     -H 'Content-Type: application/json' \
+     -d '{"email":"you@yourdomain.com"}' \
+     https://api.nerranetwork.com/api/subscribe
+
+# Download (uses cookie from previous step)
+curl -i -c jar -b jar -H 'Origin: https://nerranetwork.com' \
+     'https://api.nerranetwork.com/api/download?key=tesla/2026-05-24/ep001/<id>.jpeg' \
+     -o image.jpeg
+
+# Magic-link request
+curl -i -H 'Origin: https://nerranetwork.com' \
+     'https://api.nerranetwork.com/api/login?email=you@yourdomain.com'
+# → check inbox, click link, then re-test /api/download in a browser
+```
+
+## Local development
+
+```bash
+cd workers/gallery
+npm install
+npm run dev          # = wrangler dev → http://127.0.0.1:8787
+```
+
+`wrangler dev` serves the Worker locally and prompts for any missing
+secrets (which it stores in `.dev.vars`). The static gallery JS
+already has `localhost:8080` in its CORS allow-list — run the static
+site with `python -m http.server 8080` from the repo root and point
+the JS at the local Worker by setting `window.NN_GALLERY_API_BASE` in
+the page.
+
+## Tests
+
+```bash
+npm test          # vitest run (45 tests in 3 files)
+npm run typecheck # tsc --noEmit
+```
+
+Tests live in `test/`:
+
+* `test/jwt.test.ts` — base64url + sign/verify + tamper / scope / expiry guards.
+* `test/buttondown.test.ts` — API client with `fetch` mocked.
+* `test/handlers.test.ts` — each endpoint with fake Buttondown / Resend / R2 clients.
+
+The Workers runtime isn't required for these — handlers are pure
+functions of `(request, env, deps)` and the R2 binding is faked with
+a small in-memory map in `handlers.test.ts`. End-to-end testing
+against `wrangler dev` is operator-driven (see step 6 above).

--- a/workers/gallery/package-lock.json
+++ b/workers/gallery/package-lock.json
@@ -1,0 +1,3005 @@
+{
+  "name": "nerra-gallery-api",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nerra-gallery-api",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20241218.0",
+        "typescript": "^5.6.3",
+        "vitest": "^2.1.8",
+        "wrangler": "^3.91.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
+      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.14",
+        "workerd": "^1.20250124.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
+      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
+      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
+      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260525.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260525.1.tgz",
+      "integrity": "sha512-vQSjvQINGx2i3dovvVyszew4HU3+82eAuD2ryNmedBIzLcLwluKsnPLTAuL4FDVRyz+MikQEihEBsUmcTElEVQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20250718.3",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
+      "integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "stoppable": "1.1.0",
+        "undici": "^5.28.5",
+        "workerd": "1.20250718.0",
+        "ws": "8.18.0",
+        "youch": "3.3.4",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-inject/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-inject/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
+      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "exsolve": "^1.0.1",
+        "ohash": "^2.0.10",
+        "pathe": "^2.0.3",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/unenv/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
+      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20250718.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
+        "@cloudflare/workerd-linux-64": "1.20250718.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
+        "@cloudflare/workerd-windows-64": "1.20250718.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "3.114.17",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
+      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/unenv-preset": "2.0.2",
+        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20250718.3",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.14",
+        "workerd": "1.20250718.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250408.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/workers/gallery/package.json
+++ b/workers/gallery/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "nerra-gallery-api",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cloudflare Worker that backs the Nerra Network image gallery's email-gated download flow.",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241218.0",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.8",
+    "wrangler": "^3.91.0"
+  }
+}

--- a/workers/gallery/src/buttondown.ts
+++ b/workers/gallery/src/buttondown.ts
@@ -1,0 +1,153 @@
+/**
+ * Buttondown API client (the subset the gallery Worker needs).
+ *
+ * Buttondown's API base is https://api.buttondown.email/v1/. Auth is
+ * a bearer token in the `Authorization` header (the same key used by
+ * the Python newsletter pipeline lives in the `BUTTONDOWN_API_KEY`
+ * Worker secret — no new key needs to be provisioned).
+ *
+ * Two operations:
+ *
+ *   subscribe({email, tag})  - POST /subscribers
+ *                              Idempotent on the API side: a duplicate
+ *                              email returns a 4xx with a recognisable
+ *                              body ("already subscribed"). We treat
+ *                              that as success.
+ *
+ *   isSubscribed(email)      - GET /subscribers?email=...
+ *                              Used by the magic-link login endpoint
+ *                              to confirm the visitor exists before
+ *                              we mail them anything.
+ *
+ * Failures are surfaced as `BUTTONDOWN_DOWN` / `BUTTONDOWN_HTTP_<code>`
+ * error codes so the handler can map them to user-facing 502s without
+ * leaking the upstream error body.
+ */
+
+const BUTTONDOWN_BASE = "https://api.buttondown.email/v1";
+
+
+export interface SubscribeResult {
+  ok: boolean;
+  alreadySubscribed: boolean;
+  error?: string;
+  status?: number;
+}
+
+export async function subscribe(
+  apiKey: string,
+  email: string,
+  tag: string,
+): Promise<SubscribeResult> {
+  if (!apiKey) return { ok: false, alreadySubscribed: false, error: "no api key" };
+  let resp: Response;
+  try {
+    resp = await fetch(`${BUTTONDOWN_BASE}/subscribers`, {
+      method: "POST",
+      headers: {
+        Authorization: `Token ${apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        email_address: email,
+        tags: [tag],
+        type: "regular",
+      }),
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      alreadySubscribed: false,
+      error: `BUTTONDOWN_DOWN: ${(e as Error).message ?? "fetch failed"}`,
+    };
+  }
+
+  if (resp.status === 201 || resp.status === 200) {
+    return { ok: true, alreadySubscribed: false, status: resp.status };
+  }
+
+  // Buttondown returns 400 with a "subscriber already exists" body
+  // for duplicates. We don't want the visitor's repeat sub to look
+  // like a failure — treat as success but flag so the caller can log
+  // it as an idempotent re-subscribe.
+  const body = await safeText(resp);
+  if (resp.status === 400 && /already|exists|present/i.test(body)) {
+    return { ok: true, alreadySubscribed: true, status: resp.status };
+  }
+
+  return {
+    ok: false,
+    alreadySubscribed: false,
+    status: resp.status,
+    error: `BUTTONDOWN_HTTP_${resp.status}`,
+  };
+}
+
+
+export interface IsSubscribedResult {
+  ok: boolean;
+  exists: boolean;
+  error?: string;
+  status?: number;
+}
+
+export async function isSubscribed(
+  apiKey: string,
+  email: string,
+): Promise<IsSubscribedResult> {
+  if (!apiKey) return { ok: false, exists: false, error: "no api key" };
+  let resp: Response;
+  try {
+    resp = await fetch(
+      `${BUTTONDOWN_BASE}/subscribers?email=${encodeURIComponent(email)}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Token ${apiKey}`,
+          Accept: "application/json",
+        },
+      },
+    );
+  } catch (e) {
+    return {
+      ok: false,
+      exists: false,
+      error: `BUTTONDOWN_DOWN: ${(e as Error).message ?? "fetch failed"}`,
+    };
+  }
+  if (resp.status !== 200) {
+    return {
+      ok: false,
+      exists: false,
+      status: resp.status,
+      error: `BUTTONDOWN_HTTP_${resp.status}`,
+    };
+  }
+  let body: any;
+  try {
+    body = await resp.json();
+  } catch {
+    return { ok: false, exists: false, status: 200, error: "BUTTONDOWN_BAD_JSON" };
+  }
+  // Buttondown's list endpoint returns { count, results: [...] }.
+  // An exact email match is a single result. We don't trust the API
+  // to filter perfectly server-side — match on the returned address
+  // case-insensitively just to be safe.
+  const want = email.toLowerCase();
+  const results = Array.isArray(body?.results) ? body.results : [];
+  const exists = results.some(
+    (r: any) =>
+      typeof r?.email_address === "string" &&
+      r.email_address.toLowerCase() === want,
+  );
+  return { ok: true, exists, status: 200 };
+}
+
+async function safeText(resp: Response): Promise<string> {
+  try {
+    return await resp.text();
+  } catch {
+    return "";
+  }
+}

--- a/workers/gallery/src/cors.ts
+++ b/workers/gallery/src/cors.ts
@@ -1,0 +1,74 @@
+/**
+ * CORS helpers tailored to the gallery Worker.
+ *
+ * The Worker lives at api.nerranetwork.com and is called from
+ * nerranetwork.com (the static site). Every endpoint must:
+ *
+ *   - Echo the request Origin header *only* when it matches the
+ *     allow-list (so we don't accidentally grant credentials access
+ *     to arbitrary origins).
+ *   - Set `Access-Control-Allow-Credentials: true` because the
+ *     subscribe + download flow rely on cookies the browser only
+ *     sends when CORS credentials are explicitly allowed.
+ *   - Vary on Origin so a CDN can cache per-origin if it ever sits
+ *     in front of the Worker.
+ */
+
+const ALLOWED_ORIGINS = new Set<string>([
+  "https://nerranetwork.com",
+  "https://www.nerranetwork.com",
+  // Local dev. Adding 127.0.0.1 here so the gallery JS can be tested
+  // against the live Worker by serving the static site with
+  // `python -m http.server 8080`.
+  "http://localhost:8080",
+  "http://127.0.0.1:8080",
+]);
+
+export function pickOrigin(request: Request): string | null {
+  const origin = request.headers.get("Origin");
+  if (origin && ALLOWED_ORIGINS.has(origin)) return origin;
+  return null;
+}
+
+export function corsHeaders(request: Request): HeadersInit {
+  const origin = pickOrigin(request);
+  const headers: Record<string, string> = {
+    Vary: "Origin",
+  };
+  if (origin) {
+    headers["Access-Control-Allow-Origin"] = origin;
+    headers["Access-Control-Allow-Credentials"] = "true";
+  }
+  return headers;
+}
+
+export function handlePreflight(request: Request): Response {
+  const origin = pickOrigin(request);
+  if (!origin) {
+    return new Response(null, { status: 403, headers: corsHeaders(request) });
+  }
+  const headers = new Headers({
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Max-Age": "86400",
+    Vary: "Origin",
+  });
+  return new Response(null, { status: 204, headers });
+}
+
+export function jsonResponse(
+  request: Request,
+  status: number,
+  body: unknown,
+  extraHeaders: HeadersInit = {},
+): Response {
+  const headers = new Headers(corsHeaders(request));
+  headers.set("Content-Type", "application/json; charset=utf-8");
+  headers.set("Cache-Control", "no-store");
+  for (const [k, v] of Object.entries(extraHeaders)) {
+    headers.set(k, v as string);
+  }
+  return new Response(JSON.stringify(body), { status, headers });
+}

--- a/workers/gallery/src/handlers.ts
+++ b/workers/gallery/src/handlers.ts
@@ -1,0 +1,309 @@
+/**
+ * Endpoint handlers for the gallery Worker.
+ *
+ * Pure functions of `(request, env, deps)` — the `deps` argument
+ * gives tests a seam to inject fake Buttondown / Resend clients
+ * without touching the network. In production, `index.ts` wires the
+ * real `buttondown.ts` / `resend.ts` modules in.
+ *
+ * Endpoint behaviour:
+ *
+ *   POST /api/subscribe
+ *     Body: { email }
+ *     - Validate email.
+ *     - Subscribe via Buttondown with tag `gallery-subscriber`.
+ *     - Issue a 90-day HttpOnly Secure SameSite=Lax JWT cookie.
+ *     - 200 { ok: true }.
+ *
+ *   GET /api/login?email=...
+ *     - Validate email.
+ *     - Look up the address in Buttondown.
+ *     - If subscribed, sign a 15-minute magic-login JWT and email
+ *       a link to /api/magic?token=... via Resend.
+ *     - Always 200 { ok: true } regardless of whether the email
+ *       exists, to avoid enumeration.
+ *
+ *   GET /api/magic?token=...
+ *     - Verify the magic-login JWT.
+ *     - On success: issue the 90-day cookie and 302 to /gallery.html.
+ *     - On failure: 400.
+ *
+ *   GET /api/download?key=<r2_object_key>
+ *     - Verify the gallery-subscriber cookie.
+ *     - Validate the key is well-formed (no traversal / absolute paths).
+ *     - Fetch the R2 object via the bound bucket.
+ *     - Stream it back with Content-Disposition: attachment.
+ *
+ * Spec deviation note: the project spec calls for "generates
+ * short-lived signed R2 URL, 302 redirects" on /api/download. We
+ * proxy the bytes through the Worker instead because:
+ *   - it re-validates the JWT on every request (revocation works);
+ *   - signed URLs would be cacheable in browser history & shareable;
+ *   - no SigV4 plumbing or third-party deps are required.
+ * For the low-traffic gallery this costs negligible Worker bandwidth
+ * (under the free tier). Documented in docs/gallery_storage.md.
+ */
+
+import { corsHeaders, jsonResponse } from "./cors";
+import { signJwt, verifyJwt } from "./jwt";
+import { buildMagicLinkEmail } from "./magic-email";
+import type {
+  ButtondownClient,
+  Env,
+  HandlerDeps,
+  ResendClient,
+} from "./types";
+
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+const SUBSCRIBER_TAG = "gallery-subscriber";
+const COOKIE_NAME = "nn_gallery";
+const SUBSCRIBER_TTL_SECONDS = 90 * 24 * 60 * 60;   // 90 days
+const MAGIC_TTL_SECONDS = 15 * 60;                  // 15 minutes
+const MAGIC_TTL_MINUTES = 15;
+
+// Email shape — loose RFC compliance is fine here; the upstream
+// (Buttondown) and the SMTP path will reject obvious garbage.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// R2 key safety — every gallery key looks like
+// "<slug>/<YYYY-MM-DD>/<episode>/<imageid>.<ext>" so we only allow
+// alphanumerics, dashes, underscores, dots, and slashes, and we
+// explicitly reject anything that contains a path traversal segment
+// or starts with a slash (which would be an absolute path).
+const KEY_SAFE_RE = /^[A-Za-z0-9_./-]+$/;
+
+const REDIRECT_AFTER_MAGIC = "https://nerranetwork.com/gallery.html";
+
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+export async function handleSubscribe(
+  request: Request,
+  env: Env,
+  deps: HandlerDeps,
+): Promise<Response> {
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse(request, 400, { ok: false, error: "invalid json" });
+  }
+  const email = normaliseEmail(body?.email);
+  if (!email) {
+    return jsonResponse(request, 400, { ok: false, error: "invalid email" });
+  }
+
+  const result = await deps.buttondown.subscribe(
+    env.BUTTONDOWN_API_KEY,
+    email,
+    SUBSCRIBER_TAG,
+  );
+
+  if (!result.ok) {
+    // Don't leak upstream detail to the client; logged in the Worker tail.
+    console.warn("subscribe: buttondown failure", result.error, result.status);
+    return jsonResponse(request, 502, { ok: false, error: "subscribe failed" });
+  }
+
+  const token = await signJwt(
+    {
+      sub: email,
+      scope: "gallery-subscriber",
+      ttlSeconds: SUBSCRIBER_TTL_SECONDS,
+    },
+    env.JWT_SECRET,
+  );
+
+  return jsonResponse(
+    request,
+    200,
+    { ok: true, alreadySubscribed: result.alreadySubscribed },
+    { "Set-Cookie": cookieFor(token, SUBSCRIBER_TTL_SECONDS) },
+  );
+}
+
+
+export async function handleLogin(
+  request: Request,
+  env: Env,
+  deps: HandlerDeps,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const email = normaliseEmail(url.searchParams.get("email"));
+  if (!email) {
+    return jsonResponse(request, 400, { ok: false, error: "invalid email" });
+  }
+
+  // Always-200 contract: don't disclose whether the address is in
+  // the list. Internal failures still 200 — the operator can spot
+  // them in Worker logs / Resend dashboard.
+  try {
+    const check = await deps.buttondown.isSubscribed(
+      env.BUTTONDOWN_API_KEY,
+      email,
+    );
+    if (check.ok && check.exists) {
+      const token = await signJwt(
+        { sub: email, scope: "magic-login", ttlSeconds: MAGIC_TTL_SECONDS },
+        env.JWT_SECRET,
+      );
+      const magicUrl = `https://${url.host}/api/magic?token=${encodeURIComponent(token)}`;
+      const mail = buildMagicLinkEmail({
+        magicUrl,
+        ttlMinutes: MAGIC_TTL_MINUTES,
+      });
+      const send = await deps.resend.sendEmail(
+        env.RESEND_API_KEY,
+        env.RESEND_FROM_EMAIL,
+        { to: email, subject: mail.subject, html: mail.html, text: mail.text },
+      );
+      if (!send.ok) {
+        console.warn("login: resend failure", send.error, send.status);
+      }
+    } else if (!check.ok) {
+      console.warn("login: buttondown lookup failure", check.error, check.status);
+    }
+  } catch (e) {
+    console.warn("login: unexpected error", (e as Error).message);
+  }
+
+  return jsonResponse(request, 200, { ok: true });
+}
+
+
+export async function handleMagic(
+  request: Request,
+  env: Env,
+  _deps: HandlerDeps,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token") ?? "";
+  const verify = await verifyJwt(token, env.JWT_SECRET, {
+    expectedScope: "magic-login",
+  });
+  if (!verify.ok || !verify.claims) {
+    return new Response(
+      "This sign-in link has expired or is invalid. Request a fresh one from the gallery.",
+      {
+        status: 400,
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+      },
+    );
+  }
+  const cookieToken = await signJwt(
+    {
+      sub: verify.claims.sub,
+      scope: "gallery-subscriber",
+      ttlSeconds: SUBSCRIBER_TTL_SECONDS,
+    },
+    env.JWT_SECRET,
+  );
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: REDIRECT_AFTER_MAGIC,
+      "Set-Cookie": cookieFor(cookieToken, SUBSCRIBER_TTL_SECONDS),
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+
+export async function handleDownload(
+  request: Request,
+  env: Env,
+  _deps: HandlerDeps,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const key = url.searchParams.get("key") ?? "";
+  if (!isSafeKey(key)) {
+    return jsonResponse(request, 400, { ok: false, error: "invalid key" });
+  }
+  const cookieToken = readCookie(request.headers.get("Cookie"), COOKIE_NAME);
+  if (!cookieToken) {
+    return jsonResponse(request, 401, { ok: false, error: "auth required" });
+  }
+  const verify = await verifyJwt(cookieToken, env.JWT_SECRET, {
+    expectedScope: "gallery-subscriber",
+  });
+  if (!verify.ok) {
+    return jsonResponse(request, 401, { ok: false, error: "auth required" });
+  }
+
+  const object = await env.GALLERY_BUCKET.get(key);
+  if (!object) {
+    return jsonResponse(request, 404, { ok: false, error: "not found" });
+  }
+  const headers = new Headers(corsHeaders(request));
+  object.writeHttpMetadata(headers);
+  headers.set("etag", object.httpEtag);
+  // Force a download dialog rather than inline display; the
+  // filename strips the bucket path prefix so the browser saves
+  // the image as "<image_id>.jpeg" not the full key.
+  const filename = key.split("/").pop() ?? "image";
+  headers.set(
+    "Content-Disposition",
+    `attachment; filename="${filename}"`,
+  );
+  headers.set("Cache-Control", "private, max-age=60");
+  return new Response(object.body, { status: 200, headers });
+}
+
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function normaliseEmail(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const s = raw.trim().toLowerCase();
+  if (!EMAIL_RE.test(s)) return null;
+  if (s.length > 254) return null;
+  return s;
+}
+
+export function isSafeKey(key: string): boolean {
+  if (!key || key.length > 256) return false;
+  if (key.startsWith("/")) return false;
+  if (key.includes("..")) return false;
+  if (key.includes("//")) return false;
+  return KEY_SAFE_RE.test(key);
+}
+
+function cookieFor(token: string, ttlSeconds: number): string {
+  // Domain not set — defaults to the Worker's host. The frontend
+  // calls the Worker cross-origin with credentials:'include', so the
+  // browser sends the cookie back as long as SameSite=None... but
+  // SameSite=None requires Secure (which we have) AND allows the
+  // cookie cross-site, which we don't want. Keep SameSite=Lax and
+  // route the frontend through fetch(credentials:'include'); the
+  // CORS Allow-Credentials header on the response is what lets the
+  // browser persist the cookie set by a cross-origin response.
+  return [
+    `${COOKIE_NAME}=${token}`,
+    "Path=/",
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+    `Max-Age=${ttlSeconds}`,
+  ].join("; ");
+}
+
+function readCookie(header: string | null, name: string): string | null {
+  if (!header) return null;
+  const parts = header.split(/;\s*/);
+  for (const part of parts) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq) === name) {
+      return decodeURIComponent(part.slice(eq + 1));
+    }
+  }
+  return null;
+}

--- a/workers/gallery/src/index.ts
+++ b/workers/gallery/src/index.ts
@@ -1,0 +1,59 @@
+/**
+ * Entry point for the Nerra Network gallery Worker.
+ *
+ * Routes:
+ *
+ *   POST /api/subscribe   - email gate enrolment
+ *   GET  /api/login       - request a magic-link email
+ *   GET  /api/magic       - consume a magic-link token
+ *   GET  /api/download    - stream a private R2 object
+ *   GET  /api/health      - liveness ping (no auth)
+ *
+ * Everything else falls through to 404.
+ */
+
+import * as buttondown from "./buttondown";
+import { corsHeaders, handlePreflight, jsonResponse } from "./cors";
+import {
+  handleDownload,
+  handleLogin,
+  handleMagic,
+  handleSubscribe,
+} from "./handlers";
+import * as resend from "./resend";
+import type { Env, HandlerDeps } from "./types";
+
+const DEPS: HandlerDeps = { buttondown, resend };
+
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === "OPTIONS") {
+      return handlePreflight(request);
+    }
+    const url = new URL(request.url);
+    const route = `${request.method} ${url.pathname}`;
+    try {
+      switch (route) {
+        case "POST /api/subscribe":
+          return await handleSubscribe(request, env, DEPS);
+        case "GET /api/login":
+          return await handleLogin(request, env, DEPS);
+        case "GET /api/magic":
+          return await handleMagic(request, env, DEPS);
+        case "GET /api/download":
+          return await handleDownload(request, env, DEPS);
+        case "GET /api/health":
+          return jsonResponse(request, 200, { ok: true });
+        default:
+          return jsonResponse(request, 404, { ok: false, error: "not found" });
+      }
+    } catch (e) {
+      console.error("unhandled error", route, (e as Error).message);
+      return jsonResponse(request, 500, {
+        ok: false,
+        error: "internal error",
+      });
+    }
+  },
+};

--- a/workers/gallery/src/jwt.ts
+++ b/workers/gallery/src/jwt.ts
@@ -1,0 +1,175 @@
+/**
+ * Minimal JSON Web Token implementation for the gallery Worker.
+ *
+ * HS256 only (HMAC-SHA256) — symmetric signing with a shared secret
+ * the Worker holds in `env.JWT_SECRET`. We don't need RS256 / ES256
+ * because both ends of every token are the Worker itself.
+ *
+ * Why hand-rolled rather than a library: the standard libraries
+ * (`jose`, `jsonwebtoken`) carry kilobytes of optional features we
+ * don't use (RSA / EdDSA / JWE / JWKS resolution) and pull in
+ * dependencies that have caused supply-chain incidents in the past.
+ * Three small primitives (base64url encode/decode + HMAC-SHA256) are
+ * directly available on the Workers runtime via `crypto.subtle`, so
+ * the dependency adds nothing.
+ *
+ * Two token scopes live in the same secret + verifier:
+ *   - `gallery-subscriber` — long-lived (90 d) cookie issued after
+ *     successful Buttondown subscription OR magic-link login.
+ *   - `magic-login`        — short-lived (15 m) URL-bound token
+ *     emailed to existing subscribers. Single-use is enforced by
+ *     the cookie issued on consumption (a second visit to the same
+ *     magic URL will still issue a fresh cookie — that's a low-risk
+ *     replay window inside the 15 m exp).
+ */
+
+export type JwtScope = "gallery-subscriber" | "magic-login";
+
+export interface JwtClaims {
+  sub: string;        // subject — the visitor's email address
+  scope: JwtScope;
+  iat: number;        // issued-at, unix seconds
+  exp: number;        // expires-at, unix seconds
+}
+
+const HEADER_B64 = base64UrlEncode(
+  new TextEncoder().encode(JSON.stringify({ alg: "HS256", typ: "JWT" })),
+);
+
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function signJwt(
+  payload: Omit<JwtClaims, "iat" | "exp"> & { ttlSeconds: number },
+  secret: string,
+  now: number = Math.floor(Date.now() / 1000),
+): Promise<string> {
+  if (!secret) throw new Error("jwt: empty secret");
+  if (payload.ttlSeconds <= 0) throw new Error("jwt: ttlSeconds must be positive");
+  const claims: JwtClaims = {
+    sub: payload.sub,
+    scope: payload.scope,
+    iat: now,
+    exp: now + payload.ttlSeconds,
+  };
+  const payloadB64 = base64UrlEncode(
+    new TextEncoder().encode(JSON.stringify(claims)),
+  );
+  const signingInput = `${HEADER_B64}.${payloadB64}`;
+  const signature = await hmacSha256(secret, signingInput);
+  return `${signingInput}.${base64UrlEncode(signature)}`;
+}
+
+
+export interface VerifyOptions {
+  expectedScope?: JwtScope;
+  now?: number;
+}
+
+export interface VerifyResult {
+  ok: boolean;
+  claims?: JwtClaims;
+  reason?: string;
+}
+
+export async function verifyJwt(
+  token: string,
+  secret: string,
+  opts: VerifyOptions = {},
+): Promise<VerifyResult> {
+  if (!secret) return { ok: false, reason: "empty secret" };
+  if (typeof token !== "string" || token.length === 0) {
+    return { ok: false, reason: "missing token" };
+  }
+  const parts = token.split(".");
+  if (parts.length !== 3) return { ok: false, reason: "malformed" };
+
+  const [headerB64, payloadB64, sigB64] = parts;
+
+  // Verify signature *before* we trust the header / payload bytes.
+  let expectedSig: Uint8Array;
+  try {
+    expectedSig = await hmacSha256(secret, `${headerB64}.${payloadB64}`);
+  } catch (e) {
+    return { ok: false, reason: "hmac failed" };
+  }
+  let providedSig: Uint8Array;
+  try {
+    providedSig = base64UrlDecode(sigB64);
+  } catch {
+    return { ok: false, reason: "bad signature encoding" };
+  }
+  if (!constantTimeEquals(expectedSig, providedSig)) {
+    return { ok: false, reason: "signature mismatch" };
+  }
+
+  // Parse claims only after signature has been validated.
+  let claims: JwtClaims;
+  try {
+    const json = new TextDecoder().decode(base64UrlDecode(payloadB64));
+    claims = JSON.parse(json);
+  } catch {
+    return { ok: false, reason: "bad payload encoding" };
+  }
+  if (
+    typeof claims.sub !== "string" ||
+    typeof claims.scope !== "string" ||
+    typeof claims.iat !== "number" ||
+    typeof claims.exp !== "number"
+  ) {
+    return { ok: false, reason: "claims shape" };
+  }
+
+  const now = opts.now ?? Math.floor(Date.now() / 1000);
+  if (claims.exp <= now) return { ok: false, reason: "expired" };
+  if (claims.iat > now + 60) return { ok: false, reason: "issued in future" };
+  if (opts.expectedScope && claims.scope !== opts.expectedScope) {
+    return { ok: false, reason: "wrong scope" };
+  }
+  return { ok: true, claims };
+}
+
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+async function hmacSha256(secret: string, message: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(message),
+  );
+  return new Uint8Array(sig);
+}
+
+export function base64UrlEncode(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function base64UrlDecode(b64url: string): Uint8Array {
+  const pad = b64url.length % 4 === 0 ? "" : "=".repeat(4 - (b64url.length % 4));
+  const b64 = b64url.replace(/-/g, "+").replace(/_/g, "/") + pad;
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+function constantTimeEquals(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}

--- a/workers/gallery/src/magic-email.ts
+++ b/workers/gallery/src/magic-email.ts
@@ -1,0 +1,68 @@
+/**
+ * HTML email body for the magic-link login flow.
+ *
+ * Kept deliberately plain — single CTA, brand colour from the
+ * existing design tokens, no images (Buttondown / Outlook will
+ * sometimes block remote images on first send to a new sender).
+ * Includes a plain-text alternative for clients that prefer it.
+ */
+
+export interface MagicLinkEmail {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export function buildMagicLinkEmail(opts: {
+  magicUrl: string;
+  ttlMinutes: number;
+}): MagicLinkEmail {
+  const subject = "Sign in to the Nerra Network gallery";
+  const safeUrl = escapeHtml(opts.magicUrl);
+  const ttl = opts.ttlMinutes;
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${escapeHtml(subject)}</title>
+</head>
+<body style="margin:0;padding:0;background:#0b0f1a;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#e8ecf4;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0b0f1a;">
+    <tr><td align="center" style="padding:32px 16px;">
+      <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="max-width:480px;background:#111627;border:1px solid rgba(255,255,255,0.08);border-radius:14px;">
+        <tr><td style="padding:28px 28px 8px;">
+          <h1 style="margin:0 0 8px;font-size:1.25rem;color:#ffffff;">Nerra Network gallery</h1>
+          <p style="margin:0;color:#8b8fae;font-size:0.95rem;">Click the button below to sign in and download full-resolution images.</p>
+        </td></tr>
+        <tr><td align="center" style="padding:24px 28px;">
+          <a href="${safeUrl}"
+             style="display:inline-block;padding:12px 28px;background:#6B47FF;color:#ffffff;font-weight:600;text-decoration:none;border-radius:10px;font-size:0.95rem;">Sign in</a>
+        </td></tr>
+        <tr><td style="padding:0 28px 24px;color:#8b8fae;font-size:0.8rem;line-height:1.5;">
+          <p style="margin:0 0 8px;">The link expires in ${ttl} minutes. If you didn&rsquo;t request this email you can safely ignore it &mdash; nobody will be signed in unless they click the button above.</p>
+          <p style="margin:0;word-break:break-all;">If the button doesn&rsquo;t work, paste this URL into your browser:<br><span style="color:#cbd5e0;">${safeUrl}</span></p>
+        </td></tr>
+      </table>
+      <p style="margin:18px 0 0;color:#64748b;font-size:0.75rem;">Nerra Network &middot; <a href="https://nerranetwork.com" style="color:#64748b;">nerranetwork.com</a></p>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+  const text =
+    `Sign in to the Nerra Network gallery\n\n` +
+    `Click the link below to sign in and download full-resolution images:\n\n` +
+    `${opts.magicUrl}\n\n` +
+    `The link expires in ${ttl} minutes. If you didn't request this email ` +
+    `you can safely ignore it.\n\n` +
+    `— Nerra Network (https://nerranetwork.com)\n`;
+  return { subject, html, text };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/workers/gallery/src/resend.ts
+++ b/workers/gallery/src/resend.ts
@@ -1,0 +1,66 @@
+/**
+ * Minimal Resend transactional-email client.
+ *
+ * Resend's `POST /emails` takes JSON (`from`, `to`, `subject`, `html`,
+ * optional `text`) and an `Authorization: Bearer <RESEND_API_KEY>`
+ * header. That's the whole interface we need.
+ *
+ * The Worker keeps the API key and "from" address as secrets
+ * (`RESEND_API_KEY` + `RESEND_FROM_EMAIL`); the operator sets both
+ * via `wrangler secret put` once.
+ */
+
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+
+
+export interface SendEmailParams {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}
+
+export interface SendEmailResult {
+  ok: boolean;
+  id?: string;
+  error?: string;
+  status?: number;
+}
+
+export async function sendEmail(
+  apiKey: string,
+  fromAddress: string,
+  params: SendEmailParams,
+): Promise<SendEmailResult> {
+  if (!apiKey) return { ok: false, error: "no api key" };
+  if (!fromAddress) return { ok: false, error: "no from address" };
+  let resp: Response;
+  try {
+    resp = await fetch(RESEND_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        from: fromAddress,
+        to: [params.to],
+        subject: params.subject,
+        html: params.html,
+        text: params.text,
+      }),
+    });
+  } catch (e) {
+    return { ok: false, error: `RESEND_DOWN: ${(e as Error).message ?? "fetch failed"}` };
+  }
+  if (resp.status !== 200) {
+    return { ok: false, status: resp.status, error: `RESEND_HTTP_${resp.status}` };
+  }
+  try {
+    const body = (await resp.json()) as { id?: string };
+    return { ok: true, id: body?.id, status: 200 };
+  } catch {
+    return { ok: true, status: 200 };
+  }
+}

--- a/workers/gallery/src/types.ts
+++ b/workers/gallery/src/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Worker env + dependency types.
+ *
+ * `Env` matches the bindings declared in wrangler.toml. The R2
+ * binding is typed via the `@cloudflare/workers-types` global
+ * `R2Bucket`. Secrets are plain strings.
+ *
+ * `HandlerDeps` decouples handlers from the real Buttondown / Resend
+ * modules so tests can supply fakes.
+ */
+
+export interface Env {
+  GALLERY_BUCKET: R2Bucket;
+  JWT_SECRET: string;
+  BUTTONDOWN_API_KEY: string;
+  RESEND_API_KEY: string;
+  RESEND_FROM_EMAIL: string;
+}
+
+export interface ButtondownClient {
+  subscribe(
+    apiKey: string,
+    email: string,
+    tag: string,
+  ): Promise<{
+    ok: boolean;
+    alreadySubscribed: boolean;
+    error?: string;
+    status?: number;
+  }>;
+  isSubscribed(
+    apiKey: string,
+    email: string,
+  ): Promise<{
+    ok: boolean;
+    exists: boolean;
+    error?: string;
+    status?: number;
+  }>;
+}
+
+export interface ResendClient {
+  sendEmail(
+    apiKey: string,
+    fromAddress: string,
+    params: { to: string; subject: string; html: string; text?: string },
+  ): Promise<{ ok: boolean; id?: string; error?: string; status?: number }>;
+}
+
+export interface HandlerDeps {
+  buttondown: ButtondownClient;
+  resend: ResendClient;
+}

--- a/workers/gallery/test/buttondown.test.ts
+++ b/workers/gallery/test/buttondown.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Buttondown client tests — mocks `fetch` globally so we don't hit
+ * the real API.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isSubscribed, subscribe } from "../src/buttondown";
+
+
+function mockFetch(impl: (input: any, init?: any) => Promise<Response> | Response) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(impl as any);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+
+describe("subscribe()", () => {
+  it("sends a JSON POST with the Token auth header and tag", async () => {
+    const fetchSpy = mockFetch(async (url, init) => {
+      expect(String(url)).toBe("https://api.buttondown.email/v1/subscribers");
+      expect(init?.method).toBe("POST");
+      expect(init?.headers.Authorization).toBe("Token abc");
+      const body = JSON.parse(init?.body as string);
+      expect(body.email_address).toBe("alice@example.com");
+      expect(body.tags).toEqual(["gallery-subscriber"]);
+      return new Response("", { status: 201 });
+    });
+    const result = await subscribe("abc", "alice@example.com", "gallery-subscriber");
+    expect(result.ok).toBe(true);
+    expect(result.alreadySubscribed).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("treats 400 'already exists' as success", async () => {
+    mockFetch(async () => new Response("already subscribed", { status: 400 }));
+    const result = await subscribe("abc", "alice@example.com", "gallery-subscriber");
+    expect(result.ok).toBe(true);
+    expect(result.alreadySubscribed).toBe(true);
+  });
+
+  it("surfaces HTTP error codes as BUTTONDOWN_HTTP_<code>", async () => {
+    mockFetch(async () => new Response("server angry", { status: 500 }));
+    const result = await subscribe("abc", "alice@example.com", "gallery-subscriber");
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("BUTTONDOWN_HTTP_500");
+  });
+
+  it("returns a BUTTONDOWN_DOWN error when fetch throws", async () => {
+    mockFetch(async () => {
+      throw new Error("network is unreachable");
+    });
+    const result = await subscribe("abc", "alice@example.com", "gallery-subscriber");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("BUTTONDOWN_DOWN");
+  });
+
+  it("refuses to call without an api key", async () => {
+    const spy = mockFetch(async () => new Response("", { status: 201 }));
+    const result = await subscribe("", "x@y.z", "gallery-subscriber");
+    expect(result.ok).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+
+describe("isSubscribed()", () => {
+  it("returns exists:true when results include the email case-insensitively", async () => {
+    mockFetch(async () =>
+      new Response(JSON.stringify({
+        count: 1,
+        results: [{ email_address: "Alice@Example.com" }],
+      }), { status: 200 }),
+    );
+    const result = await isSubscribed("abc", "alice@example.com");
+    expect(result.ok).toBe(true);
+    expect(result.exists).toBe(true);
+  });
+
+  it("returns exists:false when results don't include the email", async () => {
+    mockFetch(async () =>
+      new Response(JSON.stringify({ count: 0, results: [] }), { status: 200 }),
+    );
+    const result = await isSubscribed("abc", "alice@example.com");
+    expect(result.ok).toBe(true);
+    expect(result.exists).toBe(false);
+  });
+
+  it("surfaces HTTP errors", async () => {
+    mockFetch(async () => new Response("rate limited", { status: 429 }));
+    const result = await isSubscribed("abc", "alice@example.com");
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("BUTTONDOWN_HTTP_429");
+  });
+
+  it("returns a BUTTONDOWN_DOWN error when fetch throws", async () => {
+    mockFetch(async () => {
+      throw new Error("network is unreachable");
+    });
+    const result = await isSubscribed("abc", "alice@example.com");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("BUTTONDOWN_DOWN");
+  });
+});

--- a/workers/gallery/test/handlers.test.ts
+++ b/workers/gallery/test/handlers.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Endpoint-level tests with fake Buttondown + Resend clients and a
+ * tiny in-memory R2 bucket. Exercises the full request/response
+ * surface without hitting the network.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  handleDownload,
+  handleLogin,
+  handleMagic,
+  handleSubscribe,
+  isSafeKey,
+  normaliseEmail,
+} from "../src/handlers";
+import { signJwt } from "../src/jwt";
+import type { ButtondownClient, Env, HandlerDeps, ResendClient } from "../src/types";
+
+const SECRET = "test-secret-not-for-production-use";
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    GALLERY_BUCKET: makeBucket(),
+    JWT_SECRET: SECRET,
+    BUTTONDOWN_API_KEY: "fake-bd",
+    RESEND_API_KEY: "fake-rs",
+    RESEND_FROM_EMAIL: "gallery@nerranetwork.com",
+    ...overrides,
+  };
+}
+
+function makeBucket(contents: Record<string, Uint8Array | null> = {}): R2Bucket {
+  return {
+    async get(key: string) {
+      const data = contents[key];
+      if (data === undefined || data === null) return null;
+      return {
+        body: new Response(data).body,
+        httpEtag: '"fake"',
+        writeHttpMetadata(headers: Headers) {
+          headers.set("Content-Type", "image/jpeg");
+        },
+      } as unknown as R2ObjectBody;
+    },
+  } as unknown as R2Bucket;
+}
+
+function makeDeps(overrides: Partial<HandlerDeps> = {}): HandlerDeps {
+  const buttondown: ButtondownClient = {
+    subscribe: vi.fn(async () => ({ ok: true, alreadySubscribed: false, status: 201 })),
+    isSubscribed: vi.fn(async () => ({ ok: true, exists: true, status: 200 })),
+  };
+  const resend: ResendClient = {
+    sendEmail: vi.fn(async () => ({ ok: true, id: "msg_1", status: 200 })),
+  };
+  return { buttondown, resend, ...overrides };
+}
+
+function makeRequest(method: string, url: string, init: RequestInit = {}): Request {
+  const headers = new Headers(init.headers);
+  headers.set("Origin", "https://nerranetwork.com");
+  return new Request(url, { method, ...init, headers });
+}
+
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+describe("normaliseEmail", () => {
+  it("lowercases and trims", () => {
+    expect(normaliseEmail("  Alice@Example.COM ")).toBe("alice@example.com");
+  });
+  it("rejects garbage", () => {
+    expect(normaliseEmail("")).toBeNull();
+    expect(normaliseEmail("not-an-email")).toBeNull();
+    expect(normaliseEmail("a@b")).toBeNull();
+    expect(normaliseEmail(null)).toBeNull();
+    expect(normaliseEmail(undefined)).toBeNull();
+    expect(normaliseEmail(42)).toBeNull();
+  });
+});
+
+describe("isSafeKey", () => {
+  it("accepts the bucket layout", () => {
+    expect(isSafeKey("tesla/2026-05-24/ep042/abc123def456.jpeg")).toBe(true);
+    expect(isSafeKey("models_agents_beginners/2026-05-24/ep017/img.thumb.webp")).toBe(true);
+  });
+  it("rejects traversal + absolute paths + empties", () => {
+    expect(isSafeKey("")).toBe(false);
+    expect(isSafeKey("/etc/passwd")).toBe(false);
+    expect(isSafeKey("../escape")).toBe(false);
+    expect(isSafeKey("a//b")).toBe(false);
+    expect(isSafeKey("a/../b")).toBe(false);
+    expect(isSafeKey("a b")).toBe(false);
+    expect(isSafeKey("a?b")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /api/subscribe
+// ---------------------------------------------------------------------------
+
+describe("POST /api/subscribe", () => {
+  it("subscribes and sets the cookie on success", async () => {
+    const deps = makeDeps();
+    const env = makeEnv();
+    const req = makeRequest("POST", "https://api.nerranetwork.com/api/subscribe", {
+      body: JSON.stringify({ email: "Alice@Example.com" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const resp = await handleSubscribe(req, env, deps);
+    expect(resp.status).toBe(200);
+    expect(deps.buttondown.subscribe).toHaveBeenCalledWith(
+      "fake-bd", "alice@example.com", "gallery-subscriber",
+    );
+    const setCookie = resp.headers.get("Set-Cookie");
+    expect(setCookie).toMatch(/^nn_gallery=/);
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("Secure");
+    expect(setCookie).toContain("SameSite=Lax");
+    expect(setCookie).toContain("Path=/");
+    expect(resp.headers.get("Access-Control-Allow-Origin"))
+      .toBe("https://nerranetwork.com");
+    expect(resp.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
+  it("400s on invalid JSON", async () => {
+    const req = makeRequest("POST", "https://api.nerranetwork.com/api/subscribe", {
+      body: "not json",
+      headers: { "Content-Type": "application/json" },
+    });
+    const resp = await handleSubscribe(req, makeEnv(), makeDeps());
+    expect(resp.status).toBe(400);
+  });
+
+  it("400s on bad email", async () => {
+    const req = makeRequest("POST", "https://api.nerranetwork.com/api/subscribe", {
+      body: JSON.stringify({ email: "garbage" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const resp = await handleSubscribe(req, makeEnv(), makeDeps());
+    expect(resp.status).toBe(400);
+  });
+
+  it("502s when Buttondown fails — without leaking detail", async () => {
+    const deps = makeDeps({
+      buttondown: {
+        subscribe: vi.fn(async () => ({ ok: false, alreadySubscribed: false, error: "BUTTONDOWN_HTTP_500" })),
+        isSubscribed: vi.fn(),
+      },
+    });
+    const req = makeRequest("POST", "https://api.nerranetwork.com/api/subscribe", {
+      body: JSON.stringify({ email: "alice@example.com" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const resp = await handleSubscribe(req, makeEnv(), deps);
+    expect(resp.status).toBe(502);
+    const body = await resp.json();
+    expect(body).toEqual({ ok: false, error: "subscribe failed" });
+    // Must not leak upstream error code to the client.
+    expect(JSON.stringify(body)).not.toContain("BUTTONDOWN");
+  });
+
+  it("treats already-subscribed as success", async () => {
+    const deps = makeDeps({
+      buttondown: {
+        subscribe: vi.fn(async () => ({ ok: true, alreadySubscribed: true, status: 400 })),
+        isSubscribed: vi.fn(),
+      },
+    });
+    const req = makeRequest("POST", "https://api.nerranetwork.com/api/subscribe", {
+      body: JSON.stringify({ email: "alice@example.com" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const resp = await handleSubscribe(req, makeEnv(), deps);
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { alreadySubscribed: boolean };
+    expect(body.alreadySubscribed).toBe(true);
+    expect(resp.headers.get("Set-Cookie")).toMatch(/^nn_gallery=/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /api/login
+// ---------------------------------------------------------------------------
+
+describe("GET /api/login", () => {
+  it("emails a magic link when the address is subscribed", async () => {
+    const deps = makeDeps();
+    const req = makeRequest(
+      "GET",
+      "https://api.nerranetwork.com/api/login?email=alice%40example.com",
+    );
+    const resp = await handleLogin(req, makeEnv(), deps);
+    expect(resp.status).toBe(200);
+    expect(deps.resend.sendEmail).toHaveBeenCalledOnce();
+    const args = (deps.resend.sendEmail as any).mock.calls[0];
+    expect(args[2].to).toBe("alice@example.com");
+    expect(args[2].subject).toMatch(/sign in/i);
+    expect(args[2].html).toContain("https://api.nerranetwork.com/api/magic?token=");
+  });
+
+  it("returns the same 200 when the address is NOT subscribed (enumeration-safe)", async () => {
+    const deps = makeDeps({
+      buttondown: {
+        subscribe: vi.fn(),
+        isSubscribed: vi.fn(async () => ({ ok: true, exists: false, status: 200 })),
+      },
+    });
+    const req = makeRequest(
+      "GET",
+      "https://api.nerranetwork.com/api/login?email=ghost%40example.com",
+    );
+    const resp = await handleLogin(req, makeEnv(), deps);
+    expect(resp.status).toBe(200);
+    expect(deps.resend.sendEmail).not.toHaveBeenCalled();
+    const body = await resp.json();
+    expect(body).toEqual({ ok: true });
+  });
+
+  it("400s on invalid email", async () => {
+    const req = makeRequest("GET", "https://api.nerranetwork.com/api/login?email=garbage");
+    const resp = await handleLogin(req, makeEnv(), makeDeps());
+    expect(resp.status).toBe(400);
+  });
+
+  it("still returns 200 when the upstream lookup errors (no enumeration via timing)", async () => {
+    const deps = makeDeps({
+      buttondown: {
+        subscribe: vi.fn(),
+        isSubscribed: vi.fn(async () => ({ ok: false, exists: false, error: "BUTTONDOWN_DOWN" })),
+      },
+    });
+    const req = makeRequest(
+      "GET",
+      "https://api.nerranetwork.com/api/login?email=alice%40example.com",
+    );
+    const resp = await handleLogin(req, makeEnv(), deps);
+    expect(resp.status).toBe(200);
+    expect(deps.resend.sendEmail).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /api/magic
+// ---------------------------------------------------------------------------
+
+describe("GET /api/magic", () => {
+  it("302s to /gallery.html and sets the subscriber cookie", async () => {
+    const env = makeEnv();
+    const token = await signJwt(
+      { sub: "alice@example.com", scope: "magic-login", ttlSeconds: 600 },
+      SECRET,
+    );
+    const req = makeRequest(
+      "GET",
+      `https://api.nerranetwork.com/api/magic?token=${encodeURIComponent(token)}`,
+    );
+    const resp = await handleMagic(req, env, makeDeps());
+    expect(resp.status).toBe(302);
+    expect(resp.headers.get("Location")).toBe("https://nerranetwork.com/gallery.html");
+    const setCookie = resp.headers.get("Set-Cookie");
+    expect(setCookie).toMatch(/^nn_gallery=/);
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("Secure");
+    expect(setCookie).toContain("Max-Age=7776000"); // 90 d
+  });
+
+  it("400s on missing token", async () => {
+    const req = makeRequest("GET", "https://api.nerranetwork.com/api/magic");
+    const resp = await handleMagic(req, makeEnv(), makeDeps());
+    expect(resp.status).toBe(400);
+  });
+
+  it("400s on expired token", async () => {
+    const env = makeEnv();
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt(
+      { sub: "alice@example.com", scope: "magic-login", ttlSeconds: 60 },
+      SECRET,
+      now - 3600,
+    );
+    const req = makeRequest(
+      "GET",
+      `https://api.nerranetwork.com/api/magic?token=${encodeURIComponent(token)}`,
+    );
+    const resp = await handleMagic(req, env, makeDeps());
+    expect(resp.status).toBe(400);
+  });
+
+  it("400s when the token has the wrong scope (cookie token replayed as magic)", async () => {
+    const env = makeEnv();
+    const cookieToken = await signJwt(
+      { sub: "alice@example.com", scope: "gallery-subscriber", ttlSeconds: 600 },
+      SECRET,
+    );
+    const req = makeRequest(
+      "GET",
+      `https://api.nerranetwork.com/api/magic?token=${encodeURIComponent(cookieToken)}`,
+    );
+    const resp = await handleMagic(req, env, makeDeps());
+    expect(resp.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /api/download
+// ---------------------------------------------------------------------------
+
+describe("GET /api/download", () => {
+  it("streams the R2 object when the JWT cookie is valid", async () => {
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const env = makeEnv({
+      GALLERY_BUCKET: makeBucket({
+        "tesla/2026-05-24/ep042/abc.jpeg": bytes,
+      }),
+    });
+    const cookie = await signJwt(
+      { sub: "alice@example.com", scope: "gallery-subscriber", ttlSeconds: 600 },
+      SECRET,
+    );
+    const req = makeRequest(
+      "GET",
+      "https://api.nerranetwork.com/api/download?key=tesla/2026-05-24/ep042/abc.jpeg",
+      { headers: { Cookie: `nn_gallery=${cookie}` } },
+    );
+    const resp = await handleDownload(req, env, makeDeps());
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Disposition")).toContain("attachment");
+    expect(resp.headers.get("Content-Disposition")).toContain("abc.jpeg");
+    const body = new Uint8Array(await resp.arrayBuffer());
+    expect(Array.from(body)).toEqual(Array.from(bytes));
+  });
+
+  it("401s when no cookie present", async () => {
+    const req = makeRequest(
+      "GET",
+      "https://api.nerranetwork.com/api/download?key=tesla/2026-05-24/ep042/abc.jpeg",
+    );
+    const resp = await handleDownload(req, makeEnv(), makeDeps());
+    expect(resp.status).toBe(401);
+  });
+
+  it("401s when cookie token has the wrong scope", async () => {
+    const env = makeEnv();
+    const magicToken = await signJwt(
+      { sub: "alice@example.com", scope: "magic-login", ttlSeconds: 600 },
+      SECRET,
+    );
+    const req = makeRequest(
+      "GET",
+      "https://api.nerranetwork.com/api/download?key=tesla/2026-05-24/ep042/abc.jpeg",
+      { headers: { Cookie: `nn_gallery=${magicToken}` } },
+    );
+    const resp = await handleDownload(req, env, makeDeps());
+    expect(resp.status).toBe(401);
+  });
+
+  it("400s on traversal attempt", async () => {
+    const cookie = await signJwt(
+      { sub: "x@y.z", scope: "gallery-subscriber", ttlSeconds: 600 },
+      SECRET,
+    );
+    const req = makeRequest(
+      "GET",
+      "https://api.nerranetwork.com/api/download?key=../etc/passwd",
+      { headers: { Cookie: `nn_gallery=${cookie}` } },
+    );
+    const resp = await handleDownload(req, makeEnv(), makeDeps());
+    expect(resp.status).toBe(400);
+  });
+
+  it("404s when the object is missing from R2", async () => {
+    const cookie = await signJwt(
+      { sub: "x@y.z", scope: "gallery-subscriber", ttlSeconds: 600 },
+      SECRET,
+    );
+    const req = makeRequest(
+      "GET",
+      "https://api.nerranetwork.com/api/download?key=tesla/2026-05-24/ep042/missing.jpeg",
+      { headers: { Cookie: `nn_gallery=${cookie}` } },
+    );
+    const resp = await handleDownload(req, makeEnv(), makeDeps());
+    expect(resp.status).toBe(404);
+  });
+});

--- a/workers/gallery/test/jwt.test.ts
+++ b/workers/gallery/test/jwt.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { base64UrlDecode, base64UrlEncode, signJwt, verifyJwt } from "../src/jwt";
+
+const SECRET = "test-secret-not-for-production-use";
+
+describe("base64url", () => {
+  it("round-trips arbitrary bytes", () => {
+    const bytes = new Uint8Array([0, 1, 2, 250, 251, 252, 253, 254, 255, 13, 10, 9, 32]);
+    const encoded = base64UrlEncode(bytes);
+    expect(encoded).not.toContain("+");
+    expect(encoded).not.toContain("/");
+    expect(encoded).not.toContain("=");
+    expect(Array.from(base64UrlDecode(encoded))).toEqual(Array.from(bytes));
+  });
+
+  it("handles empty input", () => {
+    expect(base64UrlEncode(new Uint8Array())).toBe("");
+    expect(base64UrlDecode("").length).toBe(0);
+  });
+
+  it("decodes without padding", () => {
+    // "M" → "TQ" (no padding) and "TQ==" (padded) decode to the same byte.
+    expect(Array.from(base64UrlDecode("TQ"))).toEqual([0x4d]);
+  });
+});
+
+describe("signJwt + verifyJwt", () => {
+  it("produces a three-part token", async () => {
+    const token = await signJwt(
+      { sub: "alice@example.com", scope: "gallery-subscriber", ttlSeconds: 60 },
+      SECRET,
+    );
+    expect(token.split(".").length).toBe(3);
+  });
+
+  it("round-trips claims via verifyJwt", async () => {
+    const now = 1_700_000_000;
+    const token = await signJwt(
+      { sub: "alice@example.com", scope: "gallery-subscriber", ttlSeconds: 3600 },
+      SECRET,
+      now,
+    );
+    const verify = await verifyJwt(token, SECRET, { now: now + 10 });
+    expect(verify.ok).toBe(true);
+    expect(verify.claims?.sub).toBe("alice@example.com");
+    expect(verify.claims?.scope).toBe("gallery-subscriber");
+    expect(verify.claims?.iat).toBe(now);
+    expect(verify.claims?.exp).toBe(now + 3600);
+  });
+
+  it("rejects expired tokens", async () => {
+    const now = 1_700_000_000;
+    const token = await signJwt(
+      { sub: "x@y.z", scope: "magic-login", ttlSeconds: 60 },
+      SECRET,
+      now,
+    );
+    const verify = await verifyJwt(token, SECRET, { now: now + 61 });
+    expect(verify.ok).toBe(false);
+    expect(verify.reason).toBe("expired");
+  });
+
+  it("rejects tampered payload", async () => {
+    const token = await signJwt(
+      { sub: "alice@example.com", scope: "gallery-subscriber", ttlSeconds: 60 },
+      SECRET,
+    );
+    const parts = token.split(".");
+    // Re-encode a malicious payload but keep the original signature.
+    const evilPayload = base64UrlEncode(
+      new TextEncoder().encode(
+        JSON.stringify({
+          sub: "evil@attacker.com",
+          scope: "gallery-subscriber",
+          iat: 0,
+          exp: 9_999_999_999,
+        }),
+      ),
+    );
+    const tampered = `${parts[0]}.${evilPayload}.${parts[2]}`;
+    const verify = await verifyJwt(tampered, SECRET);
+    expect(verify.ok).toBe(false);
+    expect(verify.reason).toBe("signature mismatch");
+  });
+
+  it("rejects tokens signed with a different secret", async () => {
+    const token = await signJwt(
+      { sub: "alice@example.com", scope: "gallery-subscriber", ttlSeconds: 60 },
+      "other-secret",
+    );
+    const verify = await verifyJwt(token, SECRET);
+    expect(verify.ok).toBe(false);
+    expect(verify.reason).toBe("signature mismatch");
+  });
+
+  it("rejects malformed tokens", async () => {
+    const verify = await verifyJwt("not.a.real.jwt", SECRET);
+    expect(verify.ok).toBe(false);
+  });
+
+  it("rejects empty token", async () => {
+    expect((await verifyJwt("", SECRET)).ok).toBe(false);
+  });
+
+  it("rejects wrong scope when expectedScope is set", async () => {
+    const now = 1_700_000_000;
+    const token = await signJwt(
+      { sub: "x@y.z", scope: "magic-login", ttlSeconds: 60 },
+      SECRET,
+      now,
+    );
+    const verify = await verifyJwt(token, SECRET, {
+      expectedScope: "gallery-subscriber",
+      now: now + 10,
+    });
+    expect(verify.ok).toBe(false);
+    expect(verify.reason).toBe("wrong scope");
+  });
+
+  it("accepts matching scope", async () => {
+    const now = 1_700_000_000;
+    const token = await signJwt(
+      { sub: "x@y.z", scope: "magic-login", ttlSeconds: 60 },
+      SECRET,
+      now,
+    );
+    const verify = await verifyJwt(token, SECRET, {
+      expectedScope: "magic-login",
+      now: now + 10,
+    });
+    expect(verify.ok).toBe(true);
+  });
+
+  it("rejects tokens issued in the future (beyond clock skew)", async () => {
+    const now = 1_700_000_000;
+    const token = await signJwt(
+      { sub: "x@y.z", scope: "magic-login", ttlSeconds: 600 },
+      SECRET,
+      now + 120, // 2 min in the future
+    );
+    const verify = await verifyJwt(token, SECRET, { now });
+    expect(verify.ok).toBe(false);
+    expect(verify.reason).toBe("issued in future");
+  });
+
+  it("refuses to sign with empty secret", async () => {
+    await expect(
+      signJwt({ sub: "x@y.z", scope: "magic-login", ttlSeconds: 60 }, ""),
+    ).rejects.toThrow();
+  });
+});

--- a/workers/gallery/tsconfig.json
+++ b/workers/gallery/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/workers/gallery/vitest.config.ts
+++ b/workers/gallery/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    globals: false,
+  },
+});

--- a/workers/gallery/wrangler.toml
+++ b/workers/gallery/wrangler.toml
@@ -1,0 +1,38 @@
+# Cloudflare Worker that backs the Nerra Network image gallery's
+# email-gated download flow. See workers/gallery/README.md for the
+# deploy + secret bootstrap steps, and docs/gallery_storage.md for
+# the architecture context.
+
+name = "nerra-gallery-api"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+account_id = ""  # set via `wrangler whoami` or CI; intentionally
+                 # blank in-repo so a developer fork doesn't bind
+                 # to the production account by mistake.
+
+# Custom route on the existing zone.  Set ZONE_ID + the api.* CNAME
+# in Cloudflare first (operator step — see README).  Until both are
+# wired, deploy goes to the *.workers.dev preview URL automatically.
+routes = [
+  { pattern = "api.nerranetwork.com/api/*", custom_domain = true },
+]
+
+# R2 binding for the gallery bucket.  The Worker uses
+# env.GALLERY_BUCKET.get(key) on download; no separate access key is
+# needed because the binding is scoped by Cloudflare to this Worker.
+[[r2_buckets]]
+binding = "GALLERY_BUCKET"
+bucket_name = "nerra-gallery"
+
+# Secrets are set out-of-band via:
+#   wrangler secret put JWT_SECRET
+#   wrangler secret put BUTTONDOWN_API_KEY
+#   wrangler secret put RESEND_API_KEY
+#   wrangler secret put RESEND_FROM_EMAIL
+# Do NOT commit them here.
+
+[observability]
+enabled = true
+
+[placement]
+mode = "smart"


### PR DESCRIPTION
## Summary

Phase 3 (the final phase) of the Nerra Network image gallery. Adds a
Cloudflare Worker at `api.nerranetwork.com` that backs the
email-gated download flow previously stubbed in Phase 2, and wires
the frontend to call it.

- **POST `/api/subscribe`** — Buttondown subscribe with tag
  `gallery-subscriber`, set a 90-day HttpOnly Secure SameSite=Lax
  JWT cookie, return 200. Already-subscribed addresses are treated
  as success so re-submitting still issues the cookie.
- **GET `/api/login?email=...`** — magic-link email via Resend
  (15-min TTL). Always returns 200 regardless of whether the
  address is subscribed, so the endpoint can't be used to enumerate
  the subscriber list.
- **GET `/api/magic?token=...`** — consume the magic-login JWT, set
  the 90-day cookie, 302 to `/gallery.html`.
- **GET `/api/download?key=<r2_key>`** — verify the cookie, stream
  the R2 object via the bound bucket with
  `Content-Disposition: attachment`.

## Spec deviation (documented)

The spec called for `/api/download` to issue a **short-lived signed
R2 URL + 302 redirect**. The Worker **proxies bytes through the
binding** instead. Rationale:

- Each request re-validates the JWT — revocation actually works
  (signed URLs would remain valid for their full TTL even after
  the visitor's cookie expires).
- No signed URLs in browser history / share sheets — originals
  can't leak via copy-paste of a working URL.
- No SigV4 plumbing or third-party dependency required.

For the gallery's traffic volume the Worker bandwidth cost is well
under the free tier. If we hit Worker bandwidth limits we'll swap to
signed URLs — the endpoint contract from the frontend is unchanged.

## What's in here

* **`workers/gallery/`** — self-contained TypeScript Worker. 17
  source files, no project-root coupling. Key modules:
  * `src/jwt.ts` — HS256 sign/verify hand-rolled with
    `crypto.subtle` (no `jose` dep). Constant-time signature
    compare, scope + exp checks, refuses empty secrets.
  * `src/buttondown.ts` — API client with `subscribe()` (treats
    "already exists" as success) and `isSubscribed()` (used by
    `/api/login`).
  * `src/resend.ts` — minimal `POST /emails` client.
  * `src/magic-email.ts` — HTML + plain-text magic-link email body
    with the existing brand colour.
  * `src/cors.ts` — origin allow-list + preflight handler.
  * `src/handlers.ts` — pure-function endpoint handlers; deps
    injected so tests can run without the network.
  * `src/index.ts` — router (4 endpoints + `/health`).
  * `wrangler.toml` — R2 binding for `nerra-gallery`, custom route
    `api.nerranetwork.com/api/*`.
* **45 vitest tests** in `workers/gallery/test/` covering JWT
  (sign/verify/tamper/expiry/scope/empty secret), Buttondown
  client (200 / already-subscribed / HTTP / network failure paths),
  and every endpoint with fake clients + an in-memory R2 bucket.
* **`assets/js/gallery.js`** — replaced the Phase 2 localStorage
  stub with real `fetch()` calls. Download flow: fetch blob →
  programmatic `<a download>` click → browser save dialog. Gate
  modal supports both "Subscribe & download" and "Already
  subscribed? Sign in instead" paths. Lightbox stops loading
  `original_url` (now private) — the watermarked thumbnail is
  shown at modal size; the download button is the only path to
  the original.
* **`scripts/build_gallery_manifest.py`** — adds `original_key` to
  every manifest entry (the R2 path the frontend passes to
  `/api/download`). Existing 18 tests updated + still pass.
* **`docs/gallery_storage.md`** + **`workers/gallery/README.md`** —
  full operator deploy guide (R2 policy split, DNS, Resend setup,
  `wrangler secret put` × 4, `wrangler deploy`, custom-domain
  binding, smoke-test curls).
* **`.gitignore`** — ignore `workers/**/node_modules/`,
  `.wrangler/`, `.dev.vars`, `dist/`.
* **`styles/main.css`** — small additions for the new modal states
  (`.nn-gate-success`, `.nn-gate-toggle`, `:disabled`).
* **`CLAUDE.md`** — Phase 3 paragraph.

## Decisions locked

| Question | Decision |
|---|---|
| Worker hostname | `api.nerranetwork.com` (custom domain on the existing zone, not a workers.dev subdomain or path-routed `/api/*`) |
| Magic-link email provider | **Resend** (3 000/month free tier, clean API, one HTTP call from the Worker) |

## Test plan

- [x] `cd workers/gallery && npm test` — 45 passed
- [x] `cd workers/gallery && npm run typecheck` — clean
- [x] `pytest tests/test_build_gallery_manifest.py tests/test_gallery_render.py tests/test_gallery_uploader.py tests/test_storage.py tests/test_config.py` — 111 passed
- [x] `node -c assets/js/gallery.js` — vanilla JS syntax-clean
- [ ] **Pending operator action:** deploy Worker, smoke-test endpoints (see operator action items below)
- [ ] **Pending operator action:** flip R2 originals to private (gate currently bites only after that's done)

## Operator action items

Full step-by-step in [`workers/gallery/README.md`](workers/gallery/README.md).
Summary:

1. **Tighten R2 bucket policy.** In the Cloudflare dashboard,
   `nerra-gallery` → originals (`*.jpeg`/`*.png`) flip to private;
   thumbnails (`*.thumb.webp`) + sidecars (`*.json`) stay public on
   `gallery.nerranetwork.com`. A simple WAF rule that returns 403
   for any path not ending in `.thumb.webp` or `.json` is the
   cleanest way to enforce the split.
2. **DNS.** Add a CNAME `api` in the `nerranetwork.com` zone,
   proxy ON, any target (the Worker custom-domain binding takes
   over after step 5).
3. **Resend.** Sign up at https://resend.com (free tier 3 000/mo).
   Verify the sending domain (typically `nerranetwork.com` or a
   subdomain). Create an API key.
4. **Worker secrets.** From `workers/gallery/`:
   ```bash
   openssl rand -base64 64 | wrangler secret put JWT_SECRET
   echo "$BUTTONDOWN_API_KEY" | wrangler secret put BUTTONDOWN_API_KEY
   echo "$RESEND_API_KEY"     | wrangler secret put RESEND_API_KEY
   echo "Nerra Network <gallery@nerranetwork.com>" | wrangler secret put RESEND_FROM_EMAIL
   ```
5. **Deploy.**
   ```bash
   cd workers/gallery && npm install && npm test && npm run deploy
   ```
6. **Bind custom domain.** Cloudflare dashboard → Workers & Pages →
   `nerra-gallery-api` → Settings → Domains & Routes → "Add Custom
   Domain" → `api.nerranetwork.com`.
7. **Smoke-test.** Four `curl` commands in
   [`workers/gallery/README.md`](workers/gallery/README.md) exercise
   subscribe → download → magic-link in sequence.

Until step 1 ships, the gate UI is fully functional but the
underlying R2 originals are still publicly readable — anyone with
the URL can fetch them. The Worker doesn't depend on the bucket
policy (proxy serves either way), but the gate doesn't *bite* until
direct R2 access is removed.

This closes the gallery project. The three phases together ship:
durable storage (Phase 1) → manifest + browse UI (Phase 2) →
email-gated downloads (Phase 3).

https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2)_