### PR TITLE
Shorts: hook overlay (0-3s) auto-shrink-to-fit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,21 @@ episode so the dashboard can show smart-vs-fallback rates. New shows
 opt in by setting `youtube.shorts_start_mode: smart` in their YAML.
 Drift guards in `tests/test_shorts_selector.py`.
 
+**Hook overlay auto-shrink-to-fit.** The 0–3 s static hook
+overlay on the Shorts MP4 used to render at a fixed
+fontsize=44 with a conservative char-based wrap (26 chars × 4
+lines = 104-char budget) that truncated longer Tesla hooks with
+"...". `engine.video.autofit_hook_overlay` now applies the same
+shrink-to-fit pattern the thumbnail uses: start at 44 px, drop
+in 4-px steps (44 → 40 → 36 → 32) only if the wrapped text
+would truncate at the larger size. Pixel-accurate wrap via PIL
+`ImageFont.getbbox` uses the actual 1080-px Shorts frame width
+instead of the char-budget approximation, so a 110-char hook
+(Tesla Ep461 Cybercab wireless-BMS) now fits at 44 px without
+truncation, and runaway 170+-char hooks shrink to 32 px and
+still fit. Drift guards in `tests/test_video_commands.py` under
+the "Shorts hook overlay auto-shrink-to-fit" header.
+
 **End-screen CTA card.** The last
 `youtube.shorts_end_card_duration_seconds` (default 3 s) of every
 Short overlays a translucent black panel with a two-line CTA:

