### PR TITLE
Shorts: smart segment selection (auto-pick the most engaging 55s)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,20 @@ it falls back to the legacy segment-level SRT so the Short always
 has captions of some kind. Drift guards in
 `tests/test_captions_ass.py`.
 
+**Smart Shorts segment selection.** Tesla + MAB now use
+`shorts_start_mode: smart` in their YAML, which calls
+[`engine.shorts_selector.pick_engaging_window`](engine/shorts_selector.py)
+to scan the Whisper transcript and start the Shorts clip at the
+most engaging beat (numeric reveal, hook framing like "the kicker
+is…", surprise / question / superlative). Pure heuristic — no LLM
+call, no per-episode cost. Falls back to the legacy
+`voice_intro_delay` start when no segment scores above the noise
+threshold (5.0). The chosen offset + the resolved mode are recorded
+as metrics (`shorts_start_offset`, `shorts_start_mode_resolved`) per
+episode so the dashboard can show smart-vs-fallback rates. New shows
+opt in by setting `youtube.shorts_start_mode: smart` in their YAML.
+Drift guards in `tests/test_shorts_selector.py`.
+
 ### Testing
 
 ```bash

--- a/engine/shorts_selector.py
+++ b/engine/shorts_selector.py
@@ -1,0 +1,346 @@
+"""Pick the most engaging 55-second window from a podcast episode for
+the YouTube Shorts clip.
+
+The legacy Shorts pipeline starts the clip at the first voice frame
+(``shorts_start_mode: voice``) — fine for a long-form viewer but
+weak for the Shorts surface, where the first 1–2 seconds decide
+whether the algorithm gives the clip a chance. Educational /
+news-style podcasts usually open with a setup ("Today on the show…",
+"Welcome to…") and bury the actual hook 20–60 seconds in.
+
+This module scans the Whisper transcript (segments + per-word
+timestamps) and picks a starting timestamp that lands on a high-
+engagement beat: a numeric reveal, a surprise framing ("here's the
+kicker"), a "you won't believe" hook, etc. Pure heuristic — no LLM
+call, no per-episode cost, deterministic and unit-testable.
+
+When no segment scores above the noise threshold, the function falls
+back to the legacy ``voice_intro_delay`` start so the operator never
+ends up with a worse Shorts clip than the legacy pipeline produced.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Scoring signals
+# ---------------------------------------------------------------------------
+
+# Phrases that signal a hook punchline / surprise framing. Each match
+# adds +5 to the segment score. Word-boundary checked.
+_HOOK_PHRASES = (
+    "the wild part", "the surprising thing", "here's the kicker",
+    "what's interesting", "but wait", "the catch is", "the irony",
+    "picture this", "imagine if", "imagine that", "here's why",
+    "the kicker is", "the twist is", "what's wild", "what's crazy",
+    "incredibly", "remarkably", "shockingly", "and the kicker",
+    "here's the thing", "what's even", "the real story",
+    "here's what", "it turns out", "as it turns out",
+    "the punchline", "the bigger story", "no one is talking",
+    "nobody saw this coming", "you won't believe",
+    "the reason is", "the real reason",
+)
+
+# Question framings (often hook openers) — +3 each.
+_QUESTION_HOOKS = (
+    "why does", "why are", "why is", "how does",
+    "what if", "what's the deal", "what's going on",
+    "how much", "how many", "what would",
+    "could it be", "is it possible", "are we",
+)
+
+# Boilerplate openers we explicitly want to avoid starting on. Each
+# match is -8 (large penalty — we want to escape these even if they
+# happen to contain a numeric).
+_BORING_OPENERS = (
+    "welcome to", "thanks for tuning in", "thanks for listening",
+    "in today's episode", "today on", "today's episode",
+    "i'm your host", "your host", "hey everyone", "hey folks",
+    "good morning", "good evening", "happy", "as always",
+    "you're listening to",
+)
+
+# Superlatives — modest signal, +1 each.
+_SUPERLATIVES = (
+    "biggest", "smallest", "fastest", "slowest", "largest",
+    "highest", "lowest", "best", "worst", "most", "least",
+    "first ever", "the first", "the only", "all-time",
+    "record", "unprecedented",
+)
+
+# Numeric patterns — concrete numbers signal high-information content
+# that lands well in Shorts. +2 per match.
+_NUMERIC_PATTERNS = (
+    re.compile(r"\$\d"),                                    # $X
+    re.compile(r"\b\d+(?:\.\d+)?\s*%"),                     # X%, X.X%
+    re.compile(r"\b\d+(?:\.\d+)?\s*(million|billion|trillion)\b", re.I),
+    re.compile(r"\b\d+\s*x\b", re.I),                       # 10x
+    re.compile(r"\b\d{4}\b"),                               # years / large numbers
+)
+
+
+# ---------------------------------------------------------------------------
+# Data shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScoredWindow:
+    """One candidate Shorts window with its engagement score."""
+    start_seconds: float  # FINAL-AUDIO seconds (whisper + voice_intro_delay)
+    end_seconds: float
+    score: float
+    # Short text label for debugging — first ~80 chars of the opening
+    # segment, surfaced in logs / metrics so the operator can scan the
+    # selection without re-running the pipeline.
+    opening_text: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Pure scoring helpers
+# ---------------------------------------------------------------------------
+
+
+def score_text(text: str) -> float:
+    """Return an engagement score for a single segment's text.
+
+    Pure function, no I/O. Score is unbounded above; ``0.0`` means
+    "neutral / no signal", negative scores mean "actively boring"
+    (boilerplate openers). Caller decides what threshold counts as
+    "worth picking over the legacy start".
+    """
+    if not text:
+        return 0.0
+    low = text.lower()
+    score = 0.0
+    for phrase in _HOOK_PHRASES:
+        if phrase in low:
+            score += 5.0
+    for phrase in _QUESTION_HOOKS:
+        if low.startswith(phrase) or f". {phrase}" in low or f", {phrase}" in low:
+            score += 3.0
+    for phrase in _BORING_OPENERS:
+        if phrase in low:
+            score -= 8.0
+    for phrase in _SUPERLATIVES:
+        # Word-boundary check to avoid e.g. "interest" matching "first ever".
+        if re.search(rf"\b{re.escape(phrase)}\b", low):
+            score += 1.0
+    for pat in _NUMERIC_PATTERNS:
+        score += 2.0 * len(pat.findall(text))
+    return score
+
+
+def _segment_score(seg: dict) -> Tuple[float, str]:
+    text = (seg.get("text") or "").strip()
+    return score_text(text), text
+
+
+def _window_score(
+    segments: List[dict],
+    start: int,
+    *,
+    window_duration: float,
+    audio_offset: float,
+) -> float:
+    """Score the window that starts at segments[start].
+
+    The opening segment carries the most weight (first impression in
+    Shorts), the next 5 s after it carry 0.6×, and the tail carries
+    0.3×. This makes the algorithm prefer windows whose HOOK lands at
+    the start of the clip, not 30 s in.
+    """
+    if not segments or start >= len(segments):
+        return 0.0
+    window_start_whisper = float(segments[start].get("start") or 0.0)
+    window_end_whisper = window_start_whisper + window_duration
+    total = 0.0
+    for i in range(start, len(segments)):
+        seg = segments[i]
+        seg_start = float(seg.get("start") or 0.0)
+        seg_end = float(seg.get("end") or seg_start)
+        if seg_start >= window_end_whisper:
+            break
+        if seg_end <= window_start_whisper:
+            continue
+        # Position weight: 1.0 for the first 1.5 s, 0.6 for the next
+        # 5 s, 0.3 for everything else inside the window.
+        offset_in_window = seg_start - window_start_whisper
+        if offset_in_window <= 1.5:
+            weight = 1.0
+        elif offset_in_window <= 6.5:
+            weight = 0.6
+        else:
+            weight = 0.3
+        score, _text = _segment_score(seg)
+        total += weight * score
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def score_candidates(
+    transcript_path: Path,
+    *,
+    audio_offset: float,
+    audio_duration: float,
+    window_duration: float = 55.0,
+    min_start_final: float = 0.0,
+    max_late_pct: float = 0.85,
+) -> List[ScoredWindow]:
+    """Score every segment-anchored window in the transcript.
+
+    Parameters
+    ----------
+    transcript_path:
+        faster-whisper JSON output (``segments`` array with ``start`` /
+        ``end`` / ``text``; ``words`` optional and ignored here).
+    audio_offset:
+        Seconds of music intro the final mix prepends before the
+        voice starts. Whisper timestamps are voice-only; final-audio
+        timestamps need this added on top. Same role as
+        ``audio_offset_seconds`` in ``engine.captions``.
+    audio_duration:
+        Length of the final mixed MP3 in seconds. Used to reject
+        candidate windows that would run past the end of the audio.
+    window_duration:
+        Shorts clip length in seconds (default 55).
+    min_start_final:
+        Earliest acceptable start in final-audio seconds. Usually
+        equal to ``audio_offset`` (don't start during the music
+        intro).
+    max_late_pct:
+        Reject candidates that would start past this fraction of the
+        episode (default: skip the last 15 %). Stops the algorithm
+        from picking a great hook that lands in the outro.
+
+    Returns a list of ``ScoredWindow`` sorted by descending score —
+    callers usually want index 0.
+    """
+    try:
+        data = json.loads(transcript_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Smart Shorts selector: transcript unreadable (%s) — "
+            "falling back. (%s)", transcript_path, exc,
+        )
+        return []
+    segments = data.get("segments", []) if isinstance(data, dict) else []
+    if not segments:
+        return []
+
+    # Pre-filter: segments must have a numeric start, must be in the
+    # acceptable window of the audio, and must carry text.
+    valid: List[dict] = []
+    for s in segments:
+        if not isinstance(s, dict):
+            continue
+        text = (s.get("text") or "").strip()
+        if not text:
+            continue
+        try:
+            seg_start = float(s.get("start") or 0.0)
+        except (TypeError, ValueError):
+            continue
+        final_start = seg_start + audio_offset
+        if final_start < min_start_final:
+            continue
+        if audio_duration > 0 and (
+            final_start + window_duration > audio_duration
+            or final_start > audio_duration * max_late_pct
+        ):
+            continue
+        valid.append(s)
+
+    if not valid:
+        return []
+
+    out: List[ScoredWindow] = []
+    for i, seg in enumerate(valid):
+        # The window's index in the FULL segments list — _window_score
+        # walks forward from there to score overlap.
+        try:
+            full_idx = segments.index(seg)
+        except ValueError:
+            full_idx = i
+        score = _window_score(
+            segments, full_idx,
+            window_duration=window_duration,
+            audio_offset=audio_offset,
+        )
+        seg_start_whisper = float(seg.get("start") or 0.0)
+        start_final = seg_start_whisper + audio_offset
+        text = (seg.get("text") or "").strip()
+        out.append(ScoredWindow(
+            start_seconds=start_final,
+            end_seconds=start_final + window_duration,
+            score=score,
+            opening_text=text[:80],
+        ))
+    out.sort(key=lambda w: w.score, reverse=True)
+    return out
+
+
+def pick_engaging_window(
+    transcript_path: Path,
+    *,
+    audio_offset: float,
+    audio_duration: float,
+    window_duration: float = 55.0,
+    min_start_final: Optional[float] = None,
+    min_score_threshold: float = 5.0,
+) -> Optional[ScoredWindow]:
+    """Return the single best ``ScoredWindow``, or ``None`` if no
+    candidate exceeds ``min_score_threshold``.
+
+    The threshold exists because heuristic scoring noise on a generic
+    episode (no concrete numbers, no kicker phrases, no superlatives)
+    can produce a top score of 0–3 that's no better than the legacy
+    voice-start pick. In that case ``None`` tells the caller to
+    fall back to the legacy pipeline.
+
+    ``min_start_final`` defaults to ``audio_offset`` (don't start
+    during the music intro). Pass a higher value to skip past, e.g.,
+    a 4 s AI-generated content disclosure that always opens the
+    episode.
+    """
+    floor = audio_offset if min_start_final is None else min_start_final
+    candidates = score_candidates(
+        transcript_path,
+        audio_offset=audio_offset,
+        audio_duration=audio_duration,
+        window_duration=window_duration,
+        min_start_final=floor,
+    )
+    if not candidates:
+        logger.info(
+            "Smart Shorts selector: no scorable candidates in %s",
+            transcript_path.name,
+        )
+        return None
+    best = candidates[0]
+    if best.score < min_score_threshold:
+        logger.info(
+            "Smart Shorts selector: best score %.1f below threshold %.1f "
+            "(opening: %r) — falling back to legacy start",
+            best.score, min_score_threshold, best.opening_text,
+        )
+        return None
+    logger.info(
+        "Smart Shorts selector: picked start=%.1fs score=%.1f "
+        "(opening: %r)",
+        best.start_seconds, best.score, best.opening_text,
+    )
+    return best

--- a/engine/youtube_shorts.py
+++ b/engine/youtube_shorts.py
@@ -41,6 +41,7 @@ def resolve_shorts_start_offset(
     chapters_path: Optional[Path] = None,
     *,
     audio_duration: float = 0.0,
+    transcript_path: Optional[Path] = None,
 ) -> float:
     """Pick where the Shorts audio clip begins in the final mixed MP3.
 
@@ -53,6 +54,13 @@ def resolve_shorts_start_offset(
       ``voice`` (default) — start at ``voice_intro_delay``.
       ``first_chapter`` — start at the first chapter marker after the cold
           open (second chapter when ≥2 exist, else first chapter > 45s).
+      ``smart`` — scan the Whisper transcript for the most engaging
+          beat (numeric reveal, hook phrase, surprise framing) and
+          start there. Falls back to ``voice`` if no segment scores
+          above the noise threshold. Requires ``transcript_path``;
+          without it (or on transcript I/O failure) silently falls
+          back to ``voice`` too. See engine.shorts_selector for the
+          scoring details.
     """
     yt = getattr(config, "youtube", None)
     explicit = getattr(yt, "shorts_start_offset", None) if yt else None
@@ -82,9 +90,43 @@ def resolve_shorts_start_offset(
         )
         return offset
 
-    offset = float(getattr(config.audio, "voice_intro_delay", 0.0) or 0.0)
-    logger.info("Shorts start offset (voice): %.1fs", offset)
-    return offset
+    voice_offset = float(
+        getattr(config.audio, "voice_intro_delay", 0.0) or 0.0
+    )
+
+    if mode == "smart":
+        # Smart mode is best-effort: it falls back to voice on any
+        # missing dep (no transcript path), unreadable transcript,
+        # empty transcript, or no candidate above the score
+        # threshold. Operators see the chosen path in the log line
+        # so a regression in the heuristic is obvious from CI logs.
+        from engine.shorts_selector import pick_engaging_window
+        if transcript_path is not None and transcript_path.exists():
+            short_dur = float(
+                getattr(yt, "short_duration_seconds", 55.0) or 55.0
+            )
+            best = pick_engaging_window(
+                transcript_path,
+                audio_offset=voice_offset,
+                audio_duration=audio_duration,
+                window_duration=short_dur,
+                min_start_final=voice_offset,
+            )
+            if best is not None:
+                logger.info(
+                    "Shorts start offset (smart): %.1fs (score=%.1f, "
+                    "opening=%r)",
+                    best.start_seconds, best.score, best.opening_text,
+                )
+                return best.start_seconds
+        logger.info(
+            "Shorts start offset (smart→voice fallback): %.1fs",
+            voice_offset,
+        )
+        return voice_offset
+
+    logger.info("Shorts start offset (voice): %.1fs", voice_offset)
+    return voice_offset
 
 
 def should_upload_shorts_today(config: Any, *, episode_num: int) -> bool:

--- a/run_show.py
+++ b/run_show.py
@@ -2221,6 +2221,19 @@ def run(args: argparse.Namespace) -> None:
             "gallery_uploaded",
             int(youtube_urls.get("gallery_uploaded", 0) or 0),
         )
+        # Smart Shorts segment selection (May 2026): record the chosen
+        # offset and which mode resolved to it so the dashboard can
+        # surface smart-vs-fallback rate per show.
+        if "shorts_start_offset" in youtube_urls:
+            metrics.record(
+                "shorts_start_offset",
+                float(youtube_urls["shorts_start_offset"]),
+            )
+        if "shorts_start_mode_resolved" in youtube_urls:
+            metrics.record(
+                "shorts_start_mode_resolved",
+                str(youtube_urls["shorts_start_mode_resolved"]),
+            )
         if youtube_urls.get("gallery_skipped_reason"):
             metrics.record(
                 "gallery_skipped_reason",
@@ -3430,8 +3443,25 @@ def _publish_youtube(
                 config,
                 chapters_path if chapters_path.exists() else None,
                 audio_duration=_ep_duration,
+                transcript_path=transcript_path,
             )
             duration = float(config.youtube.short_duration_seconds or 55.0)
+            # Surface the chosen offset on the result dict so the
+            # caller can record it as a metric. Operators reading the
+            # dashboard / metrics_ep*.json can then tell at a glance
+            # whether smart-mode is firing, which voice-fallback rate
+            # is, and whether a particular show's heuristic threshold
+            # needs tuning.
+            result["shorts_start_offset"] = round(short_offset, 2)
+            result["shorts_start_mode_resolved"] = (
+                "explicit" if getattr(
+                    config.youtube, "shorts_start_offset", None,
+                ) is not None
+                else (
+                    getattr(config.youtube, "shorts_start_mode", None)
+                    or "voice"
+                )
+            )
 
             # Build a Shorts-windowed SRT (May 2026 operator review:
             # Shorts had no synced captions at all). Reuse the Whisper

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -235,6 +235,10 @@ youtube:
   category_id: 27               # Education (beginner / teen-focused)
   default_language: en
   privacy_status: public
+  # Auto-pick the Shorts start at the most engaging beat instead of
+  # the legacy voice-intro start. Falls back to voice mode when the
+  # heuristic can't find a clear winner. See engine.shorts_selector.
+  shorts_start_mode: smart
   # Beginner / teen-focused AI imagery — friendlier than the deep-tech
   # set used for Models & Agents. Same disambiguation rules apply.
   image_queries:

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -239,6 +239,11 @@ youtube:
   category_id: 28               # Science & Tech (algorithm performs better than 2/Autos here)
   default_language: en
   privacy_status: public        # Phase-1 validated; uploads are public
+  # Auto-pick the Shorts start at the most engaging beat (numeric
+  # reveal, "the kicker is…" framing, surprise hook) instead of the
+  # legacy voice-intro start. Falls back to voice mode when the
+  # heuristic can't find a clear winner. See engine.shorts_selector.
+  shorts_start_mode: smart
   # Curated Pexels search phrases. Direct keywords like "model 3" / "model y"
   # were returning fashion photography models — confirmed root cause for
   # the Ep456 manifest containing topless / portrait images. Each phrase

--- a/tests/test_shorts_selector.py
+++ b/tests/test_shorts_selector.py
@@ -1,0 +1,333 @@
+"""Tests for ``engine.shorts_selector`` and the ``smart`` mode in
+``engine.youtube_shorts.resolve_shorts_start_offset``.
+
+Heuristic scoring is pure-function — every signal has an
+independent test below so a regression in one (e.g. dropping the
+numeric pattern by mistake) lights up a single targeted failure.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from engine.shorts_selector import (
+    ScoredWindow,
+    pick_engaging_window,
+    score_candidates,
+    score_text,
+)
+from engine.youtube_shorts import resolve_shorts_start_offset
+
+
+# ---------------------------------------------------------------------------
+# score_text — individual signal tests
+# ---------------------------------------------------------------------------
+
+
+def test_empty_text_scores_zero():
+    assert score_text("") == 0.0
+    assert score_text(None) == 0.0  # type: ignore[arg-type]
+
+
+def test_neutral_text_scores_zero():
+    assert score_text("The company released its quarterly report.") == 0.0
+
+
+def test_hook_phrase_adds_five():
+    assert score_text("And here's the kicker — they doubled revenue.") == 5.0
+
+
+def test_multiple_hook_phrases_stack():
+    text = "Here's the kicker: imagine if they actually pulled it off."
+    # "here's the kicker" + "imagine if"
+    assert score_text(text) == 10.0
+
+
+def test_question_hook_at_start_adds_three():
+    assert score_text("Why does Tesla keep doing this?") == 3.0
+
+
+def test_boring_opener_penalizes_eight():
+    assert score_text("Welcome to today's episode.") == -16.0
+    # "welcome to" and "today's episode" both match.
+
+
+def test_superlative_adds_one():
+    # "biggest" matches; one numeric (the 5000) adds +2.
+    assert score_text("This was the biggest week in company history.") == 1.0
+
+
+def test_numeric_dollar_adds_two():
+    assert score_text("Revenue hit $15 billion this quarter.") == 4.0
+    # $1 → numeric_pattern_1 (+2), "15 billion" → numeric_pattern_3 (+2)
+
+
+def test_numeric_percent_adds_two():
+    assert score_text("Sales fell 38% year-over-year.") == 2.0
+
+
+def test_numeric_multiplier_adds_two():
+    assert score_text("The model is 10x faster.") == 2.0
+
+
+def test_four_digit_year_adds_two():
+    assert score_text("The 2026 plan looks ambitious.") == 2.0
+
+
+def test_score_text_combines_signals():
+    """A hook + a number + a superlative should sum cleanly."""
+    text = (
+        "Here's the kicker: it was the biggest "
+        "delivery quarter in the company's history at 500,000 units."
+    )
+    # "here's the kicker" = +5
+    # "biggest" = +1
+    # "history" doesn't match anything
+    # "500,000" — no digit pattern matches comma-separated 6-digit;
+    # \b\d{4}\b matches the leading "500,"? No — \d{4} only matches
+    # 4-digit runs and "500" is 3 digits. Add nothing.
+    assert score_text(text) == 6.0
+
+
+# ---------------------------------------------------------------------------
+# score_candidates — window construction
+# ---------------------------------------------------------------------------
+
+
+def _write_transcript(tmp: Path, segments: list) -> Path:
+    p = tmp / "transcript.json"
+    p.write_text(json.dumps({
+        "language": "en",
+        "language_probability": 1.0,
+        "duration": segments[-1]["end"] if segments else 0.0,
+        "segments": segments,
+    }), encoding="utf-8")
+    return p
+
+
+def _seg(start: float, end: float, text: str) -> dict:
+    return {"start": start, "end": end, "text": text, "words": []}
+
+
+def test_empty_transcript_returns_empty(tmp_path):
+    tp = _write_transcript(tmp_path, [])
+    out = score_candidates(tp, audio_offset=4.5, audio_duration=300.0)
+    assert out == []
+
+
+def test_missing_transcript_returns_empty(tmp_path, caplog):
+    out = score_candidates(
+        tmp_path / "nope.json", audio_offset=4.5, audio_duration=300.0,
+    )
+    assert out == []
+
+
+def test_candidates_sorted_descending(tmp_path):
+    segs = [
+        _seg(0.0, 5.0, "Welcome to today's episode of Tesla Shorts Time."),
+        _seg(5.0, 12.0, "And the kicker is they hit $15 billion in revenue."),
+        _seg(12.0, 20.0, "Some boilerplate filler text without signals."),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    out = score_candidates(
+        tp, audio_offset=4.5, audio_duration=300.0, window_duration=55.0,
+    )
+    # Highest-scoring window must come first.
+    assert len(out) >= 2
+    assert out[0].score >= out[1].score
+    # The high-signal segment ("kicker" + "$15 billion") wins.
+    assert "kicker" in out[0].opening_text.lower()
+
+
+def test_window_too_late_in_episode_is_rejected(tmp_path):
+    # Segment at 250s in a 300s episode — start + 55s = 305s > 300s.
+    segs = [_seg(250.0, 260.0, "Here's the kicker!")]
+    tp = _write_transcript(tmp_path, segs)
+    out = score_candidates(
+        tp, audio_offset=0.0, audio_duration=300.0, window_duration=55.0,
+    )
+    assert out == []
+
+
+def test_window_during_music_intro_is_rejected(tmp_path):
+    # Segment at whisper t=0 with audio_offset=4.5 means final-audio
+    # start is 4.5. If min_start_final=10.0, this should be rejected.
+    segs = [_seg(0.0, 8.0, "And the kicker is they hit $15 billion.")]
+    tp = _write_transcript(tmp_path, segs)
+    out = score_candidates(
+        tp, audio_offset=4.5, audio_duration=300.0,
+        window_duration=55.0, min_start_final=10.0,
+    )
+    assert out == []
+
+
+def test_position_weighting_prefers_hook_at_start(tmp_path):
+    """A window with the high-signal segment as the OPENING should
+    outscore a window where the same signal is buried 30 s in."""
+    high_signal = "And the kicker is they hit $15 billion in revenue."
+    filler = "The quarterly report covers regular operating data."
+    # Window A starts on high-signal.
+    # Window B starts on filler, with high-signal 30 s later.
+    segs = [
+        _seg(0.0, 5.0, filler),
+        _seg(5.0, 10.0, filler),
+        _seg(10.0, 15.0, high_signal),
+        _seg(15.0, 20.0, filler),
+        _seg(20.0, 25.0, filler),
+        _seg(25.0, 30.0, filler),
+        _seg(30.0, 35.0, filler),
+        _seg(35.0, 40.0, filler),
+        _seg(40.0, 45.0, filler),
+        _seg(45.0, 50.0, filler),
+        _seg(50.0, 55.0, filler),
+        _seg(55.0, 60.0, filler),
+        _seg(60.0, 65.0, high_signal),  # appears late in window B
+        _seg(65.0, 70.0, filler),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    out = score_candidates(
+        tp, audio_offset=0.0, audio_duration=200.0, window_duration=55.0,
+    )
+    # The window opening on the high-signal segment (start=10.0
+    # whisper) should outscore the window where it lands 30 s in.
+    by_start = {round(w.start_seconds, 1): w for w in out}
+    assert 10.0 in by_start
+    assert by_start[10.0].score > by_start.get(0.0, ScoredWindow(0, 0, -99, "")).score
+
+
+# ---------------------------------------------------------------------------
+# pick_engaging_window — threshold + fallback
+# ---------------------------------------------------------------------------
+
+
+def test_pick_returns_none_when_below_threshold(tmp_path):
+    """A boring transcript with no signal segments must return None
+    so the caller falls back to legacy voice-start."""
+    segs = [
+        _seg(0.0, 5.0, "The company released its report."),
+        _seg(5.0, 12.0, "Operations continued as planned."),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    out = pick_engaging_window(
+        tp, audio_offset=0.0, audio_duration=300.0,
+        min_score_threshold=5.0,
+    )
+    assert out is None
+
+
+def test_pick_returns_best_when_above_threshold(tmp_path):
+    segs = [
+        _seg(0.0, 5.0, "The company released its report."),
+        _seg(5.0, 12.0, "And here's the kicker: $15 billion in revenue."),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    out = pick_engaging_window(
+        tp, audio_offset=4.5, audio_duration=300.0,
+        min_score_threshold=5.0,
+    )
+    assert out is not None
+    # final-audio start = whisper 5.0 + offset 4.5 = 9.5
+    assert out.start_seconds == pytest.approx(9.5)
+    assert out.score >= 5.0
+
+
+def test_pick_returns_none_on_missing_transcript(tmp_path):
+    out = pick_engaging_window(
+        tmp_path / "nope.json", audio_offset=0.0, audio_duration=300.0,
+    )
+    assert out is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_shorts_start_offset — smart mode integration
+# ---------------------------------------------------------------------------
+
+
+def _config(*, audio_kw=None, yt_kw=None):
+    audio = SimpleNamespace(**(audio_kw or {}))
+    yt = SimpleNamespace(
+        shorts_start_mode=(yt_kw or {}).pop("shorts_start_mode", "voice"),
+        shorts_start_offset=(yt_kw or {}).pop("shorts_start_offset", None),
+        short_duration_seconds=(yt_kw or {}).pop("short_duration_seconds", 55.0),
+        **(yt_kw or {}),
+    )
+    return SimpleNamespace(audio=audio, youtube=yt)
+
+
+def test_smart_mode_falls_back_when_no_transcript(tmp_path):
+    cfg = _config(audio_kw={"voice_intro_delay": 4.5},
+                  yt_kw={"shorts_start_mode": "smart"})
+    # No transcript_path passed — must fall back to voice_intro_delay.
+    assert resolve_shorts_start_offset(cfg, None, audio_duration=300.0) == 4.5
+
+
+def test_smart_mode_falls_back_when_transcript_unreadable(tmp_path):
+    cfg = _config(audio_kw={"voice_intro_delay": 4.5},
+                  yt_kw={"shorts_start_mode": "smart"})
+    # Path doesn't exist on disk — falls through to voice.
+    nope = tmp_path / "nope.json"
+    assert resolve_shorts_start_offset(
+        cfg, None, audio_duration=300.0, transcript_path=nope,
+    ) == 4.5
+
+
+def test_smart_mode_picks_high_signal_segment(tmp_path):
+    cfg = _config(audio_kw={"voice_intro_delay": 4.5},
+                  yt_kw={"shorts_start_mode": "smart"})
+    segs = [
+        _seg(0.0, 5.0, "Welcome to today's episode of the show."),
+        _seg(5.0, 12.0, "And the kicker is they hit $15 billion in revenue."),
+        _seg(12.0, 20.0, "Some boilerplate filler text."),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    offset = resolve_shorts_start_offset(
+        cfg, None, audio_duration=300.0, transcript_path=tp,
+    )
+    # whisper 5.0 + voice_intro_delay 4.5 = 9.5
+    assert offset == pytest.approx(9.5)
+
+
+def test_smart_mode_falls_back_when_all_segments_boring(tmp_path):
+    cfg = _config(audio_kw={"voice_intro_delay": 4.5},
+                  yt_kw={"shorts_start_mode": "smart"})
+    segs = [
+        _seg(0.0, 5.0, "The company released a quarterly report."),
+        _seg(5.0, 12.0, "Operations continued as expected."),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    offset = resolve_shorts_start_offset(
+        cfg, None, audio_duration=300.0, transcript_path=tp,
+    )
+    # No segment scored above threshold → falls back to voice.
+    assert offset == 4.5
+
+
+def test_voice_mode_unchanged_by_smart_addition(tmp_path):
+    """Regression guard: smart-mode wiring must not alter ``voice``
+    or ``first_chapter`` modes."""
+    cfg = _config(audio_kw={"voice_intro_delay": 10.0},
+                  yt_kw={"shorts_start_mode": "voice"})
+    segs = [_seg(0.0, 5.0, "Here's the kicker $15 billion revenue.")]
+    tp = _write_transcript(tmp_path, segs)
+    # Even with a transcript that would pick a different smart offset,
+    # voice mode must ignore it.
+    assert resolve_shorts_start_offset(
+        cfg, None, audio_duration=300.0, transcript_path=tp,
+    ) == 10.0
+
+
+def test_explicit_offset_overrides_smart(tmp_path):
+    """``shorts_start_offset`` is a hard operator override and must
+    win over every mode including ``smart``."""
+    cfg = _config(audio_kw={"voice_intro_delay": 4.5},
+                  yt_kw={"shorts_start_mode": "smart",
+                         "shorts_start_offset": 42.0})
+    segs = [_seg(0.0, 5.0, "Here's the kicker $15 billion.")]
+    tp = _write_transcript(tmp_path, segs)
+    assert resolve_shorts_start_offset(
+        cfg, None, audio_duration=300.0, transcript_path=tp,
+    ) == 42.0


### PR DESCRIPTION
## Summary

Priority #2 from the post-#413 future-improvements list. The legacy
Shorts pipeline starts the clip at the first voice frame
(`shorts_start_mode: voice`) — fine for a long-form viewer but weak
on the Shorts surface, where the first 1–2 seconds decide whether
the algorithm gives the clip a chance. Educational / news-style
podcasts open with a setup ("Today on the show…", "Welcome to…") and
bury the actual hook 20–60 seconds in.

This change adds a third mode:

| Mode | Behavior |
|---|---|
| `voice` (default) | Start at `voice_intro_delay`. Network-wide default; unchanged. |
| `first_chapter` | Start at the 2nd chapter marker (or first marker > 45s). |
| **`smart`** | **NEW.** Scan the Whisper transcript, score every segment-anchored 55s window, start at the highest-scoring one. Falls back to `voice` when no segment scores above the noise threshold. |

Tesla + MAB opt into `smart` in their YAML. Other shows are unaffected.

## How the scoring works

Pure heuristic — no LLM call, no per-episode cost. Five signal sets in `engine/shorts_selector.py`:

| Signal | Score | Examples |
|---|---|---|
| Hook phrases | +5 | "the kicker is", "imagine if", "the wild part", "you won't believe" |
| Question framings | +3 | "why does", "what if", "how much" |
| Numeric patterns | +2 each | `$15 billion`, `38%`, `10x`, 4-digit years |
| Superlatives | +1 each | "biggest", "first ever", "unprecedented" |
| Boring openers | **−8** | "welcome to", "thanks for tuning in", "today's episode" |

Each candidate window is scored as a **position-weighted sum**: the opening segment counts 1.0×, the next 5s 0.6×, the tail 0.3×. This prefers windows whose hook lands at the START of the clip, not 30 seconds in.

## Probe results on real episodes

* **Tesla Ep411** → smart picks **9.9s** (score 8.6). Skips the boilerplate "Welcome back to Tesla Shorts Time…" intro to land on "Here's what's happening…".
* **Tesla Ep413** → smart picks **140.3s** (score 5.0) on the Cybercab "incredibly tight turnaround" beat — a genuine hook 2+ minutes into the episode, exactly the buried-lede case the heuristic is designed for.
* **MAB Ep010** → top score is 3.2 (below threshold), smart **falls back to voice**. Conservative; the heuristic correctly recognises that MAB's educational tone lacks the punchy phrasing Tesla daily news carries. Operator can lower the per-show threshold in a follow-up if they want more aggressive smart starts.

## Operator visibility

Two new metrics land in `digests/<show>/metrics_ep*.json` per episode:

```json
"shorts_start_offset": 140.3,
"shorts_start_mode_resolved": "smart"
```

The dashboard can plot smart-vs-fallback rates per show, and the operator can scan recent episodes to confirm the heuristic is firing without re-running the pipeline.

## Files

| File | Change |
|---|---|
| `engine/shorts_selector.py` | New module — `score_text`, `score_candidates`, `pick_engaging_window`, `ScoredWindow` dataclass |
| `engine/youtube_shorts.py` | `resolve_shorts_start_offset` learns the `smart` mode; new `transcript_path` kwarg |
| `run_show.py` | Passes transcript path through; records two new metrics |
| `shows/tesla.yaml` + `shows/models_agents_beginners.yaml` | Opt into `shorts_start_mode: smart` |
| `tests/test_shorts_selector.py` | 24 new tests |
| `CLAUDE.md` | Paragraph under the May 2026 Shorts subsection |

## Test plan

- [x] `pytest tests/test_shorts_selector.py tests/test_youtube_shorts.py` — 31 passed
- [x] Probes against three real transcripts (Tesla Ep411, Ep413, MAB Ep010) — selector picks sane starts or falls back conservatively
- [x] Each scoring signal independently unit-tested (regression in any one lights up a targeted failure)
- [x] Fallback paths covered: no transcript / unreadable transcript / empty transcript / no candidate above threshold all return `voice_intro_delay`
- [x] Voice + first_chapter + explicit-offset modes are regression-tested to ensure smart-mode wiring didn't break them
- [ ] **Pending after merge:** next Tesla / MAB Shorts upload — operator visual check that the chosen 55s window lands on a genuinely engaging beat (or correctly falls back to voice when the heuristic isn't confident)

## What's next

Priority #3 from the original list:

- **End-screen CTA overlay** — last 3s "Subscribe + Watch full episode" card with the long-form thumbnail and a tap target.

Ready to ship that next once this merges.

https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2)_