### PR TITLE
chore: update repo references after rename to Planetterrian/nerranetwork

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ is a standalone X-posting script, not a podcast show.
 ### Key Directories
 
 ```
-nerranetworks/
+nerranetwork/
 ├── run_show.py                    # Unified show runner (~716 lines)
 ├── shows/                         # Per-show YAML configs
 │   ├── tesla.yaml

--- a/docs/FASCINATING_FRONTIERS_SETUP.md
+++ b/docs/FASCINATING_FRONTIERS_SETUP.md
@@ -104,7 +104,7 @@ All files are saved in `digests/fascinating_frontiers/`:
 
 The RSS feed is automatically generated at:
 - File: `fascinating_frontiers_podcast.rss` (in project root)
-- URL: `https://raw.githubusercontent.com/patricknovak/nerranetworks/main/fascinating_frontiers_podcast.rss`
+- URL: `https://raw.githubusercontent.com/Planetterrian/nerranetwork/main/fascinating_frontiers_podcast.rss`
 
 ## Differences from Planetterrian Daily
 

--- a/docs/GITHUB_PAGES_SETUP.md
+++ b/docs/GITHUB_PAGES_SETUP.md
@@ -14,7 +14,7 @@ Make sure these files are committed and pushed to your repository.
 
 ### 2. Enable GitHub Pages
 
-1. Go to your GitHub repository: `https://github.com/patricknovak/nerranetworks`
+1. Go to your GitHub repository: `https://github.com/Planetterrian/nerranetwork`
 2. Click on **Settings** (top menu)
 3. Scroll down to **Pages** in the left sidebar
 4. Under **Source**, select:
@@ -26,7 +26,7 @@ Make sure these files are committed and pushed to your repository.
 
 - GitHub Pages will take 1-2 minutes to deploy
 - You'll see a green checkmark when it's ready
-- Your site will be available at: `https://patricknovak.github.io/nerranetworks/`
+- Your site will be available at: `https://Planetterrian.github.io/nerranetwork/`
 
 ### 4. Custom Domain (Optional)
 
@@ -75,7 +75,7 @@ The player automatically reads from your RSS feed, so:
 ## Public Access
 
 Once enabled, your podcast player will be publicly accessible at:
-- `https://patricknovak.github.io/nerranetworks/`
+- `https://Planetterrian.github.io/nerranetwork/`
 - Anyone can visit and listen to your podcasts
 - No login or authentication required
 - Works on desktop, tablet, and mobile devices

--- a/docs/PLANETTERRIAN_AUTOMATION.md
+++ b/docs/PLANETTERRIAN_AUTOMATION.md
@@ -62,7 +62,7 @@ After each run, these files are automatically committed to the repository:
 ### Verify Output
 After each successful run:
 1. Check **X account** (@planetterrian) - should see new post