--- a/engine/video.py
+++ b/engine/video.py
@@ -199,6 +199,116 @@ def _wrap_caption(text: str, max_chars_per_line: int = 26,
 
 
 # ---------------------------------------------------------------------------
+# Auto-fit hook overlay
+# ---------------------------------------------------------------------------
+#
+# The 0–3 s hook overlay on a Shorts MP4 used to render at a fixed
+# fontsize=44 with a char-based word wrap (26 chars × 4 lines). Tesla
+# hooks > ~104 chars truncated with "..." at the end of line 4 —
+# operator caught this on Ep466 ("California regulators just
+# disclosed the Tesla Semi's battery sizes at 822 kWh and 548 kWh.").
+#
+# This helper applies the same shrink-to-fit pattern the thumbnail
+# renderer uses (engine.publisher.generate_episode_thumbnail). The
+# default size stays at 44 — preserving the May 2026 operator
+# preference for a non-dominant hook — and only shrinks when keeping
+# 44 would truncate. Pixel-based wrap via PIL ImageFont gives an
+# accurate fit on the actual frame width (1080 px on Shorts) instead
+# of the conservative char-budget approximation.
+
+
+def _pixel_wrap_lines(
+    text: str, font, max_width: int, max_lines: int,
+) -> tuple[list[str], bool]:
+    """Greedy word-wrap by rendered pixel width.
+
+    Returns ``(lines, fits)``. ``fits`` is True when every word in
+    ``text`` made it into the returned lines (no truncation).
+    """
+    words = text.split()
+    if not words:
+        return [], True
+    lines: list[str] = []
+    current: list[str] = []
+    for word in words:
+        candidate = (" ".join(current + [word])) if current else word
+        try:
+            bbox = font.getbbox(candidate)
+            line_px = bbox[2] - bbox[0]
+        except Exception:  # pragma: no cover — font getbbox edge case
+            line_px = len(candidate) * (font.size // 2)
+        if line_px <= max_width or not current:
+            current.append(word)
+        else:
+            lines.append(" ".join(current))
+            current = [word]
+            if len(lines) >= max_lines:
+                break
+    if current and len(lines) < max_lines:
+        lines.append(" ".join(current))
+    used = " ".join(lines).split()
+    fits = len(used) == len(words)
+    return lines, fits
+
+
+def autofit_hook_overlay(
+    hook: str,
+    *,
+    frame_width: int = 1080,
+    safe_margin: int = 80,
+    max_lines: int = 4,
+    font_path: Optional[str] = None,
+    candidates: tuple[int, ...] = (44, 40, 36, 32),
+) -> tuple[int, str]:
+    """Pick the largest font size from ``candidates`` where ``hook``
+    fits inside ``frame_width - 2*safe_margin`` and ``max_lines``.
+
+    Returns ``(fontsize, wrapped_text)``. ``wrapped_text`` joins
+    lines with ``\\n`` — the format ``_drawtext_escape`` understands
+    and the existing caller uses unchanged.
+
+    The candidate list starts at the legacy default 44 so the
+    common case (typical-length hooks) preserves the existing
+    visual exactly. Only hooks that would truncate at 44 drop to
+    40, then 36, then 32 — each step a meaningful enough size
+    change that the operator can tell at a glance which path the
+    auto-fit took.
+
+    Falls back to the char-based ``_wrap_caption`` (with a leading
+    fontsize of 44) when Pillow isn't available — the
+    pre-Phase-1 behaviour, defensive against an unexpected import
+    environment.
+    """
+    if not hook:
+        return candidates[0], ""
+    try:
+        from PIL import ImageFont
+    except ImportError:  # pragma: no cover — PIL is a hard dep
+        return candidates[0], _wrap_caption(hook)
+    if font_path is None:
+        font_path = _find_font()
+    max_width = frame_width - 2 * safe_margin
+    last_lines: list[str] = []
+    last_size = candidates[-1]
+    for size in candidates:
+        try:
+            font = ImageFont.truetype(font_path, size)
+        except (OSError, IOError):  # pragma: no cover — font missing
+            return size, _wrap_caption(hook)
+        lines, fits = _pixel_wrap_lines(hook, font, max_width, max_lines)
+        if fits:
+            return size, "\n".join(lines)
+        last_lines = lines
+        last_size = size
+    # Floor: ship at the smallest size even if it truncates.
+    # Append an explicit ellipsis on the last line so the truncation
+    # is visible to the viewer rather than feeling like a cut-off bug.
+    if last_lines and not last_lines[-1].endswith("..."):
+        last_lines[-1] = last_lines[-1].rstrip(",.; ") + "..."
+    return last_size, "\n".join(last_lines)
+
+
+# ---------------------------------------------------------------------------
 # Brand pill PNGs
 # ---------------------------------------------------------------------------
 #
@@ -602,7 +712,19 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
     #   brand pill → URL pill → hook (0-3s) → burn-in subtitles → [v]
     chain = base
     if hook:
-        wrapped = _wrap_caption(hook)
+        # Auto-shrink-to-fit (May 2026 retune): start at the legacy
+        # fontsize=44 and shrink in 4-px steps only if the wrapped
+        # text would truncate at the larger size. Pixel-accurate
+        # word wrap via PIL ImageFont uses the actual frame width
+        # (1080 px) instead of the old conservative char budget.
+        # Output: ``(fontsize, wrapped)`` ready for drawtext.
+        hook_fontsize, wrapped = autofit_hook_overlay(
+            hook,
+            frame_width=width,
+            safe_margin=80,
+            max_lines=4,
+            font_path=_find_font(),
+        )
         escaped = _drawtext_escape(wrapped)
         # May 2026 operator review: hook is the static 0-3 s
         # opening title — separate from the burn-in transcript
@@ -612,8 +734,9 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
         # inside the lower half but well above the subtitle
         # baseline at y≈1620 (MarginV=300 in
         # ``_SHORTS_SUBTITLES_FORCE_STYLE``).
-        #   * ``fontsize=44`` is still readable on a phone but
-        #     no longer dominates the slideshow.
+        #   * Default ``fontsize=44`` (auto-shrunk per hook length)
+        #     is readable on a phone but no longer dominates the
+        #     slideshow.
         #   * Outline-only (no ``box=1`` solid fill) keeps the
         #     imagery visible behind the words. A 4 px black
         #     outline + 2 px shadow stays readable on bright
@@ -622,7 +745,7 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
         hook_filter = (
             f";{post_brand_label}drawtext=fontfile='{font_path}':"
             f"text='{escaped}':"
-            f"fontsize=44:fontcolor=white:"
+            f"fontsize={hook_fontsize}:fontcolor=white:"
             f"x=(w-text_w)/2:y=h*0.55:"
             f"borderw=4:bordercolor=black:"
             f"shadowx=2:shadowy=2:shadowcolor=black@0.7:"

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1068,3 +1068,123 @@ def test_short_form_cmd_threads_end_card_params(tmp_path, monkeypatch):
     assert "CUSTOM CTA" in graph
     assert "Subscribe " in graph  # ASCII portion of the sub-text
     assert "between(t,51.00,55.00)" in graph
+
+
+# ---------------------------------------------------------------------------
+# Shorts hook overlay auto-shrink-to-fit
+# ---------------------------------------------------------------------------
+#
+# Same shrink-to-fit pattern the thumbnail uses (see
+# tests/test_thumbnail_autofit.py). The 0-3 s drawtext hook used to
+# render at a fixed fontsize=44 with a char-based 26 × 4 wrap that
+# silently truncated > 104-char hooks. Auto-fit drops the font in
+# 4-px steps (44 → 40 → 36 → 32) until the wrapped block fits the
+# frame width without dropping words.
+
+def test_autofit_hook_overlay_short_hook_stays_at_44():
+    """A short hook (< 1 line at 44 px) must keep the legacy
+    fontsize=44 — preserves the existing visual for the common case."""
+    from engine.video import autofit_hook_overlay
+    size, wrapped = autofit_hook_overlay("Tesla beats Q1 target.")
+    assert size == 44
+    # Single line, no break inserted.
+    assert "\n" not in wrapped
+
+
+def test_autofit_hook_overlay_long_hook_shrinks():
+    """A hook that genuinely exceeds the 44-px 4-line budget must
+    shrink to a smaller size in the candidate ladder. (The original
+    char-based 26 × 4 = 104-char limit was conservative — a
+    pixel-accurate wrap at 44 px fits ~38 chars / line × 4 lines =
+    ~150 chars before needing to shrink.) This hook is ~170 chars
+    so it forces a shrink."""
+    from engine.video import autofit_hook_overlay
+    long_hook = (
+        "California regulators just disclosed the Tesla Semi's "
+        "battery sizes at 822 kWh and 548 kWh, alongside a revised "
+        "Cybertruck consumer range estimate that surprised analysts."
+    )
+    size, wrapped = autofit_hook_overlay(long_hook)
+    # Must drop below the legacy default 44.
+    assert size < 44, f"expected shrink for {len(long_hook)}-char hook, got {size}"
+    assert size >= 32
+    # Must NOT truncate at the chosen size — every source word fits.
+    src_words = long_hook.split()
+    out_words = wrapped.replace("\n", " ").split()
+    assert len(out_words) == len(src_words), (
+        f"words dropped during autofit: src={len(src_words)} "
+        f"out={len(out_words)} wrapped={wrapped!r}"
+    )
+
+
+def test_autofit_hook_overlay_91_char_hook_fits_at_44():
+    """Operator's original truncation complaint was at the char-based
+    104-char budget. With the pixel-accurate wrap a 91-char hook
+    fits comfortably at 44 px — no shrink needed. This is the
+    regression direction (i.e. don't shrink hooks that don't need
+    it)."""
+    from engine.video import autofit_hook_overlay
+    hook_91 = (
+        "California regulators just disclosed the Tesla Semi's "
+        "battery sizes at 822 kWh and 548 kWh."
+    )
+    assert len(hook_91) >= 80
+    size, wrapped = autofit_hook_overlay(hook_91)
+    assert size == 44, f"91-char hook should fit at 44 px, got {size}"
+    src_words = hook_91.split()
+    out_words = wrapped.replace("\n", " ").split()
+    assert len(out_words) == len(src_words)
+
+
+def test_autofit_hook_overlay_empty_hook():
+    from engine.video import autofit_hook_overlay
+    size, wrapped = autofit_hook_overlay("")
+    assert wrapped == ""
+    # Default font size still returned so callers don't have to
+    # special-case the empty path.
+    assert size == 44
+
+
+def test_autofit_hook_overlay_respects_max_lines():
+    """A 200-char hook MUST stay within max_lines=4 regardless of
+    which fontsize wins. Too many lines on a 9:16 frame collides
+    with the burn-in caption card at y≈1480."""
+    from engine.video import autofit_hook_overlay
+    runaway = "word " * 80  # 400 chars
+    _size, wrapped = autofit_hook_overlay(runaway, max_lines=4)
+    assert wrapped.count("\n") <= 3  # ≤4 lines
+
+
+def test_autofit_hook_overlay_floor_appends_ellipsis_on_truncation():
+    """When even the smallest fontsize can't fit, the floor renders
+    the wrapped lines + a visible "…" on the last line so the
+    truncation is OBVIOUS to a viewer rather than feeling like a
+    cut-off bug."""
+    from engine.video import autofit_hook_overlay
+    runaway = "supercalifragilistic " * 30
+    _size, wrapped = autofit_hook_overlay(
+        runaway, max_lines=2, candidates=(44, 32),
+    )
+    # The last line gets the ellipsis marker once we hit the floor.
+    assert wrapped.endswith("...")
+
+
+def test_short_form_filter_graph_long_hook_uses_smaller_font():
+    """End-to-end: a long hook in the actual filter graph should
+    emit a smaller fontsize=N drawtext, not the default 44."""
+    long_hook = (
+        "Tesla just disclosed an unprecedented restructuring of its "
+        "Cybercab manufacturing supply chain across three continents "
+        "to absorb the surprise tariff changes announced overnight."
+    )
+    graph = _short_form_filter_graph(hook=long_hook)
+    # The drawtext fontsize=N where N may be 40, 36, or 32 depending
+    # on the exact font metrics — assert it's NOT the default 44.
+    import re
+    m = re.search(r"fontsize=(\d+)", graph)
+    assert m, "no fontsize found in graph"
+    chosen = int(m.group(1))
+    assert chosen < 44, (
+        f"long hook should have shrunk below 44, got {chosen}"
+    )
+    assert chosen >= 32, f"smallest allowed is 32, got {chosen}"


### PR DESCRIPTION
## Summary

Continuing through the medium-impact Shorts improvements list. The 0–3s static hook overlay on the Shorts MP4 used to render at a fixed `fontsize=44` with a conservative char-based wrap (26 chars × 4 lines = 104-char budget) that truncated longer Tesla hooks with `...`.

`autofit_hook_overlay` now applies the same shrink-to-fit pattern the thumbnail uses (PR #413): start at 44 px, drop in 4-px steps only if the wrapped text would truncate at the larger size. **Pixel-accurate wrap** via PIL `ImageFont.getbbox` measures actual rendered width on the 1080-px Shorts frame (920 px usable) instead of the char-budget approximation.

## Probed against real Tesla hooks

| Hook length | Result |
|---|---|
| 30 chars | 44 px, 1 line (unchanged) |
| 91 chars (Tesla Ep466 Semi battery) | 44 px, 3 lines — was the **original truncation complaint**; now fits cleanly without `...` |
| 110 chars (Tesla Ep461 Cybercab wireless-BMS) | 44 px, 4 lines (default fits exactly) |
| 172 chars | 32 px, 4 lines (auto-shrink to floor, still fits) |
| 178 chars | 32 px, 4 lines (still fits at floor) |

The original char-based 26 × 4 budget was conservative — pixel wrap fits ~38 chars / line × 4 lines = ~150 chars before needing to shrink. The 91-char and 110-char hooks the operator caught truncating actually fit fine at the default 44 px; the truncation was an artefact of the over-tight char budget, not the font size.

## Files

| File | Change |
|---|---|
| `engine/video.py` | New `_pixel_wrap_lines` helper + `autofit_hook_overlay` public function. `_short_form_filter_graph` calls it instead of the legacy `_wrap_caption` + hardcoded `fontsize=44`. |
| `tests/test_video_commands.py` | 7 new tests covering: short hook stays at 44, long hook shrinks, 91-char hook stays at 44 (regression — don't over-shrink), empty hook, max-lines respected, floor appends ellipsis on truncation, end-to-end filter graph emits the smaller fontsize for long hooks. |
| `CLAUDE.md` | Paragraph under the May 2026 Shorts subsection. |

## Floor behaviour

When even the smallest font (32 px) can't fit the full hook in 4 lines, the floor renders the wrapped lines + a visible `...` on the last line. The truncation is now an **explicit visible marker** rather than the silent mid-word cut-off the operator saw before.

## Test plan

- [x] `pytest tests/test_video_commands.py -k "autofit or hook"` — 15 passed
- [x] `pytest tests/test_video_commands.py tests/test_thumbnail_autofit.py tests/test_shorts_selector.py tests/test_captions.py tests/test_captions_ass.py` — 138 passed
- [x] Live probe against 5 real hook lengths (30 / 91 / 110 / 172 / 178 chars) — no truncation in any case; shrink kicks in cleanly above the ~150-char boundary
- [x] Preservation guard: 91-char Tesla Semi hook stays at 44 px (the regression direction — over-shrinking conservative hooks would be visually worse)

## Known unrelated CI failure

The recurring `test_mab_yaml_uses_pexels_image_provider` (test_config.py) and `test_gallery_enabled_requires_grok_image_provider` (test_gallery_render.py) failures continue. Not caused by this PR; operator has been merging through them since PR #413.

## What's next from the list

- **Smart vertical crop** for scene imagery (center-crop currently loses subjects)
- **Multiple Shorts per episode** (2x engagement multiplier, fits in YouTube quota)
- **Auto-hashtag injection** (parse hook for entities, inject `#TeslaCybertruck` etc. into description)
- **A/B thumbnail variants** (depends on YouTube Studio feature)
- **PNG-based end card** with the long-form thumbnail (richer than the drawtext-only version that shipped in PR #417)

https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2)_