### PR TITLE
Fix recurring dashboard FAIL + MAB stale-test (8 PRs of red CI)

### DIFF
--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -72,7 +72,17 @@ HEADERS = {
 HEAD_TIMEOUT = 5
 
 # Skip these YAML files when discovering shows — they are not shows.
-_NON_SHOW_YAMLS = {"_defaults", "_blocked_sources", "pronunciation_map"}
+# ``network_meta`` + ``scaffold_pending`` are network-level helper
+# files (cross-show metadata + pending scaffold-script state) that
+# don't have ``name`` / ``slug`` / ``episode`` / ``publishing``
+# blocks of their own — loading them via the ShowConfig dataclass
+# pulls in the network defaults and trips the item_4_output_dirs
+# landmine check, which was the root cause of the recurring FAIL
+# state on the management dashboard workflow.
+_NON_SHOW_YAMLS = {
+    "_defaults", "_blocked_sources", "pronunciation_map",
+    "network_meta", "scaffold_pending",
+}
 
 # Canonical Russian voice id (pulled from CLAUDE.md; shows/_defaults.yaml ships
 # the English default). Shows may override with either the EN or RU voice id.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -718,19 +718,18 @@ class TestYouTubeImageProviderConfig:
         cfg = load_config(SHOWS_DIR / "tesla.yaml")
         assert cfg.youtube.image_provider == "grok"
 
-    def test_mab_yaml_uses_pexels_image_provider(self):
-        """MAB was flipped from ``grok`` back to ``pexels`` in commit
-        a79df65 (May 20 2026, "YouTube pipeline P0–P2") for a one-month
-        A/B test against Tesla on Grok Imagine. The yaml comment
-        documents the intent (``Flip back to grok after operator
-        review``) but the original drift guard still asserted ``grok``
-        and started failing CI on the next run. Pin the current
-        intended state so a future yaml refactor doesn't silently
-        flip it again mid-experiment. When the operator decides the
-        A/B winner, flip both the yaml and this assertion in the same
-        commit."""
+    def test_mab_yaml_uses_grok_image_provider(self):
+        """MAB ran on ``pexels`` for the May 2026 A/B test against
+        Tesla on Grok Imagine; operator concluded the A/B was
+        inconclusive AND the Phase 1 gallery uploader is wired only
+        into the Grok Imagine code path (Pexels images never reach
+        the gallery R2 bucket). MAB flipped back to ``grok`` so the
+        per-show gallery embed on the MAB show page actually has
+        images to render. Cost: ~$0.16/episode added (8 images ×
+        $0.02 standard model). Flip the YAML AND this assertion in
+        the same commit if the show ever moves back to Pexels."""
         cfg = load_config(SHOWS_DIR / "models_agents_beginners.yaml")
-        assert cfg.youtube.image_provider == "pexels"
+        assert cfg.youtube.image_provider == "grok"
 
     def test_other_shows_remain_on_pexels(self):
         """Every other show (the 9 that aren't YouTube-enabled today,

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -256,3 +256,43 @@ def test_claude_md_drift_banner_fires_when_stale_triple_present():
     lm = gd.item_9_voice_settings(voice)
     assert lm["status"] in ("warn", "fail")
     assert "CLAUDE.md" in lm["details"]
+
+
+def test_network_meta_and_scaffold_pending_excluded_from_shows():
+    """``shows/network_meta.yaml`` and ``shows/scaffold_pending.yaml``
+    are network-level helper YAMLs (cross-show metadata + pending
+    scaffold-script state), NOT real shows. Loading them as shows
+    pulls in the ``digests`` default for ``episode.output_dir`` /
+    ``publishing.audio_subdir``, which the item_4_output_dirs
+    landmine check then flags as a violation. That landmine has
+    been firing FAIL on the management dashboard workflow on every
+    daily run, blocking the workflow + spamming notifications.
+    Regression guard: keep both files in ``_NON_SHOW_YAMLS`` so
+    they never end up in the shows list."""
+    import scripts.generate_dashboard as gd
+    assert "network_meta" in gd._NON_SHOW_YAMLS, (
+        "network_meta.yaml is a cross-show metadata file, not a show "
+        "— include it in _NON_SHOW_YAMLS or item_4_output_dirs will "
+        "fire FAIL on every dashboard run"
+    )
+    assert "scaffold_pending" in gd._NON_SHOW_YAMLS, (
+        "scaffold_pending.yaml is scaffold-script state, not a show"
+    )
+
+
+def test_item_4_output_dirs_no_violations_on_real_shows(tmp_path, monkeypatch):
+    """End-to-end: with the fixed ``_NON_SHOW_YAMLS`` set, the
+    item_4_output_dirs check should report ``ok`` against the
+    actual repo state. If this fails the dashboard workflow's
+    final ``Fail the job on landmine FAIL`` step will fail again."""
+    from pathlib import Path
+
+    import scripts.generate_dashboard as gd
+
+    repo_root = Path(__file__).resolve().parents[1]
+    shows = gd.load_shows_from_yaml(repo_root / "shows", repo_root)
+    result = gd.item_4_output_dirs(shows)
+    assert result["status"] in ("ok", "warn"), (
+        f"item_4_output_dirs still FAIL: {result.get('details')} "
+        f"violations={result.get('evidence', {}).get('violations')}"
+    )

--- a/tests/test_gallery_render.py
+++ b/tests/test_gallery_render.py
@@ -182,16 +182,19 @@ def test_gallery_enabled_requires_grok_image_provider():
         bool(mab_yt.get("youtube_enabled"))
         and mab_provider in ("grok", "hybrid")
     )
-    # MAB is on Pexels today (no gallery images produced) — section
-    # must stay hidden. The day MAB flips to grok / hybrid this test
-    # also needs to flip; that's the intended contract.
-    assert mab_provider == "pexels", (
-        f"MAB expected on pexels, got {mab_provider!r}. If you "
-        "intentionally migrated MAB to Grok Imagine, flip this "
-        "assertion to expect 'grok' / 'hybrid' and the gallery "
-        "section will start rendering on the MAB show page."
+    # MAB was flipped to ``grok`` after the May 2026 A/B vs Tesla;
+    # Pexels images don't flow into the gallery bucket so MAB on
+    # Pexels would have rendered an empty gallery embed forever.
+    # If MAB ever moves back to Pexels, flip this assertion AND the
+    # YAML in the same commit (the section will auto-hide either
+    # way thanks to the provider gate added in PR #412).
+    assert mab_provider in ("grok", "hybrid"), (
+        f"MAB expected on grok / hybrid, got {mab_provider!r}. If "
+        "you intentionally moved MAB back to Pexels, flip this "
+        "assertion to expect 'pexels' and the gallery section will "
+        "auto-hide on the MAB show page."
     )
-    assert mab_enabled is False, "MAB gallery_enabled must stay False"
+    assert mab_enabled is True, "MAB gallery_enabled must be True"
 
 
 def test_read_show_image_provider_defaults_to_pexels_for_unknown_show():


### PR DESCRIPTION
## Summary

Two operator-reported issues diagnosed and fixed in one PR:

1. **Management dashboard workflow fails on every daily run** (and on every `workflow_run` after a show completes — 11+ triggers/day) sending notification spam.
2. **The MAB stale-test failure** that's blocked CI on every PR since #413 (8 in a row).

## Diagnosis #1 — Dashboard FAIL landmine

`scripts/generate_dashboard.py` flagged 4 violations in `item_4_output_dirs`:

```
network_meta.episode.output_dir         = "digests"
network_meta.publishing.audio_subdir    = "digests"
scaffold_pending.episode.output_dir     = "digests"
scaffold_pending.publishing.audio_subdir = "digests"
```

`shows/network_meta.yaml` and `shows/scaffold_pending.yaml` are **not** real shows — they're network-level helpers (cross-show metadata + scaffold-script state). But `_NON_SHOW_YAMLS` only skipped `_defaults` / `_blocked_sources` / `pronunciation_map`, so the loader pulled them in. The config loader applied the network-default `output_dir: digests` (with no slug suffix) for both, and `item_4_output_dirs` correctly flagged the result as "outside `digests/<slug>/`" — but the YAMLs being scanned weren't real shows to begin with.

**Fix:** add `network_meta` + `scaffold_pending` to `_NON_SHOW_YAMLS`. Local probe: landmine FAIL count drops from **1 → 0**. The dashboard workflow's `Fail the job on landmine FAIL` step won't trip anymore.

## Diagnosis #2 — MAB stale tests

Two tests still pinned MAB's `image_provider` to `pexels`:
- `tests/test_config.py:733::test_mab_yaml_uses_pexels_image_provider`
- `tests/test_gallery_render.py:188::test_gallery_enabled_requires_grok_image_provider` (MAB block)

But MAB's YAML was flipped to `grok` per operator request — it had to be, for the gallery embed to populate (the Phase 1 gallery uploader is wired only into the Grok Imagine path). Every PR since #413 has merged through the red CI on this one test.

**Fix:** flip both assertions to match the YAML. Names + docstrings updated so the contract reads forward ("must be grok unless you intentionally moved MAB back to Pexels").

## Files

| File | Change |
|---|---|
| `scripts/generate_dashboard.py` | `_NON_SHOW_YAMLS` gains `network_meta` + `scaffold_pending` |
| `tests/test_config.py` | `test_mab_yaml_uses_pexels_image_provider` → renamed + assertion flipped to `grok` |
| `tests/test_gallery_render.py` | MAB block in `test_gallery_enabled_requires_grok_image_provider` → expects `grok / hybrid` + `gallery_enabled=True` |
| `tests/test_dashboard.py` | 2 new regression guards: `_NON_SHOW_YAMLS` pin + end-to-end item_4 check against live repo state |

## Test plan

- [x] `pytest tests/test_config.py tests/test_gallery_render.py tests/test_dashboard.py` — 72 passed, 1 skipped
- [x] `pytest tests/` (full suite) — **2185 passed, 3 skipped, 0 failed**
- [x] Local dashboard regen: `python scripts/generate_dashboard.py` → 0 FAIL landmines (was 1)
- [ ] **Pending after merge:** next dashboard workflow run should land green (no `Fail the job on landmine FAIL` step trip)
- [ ] **Pending after merge:** next PR's CI should pass without the recurring MAB failure

## What this fixes downstream

- Dashboard notifications stop spamming on every show run
- Future PRs no longer need to merge-through a known-failing test
- The recurring `assert 'grok' == 'pexels'` failure is gone permanently — the new tests reflect the actual intended state

https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY1kyrB8txbJtbS9fgYjL2)_