### PR TITLE
fix(tst): hook overlay wrap, newsletter Buttondown field, gallery error noise

### DIFF
--- a/engine/gallery_uploader.py
+++ b/engine/gallery_uploader.py
@@ -436,7 +436,15 @@ def upload_image(
                 content_type="application/json",
             )
         except Exception as exc:  # noqa: BLE001 — log + soft-fail
-            logger.error(
+            # WARNING-level per-image: gallery upload is soft-fail by
+            # design (the audio pipeline doesn't depend on it), and
+            # when the bucket / credentials are misconfigured every
+            # one of the N images fails the same way — a per-image
+            # ERROR flood drowns out real issues. The aggregate is
+            # captured at INFO by ``run_show``'s per-aspect summary
+            # line ("Gallery: ep??? aspect=??? attempted=N uploaded=0
+            # bucket=??? first_failure=???").
+            logger.warning(
                 "Gallery R2 upload failed for image %s (%s): %s",
                 metadata.image_id, type(exc).__name__, exc,
             )

--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -241,9 +241,21 @@ def send_newsletter(
         # Older clients sent ``{operator, predicates}`` and got
         # HTTP 422; the predicate enum is also strict — only "and"
         # or "or" are accepted (not "any"/"all").
+        #
+        # May 26 2026: Buttondown tightened the ``field`` enum on
+        # the leaf condition; ``field: "tag"`` now returns HTTP 422
+        # with a literal_error listing the accepted values:
+        # ``subscriber.churn_date``, ``subscriber.click_rate``,
+        # ``subscriber.last_click_date``, ``subscriber.last_open_date``,
+        # ``subscriber.open_rate``, ``subscriber.price``,
+        # ``subscriber.source``, ``subscriber.status``,
+        # ``subscriber.subscription_date``, ``subscriber.tags``,
+        # ``subscriber.upgrade_date``. Tag membership now lives at
+        # ``subscriber.tags``; the operator for "subscriber has this
+        # tag" is ``contains`` because tags is a list field.
         data["filters"] = {
             "filters": [
-                {"field": "tag", "operator": "equals", "value": t}
+                {"field": "subscriber.tags", "operator": "contains", "value": t}
                 for t in tags
             ],
             "groups": [],

--- a/engine/video.py
+++ b/engine/video.py
@@ -726,15 +726,33 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
             max_lines=4,
             font_path=_find_font(),
         )
-        escaped = _drawtext_escape(wrapped)
+        # May 26 2026 operator-caught regression (Tesla Ep485 + MAB):
+        # multi-line hooks rendered as ONE overflowing line with the
+        # `\n` byte showing up as the letter "n" between words —
+        # "major warning" → "majornwarning", "volume reductions" →
+        # "volumenreductions". The single-drawtext path emitted
+        # `text='line1\nline2'` and relied on ffmpeg drawtext's
+        # text= expansion to render `\n` as a newline. In practice
+        # the backslash gets eaten somewhere in the filter_complex
+        # parse → drawtext text= pipeline and only the literal "n"
+        # survives. Fix: stack one drawtext filter PER wrapped line
+        # with explicit y-offsets — sidesteps the `\n` escape
+        # entirely and produces deterministic per-line layout.
+        wrapped_lines = wrapped.split("\n") if wrapped else []
+        n_lines = max(len(wrapped_lines), 1)
+        line_spacing = 10
+        line_h = hook_fontsize + line_spacing
         # May 2026 operator review: hook is the static 0-3 s
         # opening title — separate from the burn-in transcript
         # that follows. Position lifted ABOVE the burn-in zone
         # so the two overlays don't visually collide during the
-        # first 3 s. ``y=h*0.55`` puts the hook around y≈1056 —
-        # inside the lower half but well above the subtitle
-        # baseline at y≈1620 (MarginV=300 in
-        # ``_SHORTS_SUBTITLES_FORCE_STYLE``).
+        # first 3 s. ``y=h*0.55`` puts the hook block CENTER
+        # around y≈1056 — inside the lower half but well above
+        # the subtitle baseline at y≈1620 (MarginV=300 in
+        # ``_SHORTS_SUBTITLES_FORCE_STYLE``). With multi-line
+        # hooks, line i is offset from the block center by
+        # ``(i - (n-1)/2) * line_h`` so the wrap stays visually
+        # centered regardless of line count.
         #   * Default ``fontsize=44`` (auto-shrunk per hook length)
         #     is readable on a phone but no longer dominates the
         #     slideshow.
@@ -743,19 +761,24 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
         #     outline + 2 px shadow stays readable on bright
         #     backgrounds without painting a black rectangle.
         hook_label = "[hooked]" if subtitles_path else "[v]"
-        hook_filter = (
-            f";{post_brand_label}drawtext=fontfile='{font_path}':"
-            f"text='{escaped}':"
-            f"fontsize={hook_fontsize}:fontcolor=white:"
-            f"x=(w-text_w)/2:y=h*0.55:"
-            f"borderw=4:bordercolor=black:"
-            f"shadowx=2:shadowy=2:shadowcolor=black@0.7:"
-            f"line_spacing=10:"
-            f"enable='between(t,0,3)'"
-            f"{hook_label}"
-        )
-        chain += hook_filter
-        post_brand_label = hook_label
+        for i, line in enumerate(wrapped_lines):
+            escaped_line = _drawtext_escape(line)
+            offset_px = (i - (n_lines - 1) / 2.0) * line_h
+            sign = "+" if offset_px >= 0 else "-"
+            y_expr = f"h*0.55{sign}{abs(offset_px):.0f}"
+            is_last = (i == n_lines - 1)
+            line_label = hook_label if is_last else f"[hookln{i}]"
+            chain += (
+                f";{post_brand_label}drawtext=fontfile='{font_path}':"
+                f"text='{escaped_line}':"
+                f"fontsize={hook_fontsize}:fontcolor=white:"
+                f"x=(w-text_w)/2:y={y_expr}:"
+                f"borderw=4:bordercolor=black:"
+                f"shadowx=2:shadowy=2:shadowcolor=black@0.7:"
+                f"enable='between(t,0,3)'"
+                f"{line_label}"
+            )
+            post_brand_label = line_label
 
     if subtitles_path:
         escaped_sub = _subtitles_path_escape(subtitles_path)

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -499,10 +499,13 @@ def test_send_newsletter_uses_v2_filter_tree_when_tags_set(monkeypatch):
     # Each tag becomes a leaf condition.
     leaf_tags = {f["value"] for f in filters["filters"]}
     assert leaf_tags == {"Tesla Shorts Time", "Privet Russian"}
-    # No leftover keys from the old schema.
+    # No leftover keys from the old schema. May 26 2026: Buttondown
+    # tightened the leaf-condition field enum — ``"tag"`` now 422s,
+    # ``"subscriber.tags"`` is the accepted form, and the operator
+    # for list membership is ``"contains"``.
     for leaf in filters["filters"]:
-        assert leaf["field"] == "tag"
-        assert leaf["operator"] == "equals"
+        assert leaf["field"] == "subscriber.tags"
+        assert leaf["operator"] == "contains"
     # Old keys must NOT appear.
     assert "predicates" not in filters
     assert "operator" not in filters

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -472,32 +472,42 @@ def test_drawtext_escape_escapes_real_newlines():
 
 
 def test_short_form_filter_graph_caption_has_no_real_newlines():
-    """End-to-end pin: the rendered Shorts filter graph for a
-    realistic multi-line hook MUST NOT contain real newline
-    characters inside the drawtext text= region. A real newline
-    there terminates ffmpeg's single-quoted parsing region and
-    breaks the entire filter graph — exactly what failed Tesla
-    Ep466's Shorts upload on May 8 2026."""
+    """End-to-end pin: each drawtext text= region in the rendered
+    Shorts filter graph MUST contain neither a real newline (which
+    closes ffmpeg's single-quoted parsing region — broke Tesla
+    Ep466's Shorts upload on May 8 2026) NOR a literal ``\\n``
+    escape (which silently rendered as the letter "n" between
+    wrap points — broke Tesla Ep485 / MAB Shorts on May 26 2026:
+    "major warning" → "majornwarning", "volume reductions" →
+    "volumenreductions"). The fix stacks one drawtext per
+    wrapped line, so each text= value is a single physical line
+    of plain words — no newline of any kind."""
     hook = (
         "California regulators just disclosed the Tesla Semi's "
         "battery sizes at 822 kWh and 548 kWh."
     )
     graph = _short_form_filter_graph(hook=hook)
-    # Find the drawtext text= region.
     import re as _re
-    m = _re.search(r"text='([^']*(?:\\'[^']*)*)'", graph)
-    assert m is not None, "drawtext text= region not found in graph"
-    text_value = m.group(1)
-    # No real newlines may appear inside the quoted region.
-    assert "\n" not in text_value, (
-        f"Real newline survived into drawtext text= value (would break "
-        f"ffmpeg parsing): {text_value!r}"
-    )
-    # But the literal escape sequence \n MUST be present so the rendered
-    # caption still wraps to multiple lines.
-    assert r"\n" in text_value, (
-        f"Multi-line hook should produce literal \\n breaks; got "
-        f"{text_value!r}"
+    # Every drawtext text= region in the graph must be newline-free
+    # AND must not contain the literal \n escape sequence.
+    text_values = _re.findall(r"text='([^']*(?:\\'[^']*)*)'", graph)
+    assert text_values, "no drawtext text= regions found in graph"
+    for tv in text_values:
+        assert "\n" not in tv, (
+            f"Real newline survived into drawtext text= value (would "
+            f"break ffmpeg parsing): {tv!r}"
+        )
+        assert r"\n" not in tv, (
+            f"Literal \\n escape in drawtext text= value (would render "
+            f"as the letter 'n' between words): {tv!r}"
+        )
+    # A long multi-line hook must produce MULTIPLE drawtext filters
+    # (one per wrapped line). Single-drawtext graph would be the
+    # broken legacy path.
+    drawtext_count = graph.count("drawtext=")
+    assert drawtext_count >= 2, (
+        f"long hook should produce >=2 stacked drawtext filters, "
+        f"got {drawtext_count}"
     )
 
 


### PR DESCRIPTION
## Summary

Three fixes from the Tesla Ep485 dry-run + screenshots:

### 1. Shorts hook overlay rendered "majornwarning" / "volumenreductions"

Multi-line wrapped hooks were being joined with `\n` and passed to a single ffmpeg `drawtext text='...\n...'` filter. ffmpeg's `text=` `\n`-as-newline expansion was dropping the backslash and leaving only the literal letter "n", concatenating words AND pushing the whole hook onto a single line that overflowed the 1080-px Shorts frame on both sides.

**Fix:** stack one `drawtext` filter per wrapped line with explicit per-line y-offsets centered around `y=h*0.55`. Sidesteps the `\n` escape entirely. The autofit shrink-to-fit pipeline (font candidates 44 → 40 → 36 → 32, pixel-accurate wrap) is unchanged — only the rendering changed.

### 2. Newsletter HTTP 422 — Buttondown field enum tightened

Buttondown's email-send filters now reject `field: "tag"`. The 422 response listed the accepted enum: `subscriber.churn_date`, `subscriber.click_rate`, `subscriber.last_click_date`, `subscriber.last_open_date`, `subscriber.open_rate`, `subscriber.price`, `subscriber.source`, `subscriber.status`, `subscriber.subscription_date`, `subscriber.tags`, `subscriber.upgrade_date`. Tag membership now lives at `subscriber.tags`; the list-membership operator is `contains`.

### 3. Gallery R2 upload error flood

When the `nerra-gallery` bucket is misconfigured (the actual cause of the Ep485 0/8 uploads is infra, not code), every image dumped a per-image `ERROR` line. Downgraded to `WARNING`; the per-aspect aggregate `INFO` line in `run_show` (`Gallery: ep??? aspect=??? attempted=N uploaded=0 ...`) already captures the failure count and first cause.

## Tests

- `tests/test_video_commands.py::test_short_form_filter_graph_caption_has_no_real_newlines` — rewritten to pin the new multi-drawtext approach. Asserts (a) no real newline in any `text=` region, (b) no literal `\n` either, (c) long hooks produce ≥2 stacked drawtext filters.
- `tests/test_newsletter.py::test_send_newsletter_with_tags_uses_filters_groups_predicate` — updated to assert `subscriber.tags` + `contains`.
- All 79 video_commands tests pass.
- All 57 newsletter tests pass.

## Not addressed in this PR

- **X 402 Payment Required** on @teslashortstime — operator's billing, not code.
- **Gallery bucket actually being misconfigured** — infra (Cloudflare side: either create `nerra-gallery` bucket on this account, or grant the existing R2 API key write perms on it). The per-episode aggregate INFO log will tell you when it's healthy again.

## Test plan

- [x] `pytest tests/test_video_commands.py tests/test_newsletter.py` → 136 passed
- [ ] Next TST run: Shorts hook overlay wraps onto multiple lines centered, no "n" between words, fits inside frame
- [ ] Next newsletter send: returns 200/201 (no 422)
- [ ] Gallery log: at most one WARNING per failed image; INFO aggregate per aspect

https://claude.ai/code/session_019TYz5n4qhesUuJw7uGsV63

---
_Generated by [Claude Code](https://claude.ai/code/session_019TYz5n4qhesUuJw7uGsV63)_