### PR TITLE
Shorts: end-screen CTA card (last 3s subscribe overlay)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,21 @@ episode so the dashboard can show smart-vs-fallback rates. New shows
 opt in by setting `youtube.shorts_start_mode: smart` in their YAML.
 Drift guards in `tests/test_shorts_selector.py`.
 
+**End-screen CTA card.** The last
+`youtube.shorts_end_card_duration_seconds` (default 3 s) of every
+Short overlays a translucent black panel with a two-line CTA:
+big headline ("WATCH FULL EPISODE") + a cyan sub-line ("Tap
+Subscribe ↗") pointing at YouTube's own Subscribe button on the
+Shorts player's right rail. Implemented as a drawbox + 2 drawtext
+filters in the existing filter graph — zero filesystem dependency,
+no per-episode asset generation. YAML knobs to customise:
+`shorts_end_card_enabled` (default true network-wide), plus
+`shorts_end_card_main_text` / `shorts_end_card_sub_text` /
+`shorts_end_card_duration_seconds` for per-show overrides (useful
+for Russian-language shows when they migrate to YouTube). Drift
+guards in `tests/test_video_commands.py` under the "Shorts end-
+screen CTA card" header.
+
 ### Testing
 
 ```bash

--- a/engine/config.py
+++ b/engine/config.py
@@ -385,6 +385,18 @@ class YouTubeConfig:
     # thumbnail instead of reusing the 1280×720 long-form thumb.
     shorts_thumbnail_from_scene: bool = True
 
+    # End-screen CTA card on Shorts (May 2026). When enabled, the last
+    # ``shorts_end_card_duration_seconds`` of the Shorts MP4 overlay a
+    # translucent black panel with a "WATCH FULL EPISODE / Tap Subscribe ↗"
+    # CTA — pointing the viewer at YouTube's own Subscribe button on
+    # the Shorts player's right rail. Per-show texts let an operator
+    # localise (Russian shows, etc.) or A/B different copy without
+    # touching engine/video.py.
+    shorts_end_card_enabled: bool = True
+    shorts_end_card_main_text: str = "WATCH FULL EPISODE"
+    shorts_end_card_sub_text: str = "Tap Subscribe ↗"
+    shorts_end_card_duration_seconds: float = 3.0
+
 
 @dataclass
 class ShowConfig:

--- a/engine/video.py
+++ b/engine/video.py
@@ -547,7 +547,12 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
                              hook: Optional[str] = None,
                              bg_is_video: bool = False,
                              with_url_pill: bool = False,
-                             subtitles_path: Optional[str] = None) -> str:
+                             subtitles_path: Optional[str] = None,
+                             end_card: bool = False,
+                             end_card_duration: float = 3.0,
+                             total_duration: float = 55.0,
+                             end_card_main_text: str = "WATCH FULL EPISODE",
+                             end_card_sub_text: str = "Tap Subscribe ↗") -> str:
     """filter_complex for the 1080x1920 Shorts build.
 
     Inputs:
@@ -633,14 +638,76 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
         # Use the dedicated Shorts force-style so font + position
         # are tuned for the 1080x1920 vertical frame and don't
         # overlap the hook (above) or the URL pill (below).
+        sub_label = "[capted]" if end_card else "[v]"
         chain += (
             f";{post_brand_label}subtitles='{escaped_sub}'"
-            f":force_style='{_SHORTS_SUBTITLES_FORCE_STYLE}'[v]"
+            f":force_style='{_SHORTS_SUBTITLES_FORCE_STYLE}'{sub_label}"
         )
-        return chain
-    if hook:
+        post_brand_label = sub_label
+        if not end_card:
+            return chain
+    elif hook and not end_card:
         # Hook was the last filter — already terminated at [v].
         return chain
+
+    if end_card:
+        # Last-3-seconds CTA card. Three stacked overlays bound to a
+        # single enable window so the layer is atomic — either all
+        # three render (between t=END-3 and t=END) or none do.
+        #
+        #   1. ``drawbox`` paints a full-frame translucent black panel
+        #      to wipe the slideshow + captions, focusing attention.
+        #   2. ``drawtext`` for the headline ("WATCH FULL EPISODE")
+        #      sits centred slightly above mid-frame.
+        #   3. ``drawtext`` for the sub-line ("Tap Subscribe ↗") sits
+        #      under the headline, pointing the viewer at YouTube's
+        #      own subscribe button on the right rail of the Shorts
+        #      player.
+        #
+        # Why drawbox / drawtext rather than a composited PNG: zero
+        # filesystem dependency (no new asset to generate per-episode),
+        # the text is parameterisable per-show via YAML, and the
+        # filter chain stays self-contained. A PNG end-card with the
+        # long-form thumbnail is a worthwhile follow-up but adds an
+        # asset-generation step that ffmpeg doesn't need today.
+        font_path = _drawtext_escape(_find_font())
+        if total_duration <= end_card_duration:
+            # Degenerate case: clip shorter than the end card. Run
+            # the card for the whole clip.
+            end_card_start = 0.0
+        else:
+            end_card_start = max(0.0, total_duration - end_card_duration)
+        end_card_end = total_duration
+        enable_clause = (
+            f"between(t,{end_card_start:.2f},{end_card_end:.2f})"
+        )
+        escaped_main = _drawtext_escape(end_card_main_text)
+        escaped_sub = _drawtext_escape(end_card_sub_text)
+        chain += (
+            f";{post_brand_label}"
+            # 1. Translucent black backdrop.
+            f"drawbox=x=0:y=0:w=iw:h=ih:"
+            f"color=black@0.78:t=fill:enable='{enable_clause}'"
+            # 2. Headline.
+            f",drawtext=fontfile='{font_path}':"
+            f"text='{escaped_main}':"
+            f"fontsize=88:fontcolor=white:"
+            f"x=(w-text_w)/2:y=(h-text_h)/2-100:"
+            f"borderw=4:bordercolor=black:"
+            f"shadowx=2:shadowy=2:shadowcolor=black@0.7:"
+            f"enable='{enable_clause}'"
+            # 3. Sub-line — smaller, accent colour (cyan, matches
+            # the per-word caption highlight from the previous PR).
+            f",drawtext=fontfile='{font_path}':"
+            f"text='{escaped_sub}':"
+            f"fontsize=56:fontcolor=0x00D4FF:"
+            f"x=(w-text_w)/2:y=(h+text_h)/2+40:"
+            f"borderw=3:bordercolor=black:"
+            f"enable='{enable_clause}'"
+            f"[v]"
+        )
+        return chain
+
     return chain + f";{post_brand_label}null[v]"
 
 
@@ -706,7 +773,11 @@ def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
                     hook: Optional[str] = None,
                     bg_is_video: bool = False,
                     url_pill_in: Optional[str] = None,
-                    subtitles_path: Optional[str] = None) -> List[str]:
+                    subtitles_path: Optional[str] = None,
+                    end_card: bool = False,
+                    end_card_main_text: str = "WATCH FULL EPISODE",
+                    end_card_sub_text: str = "Tap Subscribe ↗",
+                    end_card_duration: float = 3.0) -> List[str]:
     """ffmpeg command for the 1080x1920 Shorts build.
 
     When *bg_is_video* is True, *bg_in* is a pre-rendered vertical
@@ -748,7 +819,12 @@ def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
         _short_form_filter_graph(1080, 1920, fps, hook,
                                  bg_is_video=bg_is_video,
                                  with_url_pill=bool(url_pill_in),
-                                 subtitles_path=subtitles_path),
+                                 subtitles_path=subtitles_path,
+                                 end_card=end_card,
+                                 end_card_duration=end_card_duration,
+                                 total_duration=duration,
+                                 end_card_main_text=end_card_main_text,
+                                 end_card_sub_text=end_card_sub_text),
         "-map", "[v]", "-map", "1:a",
         *_VIDEO_ENCODE,
         "-r", str(fps),
@@ -888,7 +964,11 @@ def build_short_video(audio_path: Path, cover_path: Path,
                       hook: Optional[str] = None,
                       scene_paths: Optional[Sequence[Path]] = None,
                       show_name: Optional[str] = None,
-                      subtitles_path: Optional[Path] = None) -> Path:
+                      subtitles_path: Optional[Path] = None,
+                      end_card: bool = False,
+                      end_card_main_text: str = "WATCH FULL EPISODE",
+                      end_card_sub_text: str = "Tap Subscribe ↗",
+                      end_card_duration: float = 3.0) -> Path:
     """Render a 1080x1920 vertical YouTube Shorts video.
 
     Parameters
@@ -971,12 +1051,16 @@ def build_short_video(audio_path: Path, cover_path: Path,
         bg_is_video=bg_is_video,
         url_pill_in=str(url_pill_path) if url_pill_path else None,
         subtitles_path=str(subtitles_path) if subtitles_path else None,
+        end_card=end_card,
+        end_card_main_text=end_card_main_text,
+        end_card_sub_text=end_card_sub_text,
+        end_card_duration=end_card_duration,
     )
     logger.info(
         "Building Shorts video (%.1fs from %.1fs) → %s "
-        "(subtitles=%s)",
+        "(subtitles=%s, end_card=%s)",
         duration, start_offset, output_path.name,
-        bool(subtitles_path),
+        bool(subtitles_path), end_card,
     )
     _run_ffmpeg(cmd, label="shorts video")
     return output_path

--- a/run_show.py
+++ b/run_show.py
@@ -3533,6 +3533,7 @@ def _publish_youtube(
                 except Exception as exc:  # pragma: no cover — best-effort
                     logger.warning("Shorts caption generation failed: %s", exc)
 
+            _yt = config.youtube
             build_short_video(
                 final_mp3, cover_path, short_video_path,
                 start_offset=short_offset,
@@ -3541,6 +3542,16 @@ def _publish_youtube(
                 scene_paths=short_scene_paths if len(short_scene_paths) >= 2 else None,
                 show_name=config.name,
                 subtitles_path=short_srt_path,
+                end_card=bool(getattr(_yt, "shorts_end_card_enabled", True)),
+                end_card_main_text=str(
+                    getattr(_yt, "shorts_end_card_main_text", "WATCH FULL EPISODE")
+                ),
+                end_card_sub_text=str(
+                    getattr(_yt, "shorts_end_card_sub_text", "Tap Subscribe ↗")
+                ),
+                end_card_duration=float(
+                    getattr(_yt, "shorts_end_card_duration_seconds", 3.0) or 3.0
+                ),
             )
             meta = build_short_metadata(
                 config,

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -927,3 +927,144 @@ def test_brand_pill_text_omits_ai_narrated_marker():
     assert "AI-narrated" not in _BRAND_PILL_TEXT
     assert "AI narrated" not in _BRAND_PILL_TEXT
     assert _BRAND_PILL_TEXT == "Nerra Network"
+
+
+# ---------------------------------------------------------------------------
+# Shorts end-screen CTA card — last-3s subscribe overlay
+# ---------------------------------------------------------------------------
+#
+# Operator priority #3 (May 2026): every Short ends with a 3-second
+# CTA card pointing the viewer at YouTube's own Subscribe button on
+# the Shorts player's right rail. drawbox backdrop + 2 drawtext lines.
+
+def test_short_form_filter_graph_omits_end_card_when_disabled():
+    """``end_card=False`` (default) must produce exactly the legacy
+    chain — no drawbox, no end-card drawtext, the existing
+    short-form drift guards stay green."""
+    graph = _short_form_filter_graph(end_card=False)
+    assert "drawbox" not in graph
+    assert "WATCH FULL EPISODE" not in graph
+    assert "Tap Subscribe" not in graph
+
+
+def test_short_form_filter_graph_appends_end_card_when_enabled():
+    """``end_card=True`` must add: a full-frame translucent backdrop,
+    a big headline drawtext, and a smaller sub-line drawtext — all
+    bound to the same ``between(t, total-3, total)`` enable window."""
+    graph = _short_form_filter_graph(
+        end_card=True, total_duration=55.0, end_card_duration=3.0,
+    )
+    # Backdrop covers the full frame at ~78 % opacity.
+    assert "drawbox=x=0:y=0:w=iw:h=ih" in graph
+    assert "color=black@0.78" in graph
+    # Headline + sub-line text.
+    assert "WATCH FULL EPISODE" in graph
+    assert "Tap Subscribe" in graph
+    # All three filters share a single enable window keyed off the
+    # passed ``total_duration``.
+    assert "between(t,52.00,55.00)" in graph
+    # Output is still a single [v] terminator.
+    assert graph.endswith("[v]")
+
+
+def test_short_form_filter_graph_end_card_window_scales_with_duration():
+    """A 30 s Short must still get a 3 s end card at t=27..30, not a
+    hard-coded t=52..55 window."""
+    graph = _short_form_filter_graph(
+        end_card=True, total_duration=30.0, end_card_duration=3.0,
+    )
+    assert "between(t,27.00,30.00)" in graph
+
+
+def test_short_form_filter_graph_end_card_custom_duration():
+    """``end_card_duration`` is operator-configurable; a 5 s card on
+    a 55 s clip should fire from t=50."""
+    graph = _short_form_filter_graph(
+        end_card=True, total_duration=55.0, end_card_duration=5.0,
+    )
+    assert "between(t,50.00,55.00)" in graph
+
+
+def test_short_form_filter_graph_end_card_custom_text():
+    """Per-show YAML can override the CTA copy (Russian shows, A/B
+    testing, etc.) — the override must appear verbatim in the
+    drawtext payload."""
+    graph = _short_form_filter_graph(
+        end_card=True, total_duration=55.0,
+        end_card_main_text="WATCH THE FULL SHOW",
+        end_card_sub_text="Subscribe now",
+    )
+    assert "WATCH THE FULL SHOW" in graph
+    assert "Subscribe now" in graph
+    # Defaults must NOT appear.
+    assert "WATCH FULL EPISODE" not in graph
+
+
+def test_short_form_filter_graph_end_card_composes_with_subtitles():
+    """When BOTH subtitles and the end card are present, captions
+    must stop at the [capted] label and the end-card chain becomes
+    the [v] terminator. No double-terminated graph."""
+    graph = _short_form_filter_graph(
+        end_card=True, subtitles_path="/tmp/short.srt", total_duration=55.0,
+    )
+    # Subtitles land at [capted], not [v].
+    assert "[capted]" in graph
+    # End card runs after — the only [v] is from the end-card chain.
+    assert graph.count("[v]") == 1
+    assert graph.endswith("[v]")
+    # End-card overlay paints over captions.
+    assert "drawbox" in graph
+    assert "WATCH FULL EPISODE" in graph
+
+
+def test_short_form_filter_graph_end_card_composes_with_hook_only():
+    """End card + hook (no subtitles): hook fires 0-3 s, end card
+    fires 52-55 s, both bound to drawtext but on opposite ends of
+    the clip. Both must coexist in the same chain ending at [v]."""
+    graph = _short_form_filter_graph(
+        end_card=True, hook="Today on the show.", total_duration=55.0,
+    )
+    # Hook still gates on first 3 s.
+    assert "between(t,0,3)" in graph
+    # End card gates on last 3 s.
+    assert "between(t,52.00,55.00)" in graph
+    assert graph.endswith("[v]")
+
+
+def test_short_form_filter_graph_end_card_degenerate_short_clip():
+    """If someone sets total_duration <= end_card_duration, the card
+    should render for the whole clip rather than fail / produce a
+    negative start time."""
+    graph = _short_form_filter_graph(
+        end_card=True, total_duration=2.0, end_card_duration=3.0,
+    )
+    assert "between(t,0.00,2.00)" in graph
+
+
+def test_short_form_cmd_threads_end_card_params(tmp_path, monkeypatch):
+    """``build_short_video(end_card=True, …)`` must pass the end-card
+    params down through ``_short_form_cmd`` into the filter graph."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    out = tmp_path / "short.mp4"
+
+    captured = []
+    monkeypatch.setattr(
+        "engine.video.subprocess.run",
+        lambda cmd, **kw: (captured.append(list(cmd)),
+                           type("R", (), {"returncode": 0})())[1],
+    )
+    build_short_video(
+        audio, cover, out, duration=55.0,
+        end_card=True,
+        end_card_main_text="CUSTOM CTA",
+        end_card_sub_text="Subscribe →",
+        end_card_duration=4.0,
+    )
+    assert captured, "no ffmpeg cmd captured"
+    graph = captured[-1][captured[-1].index("-filter_complex") + 1]
+    assert "CUSTOM CTA" in graph
+    assert "Subscribe " in graph  # ASCII portion of the sub-text
+    assert "between(t,51.00,55.00)" in graph


### PR DESCRIPTION
## Summary

Priority #3 from the future-improvements list. The previous wave of Shorts work optimized the **content** of the Short (auto-fit thumbnail, FontSize=48 caption card, per-word highlighting, smart segment selection). This adds the **call-to-action** — the last 3 s of every Short overlays a translucent black panel with a two-line CTA pointing the viewer at YouTube's own Subscribe button on the Shorts player's right rail.

## Card layout

| Layer | Style | Content |
|---|---|---|
| Backdrop | Full-frame `drawbox`, black @ 78 % opacity | (wipes the slideshow + captions so attention focuses on the card) |
| Headline | `drawtext`, fontsize 88, white, bold outline, centred slightly above mid-frame | `WATCH FULL EPISODE` |
| Sub-line | `drawtext`, fontsize 56, **cyan** (`#00D4FF`, matches the per-word caption highlight from PR #415 for visual consistency), centred under headline | `Tap Subscribe ↗` |

All three filters bind to the same `between(t, total-3, total)` enable window so they appear atomically. The window **scales with the actual Shorts duration** (30 s clip → t=27..30; 55 s clip → t=52..55) — future shows running shorter or longer Shorts get a correctly-aligned card.

## Why drawbox + drawtext (not a composited PNG)

- Zero filesystem dependency, no per-episode asset generation step
- Text is parameterisable per-show via YAML
- The chain stays self-contained

A thumbnail-bearing PNG end card is a worthwhile follow-up but adds an asset-generation step that ffmpeg doesn't need today.

## Files

| File | Change |
|---|---|
| `engine/video.py` | `_short_form_filter_graph` learns `end_card` + `end_card_duration` + `total_duration` + `end_card_main_text` + `end_card_sub_text`. Single-output graph preserved — captions terminate at `[capted]` and the end-card chain becomes the `[v]` output. |
| `engine/video.py` | `_short_form_cmd` + `build_short_video` thread the params through. |
| `engine/config.py` | `YouTubeConfig` gains 4 new fields: `shorts_end_card_enabled` (default `True` network-wide), `shorts_end_card_main_text`, `shorts_end_card_sub_text`, `shorts_end_card_duration_seconds`. |
| `run_show.py` | Reads the new config fields and passes them to `build_short_video`. |
| `tests/test_video_commands.py` | 9 new tests under "Shorts end-screen CTA card". |
| `CLAUDE.md` | Paragraph under the May 2026 Shorts subsection. |

## YAML knobs (no per-show change needed by default)

Every YouTube-enabled show inherits the CTA card free. Per-show overrides:

```yaml
youtube:
  shorts_end_card_enabled: false                 # opt out entirely
  shorts_end_card_main_text: "WATCH THE FULL SHOW"
  shorts_end_card_sub_text: "Подписывайтесь ↗"   # Russian shows
  shorts_end_card_duration_seconds: 4.0          # longer card
```

## Test plan

- [x] `pytest tests/test_video_commands.py -k "end_card or short_form"` — 26 passed
- [x] `pytest tests/ --ignore=tests/test_config.py --deselect tests/test_gallery_render.py::test_gallery_enabled_requires_grok_image_provider` — 2079 passed, 3 skipped
- [x] Degenerate cases covered: subtitles-only / hook-only / both / neither all compose into a single `[v]` output
- [x] Custom text and custom duration are threaded through verbatim
- [x] Clip shorter than card duration runs the card for the whole clip rather than producing a negative start time
- [ ] **Pending after merge:** next Tesla / MAB Shorts upload — operator-side phone check that the CTA actually pops in the last 3 s and the cyan sub-line reads cleanly

## Known unrelated CI failures

The persistent `test_mab_yaml_uses_pexels_image_provider` (test_config.py) and `test_gallery_enabled_requires_grok_image_provider` (test_gallery_render.py) failures pre-date this PR. Both pin MAB on Pexels while the YAML carries `image_provider: grok`. Operator has been merging through them since PR #413; not addressed here per system guidance.

## What's next from the future-improvements list

All three high-impact items now shipped:
- ✅ Per-word caption highlighting (PR #415)
- ✅ Smart Shorts segment selection (PR #416)
- ✅ End-screen CTA overlay (this PR)

Remaining medium-impact items from the list (smart vertical crop, multiple Shorts per episode, auto-hashtag injection, hook overlay auto-shrink, A/B thumbnail variants) — ready to tackle in operator-priority order.

https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2)_