### PR TITLE
Shorts: opt Tesla + MAB into 2 shorter (40s) Shorts per episode

### DIFF
--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -239,6 +239,15 @@ youtube:
   # the legacy voice-intro start. Falls back to voice mode when the
   # heuristic can't find a clear winner. See engine.shorts_selector.
   shorts_start_mode: smart
+  # Publish 2 Shorts per episode (May 2026 retune). See the parallel
+  # block in shows/tesla.yaml for the quota math — Tesla + MAB
+  # combined are at 96 % of the daily 10 000-unit YouTube quota on
+  # the @NerraNetwork channel. Tight; one of these dials back to 1
+  # if uploads start 429-ing.
+  shorts_per_episode: 2
+  # Shorter clips perform better on the Shorts surface — 40 s lands
+  # in the 30-45 s "high completion rate" sweet spot.
+  short_duration_seconds: 40
   # Beginner / teen-focused AI imagery — friendlier than the deep-tech
   # set used for Models & Agents. Same disambiguation rules apply.
   image_queries:

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -244,6 +244,18 @@ youtube:
   # legacy voice-intro start. Falls back to voice mode when the
   # heuristic can't find a clear winner. See engine.shorts_selector.
   shorts_start_mode: smart
+  # Publish 2 Shorts per episode (May 2026 retune). Each is sourced
+  # from a different non-overlapping engaging window via
+  # ``engine.shorts_selector.pick_top_n_engaging_windows``; each
+  # gets a distinct headline, thumbnail, and caption track. Quota
+  # math: Tesla long + 2 shorts = 4 800 + MAB long + 2 shorts
+  # = 4 800 = 9 600 / 10 000 daily YouTube quota. Tight on retries;
+  # if uploads start 429-ing dial one of them back to 1.
+  shorts_per_episode: 2
+  # Shorter clips perform better on the Shorts surface — 40 s lands
+  # in the 30-45 s "high completion rate" sweet spot vs the previous
+  # 55 s near-max. Same generation cost, better algorithmic signal.
+  short_duration_seconds: 40
   # Curated Pexels search phrases. Direct keywords like "model 3" / "model y"
   # were returning fashion photography models — confirmed root cause for
   # the Ep456 manifest containing topless / portrait images. Each phrase


### PR DESCRIPTION
## Summary

Operator request: activate the multi-Shorts infrastructure shipped in PR #421 for **both** Tesla and MAB, and shorten the clips from 55 s to 40 s.

Two YAML knobs flipped per show:

```yaml
youtube:
  shorts_per_episode: 2          # was implicit default 1
  short_duration_seconds: 40     # was implicit default 55
```

No code changes — the per-Short pipeline shipped in #421 runs unchanged at the higher count, and `short_duration_seconds` was always a configurable knob (`engine/config.py:YouTubeConfig.short_duration_seconds`).

## Why 40 s

- YouTube Shorts data shows **30–45 s clips** have the highest completion rates
- 55 s sits near the 60 s cap where many viewers swipe before completion
- Same generation cost (the audio slice + caption window + thumbnail render don't scale with duration)
- Better algorithmic signal — completion rate is a direct ranking lever

## Quota math (CLAUDE.md landmine #20)

`@NerraNetwork` daily YouTube Data API quota: **10 000 units**. Each upload (long or short): **1 600 units**.

| Show | Uploads | Cost |
|---|---|---|
| Tesla long + 2 shorts | 3 × 1 600 | 4 800 |
| MAB long + 2 shorts | 3 × 1 600 | 4 800 |
| **Total** | **6 uploads** | **9 600 (96 %)** |

Tight on retries — if uploads start hitting 429 quotaExceeded the operator should dial ONE of the shows back to `shorts_per_episode: 1`. The `shorts_count_uploaded` metric in `metrics_ep*.json` surfaces the actual outcome per episode so the operator can spot a quota miss within minutes of the daily run finishing.

## Files

| File | Change |
|---|---|
| `shows/tesla.yaml` | + `shorts_per_episode: 2` + `short_duration_seconds: 40` |
| `shows/models_agents_beginners.yaml` | same |

## Test plan

- [x] `pytest tests/test_config.py tests/test_shorts_selector.py tests/test_youtube_shorts.py` — 93 passed (1 deselected for the recurring MAB stale-test)
- [x] Both YAMLs load cleanly via `load_config()` — `shorts_per_episode=2, short_duration_seconds=40, shorts_start_mode=smart` verified
- [ ] **Pending after merge:** next Tesla + MAB runs — operator-side check that:
  - `metrics_ep*.json` shows `shorts_count_uploaded: 2` for both shows
  - Each Short is ~40 s long
  - Both Shorts have distinct thumbnails and titles
  - YouTube quota wasn't exhausted (no 429 in the long-form or short upload logs)

## Rollback

One-line revert if any of:
- Quota 429s start blocking publishes
- The 40 s clips truncate mid-thought (the smart selector picks a 40 s window; if a story takes longer the cut may feel abrupt)
- Engagement drops vs the 55 s baseline

Revert path: drop `shorts_per_episode` and/or `short_duration_seconds` from the YAML — the defaults (1 and 55 respectively) take over.

https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2)_