### PR TITLE
Diagnose empty gallery: upload counters, MAB gating, R2 probe script

### DIFF
--- a/generate_html.py
+++ b/generate_html.py
@@ -80,6 +80,26 @@ def _read_show_youtube(slug: str) -> dict:
         "youtube_channel_url": f"https://www.youtube.com/{handle}",
     }
 
+
+def _read_show_image_provider(slug: str) -> str:
+    """Return the show's YouTube ``image_provider`` setting (``pexels``,
+    ``grok``, or ``hybrid``). Defaults to ``pexels`` to match
+    run_show.py's default — only shows that opt into ``grok`` produce
+    gallery images, so this is the signal the show page uses to
+    decide whether to embed the gallery section."""
+    import yaml as _yaml
+
+    yaml_path = SHOWS_DIR / f"{slug}.yaml"
+    if not yaml_path.exists():
+        return "pexels"
+    try:
+        data = _yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+    except _yaml.YAMLError:
+        return "pexels"
+    yt = data.get("youtube") or {}
+    return (yt.get("image_provider") or "pexels").strip().lower() or "pexels"
+
+
 # ---------------------------------------------------------------------------
 # Marketing / Analytics configuration
 # ---------------------------------------------------------------------------
@@ -1589,11 +1609,19 @@ def generate_show_page(slug, *, dry_run=False):
     is_russian = slug in ("finansy_prosto", "privet_russian")
 
     yt_meta = _read_show_youtube(slug)
-    # Phase 2 gallery: enable the embedded per-show gallery section on
-    # any show whose YouTube path is on, since those are the shows
-    # currently producing Grok Imagine artwork. When a show migrates
-    # off YouTube (or off Grok Imagine), the section auto-disables.
-    gallery_enabled = bool(yt_meta.get("youtube_enabled"))
+    # Phase 2 gallery: enable the embedded per-show gallery section
+    # only on shows that *also* use Grok Imagine for their YouTube
+    # slideshow. The Phase 1 gallery uploader is wired exclusively
+    # into the Grok Imagine code path in run_show.py; Pexels-sourced
+    # slideshows are stock photography and don't land in the gallery
+    # bucket — embedding the section on those pages would render an
+    # empty state forever. Switching a show from `image_provider:
+    # pexels` to `grok` (or `hybrid`) in its YAML opts it in.
+    image_provider = _read_show_image_provider(slug)
+    gallery_enabled = (
+        bool(yt_meta.get("youtube_enabled"))
+        and image_provider in ("grok", "hybrid")
+    )
 
     context = {
         **cfg,

--- a/run_show.py
+++ b/run_show.py
@@ -2209,6 +2209,23 @@ def run(args: argparse.Namespace) -> None:
             "image_provider",
             youtube_urls.get("image_provider", "pexels"),
         )
+        # Gallery upload outcome (Phase 1 → diagnostics added May 2026).
+        # Always recorded so the operator can read the metrics file
+        # for the latest episode and tell at a glance whether the
+        # gallery R2 bucket is receiving uploads.
+        metrics.record(
+            "gallery_attempted",
+            int(youtube_urls.get("gallery_attempted", 0) or 0),
+        )
+        metrics.record(
+            "gallery_uploaded",
+            int(youtube_urls.get("gallery_uploaded", 0) or 0),
+        )
+        if youtube_urls.get("gallery_skipped_reason"):
+            metrics.record(
+                "gallery_skipped_reason",
+                str(youtube_urls["gallery_skipped_reason"]),
+            )
         # Surface the first 5 Grok Imagine failure messages when the
         # provider is grok / hybrid AND the run produced 0 images. Tells
         # the operator WHY the slideshow fell back to the cover (bad
