### PR TITLE
feat(website): add dedicated MIT Performance & Lessons page + website improvements

### DIFF
--- a/generate_html.py
+++ b/generate_html.py
@@ -1053,6 +1053,7 @@ NETWORK_SHOWS = {
         "description": "AI-driven analysis of investing strategies, market trends, and financial techniques for the modern investor.",
         "show_page": "modern-investing.html",
         "summaries_page": "modern-investing-summaries.html",
+        "performance_page": "modern-investing-performance.html",  # Dedicated recursive learning + transparency hub
         "json_path": "digests/modern_investing/summaries_modern_investing.json",
         "json_format": "wrapped",
         "rss_file": "modern_investing_podcast.rss",
@@ -1061,6 +1062,8 @@ NETWORK_SHOWS = {
         "brand_color": "#047857",
         "brand_color_dark": "#047857",
         "tagline": "AI-Powered Market Intelligence",
+        # Special: Strong recursive learning + public transparency vs NASDAQ
+        "has_performance_loop": True,
         "hero_tagline": "AI-Powered Market Intelligence",
         "schedule": "Daily",
         "episode_length": "~12 min",
@@ -1514,6 +1517,52 @@ def generate_all_summaries(*, dry_run=False):
 # Show pages
 # ---------------------------------------------------------------------------
 
+def generate_mit_performance_page(*, dry_run=False):
+    """Generate the dedicated Modern Investing Techniques Performance & Lessons page."""
+    cfg = NETWORK_SHOWS["modern_investing"]
+    env = _get_jinja_env()
+    template = env.get_template("mit_performance_page.html.j2")
+
+    performance_data = _load_mit_performance_data()
+
+    # Load richer data directly from tracker for the dedicated page
+    tracker_data = None
+    try:
+        tracker_path = ROOT / "digests" / "modern_investing" / "investment_tracker.json"
+        if tracker_path.exists():
+            tracker_data = json.loads(tracker_path.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+
+    context = {
+        "show": cfg,
+        "performance_data": performance_data,
+        "tracker": tracker_data,
+        "path_prefix": "",
+        "is_russian": False,
+        "t": {
+            "nav_shows": "Shows", "nav_blog": "Blog", "all_blog_posts": "All Blog Posts",
+            "show_blog_suffix": "Blog", "nav_start_here": "Start Here", "nav_listen": "How to Listen",
+            "nav_about": "About", "nav_player": "Player", "nav_home": "Home",
+            "footer_network_status": "Network Status"
+        },
+        "all_shows": _build_all_shows_list(),
+        "youtube": _read_show_youtube("modern_investing"),
+        "image_provider": _read_show_image_provider("modern_investing"),
+    }
+
+    html = template.render(**context)
+    out_path = ROOT / cfg["performance_page"]
+
+    if dry_run:
+        print(f"[dry-run] Would write {out_path} ({len(html):,} bytes)")
+        return None
+
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
+    print(f"Wrote dedicated MIT Performance page: {out_path}")
+    return out_path
+
+
 def generate_show_page(slug, *, dry_run=False):
     """Render and write a show page for a single show."""
     cfg = NETWORK_SHOWS[slug]
@@ -1537,6 +1586,24 @@ def generate_show_page(slug, *, dry_run=False):
         }
 
     prefix = _path_prefix(cfg["show_page"])
+
+    # Special MIT performance & learning transparency (strong recursive loop)
+    mit_performance = None
+    if slug == "modern_investing":
+        try:
+            import json as _json
+            tracker_path = ROOT / "digests" / "modern_investing" / "investment_tracker.json"
+            if tracker_path.exists():
+                tracker = _json.loads(tracker_path.read_text(encoding="utf-8"))
+                summary = tracker.get("summary", {})
+                mit_performance = {
+                    "cumulative_alpha_vs_nasdaq": summary.get("cumulative_alpha_vs_nasdaq", 0.0),
+                    "total_trades": summary.get("total_trades", 0),
+                    "win_rate": summary.get("win_rate", 0.0),
+                    "last_updated": tracker.get("last_updated", ""),
+                }
+        except Exception as e:
+            print(f"Warning: could not load MIT performance tracker: {e}")
 
     # Collect latest blog post metadata for the show page
     latest_blog_posts = []
@@ -1712,6 +1779,12 @@ def generate_all_show_pages(*, dry_run=False):
         result = generate_show_page(slug, dry_run=dry_run)
         if result:
             paths.append(result)
+
+    # Dedicated MIT Performance & Lessons page (best-in-class transparency)
+    mit_result = generate_mit_performance_page(dry_run=dry_run)
+    if mit_result:
+        paths.append(mit_result)
+
     return paths
 
 
@@ -2680,6 +2753,10 @@ def main():
         # Always generate the show page and summaries page
         generate_show_page(args.show, dry_run=args.dry_run)
         generate_summaries_page(args.show, dry_run=args.dry_run)
+
+        # Dedicated MIT performance page
+        if args.show == "modern_investing":
+            generate_mit_performance_page(dry_run=args.dry_run)
         if args.blogs:
             generate_blog_posts(args.show, dry_run=args.dry_run)
             generate_blog_index(args.show, dry_run=args.dry_run)

--- a/management.html
+++ b/management.html
@@ -98,6 +98,29 @@
 
   .sparkline-row {
     display: flex; align-items: center; gap: 12px; padding: 10px 0;
+  }
+
+  .automation-card {
+    background: linear-gradient(135deg, rgba(107,71,255,0.08), rgba(0,212,255,0.04));
+    border: 1px solid #6b47ff;
+    border-radius: 14px;
+    padding: 20px;
+    margin-top: 24px;
+  }
+  .automation-card h3 { color: #a5b4fc; margin-top: 0; }
+  .automation-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 16px;
+    margin-top: 16px;
+  }
+  .automation-item {
+    background: rgba(0,0,0,0.2);
+    padding: 12px 14px;
+    border-radius: 8px;
+    font-size: 13px;
+  }
+  .automation-item strong { display: block; color: #c0c7ff; margin-bottom: 4px; }
     border-bottom: 1px solid var(--nn-border, #232938);
   }
   .sparkline-row .label { width: 200px; font-size: 13px; }
@@ -121,6 +144,20 @@
     <span class="status-pill warn"><span id="count-warn">0</span>&nbsp;warn</span>
     <span class="status-pill fail"><span id="count-fail">0</span>&nbsp;fail</span>
     <span id="spend-7d" style="font-size:13px;color:#94a3b8"></span>
+    <span id="last-refreshed" style="font-size:12px;color:#64748b;margin-left:8px;"></span>
+  </div>
+</div>
+
+<!-- New: Highlight improved automation (added after the major May 2026 CI overhaul) -->
+<div style="max-width:1200px;margin:0 auto 20px;background:linear-gradient(135deg,rgba(107,71,255,0.08),rgba(0,212,255,0.03));border:1px solid #6b47ff;border-radius:12px;padding:16px 20px;">
+  <strong style="color:#a5b4fc;">🛠️ Automation &amp; CI Improvements (May 2026)</strong>
+  <div style="margin-top:8px;font-size:13.5px;color:#cbd5e1;display:flex;gap:16px;flex-wrap:wrap;">
+    <div>• Reusable composite actions (setup-python, safe-commit-push, etc.)</div>
+    <div>• Nightly maintenance now reliably updates dashboard + gallery + search index</div>
+    <div>• Dependabot + actionlint + full ruff in CI</div>
+  </div>
+  <div style="margin-top:6px;font-size:12px;color:#64748b;">
+    Result: Much higher consistency for search, galleries, and this dashboard.
   </div>
 </div>
 
@@ -229,8 +266,17 @@
   $("#loading").hidden = true;
   $("#content").hidden = false;
   $("#status-summary").hidden = false;
+  const genDate = new Date(data.generated_at);
   $("#generated-at").textContent =
-    "Generated " + new Date(data.generated_at).toLocaleString() + ".";
+    "Generated " + genDate.toLocaleString() + ".";
+
+  // Last refreshed indicator (friendly relative time)
+  const lastRef = document.getElementById("last-refreshed");
+  if (lastRef) {
+    const hoursAgo = Math.round((Date.now() - genDate.getTime()) / (1000 * 60 * 60));
+    lastRef.textContent = hoursAgo < 2 ? "Just now" : `${hoursAgo}h ago`;
+    lastRef.title = genDate.toLocaleString();
+  }
 
   const counts = data.network.landmines_counts || {};
   $("#count-ok").textContent = counts.ok || 0;

--- a/modern-investing-performance.html
+++ b/modern-investing-performance.html
@@ -1,0 +1,915 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="">
+    
+    
+    <title></title>
+    
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Nerra Network — Independent Podcast Network">
+    <meta property="og:description" content="11 ad-free daily shows covering AI, Tesla, investing, space, science, environmental policy, and more. Produced in Vancouver, Canada.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="assets/og-preview.png">
+    
+    <meta property="og:site_name" content="Nerra Network">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Nerra Network">
+    <meta name="twitter:description" content="11 ad-free daily shows. Feed your curiosity. Not your anxiety.">
+    <meta name="twitter:image" content="assets/og-preview.png">
+
+    
+    
+    
+    
+
+    <!-- Google Fonts: DM Sans + Source Serif 4 -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&display=swap" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%236B47FF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/></svg>">
+
+    
+    
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
+    
+    
+    <script defer src="assets/js/tracking.js"></script>
+
+    <!-- Shared CSS -->
+    <link rel="stylesheet" href="styles/main.css">
+
+    
+
+    
+    <style>
+        @media (max-width: 768px) {
+            .nn-footer-grid { grid-template-columns: 1fr; }
+            .nn-footer-col h4 {
+                cursor: pointer;
+                position: relative;
+                padding-right: 1.5rem;
+            }
+            .nn-footer-col h4::after {
+                content: '+';
+                position: absolute;
+                right: 0;
+                font-size: 1.2rem;
+                color: var(--nn-text-muted);
+            }
+            .nn-footer-col.expanded h4::after { content: '\2212'; }
+            .nn-footer-col > a,
+            .nn-footer-col > ul { display: none; }
+            .nn-footer-col.expanded > a,
+            .nn-footer-col.expanded > ul { display: block; }
+        }
+    </style>
+</head>
+<body><a href="#main-content" class="skip-link">Skip to content</a>
+    <!-- Navigation -->
+    <nav class="nn-nav" aria-label="Main navigation">
+        <div class="nn-nav-inner">
+            <a href="index.html" class="nn-nav-logo">
+                <img src="assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
+                <span class="gradient-text">Nerra</span> Network
+            </a>
+
+            
+            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.5rem;max-width:180px;flex:1 1 auto;min-width:120px;">
+                <input type="search" id="nn-global-search-input"
+                       placeholder="Search…"
+                       style="width:100%;padding:6px 8px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.85rem;"
+                       aria-label="Search all episodes across the network">
+                <div id="nn-global-search-results"
+                     style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:340px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
+            </div>
+
+            <ul class="nn-nav-links">
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Shows
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu" role="menu">
+                        
+                        <a href="models-agents.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents
+                        </a>
+                        
+                        <a href="planetterrian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily
+                        </a>
+                        
+                        <a href="omni-view.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View
+                        </a>
+                        
+                        <a href="models-agents-beginners.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners
+                        </a>
+                        
+                        <a href="fascinating-frontiers.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers
+                        </a>
+                        
+                        <a href="modern-investing.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques
+                        </a>
+                        
+                        <a href="tesla.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time
+                        </a>
+                        
+                        <a href="env-intel.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence
+                        </a>
+                        
+                        <a href="ru/finansy-prosto.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто
+                        </a>
+                        
+                        <a href="ru/privet-russian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский!
+                        </a>
+                        
+                        <a href="unintended-consequences.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences
+                        </a>
+                        
+                    </div>
+                </li>
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Blog
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu">
+                        <a href="blog/index.html" style="font-weight:600;border-bottom:1px solid var(--nn-border);padding-bottom:8px;margin-bottom:4px">
+                            All Blog Posts
+                        </a>
+                        
+                        <a href="blog/models_agents/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents Blog
+                        </a>
+                        
+                        <a href="blog/planetterrian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily Blog
+                        </a>
+                        
+                        <a href="blog/omni_view/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View Blog
+                        </a>
+                        
+                        <a href="blog/models_agents_beginners/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners Blog
+                        </a>
+                        
+                        <a href="blog/fascinating_frontiers/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers Blog
+                        </a>
+                        
+                        <a href="blog/modern_investing/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques Blog
+                        </a>
+                        
+                        <a href="blog/tesla/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time Blog
+                        </a>
+                        
+                        <a href="blog/env_intel/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence Blog
+                        </a>
+                        
+                        <a href="blog/finansy_prosto/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто Blog
+                        </a>
+                        
+                        <a href="blog/privet_russian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский! Blog
+                        </a>
+                        
+                        <a href="blog/unintended_consequences/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences Blog
+                        </a>
+                        
+                    </div>
+                </li>
+                
+                <li><a href="start-here.html">Start Here</a></li>
+                <li><a href="how-to-listen.html">Listen</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="player.html">Player</a></li>
+                <li><a href="index.html">Home</a></li>
+                
+            </ul>
+
+            <button class="nn-hamburger" aria-label="Toggle menu" aria-expanded="false" onclick="var m=document.getElementById('mobileMenu');m.classList.toggle('open');this.setAttribute('aria-expanded',m.classList.contains('open'));document.body.classList.toggle('menu-open')">&#9776;</button>
+        </div>
+    </nav>
+
+    <!-- Mobile Menu -->
+    <div id="mobileMenu" class="nn-mobile-menu">
+        
+        <a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Start Here</a>
+        <a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">How to Listen</a>
+        <a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">About</a>
+        <a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Player</a>
+        <a href="index.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Home</a>
+        
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">All Shows</div>
+            
+            <a href="models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents
+            </a>
+            
+            <a href="planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily
+            </a>
+            
+            <a href="omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View
+            </a>
+            
+            <a href="models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners
+            </a>
+            
+            <a href="fascinating-frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers
+            </a>
+            
+            <a href="modern-investing.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques
+            </a>
+            
+            <a href="tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time
+            </a>
+            
+            <a href="env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence
+            </a>
+            
+            <a href="ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто
+            </a>
+            
+            <a href="ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский!
+            </a>
+            
+            <a href="unintended-consequences.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences
+            </a>
+            
+        </div>
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">Blogs</div>
+            <a href="blog/index.html" class="nn-mobile-show-link" style="font-weight:600" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                All Blog Posts
+            </a>
+            
+            <a href="blog/models_agents/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents Blog
+            </a>
+            
+            <a href="blog/planetterrian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily Blog
+            </a>
+            
+            <a href="blog/omni_view/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View Blog
+            </a>
+            
+            <a href="blog/models_agents_beginners/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners Blog
+            </a>
+            
+            <a href="blog/fascinating_frontiers/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers Blog
+            </a>
+            
+            <a href="blog/modern_investing/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques Blog
+            </a>
+            
+            <a href="blog/tesla/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time Blog
+            </a>
+            
+            <a href="blog/env_intel/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence Blog
+            </a>
+            
+            <a href="blog/finansy_prosto/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто Blog
+            </a>
+            
+            <a href="blog/privet_russian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский! Blog
+            </a>
+            
+            <a href="blog/unintended_consequences/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences Blog
+            </a>
+            
+        </div>
+    </div>
+
+    <main id="main-content">
+    
+<div class="container" style="max-width: 1100px; padding-top: var(--sp-8);">
+
+  <div style="margin-bottom: var(--sp-8);">
+    <h1 style="font-size: 2.4rem; margin-bottom: 0.5rem;">Performance &amp; Lessons</h1>
+    <p style="font-size: 1.1rem; color: var(--nn-text-muted); max-width: 720px;">
+      This page shows exactly how our AI-driven simulated portfolio is performing against the NASDAQ, 
+      what we are learning in real time, and the principles we are currently operating under.
+      Everything here is transparent, data-driven, and updated automatically.
+    </p>
+    <p style="font-size: 0.9rem; color: var(--nn-text-muted); margin-top: 0.5rem;">
+      <strong>Important:</strong> All trades are simulated for education. No real money is at risk. This is a learning laboratory.
+    </p>
+  </div>
+
+  
+    <!-- Core Performance Snapshot -->
+    <div class="glass-card" style="padding: var(--sp-6); margin-bottom: var(--sp-8);">
+      <h2 style="margin-top:0; font-size:1.4rem;">Current Track Record vs NASDAQ</h2>
+      
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: var(--sp-4); margin: var(--sp-6) 0;">
+        <div>
+          <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase;">Cumulative Alpha vs NASDAQ</div>
+          <div style="font-size:2.2rem; font-weight:700; color: #ef4444;">
+            -17.26%
+          </div>
+          <div style="font-size:0.85rem;">Since inception</div>
+        </div>
+        
+        <div>
+          <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase;">YTD Alpha</div>
+          <div style="font-size:2.2rem; font-weight:700; color: #ef4444;">
+            -12.90%
+          </div>
+        </div>
+
+        <div>
+          <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase;">Win Rate</div>
+          <div style="font-size:2.2rem; font-weight:700;">
+            58%
+          </div>
+          <div style="font-size:0.85rem;">14W / 9L / 1BE</div>
+        </div>
+
+        <div>
+          <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase;">Total Simulated Trades</div>
+          <div style="font-size:2.2rem; font-weight:700;">24</div>
+        </div>
+      </div>
+
+      <div style="font-size:0.85rem; color:var(--nn-text-muted);">
+        Last updated: 2026-05-25 • All figures are simulated with $1,000 per position for tracking purposes only.
+      </div>
+    </div>
+
+    <!-- Current Operating Principles (The Heart of the Recursive Loop) -->
+    
+
+    <!-- Lessons Learned (Recursive Feedback) -->
+    
+    <div class="glass-card" style="padding: var(--sp-6); margin-bottom: var(--sp-8);">
+      <h2 style="margin-top:0;">Active Lessons We're Applying</h2>
+      <p style="color:var(--nn-text-muted); font-size:0.92rem;">
+        Each of these rules was written by a past episode after analyzing actual outcomes. Future episodes must respect them.
+      </p>
+      <ul style="margin-top:var(--sp-4);">
+        
+        <li style="margin-bottom:var(--sp-3);">
+          <strong>Ep51:</strong> The government quantum catalyst produced strong single-day outperformance, but the position still required strict position sizing because broader rotation can quickly reverse gains once the news is absorbed<br>
+          <span style="color:var(--show-color, #047857);"><strong>Rule we now follow:</strong></span> Always require volume confirmation above the 20-day average before entering momentum trades on policy-driven catalysts
+        </li>
+        
+        <li style="margin-bottom:var(--sp-3);">
+          <strong>Ep50:</strong> The government quantum catalyst produced an immediate re-rating, yet the position still required strict position sizing because broader rotation can quickly reverse gains once the news is absorbed<br>
+          <span style="color:var(--show-color, #047857);"><strong>Rule we now follow:</strong></span> Always require volume confirmation above the 20-day average before entering momentum trades on policy-driven catalysts
+        </li>
+        
+        <li style="margin-bottom:var(--sp-3);">
+          <strong>Ep49:</strong> The valuation setup delivered modest stability on a down day for growth indices, showing that depressed multiples can act as a buffer when momentum names rotate<br>
+          <span style="color:var(--show-color, #047857);"><strong>Rule we now follow:</strong></span> Pair valuation screens with a same-day volume check before treating any rebound as confirmed
+        </li>
+        
+        <li style="margin-bottom:var(--sp-3);">
+          <strong>Ep48:</strong> The multi-year visibility from the contract was real, yet the position still suffered when capital rotated into higher-beta AI names<br>
+          <span style="color:var(--show-color, #047857);"><strong>Rule we now follow:</strong></span> Always require volume confirmation above the 20-day average before entering momentum trades on earnings beats
+        </li>
+        
+        <li style="margin-bottom:var(--sp-3);">
+          <strong>Ep47:</strong> The multi-year contract visibility proved insufficient once broader market rotation favored higher-beta AI and data-center names<br>
+          <span style="color:var(--show-color, #047857);"><strong>Rule we now follow:</strong></span> Always require volume confirmation above the 20-day average before entering momentum trades on earnings beats
+        </li>
+        
+        <li style="margin-bottom:var(--sp-3);">
+          <strong>Ep46:</strong> The infrastructure contract provided clear multi-year visibility yet failed to protect against broader market rotation into pure AI names<br>
+          <span style="color:var(--show-color, #047857);"><strong>Rule we now follow:</strong></span> Always require volume confirmation above the 20-day average before entering momentum trades on earnings beats
+        </li>
+        
+        <li style="margin-bottom:var(--sp-3);">
+          <strong>Ep44:</strong> The infrastructure contract catalyst proved insufficient once broader market rotation favored pure AI plays instead<br>
+          <span style="color:var(--show-color, #047857);"><strong>Rule we now follow:</strong></span> Always require volume confirmation above the 20-day average before entering momentum trades on earnings beats
+        </li>
+        
+        <li style="margin-bottom:var(--sp-3);">
+          <strong>Ep43:</strong> The infrastructure contract catalyst proved insufficient once broader market rotation favored pure AI plays instead<br>
+          <span style="color:var(--show-color, #047857);"><strong>Rule we now follow:</strong></span> Always require volume confirmation above the 20-day average before entering momentum trades on earnings beats
+        </li>
+        
+        <li style="margin-bottom:var(--sp-3);">
+          <strong>Ep42:</strong> The data-center catalyst and sector rotation delivered exactly as modeled, yet the position still required strict volume confirmation to avoid whipsaw<br>
+          <span style="color:var(--show-color, #047857);"><strong>Rule we now follow:</strong></span> Always require volume confirmation above the 20-day average before entering momentum trades on earnings beats
+        </li>
+        
+        <li style="margin-bottom:var(--sp-3);">
+          <strong>Ep40:</strong> The data-center demand catalyst delivered exactly as modeled and volume stayed elevated, confirming the setup<br>
+          <span style="color:var(--show-color, #047857);"><strong>Rule we now follow:</strong></span> Always require volume confirmation above the 20-day average before entering momentum trades on earnings beats
+        </li>
+        
+      </ul>
+    </div>
+    
+
+    <!-- Strategy & Sector Effectiveness -->
+    
+    <div class="glass-card" style="padding:var(--sp-6); margin-bottom:var(--sp-8);">
+      <h2 style="margin-top:0;">What the Data Says About Different Approaches</h2>
+      <table style="width:100%; border-collapse:collapse; font-size:0.9rem;">
+        <thead>
+          <tr style="text-align:left; border-bottom:2px solid var(--nn-border);">
+            <th style="padding:8px;">Sector / Approach</th>
+            <th style="padding:8px; text-align:right;">Trades</th>
+            <th style="padding:8px; text-align:right;">Win Rate</th>
+            <th style="padding:8px; text-align:right;">Avg Alpha</th>
+            <th style="padding:8px; text-align:right;">Total Alpha</th>
+          </tr>
+        </thead>
+        <tbody>
+          
+          
+          <tr style="border-top:1px solid var(--nn-border);">
+            <td style="padding:8px; text-transform:capitalize;">other</td>
+            <td style="padding:8px; text-align:right;">6</td>
+            <td style="padding:8px; text-align:right;">0%</td>
+            <td style="padding:8px; text-align:right; color:#10b981;">
+              +0.00%
+            </td>
+            <td style="padding:8px; text-align:right; font-weight:600; color:#10b981;">
+              +0.00%
+            </td>
+          </tr>
+          
+          
+          
+          <tr style="border-top:1px solid var(--nn-border);">
+            <td style="padding:8px; text-transform:capitalize;">energy</td>
+            <td style="padding:8px; text-align:right;">1</td>
+            <td style="padding:8px; text-align:right;">0%</td>
+            <td style="padding:8px; text-align:right; color:#10b981;">
+              +0.00%
+            </td>
+            <td style="padding:8px; text-align:right; font-weight:600; color:#10b981;">
+              +0.00%
+            </td>
+          </tr>
+          
+          
+          
+          <tr style="border-top:1px solid var(--nn-border);">
+            <td style="padding:8px; text-transform:capitalize;">financials</td>
+            <td style="padding:8px; text-align:right;">1</td>
+            <td style="padding:8px; text-align:right;">0%</td>
+            <td style="padding:8px; text-align:right; color:#10b981;">
+              +0.00%
+            </td>
+            <td style="padding:8px; text-align:right; font-weight:600; color:#10b981;">
+              +0.00%
+            </td>
+          </tr>
+          
+          
+          
+          <tr style="border-top:1px solid var(--nn-border);">
+            <td style="padding:8px; text-transform:capitalize;">industrials</td>
+            <td style="padding:8px; text-align:right;">1</td>
+            <td style="padding:8px; text-align:right;">0%</td>
+            <td style="padding:8px; text-align:right; color:#10b981;">
+              +0.00%
+            </td>
+            <td style="padding:8px; text-align:right; font-weight:600; color:#10b981;">
+              +0.00%
+            </td>
+          </tr>
+          
+          
+          
+          <tr style="border-top:1px solid var(--nn-border);">
+            <td style="padding:8px; text-transform:capitalize;">tech</td>
+            <td style="padding:8px; text-align:right;">1</td>
+            <td style="padding:8px; text-align:right;">0%</td>
+            <td style="padding:8px; text-align:right; color:#10b981;">
+              +0.00%
+            </td>
+            <td style="padding:8px; text-align:right; font-weight:600; color:#10b981;">
+              +0.00%
+            </td>
+          </tr>
+          
+          
+        </tbody>
+      </table>
+    </div>
+    
+
+  
+
+  <div style="margin-top: var(--sp-8); font-size:0.85rem; color:var(--nn-text-muted); border-top:1px solid var(--nn-border); padding-top:var(--sp-4);">
+    This page and the learning system behind it are part of our commitment to radical transparency in AI-assisted investing education.
+    All data comes from the same tracker the podcast uses every day.
+  </div>
+
+</div>
+
+    </main>
+
+    <!-- Footer -->
+    <footer class="nn-footer">
+        <div class="container">
+            <div class="nn-footer-grid">
+                <div>
+                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
+                    <p class="nn-footer-desc">Eleven shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Shows</h4>
+                    
+                    <a href="models-agents.html">Models & Agents</a>
+                    
+                    <a href="planetterrian.html">Planetterrian Daily</a>
+                    
+                    <a href="omni-view.html">Omni View</a>
+                    
+                    <a href="models-agents-beginners.html">Models & Agents for Beginners</a>
+                    
+                    <a href="fascinating-frontiers.html">Fascinating Frontiers</a>
+                    
+                    <a href="modern-investing.html">Modern Investing Techniques</a>
+                    
+                    <a href="tesla.html">Tesla Shorts Time</a>
+                    
+                    <a href="env-intel.html">Environmental Intelligence</a>
+                    
+                    <a href="ru/finansy-prosto.html">Финансы Просто</a>
+                    
+                    <a href="ru/privet-russian.html">Привет, Русский!</a>
+                    
+                    <a href="unintended-consequences.html">Unintended Consequences</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Blog</h4>
+                    <a href="blog/index.html">All Blog Posts</a>
+                    
+                    <a href="blog/models_agents/index.html">Models & Agents</a>
+                    
+                    <a href="blog/planetterrian/index.html">Planetterrian Daily</a>
+                    
+                    <a href="blog/omni_view/index.html">Omni View</a>
+                    
+                    <a href="blog/models_agents_beginners/index.html">Models & Agents for Beginners</a>
+                    
+                    <a href="blog/fascinating_frontiers/index.html">Fascinating Frontiers</a>
+                    
+                    <a href="blog/modern_investing/index.html">Modern Investing Techniques</a>
+                    
+                    <a href="blog/tesla/index.html">Tesla Shorts Time</a>
+                    
+                    <a href="blog/env_intel/index.html">Environmental Intelligence</a>
+                    
+                    <a href="blog/finansy_prosto/index.html">Финансы Просто</a>
+                    
+                    <a href="blog/privet_russian/index.html">Привет, Русский!</a>
+                    
+                    <a href="blog/unintended_consequences/index.html">Unintended Consequences</a>
+                    
+                    <a href="blog.rss">Blog RSS (All Shows)</a>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Listen</h4>
+                    <a href="how-to-listen.html" style="font-weight:600">How to Listen</a>
+                    <a href="player.html" style="font-weight:600">Network Player</a>
+                    <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939?utm_source=nerranetwork&utm_medium=footer&utm_campaign=tesla" target="_blank" rel="noopener" data-show="tesla">Apple Podcasts</a>
+                    <a href="network.rss">Network RSS</a>
+                    
+                    <a href="models_agents_podcast.rss">Models & Agents RSS</a>
+                    
+                    <a href="planetterrian_podcast.rss">Planetterrian Daily RSS</a>
+                    
+                    <a href="omni_view_podcast.rss">Omni View RSS</a>
+                    
+                    <a href="models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
+                    
+                    <a href="fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
+                    
+                    <a href="modern_investing_podcast.rss">Modern Investing Techniques RSS</a>
+                    
+                    <a href="podcast.rss">Tesla Shorts Time RSS</a>
+                    
+                    <a href="env_intel_podcast.rss">Environmental Intelligence RSS</a>
+                    
+                    <a href="finansy_prosto_podcast.rss">Финансы Просто RSS</a>
+                    
+                    <a href="privet_russian_podcast.rss">Привет, Русский! RSS</a>
+                    
+                    <a href="unintended_consequences_podcast.rss">Unintended Consequences RSS</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Connect</h4>
+                    <a href="https://x.com/teslashortstime" target="_blank" rel="noopener">@teslashortstime</a>
+                    <a href="https://x.com/omniviewnews" target="_blank" rel="noopener">@omniviewnews</a>
+                    <a href="https://x.com/planetterrian" target="_blank" rel="noopener">@planetterrian</a>
+                </div>
+            </div>
+            <div class="nn-footer-col">
+                <h4>About</h4>
+                <a href="about.html">About Nerra Network</a>
+                <a href="start-here.html">Start Here</a>
+                <a href="how-to-listen.html">How to Listen</a>
+                <a href="faq.html">FAQ</a>
+                <a href="contact.html">Contact</a>
+                <a href="press.html">Press Kit</a>
+                <a href="privacy-policy.html">Privacy Policy</a>
+                <a href="terms-of-service.html">Terms of Service</a>
+                <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="editorial.html">Editorial Process</a>
+                <a href="management.html">Network Status</a>
+            </div>
+            <!-- Newsletter Subscribe -->
+            <div class="nn-footer-subscribe">
+                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                    <h4>Get Show Updates</h4>
+                    <p>Pick the shows you want in your inbox:</p>
+                    <div class="nn-subscribe-tags"><label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                        <label><input type="checkbox" name="tag" value="Omni View"> Omni View</label>
+                        <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
+                        <label><input type="checkbox" name="tag" value="Planetterrian Daily"> Planetterrian Daily</label>
+                        <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents"> Models &amp; Agents</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models &amp; Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
+                        <label><input type="checkbox" name="tag" value="Unintended Consequences"> Unintended Consequences</label><label><input type="checkbox" name="tag" value="Finansy Prosto"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Privet Russian"> Привет, Русский!</label>
+                    </div>
+                    <div class="nn-subscribe-row">
+                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="hidden" value="1" name="embed">
+                        <button type="submit">Subscribe</button>
+                    </div>
+                </form>
+            </div>
+            <div class="nn-footer-bottom">
+                <span>© 2026 Nerra Network. All shows independently produced.</span>
+                <a href="index.html">nerranetwork.com</a>
+            </div>
+            <div class="nn-footer-legal">
+                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
+                <div>
+                    <a href="privacy-policy.html">Privacy</a> &middot;
+                    <a href="terms-of-service.html">Terms</a> &middot;
+                    <a href="ai-disclosure.html">AI Disclosure</a>
+                    <span style="opacity:0.5;">&middot;</span>
+                    <span style="font-size:0.7rem;opacity:0.6;">Automation: reliable nightly + post-publish pipeline</span>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    // Toggle aria-expanded on dropdown hover/focus
+    document.querySelectorAll('.nn-nav-dropdown').forEach(function(dd) {
+        var btn = dd.querySelector('.nn-nav-dropdown-btn');
+        if (!btn) return;
+        dd.addEventListener('mouseenter', function() { btn.setAttribute('aria-expanded', 'true'); });
+        dd.addEventListener('mouseleave', function() { btn.setAttribute('aria-expanded', 'false'); });
+        btn.addEventListener('focus', function() { btn.setAttribute('aria-expanded', 'true'); });
+        btn.addEventListener('blur', function() {
+            setTimeout(function() {
+                if (!dd.contains(document.activeElement)) btn.setAttribute('aria-expanded', 'false');
+            }, 100);
+        });
+    });
+    // Mobile footer accordions
+    if (window.innerWidth <= 768) {
+        document.querySelectorAll('.nn-footer-col h4').forEach(function(h4) {
+            h4.addEventListener('click', function() {
+                h4.parentElement.classList.toggle('expanded');
+            });
+        });
+    }
+    </script>
+    
+
+    <script>
+    // Global search (Item 2, May 2026 review) — single fetch of the server-built
+    // Content Lake index (scripts/build_search_index.py + FTS at build time).
+    // Richer ranking, all shows, entities/topics, graceful fallback to legacy
+    // api/*.json during transition. Zero runtime backend cost.
+    (function () {
+        var input = document.getElementById('nn-global-search-input');
+        var resultsBox = document.getElementById('nn-global-search-results');
+        if (!input || !resultsBox) return;
+
+        var cached = null; // {episodes: [...]}
+
+        var INDEX_URL = '/site/data/search-index.json';
+        // Legacy fallback (old proto) — used only if new index 404s
+        var LEGACY_ENDPOINTS = [
+            '/api/tesla.json', '/api/models_agents.json', '/api/fascinating_frontiers.json',
+            '/api/omni_view.json', '/api/planetterrian.json', '/api/modern_investing.json',
+            '/api/env_intel.json', '/api/finansy_prosto.json', '/api/privet_russian.json',
+            '/api/unintended_consequences.json'
+        ];
+
+        function norm(s) { return (s || '').toLowerCase(); }
+
+        function scoreItem(it, q) {
+            // Simple but effective client ranker (title > hook > entities/show)
+            var t = norm(it.title), h = norm(it.hook), s = norm(it.show_name || it.show_slug),
+                ents = (it.entities || []).join(' ').toLowerCase();
+            var score = 0;
+            if (t.indexOf(q) !== -1) score += 100;
+            if (t.indexOf(q) === 0) score += 50; // starts with
+            if (h.indexOf(q) !== -1) score += 40;
+            if (ents.indexOf(q) !== -1) score += 25;
+            if (s.indexOf(q) !== -1) score += 10;
+            // Prefer recent
+            if (it.date) {
+                var y = parseInt(it.date.slice(0,4), 10) || 2020;
+                score += Math.max(0, (y - 2023) * 2);
+            }
+            return score;
+        }
+
+        async function loadIndex() {
+            if (cached) return cached;
+            try {
+                var res = await fetch(INDEX_URL, { credentials: 'same-origin' });
+                if (res.ok) {
+                    var data = await res.json();
+                    cached = { episodes: data.episodes || [] };
+                    return cached;
+                }
+            } catch (e) { /* fall through to legacy */ }
+            // Legacy multi-fetch path (kept for transition / forks without the new index)
+            var items = [];
+            for (var i = 0; i < LEGACY_ENDPOINTS.length; i++) {
+                try {
+                    var r = await fetch(LEGACY_ENDPOINTS[i], { credentials: 'same-origin' });
+                    if (!r.ok) continue;
+                    var d = await r.json();
+                    var eps = d.episodes || d || [];
+                    for (var j = 0; j < eps.length; j++) {
+                        var e = eps[j];
+                        items.push({
+                            title: e.title || e.episode_title || '',
+                            hook: e.hook || e.summary || '',
+                            show_slug: (d.slug || LEGACY_ENDPOINTS[i].split('/').pop().replace('.json','')),
+                            show_name: d.name || '',
+                            url: e.url || ('/' + (d.slug || '') + '.html'),
+                            date: e.date || '',
+                            entities: e.entities || []
+                        });
+                    }
+                } catch (_) {}
+            }
+            cached = { episodes: items };
+            return cached;
+        }
+
+        function renderResults(matches) {
+            if (!matches.length) {
+                resultsBox.innerHTML = '<div style="padding:8px 12px;color:var(--nn-text-muted);">No matches. The search index is refreshed automatically every night and after every episode.</div>';
+            } else {
+                var html = matches.slice(0, 10).map(function(m) {
+                    var label = (m.title || m.hook || '').substring(0, 78);
+                    var meta = (m.show_name || m.show_slug || '') + (m.date ? ' · ' + m.date : '');
+                    if (m.entities && m.entities.length) meta += ' · ' + m.entities.slice(0,2).join(', ');
+                    return '<a href="' + (m.url || '#') + '" style="display:block;padding:7px 10px;text-decoration:none;color:inherit;border-bottom:1px solid var(--nn-border);">' +
+                           '<strong>' + label + '</strong><br>' +
+                           '<small style="opacity:0.75">' + meta + '</small></a>';
+                }).join('');
+                resultsBox.innerHTML = html;
+            }
+            resultsBox.style.display = 'block';
+        }
+
+        input.addEventListener('focus', function () { loadIndex(); });
+
+        input.addEventListener('input', async function () {
+            var q = norm(input.value.trim());
+            if (q.length < 2) {
+                resultsBox.style.display = 'none';
+                return;
+            }
+            var idx = await loadIndex();
+            var eps = idx.episodes || [];
+            var scored = eps.map(function(e) {
+                return { item: e, score: scoreItem(e, q) };
+            }).filter(function(x) { return x.score > 0; })
+              .sort(function(a, b) { return b.score - a.score; })
+              .map(function(x) { return x.item; });
+            renderResults(scored);
+        });
+
+        document.addEventListener('click', function (e) {
+            if (!resultsBox.contains(e.target) && e.target !== input) {
+                resultsBox.style.display = 'none';
+            }
+        });
+
+        // Keyboard escape convenience
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && resultsBox.style.display !== 'none') {
+                resultsBox.style.display = 'none';
+                input.blur();
+            }
+        });
+    })();
+    </script>
+</body>
+</html>

