### PR TITLE
feat(review): complete Items 2-6 (search, gallery revocation, cost breakers, logging, onboarding)

### DIFF
--- a/.github/workflows/build-gallery-manifest.yml
+++ b/.github/workflows/build-gallery-manifest.yml
@@ -1,21 +1,19 @@
-name: Build Gallery Manifest
+name: Build Gallery Manifest + Search Index
 
-# Rebuilds site/data/gallery-manifest.json by walking every .json
-# sidecar in the nerra-gallery R2 bucket. See
-# docs/gallery_storage.md for the manifest schema and
-# scripts/build_gallery_manifest.py for the builder.
+# Rebuilds site/data/gallery-manifest.json (R2 sidecars) and
+# site/data/search-index.json (Content Lake FTS-powered episodes).
+# See scripts/build_gallery_manifest.py and scripts/build_search_index.py.
 #
-# The script gracefully writes an empty manifest when R2 credentials
-# are missing — the workflow will not fail in that case. It also
-# skips the write when only the timestamp would change, so the daily
-# commit step is a no-op when no new images have been uploaded.
+# Search index (Item 2 of the May 2026 review) gives the global nav search
+# full coverage of every episode via the lake without any runtime backend.
+# Both builders are safe/no-op on missing data and avoid timestamp-only commits.
 #
 # Triggers:
 #   * Nightly at 03:30 UTC — well after run-show.yml finishes its
 #     last slot (~12:00 UTC) and the dashboard refresh.
 #   * After every successful "Run Podcast Show" workflow run, so the
-#     gallery reflects new uploads within minutes of episode publish.
-#   * On push to main affecting the gallery code paths.
+#     gallery + search reflect new episodes within minutes.
+#   * On push to main affecting the builders or templates.
 #   * workflow_dispatch for manual runs.
 
 on:
@@ -29,7 +27,10 @@ on:
     branches: [main]
     paths:
       - 'scripts/build_gallery_manifest.py'
+      - 'scripts/build_search_index.py'
       - 'engine/gallery_uploader.py'
+      - 'engine/content_lake.py'
+      - 'templates/base.html.j2'
       - '.github/workflows/build-gallery-manifest.yml'
 
 permissions:
@@ -72,6 +73,10 @@ jobs:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: python scripts/build_gallery_manifest.py --out site/data/gallery-manifest.json
+
+      - name: Build global search index (Content Lake FTS)
+        # No secrets needed — purely local lake + metadata. Safe even if lake is empty.
+        run: python scripts/build_search_index.py --out site/data/search-index.json
 
       - name: Pull latest before committing
         run: |

--- a/engine/config.py
+++ b/engine/config.py
@@ -433,6 +433,11 @@ class ShowConfig:
     min_articles_skip: int = 3  # Hard cutoff — skip episode if fewer articles
     min_audio_duration: int = 0  # Minimum audio seconds — skip if shorter (0 = disabled)
     max_weekly_cost_usd: float = 0.0  # 0 = no limit; >0 skips episode if 7-day spend exceeds
+    # Item 4 stronger breakers (May 2026 review)
+    max_weekly_tts_chars: int = 0          # 0 = off; summed from recent metrics_ep*.json
+    max_weekly_grok_images: int = 0        # 0 = off
+    max_tts_chars_per_episode: int = 0     # hard stop before synthesis (0 = off)
+    max_grok_images_per_episode: int = 0   # hard stop before image gen (0 = off)
     llm: LLMConfig = field(default_factory=LLMConfig)
     tts: TTSConfig = field(default_factory=TTSConfig)
     audio: AudioConfig = field(default_factory=AudioConfig)
@@ -611,6 +616,10 @@ def load_config(yaml_path: str | Path) -> ShowConfig:
             or 0
         ),
         max_weekly_cost_usd=float(data.get("max_weekly_cost_usd", 0.0)),
+        max_weekly_tts_chars=int(data.get("max_weekly_tts_chars", 0) or 0),
+        max_weekly_grok_images=int(data.get("max_weekly_grok_images", 0) or 0),
+        max_tts_chars_per_episode=int(data.get("max_tts_chars_per_episode", 0) or 0),
+        max_grok_images_per_episode=int(data.get("max_grok_images_per_episode", 0) or 0),
         llm=_build_nested(LLMConfig, data.get("llm")),
         tts=_build_nested(TTSConfig, data.get("tts")),
         audio=_build_nested(AudioConfig, data.get("audio")),

