### PR TITLE
fix: prevent Undefined error in blog post JSON-LD generation

### DIFF
--- a/engine/blog.py
+++ b/engine/blog.py
@@ -705,6 +705,9 @@ def generate_blog_post_html(
         # "Watch on YouTube" button next to the existing podcast/summaries CTAs.
         "youtube_url": youtube_url or metadata.get("youtube_url", ""),
         "youtube_short_url": youtube_short_url or metadata.get("youtube_short_url", ""),
+        # For structured data in the blog post template (PodcastEpisode JSON-LD).
+        # Falls back gracefully so | tojson never receives Undefined.
+        "summary": metadata.get("hook", "") or metadata.get("title", ""),
     }
 
     return template.render(**context)

--- a/templates/blog_post.html.j2
+++ b/templates/blog_post.html.j2
@@ -33,7 +33,7 @@
       "name": "{{ title }}",
       "url": "{{ page_url }}",
       "datePublished": "{{ date }}",
-      "description": {{ summary | tojson }},
+      "description": {{ (summary or "") | tojson }},
       "associatedMedia": {
         "@type": "MediaObject",
         "contentUrl": "{{ audio_url }}"


### PR DESCRIPTION
The post-publish 'Regenerate show HTML + blog posts' step was crashing with:

```
TypeError: Object of type Undefined is not JSON serializable
```

Root cause: `blog_post.html.j2` does `{{ summary | tojson }}` for the PodcastEpisode structured data block, but `generate_blog_post_html` never passed a `summary` key. Jinja supplied an `Undefined` object.

This only affected the HTML regeneration step (after the actual episode had already been fully published to R2 + YouTube), but it made the workflow job fail.

Fix:
- Pass an explicit `summary` (falling back to hook/title) in the template context.
- Make the template usage safe with `(summary or "") | tojson`.

This was the only remaining hard failure in the Tesla Ep487 run after the two generator/phase crashes were fixed in #444 and #445.