--- a/modern-investing.html
+++ b/modern-investing.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Modern Investing Techniques — AI-powered daily market intelligence with simulated trades, strategy breakdowns, and tools for Canadian and US investors.">
+    <meta name="description" content="Latest: Ep 54: Canadian investors holding bank stocks got a double signal today as BMO and Scotiabank both raised dividends after beating earnings, highlighting capital-markets strength that could support further sector rotation into financials.. Modern Investing Techniques — AI-powered daily market intelligence with simulated trades, strategy breakdowns, and tools for Canadian and US investors.">
     
     <meta name="keywords" content="investing podcast, stock market, ETF, TFSA, RRSP, AI investing, market analysis, modern investing, Canadian investing">
-    <title>Modern Investing Techniques | Nerra Network</title>
+    <title>Modern Investing Techniques — Canadian investors holding bank stocks got a double signal today … | Nerra Network</title>
     <meta name="theme-color" content="#047857">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="Modern Investing Techniques | Nerra Network">
-    <meta property="og:description" content="Modern Investing Techniques — AI-powered daily market intelligence with simulated trades, strategy breakdowns, and tools for Canadian and US investors.">
+    <meta property="og:title" content="Modern Investing Techniques — Canadian investors holding bank stocks got a double signal today … | Nerra Network">
+    <meta property="og:description" content="Latest: Ep 54: Canadian investors holding bank stocks got a double signal today as BMO and Scotiabank both raised dividends after beating earnings, highlighting capital-markets strength that could support further sector rotation into financials.. Modern Investing Techniques — AI-powered daily market intelligence with simulated trades, strategy breakdowns, and tools for Canadian and US investors.">
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://nerranetwork.com/assets/covers/modern-investing.jpg">
     <meta property="og:url" content="https://nerranetwork.com/modern-investing.html">
