### PR TITLE
Shorts: PNG end-card with composited long-form thumbnail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,10 +322,19 @@ the "Shorts hook overlay auto-shrink-to-fit" header.
 
 **End-screen CTA card.** The last
 `youtube.shorts_end_card_duration_seconds` (default 3 s) of every
-Short overlays a translucent black panel with a two-line CTA:
-big headline ("WATCH FULL EPISODE") + a cyan sub-line ("Tap
-Subscribe ↗") pointing at YouTube's own Subscribe button on the
-Shorts player's right rail. Implemented as a drawbox + 2 drawtext
+Short overlays a PNG end card composited at run time by
+[`engine.publisher.generate_shorts_end_card`](engine/publisher.py).
+The card shows the long-form 1280×720 thumbnail in the upper third
+(framed with a thin white border so it reads as a tap target),
+a big white headline ("WATCH FULL EPISODE"), a cyan sub-line
+("Tap Subscribe ↗", matching the per-word caption highlight from
+PR #415), and a small `nerranetwork.com` footer. The
+`engine.video._short_form_filter_graph` overlays the PNG via a
+single `overlay=enable='between(t,END-3,END)'` filter. When PNG
+generation fails (or the long-form thumbnail upstream failed),
+the chain falls back to the drawtext-only version originally
+shipped in PR #417 — soft degradation, never blocks the Shorts
+publish. Implemented as a drawbox + 2 drawtext
 filters in the existing filter graph — zero filesystem dependency,
 no per-episode asset generation. YAML knobs to customise:
 `shorts_end_card_enabled` (default true network-wide), plus

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -1303,6 +1303,131 @@ def generate_shorts_thumbnail(
     )
 
 
+def generate_shorts_end_card(
+    long_form_thumbnail_path: Path,
+    output_path: Path,
+    *,
+    show_name: str = "",
+    main_text: str = "WATCH FULL EPISODE",
+    sub_text: str = "Tap Subscribe ↗",
+    size: tuple = (1080, 1920),
+) -> Path:
+    """Render the 1080×1920 PNG end-card overlay for a Shorts MP4.
+
+    The drawn card composites the long-form 1280×720 thumbnail into
+    the upper third of a dark vertical frame, then layers a big
+    headline ("WATCH FULL EPISODE") + cyan sub-line ("Tap Subscribe
+    ↗") + a small ``nerranetwork.com`` footer below it. The output
+    is a PNG (transparent background pixels would be wasted — the
+    image fills the whole frame), used as an ffmpeg overlay input
+    on the Shorts MP4 during the last 3 seconds in
+    ``engine.video._short_form_filter_graph``.
+
+    This is the visual upgrade over the drawtext-only end card
+    shipped in PR #417: viewers see what the actual long-form
+    episode looks like, which is significantly more compelling
+    than a text-only "WATCH FULL EPISODE" prompt.
+
+    Falls back to a text-only render when ``long_form_thumbnail_path``
+    is missing or fails to load (defensive: thumbnail generation can
+    fail upstream and we want the end card to still ship).
+    """
+    from PIL import Image, ImageDraw
+
+    width, height = size
+    # Solid dark background — matches the existing drawtext end card's
+    # 78%-opaque black panel but goes full opaque (no need to see the
+    # slideshow behind a PNG overlay).
+    bg = Image.new("RGB", (width, height), (11, 15, 26))  # --nn-bg
+
+    # Crop the long-form thumbnail into the upper third. Long-form
+    # thumbs are 1280×720 (16:9). Scale to 1080 wide → 1080×608.
+    # Centre vertically inside a 1080×~720 slot at y≈300..1020.
+    thumb_section_top = int(height * 0.16)   # y ≈ 307
+    thumb_section_h = int(height * 0.38)     # h ≈ 730
+    try:
+        thumb = Image.open(long_form_thumbnail_path).convert("RGB")
+        # Scale-to-fit (preserve aspect, fit inside thumb_section).
+        src_ratio = thumb.width / thumb.height
+        target_w = width
+        target_h = int(round(target_w / src_ratio))
+        if target_h > thumb_section_h:
+            target_h = thumb_section_h
+            target_w = int(round(target_h * src_ratio))
+        thumb = thumb.resize((target_w, target_h), Image.LANCZOS)
+        thumb_x = (width - target_w) // 2
+        thumb_y = thumb_section_top + (thumb_section_h - target_h) // 2
+        bg.paste(thumb, (thumb_x, thumb_y))
+        # Subtle 4-px white frame around the thumbnail so it reads as
+        # a "tap me" target rather than blending into the background.
+        ImageDraw.Draw(bg).rectangle(
+            (thumb_x - 4, thumb_y - 4,
+             thumb_x + target_w + 4, thumb_y + target_h + 4),
+            outline=(255, 255, 255), width=4,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        logger.warning(
+            "Shorts end card: long-form thumbnail unavailable (%s) — "
+            "rendering text-only card. (%s)",
+            long_form_thumbnail_path, exc,
+        )
+        # No thumbnail to paste — the rest of the card still renders.
+
+    draw = ImageDraw.Draw(bg)
+
+    # Optional show pill at the very top (mirrors the brand pill on
+    # the Shorts MP4 above the slideshow).
+    if show_name:
+        show_font = _load_font(36)
+        sw_bbox = show_font.getbbox(show_name)
+        show_w = sw_bbox[2] - sw_bbox[0]
+        draw.text(
+            ((width - show_w) // 2, int(height * 0.07)),
+            show_name, font=show_font, fill=(232, 236, 244),
+        )
+
+    # Main CTA headline — same fontsize as the drawtext end card so
+    # the visual jump from PNG → drawtext fallback isn't jarring.
+    main_y = int(height * 0.62)
+    main_font = _load_font(88)
+    mw_bbox = main_font.getbbox(main_text)
+    main_w = mw_bbox[2] - mw_bbox[0]
+    main_x = (width - main_w) // 2
+    # Subtle drop shadow + outline for legibility on the dark BG.
+    draw.text((main_x + 3, main_y + 3), main_text, font=main_font,
+              fill=(0, 0, 0))
+    draw.text((main_x, main_y), main_text, font=main_font,
+              fill=(255, 255, 255))
+
+    # Sub-line in Nerra cyan (#00D4FF) — matches the per-word caption
+    # highlight from PR #415 + the drawtext sub-line from PR #417.
+    sub_y = int(height * 0.74)
+    sub_font = _load_font(56)
+    sw2_bbox = sub_font.getbbox(sub_text)
+    sub_w = sw2_bbox[2] - sw2_bbox[0]
+    sub_x = (width - sub_w) // 2
+    draw.text((sub_x + 2, sub_y + 2), sub_text, font=sub_font,
+              fill=(0, 0, 0))
+    draw.text((sub_x, sub_y), sub_text, font=sub_font,
+              fill=(0, 212, 255))
+
+    # Footer with the network URL — small + muted so it doesn't
+    # compete with the CTA above. Sits clear of the Shorts URL pill
+    # at y≈1820 by living at y≈1870.
+    footer_y = int(height * 0.93)
+    footer_font = _load_font(32)
+    footer_text = "nerranetwork.com"
+    fw_bbox = footer_font.getbbox(footer_text)
+    footer_w = fw_bbox[2] - fw_bbox[0]
+    draw.text(
+        ((width - footer_w) // 2, footer_y),
+        footer_text, font=footer_font, fill=(139, 143, 174),  # --nn-text-muted
+    )
+
+    bg.save(output_path, format="PNG", optimize=True)
+    return output_path
+
+
 # ---------------------------------------------------------------------------
 # Digest formatting for X posting
 # ---------------------------------------------------------------------------

--- a/engine/video.py
+++ b/engine/video.py
@@ -662,7 +662,8 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
                              end_card_duration: float = 3.0,
                              total_duration: float = 55.0,
                              end_card_main_text: str = "WATCH FULL EPISODE",
-                             end_card_sub_text: str = "Tap Subscribe ↗") -> str:
+                             end_card_sub_text: str = "Tap Subscribe ↗",
+                             end_card_image_input_label: Optional[str] = None) -> str:
     """filter_complex for the 1080x1920 Shorts build.
 
     Inputs:
@@ -774,29 +775,27 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
         return chain
 
     if end_card:
-        # Last-3-seconds CTA card. Three stacked overlays bound to a
-        # single enable window so the layer is atomic — either all
-        # three render (between t=END-3 and t=END) or none do.
+        # Last-N-seconds CTA card. Two render paths, gated by
+        # ``end_card_image_input_label``:
         #
-        #   1. ``drawbox`` paints a full-frame translucent black panel
-        #      to wipe the slideshow + captions, focusing attention.
-        #   2. ``drawtext`` for the headline ("WATCH FULL EPISODE")
-        #      sits centred slightly above mid-frame.
-        #   3. ``drawtext`` for the sub-line ("Tap Subscribe ↗") sits
-        #      under the headline, pointing the viewer at YouTube's
-        #      own subscribe button on the right rail of the Shorts
-        #      player.
+        # * PNG overlay (preferred). The caller renders the card
+        #   PNG via engine.publisher.generate_shorts_end_card —
+        #   that image composites the long-form thumbnail with
+        #   the CTA copy in a richer layout than ffmpeg can paint
+        #   inline. The label points at the ffmpeg input index
+        #   for the PNG (e.g. ``[4:v]``). We overlay it on top of
+        #   the slideshow with an ``enable`` clause for the last
+        #   N seconds.
         #
-        # Why drawbox / drawtext rather than a composited PNG: zero
-        # filesystem dependency (no new asset to generate per-episode),
-        # the text is parameterisable per-show via YAML, and the
-        # filter chain stays self-contained. A PNG end-card with the
-        # long-form thumbnail is a worthwhile follow-up but adds an
-        # asset-generation step that ffmpeg doesn't need today.
-        font_path = _drawtext_escape(_find_font())
+        # * Drawtext fallback (no PNG provided). drawbox + 2
+        #   drawtext filters paint the card inline — the
+        #   pre-PR-#420 behaviour. Useful for tests / when PNG
+        #   generation fails / for shows that opt-out of the
+        #   thumbnail-bearing card.
+        #
+        # Both paths bind to the same ``between(t, END-N, END)``
+        # enable window so the layer is atomic.
         if total_duration <= end_card_duration:
-            # Degenerate case: clip shorter than the end card. Run
-            # the card for the whole clip.
             end_card_start = 0.0
         else:
             end_card_start = max(0.0, total_duration - end_card_duration)
@@ -804,6 +803,20 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
         enable_clause = (
             f"between(t,{end_card_start:.2f},{end_card_end:.2f})"
         )
+
+        if end_card_image_input_label:
+            # PNG path. The input is added as a video stream
+            # upstream (in _short_form_cmd) and labelled with
+            # whatever index the caller assigned, e.g. ``[4:v]``.
+            chain += (
+                f";{end_card_image_input_label}format=rgba[endcard];"
+                f"{post_brand_label}[endcard]overlay="
+                f"x=0:y=0:enable='{enable_clause}'[v]"
+            )
+            return chain
+
+        # Drawtext fallback path.
+        font_path = _drawtext_escape(_find_font())
         escaped_main = _drawtext_escape(end_card_main_text)
         escaped_sub = _drawtext_escape(end_card_sub_text)
         chain += (
@@ -820,7 +833,7 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
             f"shadowx=2:shadowy=2:shadowcolor=black@0.7:"
             f"enable='{enable_clause}'"
             # 3. Sub-line — smaller, accent colour (cyan, matches
-            # the per-word caption highlight from the previous PR).
+            # the per-word caption highlight from PR #415).
             f",drawtext=fontfile='{font_path}':"
             f"text='{escaped_sub}':"
             f"fontsize=56:fontcolor=0x00D4FF:"
@@ -900,7 +913,8 @@ def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
                     end_card: bool = False,
                     end_card_main_text: str = "WATCH FULL EPISODE",
                     end_card_sub_text: str = "Tap Subscribe ↗",
-                    end_card_duration: float = 3.0) -> List[str]:
+                    end_card_duration: float = 3.0,
+                    end_card_image_in: Optional[str] = None) -> List[str]:
     """ffmpeg command for the 1080x1920 Shorts build.
 
     When *bg_is_video* is True, *bg_in* is a pre-rendered vertical
@@ -925,10 +939,23 @@ def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
         bg_input = ["-loop", "1", "-framerate", str(fps), "-i", bg_in]
 
     extra_inputs: List[str] = []
+    # ffmpeg input order is fixed: [0:v] bg, [1:a] audio, [2:v] brand,
+    # then optional [3:v] url_pill, then optional [N:v] end_card_image.
+    # Compute the end-card image's input index based on what came
+    # before it so the filter graph references the right stream.
+    next_input_index = 3
     if url_pill_in:
-        extra_inputs = [
+        extra_inputs.extend([
             "-loop", "1", "-framerate", str(fps), "-i", url_pill_in,
-        ]
+        ])
+        next_input_index += 1
+
+    end_card_image_input_label: Optional[str] = None
+    if end_card and end_card_image_in:
+        extra_inputs.extend([
+            "-loop", "1", "-framerate", str(fps), "-i", end_card_image_in,
+        ])
+        end_card_image_input_label = f"[{next_input_index}:v]"
 
     return [
         "ffmpeg", "-y", "-threads", "0",
@@ -947,7 +974,8 @@ def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
                                  end_card_duration=end_card_duration,
                                  total_duration=duration,
                                  end_card_main_text=end_card_main_text,
-                                 end_card_sub_text=end_card_sub_text),
+                                 end_card_sub_text=end_card_sub_text,
+                                 end_card_image_input_label=end_card_image_input_label),
         "-map", "[v]", "-map", "1:a",
         *_VIDEO_ENCODE,
         "-r", str(fps),
@@ -1091,7 +1119,8 @@ def build_short_video(audio_path: Path, cover_path: Path,
                       end_card: bool = False,
                       end_card_main_text: str = "WATCH FULL EPISODE",
                       end_card_sub_text: str = "Tap Subscribe ↗",
-                      end_card_duration: float = 3.0) -> Path:
+                      end_card_duration: float = 3.0,
+                      end_card_image_path: Optional[Path] = None) -> Path:
     """Render a 1080x1920 vertical YouTube Shorts video.
 
     Parameters
@@ -1178,6 +1207,11 @@ def build_short_video(audio_path: Path, cover_path: Path,
         end_card_main_text=end_card_main_text,
         end_card_sub_text=end_card_sub_text,
         end_card_duration=end_card_duration,
+        end_card_image_in=(
+            str(end_card_image_path)
+            if end_card_image_path and Path(end_card_image_path).exists()
+            else None
+        ),
     )
     logger.info(
         "Building Shorts video (%.1fs from %.1fs) → %s "

--- a/run_show.py
+++ b/run_show.py
@@ -3013,6 +3013,7 @@ def _publish_youtube(
     )
     from engine.publisher import (
         generate_episode_thumbnail,
+        generate_shorts_end_card,
         generate_shorts_thumbnail,
     )
     from engine.video import build_long_form_video, build_short_video
@@ -3534,6 +3535,44 @@ def _publish_youtube(
                     logger.warning("Shorts caption generation failed: %s", exc)
 
             _yt = config.youtube
+            _end_card_enabled = bool(
+                getattr(_yt, "shorts_end_card_enabled", True)
+            )
+            _end_card_main = str(
+                getattr(_yt, "shorts_end_card_main_text", "WATCH FULL EPISODE")
+            )
+            _end_card_sub = str(
+                getattr(_yt, "shorts_end_card_sub_text", "Tap Subscribe ↗")
+            )
+            _end_card_dur = float(
+                getattr(_yt, "shorts_end_card_duration_seconds", 3.0) or 3.0
+            )
+
+            # PNG end card with the long-form thumbnail composited in
+            # (May 2026 visual upgrade). Generated only when end-card
+            # is enabled AND we successfully built a long-form
+            # thumbnail upstream. Failure here drops back to the
+            # drawtext-only path inside build_short_video — soft
+            # degradation, never blocks the Shorts publish.
+            _end_card_image_path = None
+            if _end_card_enabled and thumbnail_path and Path(thumbnail_path).exists():
+                try:
+                    _end_card_image_candidate = work_dir / f"{base_name}_end_card.png"
+                    generate_shorts_end_card(
+                        thumbnail_path,
+                        _end_card_image_candidate,
+                        show_name=config.name,
+                        main_text=_end_card_main,
+                        sub_text=_end_card_sub,
+                    )
+                    if _end_card_image_candidate.exists():
+                        _end_card_image_path = _end_card_image_candidate
+                except Exception as exc:  # pragma: no cover — best-effort
+                    logger.warning(
+                        "Shorts end-card PNG render failed: %s — "
+                        "falling back to drawtext-only end card", exc,
+                    )
+
             build_short_video(
                 final_mp3, cover_path, short_video_path,
                 start_offset=short_offset,
@@ -3542,16 +3581,11 @@ def _publish_youtube(
                 scene_paths=short_scene_paths if len(short_scene_paths) >= 2 else None,
                 show_name=config.name,
                 subtitles_path=short_srt_path,
-                end_card=bool(getattr(_yt, "shorts_end_card_enabled", True)),
-                end_card_main_text=str(
-                    getattr(_yt, "shorts_end_card_main_text", "WATCH FULL EPISODE")
-                ),
-                end_card_sub_text=str(
-                    getattr(_yt, "shorts_end_card_sub_text", "Tap Subscribe ↗")
-                ),
-                end_card_duration=float(
-                    getattr(_yt, "shorts_end_card_duration_seconds", 3.0) or 3.0
-                ),
+                end_card=_end_card_enabled,
+                end_card_main_text=_end_card_main,
+                end_card_sub_text=_end_card_sub,
+                end_card_duration=_end_card_dur,
+                end_card_image_path=_end_card_image_path,
             )
             meta = build_short_metadata(
                 config,

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1188,3 +1188,216 @@ def test_short_form_filter_graph_long_hook_uses_smaller_font():
         f"long hook should have shrunk below 44, got {chosen}"
     )
     assert chosen >= 32, f"smallest allowed is 32, got {chosen}"
+
+
+# ---------------------------------------------------------------------------
+# Shorts end-card PNG overlay path
+# ---------------------------------------------------------------------------
+#
+# May 2026 visual upgrade (PR #420): when a pre-rendered end-card
+# PNG is passed to build_short_video, the filter graph swaps the
+# drawbox+drawtext fallback for a single overlay= filter sourcing
+# the PNG. The drawtext path stays as the soft-failure fallback
+# (PNG generation failed → ship the text-only card).
+
+def test_short_form_filter_graph_end_card_image_uses_overlay():
+    """When ``end_card_image_input_label`` is provided, the filter
+    graph must overlay that image (NOT emit drawbox + drawtext)."""
+    graph = _short_form_filter_graph(
+        end_card=True, total_duration=55.0,
+        end_card_image_input_label="[3:v]",
+    )
+    # Overlay filter sourcing the image label.
+    assert "[3:v]format=rgba[endcard]" in graph
+    assert "[endcard]overlay=x=0:y=0:enable='between(t,52.00,55.00)'[v]" in graph
+    # Drawtext fallback is NOT emitted.
+    assert "drawbox" not in graph
+    assert "WATCH FULL EPISODE" not in graph
+
+
+def test_short_form_filter_graph_end_card_drawtext_when_no_image():
+    """No ``end_card_image_input_label`` keeps the legacy drawtext +
+    drawbox fallback path so the soft-failure behaviour ships."""
+    graph = _short_form_filter_graph(
+        end_card=True, total_duration=55.0,
+        end_card_image_input_label=None,
+    )
+    assert "drawbox" in graph
+    assert "WATCH FULL EPISODE" in graph
+    assert "[endcard]overlay" not in graph
+
+
+def test_short_form_filter_graph_end_card_image_composes_with_captions():
+    """Overlay path must compose cleanly with subtitles too —
+    captions terminate at ``[capted]`` and the overlay chains from
+    there to the final ``[v]``."""
+    graph = _short_form_filter_graph(
+        end_card=True, total_duration=55.0,
+        subtitles_path="/tmp/short.srt",
+        end_card_image_input_label="[4:v]",
+    )
+    assert "[capted]" in graph
+    assert "[4:v]format=rgba[endcard]" in graph
+    assert "[capted][endcard]overlay" in graph
+    assert graph.endswith("[v]")
+    assert graph.count("[v]") == 1
+
+
+def test_short_form_cmd_adds_end_card_image_as_input(tmp_path, monkeypatch):
+    """``build_short_video(end_card_image_path=path)`` must add the
+    image as another ffmpeg ``-i`` input AND wire the right index
+    label into the filter graph."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    end_card = tmp_path / "end_card.png"
+    end_card.write_bytes(b"\x89PNG\r\n\x1a\n")  # minimal PNG magic
+    out = tmp_path / "short.mp4"
+
+    captured = []
+    monkeypatch.setattr(
+        "engine.video.subprocess.run",
+        lambda cmd, **kw: (captured.append(list(cmd)),
+                           type("R", (), {"returncode": 0})())[1],
+    )
+    build_short_video(
+        audio, cover, out, duration=55.0,
+        show_name="Tesla Shorts Time",  # → adds url_pill at [3:v]
+        end_card=True,
+        end_card_image_path=end_card,
+    )
+    assert captured, "no ffmpeg cmd captured"
+    cmd = captured[-1]
+    # The end-card PNG appears as a -i input.
+    assert str(end_card) in cmd
+    # Filter graph references the right index. With show_name=Tesla
+    # the URL pill takes [3:v], so the end-card lands at [4:v].
+    graph = cmd[cmd.index("-filter_complex") + 1]
+    assert "[4:v]format=rgba[endcard]" in graph
+
+
+def test_short_form_cmd_end_card_image_index_when_no_url_pill(tmp_path, monkeypatch):
+    """When the show passes ``show_name=None`` (legacy single
+    pill), there's no URL pill at [3:v], so the end-card PNG lands
+    at [3:v] instead of [4:v]."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    end_card = tmp_path / "end_card.png"
+    end_card.write_bytes(b"\x89PNG\r\n\x1a\n")
+    out = tmp_path / "short.mp4"
+
+    captured = []
+    monkeypatch.setattr(
+        "engine.video.subprocess.run",
+        lambda cmd, **kw: (captured.append(list(cmd)),
+                           type("R", (), {"returncode": 0})())[1],
+    )
+    build_short_video(
+        audio, cover, out, duration=55.0,
+        show_name=None,  # legacy "Nerra Network" single pill, no URL pill
+        end_card=True,
+        end_card_image_path=end_card,
+    )
+    assert captured
+    cmd = captured[-1]
+    graph = cmd[cmd.index("-filter_complex") + 1]
+    assert "[3:v]format=rgba[endcard]" in graph
+
+
+def test_short_form_cmd_missing_end_card_image_falls_back_to_drawtext(
+    tmp_path, monkeypatch,
+):
+    """When the operator passes ``end_card_image_path`` but the file
+    doesn't exist on disk, build_short_video must fall back to the
+    drawtext path rather than crash or feed a missing file to
+    ffmpeg."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    out = tmp_path / "short.mp4"
+
+    captured = []
+    monkeypatch.setattr(
+        "engine.video.subprocess.run",
+        lambda cmd, **kw: (captured.append(list(cmd)),
+                           type("R", (), {"returncode": 0})())[1],
+    )
+    build_short_video(
+        audio, cover, out, duration=55.0,
+        show_name="Tesla Shorts Time",
+        end_card=True,
+        end_card_image_path=tmp_path / "nonexistent_end_card.png",
+    )
+    assert captured
+    cmd = captured[-1]
+    graph = cmd[cmd.index("-filter_complex") + 1]
+    # Drawtext fallback in use.
+    assert "drawbox" in graph
+    assert "WATCH FULL EPISODE" in graph
+    # Filter graph does NOT reference any [N:v] for the missing image.
+    assert "[endcard]overlay" not in graph
+
+
+# ---------------------------------------------------------------------------
+# generate_shorts_end_card — PNG composition
+# ---------------------------------------------------------------------------
+
+def test_generate_shorts_end_card_produces_valid_png(tmp_path):
+    """Smoke test: feed a tiny stub thumbnail in, get a 1080×1920
+    PNG out with the expected text rendered."""
+    from PIL import Image
+    from engine.publisher import generate_shorts_end_card
+
+    thumb = tmp_path / "long_thumb.jpg"
+    Image.new("RGB", (1280, 720), (60, 80, 120)).save(thumb, format="JPEG")
+    out = tmp_path / "end_card.png"
+
+    generate_shorts_end_card(
+        thumb, out,
+        show_name="Tesla Shorts Time",
+    )
+
+    assert out.exists()
+    with Image.open(out) as img:
+        assert img.format == "PNG"
+        assert img.size == (1080, 1920)
+
+
+def test_generate_shorts_end_card_missing_thumbnail_still_renders(tmp_path):
+    """Long-form thumbnail can fail upstream; the end card must
+    still ship (just without the embedded thumbnail). Defensive
+    against an unexpected upstream failure on rare episodes."""
+    from PIL import Image
+    from engine.publisher import generate_shorts_end_card
+
+    out = tmp_path / "end_card.png"
+    generate_shorts_end_card(
+        tmp_path / "nonexistent.jpg", out,
+        show_name="Tesla Shorts Time",
+    )
+    assert out.exists()
+    with Image.open(out) as img:
+        assert img.size == (1080, 1920)
+
+
+def test_generate_shorts_end_card_custom_text(tmp_path):
+    """``main_text`` / ``sub_text`` are configurable per show."""
+    from PIL import Image
+    from engine.publisher import generate_shorts_end_card
+
+    thumb = tmp_path / "long_thumb.jpg"
+    Image.new("RGB", (1280, 720), (10, 10, 10)).save(thumb, format="JPEG")
+    out = tmp_path / "end_card.png"
+    # Default vs custom shouldn't crash either way — that's the
+    # contract we're verifying here.
+    generate_shorts_end_card(
+        thumb, out,
+        show_name="Russian Show",
+        main_text="СМОТРИТЕ ВЕСЬ ЭПИЗОД",
+        sub_text="Подписывайтесь ↗",
+    )
+    assert out.exists()


### PR DESCRIPTION
## Summary

Visual upgrade to the end card shipped in PR #417. The drawtext-only version was a 78%-opaque black panel + 2 lines of text — functional but generic. This PR composites the long-form thumbnail into the card so viewers see what the actual full episode looks like, which is significantly more compelling than a text-only "WATCH FULL EPISODE" prompt.

## Layout (1080×1920 PNG)

| Section | y range | Content |
|---|---|---|
| Show pill | y ≈ 134 | Show name in white DM Sans-equivalent |
| Long-form thumbnail | y ≈ 307–1037 | 1280×720 thumb scaled to 1080 wide, framed with a 4-px white border (signals "tap target") |
| Headline | y ≈ 1190 | `WATCH FULL EPISODE` — 88 px white, bold, drop shadow |
| Sub-line | y ≈ 1421 | `Tap Subscribe ↗` — 56 px Nerra cyan `#00D4FF` (matches the per-word caption highlight from #415) |
| Footer | y ≈ 1786 | `nerranetwork.com` — 32 px muted slate |

## Pipeline flow

1. `run_show.py` generates the end-card PNG via `engine.publisher.generate_shorts_end_card(long_form_thumbnail, …)` before calling `build_short_video`.
2. `build_short_video` accepts `end_card_image_path` and threads it down.
3. `_short_form_cmd` adds the PNG as another ffmpeg `-i` input. Index is computed dynamically: `[3:v]` when there's no URL pill, `[4:v]` when there is.
4. `_short_form_filter_graph` swaps the drawbox + 2 drawtext filters for a single `overlay=enable='between(t,END-3,END)'` filter sourcing the PNG.

## Fallback behaviour

The drawtext-only path from PR #417 stays as the soft-failure fallback. Two ways to land there:

- `run_show.py` PNG generation throws (rare PIL crash, font missing) → caught + logged, `end_card_image_path=None` passed down → drawtext fires.
- `end_card_image_path` is set but the file doesn't exist when `build_short_video` runs → existence check fails → drawtext fires.

Either way the operator gets a CTA card, just text-only. No regression vs PR #417.

## Files

| File | Change |
|---|---|
| `engine/publisher.py` | New `generate_shorts_end_card` — pure PIL composition, defensive against missing thumbnail |
| `engine/video.py` | `_short_form_filter_graph` learns `end_card_image_input_label`; `_short_form_cmd` adds PNG input + computes index; `build_short_video` threads `end_card_image_path` through |
| `run_show.py` | Generates PNG before `build_short_video`, passes path through |
| `tests/test_video_commands.py` | 9 new tests |
| `CLAUDE.md` | Replaced the May 2026 end-card paragraph with the PNG-upgraded description |

## Test plan

- [x] `pytest tests/test_video_commands.py -k "end_card or generate_shorts_end_card"` — 18 passed
- [x] `pytest tests/ --deselect [the 2 stale MAB tests]` — 2173 passed, 3 skipped
- [x] Custom Russian-text card (`СМОТРИТЕ ВЕСЬ ЭПИЗОД`) renders without crashing
- [x] Missing-thumbnail path produces a valid 1080×1920 PNG (just without the embedded thumbnail)
- [x] Filter-graph input index computed correctly with + without URL pill
- [ ] **Pending after merge:** next Tesla / MAB Shorts upload — operator-side phone check that the long-form thumbnail composites cleanly into the last 3 s of the Short

## Known unrelated CI failure

Same recurring MAB stale-test failure as PRs #413, #415, #416, #417, #418, #419. Not caused by this PR.

## What's next from the list

- **Multiple Shorts per episode** — biggest remaining engagement multiplier. Quota fits (4/6 daily slots used, 2 available). Real pipeline refactor.
- **A/B thumbnail variants** — depends on YouTube Studio API exposure; uncertain feasibility.
- **Smart vertical crop** — de-prioritised; Grok generates 9:16 directly.

https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2)_