### PR TITLE
chore: quick wins from full codebase review (May 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 Automated daily podcast generation system running **11 shows** via a unified
 `run_show.py` runner + per-show YAML configs. Each show fetches news via RSS
-and xAI/Grok web search, generates a digest and podcast script via xAI/Grok,
-synthesizes audio via ElevenLabs TTS, mixes intro/outro music, and publishes
-to RSS feeds, GitHub Pages, and X/Twitter.
+and xAI/Grok web search (or topic queues for narrative shows), generates a
+digest and podcast script via xAI/Grok, synthesizes audio via Grok TTS (full
+network migration May 2026; ElevenLabs retained only as emergency rollback),
+mixes intro/outro music, and publishes to RSS, GitHub Pages, YouTube (long-form
++ smart Shorts for enabled shows), and X/Twitter where configured.
 
 All shows are produced independently in Vancouver, Canada.
 
@@ -24,6 +26,7 @@ All shows are produced independently in Vancouver, Canada.
 | **Финансы Просто** | Even days | [Player](https://nerranetwork.com/ru/finansy-prosto.html) | [RSS](https://nerranetwork.com/finansy_prosto_podcast.rss) |
 | **Modern Investing Techniques** | Weekdays | [Player](https://nerranetwork.com/modern-investing.html) | [RSS](https://nerranetwork.com/modern_investing_podcast.rss) |
 | **Привет, Русский!** | Even days | [Player](https://nerranetwork.com/ru/privet-russian.html) | [RSS](https://nerranetwork.com/privet_russian_podcast.rss) |
+| **Unintended Consequences** | Weekdays (narrative) | [Player](https://nerranetwork.com/unintended-consequences.html) | [RSS](https://nerranetwork.com/unintended_consequences_podcast.rss) |
 
 ## Listen
 
@@ -39,68 +42,61 @@ All shows are available on **Apple Podcasts**, **Spotify**, and via **RSS**.
 | M&A for Beginners | [Apple](https://podcasts.apple.com/us/podcast/models-agents-for-beginners/id1885231582) | [Spotify](https://open.spotify.com/show/7vRUrQAJWzOB729A9aVDd5) |
 | Modern Investing | [Apple](https://podcasts.apple.com/us/podcast/modern-investing-techniques/id1886870483) | [Spotify](https://open.spotify.com/show/2Txa9atsocnmm91r65Ahy9) |
 | Финансы Просто | [Apple](https://podcasts.apple.com/us/podcast/%D1%84%D0%B8%D0%BD%D0%B0%D0%BD%D1%81%D1%8B-%D0%BF%D1%80%D0%BE%D1%81%D1%82%D0%BE/id1885235226) | [Spotify](https://open.spotify.com/show/35jCJTVe3ITGah3ryeKzzM) |
-| Привет, Русский! | [Apple](https://podcasts.apple.com/us/podcast/%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82-%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9/id1885236720) | [Spotify](https://open.spotify.com/show/7rB9mPNBp5S6RCpHPKIZbL) |
+| Привет, Русский! | [Apple](https://podcasts.apple.com/us/podcast/%D0%BF%D1%80%D0%B1%D0%B8%D0%B2%D0%B5%D1%82-%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9/id1885236720) | [Spotify](https://open.spotify.com/show/7rB9mPNBp5S6RCpHPKIZbL) |
+| Unintended Consequences | Search "Nerra Network" on Apple | Search "Nerra Network" on Spotify |
 
 ## Architecture
 
 ```
-run_show.py                     # Unified entry point for all shows
-├── engine/                     # Shared modules (22 files)
-│   ├── config.py               # YAML-based show configuration
-│   ├── fetcher.py              # RSS feed fetching + keyword scoring
-│   ├── generator.py            # xAI/Grok LLM digest + podcast generation
-│   ├── tts.py                  # ElevenLabs TTS synthesis
-│   ├── audio.py                # ffmpeg audio processing + music mixing
-│   ├── publisher.py            # RSS feed update, GitHub Pages, X posting
-│   ├── content_tracker.py      # Cross-episode deduplication
-│   ├── newsletter.py           # Buttondown newsletter integration
-│   ├── storage.py              # Cloudflare R2 audio storage
-│   ├── blog.py                 # Blog post generation
-│   ├── chapters.py             # MP3 chapter markers
-│   ├── transcripts.py          # Episode transcript generation
-│   ├── synthesizer.py          # Newsletter/report content synthesis
-│   ├── tracking.py             # API usage + cost tracking
-│   ├── validation.py           # Output validation + repair
-│   └── utils.py                # Text processing, similarity, helpers
-├── shows/                      # Per-show configuration
-│   ├── _defaults.yaml          # Network-wide defaults (TTS, audio, storage)
-│   ├── *.yaml                  # Show configs (sources, LLM, TTS, publishing)
-│   ├── prompts/                # LLM prompt templates (4 per show)
-│   ├── hooks/                  # Show-specific pre-fetch hooks
-│   ├── segments/               # Slow-news segment libraries
-│   └── templates/              # Jinja2 templates for shows
-├── digests/                    # Generated output (audio, markdown, JSON)
-│   └── <show>/                 # Per-show subdirectories
+run_show.py                     # Unified entry point for all 11 shows
+├── engine/                     # ~50 shared modules (see engine/ + CLAUDE.md)
+│   ├── config.py               # YAML deep-merge + ShowConfig dataclasses
+│   ├── fetcher.py              # RSS + web_search + x_search
+│   ├── generator.py            # Grok LLM digest/script (refusals, fallbacks)
+│   ├── tts.py                  # Grok TTS (primary) + ElevenLabs (rollback)
+│   ├── audio.py                # ffmpeg mix + normalize + sidechain ducking
+│   ├── publisher.py            # RSS, GitHub Pages, X, thumbnails, end-cards
+│   ├── content_tracker.py      # Cross-episode dedup + cooldowns
+│   ├── content_lake.py         # SQLite for weekly recaps, briefings, search
+│   ├── weekly_recap.py         # Sunday synthetic digest from lake (7 shows)
+│   ├── shorts_selector.py      # Heuristic "most engaging" window picker
+│   ├── youtube*.py + video.py  # Long-form + multi-Shorts (smart + hashtags)
+│   ├── gallery_uploader.py     # Grok-Imagine scenes → R2 + sidecars
+│   ├── tracking.py             # Per-ep LLM/TTS/X/Imagine cost rollup
+│   ├── metrics.py              # Stage timings + counters (dashboard fuel)
+│   ├── newsletter*.py          # Sanitizer + body transforms + template (v2)
+│   └── ...                     # transcripts, chapters, grok_imagine, etc.
+├── shows/                      # Per-show configuration (11 + _defaults)
+│   ├── *.yaml                  # Sources, LLM, TTS, audio, youtube, hooks
+│   ├── prompts/                # digest / podcast / system / weekly
+│   ├── hooks/                  # Pre-fetch (Tesla TSLA price, etc.)
+│   └── topic_queues/           # Narrative shows (Unintended Consequences)
+├── digests/                    # All generated output (per-show subdirs)
+├── workers/gallery/            # Cloudflare Worker (email-gate + JWT + R2 proxy)
 ├── assets/
-│   ├── music/                  # Intro/outro music files
-│   └── pronunciation.py        # Shared TTS pronunciation fixes
-├── scripts/                    # Utility scripts (dashboard, audits, etc.)
-├── styles/
-│   └── main.css                # Shared stylesheet (dark theme, glassmorphism)
-├── .github/workflows/
-│   ├── run-show.yml            # Unified daily cron workflow (all shows)
-│   ├── test.yml                # CI test + lint
-│   ├── dashboard.yml           # Management dashboard updates
-│   └── ...                     # Feed audit, newsletters, reports, etc.
-└── *.rss                       # Podcast RSS feeds
+│   ├── music/                  # Centralized intro/outro (per-show)
+│   └── pronunciation.py        # Shared TTS fixes + map
+├── scripts/                    # 30+ ops tools (scaffold, dashboard, audits, backfills)
+├── .github/workflows/          # 12 workflows (staggered cron + matrix + landmines)
+└── *.rss + *.html            # Public RSS feeds + static site
 ```
+
+See `CLAUDE.md` (operator bible) and `docs/` for the full current module list and 20+ live landmines tracked on the management dashboard.
 
 ### Pipeline (per show, per run)
 
-1. **Load config** from `shows/<show>.yaml` (merged with `_defaults.yaml`)
-2. **Pre-fetch hook** (optional — e.g., Tesla stock price via yfinance)
-3. **Fetch** news from RSS sources + xAI/Grok web search
-4. **Dedup** via ContentTracker (cross-episode) + entity dedup
-5. **Generate** digest text via xAI/Grok API
-6. **Generate** podcast script via xAI/Grok API
-7. **Synthesize** audio via ElevenLabs TTS (with chunking + section-aware synthesis)
-8. **Mix** intro/outro music with voice (ffmpeg)
-9. **Upload** to Cloudflare R2
-10. **Update** RSS feed + chapter markers
-11. **Generate** blog post, transcript
-12. **Save** summary to GitHub Pages JSON
-13. **Send** newsletter (if configured)
-14. **Post** X/Twitter teaser (if configured)
+1. **Load + preflight** config (YAML + _defaults deep merge, env keys, prompts, music, cost circuit breaker, LLM ping)
+2. **Pre-fetch hook** (optional, e.g. yfinance TSLA) + resume decision (publish / YouTube only)
+3. **Fetch + dedup** (RSS + Grok web_search + X accounts, multi-layer ContentTracker + entity + sim + lake)
+4. **Digest** (or Sunday weekly recap from content lake for 7 shows)
+5. **Podcast script** (with pronunciation, chapters, AI disclosure, length gates)
+6. **TTS** (Grok single-chunk primary; section stings optional) + Whisper transcript
+7. **Audio mix** (music ducking, EBU R128 -16 LUFS, chapters JSON)
+8. **Upload + publish** (R2 + OP3, post-run validation hard gate, RSS + chapters, GitHub Pages, blog)
+9. **YouTube** (long-form + N smart Shorts with per-word captions, auto-hashtags, end-card CTA — only TST + MAB enabled due to quota)
+10. **Gallery side-effect** (Grok-Imagine scenes → nerra-gallery R2 + thumbs + sidecars for enabled shows)
+11. **Newsletter + X** (sanitized, Buttondown tag-aware; teaser with YouTube link)
+12. **Metrics + lake write** (full cost + timing + entity extraction for recaps)
 
 ## Usage
 
@@ -124,7 +120,7 @@ python generate_html.py --all
 
 ### Available shows
 
-`tesla`, `omni_view`, `fascinating_frontiers`, `planetterrian`, `env_intel`, `models_agents`, `models_agents_beginners`, `finansy_prosto`, `modern_investing`, `privet_russian`
+`tesla`, `omni_view`, `fascinating_frontiers`, `planetterrian`, `env_intel`, `models_agents`, `models_agents_beginners`, `finansy_prosto`, `modern_investing`, `privet_russian`, `unintended_consequences`
 
 ## Adding a New Show
 
@@ -185,3 +181,21 @@ deployed.
 - `docs/newsletter_comparison.md` — Newsletter platform evaluation
 - `docs/podcast_directories.md` — Directory submission guide
 - `docs/monetization_roadmap.md` — Revenue strategy and timeline
+
+## Recent Improvements & Roadmap (May 2026+)
+
+Major 2026 milestones shipped:
+- Full-network Grok TTS migration (36× cheaper than previous ElevenLabs baseline; custom trained voice for consistent host identity across English shows).
+- YouTube Shorts production for Tesla Shorts Time + Models & Agents for Beginners (smart segment selection, per-word highlighting, auto-hashtags, end-screen CTAs, multi-Shorts per episode).
+- Nerra Gallery (Phases 1-3): Grok-Imagine scenes stored in dedicated R2 bucket with sidecars + watermarked WebP thumbs; network-wide + per-show embeds; email-gated full-res downloads (Buttondown + magic-link JWT via Cloudflare Worker).
+- Sunday weekly recap episodes for the 7 daily shows (synthesized from the content lake instead of fresh news fetch).
+- Broadcast-quality audio pipeline (48 kHz WAV Grok TTS → single lossy encode, sidechain-ducked music, -16 LUFS EBU R128).
+
+A full internal codebase review was performed in May 2026. Quick wins and strategic improvements (global site search, progressive enhancement for JS surfaces, gallery auth hardening, proactive alerting, pipeline modularization, dynamic metadata, live quota/cost visibility, onboarding automation, etc.) are tracked in the operator plan.
+
+See:
+- `CLAUDE.md` — Single source of truth for architecture, 20+ live landmines (enforced on the management dashboard), and current invariants.
+- `management.html` (powered by `api/dashboard.json`) — Live status of costs, landmines, RSS health, YouTube success rates, etc.
+- `docs/` — Detailed audits (gallery_storage.md, youtube_quota..., pipeline_audit..., etc.).
+
+The network is intentionally kept as a set of static sites + GitHub Actions + serverless Worker so it remains simple, cheap, and reliable at 10+ episodes/week.

--- a/engine/config.py
+++ b/engine/config.py
@@ -128,6 +128,14 @@ class TTSConfig:
     whisper_model: str = "base"  # "tiny", "base", "small", "medium"
     whisper_threshold: float = 0.7  # Minimum match score (0.0–1.0)
 
+    # Tag-leak hard block (quick win from May 2026 full codebase review)
+    # When True, scan_transcript() finding any spoken speech tag after Grok TTS
+    # causes the pipeline to hard-fail the episode (before audio mix / publish).
+    # Default False keeps the historical best-effort behaviour (metric + warning).
+    # Per-show override allowed once the detector's false-positive rate is
+    # calibrated on real episodes for that voice/show.
+    tag_leak_hard_block: bool = False
+
 
 @dataclass
 class AudioConfig:

--- a/generate_html.py
+++ b/generate_html.py
@@ -1599,6 +1599,23 @@ def generate_show_page(slug, *, dry_run=False):
     except Exception as e:
         print(f"Warning: could not collect episodes from RSS for {slug}: {e}")
 
+    # Quick-win dynamic metadata (May 2026 review): inject freshest episode title/hook
+    # into page_title and meta description so social cards + search snippets reflect
+    # the current episode instead of static NETWORK_SHOWS text. RSS parse already
+    # happens above for the episodes rail; we just reuse the first item.
+    latest_episode_title = None
+    dynamic_meta_description = cfg.get("meta_description", "")
+    if static_episodes:
+        latest_episode_title = static_episodes[0].get("title")
+        if latest_episode_title:
+            # Keep original meta but lead with the fresh episode for better CTR/SEO
+            dynamic_meta_description = f"Latest: {latest_episode_title}. {cfg.get('meta_description', '')}".strip()
+            # Page title becomes "Show — Latest Hook Snippet | Nerra Network" (safe length)
+            hook_snippet = latest_episode_title.split(":", 1)[-1].strip() if ":" in latest_episode_title else latest_episode_title
+            if len(hook_snippet) > 70:
+                hook_snippet = hook_snippet[:67] + "…"
+            page_title = f"{cfg['name']} — {hook_snippet} | Nerra Network"
+
     # Modern Investing: pull the mock-trade performance block from
     # api/dashboard.json if it's already been generated this run (normal
     # CI flow), or compute it on the fly as a fallback (dev / dry-run).
@@ -1623,13 +1640,28 @@ def generate_show_page(slug, *, dry_run=False):
         and image_provider in ("grok", "hybrid")
     )
 
+    # Quick-win (May 2026 review): dynamic metadata from the RSS we already
+    # parsed for the episodes rail. Makes <title>, meta description, and OG
+    # cards reflect the current episode hook instead of static NETWORK_SHOWS text.
+    page_title = f"{cfg['name']} | Nerra Network"
+    meta_description = cfg.get("meta_description", "")
+    latest_episode_title = static_episodes[0]["title"] if static_episodes else None
+    if latest_episode_title:
+        hook_snippet = latest_episode_title.split(":", 1)[-1].strip() if ":" in latest_episode_title else latest_episode_title
+        if len(hook_snippet) > 68:
+            hook_snippet = hook_snippet[:65] + "…"
+        page_title = f"{cfg['name']} — {hook_snippet} | Nerra Network"
+        meta_description = f"Latest: {latest_episode_title}. {cfg.get('meta_description', '')}".strip()
+
     context = {
         **cfg,
         "path_prefix": prefix,
         "show_name": cfg["name"],
         "show_slug": cfg["slug"],
         "show_description": cfg.get("about_text", cfg["description"]),
-        "page_title": f"{cfg['name']} | Nerra Network",
+        "page_title": page_title,
+        "meta_description": meta_description,  # override the static one from **cfg
+        "latest_episode_title": latest_episode_title,
         "podcast_image_url": podcast_image_url,
         "og_image": f"{GITHUB_RAW}/{_url_encode_image(cfg['podcast_image'])}",
         "show_color": cfg["brand_color"],

--- a/run_show.py
+++ b/run_show.py
@@ -2037,6 +2037,19 @@ def run(args: argparse.Namespace) -> None:
                         metrics.record("tag_leaks_by_pattern", _by_pattern)
                     else:
                         logger.info("Tag-leak detector: clean transcript.")
+
+                    # Quick-win hard block (May 2026 review): if the show has opted in
+                    # via tts.tag_leak_hard_block (default False in _defaults), any
+                    # detected spoken tag aborts the episode here (before expensive
+                    # audio mix + publish). This is the calibrated "flip to hard"
+                    # path the original detector comment anticipated.
+                    if getattr(config.tts, "tag_leak_hard_block", False) and _leaks:
+                        logger.error(
+                            "Tag-leak hard block enabled for %s and %d leak(s) found — "
+                            "aborting episode to protect listener experience.",
+                            config.name, len(_leaks)
+                        )
+                        sys.exit(1)
                 except Exception as exc:
                     logger.debug("Tag-leak detector failed (non-fatal): %s", exc)
 

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1141,10 +1141,28 @@ def aggregate_costs(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]:
         for k in ("grok", "tts", "total"):
             bucket[k] = round(bucket[k], 4)
 
+    # Quick-win enhancements (May 2026 codebase review):
+    # - Simple projection so operators see "at current burn rate, what does a week cost?"
+    # - Surface for future live YT quota remaining (engine.youtube_quota already exists).
+    episodes_7 = max(network_7.get("episodes", 0), 1)
+    avg_per_episode = round(network_7["total"] / episodes_7, 4)
+    # Conservative: network ships ~60-70 episodes/week across 11 shows
+    projected_weekly = round(avg_per_episode * 65, 2)
+
     return {
         "per_show": per_show,
         "network_last_7_days": network_7,
         "network_last_30_days": network_30,
+        "projections": {
+            "avg_cost_per_episode_usd": avg_per_episode,
+            "projected_weekly_usd": projected_weekly,
+            "note": "Projection uses last-7d average × 65 (network volume). Tune per operator knowledge.",
+        },
+        "youtube_quota": {
+            "enabled_shows_count": 2,  # TST + MAB only (per landmine #20 quota cap)
+            "daily_insert_cost_units": 1600,  # long + short typical (see engine/youtube_quota.py)
+            "note": "Hard cap ~10k units/day per channel. Preflight + youtube_quota.py have the estimators. Only 2 shows currently enabled.",
+        },
     }
 
 

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -88,6 +88,12 @@ tts:
   style: 0.0
   use_speaker_boost: true
   apply_text_normalization: "on"
+  # Tag-leak hard block (added as quick win in May 2026 codebase review).
+  # Default False = best-effort (metric recorded + warning logged; episode ships).
+  # Set to true on a per-show basis (or here for the whole network) once the
+  # detector has low false-positive rate on real transcripts for that voice.
+  # When true, any leak aborts the episode before mixing/publishing.
+  tag_leak_hard_block: false
 
 audio:
   min_audio_duration: 180

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -182,6 +182,19 @@
                 <span class="gradient-text">Nerra</span> Network
             </a>
 
+            {# Quick-win global search proto (client-only, May 2026 review).
+               Fetches a few small api/*.json on first use, builds an in-memory
+               index across shows, and shows a lightweight dropdown. Zero backend
+               cost; can be upgraded to server-side + content_lake later. #}
+            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.75rem;max-width:220px;flex:1 1 auto;">
+                <input type="search" id="nn-global-search-input"
+                       placeholder="Search episodes &amp; posts…"
+                       style="width:100%;padding:6px 10px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.9rem;"
+                       aria-label="Search all shows">
+                <div id="nn-global-search-results"
+                     style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:320px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
+            </div>
+
             <ul class="nn-nav-links">
                 <li class="nn-nav-dropdown">
                     <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
@@ -398,5 +411,93 @@
     }
     </script>
     {% block scripts %}{% endblock %}
+
+    <script>
+    // Global search proto (client-only, May 2026 quick win).
+    // Fetches a handful of small /api/*.json on first interaction, unions episodes,
+    // and renders a simple dropdown with links. Zero server cost; upgrade path
+    // is obvious (server index or content_lake FTS + dedicated endpoint).
+    (function () {
+        var input = document.getElementById('nn-global-search-input');
+        var resultsBox = document.getElementById('nn-global-search-results');
+        if (!input || !resultsBox) return;
+
+        var index = null; // cached {items: [...]}
+        var API_ENDPOINTS = [
+            '/api/tesla.json',
+            '/api/models_agents.json',
+            '/api/fascinating_frontiers.json',
+            '/api/omni_view.json',
+            '/api/planetterrian.json',
+            '/api/modern_investing.json'
+        ];
+
+        function normalise(s) { return (s || '').toLowerCase(); }
+
+        async function buildIndex() {
+            if (index) return index;
+            var items = [];
+            for (var i = 0; i < API_ENDPOINTS.length; i++) {
+                try {
+                    var res = await fetch(API_ENDPOINTS[i], { credentials: 'same-origin' });
+                    if (!res.ok) continue;
+                    var data = await res.json();
+                    var eps = data.episodes || data || [];
+                    for (var j = 0; j < eps.length; j++) {
+                        var e = eps[j];
+                        items.push({
+                            title: e.title || e.episode_title || '',
+                            hook: e.hook || e.summary || '',
+                            show: data.name || API_ENDPOINTS[i].split('/').pop().replace('.json',''),
+                            url: e.url || ('/' + (data.slug || '') + '.html'),
+                            date: e.date || ''
+                        });
+                    }
+                } catch (e) { /* ignore individual fetch failures for proto */ }
+            }
+            index = { items: items };
+            return index;
+        }
+
+        function renderResults(matches) {
+            if (!matches.length) {
+                resultsBox.innerHTML = '<div style="padding:8px 12px;color:var(--nn-text-muted);">No matches</div>';
+            } else {
+                var html = matches.slice(0, 8).map(function(m) {
+                    return '<a href="' + m.url + '" style="display:block;padding:6px 10px;text-decoration:none;color:inherit;border-bottom:1px solid var(--nn-border);">' +
+                           '<strong>' + (m.title || m.hook).substring(0,80) + '</strong><br>' +
+                           '<small>' + m.show + (m.date ? ' · ' + m.date : '') + '</small></a>';
+                }).join('');
+                resultsBox.innerHTML = html;
+            }
+            resultsBox.style.display = 'block';
+        }
+
+        input.addEventListener('focus', async function () {
+            await buildIndex();
+        });
+
+        input.addEventListener('input', async function () {
+            var q = normalise(input.value.trim());
+            if (q.length < 2) {
+                resultsBox.style.display = 'none';
+                return;
+            }
+            await buildIndex();
+            var matches = (index.items || []).filter(function(it) {
+                return normalise(it.title).indexOf(q) !== -1 ||
+                       normalise(it.hook).indexOf(q) !== -1 ||
+                       normalise(it.show).indexOf(q) !== -1;
+            });
+            renderResults(matches);
+        });
+
+        document.addEventListener('click', function (e) {
+            if (!resultsBox.contains(e.target) && e.target !== input) {
+                resultsBox.style.display = 'none';
+            }
+        });
+    })();
+    </script>
 </body>
 </html>

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -165,6 +165,24 @@
                 <div class="latest-episode-date" id="latest-date"></div>
                 <audio id="latest-audio" controls preload="none" aria-label="Latest episode audio player" style="width:100%;height:42px;border-radius:8px;"></audio>
                 <div id="latest-summary" style="margin-top:var(--sp-4);color:var(--nn-text-muted);font-size:0.92rem;display:none;"></div>
+
+                {# Quick-win noscript fallback (May 2026 review): the JS "Latest Episode"
+                   card is the only major surface that was previously empty without JS.
+                   We already parse the RSS into static_episodes for the archive grid below;
+                   reuse the first item here so no-JS visitors (and search crawlers) see
+                   real content + a working <audio> player immediately. #}
+                <noscript>
+                    {% if static_episodes %}
+                    <div class="latest-episode-title" style="font-size:1.05rem;font-weight:600;margin:0.5rem 0;">{{ static_episodes[0].title }}</div>
+                    {% if static_episodes[0].date_display %}
+                    <div style="color:var(--nn-text-muted);font-size:0.85rem;margin-bottom:0.5rem;">{{ static_episodes[0].date_display }}</div>
+                    {% endif %}
+                    {% if static_episodes[0].audio_url %}
+                    <audio controls preload="none" src="{{ static_episodes[0].audio_url }}" style="width:100%;height:42px;border-radius:8px;" aria-label="Latest episode audio"></audio>
+                    {% endif %}
+                    <div style="margin-top:0.5rem;font-size:0.8rem;opacity:0.7;">(JavaScript disabled — showing first episode from RSS)</div>
+                    {% endif %}
+                </noscript>
             </div>
         </div>
     </section>

--- a/tests/test_quick_wins.py
+++ b/tests/test_quick_wins.py
@@ -1,0 +1,71 @@
+"""Drift guards for the May 2026 quick-win batch (codebase review).
+
+These tests pin the new behaviour so future changes cannot silently regress
+the improvements without updating the test (following the established pattern
+in test_tts_grok.py, test_dashboard.py, test_config.py, etc.).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_tag_leak_hard_block_exists_in_config_and_defaults_false():
+    """The new configurable hard-block flag must exist and default to False."""
+    from engine.config import load_config
+    from pathlib import Path
+
+    SHOWS_DIR = Path(__file__).resolve().parent.parent / "shows"
+    # Load a real show YAML; the flag is defined in the TTSConfig dataclass + _defaults
+    cfg = load_config(SHOWS_DIR / "tesla.yaml")
+    assert hasattr(cfg.tts, "tag_leak_hard_block")
+    assert cfg.tts.tag_leak_hard_block is False, "tag_leak_hard_block must default to False (best-effort)"
+
+
+def test_generate_html_injects_dynamic_meta_from_rss():
+    """Dynamic metadata quick win: show pages must receive page_title + meta_description
+    derived from the freshest RSS item (static_episodes) instead of purely static text.
+    """
+    # We can't easily exec the whole generator without side effects, but we can
+    # verify the generation logic path exists and the override code is present.
+    src = (ROOT / "generate_html.py").read_text(encoding="utf-8")
+    assert "dynamic_meta_description" in src or "latest_episode_title" in src
+    assert "Quick-win (May 2026 review): dynamic metadata" in src
+
+
+def test_readme_contains_recent_improvements_section():
+    """Docs refresh quick win: README must document the 2026 milestones and point to the review."""
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "Recent Improvements & Roadmap (May 2026+)" in readme
+    assert "Grok TTS migration" in readme
+    assert "Nerra Gallery" in readme
+    assert "smart Shorts" in readme or "Smart Shorts" in readme
+
+
+def test_dashboard_json_will_contain_projections_after_regen():
+    """Dashboard quick win: the aggregate_costs path now emits projections + youtube_quota surface."""
+    src = (ROOT / "scripts/generate_dashboard.py").read_text(encoding="utf-8")
+    assert "projections" in src
+    assert "projected_weekly_usd" in src
+    assert "youtube_quota" in src
+    assert "Quick-win enhancements (May 2026 codebase review)" in src
+
+
+def test_global_search_proto_markup_present():
+    """Audience quick win: the nav now contains the global search input + results container."""
+    base = (ROOT / "templates/base.html.j2").read_text(encoding="utf-8")
+    assert "nn-global-search-input" in base
+    assert "Global search proto (client-only" in base
+
+
+def test_noscript_fallback_in_show_page_template():
+    """Progressive enhancement quick win: the hero Latest Episode card has a noscript block."""
+    tpl = (ROOT / "templates/show_page.html.j2").read_text(encoding="utf-8")
+    assert "<noscript>" in tpl
+    assert "static_episodes[0]" in tpl
+    assert "JavaScript disabled" in tpl or "noscript" in tpl.lower()


### PR DESCRIPTION
## Summary

This PR delivers the **Quick Wins** batch from the full nerranetwork codebase review (May 2026).

### Changes

- **README.md** — Major refresh: updated architecture diagram, current show list (including Unintended Consequences), Grok TTS reality, 2026 milestones, and new "Recent Improvements & Roadmap" section.
- **Dynamic metadata** — Show pages now use the freshest episode title/hook from RSS for `<title>`, meta description, and OG cards (much better SEO/social sharing).
- **Tag-leak hardening** — New configurable `tts.tag_leak_hard_block` flag (defaults to `false` for safety). When enabled, spoken speech tags in Whisper transcripts will hard-fail the episode.
- **Dashboard improvements** — Added cost projections (`projected_weekly_usd`) and YouTube quota surface to `api/dashboard.json`.
- **Progressive enhancement** — Added `<noscript>` fallback for the "Latest Episode" hero card on show pages.
- **Global search prototype** — Lightweight client-side search added to the main navigation (searches across several `api/*.json` files).
- **Tests** — New `tests/test_quick_wins.py` with drift guards for all the above.

All relevant tests pass (including the new drift guards + `test_config.py`).

### Verification

- `pytest tests/test_quick_wins.py tests/test_config.py` — green
- Multiple `run_show.py --dry-run`
- `generate_html.py` dry generation
- `scripts/generate_dashboard.py --dry-run`
- Manual review of generated pages

This is additive / behind safe defaults. No impact on daily pipeline, RSS, or existing listeners.

See the internal codebase review plan for full context and the rest of the prioritized backlog.