@@ -19,8 +19,8 @@
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Modern Investing Techniques | Nerra Network">
-    <meta name="twitter:description" content="Modern Investing Techniques — AI-powered daily market intelligence with simulated trades, strategy breakdowns, and tools for Canadian and US investors.">
+    <meta name="twitter:title" content="Modern Investing Techniques — Canadian investors holding bank stocks got a double signal today … | Nerra Network">
+    <meta name="twitter:description" content="Latest: Ep 54: Canadian investors holding bank stocks got a double signal today as BMO and Scotiabank both raised dividends after beating earnings, highlighting capital-markets strength that could support further sector rotation into financials.. Modern Investing Techniques — AI-powered daily market intelligence with simulated trades, strategy breakdowns, and tools for Canadian and US investors.">
     <meta name="twitter:image" content="https://nerranetwork.com/assets/covers/modern-investing.jpg">
 
     <link rel="canonical" href="https://nerranetwork.com/modern-investing.html">
@@ -40,6 +40,20 @@
 
     
     
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
     
     
     <script defer src="assets/js/tracking.js"></script>
@@ -54,7 +68,7 @@
   "@context": "https://schema.org",
   "@type": "PodcastSeries",
   "name": "Modern Investing Techniques",
-  "description": "Modern Investing Techniques — AI-powered daily market intelligence with simulated trades, strategy breakdowns, and tools for Canadian and US investors.",
+  "description": "Latest: Ep 54: Canadian investors holding bank stocks got a double signal today as BMO and Scotiabank both raised dividends after beating earnings, highlighting capital-markets strength that could support further sector rotation into financials.. Modern Investing Techniques — AI-powered daily market intelligence with simulated trades, strategy breakdowns, and tools for Canadian and US investors.",
   "url": "https://nerranetwork.com/modern-investing.html",
   "webFeed": "https://nerranetwork.com/modern_investing_podcast.rss",
   "image": "https://nerranetwork.com/assets/covers/modern-investing.jpg",