-2. Check **RSS feed**: `https://raw.githubusercontent.com/patricknovak/nerranetworks/main/planetterrian_podcast.rss`
+2. Check **RSS feed**: `https://raw.githubusercontent.com/Planetterrian/nerranetwork/main/planetterrian_podcast.rss`
 3. Check **digests/** folder - should see new files
 4. Check **credit_usage_*.json** - see API costs
 

--- a/docs/PLANETTERRIAN_SETUP.md
+++ b/docs/PLANETTERRIAN_SETUP.md
@@ -107,7 +107,7 @@ All files are saved in `digests/planetterrian/`:
 
 The RSS feed is automatically generated at:
 - File: `planetterrian_podcast.rss` (in project root)
-- URL: `https://raw.githubusercontent.com/patricknovak/nerranetworks/main/planetterrian_podcast.rss`
+- URL: `https://raw.githubusercontent.com/Planetterrian/nerranetwork/main/planetterrian_podcast.rss`
 
 ## GitHub Pages Setup
 

--- a/docs/audio_storage_plan.md
+++ b/docs/audio_storage_plan.md
@@ -111,7 +111,7 @@ the purpose since we'd need a URL migration anyway.
 
 The URL would change from:
 ```
-https://raw.githubusercontent.com/patricknovak/nerranetworks/main/digests/Tesla_Shorts_Time_Pod_Ep404_20260215.mp3
+https://raw.githubusercontent.com/Planetterrian/nerranetwork/main/digests/Tesla_Shorts_Time_Pod_Ep404_20260215.mp3
 ```
 to something like:
 ```
@@ -190,7 +190,7 @@ Each script constructs RSS enclosure URLs:
 | `planetterrian.py` | ~1541, 1695, 2595 | `{base_url}/digests/planetterrian/{mp3_filename}` |
 | `fascinating_frontiers.py` | ~2616, 2706 | `{base_url}/digests/fascinating_frontiers/{mp3_filename}` |
 
-`base_url` is `https://raw.githubusercontent.com/patricknovak/nerranetworks/main`
+`base_url` is `https://raw.githubusercontent.com/Planetterrian/nerranetwork/main`
 
 These must be updated to point to the new storage URL for new episodes.
 
@@ -315,7 +315,7 @@ If setting up a Cloudflare account is undesirable, GitHub Releases work:
      --title "Tesla Shorts Time Ep404"
    ```
 
-2. **URL format**: `https://github.com/patricknovak/nerranetworks/releases/download/tesla-ep404-20260215/Tesla_Shorts_Time_Pod_Ep404_20260215.mp3`
+2. **URL format**: `https://github.com/Planetterrian/nerranetwork/releases/download/tesla-ep404-20260215/Tesla_Shorts_Time_Pod_Ep404_20260215.mp3`
 
 3. Same RSS migration process, just different URL format.
 

--- a/docs/directory_audit.md
+++ b/docs/directory_audit.md
@@ -103,7 +103,7 @@ All RSS feeds use `raw.githubusercontent.com` URLs pointing to `digests/` paths 
 
 | RSS Feed | Enclosure URL Pattern |
 |----------|----------------------|
-| `podcast.rss` | `https://raw.githubusercontent.com/patricknovak/nerranetworks/main/digests/Tesla_Shorts_Time_Pod_Ep*.mp3` |
+| `podcast.rss` | `https://raw.githubusercontent.com/Planetterrian/nerranetwork/main/digests/Tesla_Shorts_Time_Pod_Ep*.mp3` |
 | `podcast.rss` (legacy) | `...main/digests/digests/Tesla_Shorts_Time_Pod_Ep32[4-9].mp3` |
 | `planetterrian_podcast.rss` | `...main/digests/planetterrian/Planetterrian_Daily_Ep*.mp3` |
 | `fascinating_frontiers_podcast.rss` | `...main/digests/fascinating_frontiers/Fascinating_Frontiers_Ep*.mp3` |
@@ -135,7 +135,7 @@ Each script constructs output paths using `project_root / "digests" / ...`:
 | `planetterrian.py` | `project_root / "digests" / "planetterrian"` | `digests/planetterrian/` |
 | `fascinating_frontiers.py` | `project_root / "digests" / "fascinating_frontiers"` | `digests/fascinating_frontiers/` |
 
-**Also constructed in scripts**: RSS feed `<enclosure url="...">` URLs using `https://raw.githubusercontent.com/patricknovak/nerranetworks/main/digests/...`
+**Also constructed in scripts**: RSS feed `<enclosure url="...">` URLs using `https://raw.githubusercontent.com/Planetterrian/nerranetwork/main/digests/...`
 
 ### 2d. HTML Pages
 
@@ -188,7 +188,7 @@ All four `summaries_*.json` files live at `digests/` top-level, not in their res
 ### 4a. Separate Source from Output
 
 ```
-nerranetworks/
+nerranetwork/
 ├── src/                              # ALL source code (NEW)
 │   ├── shows/
 │   │   ├── tesla_shorts_time.py

--- a/editorial.html
+++ b/editorial.html
@@ -606,7 +606,7 @@
     <section class="editorial-section">
         <h2>Open infrastructure</h2>
         <p>
-            The <a href="https://github.com/patricknovak/nerranetworks">Nerra Network repository</a>
+            The <a href="https://github.com/Planetterrian/nerranetwork">Nerra Network repository</a>
             is public. Source lists, prompts, music timing, contrast
             thresholds, RSS feed generation — all of it lives there.
             Anyone can audit how a particular episode was made.

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -450,7 +450,7 @@ def update_rss_feed(
     fg.podcast.itunes_explicit("no")
 
     # --- Migrate legacy GitHub raw URLs to R2 CDN --------------------------
-    _GITHUB_RAW_PREFIX = "https://raw.githubusercontent.com/patricknovak/nerranetworks/main/"
+    _GITHUB_RAW_PREFIX = "https://raw.githubusercontent.com/Planetterrian/nerranetwork/main/"
     r2_base = "https://audio.nerranetwork.com"
     migrated_count = 0
     for ep_data in episodes_by_number.values():

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -486,7 +486,7 @@ def enforce_x_char_limit(text: str, max_chars: int = 280) -> str:
 # ---------------------------------------------------------------------------
 
 DEFAULT_HEADERS = {
-    "User-Agent": "PodcastBot/1.0 (+https://github.com/patricknovak/nerranetworks)"
+    "User-Agent": "PodcastBot/1.0 (+https://github.com/Planetterrian/nerranetwork)"
 }
 HTTP_TIMEOUT_SECONDS = 10
 

--- a/scripts/audit_feeds.py
+++ b/scripts/audit_feeds.py
@@ -25,7 +25,7 @@ DATA_DIR = ROOT / "data"
 SKIP_FILES = {"_defaults.yaml", "_blocked_sources.yaml"}
 
 HEADERS = {
-    "User-Agent": "PodcastBot/1.0 (+https://github.com/patricknovak/nerranetworks)"
+    "User-Agent": "PodcastBot/1.0 (+https://github.com/Planetterrian/nerranetwork)"
 }
 TIMEOUT = 15
 

--- a/templates/editorial.html.j2
+++ b/templates/editorial.html.j2
@@ -236,7 +236,7 @@
     <section class="editorial-section">
         <h2>Open infrastructure</h2>
         <p>
-            The <a href="https://github.com/patricknovak/nerranetworks">Nerra Network repository</a>
+            The <a href="https://github.com/Planetterrian/nerranetwork">Nerra Network repository</a>
             is public. Source lists, prompts, music timing, contrast
             thresholds, RSS feed generation — all of it lives there.
             Anyone can audit how a particular episode was made.

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -224,7 +224,7 @@ class TestChannelMetadata:
 # TEST: Item / Episode structure
 # ===================================================================
 
-BASE_URL = "https://raw.githubusercontent.com/patricknovak/nerranetworks/main"
+BASE_URL = "https://raw.githubusercontent.com/Planetterrian/nerranetwork/main"
 R2_BASE_URL = "https://audio.nerranetwork.com"
 OP3_PREFIX = "https://op3.dev/e/"
 


### PR DESCRIPTION
## Summary

Repo was transferred from `patricknovak/nerranetworks` to `Planetterrian/nerranetwork` (owner AND name changed — note the trailing 's' dropped). This PR updates every literal URL / path reference in code, tests, docs, and templates so workflows, scripts, and docs all point at the new location.

**13 files changed, 19 insertions(+), 19 deletions(-)**

### Code / tests
- `engine/publisher.py` — `_GITHUB_RAW_PREFIX` (legacy URL migration prefix — see flag below)
- `engine/utils.py` — `DEFAULT_HEADERS` User-Agent URL
- `scripts/audit_feeds.py` — `HEADERS` User-Agent URL
- `tests/test_rss.py` — `BASE_URL` constant

### Templates / HTML
- `editorial.html` + `templates/editorial.html.j2` — "Nerra Network repository" link

### Docs
- `CLAUDE.md`, `docs/directory_audit.md` — directory tree heading
- `docs/FASCINATING_FRONTIERS_SETUP.md`, `docs/PLANETTERRIAN_AUTOMATION.md`, `docs/PLANETTERRIAN_SETUP.md` — RSS URLs
- `docs/GITHUB_PAGES_SETUP.md` — repo + GitHub Pages URLs
- `docs/audio_storage_plan.md` — 3× raw / releases URLs

## Deliberately NOT touched
- `patricknovak1` (Buttondown account in HTML, blog/*.html) — human's account, not the repo
- `patricknovak1@gmail.com` in `docs/youtube_quota_audit_form_answers.md` — human's email
- `/Users/patricknovak/...` in `docs/GITHUB_SETUP.md` — local filesystem path on the human's mac
- `digests/`, `shows/`, `blog/` — generated / historical content per scope rules
- `workers/gallery/wrangler.toml` — only contains `api.nerranetwork.com` (website domain, not the repo)

## Flag for review

`engine/publisher.py:453` `_GITHUB_RAW_PREFIX` is used to **match legacy URLs already stored in old episode metadata** and rewrite them to the R2 CDN. Historical RSS data still contains literal `patricknovak/nerranetworks` URLs. Updating the prefix follows the "every literal reference" rule but may break the legacy-URL→R2 migration for any old episode whose feed entry still carries the pre-rename URL. If GitHub's auto-redirect covers `raw.githubusercontent.com` cleanly, this is fine; otherwise consider either reverting that one line or matching both prefixes as fallbacks.

## Test plan

- [x] `tests/test_rss.py` — 111 passed
- [x] `tests/test_utils.py` — 50 passed
- [x] `tests/test_publisher.py`, `test_rss_markdown_render.py`, `test_url_utils.py` — 29 passed
- [x] Grep for `patricknovak/nerranetwork*` or `raw.githubusercontent.com/patricknovak` returns zero outside skipped dirs
- [ ] Confirm GitHub auto-redirects from old owner / old repo name work for `raw.githubusercontent.com` URLs (affects `_GITHUB_RAW_PREFIX` decision above)
- [ ] Confirm GitHub Pages serves at new `Planetterrian.github.io/nerranetwork/` (or that the custom domain handles the rename)

https://claude.ai/code/session_019TYz5n4qhesUuJw7uGsV63

---
_Generated by [Claude Code](https://claude.ai/code/session_019TYz5n4qhesUuJw7uGsV63)_