### PR TITLE
feat(tst): safe prompt improvements for voice vibrancy and memory utilization

### DIFF
--- a/shows/prompts/tesla_digest.txt
+++ b/shows/prompts/tesla_digest.txt
@@ -49,14 +49,16 @@ The following stories and topics were already covered in recent episodes. DO NOT
 
 If any item above overlaps with a story you are about to lead with, change course.
 
-### TESLA NARRATIVE & PERFORMANCE MEMORY (use for context and emphasis — do not force)
+### TESLA NARRATIVE & PERFORMANCE MEMORY
 {tesla_narrative_status_block}
 
 {tesla_performance_signals_block}
 
 {tesla_theme_context_block}
 
-When a news development touches one of the tracked major programs, briefly note how it updates the current status. Use recent audience signals to decide relative emphasis (e.g. lean into factory/construction progress if it has been performing strongly). Use theme history only to avoid repetition and to add evolutionary context ("as the Optimus story has progressed from demo to factory..."). Listeners who follow more than one Nerra Network show will recognize when the same story is recycled across the network within hours. Pick a different angle, a different story, or a deeper dive on the SAME story that adds something the sister shows did not cover. The goal is for the network to feel coherent and complementary, not redundant.
+When a news development touches one of the tracked major programs, give the listener 1-2 sentences of "where we are in the bigger arc" context. Use recent audience signals to decide relative emphasis and energy — lean into topics showing strong recent engagement. Use theme history only to add evolutionary texture ("as the Optimus story has progressed from early demos to factory construction..."). Never force callbacks that feel artificial. The goal is narrative continuity without sacrificing freshness.
+
+The memory blocks above contain high-signal information generated specifically for this episode. Use them to improve context and appropriate emphasis.
 
 
 ### FRESHNESS INSTRUCTIONS (do not include these in your output):
@@ -84,7 +86,9 @@ If fewer than 5 quality articles are available today:
 **Date:** {today_str}
 **REAL-TIME TSLA price:** ${price} {change_str}
 
-**HOOK:** [One sentence (under 120 characters) that captures today's most important Tesla story. **Lead with the consequence or stake, then the fact** — don't just state what happened. Compare these styles: WEAK ("Tesla unveils robotaxi service in three Texas cities.") vs STRONG ("Tesla's Texas robotaxi rollout is the first real-world test of FSD without a driver."). WEAK ("California regulators disclosed Tesla Semi battery sizes at 822 kWh and 548 kWh.") vs STRONG ("Tesla Semi's 822 kWh battery just settled the long-haul-electric-truck argument."). Specific, not hype. No URLs, no dates, no emoji.]
+**HOOK:** [One sentence (under 120 characters) that captures today's most important Tesla story. **Lead with the consequence or stake, then the fact** — don't just state what happened. Compare these styles: WEAK ("Tesla unveils robotaxi service in three Texas cities.") vs STRONG ("Tesla's Texas robotaxi rollout is the first real-world test of FSD without a driver."). WEAK ("California regulators disclosed Tesla Semi battery sizes at 822 kWh and 548 kWh.") vs STRONG ("Tesla Semi's 822 kWh battery just settled the long-haul-electric-truck argument."). Specific, not hype. No URLs, no dates, no emoji.
+
+When multiple strong stories exist, favor the one that aligns with topics showing strong recent audience engagement in the performance signals, provided it is genuinely one of the biggest developments of the day.]
 
 ━━━━━━━━━━━━━━━━━━━━
 ### Top 12 News Items

--- a/shows/prompts/tesla_podcast.txt
+++ b/shows/prompts/tesla_podcast.txt
@@ -52,14 +52,16 @@ Do not include any of the following (they break TTS audio quality):
 - Pet names for the audience (e.g. "buddy", "pal", "bro", "friend", "folks", "gang") — use "you" or "listeners"
 Instead: mention source names naturally in conversation ("according to Teslarati"), use natural dates ("today", "this morning"), and describe price moves in words.
 
-### TESLA NARRATIVE & PERFORMANCE MEMORY (use for context — do not force)
+### TESLA NARRATIVE & PERFORMANCE MEMORY
 {tesla_narrative_status_block}
 
 {tesla_performance_signals_block}
 
 {tesla_theme_context_block}
 