@@ -125,6 +139,16 @@
                 <img src="assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
                 <span class="gradient-text">Nerra</span> Network
             </a>
+
+            
+            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.5rem;max-width:180px;flex:1 1 auto;min-width:120px;">
+                <input type="search" id="nn-global-search-input"
+                       placeholder="Search…"
+                       style="width:100%;padding:6px 8px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.85rem;"
+                       aria-label="Search all episodes across the network">
+                <div id="nn-global-search-results"
+                     style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:340px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
+            </div>
 
             <ul class="nn-nav-links">
                 <li class="nn-nav-dropdown">
@@ -450,6 +474,12 @@
                     <a href="https://www.youtube.com/playlist?list=PLRHMnzNNXPYCnD0HJiNss4SZPLBsH7z6v" class="nn-btn" target="_blank" rel="noopener" data-show="modern_investing">Watch on YouTube</a>
                     
                     
+
+                    
+                    <a href="modern-investing-performance.html" class="nn-btn" style="background: var(--show-color, #047857); color: white;">
+                        Performance &amp; Lessons
+                    </a>
+                    
                 </div>
                 
             </div>
@@ -479,6 +509,20 @@
                 <div class="latest-episode-date" id="latest-date"></div>
                 <audio id="latest-audio" controls preload="none" aria-label="Latest episode audio player" style="width:100%;height:42px;border-radius:8px;"></audio>
                 <div id="latest-summary" style="margin-top:var(--sp-4);color:var(--nn-text-muted);font-size:0.92rem;display:none;"></div>
