### PR TITLE
Shorts: auto-hashtag injection on descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,24 @@ episode so the dashboard can show smart-vs-fallback rates. New shows
 opt in by setting `youtube.shorts_start_mode: smart` in their YAML.
 Drift guards in `tests/test_shorts_selector.py`.
 
+**Auto-hashtag injection on Shorts descriptions.** Every Shorts
+upload now carries entity-derived hashtags in its description
+(via [`engine.shorts_hashtags.extract_hashtags`](engine/shorts_hashtags.py)).
+YouTube renders the **first 3** hashtags as clickable topic-tag
+links above the video title — biggest discovery lever on Shorts
+after the title itself. Heuristic-only parser, no LLM call:
+multi-word Title-Case entities (`Tesla Cybercab` →
+`#TeslaCybercab`) outrank single proper nouns (`Tesla` →
+`#Tesla`) which outrank all-caps acronyms (`TSLA` → `#TSLA`),
+with the show's YAML `keywords` blended in at the tail to fill
+remaining slots. Substring de-dupe across bands prevents
+"#Tesla" eating a slot when "#TeslaCybercab" already covers the
+entity. Caps at 5 hashtags + the static `#Shorts #podcast`
+suffix. Real-hook probes: Tesla wireless-BMS hook →
+`#BatteryManagementSystem #Tesla #Cybercab`; Modern Investing
+TFSA/RRSP hook → `#ModernInvestingTechniques #TFSA #RRSP`. Drift
+guards in `tests/test_shorts_hashtags.py`.
+
 **Hook overlay auto-shrink-to-fit.** The 0–3 s static hook
 overlay on the Shorts MP4 used to render at a fixed
 fontsize=44 with a conservative char-based wrap (26 chars × 4

--- a/engine/shorts_hashtags.py
+++ b/engine/shorts_hashtags.py
@@ -1,0 +1,276 @@
+"""Extract YouTube-style hashtags from a podcast hook line.
+
+YouTube treats the **first 3** hashtags in a video description as
+"topic tags" rendered above the title as clickable links — the
+biggest discovery lever on Shorts after the title itself. Beyond
+the first 3 they still index for search but stop being visible
+above the fold; YouTube ignores all hashtags entirely past the
+first 15.
+
+This module is a pure-function parser over the episode hook (the
+one-line topic of the day) + the show's network tag list. No
+LLM call, no per-episode cost. Heuristics:
+
+* Multi-word Title-Case phrases ("Tesla Cybercab", "Modern
+  Investing Techniques") collapse to a single hashtag
+  (``#TeslaCybercab``) — the entity reads as one search target.
+* Single-word capitalised proper nouns ("Tesla", "Cybercab")
+  become hashtags too, after the multi-word forms claim their
+  spots so we don't double-rank the same entity.
+* Short all-caps acronyms (``AI``, ``TSLA``, ``GPT``) survive
+  verbatim; they're high-value search tokens.
+* Show-level tags from the YAML (``keywords``) are blended in at
+  the tail so each Short carries the show's evergreen discovery
+  set even when the hook is generic.
+
+The output is ranked: multi-word entities first (highest signal),
+then single-word capitalised entities, then acronyms, then show
+keywords. The caller decides how many to splice into the
+description (typically the top 5 — 3 for YouTube's visible row
++ 2 buffer for de-dupe collisions).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+# Tokens we never hashtag — sentence connectives, "common" capitalised
+# words that lead a sentence ("The", "And") aren't entity signals.
+_STOPWORDS = frozenset((
+    "The", "A", "An", "And", "Or", "But", "If", "Then", "So",
+    "This", "That", "These", "Those", "Here", "There",
+    "Today", "Tomorrow", "Yesterday", "Now", "Soon",
+    "Why", "How", "What", "When", "Where", "Who", "Which",
+    "Is", "Are", "Was", "Were", "Be", "Been", "Being",
+    "Has", "Have", "Had", "Do", "Does", "Did",
+    "Just", "Even", "Also", "Only", "Still", "More", "Less",
+    "May", "June", "July", "August", "September", "October",
+    "November", "December", "January", "February", "March", "April",
+    "Monday", "Tuesday", "Wednesday", "Thursday", "Friday",
+    "Saturday", "Sunday",
+))
+
+# Acronyms shorter than 2 chars are noise (single-letter capitals
+# show up in "I" / "U" framings). Longer than 6 is usually a
+# noun-cased token, not an acronym.
+_MIN_ACRONYM_LEN = 2
+_MAX_ACRONYM_LEN = 6
+
+# Hashtag character class — YouTube accepts letters / digits /
+# underscores after the ``#``. Anything else terminates the tag.
+_HASHTAG_BODY_RE = re.compile(r"[A-Za-z0-9_]+")
+
+
+# ---------------------------------------------------------------------------
+# Token extraction
+# ---------------------------------------------------------------------------
+
+
+def _clean_for_tag(token: str) -> str:
+    """Return the alphanumeric body of a token suitable for use after
+    a ``#``. Strips punctuation, internal whitespace, hyphens."""
+    parts = _HASHTAG_BODY_RE.findall(token)
+    return "".join(parts)
+
+
+def _is_acronym(token: str) -> bool:
+    body = _clean_for_tag(token)
+    if not body or len(body) < _MIN_ACRONYM_LEN or len(body) > _MAX_ACRONYM_LEN:
+        return False
+    # All-caps with at least one letter (drop pure-digit tokens like
+    # "2026" which are years, not acronyms).
+    return body.isupper() and any(c.isalpha() for c in body)
+
+
+def _is_proper_noun(token: str) -> bool:
+    body = _clean_for_tag(token)
+    if not body or not body[0].isupper():
+        return False
+    if body in _STOPWORDS:
+        return False
+    # Title-case with at least one lower-case letter (drop full-caps
+    # tokens — those go through the acronym branch).
+    return any(c.islower() for c in body)
+
+
+def _extract_multi_word_entities(hook: str) -> List[str]:
+    """Find consecutive runs of Title-Case words (e.g. "Tesla Cybercab",
+    "Modern Investing Techniques"). Returns the entities preserving
+    document order; duplicates dropped on first appearance."""
+    if not hook:
+        return []
+    tokens = hook.split()
+    out: List[str] = []
+    seen: set = set()
+    i = 0
+    while i < len(tokens):
+        if _is_proper_noun(tokens[i]):
+            run = [tokens[i]]
+            j = i + 1
+            while j < len(tokens) and _is_proper_noun(tokens[j]):
+                run.append(tokens[j])
+                j += 1
+            if len(run) >= 2:
+                joined = "".join(_clean_for_tag(t) for t in run)
+                key = joined.lower()
+                if joined and key not in seen:
+                    seen.add(key)
+                    out.append(joined)
+            i = j
+        else:
+            i += 1
+    return out
+
+
+def _extract_single_proper_nouns(hook: str) -> List[str]:
+    if not hook:
+        return []
+    out: List[str] = []
+    seen: set = set()
+    for token in hook.split():
+        if not _is_proper_noun(token):
+            continue
+        body = _clean_for_tag(token)
+        if not body:
+            continue
+        key = body.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(body)
+    return out
+
+
+def _extract_acronyms(hook: str) -> List[str]:
+    if not hook:
+        return []
+    out: List[str] = []
+    seen: set = set()
+    for token in hook.split():
+        if not _is_acronym(token):
+            continue
+        body = _clean_for_tag(token)
+        if not body:
+            continue
+        key = body.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(body)
+    return out
+
+
+def _normalise_show_keywords(raw: Iterable[str]) -> List[str]:
+    """Convert YAML keywords ("tesla cybertruck", "ai agents") into
+    hashtag bodies ("TeslaCybertruck", "AiAgents"). Lowercases then
+    Title-cases each word and concatenates so a single keyword
+    becomes a single tag."""
+    out: List[str] = []
+    seen: set = set()
+    for kw in raw:
+        if not isinstance(kw, str):
+            continue
+        words = [w for w in re.split(r"[\s_-]+", kw.strip()) if w]
+        if not words:
+            continue
+        body = "".join(w[:1].upper() + w[1:].lower() for w in words)
+        body = _clean_for_tag(body)
+        if not body:
+            continue
+        key = body.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(body)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def extract_hashtags(
+    hook: str,
+    *,
+    show_keywords: Optional[Sequence[str]] = None,
+    max_hashtags: int = 5,
+) -> List[str]:
+    """Return up to ``max_hashtags`` hashtag bodies (no leading ``#``)
+    ranked by signal strength: multi-word entities first, then
+    single-word proper nouns, then acronyms, then show keywords.
+
+    De-duplication is **case-insensitive across the priority bands** —
+    if "Tesla Cybercab" lands as a multi-word entity, neither
+    "Tesla" nor "Cybercab" gets a second hashtag from the
+    single-word band. This prevents the same entity occupying
+    multiple hashtag slots.
+
+    Returns ``[]`` when nothing extractable, in which case the
+    caller falls back to the static ``#Shorts #podcast`` line.
+    """
+    if not hook and not show_keywords:
+        return []
+
+    ordered: List[str] = []
+    seen: set = set()
+
+    def _add(token: str) -> bool:
+        body = _clean_for_tag(token)
+        if not body:
+            return False
+        key = body.lower()
+        if key in seen:
+            return False
+        # Also block adding "Tesla" if "TeslaCybercab" was already
+        # picked — substring match in both directions.
+        for picked in seen:
+            if key in picked or picked in key:
+                # Prefer the LONGER form. If we already have a
+                # superset, skip the substring. If the new entity
+                # is longer than an existing one, the existing one
+                # already won its slot — accept the duplicate-by-
+                # substring just to keep ordering predictable.
+                if key in picked:
+                    return False
+        seen.add(key)
+        ordered.append(body)
+        return True
+
+    for token in _extract_multi_word_entities(hook):
+        if len(ordered) >= max_hashtags:
+            break
+        _add(token)
+    for token in _extract_single_proper_nouns(hook):
+        if len(ordered) >= max_hashtags:
+            break
+        _add(token)
+    for token in _extract_acronyms(hook):
+        if len(ordered) >= max_hashtags:
+            break
+        _add(token)
+    if show_keywords:
+        for token in _normalise_show_keywords(show_keywords):
+            if len(ordered) >= max_hashtags:
+                break
+            _add(token)
+    return ordered
+
+
+def format_hashtag_line(
+    hashtag_bodies: Iterable[str], static_tags: Sequence[str] = (),
+) -> str:
+    """Build a single-line ``#A #B #C`` string from hashtag bodies.
+
+    ``static_tags`` are appended verbatim (already include the ``#``)
+    so callers can pin ``#Shorts`` / ``#podcast`` at the tail without
+    going through the extractor.
+    """
+    parts = [f"#{b}" for b in hashtag_bodies if b]
+    parts.extend(static_tags)
+    return " ".join(parts)

--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -413,7 +413,21 @@ def build_short_metadata(
     disclosure = (config.youtube.synthetic_disclosure or "").strip()
     if disclosure:
         pieces.append(disclosure)
-    pieces.append("#Shorts #podcast")
+
+    # Auto-extract hashtags from the hook so the Shorts description
+    # carries the day's entities (Tesla / Cybercab / OpenAI etc.) as
+    # search-indexable + above-the-title topic tags. YouTube renders
+    # the FIRST 3 hashtags as clickable links above the video title
+    # — biggest discovery lever on Shorts after the title itself.
+    # Falls back cleanly to the static ``#Shorts #podcast`` line when
+    # the hook has nothing extractable.
+    from engine.shorts_hashtags import extract_hashtags, format_hashtag_line
+    extracted = extract_hashtags(
+        hook,
+        show_keywords=list(getattr(config, "keywords", []) or []),
+        max_hashtags=5,
+    )
+    pieces.append(format_hashtag_line(extracted, ("#Shorts", "#podcast")))
 
     # Same ``invalidDescription`` defense as build_long_form_metadata —
     # YouTube rejects ``<`` / ``>`` even though Shorts hasn't tripped

--- a/tests/test_shorts_hashtags.py
+++ b/tests/test_shorts_hashtags.py
@@ -1,0 +1,232 @@
+"""Tests for ``engine.shorts_hashtags`` — auto-extract YouTube
+hashtags from a podcast hook line. Each scoring signal /
+de-duplication invariant has its own targeted test so a regression
+in one band (multi-word, single-noun, acronym, show-keywords)
+lights up a focused failure."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.shorts_hashtags import (
+    extract_hashtags,
+    format_hashtag_line,
+    _extract_acronyms,
+    _extract_multi_word_entities,
+    _extract_single_proper_nouns,
+    _normalise_show_keywords,
+)
+
+
+# ---------------------------------------------------------------------------
+# Multi-word entities
+# ---------------------------------------------------------------------------
+
+
+def test_multi_word_entity_collapses_consecutive_capitals():
+    out = _extract_multi_word_entities(
+        "Tesla Cybercab just got a new wireless Battery Management System."
+    )
+    # "Tesla Cybercab" and "Battery Management System" both qualify.
+    assert "TeslaCybercab" in out
+    assert "BatteryManagementSystem" in out
+
+
+def test_multi_word_entity_skips_single_capitals():
+    out = _extract_multi_word_entities("Tesla beats Q1 delivery target.")
+    # "Tesla" alone is a SINGLE proper noun, not multi-word.
+    assert out == []
+
+
+def test_multi_word_entity_drops_stopword_starts():
+    """A sentence starting with "The Tesla Roadster" must NOT promote
+    "The" into the entity — stopwords are filtered from the
+    proper-noun band."""
+    out = _extract_multi_word_entities("The Tesla Roadster ships in 2027.")
+    # "Tesla Roadster" qualifies (2 proper nouns); "The" is a
+    # stopword so it doesn't start a run with Tesla.
+    assert "TeslaRoadster" in out
+    assert "TheTesla" not in out
+
+
+# ---------------------------------------------------------------------------
+# Single proper nouns
+# ---------------------------------------------------------------------------
+
+
+def test_single_proper_noun_extracted():
+    out = _extract_single_proper_nouns("Tesla announced new battery sizes.")
+    assert "Tesla" in out
+
+
+def test_single_proper_noun_ignores_stopwords():
+    out = _extract_single_proper_nouns("Today Tesla shipped a new model.")
+    assert "Tesla" in out
+    assert "Today" not in out  # stopword
+
+
+def test_single_proper_noun_dedupes():
+    out = _extract_single_proper_nouns(
+        "Tesla beat Tesla's own record. Tesla wins."
+    )
+    # Tesla appears 3 times in the hook; only one tag.
+    assert out.count("Tesla") == 1
+
+
+# ---------------------------------------------------------------------------
+# Acronyms
+# ---------------------------------------------------------------------------
+
+
+def test_acronym_extracted():
+    out = _extract_acronyms("AI took over Q1 — TSLA stock jumped 12%.")
+    # AI and TSLA both qualify. Q1 contains a digit + capital but
+    # is 2 chars and has letter+digit; rejected as a year-like
+    # marker — actually our rule requires uppercase letters, and
+    # Q1 satisfies that. So it would qualify too.
+    assert "AI" in out
+    assert "TSLA" in out
+
+
+def test_acronym_rejects_pure_digits():
+    out = _extract_acronyms("In 2026 Tesla shipped 500000 units.")
+    assert "2026" not in out
+    assert "500000" not in out
+
+
+def test_acronym_rejects_too_long():
+    out = _extract_acronyms("CALIFORNIA passed new rules.")
+    # > 6 chars, drops.
+    assert "CALIFORNIA" not in out
+
+
+def test_acronym_rejects_lowercase_mixed():
+    out = _extract_acronyms("iPhone shipped today.")
+    # "iPhone" is not all-caps; rejected by the acronym branch
+    # (it'd qualify as a proper noun elsewhere).
+    assert "iPhone" not in out
+
+
+# ---------------------------------------------------------------------------
+# Show keyword normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_show_keyword_collapses_spaces():
+    out = _normalise_show_keywords(
+        ["tesla cybertruck", "ai agents", "modern_investing"],
+    )
+    assert "TeslaCybertruck" in out
+    assert "AiAgents" in out
+    assert "ModernInvesting" in out
+
+
+def test_show_keyword_skips_blanks():
+    out = _normalise_show_keywords(["", "  ", "\t", "valid"])
+    assert out == ["Valid"]
+
+
+def test_show_keyword_dedupes():
+    out = _normalise_show_keywords(["tesla", "Tesla", "TESLA"])
+    assert len(out) == 1
+
+
+# ---------------------------------------------------------------------------
+# extract_hashtags — ranking + dedupe across bands
+# ---------------------------------------------------------------------------
+
+
+def test_multi_word_outranks_single_word():
+    out = extract_hashtags(
+        "Tesla Cybercab beats Cybertruck.", max_hashtags=5,
+    )
+    # Multi-word "TeslaCybercab" comes first.
+    assert out[0] == "TeslaCybercab"
+    # "Cybertruck" appears as a separate single proper noun.
+    assert "Cybertruck" in out
+
+
+def test_substring_dedupe_prefers_longer_form():
+    """When a multi-word entity contains a single proper noun
+    that ALSO appears alone, the substring should NOT take a
+    second hashtag slot."""
+    out = extract_hashtags(
+        "Tesla Cybercab launched. Tesla also revealed Roadster.",
+        max_hashtags=10,
+    )
+    # "TeslaCybercab" wins the multi-word band; "Tesla" alone
+    # should be dropped (substring of the picked entity).
+    assert "TeslaCybercab" in out
+    assert "Tesla" not in out
+
+
+def test_max_hashtags_respected():
+    """Even on a hashtag-rich hook, the function caps at max_hashtags
+    so callers know the output size up-front."""
+    hook = "Tesla Cybercab and OpenAI ChatGPT and Apple iPhone Pro Max."
+    out = extract_hashtags(hook, max_hashtags=3)
+    assert len(out) <= 3
+
+
+def test_show_keywords_blend_in_at_tail():
+    """When the hook produces fewer hashtags than max_hashtags,
+    show keywords fill the remaining slots."""
+    out = extract_hashtags(
+        "Tesla launched today.",  # only "Tesla" single proper noun
+        show_keywords=["AI agents", "modern investing"],
+        max_hashtags=5,
+    )
+    assert "Tesla" in out
+    assert "AiAgents" in out
+    assert "ModernInvesting" in out
+
+
+def test_empty_hook_returns_keyword_only():
+    out = extract_hashtags("", show_keywords=["tesla"], max_hashtags=5)
+    assert out == ["Tesla"]
+
+
+def test_empty_hook_and_no_keywords_returns_empty():
+    assert extract_hashtags("") == []
+
+
+def test_real_tesla_hook():
+    """End-to-end on a realistic Tesla hook from the operator's
+    feedback."""
+    out = extract_hashtags(
+        "Tesla is hiring engineers to build a wireless Battery "
+        "Management System for Cybercab that removes heavy wiring.",
+        show_keywords=["tesla", "cybertruck", "ev"],
+        max_hashtags=5,
+    )
+    # "Battery Management System" is the multi-word entity — must
+    # take the top slot.
+    assert "BatteryManagementSystem" in out
+    # "Tesla" + "Cybercab" individually picked.
+    assert "Cybercab" in out
+    # 'Tesla' shows up either as a single proper noun OR as the
+    # blended show keyword — either way the entity is represented.
+    assert any(t.lower() == "tesla" for t in out)
+
+
+# ---------------------------------------------------------------------------
+# format_hashtag_line
+# ---------------------------------------------------------------------------
+
+
+def test_format_hashtag_line_prepends_hash():
+    line = format_hashtag_line(["Tesla", "Cybercab"], ("#Shorts", "#podcast"))
+    assert line == "#Tesla #Cybercab #Shorts #podcast"
+
+
+def test_format_hashtag_line_skips_empties():
+    line = format_hashtag_line(["", "Tesla", ""], ("#Shorts",))
+    assert line == "#Tesla #Shorts"
+
+
+def test_format_hashtag_line_no_static_tags():
+    assert format_hashtag_line(["Tesla"]) == "#Tesla"
+
+
+def test_format_hashtag_line_empty_inputs():
+    assert format_hashtag_line([], ()) == ""


### PR DESCRIPTION
## Summary

Continuing the medium-impact Shorts list. Every Shorts upload now carries entity-derived hashtags in its description. **YouTube renders the first 3 hashtags as clickable topic-tag links above the video title** — the biggest discovery lever on Shorts after the title itself.

Heuristic-only parser, no LLM cost. Three-band extraction in priority order:

| Band | Score | Example |
|---|---|---|
| Multi-word Title-Case entities | Highest | `Tesla Cybercab` → `#TeslaCybercab` |
| Single proper nouns | Mid | `Tesla` → `#Tesla` |
| Short all-caps acronyms (2-6 chars) | Mid | `TSLA` → `#TSLA` |
| Show YAML `keywords` blended in | Tail | `tesla cybertruck` → `#TeslaCybertruck` |

Substring de-dupe across bands: `#Tesla` won't take a slot when `#TeslaCybercab` already covers the entity. Caps at 5 hashtags + the static `#Shorts #podcast` suffix.

## Real-hook probes

| Hook | Generated hashtag line |
|---|---|
| "Tesla is hiring engineers to build a wireless Battery Management System for Cybercab." | `#BatteryManagementSystem #Tesla #Cybercab #Cybertruck #Shorts #podcast` |
| "OpenAI launched GPT-5 with a new pricing model." | `#OpenAI #GPT5 #AiAgents #Llm #Shorts #podcast` |
| "Modern Investing Techniques: how to think about TFSA vs RRSP." | `#ModernInvestingTechniques #TFSA #RRSP #Canada #Shorts #podcast` |
| "California regulators just disclosed the Tesla Semi battery sizes at 822 kWh." | `#TeslaSemi #California #Shorts #podcast` |

The top 3 hashtags in every example are all high-discovery search targets — significantly better than the previous static `#Shorts #podcast` pair.

## Files

| File | Change |
|---|---|
| `engine/shorts_hashtags.py` | New module: `extract_hashtags(hook, show_keywords, max_hashtags)` + `format_hashtag_line(bodies, static_tags)` + 4 private band extractors |
| `engine/video_metadata.py` | `build_short_metadata` calls extract_hashtags + replaces the legacy static `#Shorts #podcast` line with the dynamic line |
| `tests/test_shorts_hashtags.py` | 24 new tests |
| `CLAUDE.md` | Paragraph under the May 2026 Shorts section |

## Test plan

- [x] `pytest tests/test_shorts_hashtags.py` — 24 passed
- [x] `pytest tests/ -k "short_metadata or video_metadata or short"` — 133 passed
- [x] Full suite minus the persistent MAB stale-tests — 2164 passed, 3 skipped
- [x] Live probes against 5 realistic hook shapes (Tesla / OpenAI / Apple / Tesla Semi / Modern Investing) all produce sensible top-3 discovery hashtags
- [ ] **Pending after merge:** next Tesla / MAB Shorts upload — operator-side check that the YouTube Shorts player renders the first 3 hashtags as the clickable topic-tag row above the title

## Known unrelated CI failure

Same recurring MAB stale-test failure as the last 5 PRs. Not caused by this work.

## What's next from the list

- **Smart vertical crop** — actually low-priority on closer inspection: Grok already generates 1024×1792 portrait images for Shorts via the 9:16 prompt, so the scale-and-crop loss is minimal. Could re-prioritise.
- **Multiple Shorts per episode** — biggest remaining engagement multiplier. Quota math: Tesla + MAB currently use 4/6 daily upload slots, so we have headroom for 1 extra Short per show.
- **PNG-based end card** with the long-form thumbnail composited in (richer than the drawtext version)
- **A/B thumbnail variants** — depends on YouTube Studio API exposure

https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2)_