### PR TITLE
Shorts: per-word caption highlighting (TikTok / Reels look)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,9 +65,10 @@ digests/*/youtube_tmp/scenes_*/
 # are regenerated every run too and can grow large.
 digests/*/youtube_tmp/*.mp4
 digests/*/youtube_tmp/*_thumb.jpg
-# SRT subtitles for the slideshow burn-in are also derivable from
+# SRT / ASS subtitles for the slideshow burn-in are derivable from
 # the committed transcript files.
 digests/*/youtube_tmp/*.srt
+digests/*/youtube_tmp/*.ass
 
 # Keep data/ and outputs/ directories tracked
 !data/.gitkeep

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,24 @@ with the first wave of episodes:
 inconclusive and the gallery pipeline (Phase 1) requires Grok
 Imagine. Cost: ~$0.16/episode added.
 
+**Per-word caption highlighting (TikTok / Reels look).** Shorts now
+ship with per-word "current word" highlighting instead of static
+segment cards.
+[`engine.captions.transcript_to_ass_window`](engine/captions.py)
+generates an ASS file (the modern subtitle format the ffmpeg
+`subtitles` filter accepts identically to SRT — no `video.py` change
+needed) with one `Dialogue` line per word; each line shows the full
+chunk text with the active word colour-flipped to Nerra cyan
+(`#00D4FF` / ASS `&H00FFD400`). Word timestamps come from
+`faster-whisper` which already runs with `word_timestamps=True` in
+`engine.transcripts` — no new transcription cost. Words are chunked
+to ≤24 chars / ≤8 words per chunk to match the FontSize=48 caption
+card. `run_show.py` tries the ASS path first; if the transcript has
+no word data (older episodes) or no overlap with the Shorts window,
+it falls back to the legacy segment-level SRT so the Short always
+has captions of some kind. Drift guards in
+`tests/test_captions_ass.py`.
+
 ### Testing
 
 ```bash

--- a/engine/captions.py
+++ b/engine/captions.py
@@ -329,6 +329,291 @@ def transcript_to_srt_window(
     return srt_path
 
 
+# ---------------------------------------------------------------------------
+# ASS — per-word highlight for Shorts (TikTok / Reels look)
+# ---------------------------------------------------------------------------
+
+# Highlight colour for the "current word" in the per-word Shorts caption
+# card. Cyan (#00D4FF) is one of the two Nerra Network accent colours
+# (defined in styles/main.css as --nn-cyan) and lifts cleanly off the
+# 50 %-opaque black caption card without bleeding into the white text
+# of the surrounding words. ASS colour format is &HAABBGGRR so cyan
+# (R=00, G=D4, B=FF) becomes &H00FFD400.
+_HIGHLIGHT_PRIMARY_BGR = "&H00FFD400&"
+
+# Inline override that resets the cue's primary colour to whatever
+# ``force_style`` set as the default (white in
+# ``_SHORTS_SUBTITLES_FORCE_STYLE``). ``\r`` without an argument reverts
+# to the style default; we use this rather than hard-coding a white
+# colour so per-show style overrides keep working in a future change.
+_HIGHLIGHT_RESET = r"{\r}"
+
+
+def _format_ass_timestamp(seconds: float) -> str:
+    """Format ``seconds`` as ASS ``H:MM:SS.cs`` (centiseconds)."""
+    if seconds < 0:
+        seconds = 0.0
+    cs_total = int(round(seconds * 100))
+    h = cs_total // (3600 * 100)
+    rem = cs_total % (3600 * 100)
+    m = rem // (60 * 100)
+    rem = rem % (60 * 100)
+    s = rem // 100
+    cs = rem % 100
+    return f"{h}:{m:02d}:{s:02d}.{cs:02d}"
+
+
+def _ass_escape(text: str) -> str:
+    """Escape characters with special meaning in ASS dialogue text.
+
+    ASS uses ``{`` and ``}`` to delimit inline override tags, and
+    backslashes inside the braces are tag prefixes. We don't carry
+    arbitrary user content through (Whisper output is normal speech)
+    so the only realistic risk is curly braces in a quoted lyric or
+    a model artefact. Strip them; keep everything else literal.
+    """
+    if not text:
+        return ""
+    return text.replace("{", "(").replace("}", ")")
+
+
+_ASS_HEADER = """[Script Info]
+ScriptType: v4.00+
+PlayResX: 1080
+PlayResY: 1920
+WrapStyle: 0
+ScaledBorderAndShadow: yes
+YCbCr Matrix: TV.709
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,DejaVu Sans,48,&H00FFFFFF,&H00FFFFFF,&H00000000,&H80000000,-1,0,0,0,100,100,0,0,3,3,0,2,40,40,340,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""
+
+
+def _chunk_words(
+    words: List[dict], *, max_chars: int, max_words_per_chunk: int,
+) -> List[List[dict]]:
+    """Group consecutive words into render-ready chunks.
+
+    A "chunk" is the unit that occupies the caption card for the
+    duration of its first→last word range; per-word highlight cycles
+    inside a chunk. Splitting on chars (24) + max words (8) keeps
+    each chunk to a comfortable 1–2 line render at FontSize=48 on a
+    1080-wide frame.
+    """
+    chunks: List[List[dict]] = []
+    current: List[dict] = []
+    current_chars = 0
+    for w in words:
+        token = (w.get("word") or "").strip()
+        if not token:
+            continue
+        prospective = current_chars + len(token) + (1 if current else 0)
+        if current and (
+            prospective > max_chars or len(current) >= max_words_per_chunk
+        ):
+            chunks.append(current)
+            current = [w]
+            current_chars = len(token)
+        else:
+            current.append(w)
+            current_chars = prospective
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _render_chunk_dialogues(
+    chunk: List[dict],
+    *,
+    window_start: float,
+    window_end: float,
+    audio_offset: float,
+    min_word_duration: float = 0.08,
+) -> List[str]:
+    """Emit one ASS Dialogue line per word in the chunk.
+
+    Each line shows the SAME text (the whole chunk) with one word
+    coloured in the highlight cyan and the others left at the style
+    default. That produces the TikTok "current word" visual: the
+    whole sentence is visible, but the active word pops.
+
+    Word timestamps are first shifted onto the final-audio timeline
+    (``audio_offset``), then rebased to the Shorts clip's t=0 origin
+    (``window_start``), then clipped to the window.
+    """
+    if not chunk:
+        return []
+    tokens = [(w.get("word") or "").strip() for w in chunk]
+    tokens = [t for t in tokens if t]
+    if not tokens:
+        return []
+
+    lines: List[str] = []
+    for idx, w in enumerate(chunk):
+        token = (w.get("word") or "").strip()
+        if not token:
+            continue
+        try:
+            ws = float(w["start"]) + audio_offset
+            we = float(w["end"]) + audio_offset
+        except (KeyError, TypeError, ValueError):
+            continue
+        # Clip to the Shorts window, then rebase to t=0.
+        ws = max(ws, window_start)
+        we = min(we, window_end)
+        if we - ws < min_word_duration:
+            we = ws + min_word_duration
+        rel_start = ws - window_start
+        rel_end = we - window_start
+        if rel_end <= 0 or rel_start >= (window_end - window_start):
+            continue
+
+        # Build the cue text. The current word is wrapped in a
+        # primary-colour override; everything else stays default.
+        parts: List[str] = []
+        for j, t in enumerate(tokens):
+            esc = _ass_escape(t)
+            if j == idx:
+                parts.append(f"{{\\1c{_HIGHLIGHT_PRIMARY_BGR}}}{esc}{_HIGHLIGHT_RESET}")
+            else:
+                parts.append(esc)
+        cue_text = " ".join(parts)
+        lines.append(
+            f"Dialogue: 0,"
+            f"{_format_ass_timestamp(rel_start)},"
+            f"{_format_ass_timestamp(rel_end)},"
+            f"Default,,0,0,0,,{cue_text}"
+        )
+    return lines
+
+
+def transcript_to_ass_window(
+    transcript_path: Path,
+    ass_path: Path,
+    *,
+    window_start_seconds: float,
+    window_duration_seconds: float,
+    audio_offset_seconds: float = 0.0,
+    wrap_max_chars: int = 24,
+    max_words_per_chunk: int = 8,
+) -> Path:
+    """Emit an ASS caption file with per-word highlighting for a Shorts
+    window.
+
+    Drop-in replacement for ``transcript_to_srt_window`` when the
+    Whisper transcript carries per-word timestamps (the network's
+    primary transcript invocation in ``engine.transcripts`` has
+    ``word_timestamps=True`` so this is the common case). Falls back
+    silently to an empty file if no segments / no word data exists
+    in the window — the caller treats an empty caption file the same
+    as the SRT path (skip burn-in).
+
+    Visual: each chunk of ~24 chars / ≤8 words occupies the bottom-
+    third caption card; the active word is rendered in cyan
+    (``&H00FFD400``) while the rest of the chunk stays at the style
+    default (white from ``_SHORTS_SUBTITLES_FORCE_STYLE``). As speech
+    progresses, the highlight steps from one word to the next at
+    Whisper's per-word timestamps. The chunk transition is implicit:
+    the chunk's last word's end is the start of the next chunk's
+    first word.
+
+    The default style block in the file is a sensible Shorts-tuned
+    baseline; ffmpeg's ``subtitles`` filter overrides it via
+    ``force_style=`` so the values pinned in
+    ``engine.video._SHORTS_SUBTITLES_FORCE_STYLE`` remain the source
+    of truth at render time.
+    """
+    if window_start_seconds < 0:
+        raise ValueError(
+            f"window_start_seconds must be >= 0, got {window_start_seconds}"
+        )
+    if window_duration_seconds <= 0:
+        raise ValueError(
+            f"window_duration_seconds must be > 0, got {window_duration_seconds}"
+        )
+    if audio_offset_seconds < 0:
+        raise ValueError(
+            f"audio_offset_seconds must be >= 0, got {audio_offset_seconds}"
+        )
+
+    try:
+        data = json.loads(transcript_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        logger.error("Transcript not found: %s", transcript_path)
+        raise
+    except json.JSONDecodeError as exc:
+        logger.error("Transcript JSON malformed (%s): %s", transcript_path, exc)
+        raise
+
+    segments = data.get("segments", []) if isinstance(data, dict) else []
+    window_end = window_start_seconds + window_duration_seconds
+
+    dialogue_lines: List[str] = []
+    for seg in segments:
+        if not isinstance(seg, dict):
+            continue
+        words = seg.get("words") or []
+        if not words:
+            continue
+        # Filter words to the Shorts window before chunking — avoids
+        # chunks that straddle the boundary.
+        in_window: List[dict] = []
+        for w in words:
+            if not isinstance(w, dict):
+                continue
+            try:
+                ws = float(w["start"]) + audio_offset_seconds
+                we = float(w["end"]) + audio_offset_seconds
+            except (KeyError, TypeError, ValueError):
+                continue
+            if we <= window_start_seconds or ws >= window_end:
+                continue
+            in_window.append(w)
+        if not in_window:
+            continue
+        for chunk in _chunk_words(
+            in_window,
+            max_chars=wrap_max_chars,
+            max_words_per_chunk=max_words_per_chunk,
+        ):
+            dialogue_lines.extend(
+                _render_chunk_dialogues(
+                    chunk,
+                    window_start=window_start_seconds,
+                    window_end=window_end,
+                    audio_offset=audio_offset_seconds,
+                )
+            )
+
+    body = _ASS_HEADER + "\n".join(dialogue_lines) + ("\n" if dialogue_lines else "")
+    try:
+        ass_path.write_text(body, encoding="utf-8")
+    except OSError as exc:
+        logger.error(
+            "Failed to write Shorts ASS to %s (%s): %s",
+            ass_path, type(exc).__name__, exc,
+        )
+        raise
+    if not dialogue_lines:
+        logger.info(
+            "Shorts window [%.2fs, %.2fs] (offset=%.2fs) contained no "
+            "word-level transcript data — ASS file written empty",
+            window_start_seconds, window_end, audio_offset_seconds,
+        )
+    else:
+        logger.info(
+            "Wrote %d per-word Shorts caption events → %s (window=[%.1fs, %.1fs])",
+            len(dialogue_lines), ass_path.name,
+            window_start_seconds, window_end,
+        )
+    return ass_path
+
+
 def find_transcript_for_episode(digests_dir: Path,
                                 episode_prefix: str,
                                 episode_num: int,

--- a/run_show.py
+++ b/run_show.py
@@ -2994,6 +2994,7 @@ def _publish_youtube(
 
     from engine.captions import (
         find_transcript_for_episode,
+        transcript_to_ass_window,
         transcript_to_srt,
         transcript_to_srt_window,
     )
@@ -3439,29 +3440,66 @@ def _publish_youtube(
             # the Shorts clip's own t=0 timeline. Same
             # ``voice_intro_delay`` offset the long-form SRT uses so
             # the cues land on speech in the final audio.
+            #
+            # Format selection (May 2026): try ASS first for per-word
+            # highlighting (TikTok-style "current word" pop). The
+            # ffmpeg ``subtitles`` filter accepts both .ass and .srt
+            # transparently, so swapping extensions on the wire needs
+            # no video.py change. If the ASS file is empty (older
+            # transcript without word_timestamps, or no overlap with
+            # the Shorts window), fall back to the legacy SRT format
+            # — better a static cue card than no captions.
             short_srt_path = None
             if transcript_path is not None:
                 try:
-                    short_srt_candidate = work_dir / f"{base_name}_short.srt"
                     _caption_offset = float(
                         getattr(config.audio, "voice_intro_delay", 0.0) or 0.0
                     )
-                    transcript_to_srt_window(
+                    short_ass_candidate = work_dir / f"{base_name}_short.ass"
+                    transcript_to_ass_window(
                         transcript_path,
-                        short_srt_candidate,
+                        short_ass_candidate,
                         window_start_seconds=short_offset,
                         window_duration_seconds=duration,
                         audio_offset_seconds=_caption_offset,
                     )
-                    if short_srt_candidate.exists() and short_srt_candidate.stat().st_size > 0:
-                        short_srt_path = short_srt_candidate
+                    has_word_cues = (
+                        short_ass_candidate.exists()
+                        and short_ass_candidate.stat().st_size > 0
+                        # The empty-state file still has the [Script Info]
+                        # header (~480 bytes); a populated file always has
+                        # at least one Dialogue line on top of that. Use a
+                        # threshold rather than zero so empty-state files
+                        # fall through to SRT fallback cleanly.
+                        and "Dialogue:" in short_ass_candidate.read_text(
+                            encoding="utf-8", errors="replace",
+                        )
+                    )
+                    if has_word_cues:
+                        short_srt_path = short_ass_candidate
                     else:
                         logger.info(
-                            "Shorts SRT empty — no cues fell inside the "
-                            "[%.1fs, %.1fs] window. Shorts ships without "
-                            "burned-in captions.",
+                            "Shorts per-word ASS contained no events — "
+                            "falling back to segment-level SRT for the "
+                            "[%.1fs, %.1fs] window.",
                             short_offset, short_offset + duration,
                         )
+                        short_srt_candidate = work_dir / f"{base_name}_short.srt"
+                        transcript_to_srt_window(
+                            transcript_path,
+                            short_srt_candidate,
+                            window_start_seconds=short_offset,
+                            window_duration_seconds=duration,
+                            audio_offset_seconds=_caption_offset,
+                        )
+                        if short_srt_candidate.exists() and short_srt_candidate.stat().st_size > 0:
+                            short_srt_path = short_srt_candidate
+                        else:
+                            logger.info(
+                                "Shorts SRT also empty — no cues fell "
+                                "inside the window. Shorts ships without "
+                                "burned-in captions.",
+                            )
                 except Exception as exc:  # pragma: no cover — best-effort
                     logger.warning("Shorts caption generation failed: %s", exc)
 

--- a/tests/test_captions_ass.py
+++ b/tests/test_captions_ass.py
@@ -1,0 +1,362 @@
+"""Tests for ``engine.captions.transcript_to_ass_window``.
+
+Covers the per-word ASS generator that powers TikTok-style "current
+word" highlighting on YouTube Shorts. Each Whisper segment carries a
+``words[]`` array; we emit one Dialogue line per word showing the
+chunk text with the active word colour-flipped to cyan.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from engine.captions import (
+    _chunk_words,
+    _format_ass_timestamp,
+    transcript_to_ass_window,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_transcript(
+    tmp: Path, segments: list, language: str = "en",
+) -> Path:
+    """Write a faster-whisper-shaped JSON transcript and return the path."""
+    p = tmp / "transcript.json"
+    p.write_text(json.dumps({
+        "language": language,
+        "language_probability": 1.0,
+        "duration": segments[-1]["end"] if segments else 0.0,
+        "segments": segments,
+    }), encoding="utf-8")
+    return p
+
+
+def _seg(start: float, end: float, words: list) -> dict:
+    """Build a segment dict from a list of (word, ws, we) tuples."""
+    return {
+        "start": start,
+        "end": end,
+        "text": " ".join(w[0] for w in words),
+        "words": [
+            {"word": w, "start": ws, "end": we, "probability": 0.95}
+            for (w, ws, we) in words
+        ],
+    }
+
+
+def _parse_dialogue_lines(ass_text: str) -> list:
+    """Return [(start, end, text), ...] for every Dialogue line in the file."""
+    out = []
+    for line in ass_text.splitlines():
+        if not line.startswith("Dialogue:"):
+            continue
+        # Dialogue: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+        parts = line[len("Dialogue:"):].split(",", 9)
+        if len(parts) != 10:
+            continue
+        out.append((parts[1].strip(), parts[2].strip(), parts[9]))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Timestamp formatting
+# ---------------------------------------------------------------------------
+
+
+def test_ass_timestamp_zero():
+    assert _format_ass_timestamp(0.0) == "0:00:00.00"
+
+
+def test_ass_timestamp_subsecond():
+    assert _format_ass_timestamp(0.34) == "0:00:00.34"
+
+
+def test_ass_timestamp_minutes_hours():
+    # 1h 2m 3.04s
+    assert _format_ass_timestamp(3723.04) == "1:02:03.04"
+
+
+def test_ass_timestamp_rounds_centiseconds():
+    assert _format_ass_timestamp(0.005) == "0:00:00.00" or \
+           _format_ass_timestamp(0.005) == "0:00:00.01"  # both valid roundings
+
+
+def test_ass_timestamp_clamps_negative():
+    assert _format_ass_timestamp(-1.5) == "0:00:00.00"
+
+
+# ---------------------------------------------------------------------------
+# Chunking
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_words_keeps_short_segment_in_one_chunk():
+    words = [
+        {"word": "hi", "start": 0.0, "end": 0.2},
+        {"word": "world", "start": 0.2, "end": 0.5},
+    ]
+    chunks = _chunk_words(words, max_chars=24, max_words_per_chunk=8)
+    assert len(chunks) == 1
+    assert [w["word"] for w in chunks[0]] == ["hi", "world"]
+
+
+def test_chunk_words_splits_on_char_budget():
+    # 6 four-letter words = 6*4 + 5 spaces = 29 chars at one boundary
+    # Under max_chars=24 should split.
+    words = [
+        {"word": f"word{i}", "start": float(i), "end": float(i) + 0.5}
+        for i in range(6)
+    ]
+    chunks = _chunk_words(words, max_chars=24, max_words_per_chunk=8)
+    # 6×"wordN" (5 chars) + spaces > 24 → expect at least 2 chunks.
+    assert len(chunks) >= 2
+    # Every chunk must respect the char budget.
+    for c in chunks:
+        joined = " ".join(w["word"] for w in c)
+        assert len(joined) <= 24
+
+
+def test_chunk_words_splits_on_word_count_ceiling():
+    # 10 single-character words = 19 chars total — under 24 — but the
+    # word-count cap kicks in at 8.
+    words = [
+        {"word": "a", "start": float(i), "end": float(i) + 0.1}
+        for i in range(10)
+    ]
+    chunks = _chunk_words(words, max_chars=24, max_words_per_chunk=8)
+    assert len(chunks) == 2
+    assert len(chunks[0]) == 8
+    assert len(chunks[1]) == 2
+
+
+def test_chunk_words_drops_blank_tokens():
+    words = [
+        {"word": "hello", "start": 0.0, "end": 0.2},
+        {"word": " ", "start": 0.2, "end": 0.21},  # Whisper artefact
+        {"word": "world", "start": 0.21, "end": 0.5},
+    ]
+    chunks = _chunk_words(words, max_chars=24, max_words_per_chunk=8)
+    flat = [w["word"].strip() for c in chunks for w in c]
+    assert "" not in flat
+
+
+# ---------------------------------------------------------------------------
+# transcript_to_ass_window — end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_emits_header_and_one_dialogue_per_word(tmp_path):
+    seg = _seg(
+        0.0, 1.5, [
+            ("Hello", 0.0, 0.3),
+            ("world", 0.3, 0.7),
+            ("from", 0.7, 0.9),
+            ("Tesla", 0.9, 1.5),
+        ],
+    )
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "short.ass"
+    transcript_to_ass_window(
+        tp, out,
+        window_start_seconds=0.0, window_duration_seconds=10.0,
+    )
+    body = out.read_text(encoding="utf-8")
+    assert body.startswith("[Script Info]")
+    assert "[V4+ Styles]" in body
+    assert "[Events]" in body
+    dialogues = _parse_dialogue_lines(body)
+    assert len(dialogues) == 4  # one per word
+
+
+def test_active_word_is_color_flipped(tmp_path):
+    """Each Dialogue line should highlight exactly one word; the rest
+    of the chunk text appears at the style default."""
+    seg = _seg(
+        0.0, 1.2, [
+            ("alpha", 0.0, 0.3),
+            ("beta", 0.3, 0.6),
+            ("gamma", 0.6, 1.2),
+        ],
+    )
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "short.ass"
+    transcript_to_ass_window(
+        tp, out,
+        window_start_seconds=0.0, window_duration_seconds=10.0,
+    )
+    dialogues = _parse_dialogue_lines(out.read_text(encoding="utf-8"))
+    # Highlight color appears exactly once per line.
+    for start, end, text in dialogues:
+        assert text.count("{\\1c&H00FFD400&}") == 1, (
+            f"line should have one highlight: {text!r}"
+        )
+        assert text.count("{\\r}") == 1
+    # The highlighted words progress: alpha, beta, gamma.
+    highlight_re = re.compile(r"\{\\1c&H00FFD400&\}([^{]+)\{\\r\}")
+    highlighted = [highlight_re.search(t).group(1).strip() for _, _, t in dialogues]
+    assert highlighted == ["alpha", "beta", "gamma"]
+
+
+def test_timestamps_rebase_onto_shorts_window(tmp_path):
+    """Words at audio t=10s in a window starting at 5s land at t=5s in
+    the Shorts ASS."""
+    seg = _seg(10.0, 11.0, [("only", 10.0, 11.0)])
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "short.ass"
+    transcript_to_ass_window(
+        tp, out,
+        window_start_seconds=5.0, window_duration_seconds=10.0,
+    )
+    dialogues = _parse_dialogue_lines(out.read_text(encoding="utf-8"))
+    assert len(dialogues) == 1
+    start, end, _ = dialogues[0]
+    assert start == "0:00:05.00"
+    assert end == "0:00:06.00"
+
+
+def test_audio_offset_applied_before_window_check(tmp_path):
+    """``audio_offset_seconds`` shifts whisper timestamps onto the
+    final-audio timeline before the window clip — same contract as
+    the SRT window function."""
+    # Whisper time t=0 ↔ final audio t=4.5 (music intro offset).
+    # Shorts window starts at final-audio t=5.0.
+    seg = _seg(1.0, 2.0, [("hello", 1.0, 2.0)])
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "short.ass"
+    transcript_to_ass_window(
+        tp, out,
+        window_start_seconds=5.0,
+        window_duration_seconds=5.0,
+        audio_offset_seconds=4.5,
+    )
+    dialogues = _parse_dialogue_lines(out.read_text(encoding="utf-8"))
+    assert len(dialogues) == 1
+    # whisper t=1.0 + offset 4.5 = 5.5 (final); window starts at 5.0
+    # → rebased to 0.5
+    start, end, _ = dialogues[0]
+    assert start == "0:00:00.50"
+    assert end == "0:00:01.50"
+
+
+def test_empty_when_no_overlap(tmp_path):
+    """When no words fall inside the window, only the header is
+    written (no Dialogue lines) — the caller treats this as 'no
+    captions' and falls back to SRT."""
+    seg = _seg(20.0, 22.0, [("late", 20.0, 22.0)])
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "short.ass"
+    transcript_to_ass_window(
+        tp, out,
+        window_start_seconds=0.0, window_duration_seconds=5.0,
+    )
+    body = out.read_text(encoding="utf-8")
+    assert "[Script Info]" in body
+    assert "Dialogue:" not in body
+
+
+def test_segment_without_words_is_skipped(tmp_path):
+    """Older transcripts (or any segment with no word_timestamps)
+    must not crash — the function silently skips them. The fallback
+    to SRT in run_show.py then handles the visual outcome."""
+    seg = {
+        "start": 0.0, "end": 2.0, "text": "no words here",
+        # explicitly no "words" key
+    }
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "short.ass"
+    transcript_to_ass_window(
+        tp, out,
+        window_start_seconds=0.0, window_duration_seconds=5.0,
+    )
+    dialogues = _parse_dialogue_lines(out.read_text(encoding="utf-8"))
+    assert dialogues == []
+
+
+def test_chunks_render_independently(tmp_path):
+    """A long segment with many words should produce multiple chunks;
+    each chunk should run its own per-word highlight cycle without
+    bleeding into the next chunk's text."""
+    seg = _seg(
+        0.0, 5.0, [
+            ("one", 0.0, 0.3), ("two", 0.3, 0.6), ("three", 0.6, 0.9),
+            ("four", 0.9, 1.2), ("five", 1.2, 1.5), ("six", 1.5, 1.8),
+            ("seven", 1.8, 2.1), ("eight", 2.1, 2.4),
+            ("nine", 2.4, 2.7), ("ten", 2.7, 3.0),
+            ("eleven", 3.0, 3.5), ("twelve", 3.5, 4.0),
+        ],
+    )
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "short.ass"
+    transcript_to_ass_window(
+        tp, out,
+        window_start_seconds=0.0, window_duration_seconds=10.0,
+    )
+    dialogues = _parse_dialogue_lines(out.read_text(encoding="utf-8"))
+    assert len(dialogues) == 12
+    # Each dialogue's plain text (after highlight tags) must contain
+    # ONLY the words from its own chunk, never all 12 words.
+    for _, _, text in dialogues:
+        # Strip override tags to count words.
+        plain = re.sub(r"\{[^}]*\}", "", text).strip()
+        word_count = len(plain.split())
+        assert word_count <= 8, (
+            f"chunk leaked too many words ({word_count}): {plain!r}"
+        )
+
+
+def test_invalid_args_raise(tmp_path):
+    seg = _seg(0.0, 1.0, [("hi", 0.0, 1.0)])
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "short.ass"
+    with pytest.raises(ValueError):
+        transcript_to_ass_window(
+            tp, out, window_start_seconds=-1.0, window_duration_seconds=5.0,
+        )
+    with pytest.raises(ValueError):
+        transcript_to_ass_window(
+            tp, out, window_start_seconds=0.0, window_duration_seconds=0.0,
+        )
+    with pytest.raises(ValueError):
+        transcript_to_ass_window(
+            tp, out, window_start_seconds=0.0, window_duration_seconds=5.0,
+            audio_offset_seconds=-0.5,
+        )
+
+
+def test_missing_transcript_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        transcript_to_ass_window(
+            tmp_path / "nope.json", tmp_path / "out.ass",
+            window_start_seconds=0.0, window_duration_seconds=5.0,
+        )
+
+
+def test_ass_escape_strips_braces(tmp_path):
+    """Curly braces in a Whisper artefact must be neutered so they
+    don't accidentally start an inline tag block."""
+    seg = _seg(0.0, 1.0, [("{evil}", 0.0, 0.5), ("hello", 0.5, 1.0)])
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "short.ass"
+    transcript_to_ass_window(
+        tp, out,
+        window_start_seconds=0.0, window_duration_seconds=5.0,
+    )
+    body = out.read_text(encoding="utf-8")
+    # ASS tag delimiter (`{`) must only appear inside our highlight
+    # tags, never as part of a token. Strip our known good tags and
+    # check no `{` remains in any Dialogue text.
+    for _, _, text in _parse_dialogue_lines(body):
+        without_tags = re.sub(r"\{\\1c&H[0-9A-F]+&\}", "", text)
+        without_tags = without_tags.replace(r"{\r}", "")
+        assert "{" not in without_tags, (
+            f"raw brace leaked into dialogue: {text!r}"
+        )


### PR DESCRIPTION
## Summary

Priority #1 from the previous Shorts PR's future-improvements list.
YouTube Shorts now ship with **per-word caption highlighting** instead
of static segment cards — the active word pops in Nerra cyan
(`#00D4FF` / ASS `&H00FFD400`) while the rest of the chunk stays at
the white style default. Same visual idiom as modern TikTok /
Instagram Reels auto-captions; the only modern-Shorts convention the
pipeline was missing.

## Why this was cheap to ship

The audit revealed `faster-whisper` already runs with
`word_timestamps=True` in `engine/transcripts.py:106` — every
transcript on disk for the last several months already carries
`segments[].words[].{word, start, end, probability}`. **No extra
transcription cost, no Whisper config change, no per-episode latency
hit.** All this PR does is read those word arrays (currently
discarded by the SRT generator) and emit them as ASS.

Also clean: ffmpeg's `subtitles` filter accepts `.ass` and `.srt`
files identically (same `force_style=` parameter), so no
`engine/video.py` change. The existing `_SHORTS_SUBTITLES_FORCE_STYLE`
(FontSize=48 bold on a 50%-opaque black box) is the source of truth
at render time; the ASS file's own `[V4+ Styles]` block is just a
sensible baseline.

## What's in here

| File | Change |
|---|---|
| `engine/captions.py` | New `transcript_to_ass_window` + `_chunk_words` + `_format_ass_timestamp` + `_render_chunk_dialogues` helpers. Pure functions of the transcript JSON's per-word timestamps. |
| `run_show.py` | Shorts pipeline tries ASS path first, falls back to legacy SRT if no word data or no events. Failure mode unchanged: empty caption file → no burn-in. |
| `.gitignore` | Exclude derived `.ass` files under `youtube_tmp/`. |
| `tests/test_captions_ass.py` | 19 unit tests. |
| `CLAUDE.md` | New paragraph under the May 2026 Shorts subsection. |

## How the visual works

Each Whisper segment is broken into chunks of ≤24 chars / ≤8 words.
Each chunk produces one Dialogue line per word; each line shows the
full chunk text with the active word colour-flipped via the inline
override `{\1c&H00FFD400&}word{\r}`. The cue duration matches that
word's `[start, end]` from Whisper.

Real Tesla Ep 411 transcript, the line *"system. However, early
indications show it won't immediately deliver lower prices for
buyers."* produced these per-word cues:

```
0:00:49.06,0:00:49.56  {\1c&H00FFD400&}system.{\r} However, early
0:00:49.90,0:00:50.14  system. {\1c&H00FFD400&}However,{\r} early
0:00:50.42,0:00:50.62  system. However, {\1c&H00FFD400&}early{\r}
0:00:50.62,0:00:51.10  {\1c&H00FFD400&}indications{\r} show it
0:00:51.10,0:00:51.54  indications {\1c&H00FFD400&}show{\r} it
0:00:51.54,0:00:51.78  indications show {\1c&H00FFD400&}it{\r}
0:00:51.78,0:00:52.14  {\1c&H00FFD400&}won't{\r} immediately
...
```

Visible behaviour on the rendered MP4: the caption card shows a
2-3-word chunk; the active word is cyan; the highlight steps to the
next word at Whisper's word boundaries.

## Fallback behaviour

`run_show.py` checks the generated ASS for `Dialogue:` lines. If
there are none (e.g. older transcript without word data, or no
overlap with the Shorts window), it falls through to the legacy
`transcript_to_srt_window` path — segment-level cues, the same as
the previous PR. Captions are always present in *some* form; the
Shorts pipeline never silently regresses to a no-caption build.

## Test plan

- [x] `pytest tests/test_captions_ass.py` — 19 passed
- [x] `pytest tests/test_captions.py tests/test_captions_ass.py tests/test_video_commands.py tests/test_thumbnail_autofit.py` — 95 passed (no regressions on adjacent tests)
- [x] Live probe against `digests/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep411_20260318_transcript.json` — generates correct per-word ASS with realistic word timings
- [ ] **Pending after merge:** next Tesla / MAB Shorts upload — phone-screen check that the highlight visibly steps from word to word and the active word reads clearly in cyan against the black card

## What's next from the priority list

- **Smart Shorts segment selection** — auto-pick the most engaging
  55s window (heuristics over the digest, LLM scoring fallback)
- **End-screen CTA overlay** — last 3s "Subscribe + Watch full
  episode" card

Ready to tackle either next. The Shorts visual layer is now at parity
with modern conventions.

https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2)_