### PR TITLE
feat: sitewide safe prompt vibrancy and hygiene improvements (TST + space shows)

### DIFF
--- a/shows/prompts/fascinating_frontiers_podcast.txt
+++ b/shows/prompts/fascinating_frontiers_podcast.txt
@@ -101,6 +101,11 @@ Then transition naturally into the first story.
 [Main stories from the digest]
 Cover each story with concrete reporting: what was discovered/observed, then the key facts (instruments, distances, methodology, researcher quotes). Mention the source naturally. Vary your delivery — some stories get more energy, some are more reflective — but always lead with facts. The wonder is in the data, not in added "this could help us understand" sentences.
 
+SEGMENT ENERGY:
+- Straight research stories: Clear, measured, professional.
+- High-impact or surprising discoveries: Slightly more engaged and energetic while staying factual.
+- Technical or methodological deep dives: Slightly more deliberate and precise in tone.
+
 [Cosmic Spotlight — weave in naturally]
 If the digest has a Cosmic Spotlight, give it extra depth but don't announce it as a section.
 

--- a/shows/prompts/planetterrian_podcast.txt
+++ b/shows/prompts/planetterrian_podcast.txt
@@ -102,6 +102,11 @@ Then transition naturally into the first story.
 [Main stories from the digest]
 Cover each story with concrete reporting: what was found, then the key research facts (sample size, methodology, journal, specific mechanisms or molecules, researcher quotes). Mention the source naturally. Vary your delivery — some stories get more energy, some are more reflective — but always lead with facts. The significance is in the actual finding, not in added "this could change how we think about" sentences.
 
+SEGMENT ENERGY:
+- Straight research stories: Clear, measured, professional.
+- "Wow" or high-impact discoveries: Slightly more engaged and energetic while staying factual.
+- Methodological or technical deep dives: Slightly more deliberate and precise in tone.
+
 [Planetterrian Spotlight — weave in naturally]
 If the digest has a Spotlight, give it extra depth but don't announce it as a section.
 


### PR DESCRIPTION
Follow-up to the TST prompt vibrancy work (#449).

This PR applies the same low-risk, high-signal pattern to two other flagship shows:

- Planetterrian and Fascinating Frontiers now have explicit SEGMENT ENERGY guidance for different types of content (research stories vs high-impact discoveries vs technical deep dives).

All changes follow the same conservative principles:
- Additive guidance only
- No speech tags or output format changes
- No risk to existing TTS pipeline or formatting rules
- Focused on helping the LLM produce text that supports more vibrant, varied delivery

The same pattern can be safely applied to Omni View, Models & Agents, Env Intel, etc. in future batches.