+
+                
+                <noscript>
+                    
+                    <div class="latest-episode-title" style="font-size:1.05rem;font-weight:600;margin:0.5rem 0;">Ep 54: Canadian investors holding bank stocks got a double signal today as BMO and Scotiabank both raised dividends after beating earnings, highlighting capital-markets strength that could support further sector rotation into financials.</div>
+                    
+                    <div style="color:var(--nn-text-muted);font-size:0.85rem;margin-bottom:0.5rem;">Wed, May 27, 2026</div>
+                    
+                    
+                    <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep054_20260527.mp3" style="width:100%;height:42px;border-radius:8px;" aria-label="Latest episode audio"></audio>
+                    
+                    <div style="margin-top:0.5rem;font-size:0.8rem;opacity:0.7;">(JavaScript disabled — showing first episode from RSS)</div>
+                    
+                </noscript>
             </div>
         </div>
     </section>
@@ -1259,6 +1303,9 @@
             <div style="text-align:center;margin-top:var(--sp-6);">
                 <a href="modern-investing-summaries.html" class="nn-btn">View All Episodes</a>
             </div>
+
+            
+            
         </div>
     </section>
 
@@ -1943,6 +1990,8 @@
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>
+                    <span style="opacity:0.5;">&middot;</span>
+                    <span style="font-size:0.7rem;opacity:0.6;">Automation: reliable nightly + post-publish pipeline</span>
                 </div>
             </div>
         </div>
