### PR TITLE
fix: correct parse_chapters() call in run_generation_phase

### DIFF
--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -293,9 +293,15 @@ def run_generation_phase(
 
     # Chapter parsing (if enabled for the show)
     episode_chapters: list = []
-    if getattr(config, "chapters", None) and getattr(config.chapters, "enabled", False):
+    if (getattr(config, "chapters", None)
+            and getattr(config.chapters, "enabled", False)
+            and getattr(config.chapters, "section_markers", None)):
         from engine.chapters import parse_chapters
-        episode_chapters = parse_chapters(podcast_script)
+        episode_chapters = parse_chapters(
+            podcast_script,
+            config.chapters.section_markers,
+            show_name=config.name,
+        )
 
     return x_thread, podcast_script, episode_chapters, effective_hook
 


### PR DESCRIPTION
The extraction skeleton in `run_generation_phase` was calling

```python
episode_chapters = parse_chapters(podcast_script)
```

The actual function signature is:

```python
parse_chapters(script, section_markers, *, show_name="", ...)
```

This caused the TypeError on the Tesla run immediately after PR #444 was merged.

Fixed to match the call site pattern already used in the main `run_show.py` flow (and the chapters module).

This was the last obvious breakage from the incomplete phase extraction for chapter-enabled shows.