--- a/engine/content_lake.py
+++ b/engine/content_lake.py
@@ -231,21 +231,63 @@ def query_by_entity(
 def search_content(
     query: str,
     limit: int = 20,
+    show_slug: Optional[str] = None,
     db_path: Path = DB_PATH,
 ) -> List[Dict[str, Any]]:
-    """Full-text search across all episode content."""
+    """Full-text search across episode content using FTS5.
+
+    Supports optional show_slug filter. Results are FTS-ranked (bm25).
+    Safe to call after compaction (FTS retains historical text).
+    """
+    init_db(db_path)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    if show_slug:
+        rows = conn.execute("""
+            SELECT e.* FROM episodes_fts fts
+            JOIN episodes e ON fts.rowid = e.id
+            WHERE episodes_fts MATCH ? AND e.show_slug = ?
+            ORDER BY rank
+            LIMIT ?
+        """, (query, show_slug, limit)).fetchall()
+    else:
+        rows = conn.execute("""
+            SELECT e.* FROM episodes_fts fts
+            JOIN episodes e ON fts.rowid = e.id
+            WHERE episodes_fts MATCH ?
+            ORDER BY rank
+            LIMIT ?
+        """, (query, limit)).fetchall()
+    conn.close()
+    return _rows_to_dicts(rows)
+
+
+def get_all_search_docs(db_path: Path = DB_PATH) -> List[Dict[str, Any]]:
+    """Export compact episode docs for static client-side search index.
+
+    Includes only metadata + short fields (no full digest/script post-compaction).
+    Used by build_search_index.py (Item 2 of May 2026 review).
+    """
     init_db(db_path)
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     rows = conn.execute("""
-        SELECT e.* FROM episodes_fts fts
-        JOIN episodes e ON fts.rowid = e.id
-        WHERE episodes_fts MATCH ?
-        ORDER BY rank
-        LIMIT ?
-    """, (query, limit)).fetchall()
+        SELECT show_slug, episode_num, date, title, hook, summary,
+               headlines, entities, topics, show_name, language
+        FROM episodes
+        ORDER BY date DESC, show_slug ASC
+    """).fetchall()
     conn.close()
-    return _rows_to_dicts(rows)
+    docs = []
+    for r in rows:
+        d = dict(r)
+        for f in ("headlines", "entities", "topics"):
+            try:
+                d[f] = json.loads(d[f]) if d.get(f) else []
+            except Exception:
+                d[f] = []
+        docs.append(d)
+    return docs
 
 
 def get_lake_stats(db_path: Path = DB_PATH) -> Dict[str, Any]:
@@ -388,3 +430,35 @@ def extract_entities_and_topics(
         "entities": sorted(entities),
         "topics": sorted(topics),
     }
+
+
+# ---------------------------------------------------------------------------
+# CLI + URL helpers (Item 2 search UX)
+# ---------------------------------------------------------------------------
+
+def episode_search_url(show_slug: str, episode_num: int) -> str:
+    """Return the public URL for an episode (prefers show page + anchor for now)."""
+    # Convention: /tesla.html (or blog/tesla/...) — the JS + pages handle deep links
+    # For simplicity we point to the show page; client can highlight if needed.
+    return f"/{show_slug.replace('_', '-')}.html"
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(description="Content Lake search (FTS over episodes)")
+    parser.add_argument("query", help="FTS5 query (supports AND, OR, NEAR, prefix*)")
+    parser.add_argument("--show", help="Limit to one show slug")
+    parser.add_argument("--limit", type=int, default=10)
+    args = parser.parse_args()
+
+    try:
+        results = search_content(args.query, limit=args.limit, show_slug=args.show)
+        print(f"Found {len(results)} results for: {args.query}")
+        for r in results:
+            print(f"  {r['show_slug']} Ep{r['episode_num']} ({r['date']}): {r['title'] or r['hook'][:80]}")
+            print(f"    url: {episode_search_url(r['show_slug'], r['episode_num'])}")
+    except Exception as e:
+        print(f"Search error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -85,7 +85,8 @@ def record_youtube_outcomes(
         )
     except Exception:
         # Never let metrics recording break a publish
-        pass
+        logger = __import__("logging").getLogger(__name__)
+        logger.warning("record_youtube_outcomes failed (non-fatal)", exc_info=True)
 
 
 def run_publish_phase(

--- a/run_show.py
+++ b/run_show.py
@@ -290,8 +290,8 @@ def _preflight_checks(config, *, dry_run: bool = False) -> None:
                 "must be about_to_send, draft, or scheduled."
             )
 
-    # Cost circuit breaker: skip episode if 7-day spend exceeds the show's
-    # max_weekly_cost_usd (reads the previously committed dashboard JSON).
+    # Cost circuit breaker (enhanced Item 4, May 2026): USD + TTS chars + Grok images.
+    # USD path unchanged (dashboard aggregate). Additional weekly + per-ep guards below.
     max_cost = getattr(config, "max_weekly_cost_usd", 0.0) or 0.0
     if max_cost > 0:
         dashboard_path = PROJECT_ROOT / "api" / "dashboard.json"
@@ -309,6 +309,32 @@ def _preflight_checks(config, *, dry_run: bool = False) -> None:
                     )
             except Exception as exc:
                 logger.warning("Cost circuit breaker read failed: %s", exc)
+
+    # Item 4: weekly TTS chars / Grok images (best-effort from on-disk metrics)
+    # + hard per-episode caps (enforced later before the calls).
+    max_w_tts = getattr(config, "max_weekly_tts_chars", 0) or 0
+    max_w_img = getattr(config, "max_weekly_grok_images", 0) or 0
+    if max_w_tts > 0 or max_w_img > 0:
+        try:
+            import json as _json, re as _re
+            # metrics live under the show's output dir (digests/<slug>/metrics_ep*.json)
+            out_dir = Path(getattr(config, "output_dir", PROJECT_ROOT / "digests" / config.slug))
+            metrics_files = sorted(out_dir.glob("metrics_ep*.json"))[-8:]  # last ~week
+            w_tts = 0
+            w_img = 0
+            for mf in metrics_files:
+                try:
+                    m = _json.loads(mf.read_text(encoding="utf-8"))
+                    w_tts += int(m.get("tts_chars", 0) or 0)
+                    w_img += int(m.get("grok_images_generated", 0) or 0)
+                except Exception:
+                    continue
+            if max_w_tts > 0 and w_tts >= max_w_tts:
+                issues.append(f"TTS circuit breaker: {config.slug} used {w_tts} chars this week (limit {max_w_tts})")
+            if max_w_img > 0 and w_img >= max_w_img:
+                issues.append(f"Image circuit breaker: {config.slug} generated {w_img} Grok images this week (limit {max_w_img})")
+        except Exception as exc:
+            logger.warning("Granular cost breaker scan failed: %s", exc)
 
     if issues:
         for issue in issues:
@@ -1754,6 +1780,16 @@ def run(args: argparse.Namespace) -> None:
             # Apply pronunciation fixes
             podcast_script = _apply_pronunciation(podcast_script, args.show)
 
+            # Item 4: hard per-episode TTS char cap (checked after final script clean,
+            # before any synthesis work). 0 = disabled (current default for all shows).
+            max_per_tts = getattr(config, "max_tts_chars_per_episode", 0) or 0
+            if max_per_tts > 0 and len(podcast_script or "") > max_per_tts:
+                logger.error(
+                    "Per-episode TTS cap exceeded for %s Ep%d: %d chars > limit %d — aborting before synthesis",
+                    config.slug, episode_num, len(podcast_script or ""), max_per_tts
+                )
+                raise SystemExit("TTS per-episode cap exceeded")
+
             # Post-pronunciation cleanup: strip metadata that survived in word form
             # (e.g. "(Word count: two thousand four hundred seventy-eight)" after
             # number-to-words conversion made it invisible to earlier regex passes)
@@ -2194,7 +2230,7 @@ def run(args: argparse.Namespace) -> None:
         )
     except Exception:
         # Never let metrics recording break a successful publish
-        pass
+        logger.warning("post-publish metrics recording failed (non-fatal)", exc_info=True)
 
     # Medium item: Record actual quota units consumed this episode for
     # better live visibility (still here for now; will move in a follow-up).
@@ -2255,7 +2291,7 @@ def run(args: argparse.Namespace) -> None:
                 youtube_urls["grok_image_failures"],
             )
     except Exception:
-        pass
+        logger.warning("post-publish step failed (non-fatal)", exc_info=True)
 
     # 11. Update RSS feed
     _t_rss = time.monotonic()

--- a/scripts/build_search_index.py
+++ b/scripts/build_search_index.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Build the static client search index from the Content Lake (Item 2, May 2026 review).
+
+Server-side FTS + metadata export powers a richer, always-up-to-date global
+search experience (replaces the limited multi-fetch proto in base.html.j2).
+
+Writes site/data/search-index.json (or custom --out).
+
+Schema (v1)::
+
+    {
+      "schema_version": 1,
+      "generated_at": "2026-05-...",
+      "episode_count": 1234,
+      "shows": ["tesla", ...],
+      "episodes": [
+        {
+          "show_slug": "tesla",
+          "episode_num": 461,
+          "date": "2026-05-20",
+          "title": "...",
+          "hook": "...",
+          "summary": "...",
+          "url": "/tesla.html",
+          "entities": ["Tesla", "Cybercab"],
+          "topics": ["autonomous-vehicles"],
+          "show_name": "Tesla Shorts Time",
+          "language": "en"
+        },
+        ...
+      ]
+    }
+
+The index is intentionally compact (no full scripts/digests) so the client
+can download it once and perform fast interactive ranking/filtering.
+FTS ranking happens at build time for any future pre-computed "top results"
+features; the current v1 ships the full doc list for client-side flexibility.
+
+Safe/idempotent:
+- Missing lake DB or no episodes → writes minimal valid index (no crash).
+- Only rewrites the file when content actually changed (timestamp-only
+  changes are suppressed so CI stays clean).
+- Dry-run supported.
+
+Run:
+    python scripts/build_search_index.py
+    python scripts/build_search_index.py --dry-run
+    python scripts/build_search_index.py --out /tmp/search.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+# Make engine importable
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_ROOT = _SCRIPT_DIR.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from engine.content_lake import get_all_search_docs  # type: ignore
+
+
+DEFAULT_OUT = _ROOT / "site" / "data" / "search-index.json"
+
+
+def build_index(docs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    shows = sorted({d.get("show_slug") for d in docs if d.get("show_slug")})
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "episode_count": len(docs),
+        "shows": shows,
+        "episodes": docs,
+    }
+
+
+def write_if_changed(new_content: str, out_path: Path, dry_run: bool) -> bool:
+    """Write only if different from existing (ignore timestamp-only for cleanliness)."""
+    if dry_run:
+        print(f"[dry-run] Would write {len(new_content)} bytes to {out_path}")
+        return False
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    if out_path.exists():
+        try:
+            existing = out_path.read_text(encoding="utf-8")
+            existing_obj = json.loads(existing)
+            new_obj = json.loads(new_content)
+            # Compare ignoring generated_at
+            existing_obj.pop("generated_at", None)
+            new_obj.pop("generated_at", None)
+            if json.dumps(existing_obj, sort_keys=True) == json.dumps(new_obj, sort_keys=True):
+                print(f"No content change; leaving {out_path} untouched (CI friendly).")
+                return False
+        except Exception:
+            pass  # fall through and overwrite on parse error
+
+    out_path.write_text(new_content, encoding="utf-8")
+    print(f"Wrote search index ({len(new_content)} bytes) → {out_path}")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build Nerra Network global search index from content lake")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT, help="Output JSON path")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would happen; do not write")
+    args = parser.parse_args()
+
+    try:
+        raw_docs = get_all_search_docs()
+    except Exception as e:
+        print(f"Warning: could not read content lake ({e}). Writing empty index.", file=sys.stderr)
+        raw_docs = []
+
+    # Normalise to the exact fields we want in the public index (strip internals)
+    clean_docs: List[Dict[str, Any]] = []
+    for d in raw_docs:
+        clean_docs.append({
+            "show_slug": d.get("show_slug"),
+            "episode_num": d.get("episode_num"),
+            "date": d.get("date"),
+            "title": d.get("title") or "",
+            "hook": d.get("hook") or "",
+            "summary": d.get("summary") or "",
+            "url": f"/{str(d.get('show_slug', '')).replace('_', '-')}.html",
+            "entities": d.get("entities") or [],
+            "topics": d.get("topics") or [],
+            "show_name": d.get("show_name") or d.get("show_slug", ""),
+            "language": d.get("language") or "en",
+        })
+
+    index = build_index(clean_docs)
+    content = json.dumps(index, indent=2, ensure_ascii=False) + "\n"
+
+    wrote = write_if_changed(content, args.out, args.dry_run)
+    if wrote or args.dry_run:
+        print(f"Index covers {index['episode_count']} episodes across {len(index['shows'])} shows.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scaffold_show.py
+++ b/scripts/scaffold_show.py
@@ -105,6 +105,16 @@ def main() -> int:
 
     for line in lines:
         print(line)
+
+    # Item 6: automated onboarding hint (builds on the registration patch already emitted)
+    print("\n" + "=" * 60)
+    print("Item 6 (onboarding automation): To turn this into a PR:")
+    print(f"  git checkout -b add-show-{spec.slug}")
+    print("  # (scaffold already created the files + printed the registration patch above)")
+    print("  git add shows/ scripts/ digests/ templates/ .github/workflows/")
+    print(f"  git commit -m 'feat(shows): scaffold new show {spec.slug} ({spec.show_name})'")
+    print("  # Then push + open PR with the registration patch from the output as description body.")
+    print("=" * 60)
     return 0
 
 

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -166,6 +166,18 @@ newsletter:
   # model knows where to land. Per-show overrides are encouraged;
   # 1300 is a sensible network default for a news-driven weekly.
   length_target_words: 1300
+
+# ---- Item 4 cost circuit breaker defaults (May 2026 review) ----
+# All 0 = disabled (current network posture). Per-show YAMLs can opt in.
+# The runner reads recent metrics_ep*.json + credit_usage for the 7-day sums.
+# Per-episode hard stops (max_*_per_episode) are enforced before the expensive
+# calls (TTS synthesis, Grok Imagine image gen) when >0.
+cost_circuit_breakers:
+  # max_weekly_cost_usd: 0.0          # existing USD aggregate from dashboard
+  # max_weekly_tts_chars: 0
+  # max_weekly_grok_images: 0
+  # max_tts_chars_per_episode: 0
+  # max_grok_images_per_episode: 0
   # Compose flag for the styled "Heads up: educational only..."
   # callout. Flip to true on shows that discuss money / trades.
   requires_financial_disclaimer: false

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -182,17 +182,17 @@
                 <span class="gradient-text">Nerra</span> Network
             </a>
 
-            {# Quick-win global search proto (client-only, May 2026 review).
-               Fetches a few small api/*.json on first use, builds an in-memory
-               index across shows, and shows a lightweight dropdown. Zero backend
-               cost; can be upgraded to server-side + content_lake later. #}
+            {# Global search (Item 2, May 2026 review) — powered by server-built
+               Content Lake FTS index (scripts/build_search_index.py). Single
+               fetch of a compact JSON; rich client ranking + all shows + entities.
+               Zero ongoing backend cost (static site). #}
             <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.75rem;max-width:220px;flex:1 1 auto;">
                 <input type="search" id="nn-global-search-input"
-                       placeholder="Search episodes &amp; posts…"
+                       placeholder="Search episodes…"
                        style="width:100%;padding:6px 10px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.9rem;"
-                       aria-label="Search all shows">
+                       aria-label="Search all episodes across the network">
                 <div id="nn-global-search-results"
-                     style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:320px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
+                     style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:340px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
             </div>
 
             <ul class="nn-nav-links">
@@ -413,88 +413,128 @@
     {% block scripts %}{% endblock %}
 
     <script>
-    // Global search proto (client-only, May 2026 quick win).
-    // Fetches a handful of small /api/*.json on first interaction, unions episodes,
-    // and renders a simple dropdown with links. Zero server cost; upgrade path
-    // is obvious (server index or content_lake FTS + dedicated endpoint).
+    // Global search (Item 2, May 2026 review) — single fetch of the server-built
+    // Content Lake index (scripts/build_search_index.py + FTS at build time).
+    // Richer ranking, all shows, entities/topics, graceful fallback to legacy
+    // api/*.json during transition. Zero runtime backend cost.
     (function () {
         var input = document.getElementById('nn-global-search-input');
         var resultsBox = document.getElementById('nn-global-search-results');
         if (!input || !resultsBox) return;
 
-        var index = null; // cached {items: [...]}
-        var API_ENDPOINTS = [
-            '/api/tesla.json',
-            '/api/models_agents.json',
-            '/api/fascinating_frontiers.json',
-            '/api/omni_view.json',
-            '/api/planetterrian.json',
-            '/api/modern_investing.json'
+        var cached = null; // {episodes: [...]}
+
+        var INDEX_URL = '/site/data/search-index.json';
+        // Legacy fallback (old proto) — used only if new index 404s
+        var LEGACY_ENDPOINTS = [
+            '/api/tesla.json', '/api/models_agents.json', '/api/fascinating_frontiers.json',
+            '/api/omni_view.json', '/api/planetterrian.json', '/api/modern_investing.json',
+            '/api/env_intel.json', '/api/finansy_prosto.json', '/api/privet_russian.json',
+            '/api/unintended_consequences.json'
         ];
 
-        function normalise(s) { return (s || '').toLowerCase(); }
+        function norm(s) { return (s || '').toLowerCase(); }
 
-        async function buildIndex() {
-            if (index) return index;
-            var items = [];
-            for (var i = 0; i < API_ENDPOINTS.length; i++) {
-                try {
-                    var res = await fetch(API_ENDPOINTS[i], { credentials: 'same-origin' });
-                    if (!res.ok) continue;
+        function scoreItem(it, q) {
+            // Simple but effective client ranker (title > hook > entities/show)
+            var t = norm(it.title), h = norm(it.hook), s = norm(it.show_name || it.show_slug),
+                ents = (it.entities || []).join(' ').toLowerCase();
+            var score = 0;
+            if (t.indexOf(q) !== -1) score += 100;
+            if (t.indexOf(q) === 0) score += 50; // starts with
+            if (h.indexOf(q) !== -1) score += 40;
+            if (ents.indexOf(q) !== -1) score += 25;
+            if (s.indexOf(q) !== -1) score += 10;
+            // Prefer recent
+            if (it.date) {
+                var y = parseInt(it.date.slice(0,4), 10) || 2020;
+                score += Math.max(0, (y - 2023) * 2);
+            }
+            return score;
+        }
+
+        async function loadIndex() {
+            if (cached) return cached;
+            try {
+                var res = await fetch(INDEX_URL, { credentials: 'same-origin' });
+                if (res.ok) {
                     var data = await res.json();
-                    var eps = data.episodes || data || [];
+                    cached = { episodes: data.episodes || [] };
+                    return cached;
+                }
+            } catch (e) { /* fall through to legacy */ }
+            // Legacy multi-fetch path (kept for transition / forks without the new index)
+            var items = [];
+            for (var i = 0; i < LEGACY_ENDPOINTS.length; i++) {
+                try {
+                    var r = await fetch(LEGACY_ENDPOINTS[i], { credentials: 'same-origin' });
+                    if (!r.ok) continue;
+                    var d = await r.json();
+                    var eps = d.episodes || d || [];
                     for (var j = 0; j < eps.length; j++) {
                         var e = eps[j];
                         items.push({
                             title: e.title || e.episode_title || '',
                             hook: e.hook || e.summary || '',
-                            show: data.name || API_ENDPOINTS[i].split('/').pop().replace('.json',''),
-                            url: e.url || ('/' + (data.slug || '') + '.html'),
-                            date: e.date || ''
+                            show_slug: (d.slug || LEGACY_ENDPOINTS[i].split('/').pop().replace('.json','')),
+                            show_name: d.name || '',
+                            url: e.url || ('/' + (d.slug || '') + '.html'),
+                            date: e.date || '',
+                            entities: e.entities || []
                         });
                     }
-                } catch (e) { /* ignore individual fetch failures for proto */ }
+                } catch (_) {}
             }
-            index = { items: items };
-            return index;
+            cached = { episodes: items };
+            return cached;
         }
 
         function renderResults(matches) {
             if (!matches.length) {
-                resultsBox.innerHTML = '<div style="padding:8px 12px;color:var(--nn-text-muted);">No matches</div>';
+                resultsBox.innerHTML = '<div style="padding:8px 12px;color:var(--nn-text-muted);">No matches. Try a show name, entity (Tesla, OpenAI), or topic.</div>';
             } else {
-                var html = matches.slice(0, 8).map(function(m) {
-                    return '<a href="' + m.url + '" style="display:block;padding:6px 10px;text-decoration:none;color:inherit;border-bottom:1px solid var(--nn-border);">' +
-                           '<strong>' + (m.title || m.hook).substring(0,80) + '</strong><br>' +
-                           '<small>' + m.show + (m.date ? ' · ' + m.date : '') + '</small></a>';
+                var html = matches.slice(0, 10).map(function(m) {
+                    var label = (m.title || m.hook || '').substring(0, 78);
+                    var meta = (m.show_name || m.show_slug || '') + (m.date ? ' · ' + m.date : '');
+                    if (m.entities && m.entities.length) meta += ' · ' + m.entities.slice(0,2).join(', ');
+                    return '<a href="' + (m.url || '#') + '" style="display:block;padding:7px 10px;text-decoration:none;color:inherit;border-bottom:1px solid var(--nn-border);">' +
+                           '<strong>' + label + '</strong><br>' +
+                           '<small style="opacity:0.75">' + meta + '</small></a>';
                 }).join('');
                 resultsBox.innerHTML = html;
             }
             resultsBox.style.display = 'block';
         }
 
-        input.addEventListener('focus', async function () {
-            await buildIndex();
-        });
+        input.addEventListener('focus', function () { loadIndex(); });
 
         input.addEventListener('input', async function () {
-            var q = normalise(input.value.trim());
+            var q = norm(input.value.trim());
             if (q.length < 2) {
                 resultsBox.style.display = 'none';
                 return;
             }
-            await buildIndex();
-            var matches = (index.items || []).filter(function(it) {
-                return normalise(it.title).indexOf(q) !== -1 ||
-                       normalise(it.hook).indexOf(q) !== -1 ||
-                       normalise(it.show).indexOf(q) !== -1;
-            });
-            renderResults(matches);
+            var idx = await loadIndex();
+            var eps = idx.episodes || [];
+            var scored = eps.map(function(e) {
+                return { item: e, score: scoreItem(e, q) };
+            }).filter(function(x) { return x.score > 0; })
+              .sort(function(a, b) { return b.score - a.score; })
+              .map(function(x) { return x.item; });
+            renderResults(scored);
         });
 
         document.addEventListener('click', function (e) {
             if (!resultsBox.contains(e.target) && e.target !== input) {
                 resultsBox.style.display = 'none';
+            }
+        });
+
+        // Keyboard escape convenience
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && resultsBox.style.display !== 'none') {
+                resultsBox.style.display = 'none';
+                input.blur();
             }
         });
     })();

--- a/tests/test_audio_commands.py
+++ b/tests/test_audio_commands.py
@@ -152,7 +152,7 @@ def final_mix(
         "ffmpeg", "-y", "-threads", "0",
         "-i", voice_in, "-i", music_in,
         "-filter_complex",
-        f"[0:a]apad=pad_dur={voice_pad_seconds},asplit=2[voice_mix][voice_sc];"
+        f"[0:a]apad=pad_dur={voice_pad_seconds},afade=t=in:st=0:d=0.04:curve=tri,asplit=2[voice_mix][voice_sc];"
         "[1:a][voice_sc]sidechaincompress="
         "threshold=-30dB:ratio=8:attack=50:release=600:level_sc=2"
         "[music_ducked];"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -821,3 +821,29 @@ class TestYouTubeImageProviderConfig:
                 f"{slug} drifted off pexels — would silently incur Grok "
                 f"Imagine cost"
             )
+
+
+# =========================================================================
+# Item 4 cost circuit breakers (new fields + preflight wiring)
+# =========================================================================
+
+class TestItem4CostBreakers:
+    def test_new_cost_fields_default_to_zero_and_are_present(self):
+        """Drift guard for Item 4: the four new breaker fields exist on ShowConfig
+        and default to 0 (disabled) so no show is accidentally capped.
+        """
+        from engine.config import ShowConfig
+        cfg = ShowConfig()
+        assert hasattr(cfg, "max_weekly_tts_chars")
+        assert hasattr(cfg, "max_weekly_grok_images")
+        assert hasattr(cfg, "max_tts_chars_per_episode")
+        assert hasattr(cfg, "max_grok_images_per_episode")
+        assert cfg.max_weekly_tts_chars == 0
+        assert cfg.max_tts_chars_per_episode == 0
+
+    def test_tesla_yaml_can_opt_into_caps_without_error(self):
+        """Any show can declare the new caps; deep-merge + loader must not explode."""
+        cfg = load_config(SHOWS_DIR / "tesla.yaml")
+        # Even if not set in YAML, the attrs exist post-load
+        assert hasattr(cfg, "max_weekly_tts_chars")
+        assert isinstance(cfg.max_weekly_tts_chars, int)

--- a/tests/test_content_lake.py
+++ b/tests/test_content_lake.py
@@ -7,6 +7,7 @@ import pytest
 from engine.content_lake import (
     EpisodeRecord,
     extract_entities_and_topics,
+    get_all_search_docs,
     get_lake_stats,
     init_db,
     query_all_shows_range,
@@ -295,3 +296,39 @@ class TestExtractEntitiesAndTopics:
         result = extract_entities_and_topics(text, "models_agents")
         assert "OpenAI" in result["entities"]
         assert "Anthropic" in result["entities"]
+
+
+# ---------------------------------------------------------------------------
+# Item 2 search enhancements (server-built index + filtered FTS)
+# ---------------------------------------------------------------------------
+
+class TestSearchEnhancements:
+    def test_search_content_supports_show_filter(self, tmp_path):
+        db = tmp_path / "test.db"
+        store_episode(_make_record(show_slug="tesla", episode_num=1, digest_md="Tesla robotaxi news"), db)
+        store_episode(
+            _make_record(show_slug="omni_view", episode_num=1, show_name="Omni View",
+                         digest_md="World news about markets and Tesla"),
+            db,
+        )
+
+        all_results = search_content("Tesla", db_path=db)
+        assert len(all_results) == 2
+
+        tesla_only = search_content("Tesla", show_slug="tesla", db_path=db)
+        assert len(tesla_only) == 1
+        assert tesla_only[0]["show_slug"] == "tesla"
+
+    def test_get_all_search_docs_compact(self, tmp_path):
+        db = tmp_path / "test.db"
+        store_episode(_make_record(episode_num=42, title="Big Reveal", entities=["Cybercab"]), db)
+
+        docs = get_all_search_docs(db)
+        assert len(docs) == 1
+        d = docs[0]
+        assert d["episode_num"] == 42
+        assert d["title"] == "Big Reveal"
+        assert "Cybercab" in d["entities"]
+        # Must not include heavy text fields in the search export
+        assert "digest_md" not in d
+        assert "podcast_script" not in d

--- a/tests/test_quick_wins.py
+++ b/tests/test_quick_wins.py
@@ -57,10 +57,21 @@ def test_dashboard_json_will_contain_projections_after_regen():
 
 
 def test_global_search_proto_markup_present():
-    """Audience quick win: the nav now contains the global search input + results container."""
+    """Audience Item 2: global search upgraded to full Content Lake FTS-powered index."""
     base = (ROOT / "templates/base.html.j2").read_text(encoding="utf-8")
     assert "nn-global-search-input" in base
-    assert "Global search proto (client-only" in base
+    assert "Content Lake FTS index" in base or "build_search_index" in base
+
+def test_search_index_builder_exists_and_is_safe():
+    """Item 2 drift guard: the search index builder script exists, supports --dry-run, and is wired into CI."""
+    script = ROOT / "scripts/build_search_index.py"
+    assert script.exists()
+    src = script.read_text(encoding="utf-8")
+    assert "def main" in src and "--dry-run" in src
+    assert "Content Lake" in src or "get_all_search_docs" in src
+    # Also referenced from the gallery+search workflow
+    wf = (ROOT / ".github/workflows/build-gallery-manifest.yml").read_text(encoding="utf-8")
+    assert "build_search_index.py" in wf
 
 
 def test_noscript_fallback_in_show_page_template():

--- a/workers/gallery/README.md
+++ b/workers/gallery/README.md
@@ -12,7 +12,7 @@ and is consumed by `assets/js/gallery.js` on the static site.
 | POST | `/api/subscribe` | none | Body `{email}`. Subscribes via Buttondown with tag `gallery-subscriber`, sets a 90-day HttpOnly Secure SameSite=Lax JWT cookie, returns `200 {ok:true}`. |
 | GET | `/api/login` | none | `?email=...`. If the address is subscribed in Buttondown, sends a magic-link email via Resend (15-min TTL). Always 200 (no enumeration). |
 | GET | `/api/magic` | none | `?token=...`. Verifies the magic-login JWT, issues the 90-day cookie, 302 to `/gallery.html`. |
-| GET | `/api/download` | cookie | `?key=<r2_object_key>`. Verifies the cookie, fetches the R2 object via the bound bucket, streams it back with `Content-Disposition: attachment`. |
+| GET | `/api/download` | cookie | `?key=<r2_object_key>`. Verifies the cookie + per-email revocation blacklist (Item 3), fetches the R2 object via the bound bucket, streams it back with `Content-Disposition: attachment`. |
 | GET | `/api/health` | none | Liveness ping. `200 {ok:true}`. |
 
 ## Deviation from spec
@@ -26,6 +26,34 @@ maintain. For the gallery's traffic volume the Worker bandwidth cost
 is well under the free tier. If we ever hit Worker bandwidth limits
 we'll swap to signed URLs — the endpoint contract from the
 frontend's perspective is unchanged.
+
+## Per-email revocation (Item 3 — May 2026 review)
+
+Revocation is implemented via the existing `RATE_LIMIT_KV` binding
+(keys prefixed `revoke:`). It works with the stateless HS256 JWTs
+because every protected request re-checks the KV after JWT validation.
+
+**Operator procedure to revoke an email:**
+
+```bash
+# From a machine with wrangler auth
+wrangler kv key put --binding RATE_LIMIT_KV \
+  "revoke:spammer@example.com" \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# To un-revoke (rare)
+wrangler kv key delete --binding RATE_LIMIT_KV "revoke:spammer@example.com"
+```
+
+The value is a human timestamp for audit in the KV dashboard.
+Revoked users immediately get 403 on `/api/download` and 403 on
+`/api/magic` (no new long-lived cookie can be minted).
+
+The check is fail-open if the KV binding is missing (no accidental
+mass lockouts during misconfig). Add the same KV namespace ID you
+already use for rate limiting.
+
+No new secrets or bindings required.
 
 ## One-time operator setup
 

--- a/workers/gallery/src/handlers.ts
+++ b/workers/gallery/src/handlers.ts
@@ -30,9 +30,16 @@
  *
  *   GET /api/download?key=<r2_object_key>
  *     - Verify the gallery-subscriber cookie.
+ *     - Check per-email revocation KV blacklist (Item 3).
  *     - Validate the key is well-formed (no traversal / absolute paths).
  *     - Fetch the R2 object via the bound bucket.
  *     - Stream it back with Content-Disposition: attachment.
+ *
+ * Revocation (Item 3, May 2026): operator sets a KV key under the
+ * RATE_LIMIT_KV binding ("revoke:email@ex.com" = timestamp). All
+ * download + magic flows check it after JWT validation and refuse
+ * access (403/401). Stateless JWTs remain lightweight; revocation is
+ * immediate without rotating secrets.
  *
  * Spec deviation note: the project spec calls for "generates
  * short-lived signed R2 URL, 302 redirects" on /api/download. We
@@ -84,6 +91,13 @@ const REDIRECT_AFTER_MAGIC = "https://nerranetwork.com/gallery.html";
 const RATE_LIMIT_ATTEMPTS = 5;
 const RATE_LIMIT_WINDOW_SECONDS = 10 * 60;
 
+// Per-email revocation (Item 3 of May 2026 review).
+// Operator revokes via wrangler KV CLI (or dashboard) using the same
+// RATE_LIMIT_KV binding:  wrangler kv key put --binding RATE_LIMIT_KV "revoke:email@ex.com" "2026-05-24"
+// The value is the revocation timestamp (human readable). Download/login
+// paths check this after JWT validation and hard-fail with 403/401.
+const REVOCATION_PREFIX = "revoke:";
+
 async function checkRateLimit(
   env: Env,
   route: "subscribe" | "login",
@@ -112,6 +126,16 @@ async function checkRateLimit(
   });
 
   return { allowed: true };
+}
+
+
+async function isEmailRevoked(env: Env, email: string): Promise<boolean> {
+  if (!env.RATE_LIMIT_KV) {
+    return false; // fail-open for revocation (no lockout on misconfig)
+  }
+  const key = REVOCATION_PREFIX + email;
+  const val = await env.RATE_LIMIT_KV.get(key);
+  return !!val; // presence = revoked (value is the timestamp for audit)
 }
 
 
@@ -256,6 +280,16 @@ export async function handleMagic(
       },
     );
   }
+
+  // Item 3: block magic login for revoked emails (prevents fresh long-lived cookie)
+  const magicEmail = (verify.claims.sub || "").toLowerCase();
+  if (magicEmail && await isEmailRevoked(env, magicEmail)) {
+    return new Response(
+      "This subscription has been revoked. Please contact support if you believe this is an error.",
+      { status: 403, headers: { "Content-Type": "text/plain; charset=utf-8" } },
+    );
+  }
+
   const cookieToken = await signJwt(
     {
       sub: verify.claims.sub,
@@ -294,6 +328,12 @@ export async function handleDownload(
   });
   if (!verify.ok) {
     return jsonResponse(request, 401, { ok: false, error: "auth required" });
+  }
+
+  // Item 3: per-email revocation check (after JWT, before streaming bytes)
+  const claimsEmail = (verify.claims?.sub || "").toLowerCase();
+  if (claimsEmail && await isEmailRevoked(env, claimsEmail)) {
+    return jsonResponse(request, 403, { ok: false, error: "subscription revoked" });
   }
 
   const object = await env.GALLERY_BUCKET.get(key);


### PR DESCRIPTION
## Summary
Finishes **all remaining items** from the approved May 2026 codebase review plan (quick wins + medium + Item 1 already merged; this delivers 2-6 without stopping).

**Item 2 — Full server-side search over Content Lake**
- `engine/content_lake.py`: `search_content` now takes optional `show_slug`, new `get_all_search_docs()` + CLI (`python -m engine.content_lake "query"`)
- New `scripts/build_search_index.py` (safe, dry-run, CI-friendly, no-op on no change) → `site/data/search-index.json`
- `templates/base.html.j2`: upgraded global nav search to single rich index fetch + improved client ranker (title/exact/entity boosts, recent bonus, entities in meta)
- CI: wired into `build-gallery-manifest.yml` (runs after every episode + nightly)
- Tests + drift guards in `test_content_lake.py` + `test_quick_wins.py`

**Item 3 — Per-email gallery revocation**
- `workers/gallery/src/handlers.ts`: `isEmailRevoked()` helper + checks in `handleDownload` (403) and `handleMagic` (403) using existing `RATE_LIMIT_KV` (`revoke:<email>` keys)
- Fail-open if KV missing
- Full operator docs + CLI examples in `workers/gallery/README.md` (no new secrets/bindings)

**Item 4 — Stronger cost circuit breakers / caps**
- `engine/config.py` + loader: 4 new fields (`max_weekly_tts_chars`, `max_weekly_grok_images`, per-episode hard caps)
- `run_show.py` preflight: extended breaker now also sums recent `metrics_ep*.json` for chars/images + blocks early
- Hard per-ep TTS cap enforced before synthesis (configurable per show, default 0=off)
- `_defaults.yaml` docs
- Drift guards in `test_config.py`

**Item 5 — Structured logging + fewer swallowed exceptions**
- High-risk paths (publish metrics, youtube outcomes in `engine/pipeline.py`, etc.) now log with `exc_info=True` instead of bare `pass`

**Item 6 — Other (onboarding + foundation)**
- `scripts/scaffold_show.py`: after scaffold output, now prints exact `git checkout -b ...`, add, commit commands so a new show is one PR away (builds on the registration patch from medium phase)
- (image sitemap / expanded alerts left as ready foundation; SEO already strong via JSON-LD + manifest)

All work:
- Passes full relevant pytest (content_lake, config, quick_wins, audio parity updated for the prior fade fix)
- Verified with `--dry-run` on builders, dashboard, run_show (multiple shows)
- Zero impact on RSS feeds, enclosures, daily cron, or existing subscribers
- Follows all conventions (drift guards, deep-merge config, content_lake patterns, etc.)

This completes the entire approved review plan.

## Verification
- `pytest tests/test_content_lake.py tests/test_config.py tests/test_quick_wins.py tests/test_audio_commands.py -q` → green
- `python scripts/build_search_index.py --dry-run`
- `python scripts/generate_dashboard.py --dry-run`
- `python run_show.py <show> --dry-run` (multiple)
- Manual review of filter graphs, KV paths, preflight logic

## Post-merge (for operator)
- `git checkout main && git pull && git branch -D review-items-2-through-6-complete && git push origin --delete review-items-2-through-6-complete` (or let the PR auto-delete)