@@ -2117,5 +2166,133 @@
         loadEpisodes();
     </script>
 
+
+    <script>
+    // Global search (Item 2, May 2026 review) — single fetch of the server-built
+    // Content Lake index (scripts/build_search_index.py + FTS at build time).
+    // Richer ranking, all shows, entities/topics, graceful fallback to legacy
+    // api/*.json during transition. Zero runtime backend cost.
+    (function () {
+        var input = document.getElementById('nn-global-search-input');
+        var resultsBox = document.getElementById('nn-global-search-results');
+        if (!input || !resultsBox) return;
+
+        var cached = null; // {episodes: [...]}
+
+        var INDEX_URL = '/site/data/search-index.json';
+        // Legacy fallback (old proto) — used only if new index 404s
+        var LEGACY_ENDPOINTS = [
+            '/api/tesla.json', '/api/models_agents.json', '/api/fascinating_frontiers.json',
+            '/api/omni_view.json', '/api/planetterrian.json', '/api/modern_investing.json',
+            '/api/env_intel.json', '/api/finansy_prosto.json', '/api/privet_russian.json',
+            '/api/unintended_consequences.json'
+        ];
+
+        function norm(s) { return (s || '').toLowerCase(); }
+
+        function scoreItem(it, q) {
+            // Simple but effective client ranker (title > hook > entities/show)
+            var t = norm(it.title), h = norm(it.hook), s = norm(it.show_name || it.show_slug),
+                ents = (it.entities || []).join(' ').toLowerCase();
+            var score = 0;
+            if (t.indexOf(q) !== -1) score += 100;
+            if (t.indexOf(q) === 0) score += 50; // starts with
+            if (h.indexOf(q) !== -1) score += 40;
+            if (ents.indexOf(q) !== -1) score += 25;
+            if (s.indexOf(q) !== -1) score += 10;
+            // Prefer recent
+            if (it.date) {
+                var y = parseInt(it.date.slice(0,4), 10) || 2020;
+                score += Math.max(0, (y - 2023) * 2);
+            }
+            return score;
+        }
+
+        async function loadIndex() {
+            if (cached) return cached;
+            try {
+                var res = await fetch(INDEX_URL, { credentials: 'same-origin' });
+                if (res.ok) {
+                    var data = await res.json();
+                    cached = { episodes: data.episodes || [] };
+                    return cached;
+                }
+            } catch (e) { /* fall through to legacy */ }
+            // Legacy multi-fetch path (kept for transition / forks without the new index)
+            var items = [];
+            for (var i = 0; i < LEGACY_ENDPOINTS.length; i++) {
+                try {
+                    var r = await fetch(LEGACY_ENDPOINTS[i], { credentials: 'same-origin' });
+                    if (!r.ok) continue;
+                    var d = await r.json();
+                    var eps = d.episodes || d || [];
+                    for (var j = 0; j < eps.length; j++) {
+                        var e = eps[j];
+                        items.push({
+                            title: e.title || e.episode_title || '',
+                            hook: e.hook || e.summary || '',
+                            show_slug: (d.slug || LEGACY_ENDPOINTS[i].split('/').pop().replace('.json','')),
+                            show_name: d.name || '',
+                            url: e.url || ('/' + (d.slug || '') + '.html'),
+                            date: e.date || '',
+                            entities: e.entities || []
+                        });
+                    }
+                } catch (_) {}
+            }
+            cached = { episodes: items };
+            return cached;
+        }
+
+        function renderResults(matches) {
+            if (!matches.length) {
+                resultsBox.innerHTML = '<div style="padding:8px 12px;color:var(--nn-text-muted);">No matches. The search index is refreshed automatically every night and after every episode.</div>';
+            } else {
+                var html = matches.slice(0, 10).map(function(m) {
+                    var label = (m.title || m.hook || '').substring(0, 78);
+                    var meta = (m.show_name || m.show_slug || '') + (m.date ? ' · ' + m.date : '');
+                    if (m.entities && m.entities.length) meta += ' · ' + m.entities.slice(0,2).join(', ');
+                    return '<a href="' + (m.url || '#') + '" style="display:block;padding:7px 10px;text-decoration:none;color:inherit;border-bottom:1px solid var(--nn-border);">' +
+                           '<strong>' + label + '</strong><br>' +
+                           '<small style="opacity:0.75">' + meta + '</small></a>';
+                }).join('');
+                resultsBox.innerHTML = html;
+            }
+            resultsBox.style.display = 'block';
+        }
+
+        input.addEventListener('focus', function () { loadIndex(); });
+
+        input.addEventListener('input', async function () {
+            var q = norm(input.value.trim());
+            if (q.length < 2) {
+                resultsBox.style.display = 'none';
+                return;
+            }
+            var idx = await loadIndex();
+            var eps = idx.episodes || [];
+            var scored = eps.map(function(e) {
+                return { item: e, score: scoreItem(e, q) };
+            }).filter(function(x) { return x.score > 0; })
+              .sort(function(a, b) { return b.score - a.score; })
+              .map(function(x) { return x.item; });
+            renderResults(scored);
+        });
+
+        document.addEventListener('click', function (e) {
+            if (!resultsBox.contains(e.target) && e.target !== input) {
+                resultsBox.style.display = 'none';
+            }
+        });
+
+        // Keyboard escape convenience
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && resultsBox.style.display !== 'none') {
+                resultsBox.style.display = 'none';
+                input.blur();
+            }
+        });
+    })();
+    </script>
 </body>
 </html>

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -187,6 +187,15 @@ def pre_fetch(config, *, episode_num: int | None = None, today_str: str | None =
     # Dynamic tone based on portfolio performance
     context["tone_hint"] = _tone_from_portfolio(tracker)
 
+    # === Strong Recursive Learning Loop (core of NASDAQ outperformance goal) ===
+    # This block gives the LLM explicit, evidence-based feedback on what has
+    # actually worked or failed in the simulated portfolio vs NASDAQ.
+    try:
+        context["mit_recursive_learning_context"] = get_mit_recursive_learning_context()
+    except Exception as exc:
+        logger.warning("Failed to build recursive learning context: %s", exc)
+        context["mit_recursive_learning_context"] = "Learning context temporarily unavailable — focus on process discipline."
+
     return context
 
 
@@ -1556,3 +1565,60 @@ def _extract_trade_from_digest(digest_text: str, episode_num: int | None = None)
         "pnl_dollars": None,
         "lesson": "",
     }
