### PR TITLE
Shorts: support multiple Shorts per episode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,26 @@ episode so the dashboard can show smart-vs-fallback rates. New shows
 opt in by setting `youtube.shorts_start_mode: smart` in their YAML.
 Drift guards in `tests/test_shorts_selector.py`.
 
+**Multiple Shorts per episode.** Setting `youtube.shorts_per_episode`
+to N (default 1; cap at 2-3 for YouTube quota safety on the
+@NerraNetwork channel — see landmine #20) makes the runner publish
+N Shorts per episode instead of one. Each Short comes from one of
+the top-N non-overlapping windows the smart selector
+([`pick_top_n_engaging_windows`](engine/shorts_selector.py)) picks
+from the transcript; each gets a distinct headline (the window's
+opening text), a distinct thumbnail (cycled through the available
+Grok-Imagine scene images), and a distinct filename
+(`_short_1.mp4`, `_short_2.mp4`, …). Uploads are sequential; one
+failure doesn't block the others. Per-Short error captures land in
+`result["short_errors"][i]` and the aggregate
+`shorts_count_requested` / `shorts_count_uploaded` metrics fire on
+every episode so the dashboard can plot the multi-Shorts hit rate.
+Requires `shorts_start_mode: smart` (the voice / first_chapter
+modes only know about one offset). Default 1 preserves legacy
+single-Short behaviour byte-for-byte. Drift guards in
+`tests/test_shorts_selector.py` under the
+`pick_top_n_engaging_windows` block.
+
 **Auto-hashtag injection on Shorts descriptions.** Every Shorts
 upload now carries entity-derived hashtags in its description
 (via [`engine.shorts_hashtags.extract_hashtags`](engine/shorts_hashtags.py)).

--- a/engine/config.py
+++ b/engine/config.py
@@ -397,6 +397,20 @@ class YouTubeConfig:
     shorts_end_card_sub_text: str = "Tap Subscribe ↗"
     shorts_end_card_duration_seconds: float = 3.0
 
+    # Multiple Shorts per episode (May 2026). When > 1, the
+    # smart-selector picks the top-N non-overlapping engaging windows
+    # from the episode transcript and publishes each as its own
+    # Short, with distinct title (taken from each window's opening
+    # text) and distinct thumbnail. Default 1 preserves legacy
+    # single-Short behaviour. Quota caveat: each Short upload costs
+    # 1 600 quota units on the YouTube Data API; the @NerraNetwork
+    # channel has 10 000/day total. With Tesla + MAB long+short
+    # already at 6 400 (4 uploads × 1 600), only 2 extra Shorts fit
+    # before hitting the cap. ``smart`` shorts_start_mode is
+    # required: voice / first_chapter modes only know about one
+    # offset so they ignore this knob and always produce 1 Short.
+    shorts_per_episode: int = 1
+
 
 @dataclass
 class ShowConfig:

--- a/engine/shorts_selector.py
+++ b/engine/shorts_selector.py
@@ -344,3 +344,109 @@ def pick_engaging_window(
         best.start_seconds, best.score, best.opening_text,
     )
     return best
+
+
+def pick_top_n_engaging_windows(
+    transcript_path: Path,
+    *,
+    n: int,
+    audio_offset: float,
+    audio_duration: float,
+    window_duration: float = 55.0,
+    min_start_final: Optional[float] = None,
+    min_score_threshold: float = 5.0,
+    min_gap_seconds: float = 10.0,
+) -> List[ScoredWindow]:
+    """Return up to ``n`` non-overlapping windows ranked by score.
+
+    Powers the "multiple Shorts per episode" pipeline. Each window's
+    start must be at least ``min_gap_seconds`` AFTER the previous
+    picked window's end, so the N Shorts cover genuinely different
+    moments of the episode rather than near-duplicates.
+
+    Selection is greedy-by-score: take the top-scoring candidate
+    first, then filter remaining candidates to those that don't
+    overlap (with the gap), then take the next-highest, repeat.
+    This produces the N most engaging windows that are also
+    temporally distinct.
+
+    Behaviour at the edges:
+
+    * Fewer than ``n`` candidates above ``min_score_threshold`` →
+      returns whatever it found (possibly empty). Caller decides
+      whether to fall back to legacy voice-start for the missing
+      slots.
+    * No candidates at all → returns ``[]``.
+    * ``n <= 0`` → returns ``[]`` (defensive — caller bug).
+    * Transcript unreadable → returns ``[]`` (logged in score_candidates).
+
+    Returned list is sorted by ``start_seconds`` ascending so the
+    Shorts publish flow uploads them in chronological order
+    (Short 1 from earlier in the episode, Short 2 later) — a small
+    but real engagement signal for viewers who watch multiple
+    Shorts in a row.
+    """
+    if n <= 0:
+        return []
+    floor = audio_offset if min_start_final is None else min_start_final
+    candidates = score_candidates(
+        transcript_path,
+        audio_offset=audio_offset,
+        audio_duration=audio_duration,
+        window_duration=window_duration,
+        min_start_final=floor,
+    )
+    if not candidates:
+        logger.info(
+            "Smart Shorts selector (top-%d): no scorable candidates in %s",
+            n, transcript_path.name,
+        )
+        return []
+
+    picked: List[ScoredWindow] = []
+    # ``candidates`` is already sorted by score descending. Walk it
+    # greedily and accept any that doesn't overlap a previously
+    # picked window.
+    for cand in candidates:
+        if cand.score < min_score_threshold:
+            break  # remaining are all below threshold too
+        if not _overlaps_any(cand, picked, min_gap_seconds):
+            picked.append(cand)
+            if len(picked) >= n:
+                break
+
+    # Re-sort by start time so the caller can iterate chronologically.
+    picked.sort(key=lambda w: w.start_seconds)
+    if picked:
+        logger.info(
+            "Smart Shorts selector (top-%d): picked %d window(s): %s",
+            n, len(picked),
+            ", ".join(
+                f"{w.start_seconds:.1f}s(score={w.score:.1f})" for w in picked
+            ),
+        )
+    else:
+        logger.info(
+            "Smart Shorts selector (top-%d): no candidate above threshold "
+            "%.1f in %s",
+            n, min_score_threshold, transcript_path.name,
+        )
+    return picked
+
+
+def _overlaps_any(
+    candidate: ScoredWindow,
+    others: List[ScoredWindow],
+    min_gap_seconds: float,
+) -> bool:
+    """True when ``candidate`` overlaps with any window in ``others``
+    OR sits within ``min_gap_seconds`` of one. Two windows are
+    "non-overlapping with gap" iff ``other.end + gap <= candidate.start``
+    OR ``candidate.end + gap <= other.start``."""
+    for other in others:
+        if (
+            candidate.start_seconds < other.end_seconds + min_gap_seconds
+            and other.start_seconds < candidate.end_seconds + min_gap_seconds
+        ):
+            return True
+    return False

--- a/run_show.py
+++ b/run_show.py
@@ -2234,6 +2234,20 @@ def run(args: argparse.Namespace) -> None:
                 "shorts_start_mode_resolved",
                 str(youtube_urls["shorts_start_mode_resolved"]),
             )