@@ -3073,6 +3090,13 @@ def _publish_youtube(
     grok_image_cost = 0.0
     grok_images_generated = 0
     grok_image_failures: list = []
+    # Gallery upload counters (Phase 1 → diagnostics added May 2026).
+    # Surfaced in per-episode metrics so we can tell from the dashboard
+    # whether the gallery R2 bucket is actually receiving uploads or
+    # silently no-op'ing on a misconfigured environment.
+    gallery_uploaded = 0
+    gallery_attempted = 0
+    gallery_skipped_reason = ""
 
     def _run_pexels_path(into_long: bool, into_short: bool):
         nonlocal pexels_attribution, pexels_filtered
@@ -3175,7 +3199,13 @@ def _publish_youtube(
         ``fetch_scene_images_grok``; the ``NN`` is the prompt index, so
         we can pair each image back with its source prompt without
         plumbing extra state.
+
+        Always emits a single summary log line (even on 0 uploads) and
+        bumps ``gallery_uploaded`` / ``gallery_attempted`` /
+        ``gallery_skipped_reason`` so the per-episode metrics file
+        shows the gallery outcome at a glance.
         """
+        nonlocal gallery_uploaded, gallery_attempted, gallery_skipped_reason
         try:
             from engine.gallery_uploader import (
                 ImageMetadata,
@@ -3183,11 +3213,20 @@ def _publish_youtube(
                 upload_image,
             )
         except Exception as exc:  # pragma: no cover — import-time soft-fail
+            gallery_skipped_reason = f"import_error:{type(exc).__name__}"
             logger.warning("Gallery uploader import failed: %s", exc)
             return
 
         gconfig = gallery_config_from_env()
         if not gconfig.is_configured:
+            gallery_skipped_reason = "unconfigured"
+            logger.info(
+                "Gallery: skipping upload for ep%s (aspect=%s) — "
+                "R2 env vars unset (bucket=%r endpoint=%r access=%s secret=%s)",
+                episode_num, aspect,
+                gconfig.bucket, gconfig.endpoint_url,
+                bool(gconfig.access_key), bool(gconfig.secret_key),
+            )
             return
 
         import re as _re
@@ -3201,11 +3240,16 @@ def _publish_youtube(
         )
         model_id = getattr(yt, "grok_image_model", "grok-imagine-image")
 
+        attempted = 0
         uploaded = 0
+        first_failure = ""
         for scene_path in scene_paths:
+            attempted += 1
             try:
                 image_bytes = Path(scene_path).read_bytes()
             except Exception as exc:  # pragma: no cover — best-effort
+                if not first_failure:
+                    first_failure = f"read:{type(exc).__name__}:{exc}"
                 logger.warning(
                     "Gallery: failed to read %s: %s", scene_path, exc,
                 )
@@ -3235,12 +3279,26 @@ def _publish_youtube(
             )
             if result_upload is not None:
                 uploaded += 1
+            elif not first_failure:
+                # upload_image() returns None on any soft failure
+                # (R2 error, thumbnail error, missing creds). The
+                # specific cause was logged inside the helper; we
+                # capture the fact here so the per-episode metrics
+                # show a non-empty skipped_reason when uploads silently
+                # 0-out (the most operationally hostile failure mode).
+                first_failure = "upload_returned_none"
 
-        if uploaded:
-            logger.info(
-                "Gallery: uploaded %d/%d scene images for ep%s (aspect=%s)",
-                uploaded, len(scene_paths), episode_num, aspect,
-            )
+        gallery_attempted += attempted
+        gallery_uploaded += uploaded
+        if uploaded == 0 and attempted > 0 and not gallery_skipped_reason:
+            gallery_skipped_reason = first_failure or "unknown_failure"
+
+        logger.info(
+            "Gallery: ep%s aspect=%s attempted=%d uploaded=%d bucket=%s "
+            "first_failure=%r",
+            episode_num, aspect, attempted, uploaded, gconfig.bucket,
+            first_failure or None,
+        )
 
     if image_provider == "grok":
         long_scene_paths = _run_grok_path(aspect="16:9", label_suffix="")
@@ -3491,6 +3549,13 @@ def _publish_youtube(
     if grok_image_failures:
         result["grok_image_failures"] = grok_image_failures[:5]
     result["image_provider"] = image_provider
+    # Gallery (Phase 1) upload outcome. Always surfaced so the
+    # dashboard can plot "uploaded N / attempted M (reason=…)" per
+    # episode and spot a misconfigured bucket immediately.
+    result["gallery_attempted"] = gallery_attempted
+    result["gallery_uploaded"] = gallery_uploaded
+    if gallery_skipped_reason:
+        result["gallery_skipped_reason"] = gallery_skipped_reason
     return result
 
 

--- a/scripts/diagnose_gallery.py
+++ b/scripts/diagnose_gallery.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Diagnose the gallery R2 wiring end-to-end.
+
+Run when the gallery page is empty after Tesla / MAB runs and you
+need to find out *where* the chain broke. Reads the same env vars the
+live pipeline reads (``R2_GALLERY_BUCKET``, ``R2_ENDPOINT_URL``,
+``R2_ACCESS_KEY_ID``, ``R2_SECRET_ACCESS_KEY``,
+``R2_GALLERY_PUBLIC_BASE_URL``) and walks five checks:
+
+  1. Env vars present.
+  2. boto3 S3 client constructible.
+  3. ``head_bucket`` succeeds (auth + bucket name correct + region OK).
+  4. ``list_objects_v2`` returns something (bucket has contents).
+  5. The Phase 2 manifest builder produces a non-empty manifest.
+
+Each step prints PASS/FAIL with the underlying error message. The
+script exits 0 on all-pass, 1 on any fail — so the operator can wire
+it into a smoke-test script if they want.
+
+Run::
+
+    python scripts/diagnose_gallery.py
+    python scripts/diagnose_gallery.py --probe-write     # actually
+                                                          # upload a
+                                                          # 1×1 test
+                                                          # image
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from engine.gallery_uploader import (  # noqa: E402
+    ImageMetadata,
+    gallery_config_from_env,
+    upload_image,
+)
+
+logger = logging.getLogger("diagnose_gallery")
+
+CHECK_MARK = "✅"  # ✅
+CROSS_MARK = "❌"  # ❌
+WARN_MARK = "⚠️"  # ⚠️
+
+
+def _pass(msg: str) -> None:
+    print(f"{CHECK_MARK} {msg}")
+
+
+def _fail(msg: str) -> None:
+    print(f"{CROSS_MARK} {msg}")
+
+
+def _warn(msg: str) -> None:
+    print(f"{WARN_MARK} {msg}")
+
+
+def check_env() -> bool:
+    print("\n=== 1. Environment variables ===")
+    expected = {
+        "R2_GALLERY_BUCKET": os.getenv("R2_GALLERY_BUCKET", ""),
+        "R2_GALLERY_PUBLIC_BASE_URL": os.getenv("R2_GALLERY_PUBLIC_BASE_URL", ""),
+        "R2_ENDPOINT_URL": os.getenv("R2_ENDPOINT_URL", ""),
+        "R2_ACCESS_KEY_ID": os.getenv("R2_ACCESS_KEY_ID", ""),
+        "R2_SECRET_ACCESS_KEY": os.getenv("R2_SECRET_ACCESS_KEY", ""),
+    }
+    ok = True
+    for var, val in expected.items():
+        if not val:
+            if var == "R2_GALLERY_BUCKET":
+                _warn(f"{var} not set (will default to 'nerra-gallery')")
+            elif var == "R2_GALLERY_PUBLIC_BASE_URL":
+                _warn(
+                    f"{var} not set (URLs in the manifest will point at "
+                    "the raw R2 endpoint — fine for the Worker proxy, but "
+                    "the public gallery would 403 without a custom domain)"
+                )
+            else:
+                _fail(f"{var} is empty")
+                ok = False
+        else:
+            display = (
+                val[:8] + "…" + val[-4:]
+                if var.endswith("KEY") or var.endswith("ID")
+                else val
+            )
+            _pass(f"{var} = {display}")
+    return ok
+
+
+def check_client() -> tuple[bool, object]:
+    print("\n=== 2. S3 client constructible ===")
+    try:
+        import boto3
+        from botocore.config import Config as BotoConfig
+    except ImportError as e:
+        _fail(f"boto3 not installed: {e}")
+        return False, None
+
+    config = gallery_config_from_env()
+    if not config.is_configured:
+        _fail("gallery_config_from_env().is_configured is False")
+        return False, None
+
+    try:
+        client = boto3.client(
+            "s3",
+            endpoint_url=config.endpoint_url,
+            aws_access_key_id=config.access_key,
+            aws_secret_access_key=config.secret_key,
+            config=BotoConfig(
+                signature_version="s3v4",
+                retries={"max_attempts": 1},
+            ),
+        )
+    except Exception as e:
+        _fail(f"client construction failed: {type(e).__name__}: {e}")
+        return False, None
+    _pass(f"S3 client built (endpoint={config.endpoint_url})")
+    return True, client
+
+
+def check_head_bucket(client) -> bool:
+    print("\n=== 3. head_bucket — auth + bucket name + region ===")
+    config = gallery_config_from_env()
+    try:
+        client.head_bucket(Bucket=config.bucket)
+    except Exception as e:
+        _fail(
+            f"head_bucket({config.bucket!r}) failed: "
+            f"{type(e).__name__}: {e}"
+        )
+        _warn(
+            "Common causes:\n"
+            "  - Bucket name typo (operator created the bucket with a "
+            "different name than R2_GALLERY_BUCKET).\n"
+            "  - R2 token doesn't have read permission on this bucket.\n"
+            "  - The R2 token is scoped to a single bucket (e.g. "
+            "'podcast-audio') and can't see the gallery bucket.\n"
+            "  - Wrong endpoint URL for the R2 account."
+        )
+        return False
+    _pass(f"head_bucket({config.bucket!r}) OK")
+    return True
+
+
+def check_list(client) -> tuple[bool, int, int]:
+    print("\n=== 4. list_objects_v2 — bucket contents ===")
+    config = gallery_config_from_env()
+    try:
+        paginator = client.get_paginator("list_objects_v2")
+        total = 0
+        sidecars = 0
+        for page in paginator.paginate(Bucket=config.bucket, MaxKeys=1000):
+            for obj in page.get("Contents", []) or []:
+                total += 1
+                if obj.get("Key", "").endswith(".json"):
+                    sidecars += 1
+    except Exception as e:
+        _fail(f"list_objects_v2 failed: {type(e).__name__}: {e}")
+        return False, 0, 0
+    _pass(f"list_objects_v2 OK — {total} object(s), {sidecars} sidecar(s)")
+    if total == 0:
+        _warn(
+            "Bucket is empty. Either:\n"
+            "  (a) no Grok-Imagine episode has run yet,\n"
+            "  (b) the run-show CI is uploading to a different "
+            "bucket / can't reach this one (check metrics_ep*.json for "
+            "the latest episode — look for `gallery_attempted` and "
+            "`gallery_skipped_reason`),\n"
+            "  (c) the bucket was created today and writes are still "
+            "propagating (unlikely on R2)."
+        )
+    return True, total, sidecars
+
+
+def check_manifest(client, sidecar_count: int) -> bool:
+    print("\n=== 5. Manifest builder produces a non-empty manifest ===")
+    if sidecar_count == 0:
+        _warn(
+            "Skipping — bucket has no sidecars to assemble from. Fix "
+            "step 4 first."
+        )
+        return False
+    from scripts.build_gallery_manifest import build_manifest, walk_bucket
+    config = gallery_config_from_env()
+    sidecars = walk_bucket(config)
+    manifest = build_manifest(sidecars, config=config)
+    if manifest["image_count"] == 0:
+        _fail("walk_bucket returned 0 sidecars despite list reporting some")
+        return False
+    _pass(
+        f"manifest builder OK — image_count={manifest['image_count']}, "
+        f"shows={len(manifest['shows'])}"
+    )
+    return True
+
+
+def probe_write() -> bool:
+    """Optional step: actually upload a 1×1 test image to confirm
+    write permission. Only runs with --probe-write."""
+    print("\n=== 6. Probe write (1×1 test image) ===")
+    try:
+        from PIL import Image
+    except ImportError:
+        _fail("Pillow not installed; can't make a test image")
+        return False
+    img = Image.new("RGB", (1, 1), (128, 128, 128))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+
+    ts = time.strftime("%Y-%m-%d")
+    meta = ImageMetadata(
+        image_id="",
+        show_slug="_diagnostic",
+        show_name="Gallery diagnostic probe",
+        episode_id=f"ep{int(time.time()) % 1000:03d}",
+        episode_title=f"Probe write at {ts}",
+        episode_date=ts,
+        prompt="(diagnostic probe — safe to delete)",
+        model="diagnose_gallery.py",
+        intended_use="other",
+        tags=["_diagnostic"],
+    )
+    result = upload_image(buf.getvalue(), meta)
+    if result is None:
+        _fail(
+            "upload_image returned None — look further up the output "
+            "for the underlying R2 error logged by engine.gallery_uploader."
+        )
+        return False
+    _pass(
+        f"probe write OK — image_id={result.image_id} "
+        f"key={result.original_key}\n"
+        f"   thumbnail={result.thumbnail_url}\n"
+        f"   sidecar={result.sidecar_url}"
+    )
+    _warn(
+        "The probe writes a real object under _diagnostic/. Delete it "
+        "from the R2 dashboard when you're done."
+    )
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--probe-write", action="store_true",
+        help="Also attempt to upload a 1×1 probe image (writes one "
+             "object under _diagnostic/ in the gallery bucket).",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s %(name)s %(message)s",
+    )
+
+    env_ok = check_env()
+    if not env_ok:
+        print("\nEnv var problems above. Fix those before re-running.")
+        return 1
+
+    client_ok, client = check_client()
+    if not client_ok:
+        return 1
+
+    head_ok = check_head_bucket(client)
+    if not head_ok:
+        return 1
+
+    list_ok, _total, sidecars = check_list(client)
+    if not list_ok:
+        return 1
+
+    manifest_ok = check_manifest(client, sidecars)
+
+    write_ok = True
+    if args.probe_write:
+        write_ok = probe_write()
+
+    print()
+    if env_ok and client_ok and head_ok and list_ok and (
+        manifest_ok or sidecars == 0
+    ) and write_ok:
+        print(f"{CHECK_MARK} All checks passed.")
+        if sidecars == 0:
+            print(
+                f"{WARN_MARK} Bucket is empty though — see step 4 above for "
+                "next steps."
+            )
+        return 0
+    print(f"{CROSS_MARK} One or more checks failed; see output above.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gallery_render.py
+++ b/tests/test_gallery_render.py
@@ -152,3 +152,53 @@ def test_gallery_manifest_placeholder_is_valid_json():
     assert isinstance(data["images"], list)
     assert isinstance(data["shows"], list)
     assert "image_count" in data
+
+
+def test_gallery_enabled_requires_grok_image_provider():
+    """A show that uses Pexels for its YouTube slideshow must NOT
+    have the gallery section embedded — the gallery uploader is
+    wired only into the Grok Imagine path, so a Pexels show would
+    render an empty gallery forever."""
+    import sys
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    from generate_html import (
+        _read_show_image_provider, _read_show_youtube,
+    )
+
+    tesla_yt = _read_show_youtube("tesla")
+    tesla_provider = _read_show_image_provider("tesla")
+    tesla_enabled = (
+        bool(tesla_yt.get("youtube_enabled"))
+        and tesla_provider in ("grok", "hybrid")
+    )
+    assert tesla_provider == "grok", \
+        f"Tesla expected on grok provider, got {tesla_provider!r}"
+    assert tesla_enabled, "Tesla should have gallery_enabled=True"
+
+    mab_yt = _read_show_youtube("models_agents_beginners")
+    mab_provider = _read_show_image_provider("models_agents_beginners")
+    mab_enabled = (
+        bool(mab_yt.get("youtube_enabled"))
+        and mab_provider in ("grok", "hybrid")
+    )
+    # MAB is on Pexels today (no gallery images produced) — section
+    # must stay hidden. The day MAB flips to grok / hybrid this test
+    # also needs to flip; that's the intended contract.
+    assert mab_provider == "pexels", (
+        f"MAB expected on pexels, got {mab_provider!r}. If you "
+        "intentionally migrated MAB to Grok Imagine, flip this "
+        "assertion to expect 'grok' / 'hybrid' and the gallery "
+        "section will start rendering on the MAB show page."
+    )
+    assert mab_enabled is False, "MAB gallery_enabled must stay False"
+
+
+def test_read_show_image_provider_defaults_to_pexels_for_unknown_show():
+    """An unknown / missing show YAML must default to 'pexels' so the
+    gallery section auto-disables rather than breaking the render."""
+    import sys
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    from generate_html import _read_show_image_provider
+    assert _read_show_image_provider("__nonexistent__") == "pexels"


### PR DESCRIPTION
## Why is the gallery empty?

Two reasons, plus diagnostics so the next failure is self-evident.

### Issue 1 — silent upload failures (diagnostic fix)

`_upload_scenes_to_gallery` in `run_show.py` logged per-call errors
via `engine.gallery_uploader` but emitted **no summary log line when
all uploads returned `None`**, and never surfaced the outcome to the
per-episode metrics file. So an operator with a misconfigured bucket
(wrong name, scoped token, wrong region) sees nothing:

* Tesla runs ✓ (Tesla ep484 metrics confirm: `grok_images_generated: 8`, `image_provider: grok`).
* Grok Imagine generates 8 images ✓.
* Upload silently 0-outs ✗ (no visibility).
* Manifest workflow finds an empty bucket, writes the same empty manifest, no commit.
* `site/data/gallery-manifest.json` hasn't changed since the Phase 2 PR (`generated_at: 2026-05-24T00:00:00`).

**Fix:** track `gallery_attempted` / `gallery_uploaded` /
`gallery_skipped_reason` nonlocals in `_publish_youtube`, surface
them in the returned result dict, record them as metrics counters,
and emit a single summary log line per call (**even on 0 uploads**).

The next Tesla run will produce a `metrics_ep*.json` row that reads:

```json
"gallery_attempted": 8,
"gallery_uploaded": 0,
"gallery_skipped_reason": "upload_returned_none"
```

(if R2 writes are failing) or `"unconfigured"` (if env vars aren't
reaching the workflow). That row + the CI step's log line will pin
the exact failure mode in one run.

### Issue 2 — MAB gallery section embedded despite Pexels images (real fix)

Phase 2 enabled the gallery section on any show with
`youtube.enabled: true`. But MAB has `image_provider: pexels` in
`shows/models_agents_beginners.yaml`, and the Phase 1 gallery
uploader is wired **only** into `_run_grok_path` — Pexels images
never land in the gallery bucket. So MAB's show page would render an
empty gallery indefinitely no matter what the operator did.

**Fix:** gate `gallery_enabled` on `image_provider in {grok, hybrid}`
in addition to `youtube_enabled`. MAB's section auto-disables today;
the day MAB migrates to grok the section auto-enables. New helper
`_read_show_image_provider()` is one YAML read per render. Tesla is
unaffected (already on `grok`).

### Diagnostic — `scripts/diagnose_gallery.py`

Walks five checks against the operator's local R2 credentials:

1. Env vars present.
2. boto3 S3 client constructible.
3. `head_bucket` (auth + bucket name + region OK).
4. `list_objects_v2` (bucket contents).
5. Manifest builder produces a non-empty manifest.

Each step prints PASS/FAIL with the underlying error. With
`--probe-write` it also uploads a 1×1 image to confirm write
permission (writes one object under `_diagnostic/` in the bucket —
manual cleanup after).

## What's in here

| File | Change |
|---|---|
| `run_show.py` | `_upload_scenes_to_gallery` now tracks attempted/uploaded/skipped + always logs a summary; `_publish_youtube` returns the three counters; caller records them in `metrics.json` |
| `generate_html.py` | New `_read_show_image_provider()` + `gallery_enabled` gating includes provider check |
| `scripts/diagnose_gallery.py` | New 5-step local probe with optional `--probe-write` |
| `tests/test_gallery_render.py` | 3 new tests: Tesla stays enabled, MAB stays disabled until provider flips, unknown-show defaults to `pexels` |

## Test plan

- [x] `pytest tests/test_gallery_render.py tests/test_build_gallery_manifest.py tests/test_gallery_uploader.py` — 49 passed
- [x] Local render of Tesla page emits gallery section ✓; MAB page does not ✓
- [x] `python scripts/diagnose_gallery.py` runs end-to-end (env vars absent in dev shell → step 1 fails cleanly with actionable warnings)
- [x] `python3 -m ast` on the three modified files — clean

## Operator next steps

After this merges:

1. **Run the diagnostic locally** (export the same env vars CI uses):
   ```bash
   export R2_GALLERY_BUCKET=nerra-gallery
   export R2_GALLERY_PUBLIC_BASE_URL=https://gallery.nerranetwork.com
   export R2_ENDPOINT_URL=...
   export R2_ACCESS_KEY_ID=...
   export R2_SECRET_ACCESS_KEY=...
   python scripts/diagnose_gallery.py --probe-write
   ```
   Output will pinpoint the failure in seconds. Most likely causes
   given Tesla is on Grok and Phase 1/2 shipped clean:
   - **Bucket name typo** — operator created the bucket as e.g.
     `nerra_gallery` (underscore) but the default is `nerra-gallery`
     (hyphen). Fix: rename the bucket OR set
     `R2_GALLERY_BUCKET=<actual-name>` as a GHA secret.
   - **R2 API token scoped to a single bucket** — the existing token
     in GHA secrets was created for `podcast-audio` and lacks
     permission on the new bucket. Fix: create a new R2 token in the
     Cloudflare dashboard scoped to "both buckets" or "all buckets",
     update the GHA secret.

2. **After the next Tesla run** (within 24 h), look at
   `digests/tesla_shorts_time/metrics_ep<latest>.json` for the new
   `gallery_*` keys. That row tells the story without needing CI log
   archeology.

3. **MAB gallery** will stay hidden until you set
   `image_provider: grok` (or `hybrid`) in
   `shows/models_agents_beginners.yaml`. Cost: ~$0.16/episode added
   (8 images × $0.02). Once flipped, the section reappears
   automatically on the next render.

https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2)_