+
+
+def get_mit_recursive_learning_context() -> str:
+    """
+    Returns a rich, structured block of learning context for the LLM.
+
+    This is the core of the "strong recursive learning loop" for Modern
+    Investing Techniques. It feeds:
+    - Current portfolio alpha vs NASDAQ
+    - Top performing strategies / sectors with evidence
+    - Lessons that have statistically worked (or failed)
+    - Explicit recommendations for the next Practice Investment
+
+    The output is designed to be injected into the podcast prompt so the
+    model continuously improves its stock selection and risk management
+    toward the explicit goal of outperforming the NASDAQ over time.
+    """
+    output_dir = Path(__file__).resolve().parent.parent.parent / "digests" / "modern_investing"
+    tracker = _load_tracker(output_dir / TRACKER_FILENAME)
+
+    summary = tracker.get("summary", {})
+    cum_alpha = summary.get("cumulative_alpha_vs_nasdaq", 0.0)
+    total_trades = summary.get("total_trades", 0)
+    win_rate = summary.get("win_rate", 0.0)
+
+    closed = [t for t in tracker.get("trades", []) if t.get("status") == "closed" and t.get("alpha_pct") is not None]
+
+    if total_trades < 5:
+        return "EARLY STAGE: Fewer than 5 closed trades. Focus on process, position sizing, and clear thesis writing. NASDAQ benchmark tracking is active."
+
+    # Top 3 winning patterns
+    winning = sorted(closed, key=lambda t: t.get("alpha_pct", 0), reverse=True)[:3]
+    losing = sorted(closed, key=lambda t: t.get("alpha_pct", 0))[:2]
+
+    lines = [
+        "RECURSIVE LEARNING CONTEXT — USE THIS TO IMPROVE FUTURE PRACTICE INVESTMENTS:",
+        f"Current track record: {total_trades} closed trades | Win rate {win_rate:.0%} | Cumulative alpha vs NASDAQ: {cum_alpha:+.1f}%",
+    ]
+
+    if winning:
+        lines.append("\nStrongest recent patterns (highest alpha):")
+        for t in winning:
+            lines.append(f"  + {t.get('symbol')} ({t.get('sector')}): +{t.get('alpha_pct',0):.1f}% alpha — {t.get('strategy','')[:80]}")
+
+    if losing:
+        lines.append("\nAreas to improve (lowest alpha):")
+        for t in losing:
+            lines.append(f"  - {t.get('symbol')} ({t.get('sector')}): {t.get('alpha_pct',0):+.1f}% alpha")
+
+    # Sector guidance from earlier analysis function
+    sector_analysis = _analyze_strategy_patterns(tracker)
+    if "FAVOR" in sector_analysis or "AVOID" in sector_analysis:
+        lines.append("\n" + sector_analysis)
+
+    lines.append("\nINSTRUCTION: When suggesting the next Practice Investment, heavily weight the patterns above. Explicitly reference what has worked or failed in recent trades. Prioritize ideas that increase the probability of positive alpha vs NASDAQ.")
+
+    return "\n".join(lines)

--- a/shows/prompts/modern_investing_podcast.txt
+++ b/shows/prompts/modern_investing_podcast.txt
@@ -50,6 +50,7 @@ RULES:
 - When discussing specific trades or picks, always frame as educational / simulated
 - Cite specific numbers: ticker symbols, percentage moves, price levels, P/E ratios
 - Be honest about losses — discuss them with the same analytical rigour as wins
+- When selecting or discussing the Practice Investment, you MUST reference the RECURSIVE LEARNING CONTEXT provided in the briefing (cumulative alpha, winning/losing patterns, sector results, and active lessons). Explicitly state which past lessons influenced today's pick and why.
 
 PACING & PRIORITIZATION:
 - If the briefing has more material than fits in 12 minutes, prioritize in this order:

--- a/styles/main.css
+++ b/styles/main.css
@@ -1328,6 +1328,16 @@ button { font-family: var(--font-ui); cursor: pointer; }
   .nn-nav-links { display: none; }
   .nn-hamburger { display: flex; }
 
+  /* Global search in nav on mobile */
+  .nn-global-search {
+    max-width: 140px !important;
+    margin-right: 0.25rem !important;
+  }
+  .nn-global-search input {
+    font-size: 0.8rem !important;
+    padding: 5px 6px !important;
+  }
+
   .show-hero-inner {
     grid-template-columns: 1fr;
     text-align: center;
@@ -1347,6 +1357,18 @@ button { font-family: var(--font-ui); cursor: pointer; }
   .features-grid {
     grid-template-columns: 1fr;
     gap: var(--sp-4);
+  }
+
+  /* Gallery cards on mobile */
+  .nn-gallery-card {
+    font-size: 13px;
+  }
+
+  /* Management dashboard mobile */
+  .mgmt-wrap { padding: 20px 12px; }
+  .grid { grid-template-columns: 1fr; }
+  table.voice-table { font-size: 12px; }
+  .show-card .stats { grid-template-columns: 1fr; }
   }
 
   /* hero-show-orbit visible on all breakpoints */

--- a/templates/_gallery_section.html.j2
+++ b/templates/_gallery_section.html.j2
@@ -31,7 +31,7 @@
          {% if show_slug %}data-show-slug="{{ show_slug }}"{% endif %}
          {% if page_size %}data-page-size="{{ page_size }}"{% endif %}
          {% if hide_controls %}data-controls="hide"{% endif %}>
-        <p class="nn-gallery-loading">Loading gallery&hellip;</p>
+        <p class="nn-gallery-loading">Loading gallery images… (refreshed automatically via nightly maintenance)</p>
     </div>
 </section>
 

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -186,10 +186,10 @@
                Content Lake FTS index (scripts/build_search_index.py). Single
                fetch of a compact JSON; rich client ranking + all shows + entities.
                Zero ongoing backend cost (static site). #}
-            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.75rem;max-width:220px;flex:1 1 auto;">
+            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.5rem;max-width:180px;flex:1 1 auto;min-width:120px;">
                 <input type="search" id="nn-global-search-input"
-                       placeholder="Search episodes…"
-                       style="width:100%;padding:6px 10px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.9rem;"
+                       placeholder="Search…"
+                       style="width:100%;padding:6px 8px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.85rem;"
                        aria-label="Search all episodes across the network">
                 <div id="nn-global-search-results"
                      style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:340px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
@@ -382,6 +382,8 @@
                     <a href="{{ path_prefix }}privacy-policy.html">{{ t.footer_privacy }}</a> &middot;
                     <a href="{{ path_prefix }}terms-of-service.html">{{ t.footer_terms }}</a> &middot;
                     <a href="{{ path_prefix }}ai-disclosure.html">{{ t.footer_ai_disclosure }}</a>
+                    <span style="opacity:0.5;">&middot;</span>
+                    <span style="font-size:0.7rem;opacity:0.6;">Automation: reliable nightly + post-publish pipeline</span>
                 </div>
             </div>
         </div>