-When narrating a story that touches a tracked major program, give listeners 1-2 sentences of "where we are in the bigger arc" context if it adds clarity. Use recent performance signals to decide energy/emphasis. Never sacrifice news value for memory.
+When a story touches a tracked major program, give listeners 1-2 sentences of "where we are in the bigger arc" context. Use recent performance signals to decide energy and emphasis — give stronger recent performers slightly more energy and specificity where it fits naturally. Never sacrifice news value or accuracy for memory.
+
+The memory blocks above contain high-signal information generated specifically for this episode. Use them to improve clarity, narrative continuity, and appropriate energy — treat them as important context, not optional flavor text.
 
 AVOID EDITORIAL PADDING (this is the #1 reason episodes feel like commentary rather than news):
 The following sentence patterns are how a script accidentally drifts from reporting into editorializing. Use them sparingly — AT MOST ONCE per story, and only when the sentence adds real insight beyond what was just stated:
@@ -113,14 +115,20 @@ Then transition naturally into the first story.
 [Main stories from the Top 12 News section]
 Cover each story with concrete reporting: what happened, then the key facts, numbers, names, and quotes from the source. Mention the source naturally. Vary your delivery — some stories get more energy, some are more reflective — but always lead with facts, not framing.
 
+SEGMENT-SPECIFIC ENERGY:
+- Straight news stories: Clear, measured, professional. Let the facts carry the weight.
+- Tesla X Takeover items: Slightly more conversational and engaged — these are the "what people are actually buzzing about" moments.
+- The Counterpoint: Honest and direct, but never alarmist. Slightly more serious tone while remaining constructive.
+- First Principles: Thoughtful and slightly more deliberate. Let the logic build with a sense of discovery as you move from the surprising fact through the data to the implication. This is the one place where a more reflective, analytical voice is appropriate.
+
 [Tesla X Takeover stories — weave in naturally]
 Pick the 2–3 most interesting items from the X Takeover section and cover them with the same depth as the main news. Do NOT announce "Tesla X Takeover" as a section — just continue covering stories naturally.
 
 [The Counterpoint — from the Short Spot section]
-Cover the challenge or bearish story honestly. Acknowledge it, explain the context, then explain why Tesla is positioned to handle it. Be measured here — don't dismiss legitimate concerns, but don't catastrophize either. Do NOT say "Short Spot" — just transition into it naturally ("Now, one thing worth watching..." or "There is a challenge worth discussing...").
+Cover the challenge or bearish story honestly. Acknowledge it, explain the context, then explain why Tesla is positioned to handle it. Be measured here — don't dismiss legitimate concerns, but don't catastrophize either. The tone should feel direct and constructive rather than negative. Do NOT say "Short Spot" — just transition into it naturally ("Now, one thing worth watching..." or "There is a challenge worth discussing...").
 
 [First Principles — brief analytical segment]
-If the digest includes a First Principles section, cover it in about 60–90 seconds. Explain the question, the data, and Tesla's approach. This is your analytical moment — be educational. Do NOT announce it as "Tesla First Principles" — just flow into it.
+If the digest includes a First Principles section, cover it in about 60–90 seconds. Explain the question, the data, and Tesla's approach. Write with slightly more weight and thoughtfulness than the straight news sections. Let the logic build with a sense of discovery. This is your analytical moment — be educational and measured. Do NOT announce it as "Tesla First Principles" — just flow into it.
 
 [Tomorrow Teaser — one sentence before the closing]
 Patrick: Before we go — briefly tease something listeners should watch for tomorrow based on developing stories from today's news. Keep it specific and forward-looking: "Tomorrow, we'll be watching for..." or "Keep an eye on..." This builds habitual listening.


### PR DESCRIPTION
Low-risk, additive improvements to Tesla digest and podcast prompts focused on:

- Making the new memory system (narrative + performance + themes) more actionable for emphasis and delivery energy.
- Adding explicit segment-specific energy guidance to support more vibrant, varied spoken delivery.
- Strengthening Counterpoint and First Principles tone instructions.
- Tying hook selection lightly to performance signals.
- Adding explicit reminders to use the memory context.

All changes are guidance only. Zero changes to output structure, formatting, length targets, or anything with previous regression history.

This is the first batch of safe vibrancy and stack-leverage improvements for TST.