+        # Multi-Shorts counters (May 2026). Single-Short runs still
+        # report ``requested=1, uploaded=0/1`` so the dashboard can
+        # compute the fallback rate across the network without
+        # special-casing the legacy path.
+        if "shorts_count_requested" in youtube_urls:
+            metrics.record(
+                "shorts_count_requested",
+                int(youtube_urls.get("shorts_count_requested", 1) or 1),
+            )
+        if "shorts_count_uploaded" in youtube_urls:
+            metrics.record(
+                "shorts_count_uploaded",
+                int(youtube_urls.get("shorts_count_uploaded", 0) or 0),
+            )
         if youtube_urls.get("gallery_skipped_reason"):
             metrics.record(
                 "gallery_skipped_reason",
@@ -3440,21 +3454,18 @@ def _publish_youtube(
         config, episode_num=episode_num,
     ):
         try:
-            short_offset = resolve_shorts_start_offset(
-                config,
-                chapters_path if chapters_path.exists() else None,
-                audio_duration=_ep_duration,
-                transcript_path=transcript_path,
-            )
             duration = float(config.youtube.short_duration_seconds or 55.0)
-            # Surface the chosen offset on the result dict so the
-            # caller can record it as a metric. Operators reading the
-            # dashboard / metrics_ep*.json can then tell at a glance
-            # whether smart-mode is firing, which voice-fallback rate
-            # is, and whether a particular show's heuristic threshold
-            # needs tuning.
-            result["shorts_start_offset"] = round(short_offset, 2)
-            result["shorts_start_mode_resolved"] = (
+
+            # Resolve the "shorts plan" — a list of (start_offset, hook)
+            # pairs to publish, one per Short. Legacy single-Short
+            # behaviour is the len==1 case of this loop; multiple
+            # Shorts requires ``shorts_per_episode > 1`` AND
+            # ``shorts_start_mode: smart`` so the top-N selector has
+            # something to rank.
+            shorts_count_yaml = max(
+                1, int(getattr(config.youtube, "shorts_per_episode", 1) or 1)
+            )
+            mode_resolved = (
                 "explicit" if getattr(
                     config.youtube, "shorts_start_offset", None,
                 ) is not None
@@ -3463,77 +3474,60 @@ def _publish_youtube(
                     or "voice"
                 )
             )
-
-            # Build a Shorts-windowed SRT (May 2026 operator review:
-            # Shorts had no synced captions at all). Reuse the Whisper
-            # transcript that already powers the long-form SRT, slice
-            # it to the Shorts time window, and rebase timestamps to
-            # the Shorts clip's own t=0 timeline. Same
-            # ``voice_intro_delay`` offset the long-form SRT uses so
-            # the cues land on speech in the final audio.
-            #
-            # Format selection (May 2026): try ASS first for per-word
-            # highlighting (TikTok-style "current word" pop). The
-            # ffmpeg ``subtitles`` filter accepts both .ass and .srt
-            # transparently, so swapping extensions on the wire needs
-            # no video.py change. If the ASS file is empty (older
-            # transcript without word_timestamps, or no overlap with
-            # the Shorts window), fall back to the legacy SRT format
-            # — better a static cue card than no captions.
-            short_srt_path = None
-            if transcript_path is not None:
+            shorts_plan: "list[tuple[float, str]]" = []
+            if shorts_count_yaml > 1 and mode_resolved == "smart":
                 try:
-                    _caption_offset = float(
+                    from engine.shorts_selector import (
+                        pick_top_n_engaging_windows,
+                    )
+                    voice_offset = float(
                         getattr(config.audio, "voice_intro_delay", 0.0) or 0.0
                     )
-                    short_ass_candidate = work_dir / f"{base_name}_short.ass"
-                    transcript_to_ass_window(
-                        transcript_path,
-                        short_ass_candidate,
-                        window_start_seconds=short_offset,
-                        window_duration_seconds=duration,
-                        audio_offset_seconds=_caption_offset,
-                    )
-                    has_word_cues = (
-                        short_ass_candidate.exists()
-                        and short_ass_candidate.stat().st_size > 0
-                        # The empty-state file still has the [Script Info]
-                        # header (~480 bytes); a populated file always has
-                        # at least one Dialogue line on top of that. Use a
-                        # threshold rather than zero so empty-state files
-                        # fall through to SRT fallback cleanly.
-                        and "Dialogue:" in short_ass_candidate.read_text(
-                            encoding="utf-8", errors="replace",
-                        )
-                    )
-                    if has_word_cues:
-                        short_srt_path = short_ass_candidate
-                    else:
-                        logger.info(
-                            "Shorts per-word ASS contained no events — "
-                            "falling back to segment-level SRT for the "
-                            "[%.1fs, %.1fs] window.",
-                            short_offset, short_offset + duration,
-                        )
-                        short_srt_candidate = work_dir / f"{base_name}_short.srt"
-                        transcript_to_srt_window(
+                    if transcript_path is not None:
+                        windows = pick_top_n_engaging_windows(
                             transcript_path,
-                            short_srt_candidate,
-                            window_start_seconds=short_offset,
-                            window_duration_seconds=duration,
-                            audio_offset_seconds=_caption_offset,
+                            n=shorts_count_yaml,
+                            audio_offset=voice_offset,
+                            audio_duration=_ep_duration,
+                            window_duration=duration,
+                            min_start_final=voice_offset,
                         )
-                        if short_srt_candidate.exists() and short_srt_candidate.stat().st_size > 0:
-                            short_srt_path = short_srt_candidate
-                        else:
-                            logger.info(
-                                "Shorts SRT also empty — no cues fell "
-                                "inside the window. Shorts ships without "
-                                "burned-in captions.",
+                        shorts_plan = [
+                            (
+                                w.start_seconds,
+                                (w.opening_text or hook).strip() or hook,
                             )
+                            for w in windows
+                        ]
                 except Exception as exc:  # pragma: no cover — best-effort
-                    logger.warning("Shorts caption generation failed: %s", exc)
+                    logger.warning(
+                        "Multi-Shorts top-N selection failed (%s) — "
+                        "falling back to single short", exc,
+                    )
+                    shorts_plan = []
 
+            if not shorts_plan:
+                # Single-Short fallback: legacy resolved offset + the
+                # episode-level hook. Same code path as before
+                # ``shorts_per_episode`` existed.
+                fallback_offset = resolve_shorts_start_offset(
+                    config,
+                    chapters_path if chapters_path.exists() else None,
+                    audio_duration=_ep_duration,
+                    transcript_path=transcript_path,
+                )
+                shorts_plan = [(fallback_offset, hook)]
+
+            # Surface the resolved plan on the result dict. Single-
+            # Short fields stay for backwards compatibility with the
+            # dashboard / metrics consumers; the list-shaped fields
+            # are new and only useful when len(plan) > 1.
+            result["shorts_start_offset"] = round(shorts_plan[0][0], 2)
+            result["shorts_start_offsets"] = [round(o, 2) for o, _ in shorts_plan]
+            result["shorts_start_mode_resolved"] = mode_resolved
+            result["shorts_count_requested"] = shorts_count_yaml
+
+            # ---- Pre-loop assets shared across every Short ----
             _yt = config.youtube
             _end_card_enabled = bool(
                 getattr(_yt, "shorts_end_card_enabled", True)
@@ -3547,13 +3541,6 @@ def _publish_youtube(
             _end_card_dur = float(
                 getattr(_yt, "shorts_end_card_duration_seconds", 3.0) or 3.0
             )
-
-            # PNG end card with the long-form thumbnail composited in
-            # (May 2026 visual upgrade). Generated only when end-card
-            # is enabled AND we successfully built a long-form
-            # thumbnail upstream. Failure here drops back to the
-            # drawtext-only path inside build_short_video — soft
-            # degradation, never blocks the Shorts publish.
             _end_card_image_path = None
             if _end_card_enabled and thumbnail_path and Path(thumbnail_path).exists():
                 try:
@@ -3573,63 +3560,203 @@ def _publish_youtube(
                         "falling back to drawtext-only end card", exc,
                     )
 
-            build_short_video(
-                final_mp3, cover_path, short_video_path,
-                start_offset=short_offset,
-                duration=duration,
-                hook=hook or None,
-                scene_paths=short_scene_paths if len(short_scene_paths) >= 2 else None,
-                show_name=config.name,
-                subtitles_path=short_srt_path,
-                end_card=_end_card_enabled,
-                end_card_main_text=_end_card_main,
-                end_card_sub_text=_end_card_sub,
-                end_card_duration=_end_card_dur,
-                end_card_image_path=_end_card_image_path,
+            _caption_offset = float(
+                getattr(config.audio, "voice_intro_delay", 0.0) or 0.0
             )
-            meta = build_short_metadata(
-                config,
-                episode_num=episode_num,
-                today_str=today_str,
-                hook=hook,
-                long_form_url=long_url,
-            )
-            short_thumb = (
-                short_thumbnail_path
-                if short_thumbnail_path and Path(short_thumbnail_path).exists()
-                else thumbnail_path
-            )
-            short_upload = upload_video(
-                short_video_path,
-                credentials=credentials,
-                title=meta["title"],
-                description=meta["description"],
-                tags=meta["tags"],
-                category_id=meta["category_id"],
-                default_language=meta["default_language"],
-                privacy_status=config.youtube.privacy_status,
-                thumbnail_path=short_thumb,
-            )
-            result["short_url"] = short_upload.watch_url
-            playlist_id = (
-                getattr(config.youtube, "podcast_playlist_id", None) or ""
-            ).strip()
-            if not playlist_id:
-                logger.info(
-                    "Podcast playlist ID empty — skipping playlist add."
+
+            # ---- Per-Short loop ----
+            short_urls_out: "list[str]" = []
+            short_video_ids_out: "list[str]" = []
+            short_errors_out: "list[dict]" = []
+            multi = len(shorts_plan) > 1
+            for short_idx, (this_offset, this_hook) in enumerate(shorts_plan):
+                # Filename suffix is empty for the single-Short case so
+                # the legacy ``{base}_short.mp4`` path stays exactly the
+                # same when ``shorts_per_episode == 1``.
+                suffix = f"_{short_idx + 1}" if multi else ""
+                this_short_video_path = work_dir / f"{base_name}_short{suffix}.mp4"
+                this_short_thumb_path = (
+                    work_dir / f"{base_name}_short{suffix}_thumb.jpg"
+                    if multi else short_thumbnail_path
                 )
-            else:
-                add_video_to_playlist(
-                    credentials=credentials,
-                    video_id=short_upload.video_id,
-                    playlist_id=playlist_id,
-                )
+                try:
+                    # Per-Short thumbnail: cycle through the available
+                    # scene images so each Short has a visually
+                    # distinct preview in YouTube's grid. Falls back
+                    # to the long-form cover for any iteration where
+                    # the scene path doesn't exist on disk.
+                    if multi or getattr(_yt, "shorts_thumbnail_from_scene", True):
+                        _thumb_base = cover_path
+                        if short_scene_paths:
+                            _thumb_base = short_scene_paths[
+                                short_idx % len(short_scene_paths)
+                            ]
+                        try:
+                            generate_shorts_thumbnail(
+                                _thumb_base,
+                                episode_num=episode_num,
+                                date_str=today_str,
+                                output_path=this_short_thumb_path,
+                                hook=this_hook,
+                                show_name=show_label,
+                            )
+                        except Exception as exc:  # pragma: no cover
+                            logger.warning(
+                                "Shorts thumbnail #%d failed: %s — "
+                                "falling back to long-form thumbnail",
+                                short_idx + 1, exc,
+                            )
+                            this_short_thumb_path = thumbnail_path
+
+                    # Per-Short caption (ASS first, SRT fallback) —
+                    # same selection logic as the single-Short path.
+                    this_srt_path = None
+                    if transcript_path is not None:
+                        try:
+                            ass_candidate = (
+                                work_dir / f"{base_name}_short{suffix}.ass"
+                            )
+                            transcript_to_ass_window(
+                                transcript_path,
+                                ass_candidate,
+                                window_start_seconds=this_offset,
+                                window_duration_seconds=duration,
+                                audio_offset_seconds=_caption_offset,
+                            )
+                            has_word_cues = (
+                                ass_candidate.exists()
+                                and ass_candidate.stat().st_size > 0
+                                and "Dialogue:" in ass_candidate.read_text(
+                                    encoding="utf-8", errors="replace",
+                                )
+                            )
+                            if has_word_cues:
+                                this_srt_path = ass_candidate
+                            else:
+                                srt_candidate = (
+                                    work_dir / f"{base_name}_short{suffix}.srt"
+                                )
+                                transcript_to_srt_window(
+                                    transcript_path,
+                                    srt_candidate,
+                                    window_start_seconds=this_offset,
+                                    window_duration_seconds=duration,
+                                    audio_offset_seconds=_caption_offset,
+                                )
+                                if srt_candidate.exists() and srt_candidate.stat().st_size > 0:
+                                    this_srt_path = srt_candidate
+                        except Exception as exc:  # pragma: no cover
+                            logger.warning(
+                                "Shorts caption #%d generation failed: %s",
+                                short_idx + 1, exc,
+                            )
+
+                    build_short_video(
+                        final_mp3, cover_path, this_short_video_path,
+                        start_offset=this_offset,
+                        duration=duration,
+                        hook=this_hook or None,
+                        scene_paths=(
+                            short_scene_paths
+                            if len(short_scene_paths) >= 2 else None
+                        ),
+                        show_name=config.name,
+                        subtitles_path=this_srt_path,
+                        end_card=_end_card_enabled,
+                        end_card_main_text=_end_card_main,
+                        end_card_sub_text=_end_card_sub,
+                        end_card_duration=_end_card_dur,
+                        end_card_image_path=_end_card_image_path,
+                    )
+                    meta = build_short_metadata(
+                        config,
+                        episode_num=episode_num,
+                        today_str=today_str,
+                        hook=this_hook,
+                        long_form_url=long_url,
+                    )
+                    upload_thumb = (
+                        this_short_thumb_path
+                        if this_short_thumb_path and Path(this_short_thumb_path).exists()
+                        else thumbnail_path
+                    )
+                    this_upload = upload_video(
+                        this_short_video_path,
+                        credentials=credentials,
+                        title=meta["title"],
+                        description=meta["description"],
+                        tags=meta["tags"],
+                        category_id=meta["category_id"],
+                        default_language=meta["default_language"],
+                        privacy_status=config.youtube.privacy_status,
+                        thumbnail_path=upload_thumb,
+                    )
+                    short_urls_out.append(this_upload.watch_url)
+                    short_video_ids_out.append(this_upload.video_id)
+                    playlist_id = (
+                        getattr(config.youtube, "podcast_playlist_id", None) or ""
+                    ).strip()
+                    if not playlist_id:
+                        if short_idx == 0:
+                            logger.info(
+                                "Podcast playlist ID empty — skipping playlist add."
+                            )
+                    else:
+                        try:
+                            add_video_to_playlist(
+                                credentials=credentials,
+                                video_id=this_upload.video_id,
+                                playlist_id=playlist_id,
+                            )
+                        except Exception as exc:  # pragma: no cover
+                            logger.warning(
+                                "Playlist add failed for short #%d: %s",
+                                short_idx + 1, exc,
+                            )
+                    # Best-effort cleanup of this Short's MP4 now
+                    # that YouTube has the canonical copy.
+                    try:
+                        if this_short_video_path.exists():
+                            this_short_video_path.unlink()
+                    except OSError:
+                        pass
+                except Exception as exc:
+                    logger.exception(
+                        "YouTube Shorts #%d publish failed: %s",
+                        short_idx + 1, exc,
+                    )
+                    err_type = type(exc).__name__
+                    err_msg = str(exc)[:1000]
+                    err_status = getattr(exc, "status_code", None) or getattr(
+                        getattr(exc, "resp", None), "status", None
+                    )
+                    short_errors_out.append({
+                        "idx": short_idx + 1,
+                        "type": err_type,
+                        "status": err_status,
+                        "message": err_msg,
+                    })
+
+            # ---- Aggregate results onto ``result`` ----
+            if short_urls_out:
+                # Backwards-compat fields (legacy consumers expect a
+                # single ``short_url`` / ``short_error``). Plural
+                # variants are new and present when len > 1.
+                result["short_url"] = short_urls_out[0]
+                if multi:
+                    result["short_urls"] = short_urls_out
+                    result["short_video_ids"] = short_video_ids_out
+            result["shorts_count_uploaded"] = len(short_urls_out)
+            if short_errors_out:
+                result["short_error"] = short_errors_out[0]
+                if multi:
+                    result["short_errors"] = short_errors_out
         except Exception as exc:
+            # Outer try / except that catches setup-stage errors
+            # (resolve_shorts_start_offset, plan construction) — the
+            # per-Short upload loop already catches and aggregates
+            # its own errors, so this rarely fires.
             logger.exception("YouTube Shorts publish failed: %s", exc)
-            # Mirror the long-form error capture so metrics.json
-            # carries actionable context for the operator. 1000 chars
-            # (was 300) — YouTube errors include the offending
-            # location at the END of the message.
             err_type = type(exc).__name__
             err_msg = str(exc)[:1000]
             err_status = getattr(exc, "status_code", None) or getattr(
@@ -3641,14 +3768,15 @@ def _publish_youtube(
                 "message": err_msg,
             }
 
-    # Best-effort cleanup of the rendered MP4s (large files; YouTube has
-    # the canonical copy now). Thumbnail kept on disk for debugging.
-    for video_file in (long_video_path, short_video_path):
-        try:
-            if video_file.exists():
-                video_file.unlink()
-        except OSError:
-            pass
+    # Best-effort cleanup of the long-form MP4 (large file; YouTube
+    # has the canonical copy now). Per-Short MP4s are cleaned up
+    # inside the loop above. Thumbnails are kept on disk for
+    # debugging.
+    try:
+        if long_video_path.exists():
+            long_video_path.unlink()
+    except OSError:
+        pass
 
     # Surface the Pexels safety-filter count so the caller can record
     # it as a metric. A spike here is the operator's signal that the

--- a/tests/test_shorts_selector.py
+++ b/tests/test_shorts_selector.py
@@ -331,3 +331,171 @@ def test_explicit_offset_overrides_smart(tmp_path):
     assert resolve_shorts_start_offset(
         cfg, None, audio_duration=300.0, transcript_path=tp,
     ) == 42.0
+
+
+# ---------------------------------------------------------------------------
+# pick_top_n_engaging_windows — multi-Shorts selection
+# ---------------------------------------------------------------------------
+
+
+def test_pick_top_n_returns_empty_when_n_le_0(tmp_path):
+    """Defensive — n=0 (or negative) is a caller bug; return empty
+    rather than picking anything."""
+    from engine.shorts_selector import pick_top_n_engaging_windows
+    segs = [_seg(0.0, 5.0, "And the kicker is they hit $15 billion in revenue.")]
+    tp = _write_transcript(tmp_path, segs)
+    out = pick_top_n_engaging_windows(
+        tp, n=0, audio_offset=0.0, audio_duration=300.0,
+    )
+    assert out == []
+
+
+def test_pick_top_n_returns_one_for_n_equals_1(tmp_path):
+    """n=1 must behave identically to pick_engaging_window — caller
+    that's already on the single-Short path can swap if desired."""
+    from engine.shorts_selector import (
+        pick_engaging_window,
+        pick_top_n_engaging_windows,
+    )
+    segs = [
+        _seg(0.0, 5.0, "Welcome to today's episode."),
+        _seg(5.0, 12.0, "And the kicker is they hit $15 billion in revenue."),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    single = pick_engaging_window(
+        tp, audio_offset=0.0, audio_duration=300.0,
+    )
+    multi = pick_top_n_engaging_windows(
+        tp, n=1, audio_offset=0.0, audio_duration=300.0,
+    )
+    assert single is not None
+    assert len(multi) == 1
+    assert multi[0].start_seconds == single.start_seconds
+
+
+def test_pick_top_n_picks_non_overlapping_windows(tmp_path):
+    """N=2 must produce two windows whose [start, end] don't
+    overlap with each other (or share less than min_gap_seconds
+    between end and next start)."""
+    from engine.shorts_selector import pick_top_n_engaging_windows
+    # Two clearly distinct engaging beats far apart in the episode.
+    high_signal_a = "Here's the kicker: $15 billion this quarter."
+    high_signal_b = "And the wild part is they hit 38% revenue."
+    filler = "The quarterly report covers regular data."
+    segs = [
+        _seg(0.0, 5.0, filler),
+        _seg(5.0, 12.0, high_signal_a),       # window candidate A
+        _seg(12.0, 60.0, filler),
+        _seg(70.0, 80.0, high_signal_b),      # window candidate B (way later)
+        _seg(80.0, 100.0, filler),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    out = pick_top_n_engaging_windows(
+        tp, n=2, audio_offset=0.0, audio_duration=300.0,
+        window_duration=55.0, min_gap_seconds=10.0,
+    )
+    assert len(out) == 2
+    # Sorted chronologically.
+    assert out[0].start_seconds < out[1].start_seconds
+    # Non-overlapping with the configured gap.
+    assert out[0].end_seconds + 10.0 <= out[1].start_seconds
+
+
+def test_pick_top_n_rejects_overlapping_candidates(tmp_path):
+    """When two engaging beats are inside the same 55s window, only
+    one of them survives — the other would overlap."""
+    from engine.shorts_selector import pick_top_n_engaging_windows
+    # Both beats fall inside [0, 55] so picking both as starts would
+    # produce overlapping windows.
+    segs = [
+        _seg(0.0, 5.0, "Welcome to today's episode."),
+        _seg(5.0, 12.0, "Here's the kicker: $15 billion this quarter."),
+        _seg(12.0, 20.0, "And the wild part is they hit 38% growth."),
+        _seg(20.0, 80.0, "More content."),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    out = pick_top_n_engaging_windows(
+        tp, n=2, audio_offset=0.0, audio_duration=200.0,
+        window_duration=55.0, min_gap_seconds=10.0,
+    )
+    # Only one of the two close-by signals survives — the other
+    # falls inside the picked window.
+    assert len(out) == 1
+
+
+def test_pick_top_n_returns_fewer_than_n_when_supply_short(tmp_path):
+    """If the episode only has 1 strong beat, n=3 returns 1 window
+    rather than padding with garbage."""
+    from engine.shorts_selector import pick_top_n_engaging_windows
+    segs = [
+        _seg(0.0, 5.0, "Welcome to today's episode."),
+        _seg(5.0, 12.0, "Here's the kicker: $15 billion this quarter."),
+        _seg(12.0, 200.0, "Some boring filler content."),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    out = pick_top_n_engaging_windows(
+        tp, n=3, audio_offset=0.0, audio_duration=300.0,
+    )
+    assert len(out) == 1
+
+
+def test_pick_top_n_returns_empty_when_no_threshold_breakers(tmp_path):
+    """All-boilerplate episode produces no Shorts plan; caller falls
+    back to the legacy voice-start single Short."""
+    from engine.shorts_selector import pick_top_n_engaging_windows
+    segs = [
+        _seg(0.0, 5.0, "Welcome to today's episode."),
+        _seg(5.0, 12.0, "The company released a report."),
+        _seg(12.0, 20.0, "Operations continue as expected."),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    out = pick_top_n_engaging_windows(
+        tp, n=3, audio_offset=0.0, audio_duration=300.0,
+        min_score_threshold=5.0,
+    )
+    assert out == []
+
+
+def test_pick_top_n_sorted_chronologically(tmp_path):
+    """The returned list is sorted by start_seconds ascending so the
+    Shorts publish flow uploads them in episode order (Short 1 from
+    earlier in the episode, Short 2 later) — small but real signal
+    for viewers who watch multiple Shorts in a row."""
+    from engine.shorts_selector import pick_top_n_engaging_windows
+    # Two engaging beats; the later one has a HIGHER raw score so
+    # we'd take it first if sort were by score. After re-sort, it
+    # comes second.
+    segs = [
+        _seg(0.0, 5.0, "Filler before any signal."),
+        _seg(5.0, 12.0, "The kicker is they hit $15 billion."),  # mid score
+        _seg(12.0, 60.0, "More filler."),
+        _seg(70.0, 80.0, "Here's the kicker: incredibly the wild part is 80%."),  # higher score
+        _seg(80.0, 200.0, "More filler."),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    out = pick_top_n_engaging_windows(
+        tp, n=2, audio_offset=0.0, audio_duration=300.0,
+        window_duration=55.0, min_gap_seconds=10.0,
+    )
+    assert len(out) == 2
+    # Returned chronologically even though the latter has a higher
+    # raw score.
+    assert out[0].start_seconds < out[1].start_seconds
+
+
+def test_pick_top_n_respects_min_start_final(tmp_path):
+    """An engaging beat that lands during the music intro (final-
+    audio time < min_start_final) must be rejected even if its
+    Whisper timestamp is t=0."""
+    from engine.shorts_selector import pick_top_n_engaging_windows
+    segs = [
+        _seg(0.0, 5.0, "Here's the kicker: $15 billion this quarter."),
+    ]
+    tp = _write_transcript(tmp_path, segs)
+    # Whisper t=0..5; final audio adds 4.5s offset; window starts at
+    # final t=4.5. With min_start_final=10.0, the window is rejected.
+    out = pick_top_n_engaging_windows(
+        tp, n=3, audio_offset=4.5, audio_duration=300.0,
+        min_start_final=10.0, window_duration=55.0,
+    )
+    assert out == []


### PR DESCRIPTION
## Summary

Biggest remaining engagement multiplier from the future-improvements list. Setting `youtube.shorts_per_episode: N` (default 1) makes the runner publish N Shorts per episode instead of one — same generation cost, N× the discovery surface on YouTube Shorts.

Each Short comes from one of the top-N non-overlapping windows the smart selector picks from the transcript; each gets:

- **Distinct start offset** — the window's start time
- **Distinct headline** — the window's opening segment text (becomes the title + 0-3s hook overlay)
- **Distinct thumbnail** — cycled through the available Grok-Imagine scene images
- **Distinct filename** — `_short_1.mp4`, `_short_2.mp4`, …
- **Distinct caption track** — windowed ASS / SRT for that specific clip
- Shared end-card PNG (generated once before the loop)

Uploads are sequential; one failure doesn't block the others. Per-Short error captures land in `result["short_errors"][i]`.

## Backwards compatibility

`shorts_per_episode: 1` (the default) preserves legacy behaviour **byte-for-byte**:

- Output filename stays `_short.mp4` (no `_1` suffix when only one Short)
- The same hook drives the title + caption + end-card
- Legacy single-element `result["short_url"]` / `result["short_error"]` stay populated as before
- New plural variants (`short_urls` / `short_errors` / `short_video_ids`) are only present when N > 1

## YouTube quota math

Each Short upload costs 1 600 quota units on the YouTube Data API. The `@NerraNetwork` channel has 10 000 / day (see CLAUDE.md landmine #20).

| Today | Quota used |
|---|---|
| Tesla long + 1 short | 3 200 |
| MAB long + 1 short | 3 200 |
| **Total** | **6 400 (64 %)** |

| If operator flips Tesla to `shorts_per_episode: 2` | Quota used |
|---|---|
| Tesla long + 2 shorts | 4 800 |
| MAB long + 1 short | 3 200 |
| **Total** | **8 000 (80 %)** |

Flipping BOTH to 2 (Tesla + MAB) would push to **9 600 (96 %)** — feasible but no headroom for retries. Recommended start: opt Tesla alone into 2, see how engagement responds, then decide.

This PR ships the infrastructure with `shorts_per_episode: 1` everywhere. Operator flips per-show via YAML when ready.

## Files

| File | Change |
|---|---|
| `engine/shorts_selector.py` | New `pick_top_n_engaging_windows` — greedy-by-score with `min_gap_seconds` non-overlap, returns chronologically-sorted list |
| `engine/config.py` | `YouTubeConfig.shorts_per_episode: int = 1` |
| `run_show.py` | Shorts publish block becomes a loop over the shorts plan. Single-Short path is the len==1 case of the loop with file naming preserved. Per-Short errors aggregated. New metrics `shorts_count_requested` / `shorts_count_uploaded`. |
| `tests/test_shorts_selector.py` | 8 new tests covering n=0 / n=1 / n>1 / non-overlap / chronological sort / supply-shorter-than-n / threshold-respect / min_start_final enforcement |
| `CLAUDE.md` | Paragraph under the May 2026 Shorts section |

## Test plan

- [x] `pytest tests/test_shorts_selector.py` — 35 passed (27 existing + 8 new)
- [x] `pytest tests/ --deselect [2 stale MAB tests]` — 2181 passed, 3 skipped
- [x] Default `shorts_per_episode: 1` path unchanged (legacy single-Short flow byte-for-byte equivalent)
- [x] Top-N selection produces non-overlapping windows (close-by signals collapse to one Short)
- [x] Fewer-candidates-than-N case returns what it found; caller fills gap with voice-start fallback
- [ ] **Pending after merge:** operator opts Tesla into `shorts_per_episode: 2`, watches the next 2 episodes to confirm both Shorts upload, each gets a distinct thumbnail + title, and the per-Short caption windows align with the speech

## Operator action to activate

After merge, in `shows/tesla.yaml`:

```yaml
youtube:
  ...
  shorts_start_mode: smart      # already set
  shorts_per_episode: 2          # NEW — opts Tesla into 2 Shorts per episode
```

Then watch the next Tesla episode upload. The dashboard's
`shorts_count_uploaded` metric tells you whether both made it.

## Known unrelated CI failure

Same recurring MAB stale-test failure as PRs #413, #415, #416, #417, #418, #419, #420. Not caused by this PR.

## What's next from the list

- **A/B thumbnail variants** — depends on YouTube Studio API exposure; uncertain feasibility without research
- **Smart vertical crop** — de-prioritised; Grok already generates 9:16

The high-impact list is essentially done. Remaining items have either high uncertainty (A/B) or low expected impact (vertical crop).

https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2)_