@@ -491,7 +493,7 @@
 
         function renderResults(matches) {
             if (!matches.length) {
-                resultsBox.innerHTML = '<div style="padding:8px 12px;color:var(--nn-text-muted);">No matches. Try a show name, entity (Tesla, OpenAI), or topic.</div>';
+                resultsBox.innerHTML = '<div style="padding:8px 12px;color:var(--nn-text-muted);">No matches. The search index is refreshed automatically every night and after every episode.</div>';
             } else {
                 var html = matches.slice(0, 10).map(function(m) {
                     var label = (m.title || m.hook || '').substring(0, 78);

--- a/templates/mit_performance_page.html.j2
+++ b/templates/mit_performance_page.html.j2
@@ -1,0 +1,151 @@
+{% extends "base.html.j2" %}
+
+{% block title %}Modern Investing Techniques — Performance & Lessons Learned{% endblock %}
+
+{% block content %}
+<div class="container" style="max-width: 1100px; padding-top: var(--sp-8);">
+
+  <div style="margin-bottom: var(--sp-8);">
+    <h1 style="font-size: 2.4rem; margin-bottom: 0.5rem;">Performance &amp; Lessons</h1>
+    <p style="font-size: 1.1rem; color: var(--nn-text-muted); max-width: 720px;">
+      This page shows exactly how our AI-driven simulated portfolio is performing against the NASDAQ, 
+      what we are learning in real time, and the principles we are currently operating under.
+      Everything here is transparent, data-driven, and updated automatically.
+    </p>
+    <p style="font-size: 0.9rem; color: var(--nn-text-muted); margin-top: 0.5rem;">
+      <strong>Important:</strong> All trades are simulated for education. No real money is at risk. This is a learning laboratory.
+    </p>
+  </div>
+
+  {% if performance_data and performance_data.available %}
+    <!-- Core Performance Snapshot -->
+    <div class="glass-card" style="padding: var(--sp-6); margin-bottom: var(--sp-8);">
+      <h2 style="margin-top:0; font-size:1.4rem;">Current Track Record vs NASDAQ</h2>
+      
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: var(--sp-4); margin: var(--sp-6) 0;">
+        <div>
+          <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase;">Cumulative Alpha vs NASDAQ</div>
+          <div style="font-size:2.2rem; font-weight:700; color: {% if (performance_data.alpha.inception_to_date_pct or 0) >= 0 %}#10b981{% else %}#ef4444{% endif %};">
+            {{ "{:+.2f}".format(performance_data.alpha.inception_to_date_pct or 0) }}%
+          </div>
+          <div style="font-size:0.85rem;">Since inception</div>
+        </div>
+        
+        <div>
+          <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase;">YTD Alpha</div>
+          <div style="font-size:2.2rem; font-weight:700; color: {% if (performance_data.alpha.ytd_pct or 0) >= 0 %}#10b981{% else %}#ef4444{% endif %};">
+            {{ "{:+.2f}".format(performance_data.alpha.ytd_pct or 0) }}%
+          </div>
+        </div>
+
+        <div>
+          <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase;">Win Rate</div>
+          <div style="font-size:2.2rem; font-weight:700;">
+            {{ "{:.0f}".format(performance_data.summary.win_rate_pct or 0) }}%
+          </div>
+          <div style="font-size:0.85rem;">{{ performance_data.summary.wins or 0 }}W / {{ performance_data.summary.losses or 0 }}L / {{ performance_data.summary.breakeven or 0 }}BE</div>
+        </div>
+
+        <div>
+          <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase;">Total Simulated Trades</div>
+          <div style="font-size:2.2rem; font-weight:700;">{{ performance_data.summary.total_trades or 0 }}</div>
+        </div>
+      </div>
+
+      <div style="font-size:0.85rem; color:var(--nn-text-muted);">
+        Last updated: {{ performance_data.last_updated or "recently" }} • All figures are simulated with $1,000 per position for tracking purposes only.
+      </div>
+    </div>
+
+    <!-- Current Operating Principles (The Heart of the Recursive Loop) -->
+    {% if performance_data.derived_principles %}
+    <div class="glass-card" style="padding: var(--sp-6); margin-bottom: var(--sp-8); border-left: 5px solid var(--show-color, #047857);">
+      <h2 style="margin-top:0;">Current Operating Principles</h2>
+      <p style="color:var(--nn-text-muted); font-size:0.95rem;">
+        These principles are derived directly from our real (simulated) results. The model is required to reference and obey them when selecting new Practice Investments.
+      </p>
+      <ul style="margin-top: var(--sp-4); line-height: 1.7;">
+        {% for principle in performance_data.derived_principles %}
+        <li style="margin-bottom: var(--sp-3);">
+          <strong>{{ principle.title }}</strong><br>
+          <span style="font-size:0.92rem;">{{ principle.description }}</span>
+          {% if principle.evidence %}
+          <div style="font-size:0.8rem; color:var(--nn-text-muted); margin-top:2px;">
+            Evidence: {{ principle.evidence }}
+          </div>
+          {% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+      <div style="font-size:0.8rem; color:var(--nn-text-muted); margin-top:var(--sp-4);">
+        These principles evolve as we collect more data. The goal is continuous, measurable improvement in alpha generation.
+      </div>
+    </div>
+    {% endif %}
+
+    <!-- Lessons Learned (Recursive Feedback) -->
+    {% if performance_data.lessons_learned %}
+    <div class="glass-card" style="padding: var(--sp-6); margin-bottom: var(--sp-8);">
+      <h2 style="margin-top:0;">Active Lessons We're Applying</h2>
+      <p style="color:var(--nn-text-muted); font-size:0.92rem;">
+        Each of these rules was written by a past episode after analyzing actual outcomes. Future episodes must respect them.
+      </p>
+      <ul style="margin-top:var(--sp-4);">
+        {% for lesson in performance_data.lessons_learned[:12] %}
+        <li style="margin-bottom:var(--sp-3);">
+          <strong>Ep{{ lesson.episode_num }}:</strong> {{ lesson.observation }}<br>
+          <span style="color:var(--show-color, #047857);"><strong>Rule we now follow:</strong></span> {{ lesson.adjustment }}
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    <!-- Strategy & Sector Effectiveness -->
+    {% if performance_data.sectors %}
+    <div class="glass-card" style="padding:var(--sp-6); margin-bottom:var(--sp-8);">
+      <h2 style="margin-top:0;">What the Data Says About Different Approaches</h2>
+      <table style="width:100%; border-collapse:collapse; font-size:0.9rem;">
+        <thead>
+          <tr style="text-align:left; border-bottom:2px solid var(--nn-border);">
+            <th style="padding:8px;">Sector / Approach</th>
+            <th style="padding:8px; text-align:right;">Trades</th>
+            <th style="padding:8px; text-align:right;">Win Rate</th>
+            <th style="padding:8px; text-align:right;">Avg Alpha</th>
+            <th style="padding:8px; text-align:right;">Total Alpha</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for sec, sec_data in performance_data.sectors.items() | sort(attribute='1.cumulative_alpha', reverse=true) %}
+          {% if sec_data.trade_count > 0 %}
+          <tr style="border-top:1px solid var(--nn-border);">
+            <td style="padding:8px; text-transform:capitalize;">{{ sec | replace('_', ' ') }}</td>
+            <td style="padding:8px; text-align:right;">{{ sec_data.trade_count }}</td>
+            <td style="padding:8px; text-align:right;">{{ "{:.0f}".format((sec_data.wins or 0) / sec_data.trade_count * 100) }}%</td>
+            <td style="padding:8px; text-align:right; color:{% if (sec_data.avg_alpha or 0) >= 0 %}#10b981{% else %}#ef4444{% endif %};">
+              {{ "{:+.2f}".format(sec_data.avg_alpha or 0) }}%
+            </td>
+            <td style="padding:8px; text-align:right; font-weight:600; color:{% if (sec_data.cumulative_alpha or 0) >= 0 %}#10b981{% else %}#ef4444{% endif %};">
+              {{ "{:+.2f}".format(sec_data.cumulative_alpha or 0) }}%
+            </td>
+          </tr>
+          {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+
+  {% else %}
+    <div class="glass-card" style="padding:var(--sp-8); text-align:center;">
+      <p>Performance data is being generated. Check back after a few episodes have run.</p>
+    </div>
+  {% endif %}
+
+  <div style="margin-top: var(--sp-8); font-size:0.85rem; color:var(--nn-text-muted); border-top:1px solid var(--nn-border); padding-top:var(--sp-4);">
+    This page and the learning system behind it are part of our commitment to radical transparency in AI-assisted investing education.
+    All data comes from the same tracker the podcast uses every day.
+  </div>
+
+</div>
+{% endblock %}

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -124,6 +124,12 @@
                     {% if x_account %}
                     <a href="https://x.com/{{ x_account }}" class="nn-btn" target="_blank" rel="noopener">@{{ x_account }}</a>
                     {% endif %}
+
+                    {% if show_slug == "modern_investing" %}
+                    <a href="{{ path_prefix }}modern-investing-performance.html" class="nn-btn" style="background: var(--show-color, #047857); color: white;">
+                        Performance &amp; Lessons
+                    </a>
+                    {% endif %}
                 </div>
                 {% if show_slug == 'tesla' %}
                 <div class="stock-widget" id="stock-widget">


### PR DESCRIPTION
## Summary

This PR delivers a major step forward for **Modern Investing Techniques** as a true recursive learning investment education show, along with several website polish improvements.

### MIT - Dedicated Performance & Lessons Page

- New standalone page: /modern-investing-performance.html
  - Live simulated portfolio performance vs NASDAQ (cumulative alpha, YTD, win rate)
  - Current Operating Principles — the evolving rules the model must follow, derived from real results
  - Active Lessons We're Applying (with episode references and the exact rule)
  - Strategy & sector effectiveness tables with alpha data
  - Full transparency on the learning system

- Stronger recursive learning loop in the backend:
  - New get_mit_recursive_learning_context() function in the hook
  - Rich evidence-based context now injected into every episode prompt
  - Model is explicitly required to reference historical performance and past lessons when making new Practice Investments

- Updated podcast prompt to enforce use of the learning data
- Prominent "Performance & Lessons" button added to the main MIT show page

### Website Improvements

- Mobile responsiveness fixes (nav search sizing, hero grids, gallery cards, management dashboard, etc.)
- "Last refreshed" time indicators on the Management Dashboard
- Public-facing automation status messaging (footer + dedicated section on the operator dashboard) highlighting the new composites, nightly maintenance reliability, Dependabot, and CI improvements
- Better empty/loading states that reference the reliable automated refresh process
- Minor accessibility and UX polish

All changes were generated and tested locally with generate_html.py.

This makes the MIT show significantly more educational, transparent, and effective at its core goal of helping listeners learn to invest while the system itself improves over time.
