### PR TITLE
feat(search): robust global search — cache, richer scoring, a11y, clear UX + real 532-ep index

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,14 +1,15 @@
 /**
  * Global site search powered by the static Content Lake index.
  *
- * Improvements for robustness and UX:
- * - Debounced input
- * - Loading state while fetching index
- * - Clear error/empty states
- * - Keyboard navigation (arrows + enter)
- * - Simple match highlighting
- * - Result count indicator
- * - Graceful handling when index is missing or empty
+ * Robustness & UX features:
+ * - Debounced input + localStorage cache (12h TTL) for instant repeat visits
+ *   and tolerance of transient fetch issues during deploys/index rebuilds
+ * - Loading / error / empty states with actionable guidance
+ * - Keyboard navigation (arrows, Enter, Escape, '/' to focus)
+ * - ARIA roles for screen readers (combobox + listbox + live region)
+ * - Match highlighting + improved scoring (title, hook, summary, entities, recency, episode #)
+ * - Clear (×) button, result caps, indexed count footer
+ * - Graceful fallback when index empty or unavailable
  */
 
 (function () {
@@ -43,26 +44,39 @@
   function scoreItem(it, q) {
     const t = norm(it.title);
     const h = norm(it.hook);
+    const sum = norm(it.summary);
     const s = norm(it.show_name || it.show_slug);
     const ents = (it.entities || []).join(' ').toLowerCase();
     const topics = (it.topics || []).join(' ').toLowerCase();
+    const epNum = String(it.episode_num || '').toLowerCase();
 
     let score = 0;
 
-    // Stronger title matching
-    if (t === q) score += 200;
-    else if (t.startsWith(q)) score += 120;
-    else if (t.includes(q)) score += 80;
+    // Title (highest weight)
+    if (t === q) score += 220;
+    else if (t.startsWith(q)) score += 140;
+    else if (t.includes(q)) score += 95;
+    else if (q.length > 3 && t.split(/\s+/).some(w => w.startsWith(q))) score += 60; // word start
 
-    if (h.includes(q)) score += 35;
-    if (ents.includes(q)) score += 25;
-    if (topics.includes(q)) score += 20;
-    if (s.includes(q)) score += 10;
+    // Hook + summary (core content)
+    if (h.includes(q)) score += 45;
+    if (sum.includes(q)) score += 40;
+    if (h.includes(q) && sum.includes(q)) score += 10; // both
 
-    // Recency boost
+    if (ents.includes(q)) score += 30;
+    if (topics.includes(q)) score += 22;
+    if (s.includes(q)) score += 12;
+
+    // Direct episode number match (very useful for "ep 461")
+    if (epNum && (epNum === q || epNum.includes(q))) score += 85;
+
+    // Recency (days-based, favors last ~90 days)
     if (it.date) {
-      const y = parseInt(it.date.slice(0, 4), 10) || 2020;
-      score += Math.max(0, (y - 2022) * 1.5);
+      const d = new Date(it.date);
+      if (!isNaN(d.getTime())) {
+        const days = Math.max(0, (Date.now() - d.getTime()) / 86400000);
+        score += Math.max(0, 28 - Math.min(days / 3.5, 28));
+      }
     }
 
     return score;
@@ -75,10 +89,43 @@
     return text.replace(regex, '<mark>$1</mark>');
   }
 
+  const CACHE_KEY = 'nn_search_index_v1';
+  const CACHE_TTL_MS = 12 * 60 * 60 * 1000; // 12h — robust to brief deploys / rebuilds
+
+  function readCache() {
+    try {
+      const raw = localStorage.getItem(CACHE_KEY);
+      if (!raw) return null;
+      const obj = JSON.parse(raw);
+      if (obj && obj.t && (Date.now() - obj.t) < CACHE_TTL_MS && obj.data && Array.isArray(obj.data.episodes)) {
+        return { episodes: obj.data.episodes };
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  function writeCache(episodes) {
+    try {
+      localStorage.setItem(CACHE_KEY, JSON.stringify({
+        t: Date.now(),
+        data: { episodes: episodes }
+      }));
+    } catch (_) { /* quota or private mode */ }
+  }
+
   async function loadIndex() {
     if (cached) return cached;
-    if (isLoading) return null;
 
+    // Fast path: recent localStorage cache (robustness + instant UX)
+    const fromCache = readCache();
+    if (fromCache && fromCache.episodes && fromCache.episodes.length > 0) {
+      cached = fromCache;
+      // Background refresh (non-blocking)
+      refreshIndexInBackground();
+      return cached;
+    }
+
+    if (isLoading) return null;
     isLoading = true;
     showLoading();
 
@@ -86,16 +133,18 @@
       const res = await fetch(INDEX_URL, { credentials: 'same-origin' });
       if (res.ok) {
         const data = await res.json();
-        cached = { episodes: data.episodes || [] };
+        const eps = data.episodes || [];
+        cached = { episodes: eps };
+        writeCache(eps);
         hideLoading();
         isLoading = false;
         return cached;
       }
     } catch (e) {
-      // fall through to legacy
+      // fall through to legacy + cache
     }
 
-    // Legacy fallback
+    // Legacy fallback (kept for extreme robustness during transition)
     try {
       const items = [];
       for (const endpoint of LEGACY_ENDPOINTS) {
@@ -113,90 +162,158 @@
               url: e.url || ('/' + (d.slug || '') + '.html'),
               date: e.date || '',
               entities: e.entities || [],
-              topics: e.topics || []
+              topics: e.topics || [],
+              episode_num: e.episode_num || null
             });
           }
         } catch (_) {}
       }
-      cached = { episodes: items };
+      if (items.length > 0) {
+        cached = { episodes: items };
+        writeCache(items);
+      }
       hideLoading();
       isLoading = false;
-      return cached;
+      return cached || { episodes: [] };
     } catch (e) {
       hideLoading();
       isLoading = false;
+      // Last resort: stale cache even if expired
+      const stale = readCache();
+      if (stale) return stale;
       showError("Search is temporarily unavailable. Please try again later.");
       return { episodes: [] };
     }
   }
 
+  async function refreshIndexInBackground() {
+    try {
+      const res = await fetch(INDEX_URL, { credentials: 'same-origin' });
+      if (res.ok) {
+        const data = await res.json();
+        const eps = data.episodes || [];
+        if (eps.length > 0) {
+          cached = { episodes: eps };
+          writeCache(eps);
+        }
+      }
+    } catch (_) {}
+  }
+
+  // Live region for screen readers (robust a11y)
+  let liveRegion = null;
+  function ensureLiveRegion() {
+    if (liveRegion) return liveRegion;
+    liveRegion = document.createElement('div');
+    liveRegion.setAttribute('aria-live', 'polite');
+    liveRegion.setAttribute('aria-atomic', 'true');
+    liveRegion.className = 'sr-only';
+    liveRegion.style.cssText = 'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;';
+    document.body.appendChild(liveRegion);
+    return liveRegion;
+  }
+
+  function announce(msg) {
+    const lr = ensureLiveRegion();
+    lr.textContent = msg;
+  }
+
   function showLoading() {
     resultsBox.innerHTML = '<div style="padding:8px 12px;color:var(--nn-text-muted);">Loading search index...</div>';
     resultsBox.style.display = 'block';
+    resultsBox.setAttribute('aria-busy', 'true');
   }
 
   function hideLoading() {
-    // Will be overwritten by renderResults
+    resultsBox.setAttribute('aria-busy', 'false');
   }
 
   function showError(msg) {
     resultsBox.innerHTML = `<div style="padding:8px 12px;color:#ef4444;">${msg}</div>`;
     resultsBox.style.display = 'block';
+    announce(msg);
   }
 
   function renderResults(matches, query) {
     selectedIndex = -1;
 
+    const totalIndexed = (cached && cached.episodes) ? cached.episodes.length : 0;
+
     if (!matches.length) {
+      const emptyMsg = totalIndexed > 0
+        ? `No matches for “${query}”. Index covers ${totalIndexed} episodes — try a show name, topic, or fewer words.`
+        : 'Search index is updating (refreshes after every episode). Try again shortly or browse shows directly.';
       resultsBox.innerHTML = `
-        <div style="padding:8px 12px;color:var(--nn-text-muted);">
-          No matches found.
-          <br><small>The search index is refreshed after every episode and nightly.</small>
+        <div style="padding:10px 12px;color:var(--nn-text-muted);">
+          ${emptyMsg}
         </div>`;
+      announce(`No matches for ${query}. ${totalIndexed} episodes indexed.`);
     } else {
       const total = matches.length;
-      const shown = Math.min(12, total);
+      const shown = Math.min(14, total); // a few more now that scoring is richer
 
       let html = matches.slice(0, shown).map((m, i) => {
-        const label = highlight((m.title || m.hook || '').substring(0, 85), query);
-        const meta = [
+        const primary = (m.title || m.hook || '').substring(0, 92);
+        const label = highlight(primary, query);
+        const ep = m.episode_num ? `Ep ${m.episode_num}` : '';
+        const metaParts = [
           m.show_name || m.show_slug || '',
+          ep,
           m.date || ''
-        ].filter(Boolean).join(' · ');
+        ].filter(Boolean);
+        const meta = metaParts.join(' · ');
 
         const entities = (m.entities || []).slice(0, 2).join(', ');
+        const sub = (m.hook && m.hook.length > 12 ? m.hook : (m.summary || '')).substring(0, 110);
+        const subLabel = sub ? highlight(sub, query) : '';
+
         const fullMeta = meta + (entities ? ` · ${entities}` : '');
 
         return `
           <a href="${m.url || '#'}" 
              class="search-result" 
              data-index="${i}"
+             role="option"
              style="display:block;padding:8px 12px;text-decoration:none;color:inherit;border-bottom:1px solid var(--nn-border);">
             <div><strong>${label}</strong></div>
-            <small style="opacity:0.7">${fullMeta}</small>
+            ${subLabel ? `<div style="font-size:0.8em;opacity:0.75;margin:2px 0 1px;">${subLabel}</div>` : ''}
+            <small style="opacity:0.65">${fullMeta}</small>
           </a>`;
       }).join('');
 
       if (total > shown) {
         html += `<div style="padding:6px 12px;font-size:0.75rem;color:var(--nn-text-muted);background:var(--nn-bg);">
-          Showing ${shown} of ${total} results
+          Showing ${shown} of ${total} matches
+        </div>`;
+      }
+      if (totalIndexed > 0) {
+        html += `<div style="padding:4px 12px;font-size:0.7rem;color:var(--nn-text-muted);opacity:0.6;border-top:1px solid var(--nn-border);">
+          ${totalIndexed} episodes indexed • updates after every episode
         </div>`;
       }
 
       resultsBox.innerHTML = html;
+      announce(`${total} results for ${query}.`);
     }
 
     resultsBox.style.display = 'block';
 
-    // Add hover/selection styles for keyboard nav
+    // Hover + keyboard selection sync
     const links = resultsBox.querySelectorAll('.search-result');
     links.forEach(link => {
       link.addEventListener('mouseenter', () => {
         links.forEach(l => l.style.background = '');
         link.style.background = 'var(--nn-surface)';
-        selectedIndex = parseInt(link.dataset.index);
+        selectedIndex = parseInt(link.dataset.index || '-1', 10);
+      });
+      link.addEventListener('mouseleave', () => {
+        link.style.background = '';
       });
     });
+
+    // Update ARIA
+    input.setAttribute('aria-expanded', 'true');
+    resultsBox.setAttribute('aria-activedescendant', '');
   }
 
   function selectResult(index) {
@@ -233,53 +350,139 @@
     renderResults(scored, q);
   }, 120);
 
-  function debounce(fn, delay) {
-    let timeout;
-    return function (...args) {
-      clearTimeout(timeout);
-      timeout = setTimeout(() => fn.apply(this, args), delay);
-    };
+  // Wire ARIA + clear button + hotkeys
+  input.setAttribute('role', 'combobox');
+  input.setAttribute('aria-autocomplete', 'list');
+  input.setAttribute('aria-controls', 'nn-global-search-results');
+  input.setAttribute('aria-expanded', 'false');
+  resultsBox.setAttribute('role', 'listbox');
+  resultsBox.setAttribute('aria-label', 'Search results');
+
+  // Clear (×) button — injected once
+  let clearBtn = null;
+  function ensureClearButton() {
+    if (clearBtn) return clearBtn;
+    clearBtn = document.createElement('button');
+    clearBtn.type = 'button';
+    clearBtn.setAttribute('aria-label', 'Clear search');
+    clearBtn.textContent = '×';
+    clearBtn.style.cssText = 'position:absolute;right:6px;top:50%;transform:translateY(-50%);width:18px;height:18px;border:0;background:transparent;color:var(--nn-text-muted);font-size:16px;line-height:1;cursor:pointer;opacity:0.6;display:none;';
+    clearBtn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      input.value = '';
+      resultsBox.style.display = 'none';
+      input.setAttribute('aria-expanded', 'false');
+      clearBtn.style.display = 'none';
+      input.focus();
+    });
+    // Position relative to the search container if possible
+    const container = input.parentElement;
+    if (container) {
+      if (getComputedStyle(container).position === 'static') container.style.position = 'relative';
+      container.appendChild(clearBtn);
+    } else {
+      input.parentNode.insertBefore(clearBtn, input.nextSibling);
+    }
+    return clearBtn;
   }
 
-  // Event listeners
+  function updateClearVisibility() {
+    const btn = ensureClearButton();
+    btn.style.display = input.value.trim() ? 'block' : 'none';
+  }
+
   input.addEventListener('focus', () => {
-    loadIndex(); // warm the cache
+    loadIndex(); // warm
+    updateClearVisibility();
   });
 
-  input.addEventListener('input', debouncedSearch);
+  input.addEventListener('input', () => {
+    debouncedSearch();
+    updateClearVisibility();
+    if (input.value.trim().length === 0) {
+      resultsBox.style.display = 'none';
+      input.setAttribute('aria-expanded', 'false');
+    }
+  });
 
   input.addEventListener('keydown', function (e) {
     const links = resultsBox.querySelectorAll('.search-result');
-    if (!links.length || resultsBox.style.display === 'none') return;
+    const open = resultsBox.style.display !== 'none' && links.length > 0;
 
     if (e.key === 'ArrowDown') {
+      if (!open) { debouncedSearch(); return; }
       e.preventDefault();
       selectedIndex = Math.min(selectedIndex + 1, links.length - 1);
       selectResult(selectedIndex);
     } else if (e.key === 'ArrowUp') {
+      if (!open) return;
       e.preventDefault();
       selectedIndex = Math.max(selectedIndex - 1, 0);
       selectResult(selectedIndex);
-    } else if (e.key === 'Enter' && selectedIndex >= 0) {
+    } else if (e.key === 'Enter' && selectedIndex >= 0 && open) {
       e.preventDefault();
       const link = links[selectedIndex];
       if (link) window.location.href = link.getAttribute('href');
+    } else if (e.key === 'Escape') {
+      if (open) {
+        resultsBox.style.display = 'none';
+        input.setAttribute('aria-expanded', 'false');
+      }
+      input.blur();
+    }
+  });
+
+  // Global '/' focuses the search (standard docs-site pattern, ignore when typing in fields)
+  document.addEventListener('keydown', function (e) {
+    if (e.key === '/' && document.activeElement === document.body) {
+      const activeTag = (document.activeElement && document.activeElement.tagName) || '';
+      if (!/INPUT|TEXTAREA|SELECT/.test(activeTag)) {
+        e.preventDefault();
+        input.focus();
+        input.select();
+      }
     }
   });
 
   document.addEventListener('click', function (e) {
     if (!resultsBox.contains(e.target) && e.target !== input) {
       resultsBox.style.display = 'none';
+      input.setAttribute('aria-expanded', 'false');
     }
   });
 
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape' && resultsBox.style.display !== 'none') {
       resultsBox.style.display = 'none';
+      input.setAttribute('aria-expanded', 'false');
       input.blur();
     }
   });
 
-  // Expose for debugging if needed
-  window.NerraSearch = { loadIndex, clearCache: () => { cached = null; } };
+  // Keep aria-expanded in sync
+  function closeResults() {
+    resultsBox.style.display = 'none';
+    input.setAttribute('aria-expanded', 'false');
+  }
+
+  // Patch selectResult to manage aria-activedescendant
+  const _origSelect = selectResult;
+  selectResult = function (index) {
+    _origSelect(index);
+    const links = resultsBox.querySelectorAll('.search-result');
+    const link = links[index];
+    if (link) {
+      input.setAttribute('aria-activedescendant', link.id || '');
+      // ensure it has an id for aria
+      if (!link.id) link.id = 'nn-search-opt-' + index;
+      input.setAttribute('aria-activedescendant', link.id);
+    }
+  };
+
+  // Expose for debugging / operator smoke tests
+  window.NerraSearch = {
+    loadIndex,
+    clearCache: () => { cached = null; try { localStorage.removeItem(CACHE_KEY); } catch(_) {} },
+    refresh: refreshIndexInBackground
+  };
 })();

--- a/site/data/search-index.json
+++ b/site/data/search-index.json
@@ -1,7 +1,15339 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-27T16:40:43.830125+00:00",
-  "episode_count": 0,
-  "shows": [],
-  "episodes": []
+  "generated_at": "2026-05-27T21:31:33.668161+00:00",
+  "episode_count": 532,
+  "shows": [
+    "env_intel",
+    "fascinating_frontiers",
+    "finansy_prosto",
+    "models_agents",
+    "models_agents_beginners",
+    "modern_investing",
+    "omni_view",
+    "planetterrian",
+    "privet_russian",
+    "tesla",
+    "unintended_consequences"
+  ],
+  "episodes": [
+    {
+      "show_slug": "env_intel",
+      "episode_num": 36,
+      "date": "2026-05-27",
+      "title": "Environmental Intelligence",
+      "hook": "Environmental Intelligence",
+      "summary": "# Environmental Intelligence\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n> **Alberta commits $5 million to lobbyists securing BC Indigenous support for pipelines, directly affecting project timelines under IAA and provincial environmental assessments.**\n\n**Executive Summary:** Alberta’s pipeline support initiative intersects with ongoing BC forest protection disputes involving salmon habitat. Cross-border enforcement signals from Washington State underscore th",
+      "url": "/env-intel.html",
+      "entities": [
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 82,
+      "date": "2026-05-27",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **NASA is ordering the first rovers, landers and drones to build a Moon base spanning hundreds of square miles.**\n---\n### Top 15 Space & Astronomy Stories\n1. **NASA Selects Rovers and Landers for Moon Base** — Spaceflight Now\n   NASA has awarded initial contracts to Astrolab and Lunar Outpost for roughly one-ton rovers that astronauts will drive on the lunar surface. The vehicles will support travel, supply transport ",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Astronomy Magazine Highlights La Superba",
+        "ESA",
+        "Fascinating Frontiers",
+        "Meta",
+        "NASA"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 61,
+      "date": "2026-05-27",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **Anthropic just published concrete sandboxing patterns that let agents scale capabilities without expanding their blast radius.**\n\n**What You Need to Know:** Anthropic released a detailed engineering post on how they contain Claude agents through evolving access controls and sandbox limits. EAGLE 3.1 fixes attention drift in speculative decoding for more stable production inference. Several new agent frameworks and training methods for reasoning agents also dropped today.\n--",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "Conv-to-Bench evaluation framework: arXiv",
+        "EAGLE 3.1: MarkTechPost",
+        "Hyvemind OSS: r/LocalLLaMA",
+        "Llama",
+        "MicroSpec: arXiv",
+        "Nvidia",
+        "OpenAI",
+        "SPEAR prompt optimizer: arXiv",
+        "Self-Verified Distillation: arXiv",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 52,
+      "date": "2026-05-27",
+      "title": "People are fleeing Google because they hate AI answers mixed into search:",
+      "hook": "People are fleeing Google because they hate AI answers mixed into search:",
+      "summary": "# Models & Agents for Beginners\n> **Perplexity just beat ChatGPT in a new study on which AI chatbot you can actually trust for real work.**\nA fresh report shows Perplexity giving more reliable answers than ChatGPT for everyday tasks. Meanwhile, people are ditching Google Search in big numbers because they don't want AI answers forced on them. Today we'll break down why reliability matters, how these systems actually work under the hood, and two simple tools you can open right now on your phone t",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "GPT",
+        "Google"
+      ],
+      "topics": [
+        "language-models"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 54,
+      "date": "2026-05-27",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Canadian investors holding bank stocks got a double signal today as BMO and Scotiabank both raised dividends after beating earnings, highlighting capital-markets strength that could support further sector rotation into financials.**\n\n**Market Pulse:** North American markets showed divergence with the S&P 500 at 7,519 (+0.6%) and NASDAQ Composite at 26,656 (+1.2%) both hitting fresh records ",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Agora Denodo Cloud Service:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Microsoft",
+        "Modern Investing Techniques",
+        "NIQ Survey Groups:",
+        "OpenAI",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "SpaceX",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Tesla",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 62,
+      "date": "2026-05-27",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Escalating Israeli strikes in Lebanon and the killing of a militant leader are intensifying Middle East fighting, threatening civilian safety and pushing energy costs higher for households.**\n\n## Top stories (5)\n### 1) Israel eliminates new militant commander in targeted strike\n**What happened (neutral):** Israeli officials announced the killing of Mohammed Odeh, described as the new head of a group's armed wing. Defence Minister Israel Katz stated Odeh was \"",
+      "url": "/omni-view.html",
+      "entities": [
+        "ESA",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 71,
+      "date": "2026-05-27",
+      "title": "Nanoscale Circuit Generates Light-Based Information at Room Temperature — r/science",
+      "hook": "Nanoscale Circuit Generates Light-Based Information at Room Temperature — r/science",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **Older adults allocate extra cortical resources to balance as sensory and motor signals slow with age.**\n---\n### Top 15 Science & Health Discoveries\n1. **Nanoscale Circuit Generates Light-Based Information at Room Temperature — r/science**\n   Researchers built a single-chip device that both produces and processes optical signals without needing cryogenic cooling. The circuit operates at ambient temperatu",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 488,
+      "date": "2026-05-27",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $440.36 ▲ $6.77 (1.6%)\n> **Tesla's scrapped India factory hands local EV rivals an open runway in a market it once targeted for growth.**\n---\n### Top 12 News Items\n1. **Tesla scraps India factory after years of broken promises as EV rivals move in:** May 25, 2026, Yahoo Finance\n   Tesla has abandoned long-discussed plans for a factory in India after repeated delays. Rivals have already begun setting up local production and sales operations in the cou",
+      "url": "/tesla.html",
+      "entities": [
+        "Apple",
+        "Google",
+        "Meta",
+        "NASA",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "Tesla ‘Model 2’ Takes Shape:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 487,
+      "date": "2026-05-27",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $438.27 ▲ $4.68 (1.1%)\n> **Construction of Tesla’s dedicated Optimus factory at Giga Texas marks the first physical step toward scaling humanoid robot production at volume.**\n---\n### Top 12 News Items\n1. **Tesla’s dedicated Optimus factory construction officially underway at Giga Texas:** May 27, 2026, Teslarati\n   Drone footage from May 27 shows the first steel structure now standing on the North Campus of Gigafactory Texas. The dedicated facility i",
+      "url": "/tesla.html",
+      "entities": [
+        "Elon Musk",
+        "Google",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 486,
+      "date": "2026-05-27",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $433.59 ▲ $7.58 (1.8%)\n> **Tesla's dry cathode process could slash battery production costs as Elon confirms the tech's potential.**\n---\n### Top 12 News Items\n1. **Elon Musk confirms Tesla dry cathode tech could “significantly” reduce battery costs:** May 27, 2026, The Driven\n   Elon Musk stated that the dry cathode manufacturing method under development at Tesla could cut battery costs in a meaningful way. The approach eliminates solvents during ele",
+      "url": "/tesla.html",
+      "entities": [
+        "ESA",
+        "Elon Musk",
+        "Google",
+        "NASA",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "Unmonitored robotaxi count drops sharply",
+        "Used Tesla values continue sliding"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 81,
+      "date": "2026-05-26",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **NASA's Psyche spacecraft is using Mars gravity to reach a metal asteroid never visited before.**\n---\n### Top 15 Space & Astronomy Stories\n1. **Perseverance Rover Spots Signs of Ancient Martian Water** — r/space\n   The rover identified rock formations indicating past water flows in Jezero Crater. These features include layered sediments and mineral deposits consistent with prolonged liquid activity. The observations ",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Fascinating Frontiers",
+        "Meta",
+        "NASA",
+        "SpaceX",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 60,
+      "date": "2026-05-26",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **Local builders can now treat markdown skill files as optimizable parameters with automated validation gates instead of manual tweaking.**\n\n**What You Need to Know:** A new paper formalizes SkillOpt, using frontier models to propose bounded edits to markdown skills and accepting only those that improve a held-out validation set. Qwen3.5 and Qwen3.6 receive new uncensored and diffusion variants with detailed training notes for consumer hardware. Practical local setups gain co",
+      "url": "/models-agents.html",
+      "entities": [
+        "Claude",
+        "GPT",
+        "Google",
+        "Hugging Face",
+        "Intel",
+        "Llama",
+        "Multimodal RLVR pipeline tutorial: MarkTechPost",
+        "Raon-Speech 9B SpeechLM: cs.CL arXiv",
+        "Shard KV cache compression: r/LocalLLaMA",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 51,
+      "date": "2026-05-26",
+      "title": "Pope Leo just dropped a major warning about keeping humans at the center as AI grows.",
+      "hook": "Pope Leo just dropped a major warning about keeping humans at the center as AI grows.",
+      "summary": "# Models & Agents for Beginners\n> **Pope Leo just dropped a major warning about keeping humans at the center as AI grows.**\nToday we're looking at a powerful new message from the Pope about staying human while AI changes everything around us. We'll break down what that actually means in everyday life, then dive into how \"vibe coding\" is quietly opening AI to way more people than before. Stick around for quick looks at how robots might learn from your chores and what shrinking entry-level jobs co",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "GPT",
+        "Intel"
+      ],
+      "topics": [
+        "language-models",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 61,
+      "date": "2026-05-26",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **An exam leak scandal in India has triggered suicides and protests among millions of aspiring doctors, exposing deep flaws in a high-stakes system that shapes futures for an entire generation.**\n\n## Top stories (5)\n### 1) Indian exam leak leaves trail of death and despair\n**What happened (neutral):** More than two million students sat India’s NEET medical entrance exam. The test was later compromised and cancelled, prompting widespread anger, protests, and rep",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 70,
+      "date": "2026-05-26",
+      "title": "Satellites have measured sulfur dioxide released by refinery fires in Tehran.",
+      "hook": "Satellites have measured sulfur dioxide released by refinery fires in Tehran.",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **Satellites have measured sulfur dioxide released by refinery fires in Tehran.**\n---\n### Top 15 Science & Health Discoveries\n1. **Satellites Track SO₂ Emissions from Tehran Refinery Fires — Phys.org**\n   A research team used a constellation of satellites to investigate and quantify sulfur dioxide pollution after explosions and fires at oil storage and refining facilities in Tehran on March 7, 2026. The a",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Google",
+        "Intel",
+        "Meta",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "energy",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 485,
+      "date": "2026-05-26",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $433.59 ▲ $7.58 (1.8%)\n> **Tesla’s quiet charging zones at Superchargers force volume reductions to cut neighborhood noise complaints.**\n---\n### Top 12 News Items\n1. **Tesla Ships Quiet Charging Zones to Address Supercharger Noise:** May 26, 2026, Teslarati\n   Tesla began rolling out location-specific Quiet Charging Zones that prompt drivers to lower audio volume near residential areas. The feature targets complaints about excessive noise from vehicl",
+      "url": "/tesla.html",
+      "entities": [
+        "Google",
+        "Mechanic Highlights Cybertruck Service Difficulties",
+        "REAL-TIME TSLA price:",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "safety"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 80,
+      "date": "2026-05-25",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **NASA’s new directive targets a nuclear reactor on the Moon by 2030 to support sustained surface operations.**\n---\n### Top 15 Space & Astronomy Stories\n1. **NASA Directive Sets 2030 Moon Nuclear Reactor Target — Space Daily**\n   The agency will develop a fission surface power system for lunar operations under a fresh policy reviving earlier nuclear ambitions. Work includes ground testing of nuclear thermal propulsion",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "AMD",
+        "AWS",
+        "Fascinating Frontiers",
+        "Google",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 59,
+      "date": "2026-05-25",
+      "title": "Datasette's new slash-key jump menu now launches agent conversations directly from your databases.",
+      "hook": "Datasette's new slash-key jump menu now launches agent conversations directly from your databases.",
+      "summary": "# Models & Agents\n> **Datasette's new slash-key jump menu now launches agent conversations directly from your databases.**\n\n**What You Need to Know:** Simon Willison shipped Datasette 1.0a30 with a keyboard-driven \"jump to\" menu that plugins can extend, plus a datasette-agent plugin that adds a conversation starter form. NuExtract3, a new 4B vision-language model, arrived on Hugging Face for structured extraction and Markdown conversion from documents. Builders should watch how these small, targ",
+      "url": "/models-agents.html",
+      "entities": [
+        "AWS",
+        "Apple",
+        "Cider W8A8 quantization: r/LocalLLaMA",
+        "Computer-use sandbox framework: r/LocalLLaMA",
+        "Hugging Face",
+        "Llama",
+        "MCP tutorial repo: r/LocalLLaMA",
+        "Meta",
+        "NuExtract3: r/LocalLLaMA",
+        "Qwen 3.6 benchmarks: r/LocalLLaMA",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "language-models",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 50,
+      "date": "2026-05-25",
+      "title": "Robots Cooking Meals for People Who Need Them:",
+      "hook": "Robots Cooking Meals for People Who Need Them:",
+      "summary": "# Models & Agents for Beginners\n> **Google's new AI can turn almost anything into video, like making your favorite stuffed animal star in its own adventure.**\nToday we're looking at a Google AI that creates videos from almost any idea, including wild experiments like sending a plush deer on vacation. This matters because it shows how AI is moving from just chatting to actually making creative media anyone can play with. We'll also dig into why picking the right AI \"mode\" changes everything, chec",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "Gemini",
+        "Google"
+      ],
+      "topics": [
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 49,
+      "date": "2026-05-25",
+      "title": "Quantum computers just helped an AI get smarter with fewer changes",
+      "hook": "Quantum computers just helped an AI get smarter with fewer changes",
+      "summary": "# Models & Agents for Beginners\n> **AI just diagnosed millions of people with a disease that doesn't exist — here's why that matters to you.**\nResearchers planted a completely fake illness online just to test whether AI would repeat it, and the results were eye-opening. This story shows how quickly wrong information can spread through chatbots millions of people use for health questions every day. We'll also look at a surprising new way scientists are making AI more accurate and why robots sorti",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "GPT",
+        "Gemini",
+        "Google",
+        "Microsoft",
+        "OpenAI"
+      ],
+      "topics": [
+        "health",
+        "language-models",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 53,
+      "date": "2026-05-25",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Oil price drops could ease energy costs for Canadian portfolios as U.S.-Iran talks progress toward reopening the Strait of Hormuz.**\n\n**Market Pulse:** Markets rose modestly with the S&P 500 at 7,473 (+0.4%), NASDAQ Composite at 26,344 (+0.2%), and TSX Composite at 34,471 (+0.2%). Sentiment lifted on U.S.-Iran talks that sent oil prices down more than $4. The NASDAQ YTD gain stands at +13.3",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Claude",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "GPT",
+        "Hold Period:",
+        "Intel",
+        "Interactive Brokers TWS Scanner:",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Meta",
+        "Modern Investing Techniques",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Wealthsimple Trade Options Chain:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 60,
+      "date": "2026-05-25",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Britain faces a potential record bank holiday as forecasters warn temperatures could reach 35C, testing public health and infrastructure.**\n\n## Top stories (5)\n### 1) Britain prepares for hottest bank holiday on record\n**What happened (neutral):** Forecasters predict temperatures could hit 35C on the warmest May day in at least 79 years, following unusually high readings across parts of the country on Sunday. The heat has already brought Mediterranean-like co",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "Samsung",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "language-models",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 69,
+      "date": "2026-05-25",
+      "title": "A liver protein called HELZ2 shuts down production of the cholesterol carrier apoB.",
+      "hook": "A liver protein called HELZ2 shuts down production of the cholesterol carrier apoB.",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **A liver protein called HELZ2 shuts down production of the cholesterol carrier apoB.**\n---\n### Top 15 Science & Health Discoveries\n1. **Tiny blue octopus identified as new species — Science Daily**\n   Researchers formally described a golf-ball-sized blue octopus found at nearly 6,000 feet near an underwater mountain in the Galápagos. The animal was observed crawling across the seafloor during a deep-sea ",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "energy",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 484,
+      "date": "2026-05-25",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $426.01 ▲ $8.16 (2.0%)\n> **Tesla's rebrand of FSD to \"Assisted Driving\" in China shows how local regulators are forcing clearer limits on autonomy claims.**\n---\n### Top 12 News Items\n1. **Tesla rebrands FSD in China to Tesla Assisted Driving:** May 24, 2026, ArenaEV\n   Tesla changed the name of its Full Self-Driving software to Tesla Assisted Driving for the China market. The move aligns the product label with stricter local rules that treat higher l",
+      "url": "/tesla.html",
+      "entities": [
+        "Appreciation for Starlink scale notes",
+        "Google",
+        "REAL-TIME TSLA price:",
+        "Tesla",
+        "Tesla test drive page promoted",
+        "XPENG P7+ review posted"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 483,
+      "date": "2026-05-25",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $426.01 ▲ $8.16 (2.0%)\n> **Franz von Holzhausen confirmed the Tesla Roadster will be built at Gigafactory Texas, locking in the long-delayed halo car's manufacturing location.**\n---\n### Top 12 News Items\n1. **Tesla Roadster production site confirmed:** May 25, 2026, Teslarati\n   Franz von Holzhausen revealed on the Ride the Lightning podcast that the next-generation Roadster will be assembled at Gigafactory Texas. The announcement clarifies a key pie",
+      "url": "/tesla.html",
+      "entities": [
+        "Cybercab certified at 165 Wh/mi",
+        "Europe shifts FSD to subscription-only",
+        "Google",
+        "Grok",
+        "Optimus shares short video clip:",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "Tesla Roadster production site confirmed:",
+        "Tesla shares FSD no-car-payment story:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 16,
+      "date": "2026-05-25",
+      "title": "Episode 16",
+      "hook": "",
+      "summary": "> **PageRank was meant to surface the web’s most relevant pages — and it trained everyone to write for the algorithm instead.**\n---\n### Segment 1 — The Cold Open\nIn the fall of 1998, two Stanford graduate students finished a prototype that ranked web pages by counting and weighting the links pointing to them. Larry Page and Sergey Brin called the method PageRank, and they believed it would finally separate authoritative sources from noise. Within a few years the same system had given rise to an ",
+      "url": "/unintended-consequences.html",
+      "entities": [
+        "Google"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 79,
+      "date": "2026-05-24",
+      "title": "From Ep 73 (2026-05-18): Fascinating Frontiers",
+      "hook": "From Ep 73 (2026-05-18): Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers — Weekly Recap\n> **Looking back at 6 episodes from 2026-05-18 to 2026-05-24 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 73 (2026-05-18): Fascinating Frontiers**\n   2. **Three Major Carriers Form Rare Alliance to Counter Starlink — Teslarati**\n   Verizon, AT&T, and T-Mobile have joined forces for the first time to develop direct-to-device satellite service. The move responds to Starlink’s expanding c",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Cohere",
+        "Gemini",
+        "Google",
+        "NASA",
+        "SpaceX",
+        "Tesla"
+      ],
+      "topics": [
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 42,
+      "date": "2026-05-24",
+      "title": "CRA закрывает все ящики для документов 29 мая — как это повлияет на вашу налоговую декларацию",
+      "hook": "CRA закрывает все ящики для документов 29 мая — как это повлияет на вашу налоговую декларацию",
+      "summary": "# Финансы Просто\n**Дата:** May 24, 2026\n> **CRA закрывает все ящики для документов 29 мая — как это повлияет на вашу налоговую декларацию**\n\n**Что сегодня важного:** Сегодня мы поговорим о важном изменении от налоговой службы Канады, которое коснётся всех, кто ещё не подал декларацию. Также разберёмся, как работает RESP и почему многие родители сталкиваются с проблемами при выводе денег. В конце — практические шаги, которые можно сделать уже сегодня.\n---\n### Главная тема\n29 мая 2026 года Канада ",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "CIBC изменила конверсию баллов Aventura",
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "Посмотрите лимит RRSP:",
+        "Проверьте свой CRA My Account:",
+        "Сравните ставки по кредитным картам:",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 58,
+      "date": "2026-05-24",
+      "title": "From Ep 52 (2026-05-18): What You Need to Know:",
+      "hook": "From Ep 52 (2026-05-18): What You Need to Know:",
+      "summary": "# Models & Agents — Weekly Recap\n> **Looking back at 6 episodes from 2026-05-18 to 2026-05-24 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 52 (2026-05-18): What You Need to Know:**\n   **What You Need to Know:** NVIDIA released a full 4-bit pretraining stack (NVFP4) that was validated on a 12B Mamba-Transformer trained for 10 trillion tokens. The approach combines selective BF16 layers, Hadamard transforms, and stochastic ro",
+      "url": "/models-agents.html",
+      "entities": [
+        "AWS",
+        "Anthropic",
+        "Claude",
+        "Cohere",
+        "Gemini",
+        "Google",
+        "Microsoft",
+        "Nvidia",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 48,
+      "date": "2026-05-24",
+      "title": "Creating wild food infographics with GPT Image 2:",
+      "hook": "Creating wild food infographics with GPT Image 2:",
+      "summary": "# Models & Agents for Beginners — Weekly Recap\n> **Looking back at 6 episodes from 2026-05-18 to 2026-05-24 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 42 (2026-05-18): Imagine turning your random ideas into working apps just by chatting — no coding classes required.**\n   **Creating wild food infographics with GPT Image 2:** Reddit ChatGPT community\nPeople are testing GPT Image 2 to turn simple food facts into colorful, sh",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "AWS",
+        "Apple",
+        "Claude",
+        "Cohere",
+        "Elon Musk",
+        "GPT",
+        "Gemini",
+        "Google",
+        "Grok",
+        "OpenAI"
+      ],
+      "topics": [
+        "health",
+        "language-models",
+        "manufacturing",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 52,
+      "date": "2026-05-24",
+      "title": "From Ep 46 (2026-05-18): Modern Investing Techniques",
+      "hook": "From Ep 46 (2026-05-18): Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques — Weekly Recap\n> **Looking back at 6 episodes from 2026-05-18 to 2026-05-24 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 46 (2026-05-18): Modern Investing Techniques**\n   **Market Pulse:** Markets opened lower with the S&P 500 at 7,408 (-1.2%), NASDAQ Composite at 26,225 (-1.5%), and TSX Composite at 33,833 (-1.3%). Sentiment reflects ongoing rotation out of broad tech into selective healthcare",
+      "url": "/modern-investing.html",
+      "entities": [
+        "Cohere",
+        "Market Pulse:",
+        "Nvidia"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 59,
+      "date": "2026-05-24",
+      "title": "From Ep 54 (2026-05-18): What happened (neutral):",
+      "hook": "From Ep 54 (2026-05-18): What happened (neutral):",
+      "summary": "# Omni View — Weekly Recap\n> **Looking back at 5 episodes from 2026-05-18 to 2026-05-24 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 54 (2026-05-18): What happened (neutral):**\n   **Perspectives:** Outlets such as the Daily Mail and Al Jazeera presented the post as a clear escalation in pressure from Washington, linking it to stalled negotiations and ongoing regional incidents. The Guardian coverage framed the warning withi",
+      "url": "/omni-view.html",
+      "entities": [
+        "Cohere",
+        "Perspectives:",
+        "Questions to consider:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 68,
+      "date": "2026-05-24",
+      "title": "From Ep 66 (2026-05-22): Ancient Microbial Conflicts Shaped Human Immune Defenses — Science Magazine",
+      "hook": "From Ep 66 (2026-05-22): Ancient Microbial Conflicts Shaped Human Immune Defenses — Science Magazine",
+      "summary": "# Planetterrian Daily — Weekly Recap\n> **Looking back at 3 episodes from 2026-05-18 to 2026-05-24 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 65 (2026-05-18): Sunlight alone can now generate quantum photon pairs for high-quality ghost imaging.**\n   \n\n2. **From Ep 66 (2026-05-22): Ancient Microbial Conflicts Shaped Human Immune Defenses — Science Magazine**\n   2. **Sleep Physiology Linked to Dementia Pathways — Science Maga",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Cohere"
+      ],
+      "topics": [
+        "health"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 30,
+      "date": "2026-05-24",
+      "title": "Word Origins — Deep Dive: планета",
+      "hook": "Word Origins — Deep Dive: планета",
+      "summary": "# Привет, Русский! — Episode Plan\n- Russian (Cyrillic): космос\n  Transliteration: KOS-mos\n  English: space\n  Example sentence: Мы летим в космос.\n  Example translation: We are flying to space.\n  Memory hook: It sounds exactly like the English word \"cosmos\" — both mean the big starry universe!\n\n- Russian (Cyrillic): звезда\n  Transliteration: zvez-DA\n  English: star\n  Example sentence: Смотри на звезду!\n  Example translation: Look at the star!\n  Memory hook: Imagine a \"zvez\" sparkling like a star ",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Grammar Spotlight:",
+        "Practice Challenge:"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 482,
+      "date": "2026-05-24",
+      "title": "From Ep 476 (2026-05-18): REAL-TIME TSLA price:",
+      "hook": "From Ep 476 (2026-05-18): REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time — Weekly Recap\n> **Looking back at 6 episodes from 2026-05-18 to 2026-05-24 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 476 (2026-05-18): REAL-TIME TSLA price:**\n   2. **Tesla’s hardware admission reveals a looming challenge for the entire auto industry:** May 18, 2026, Automotive News\n   Tesla acknowledged limits in its current vehicle hardware for certain advanced functions. The admission points to br",
+      "url": "/tesla.html",
+      "entities": [
+        "Cohere",
+        "Google",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 78,
+      "date": "2026-05-23",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **SpaceX just flew its largest Starship yet on a test that ended with a controlled splashdown halfway around the world.**\n---\n### Top 15 Space & Astronomy Stories\n1. **Starship V3 Completes First Flight Test Despite Engine Issue — Space.com**\n   The vehicle lifted off from Texas carrying six third-generation Raptor engines on the upper stage. One vacuum-optimized engine shut down early, yet the flight computer extende",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Fascinating Frontiers",
+        "Google",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 57,
+      "date": "2026-05-23",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **OpenAI just added goal mode and screen-aware context to Codex, letting agents work autonomously for hours on real tasks.**\n\n**What You Need to Know:** OpenAI rolled out Goal mode, Appshots, and advanced annotation in Codex across app, IDE, and CLI. Anthropic reported finding over 10,000 high-severity vulnerabilities through Project Glasswing using Claude models. Multiple new open-source releases focus on faster inference and smaller footprints for consumer hardware.\n---\n###",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "Blackwell PDL Performance: Source r/LocalLLaMA",
+        "ByteShape Qwen3.6-35B-A3B Quant: Source r/LocalLLaMA",
+        "Claude",
+        "G4-MeroMero-26B-A4B Uncensored: Source r/LocalLLaMA",
+        "Hugging Face",
+        "Llama",
+        "LongCat-Video-Avatar 1.5: Source r/LocalLLaMA",
+        "OpenAI",
+        "Spice Decision Layer: Source r/MachineLearning",
+        "Supra-50M Released: Source r/LocalLLaMA",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 47,
+      "date": "2026-05-23",
+      "title": "OpenAI just gave its coding AI the power to see whatever’s on your Mac screen with one click.",
+      "hook": "OpenAI just gave its coding AI the power to see whatever’s on your Mac screen with one click.",
+      "summary": "# Models & Agents for Beginners\n> **OpenAI just gave its coding AI the power to see whatever’s on your Mac screen with one click.**\nToday we’re looking at a new way to feed real context from your computer straight into an AI coding helper. We’ll also break down exactly how large language models turn simple math into writing essays and code. Plus we’ll check out why one company is warning that AI is spotting security problems faster than humans can fix them, and what that means for everyday tech ",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "Elon Musk",
+        "GPT",
+        "Google",
+        "Grok",
+        "Intel",
+        "OpenAI"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 51,
+      "date": "2026-05-23",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Bitcoin index options are coming to Nasdaq, giving Canadian investors in TFSA accounts a new listed vehicle to express views on crypto without holding the underlying coins directly.**\n\n**Market Pulse:** Markets opened modestly higher with the S&P 500 at 7,473 (+0.4%), NASDAQ Composite at 26,344 (+0.2%), and TSX Composite at 34,471 (+0.2%). Sentiment is being shaped by persistent inflation s",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Benzinga Pro Stock Screener:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Interactive Brokers TWS API:",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Nvidia",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "SpaceX",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 67,
+      "date": "2026-05-23",
+      "title": "Ordinary WiFi signals can identify people with near-perfect accuracy even when phones are off.",
+      "hook": "Ordinary WiFi signals can identify people with near-perfect accuracy even when phones are off.",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **Ordinary WiFi signals can identify people with near-perfect accuracy even when phones are off.**\n---\n### Top 15 Science & Health Discoveries\n1. **WiFi signals identify people without devices — Science Daily**\n   German researchers showed that analyzing how radio waves bounce around a room allows recognition of individuals. The method works even when a person carries no device and has turned their phone ",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Meta",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "energy",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 481,
+      "date": "2026-05-23",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $426.01 ▲ $8.16 (2.0%)\n> **Tesla’s new magnet patent cuts rare-earth content below one percent by weight while keeping the part structurally intact.**\n---\n### Top 12 News Items\n1. **Tesla’s Microscopic Slit Patent Saves Rare Earths:** May 23, 2026, TSLAming\n   Tesla’s newly patented process machines a fraction-of-a-millimeter slit into the magnet block that stops short of cutting through, allowing a rare-earth slurry containing terbium to diffuse inw",
+      "url": "/tesla.html",
+      "entities": [
+        "FSD v14.3.3 Avoids Wide-Turning Car",
+        "Google",
+        "Meta",
+        "REAL-TIME TSLA price:",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 77,
+      "date": "2026-05-22",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **SpaceX halted the first flight of its heavily redesigned Starship V3 vehicle after a last-minute ground equipment problem.**\n---\n### Top 15 Space & Astronomy Stories\n1. **NASA Previews Moon Base Strategy Update** — Moneycontrol.com\n   NASA plans to share details on its evolving approach to a sustained lunar presence and the missions that will follow. The update will outline how the agency intends to move from initia",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Ara Offers Southern Deep-Sky Views",
+        "Auriga Features Bright Capella",
+        "Copernicus Sentinel-2 Captures Algerian Sahara",
+        "Fascinating Frontiers",
+        "NASA",
+        "Ophiuchus Holds Deep-Sky Targets",
+        "Public Meteorite Testing Options Explained",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 41,
+      "date": "2026-05-22",
+      "title": "FHSA за два года до покупки дома: стоит ли открывать счёт, если доход средний",
+      "hook": "FHSA за два года до покупки дома: стоит ли открывать счёт, если доход средний",
+      "summary": "# Финансы Просто\n**Дата:** May 22, 2026\n> **FHSA за два года до покупки дома: стоит ли открывать счёт, если доход средний**\n\n**Что сегодня важного:** Сегодня разберём, как новичкам в Канаде подойти к FHSA, если дом планируется через пару лет. Многие иммигрантки из Украины и России слышат про этот счёт, но не уверены, стоит ли его заводить при доходе около 60 тысяч долларов. Также поговорим о скрытых долгах, налоговых формах TD1 и о том, как сэкономить на продуктах в Ванкувере. Всё объясню просты",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "TFSA",
+        "Высокие проценты по автокредиту",
+        "Дата:",
+        "Налоговые возможности 2026 года",
+        "Проверка скрытого долга:",
+        "Рынок труда и малый бизнес",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 56,
+      "date": "2026-05-22",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **OpenAI just gave Codex the ability to control locked Macs and run multi-day goals, turning it into a true background agent you can launch from your phone.**\n\n**What You Need to Know:** OpenAI shipped several Codex updates today including secure computer use on locked Macs, Goal mode for hours-long autonomous work, and advanced annotation tools. Microsoft released Fara1.5, a family of browser agents that beat OpenAI Operator and Gemini 2.5 on web tasks. Developers should wat",
+      "url": "/models-agents.html",
+      "entities": [
+        "ACC for Long-Context Training: arXiv",
+        "AWS",
+        "Fara1.5 Browser Agents: MarkTechPost",
+        "Gemini",
+        "Google",
+        "Hugging Face",
+        "Llama",
+        "Low-Level Coding Dataset: r/LocalLLaMA",
+        "Microsoft",
+        "OpenAI",
+        "Probabilistic Attribution for LLMs: arXiv",
+        "PromptNCE for Zero-Shot PMI: arXiv",
+        "RankJudge Multi-Turn Judge Benchmark: arXiv",
+        "Recurrent-Depth Transformers with OpenMythos: MarkTechPost",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 46,
+      "date": "2026-05-22",
+      "title": "AI tried to run a graduation and the crowd booed:",
+      "hook": "AI tried to run a graduation and the crowd booed:",
+      "summary": "# Models & Agents for Beginners\n> **Spotify just built an AI that turns your listening history, emails, and notes into a daily podcast made only for you.**\nThe biggest story is Spotify's new standalone app that creates personalized audio briefings and podcasts on demand. This matters because it shows how AI is moving from answering questions to actively making creative things you can listen to every day. We'll also look at why AI still struggles in real-life moments like graduations, plus a fun ",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "GPT"
+      ],
+      "topics": [
+        "language-models",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 50,
+      "date": "2026-05-22",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Canadian investors holding rail or dividend-growth names should watch CNR closely after its lengthy bear-market slump created an unusually attractive entry point for long-term compounding.**\n\n**Market Pulse:** Markets opened modestly higher with the S&P 500 at 7,446 (+0.2%), NASDAQ Composite at 26,293 (+0.1%), and TSX Composite at 34,410 (+0.7%). Sentiment remains cautious as investors dige",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "AI Candidate Screening Tools:",
+        "Action:",
+        "Advance Auto Parts Earnings Surprise",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Fed Floats “Skinny” Payment Accounts",
+        "Hold Period:",
+        "Intel",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Nvidia",
+        "Polymarket–Nasdaq Private Market Partnership:",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Warsh Swearing-In Friday",
+        "Wealthsimple Kids & Business Accounts:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 58,
+      "date": "2026-05-22",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **US-Iran talks show tentative progress toward ending conflict, yet disagreements over uranium stockpiles and Hormuz access keep energy markets and regional security on edge.**\n\n## Top stories (5)\n### 1) US and Iran signal progress in mediated talks\n**What happened (neutral):** US Secretary of State Marco Rubio described “good signs” that an agreement could be reached to end the Middle East conflict. Both sides have exchanged draft proposals during ongoing talk",
+      "url": "/omni-view.html",
+      "entities": [
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 66,
+      "date": "2026-05-22",
+      "title": "Ancient Microbial Conflicts Shaped Human Immune Defenses — Science Magazine",
+      "hook": "Ancient Microbial Conflicts Shaped Human Immune Defenses — Science Magazine",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **A new review details how sleep physiology influences dementia risk through glymphatic clearance and vascular dynamics.**\n---\n### Top 15 Science & Health Discoveries\n1. **Ancient Microbial Conflicts Shaped Human Immune Defenses — Science Magazine**\n   Researchers traced key immune system components to ancient battles between microbes. The work maps molecular defenses that emerged from those early conflic",
+      "url": "/planetterrian.html",
+      "entities": [
+        "AWS",
+        "GPT",
+        "Meta",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "finance",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 29,
+      "date": "2026-05-22",
+      "title": "Word Origins — Deep Dive: ракета",
+      "hook": "Word Origins — Deep Dive: ракета",
+      "summary": "# Привет, Русский! — Episode Plan\n- Russian (Cyrillic): космос\n  Transliteration: KOS-mos\n  English: space\n  Example sentence: Мы смотрим на космос.\n  Example translation: We look at space.\n  Memory hook: It sounds just like the English word \"cosmos\" — the whole universe!\n\n- Russian (Cyrillic): планета\n  Transliteration: pla-NYE-ta\n  English: planet\n  Example sentence: Земля — это планета.\n  Example translation: Earth is a planet.\n  Memory hook: It looks and sounds almost exactly like the Englis",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Grammar Spotlight:",
+        "Practice Challenge:"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 480,
+      "date": "2026-05-22",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $417.85 ▲ $0.59 (0.1%)\n> **Tesla's first Model Y price increase in two years tests whether buyers will absorb higher costs amid softening demand.**\n---\n### Top 12 News Items\n1. **Tesla Raises Model Y Prices for First Time in Two Years:** May 22, 2026, EVANNEX\n   Tesla quietly increased prices on three Model Y trims in the United States. The move marks the first upward adjustment in nearly two years and affects the entry-level rear-wheel-drive and Lon",
+      "url": "/tesla.html",
+      "entities": [
+        "Optimus Shares Lighthearted Video",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "Wrapmanager Inc. Reduces TSLA Holdings"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 15,
+      "date": "2026-05-22",
+      "title": "Episode 15",
+      "hook": "",
+      "summary": "> **Ian Goodfellow designed GANs in 2014 to let machines create realistic images from scratch; five years later the same system was generating non-consensual pornography and fabricated political videos at scale.**\n---\n### Segment 1 — The Cold Open\nIn a Montreal apartment in 2014, Ian Goodfellow sketched an idea on a napkin that would let one neural network critique another until both produced images no human could easily dismiss as fake. The goal was straightforward: give computers the ability t",
+      "url": "/unintended-consequences.html",
+      "entities": [
+        "AWS",
+        "Google",
+        "Nvidia"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 76,
+      "date": "2026-05-21",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **NASA is shifting its Moon strategy from the Lunar Gateway toward a permanent surface base.**\n---\n### Top 15 Space & Astronomy Stories\n1. **NASA Pivots Artemis Plans Toward Permanent Moon Base — Cleveland 13 News**\n   The agency is moving away from the Lunar Gateway station in favor of establishing a lasting presence directly on the lunar surface. This change would alter how future crews live, work, and conduct long-",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Fascinating Frontiers",
+        "Google",
+        "NASA"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 40,
+      "date": "2026-05-21",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "# Финансы Просто\n**Дата:** May 21, 2026\n> **В Британской Колумбии компания маскировала комиссии и предлагала кредиты под 60 % — как не попасть в такую ловушку**\n\n**Что сегодня важного:** Сегодня разберём, как одна компания в Суррее якобы нарушала закон с процентными ставками и почему это важно для всех, кто берёт кредиты или ипотеку. Ещё поговорим о том, как работают возобновления ипотеки, и как отличить настоящие сообщения от CRA от мошеннических. В конце дам простое задание, которое поможет ва",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Американские ставки по ипотеке выросли",
+        "Дата:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "space"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 55,
+      "date": "2026-05-21",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **A general-purpose reasoning model just disproved an 80-year-old math conjecture by finding better constructions than the square grids mathematicians expected.**\n\n**What You Need to Know:** OpenAI announced that one of its general-purpose models solved the planar unit distance problem posed by Paul Erdős in 1946, marking the first time AI has autonomously resolved a prominent open math question. At the same time, new enterprise agent platforms from Resolve AI and Kore.ai emp",
+      "url": "/models-agents.html",
+      "entities": [
+        "DeepMind",
+        "Gemini",
+        "Google",
+        "Kore.ai Artemis agent platform: VentureBeat",
+        "Llama",
+        "LlamaStation v0.9: r/LocalLLaMA",
+        "Microsoft",
+        "OpenAI",
+        "Rippletide decision context graphs: VentureBeat",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 45,
+      "date": "2026-05-21",
+      "title": "Real-time social signals from live video:",
+      "hook": "Real-time social signals from live video:",
+      "summary": "# Models & Agents for Beginners\n> **An AI built for safer mental health chats just scored way higher on safety tests than anything else out there.**\nToday we're looking at a new AI designed specifically to be safer for talking about feelings and mental health. We'll also break down how AI models can start \"eating their own words\" when they run out of fresh human examples to learn from. Plus we'll check out some hands-on experiments you can try right now with video tools and real-time social sign",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Browser-based AI experiments:",
+        "Intel"
+      ],
+      "topics": [
+        "health",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 49,
+      "date": "2026-05-21",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Nvidia topping expectations hands Canadian TFSA holders in AI names a potential re-entry window, but only if volume confirms the move before broader rotation hits.**\n\n**Market Pulse:** U.S. equities slipped as higher oil prices lifted bond yields, with the S&P 500 closing at 7,404 (-0.4%) and the NASDAQ Composite at 26,121 (-0.6%). The TSX Composite bucked the trend, rising 0.2% to 34,246 o",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Generic GLP-1 Access in Canada:",
+        "Hold Period:",
+        "Intel",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Nvidia",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 57,
+      "date": "2026-05-21",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Iran's expanded claim over the Strait of Hormuz raises risks for global oil supplies that millions depend on for energy and transport costs.**\n\n## Top stories (5)\n### 1) Iran steps up claim to control Strait of Hormuz\n**What happened (neutral):** Iran has published a map asserting armed forces oversight across more than 22,000 square kilometres of the waterway. The move comes amid ongoing regional tensions and follows statements from Iranian officials about e",
+      "url": "/omni-view.html",
+      "entities": [
+        "ESA",
+        "Elon Musk",
+        "Meta",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "SpaceX",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 28,
+      "date": "2026-05-21",
+      "title": "Word Origins — Deep Dive: температура",
+      "hook": "Word Origins — Deep Dive: температура",
+      "summary": "# Привет, Русский! — Episode Plan\n- Russian (Cyrillic): солнце\n  Transliteration: SOHLN-tseh\n  English: sun\n  Example sentence: Сегодня светит солнце.\n  Example translation: Today the sun is shining.\n  Memory hook: Imagine the sun as a big, round \"soul\" warming everyone up!\n- Russian (Cyrillic): дождь\n  Transliteration: DOZHD\n  English: rain\n  Example sentence: Идёт дождь.\n  Example translation: It is raining.\n  Memory hook: Think of \"drizzle\" but shorter and bouncier — dozh-d!\n- Russian (Cyrill",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Grammar Spotlight:",
+        "Practice Challenge:"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 479,
+      "date": "2026-05-21",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $414.00 ▼ $3.26 (0.8%)\n> **Xiaomi's YU7 undercuts the Model Y by $4,350 with extra range, raising the stakes for Tesla in China and beyond.**\n---\n### Top 12 News Items\n1. **Xiaomi’s new YU7 undercuts Tesla Model Y by $4,350 with 50 km more range:** May 21, 2026, Electrek\n   Xiaomi introduced its YU7 crossover at a lower starting price than the Model Y while claiming an additional 50 km of range. The move directly targets Tesla’s best-selling vehicle ",
+      "url": "/tesla.html",
+      "entities": [
+        "Anthropic",
+        "Elon Musk",
+        "Google",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "SpaceX discloses Anthropic compute deal",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 14,
+      "date": "2026-05-21",
+      "title": "Episode 14",
+      "hook": "",
+      "summary": "> **Justin Rosenstein built Facebook’s Like button to let friends share quick appreciation — and it became the global yardstick for personal worth.**\n---\n### Segment 1 — The Cold Open\nIn the spring of 2007, Justin Rosenstein sat at his desk inside Facebook’s Palo Alto offices and sketched a small thumbs-up icon meant to replace the longer process of typing “That’s great!” under a friend’s post. The goal was simple: remove friction so that positive signals could travel faster across the network. ",
+      "url": "/unintended-consequences.html",
+      "entities": [
+        "Meta"
+      ],
+      "topics": [
+        "regulation",
+        "space"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 75,
+      "date": "2026-05-20",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **A single Falcon 9 just added two dozen more nodes to a growing web of satellites that now blankets the planet in broadband.**\n---\n### Top 15 Space & Astronomy Stories\n1. **SpaceX Adds 24 More Starlink Satellites to Orbit — Space.com**\n   A Falcon 9 lifted off from Vandenberg Space Force Base carrying 24 Starlink satellites and successfully deployed them into low Earth orbit. The mission marks another incremental exp",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Fascinating Frontiers",
+        "Google",
+        "Intel",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "safety",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 39,
+      "date": "2026-05-20",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "# Финансы Просто\n**Дата:** May 20, 2026\n> **Мировые рынки колеблются, а ваши сбережения в Канаде остаются под защитой — разберёмся, как это работает**\n\n**Что сегодня важного:** Сегодня мировые акции немного отступили из-за роста доходности облигаций, и это напоминание, что рынки всегда меняются. Для нас в Ванкувере или Бернаби важно понимать, как такие колебания влияют на долгосрочные накопления, особенно если вы только начинаете инвестировать. В выпуске я объясню простыми словами, почему это пр",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "Помощь Украине от ЕС",
+        "Посмотрите отзывы о коллекторских компаниях:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 54,
+      "date": "2026-05-20",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **Gemini 3.5 Flash gives builders faster, cheaper frontier performance on coding and agent tasks while Gemini Omni adds real-time multimodal scene editing.**\n\n**What You Need to Know:** Google released Gemini 3.5 Flash today, claiming it outperforms the prior 3.1 Pro on coding and agentic work, runs 4x faster than other frontier models, and delivers up to 800 tokens/sec inside Antigravity. Alibaba simultaneously shipped Qwen3.5-LiveTranslate-Flash for low-latency multimodal t",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "DeepMind",
+        "Gemini",
+        "Gemini Omni: Demis Hassabis (DeepMind)",
+        "Google",
+        "Guardrails for 8B models: r/LocalLLaMA",
+        "Kay.ai insurance agent: BriefGlance",
+        "Llama",
+        "Llama.cpp optimization on Blackwell: r/LocalLLaMA",
+        "Nvidia",
+        "OpenAI",
+        "Qwen3.5-LiveTranslate-Flash: MarkTechPost",
+        "Sam Altman",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 44,
+      "date": "2026-05-20",
+      "title": "Google just turned AI from a chat buddy into something that can actually do your tasks for you.",
+      "hook": "Google just turned AI from a chat buddy into something that can actually do your tasks for you.",
+      "summary": "> **Google just turned AI from a chat buddy into something that can actually do your tasks for you.**\nToday’s biggest news comes from Google I/O, where the company showed off new AI agents that can watch topics, organize your life, and even help build apps. These tools move AI from answering questions to taking actions, which changes how you might use it for school, hobbies, or future jobs. We’ll break down what that really means, how the tech works under the hood, and a couple of fun things you",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "AWS",
+        "Gemini",
+        "Google"
+      ],
+      "topics": [
+        "language-models",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 48,
+      "date": "2026-05-20",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Canadian investors holding heavy TFSA positions in growth names should watch the 10-year Treasury yield at 4.69% because it is already repricing long-duration assets faster than earnings can offset.**\n\n**Market Pulse:** Markets closed lower with the S&P 500 at 7,354 (-0.7%), NASDAQ Composite at 25,871 (-0.8%), and TSX Composite at 33,741 (-0.3%). Sentiment is being shaped by sticky long-end",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Apple",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Meta",
+        "Modern Investing Techniques",
+        "Nvidia",
+        "OptionsPlay NVDA Flow Tracker:",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Unusual Whales Options Flow:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 56,
+      "date": "2026-05-20",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Putin and Xi’s energy pipeline talks amid Middle East tensions could reshape global supply routes and alliances that affect everyday energy costs worldwide.**\n\n## Top stories (5)\n### 1) Middle East crisis live: US and Iran trade threats but Trump insists Tehran wants deal\n**What happened (neutral):** US and Iranian officials exchanged warnings over possible further strikes while President Trump stated that Tehran seeks a deal. A South Korean oil tanker passed",
+      "url": "/omni-view.html",
+      "entities": [
+        "ESA",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "Samsung",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 27,
+      "date": "2026-05-20",
+      "title": "Word Origins — Deep Dive: магазин",
+      "hook": "Word Origins — Deep Dive: магазин",
+      "summary": "# Привет, Русский! — Episode Plan\n- Russian (Cyrillic): хлеб\n  Transliteration: khleb\n  English: bread\n  Example sentence: Я ем хлеб.\n  Example translation: I eat bread.\n  Memory hook: Sounds like \"club\" but it's the staff of life on every Russian table!\n- Russian (Cyrillic): молоко\n  Transliteration: moloko\n  English: milk\n  Example sentence: Дети пьют молоко.\n  Example translation: Children drink milk.\n  Memory hook: \"Mo-lo-ko\" — imagine a cow saying \"moo\" while giving you milk!\n- Russian (Cyr",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Grammar Spotlight:",
+        "Practice Challenge:"
+      ],
+      "topics": [
+        "health",
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 478,
+      "date": "2026-05-20",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $0.00 (price unavailable)\n> **Tesla's decision to spotlight Signature Edition Model S and X comes as production focus shifts elsewhere in the lineup.**\n---\n### Top 12 News Items\n1. **Tesla shares Signature Edition Model S & X images:** May 20, 2026, [@Tesla](https://x.com/Tesla)\n   Tesla posted images of the Signature Edition Model S and Model X along with details for a live delivery event streaming from the Fremont Factory tomorrow at 5pm PT. The ed",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "FSD Supervised cost comparison",
+        "Google",
+        "Polestar's direct challenge",
+        "REAL-TIME TSLA price:",
+        "Shared English News18 link",
+        "SpaceX",
+        "SpaceX IPO timing speculation",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 13,
+      "date": "2026-05-20",
+      "title": "Episode 13",
+      "hook": "",
+      "summary": "> **A designer removed one click to make browsing smoother in 2006 — and helped build the endless feeds that now shape how billions spend their time.**\n---\n### Segment 1 — The Cold Open\nIn the spring of 2006, Aza Raskin sat at a desk testing a new way to move through long lists of search results. Instead of clicking a “next” button to load another page, the content would simply continue as the user scrolled downward. The change felt like a small courtesy, a way to keep someone from breaking thei",
+      "url": "/unintended-consequences.html",
+      "entities": [],
+      "topics": [
+        "health",
+        "regulation"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 35,
+      "date": "2026-05-19",
+      "title": "Environmental Intelligence",
+      "hook": "Environmental Intelligence",
+      "summary": "# Environmental Intelligence\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n> **US EPA proposes delays for certain PFAS regulations, a move Canadian practitioners should monitor for CCME and provincial threshold alignment.**\n\n**Executive Summary:** The US EPA signalled flexibility on timelines for some forever-chemical rules while partially rejecting Hawaii’s regional haze plan. Separate reporting shows Germany is on track to miss its 2030 greenhouse-gas reductio",
+      "url": "/env-intel.html",
+      "entities": [
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "Google",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 74,
+      "date": "2026-05-19",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **A joint European-Chinese spacecraft is now heading out to capture the first X-ray views of the invisible boundary where the solar wind slams into our planet’s magnetic shield.**\n---\n### Top 15 Space & Astronomy Stories\n1. **SMILE Satellite Launches to Study Earth’s Magnetic Shield — European Space Agency**\n   A Vega-C rocket lifted off from French Guiana carrying the SMILE spacecraft, a joint mission between ESA and",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "ESA",
+        "Fascinating Frontiers",
+        "Gemini",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 53,
+      "date": "2026-05-19",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **Anthropic's acquisition of StainlessAPI hands developers cleaner SDKs and MCP server tooling for building production agents today.**\n\n**What You Need to Know:** Anthropic acquired StainlessAPI, the platform behind every Anthropic SDK since the API's earliest days, to accelerate SDK and MCP server development. Alibaba previewed new Qwen models that currently rank as the top Chinese entries on the LMSYS Arena. Enterprise teams now have clearer guidance on moving agentic platf",
+      "url": "/models-agents.html",
+      "entities": [
+        "AWS",
+        "Anthropic",
+        "Claude",
+        "DeepMind",
+        "Google",
+        "Hugging Face",
+        "Microsoft",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 43,
+      "date": "2026-05-19",
+      "title": "Your smart speaker can now write and record an entire podcast on any topic you name.",
+      "hook": "Your smart speaker can now write and record an entire podcast on any topic you name.",
+      "summary": "# Models & Agents for Beginners\n> **Your smart speaker can now write and record an entire podcast on any topic you name.**\nAmazon just added a feature to Alexa Plus that lets it create full AI-generated podcasts from scratch. This turns a simple voice assistant into something that can research, script, and voice an audio show while you steer the topic. Today we break down how that works, explore the tech behind turning text into natural conversation, and share quick ways to experiment with simil",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Amazon",
+        "Anthropic",
+        "Claude",
+        "Google",
+        "Intel"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "manufacturing",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 47,
+      "date": "2026-05-19",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Oil shocks and today's StatCan inflation print could lift input costs for consumer names, giving TFSA holders a narrow window to rotate into names with pricing power before margins compress further.**\n\n**Market Pulse:** Markets opened mixed with the S&P 500 at 7,403 (-0.1%), NASDAQ Composite at 26,091 (-0.5%), and TSX Composite at 33,833 (-1.3%). Oil volatility tied to Iran developments and",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Armada data-center funding round:",
+        "Bank of Canada",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Domain Money:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 55,
+      "date": "2026-05-19",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Russia and Belarus have begun joint nuclear drills while the UN Security Council meets on Ukraine, highlighting how routine military exercises can quickly raise regional tensions.**\n\n## Top stories (5)\n### 1) UN Security Council meets on Ukraine amid Russia-Belarus nuclear drills\n**What happened (neutral):** The UN Security Council convened at the request of Denmark, France, Greece, Latvia, Liberia, and the UK to discuss the situation in Ukraine. The meeting ",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "ESA",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 477,
+      "date": "2026-05-19",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $0.00 (price unavailable)\n> **Tesla's scrapped India factory plans expose how regulatory and infrastructure hurdles can derail even aggressive global expansion goals.**\n---\n### Top 12 News Items\n1. **Tesla raises EV prices amid cost pressures, Barron's**\n   Tesla increased prices on several EV models. The move comes as the company grapples with rising production costs that have begun to squeeze margins. Higher prices could help stabilize profitabilit",
+      "url": "/tesla.html",
+      "entities": [
+        "Apple",
+        "Elon Musk",
+        "Google",
+        "Grok",
+        "Heartfelt community reactions surface",
+        "OpenAI",
+        "Pennsylvania hint sparks speculation",
+        "REAL-TIME TSLA price:",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 12,
+      "date": "2026-05-19",
+      "title": "Episode 12",
+      "hook": "",
+      "summary": "> **GPS promised to erase every wrong turn, yet it quietly began shrinking the brain’s built-in navigation system.**\n---\n### Segment 1 — The Cold Open\nIn 2016 a delivery driver in London followed his GPS down a narrow towpath beside the Regent’s Canal and became wedged between two bridges, his van blocking the path for hours. The route had looked perfect on the screen. What the driver could not see was that the same device had already begun to change how his brain stored the city’s layout. This ",
+      "url": "/unintended-consequences.html",
+      "entities": [
+        "Google",
+        "Meta"
+      ],
+      "topics": [
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 73,
+      "date": "2026-05-18",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **A faint crescent Moon is sliding past Venus tonight, offering a rare chance to watch two worlds share the same patch of sky.**\n---\n### Top 15 Space & Astronomy Stories\n1. **Moon Pairs with Venus in Evening Sky — Astronomy Magazine**\n   The slender crescent Moon stands just over two days old and will appear close to Venus this evening. Observers can catch the pairing low in the west after sunset as the Moon’s lit sli",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Fascinating Frontiers",
+        "Google",
+        "NASA",
+        "SpaceX",
+        "Tesla"
+      ],
+      "topics": [
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 38,
+      "date": "2026-05-18",
+      "title": "Как защитить свои сбережения от мошенников при поиске работы в Канаде",
+      "hook": "Как защитить свои сбережения от мошенников при поиске работы в Канаде",
+      "summary": "# Финансы Просто\n**Дата:** May 18, 2026\n> **Как защитить свои сбережения от мошенников при поиске работы в Канаде**\n\n**Что сегодня важного:** Сегодня мы поговорим о том, как легко можно потерять деньги и время из-за фальшивых работодателей. Эта тема особенно актуальна для иммигранток, которые ищут первую работу или подработку. Ещё разберём, как канадские родители готовят детей к поступлению в университет и почему стоит планировать такие расходы заранее. В конце я дам простой шаг, который поможет",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Дата:",
+        "Мошенники маскируются под работодателей",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 52,
+      "date": "2026-05-18",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **NVIDIA's 4-bit pretraining technique cuts memory needs for large hybrid models while keeping accuracy nearly identical to FP8.**\n\n**What You Need to Know:** NVIDIA released a full 4-bit pretraining stack (NVFP4) that was validated on a 12B Mamba-Transformer trained for 10 trillion tokens. The approach combines selective BF16 layers, Hadamard transforms, and stochastic rounding to stay within 0.04 points of an FP8 baseline on MMLU-Pro. Builders training long-horizon models o",
+      "url": "/models-agents.html",
+      "entities": [
+        "AMD",
+        "Dialect-conditioned routing in MoE models:",
+        "Llama",
+        "Nanochat video setup friction:",
+        "Nvidia",
+        "Qwen3.6-27B inference on AMD hardware:",
+        "Respecting time with vibe-coded tools:",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 42,
+      "date": "2026-05-18",
+      "title": "Imagine turning your random ideas into working apps just by chatting — no coding classes required.",
+      "hook": "Imagine turning your random ideas into working apps just by chatting — no coding classes required.",
+      "summary": "# Models & Agents for Beginners\n> **Imagine turning your random ideas into working apps just by chatting — no coding classes required.**\nA new Wired story shows how regular people with zero tech background are already building real projects using AI chatbots. This matters because it opens doors for anyone curious about creating things, whether for school, hobbies, or future jobs. We'll also look at how AI is starting to handle personal money questions and explore what these changes really mean u",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "AWS",
+        "Apple",
+        "Claude",
+        "GPT",
+        "Google",
+        "OpenAI"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "language-models",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 46,
+      "date": "2026-05-18",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Canadian TFSA holders eyeing healthcare innovation now have fresh catalyst data to evaluate after Design Therapeutics reported positive trial results that could shift sector rotation away from pure AI names.**\n\n**Market Pulse:** Markets opened lower with the S&P 500 at 7,408 (-1.2%), NASDAQ Composite at 26,225 (-1.5%), and TSX Composite at 33,833 (-1.3%). Sentiment reflects ongoing rotation",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Artivion Completes Endospan Acquisition",
+        "Benzinga 5G Penny Stock Scanner:",
+        "Benzinga Stock Screeners:",
+        "Berkshire Hathaway Portfolio Revamp",
+        "Bitget Completes Mexico Regulatory Registrations",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "biotech",
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 54,
+      "date": "2026-05-18",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Trump's warning that \"the clock is ticking\" for Iran raises risks to global oil supplies and regional stability as peace talks stall.**\n\n## Top stories (5)\n### 1) Trump issues direct warning to Iran amid stalled talks\n**What happened (neutral):** US President Donald Trump posted on social media that the clock is ticking for Iran to reach a peace deal, warning there would not be anything left of the country if it failed to act quickly. The statement followed e",
+      "url": "/omni-view.html",
+      "entities": [
+        "Amazon",
+        "Meta",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "biotech",
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 65,
+      "date": "2026-05-18",
+      "title": "Sunlight alone can now generate quantum photon pairs for high-quality ghost imaging.",
+      "hook": "Sunlight alone can now generate quantum photon pairs for high-quality ghost imaging.",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **Sunlight alone can now generate quantum photon pairs for high-quality ghost imaging.**\n---\n### Top 15 Science & Health Discoveries\n1. **New catalyst produces clean hydrogen without platinum — Science Daily**\n   Researchers created a durable catalyst that generates hydrogen from water using only abundant materials. The advance removes a major cost barrier to scaling renewable hydrogen fuel. Source: [scie",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "safety"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 26,
+      "date": "2026-05-18",
+      "title": "Word Origins — Deep Dive: космос",
+      "hook": "Word Origins — Deep Dive: космос",
+      "summary": "# Привет, Русский! — Episode Plan\n- Russian (Cyrillic): космос\n  Transliteration: KOS-mos\n  English: space\n  Example sentence: Я вижу звёзды в космосе.\n  Example translation: I see stars in space.\n  Memory hook: Sounds exactly like the English word \"cosmos\" — the universe!\n- Russian (Cyrillic): ракета\n  Transliteration: ra-KE-ta\n  English: rocket\n  Example sentence: Ракета летит в небо.\n  Example translation: The rocket flies into the sky.\n  Memory hook: Imagine a rocket racing like a fast \"rack",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Grammar Spotlight:",
+        "Practice Challenge:"
+      ],
+      "topics": [
+        "energy",
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 476,
+      "date": "2026-05-18",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $419.75 ▲ $4.25 (1.0%) (Pre-market)\n> **Tesla lost its top spot in Hungary to a Chinese rival, underscoring how quickly local market leadership can shift.**\n---\n### Top 12 News Items\n1. **Chinese Auto Giant Dethrones Tesla in the Domestic Market:** May 18, 2026, Hungary Today\n   A Chinese automaker has overtaken Tesla as the leading EV seller in Hungary. The shift highlights intensifying competition from established Asian brands expanding across Euro",
+      "url": "/tesla.html",
+      "entities": [
+        "Elon Musk",
+        "FSD scare on 14.3.2",
+        "Google",
+        "Optimus posts animated video",
+        "Optimus shares short video clip",
+        "REAL-TIME TSLA price:",
+        "Tesla",
+        "Video post (no accompanying text)"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 11,
+      "date": "2026-05-18",
+      "title": "Episode 11",
+      "hook": "",
+      "summary": "### Segment 1 — The Hook\n> **In September 2006, Facebook rolled out its News Feed feature to give every user a personalized stream of updates rather than forcing them to hunt across separate profile pages. The engineers who built the first ranking systems wanted people to see the posts that mattered most to them, measured by clicks, likes, and comments. What the math actually rewarded, however, was the material that triggered the strongest emotional reaction, turning a tool meant to strengthen c",
+      "url": "/unintended-consequences.html",
+      "entities": [],
+      "topics": [
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 72,
+      "date": "2026-05-17",
+      "title": "From Ep 68 (2026-05-11): Fascinating Frontiers",
+      "hook": "From Ep 68 (2026-05-11): Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers — Weekly Recap\n> **Looking back at 4 episodes from 2026-05-11 to 2026-05-17 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 68 (2026-05-11): Fascinating Frontiers**\n   2. **NASA Advances Next-Generation Asteroid Telescope** — Reddit r/space\n   Engineers are shaping the design for a new near-Earth asteroid detection telescope that will improve early warning capabilities. The instrument aims to spot small",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Cohere",
+        "Google",
+        "NASA",
+        "NASA Advances Next-Generation Asteroid Telescope",
+        "SpaceX"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 51,
+      "date": "2026-05-17",
+      "title": "From Ep 45 (2026-05-11): What You Need to Know:",
+      "hook": "From Ep 45 (2026-05-11): What You Need to Know:",
+      "summary": "# Models & Agents — Weekly Recap\n> **Looking back at 6 episodes from 2026-05-11 to 2026-05-17 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 45 (2026-05-11): What You Need to Know:**\n   **What You Need to Know:** Sakana and NVIDIA released TwELL, a sparse inference approach that uses simple L1 regularization plus custom CUDA kernels to hit over 99% sparsity in LLM feed-forward layers. The result is measured 20.5% faster infer",
+      "url": "/models-agents.html",
+      "entities": [
+        "AMD",
+        "Anthropic",
+        "Claude",
+        "Cohere",
+        "GPT",
+        "Google",
+        "Llama",
+        "Nvidia",
+        "OpenAI",
+        "Sam Altman",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 41,
+      "date": "2026-05-17",
+      "title": "From Ep 36 (2026-05-12): Claude's Constitution as a free audiobook:",
+      "hook": "From Ep 36 (2026-05-12): Claude's Constitution as a free audiobook:",
+      "summary": "# Models & Agents for Beginners — Weekly Recap\n> **Looking back at 6 episodes from 2026-05-11 to 2026-05-17 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 35 (2026-05-11): OpenAI just launched a free way for students everywhere to build AI clubs and get tools.**\n   Think of it like starting a school club for chess or robotics, except this one gives you free access to AI tools, ideas for events, and a way to connect with other",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Amazon",
+        "Claude",
+        "Cohere",
+        "GPT",
+        "Google",
+        "Grok",
+        "Microsoft",
+        "OpenAI"
+      ],
+      "topics": [
+        "language-models",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 45,
+      "date": "2026-05-17",
+      "title": "From Ep 39 (2026-05-11): Modern Investing Techniques",
+      "hook": "From Ep 39 (2026-05-11): Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques — Weekly Recap\n> **Looking back at 6 episodes from 2026-05-11 to 2026-05-17 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 39 (2026-05-11): Modern Investing Techniques**\n   **Market Pulse:** North American indices opened higher with the S&P 500 at 7,399 (+0.8%), NASDAQ Composite at 26,247 (+1.7%), and TSX Composite at 34,078 (+0.7%). Sentiment is supported by earnings optimism and a sharp move in",
+      "url": "/modern-investing.html",
+      "entities": [
+        "Bank of Canada",
+        "Cohere",
+        "Market Pulse:",
+        "Meta"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 53,
+      "date": "2026-05-17",
+      "title": "From Ep 47 (2026-05-11): What happened (neutral):",
+      "hook": "From Ep 47 (2026-05-11): What happened (neutral):",
+      "summary": "# Omni View — Weekly Recap\n> **Looking back at 6 episodes from 2026-05-11 to 2026-05-17 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 47 (2026-05-11): What happened (neutral):**\n   **Perspectives:** CNBC frames the session as investors calmly digesting negotiation updates without major panic selling. Other market observers note that defense stocks often move inversely to perceived de-escalation chances because lower conflict",
+      "url": "/omni-view.html",
+      "entities": [
+        "Cohere",
+        "Perspectives:",
+        "Questions to consider:"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 64,
+      "date": "2026-05-17",
+      "title": "From Ep 60 (2026-05-11): Over 1000 genetic switches differ in female immune cells — r/science",
+      "hook": "From Ep 60 (2026-05-11): Over 1000 genetic switches differ in female immune cells — r/science",
+      "summary": "# Planetterrian Daily — Weekly Recap\n> **Looking back at 4 episodes from 2026-05-11 to 2026-05-17 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 60 (2026-05-11): Over 1000 genetic switches differ in female immune cells — r/science**\n   2. **Thymus function carries lasting consequences into adulthood — r/science**\n   New analysis shows that thymic health continues to shape immune competence well beyond childhood. Reduced thymi",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Cohere"
+      ],
+      "topics": [
+        "climate",
+        "health",
+        "manufacturing"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 475,
+      "date": "2026-05-17",
+      "title": "From Ep 469 (2026-05-11): REAL-TIME TSLA price:",
+      "hook": "From Ep 469 (2026-05-11): REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time — Weekly Recap\n> **Looking back at 6 episodes from 2026-05-11 to 2026-05-17 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 469 (2026-05-11): REAL-TIME TSLA price:**\n   2. **Tesla FSD Supervised Completes NYC to LA Record Drive**: A Tesla completed the cross-country trip from New York to Los Angeles on FSD Supervised with zero interventions. The drive demonstrates the system's ability to handle varied highw",
+      "url": "/tesla.html",
+      "entities": [
+        "Cohere",
+        "Google",
+        "Optimus posts a video:",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 71,
+      "date": "2026-05-16",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **A NASA probe is borrowing Mars’ gravity to reach a metal asteroid no spacecraft has ever visited.**\n---\n### Top 15 Space & Astronomy Stories\n1. **Psyche Spacecraft Swings Past Mars for Speed Boost** — r/space\n   The probe is using the planet’s gravity to increase its velocity on the way to its main target. Thousands of images taken during the flyby will test cameras ahead of the 2029 asteroid encounter. Source: [red",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Fascinating Frontiers",
+        "Google",
+        "Meta",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 37,
+      "date": "2026-05-16",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "# Финансы Просто\n**Дата:** May 16, 2026\n> **Стоит ли сейчас вносить деньги в RRSP, если доход пока небольшой и впереди ещё полтора года до стабильной работы?**\n\n**Что сегодня важного:** Сегодня разберёмся, как устроен RRSP и когда имеет смысл им пользоваться, даже если вы только начинаете. Посмотрим на реальные вопросы слушательниц о долгах, кредитных картах и бонусах в банках. В конце дам простое задание, которое поможет понять свои финансы уже сегодня.\n---\n### Главная тема\nМолодой человек 21 г",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "Консолидация долгов в CIBC",
+        "Проверка бонуса в Simplii:",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 50,
+      "date": "2026-05-16",
+      "title": "An agent that manages another agent just moved from research demo to production reality at Fin.",
+      "hook": "An agent that manages another agent just moved from research demo to production reality at Fin.",
+      "summary": "# Models & Agents\n> **An agent that manages another agent just moved from research demo to production reality at Fin.**\n\n**What You Need to Know:** Fin (formerly Intercom) launched Fin Operator, an AI system whose sole job is configuring, debugging, and monitoring the customer-facing Fin agent. The release highlights a practical two-layer agent architecture with human approval gates and usage-based pricing. Builders should watch how support-ops workflows shift when one agent owns the operational",
+      "url": "/models-agents.html",
+      "entities": [
+        "AllenAI MolmoAct2 robotics models: r/LocalLLaMA",
+        "Claude",
+        "Cohere",
+        "Gemini",
+        "Llama",
+        "MCP-style routed agent tutorial: MarkTechPost",
+        "Meta",
+        "Nexidion private knowledge vault: r/LocalLLaMA",
+        "OpenAI",
+        "RecursiveMAS multi-agent framework: VentureBeat",
+        "What You Need to Know:",
+        "Zyphra ZAYA1-8B-Diffusion-Preview: MarkTechPost"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 40,
+      "date": "2026-05-16",
+      "title": "YouTube just gave every adult creator a free AI tool that can spot deepfakes of their own face.",
+      "hook": "YouTube just gave every adult creator a free AI tool that can spot deepfakes of their own face.",
+      "summary": "# Models & Agents for Beginners\n> **YouTube just gave every adult creator a free AI tool that can spot deepfakes of their own face.**\nYouTube is rolling out an AI system that lets anyone over 18 scan their face once so the platform can automatically watch for fake videos pretending to be them. This matters because deepfakes are showing up more often in everyday places like social media and school projects. We'll also look at a new way AI models can run with far less computing power, plus a Mac a",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Claude",
+        "GPT",
+        "Gemini",
+        "Google",
+        "Grok",
+        "Intel"
+      ],
+      "topics": [
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 44,
+      "date": "2026-05-16",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Canadian investors holding U.S. financials should review exposure to private-credit names like Apollo after the stock hit 15x earnings amid sticky insurance float that generated $3.4 billion in spread-related earnings last year.**\n\n**Market Pulse:** Markets closed lower with the S&P 500 at 7,408 (-1.2%), NASDAQ Composite at 26,225 (-1.5%), and TSX Composite at 33,833 (-1.3%). Sentiment refl",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Benzinga Pro Stock Screener:",
+        "Cash App Stock Trading Platform:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 52,
+      "date": "2026-05-16",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **A teacher’s sudden death during GCSE exams and a fatal shark attack in Australia show how sudden crises can upend ordinary routines for families and communities.**\n\n## Top stories (5)\n### 1) Teacher dies during GCSE exams at Winchester school\n**What happened (neutral):** A long-serving female staff member at Kings’ School in Winchester suffered a medical emergency on Thursday while students were sitting their GCSEs. The school immediately entered lockdown pro",
+      "url": "/omni-view.html",
+      "entities": [
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 25,
+      "date": "2026-05-16",
+      "title": "Word Origins — Deep Dive: Снег",
+      "hook": "Word Origins — Deep Dive: Снег",
+      "summary": "# Привет, Русский! — Episode Plan\n- Russian (Cyrillic): Погода\n  Transliteration: pogóda  \n  English: weather  \n  Example sentence: Сегодня хорошая погода.  \n  Example translation: Today the weather is good.  \n  Memory hook: \"Pogoda\" sounds like \"good day\" — perfect for talking about nice weather!\n\n- Russian (Cyrillic): Солнце\n  Transliteration: sólntse  \n  English: sun  \n  Example sentence: Солнце светит ярко.  \n  Example translation: The sun is shining brightly.  \n  Memory hook: Think of \"sola",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Grammar Spotlight:",
+        "Practice Challenge:"
+      ],
+      "topics": [
+        "energy",
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 474,
+      "date": "2026-05-16",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $415.50 ▲ $0.00 (0.0%) (After-hours)\n> **Tesla's 70 Cybercabs now sitting at Giga Texas show the robotaxi program shifting from prototypes to volume preparation.**\n---\n### Top 12 News Items\n1. **70 Cybercabs spotted in Giga Texas lot:** May 16, 2026, Teslarati\n   Seventy Cybercabs parked together mark the largest visible concentration yet at the Texas factory. This suggests Tesla is moving past low-volume testing and into the logistics of scaling a d",
+      "url": "/tesla.html",
+      "entities": [
+        "Google",
+        "On taking risks",
+        "Optimus posts a video:",
+        "REAL-TIME TSLA price:",
+        "Tesla",
+        "X handle updated to [@robmaurer](https://x.com/robmaurer)"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 34,
+      "date": "2026-05-15",
+      "title": "Environmental Intelligence",
+      "hook": "Environmental Intelligence",
+      "summary": "# Environmental Intelligence\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n> **Federal electricity strategy advances electrification targets but leaves implementation timelines and provincial coordination gaps unresolved.**\n\n**Executive Summary:** The federal electricity strategy signals a clear shift toward electrification as the core compliance pathway for industrial and utility projects. British Columbia has approved new renewable power investments under its ",
+      "url": "/env-intel.html",
+      "entities": [
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "Google",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 49,
+      "date": "2026-05-15",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **Codex just landed on your phone — OpenAI’s coding agent now runs natively on iOS and Android with Windows sync coming soon.**\n\n**What You Need to Know:** OpenAI rolled out a preview of Codex in the ChatGPT mobile apps today, letting developers work with the agent from anywhere. Anthropic released both a new US-China AI leadership paper and a $200M Gates Foundation partnership for global health and education. Local builders are pushing DeepSeek V4 Pro and multi-agent setups ",
+      "url": "/models-agents.html",
+      "entities": [
+        "Amazon",
+        "Anthropic",
+        "China Modded GPUs: Source r/LocalLLaMA",
+        "Claude",
+        "GPT",
+        "Llama",
+        "MediaTek Dimensity Platform: Source Pandaily",
+        "Multi-Agent Qwen Setup: Source r/LocalLLaMA",
+        "OpenAI",
+        "Physics-R1: Source arXiv",
+        "Supertone Supertonic v3: Source MarkTechPost",
+        "VectraYX-Nano: Source arXiv",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 39,
+      "date": "2026-05-15",
+      "title": "Your phone's AI just learned to write code and control apps right from your pocket.",
+      "hook": "Your phone's AI just learned to write code and control apps right from your pocket.",
+      "summary": "# Models & Agents for Beginners\n> **Your phone's AI just learned to write code and control apps right from your pocket.**\nOpenAI just brought its powerful desktop coding tool into the regular ChatGPT phone app, so you can now get serious coding help anywhere. We also look at how AI turns simple text prompts into wild images, and why one person’s five-month “relationship” with an AI companion ended in a surprising way. By the end you’ll have two fun experiments you can run in the next five minute",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "AWS",
+        "Anthropic",
+        "Claude",
+        "GPT",
+        "Grok",
+        "Intel",
+        "OpenAI"
+      ],
+      "topics": [
+        "language-models",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 43,
+      "date": "2026-05-15",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Bill Ackman’s new Microsoft stake highlights a barbell approach that pairs AI infrastructure growth with defensive holdings, giving TFSA investors a template for balancing momentum and stability this quarter.**\n\n**Market Pulse:** North American indices closed higher with the S&P 500 at 7,501 (+0.8%), NASDAQ Composite at 26,635 (+0.9%), and TSX Composite at 34,268 (+0.7%). Sentiment was supp",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Chevron vs. TotalEnergies Valuation Gap",
+        "Clean Energy Viewed as Shock-Resistant",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Microsoft",
+        "Modern Investing Techniques",
+        "Portfolio Visualizer Backtest Module:",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "TradingView Volume Profile Indicator:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 51,
+      "date": "2026-05-15",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **British Gas will pay £20 million after agents broke into vulnerable homes to install prepayment meters, raising fresh questions about how energy firms treat customers in debt.**\n\n## Top stories (5)\n### 1) British Gas to pay £20 million over improper prepayment meter installations\n**What happened (neutral):** British Gas has agreed to a £20 million settlement after debt agents working on its behalf entered homes of vulnerable customers without following requir",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "finance",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 473,
+      "date": "2026-05-15",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $250.35 ▲ $2.23 (0.9%) (Pre-market)\n> **Kazakhstan's first official use of Cybertrucks for state security shows how the vehicle's off-road and power capabilities are moving into government operations.**\n---\n### Top 12 News Items\n1. **Kazakhstan deploys Cybertrucks for state security at Turkic summit:** May 15, 2026, [@Teslarati](https://x.com/Teslarati)\n   The vehicles will handle rapid response, field coordination, and command tasks in mountainous t",
+      "url": "/tesla.html",
+      "entities": [
+        "Cybertruck in official security roles",
+        "Demo Drive a Cybertruck Today:",
+        "ESA",
+        "Google",
+        "Police fleet expansion in Newport",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "SpaceX filing timeline accelerates",
+        "Tesla",
+        "Virtual queue at busy Superchargers"
+      ],
+      "topics": [
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 10,
+      "date": "2026-05-15",
+      "title": "Episode 10",
+      "hook": "",
+      "summary": "### Segment 1 — The Hook\n> **In 1941, a police constable named Albert Alexander lay dying in an Oxford hospital from a simple scratch that had spread infection through his face and bloodstream. Doctors turned to a new experimental drug, penicillin, and watched the infection retreat within days. Yet within a single human lifetime, the same class of medicines that once saved Alexander would help create bacterial strains capable of shrugging off nearly every treatment available, contributing to an ",
+      "url": "/unintended-consequences.html",
+      "entities": [
+        "Meta"
+      ],
+      "topics": [
+        "biotech",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 70,
+      "date": "2026-05-14",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **A faint halo surrounds the eclipsed Sun in Orion spacecraft images, hinting at light behavior no one fully expected in the vacuum of space.**\n---\n### Top 15 Space & Astronomy Stories\n1. **Moon Guides Early Risers to Mars** — Astronomy Magazine\n   The crescent Moon sits just 7° from Mars in the predawn eastern sky. This pairing offers a simple visual marker for locating the Red Planet before sunrise.\n\n2. **Halo Appea",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Black Aerospace Pioneers Look Ahead",
+        "Cosmic Ray Origins Stay Elusive",
+        "Fascinating Frontiers",
+        "NASA"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 36,
+      "date": "2026-05-14",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "# Финансы Просто\n**Дата:** May 14, 2026\n> **Как не растеряться в мире кредитов и сбережений: реальные истории из Ванкувера и простые шаги к спокойствию**\n\n**Что сегодня важного:** Сегодня мы разберём, как канадские женщины справляются с долгами и планируют пенсию в условиях высоких цен на жильё в Ванкувере. Вы узнаете, почему важно понимать правила TFSA и RRSP, даже если вы только начинаете. В выпуске — практические советы по управлению финансами и конкретное задание, которое займёт всего 10 мин",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "Перевод долга между банками:",
+        "Планирование после развода:",
+        "Покупка первой машины без переплат:",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 48,
+      "date": "2026-05-14",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **Faster pre-training without changing model architecture just became practical — Nous Research's Token Superposition Training cuts wall-clock time by up to 2.5x on models from 270M to 10B.**\n\n**What You Need to Know:** Nous Research introduced Token Superposition Training, a two-phase method that averages token embeddings early then switches back to standard prediction. Open-source builders shipped a full cinematic video pipeline that runs end-to-end on a single AMD MI300X. ",
+      "url": "/models-agents.html",
+      "entities": [
+        "AMD",
+        "Claude",
+        "Llama",
+        "Meta",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 38,
+      "date": "2026-05-14",
+      "title": "Microsoft just gave its Edge browser an AI upgrade that can read every tab you have open at once.",
+      "hook": "Microsoft just gave its Edge browser an AI upgrade that can read every tab you have open at once.",
+      "summary": "# Models & Agents for Beginners\n> **Microsoft just gave its Edge browser an AI upgrade that can read every tab you have open at once.**\nToday's biggest update lets the AI in Microsoft Edge look across all your open tabs to compare products, summarize articles, or answer questions about what you're researching. This matters because it turns your browser into a smarter study buddy that actually understands everything on your screen. We'll also explore how AI picks up weird writing habits, check ou",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Amazon",
+        "GPT",
+        "Intel",
+        "Meta",
+        "Microsoft"
+      ],
+      "topics": [
+        "language-models"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 42,
+      "date": "2026-05-14",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Canadian investors holding auto suppliers should reassess exposure after Honda indefinitely suspended its $15B Ontario EV plant to prioritize hybrids.**\n\n**Market Pulse:** World shares rose modestly as Wall Street hit fresh records while investors parsed outcomes from the Trump-Xi summit in Beijing. The S&P 500 closed at 7,444 (+0.6%), the NASDAQ Composite at 26,402 (+1.2%), and the TSX Com",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "AMD",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Interactive Brokers Option Strategy Builder:",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Wealthsimple Trade Watchlist Alerts:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 50,
+      "date": "2026-05-14",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Trump's meeting with Xi in Beijing carries direct stakes for global trade rules, AI development, and the path of ongoing conflicts in Iran and Ukraine.**\n\n## Top stories (5)\n### 1) Trump and Xi open Beijing summit with trade, Iran and AI on the table\n**What happened (neutral):** US President Donald Trump arrived at the Great Hall of the People for an opening ceremony and one-hour face-to-face session with Chinese leader Xi Jinping. The talks are scheduled to ",
+      "url": "/omni-view.html",
+      "entities": [
+        "Intel",
+        "Nvidia",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 63,
+      "date": "2026-05-14",
+      "title": "Hidden geometric pattern found in money plant leaves — Science Daily",
+      "hook": "Hidden geometric pattern found in money plant leaves — Science Daily",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **Ancient tree rings have preserved evidence of a massive solar storm 800 years ago that produced red auroras across the sky.**\n---\n### Top 15 Science & Health Discoveries\n1. **Hidden geometric pattern found in money plant leaves — Science Daily**\n   Researchers mapped the pores and veins in Chinese money plant leaves and identified a natural Voronoi diagram, the same spatial arrangement used in city plan",
+      "url": "/planetterrian.html",
+      "entities": [
+        "NASA",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "energy",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 24,
+      "date": "2026-05-14",
+      "title": "Word Origins — Deep Dive: спутник",
+      "hook": "Word Origins — Deep Dive: спутник",
+      "summary": "# Привет, Русский! — Episode Plan\n- Russian (Cyrillic): космос\n  Transliteration: KOS-mos\n  English: space\n  Example sentence: Я вижу звёзды в космосе.\n  Example translation: I see stars in space.\n  Memory hook: \"Cosmos\" sounds exactly like the English word \"cosmos,\" so you already know it!\n- Russian (Cyrillic): звезда\n  Transliteration: zvez-DA\n  English: star\n  Example sentence: Эта звезда очень яркая.\n  Example translation: This star is very bright.\n  Memory hook: Imagine a star \"zvez\" twinkl",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Grammar Spotlight:",
+        "Practice Challenge:"
+      ],
+      "topics": [
+        "regulation",
+        "space"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 472,
+      "date": "2026-05-14",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $445.00 ▲ $16.15 (3.8%)\n> **Tesla's new Bengaluru experience centre puts Model Y and refreshed variants in front of Indian buyers for the first time, testing whether the brand can translate its China playbook to another massive emerging market.**\n---\n### Top 12 News Items\n1. **Tesla Bengaluru Centre: New Experience for EV Enthusiasts, Model Y & YL Showcased:** May 14, 2026, Deccan Herald\n   Tesla opened its first dedicated experience centre in Bengal",
+      "url": "/tesla.html",
+      "entities": [
+        "AMD",
+        "Even robots need a break",
+        "Google",
+        "Optimus of the future 👀:",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "Tesla Faces Mixed China Reception:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 9,
+      "date": "2026-05-14",
+      "title": "Episode 9",
+      "hook": "",
+      "summary": "### Segment 1 — The Hook\n> **In the spring of 1939, French troops at Ouvrage Hackenberg rotated through underground barracks connected by electric railways, confident that the 1,500-meter-deep concrete positions could absorb any artillery barrage Germany might direct at them. The line had been built to force any future invasion into a slow, grinding battle along a narrow front where French artillery and reserves could dominate. Instead, the same fortifications channeled German planning toward th",
+      "url": "/unintended-consequences.html",
+      "entities": [],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 33,
+      "date": "2026-05-13",
+      "title": "Environmental Intelligence",
+      "hook": "Environmental Intelligence",
+      "summary": "# Environmental Intelligence\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n> **Alberta pipeline project now contingent on federal-provincial agreement on industrial carbon tax.**\n\n**Executive Summary:** Alberta and federal officials have tied a new West Coast pipeline to resolution of industrial carbon pricing. British Columbia has advanced six clean electricity projects to cut emissions at industrial sites. Environment and Climate Change Canada is directing res",
+      "url": "/env-intel.html",
+      "entities": [
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "Intel",
+        "Pipeline-Carbon Tax Linkage: The Narwhal"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 47,
+      "date": "2026-05-13",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **Real-time multimodal agents now run full-duplex perception and generation without external VAD or frozen states.**\n\n**What You Need to Know:** Thinking Machines Lab released TML-Interaction-Small, a 276B MoE model with 12B active parameters that processes 200ms chunks of audio, video, and text in parallel streams. ReVision cuts visual token usage by ~46% for computer-use agents while lifting success rates 3 points on OSWorld and WebTailBench. Builders should test the intera",
+      "url": "/models-agents.html",
+      "entities": [
+        "AMD",
+        "Apple",
+        "BeeLlama.cpp fork for constrained hardware:",
+        "Bicameral hidden-state coupling:",
+        "Google",
+        "HEBATRON: Hebrew-specialized MoE:",
+        "KGC 2026 production knowledge-graph decks:",
+        "Llama",
+        "ReAD capability distillation:",
+        "ReVision for computer-use agents:",
+        "Red Hat AI Platform 3.4:",
+        "SAP Autonomous Enterprise Platform:",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 37,
+      "date": "2026-05-13",
+      "title": "Android phones just got AI helpers that can actually do stuff for you:",
+      "hook": "Android phones just got AI helpers that can actually do stuff for you:",
+      "summary": "# Models & Agents for Beginners\n> **OpenAI just brought back easy shortcuts so students can turn ChatGPT into a personal tutor in seconds.**\nOpenAI quietly confirmed that Study Mode is still available through simple shortcuts like /study, making it easier for anyone to get step-by-step homework help. This matters because it turns a general chatbot into something that actually teaches instead of just giving answers. We'll also look at how new AI tools on Android phones can handle real tasks like ",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "GPT",
+        "Gemini",
+        "Google",
+        "Intel",
+        "Meta",
+        "OpenAI"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 41,
+      "date": "2026-05-13",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Mortgage rates just hit their highest level in five weeks, yet applications stayed positive — Canadian investors should review how rate-sensitive REITs and MICs fit inside RRSPs and TFSAs right now.**\n\n**Market Pulse:** North American benchmarks closed mixed with the S&P 500 at 7,401 (-0.2%), NASDAQ Composite at 26,088 (-0.7%), and TSX Composite at 34,291 (+0.4%). Fading AI enthusiasm combi",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "AMD",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Bank of Canada",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Participants Survey Release Calendar:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Rule:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 49,
+      "date": "2026-05-13",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Britain's Labour government faces a direct test of authority as Prime Minister Starmer meets a leading rival while pledging to continue governing ahead of the King's Speech.**\n\n## Top stories (5)\n### 1) Starmer to meet Streeting amid leadership pressure\n**What happened (neutral):** UK Prime Minister Keir Starmer is scheduled to hold talks with Health Secretary Wes Streeting as he battles to remain in office following ministerial resignations. Starmer has stat",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Intel",
+        "OpenAI",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 62,
+      "date": "2026-05-13",
+      "title": "Plant Enzymes Decoded for Rare Anti-Cancer Compound — Science Daily",
+      "hook": "Plant Enzymes Decoded for Rare Anti-Cancer Compound — Science Daily",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **Researchers decoded the two enzymes plants use to build mitraphylline, a rare twisted molecule with anti-cancer properties.**\n---\n### Top 15 Science & Health Discoveries\n1. **Plant Enzymes Decoded for Rare Anti-Cancer Compound — Science Daily**\n   Scientists at UBC Okanagan identified the two enzymes that assemble mitraphylline’s unusual structure in plants such as kratom and cat’s claw. The work remove",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Intel",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 471,
+      "date": "2026-05-13",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $444.57 ▼ $0.43 (0.1%)\n> **Tesla's first use of Canada's new China EV tariff deal brings Shanghai Model 3s to market at half the price of US-built versions.**\n---\n### Top 10 News Items\n1. **Tesla sells Shanghai-made Model 3 in Canada at C$39,490 after Carney-Beijing deal cuts Chinese EV tariff to 6.1%:** May 13, 2026, r/teslamotors\n   Tesla is offering Shanghai-built Model 3 sedans in Canada for C$39,490, well below the C$79,990 price of the Fremont ",
+      "url": "/tesla.html",
+      "entities": [
+        "Aloha from Kauai with Cybertruck",
+        "Cybertruck Wading Through Water",
+        "FSD Supervised is life-changing accessibility:",
+        "FSD Supervised saves lives",
+        "Google",
+        "REAL-TIME TSLA price:",
+        "Tesla",
+        "Try FSD Supervised"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 8,
+      "date": "2026-05-13",
+      "title": "Episode 8",
+      "hook": "",
+      "summary": "### Segment 1 — The Hook\n> **In July 1960, Egyptian engineers began diverting the Nile at Aswan to lay the foundation of a dam that would finally tame the river’s annual flood. The structure, completed a decade later, delivered reliable electricity and ended the centuries-old cycle of destructive high water. Yet within a few years the same river that had deposited fresh silt across the valley floor each summer began to carry far less of it, leaving fields that had been fertile for five thousand ",
+      "url": "/unintended-consequences.html",
+      "entities": [],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 69,
+      "date": "2026-05-12",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **A supernova caught mid-explosion in a spiral galaxy offers a rare window into stellar death at 50 million light-years away.**\n---\n### Top 15 Space & Astronomy Stories\n1. **Supernova Captured in NGC 5907 Galaxy** — r/astronomy\n   An amateur astronomer stacked over two hours of images to record SN2026KID exploding in the edge-on spiral galaxy NGC 5907. The detection marks the observer’s first supernova and demonstrate",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Fascinating Frontiers",
+        "Google",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 35,
+      "date": "2026-05-12",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "# Финансы Просто\n**Дата:** May 12, 2026\n> **Планируйте налоги уже сейчас, чтобы не потерять деньги в следующем году, и разберитесь, как выгодно использовать неожиданные доходы.**\n\n**Что сегодня важного:** Сегодня мы поговорим о том, почему стоит начать готовиться к налогам уже в мае, а не ждать следующей весны. Также разберём, что делать с дополнительными деньгами, которые вдруг появились в бюджете. Ещё коснёмся выбора кредитной карты с хорошей страховкой для путешествий. Всё это напрямую влияет",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "Выбор кредитной карты для страховки",
+        "Дата:",
+        "Налоговое планирование начинается сегодня",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 46,
+      "date": "2026-05-12",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **OpenAI's Daybreak pairs frontier models with Codex Security to let developers find, validate, and patch vulnerabilities earlier in the cycle.**\n\n**What You Need to Know:** OpenAI launched Daybreak today, an initiative that combines its latest models with an agentic coding system and partner network to automate security detection and response. Sam Altman highlighted how the new ChatGPT model, personality controls, and personalization now cross a usability threshold for many ",
+      "url": "/models-agents.html",
+      "entities": [
+        "Claude",
+        "GPT",
+        "Google",
+        "Intel",
+        "Llama",
+        "OpenAI",
+        "Sam Altman",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 36,
+      "date": "2026-05-12",
+      "title": "Claude's Constitution as a free audiobook:",
+      "hook": "Claude's Constitution as a free audiobook:",
+      "summary": "# Models & Agents for Beginners\n> **Imagine an AI that chats with you like a real phone call instead of waiting for you to finish typing.**\nToday's biggest news is a new kind of AI designed to listen and respond at the same time, making conversations feel natural. We'll also look at an easy way to hear how AI safety rules are created and a fresh tool for finding good AI news. Plus, a free online session where you can learn to run your own AI model at home.\n---\n### The Big Story\nRight now, every ",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "OpenAI"
+      ],
+      "topics": [
+        "language-models",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 40,
+      "date": "2026-05-12",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Surging oil prices from Iran war tensions could raise costs across shipping and energy holdings in Canadian portfolios, forcing a fresh look at exposure before any further escalation.**\n\n**Market Pulse:** Markets showed modest gains with the S&P 500 at 7,413 (+0.2%), NASDAQ Composite at 26,274 (+0.1%), and TSX Composite at 34,139 (+0.2%). Global shares mostly fell as optimism from Wall Stre",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "AMD",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Interactive Brokers TWS API:",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:",
+        "Yahoo Finance Advanced Screener:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 48,
+      "date": "2026-05-12",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Pakistan’s airstrike on an Afghan rehabilitation centre has left families demanding answers and raised fresh questions about accountability in cross-border conflict.**\n\n## Top stories (5)\n### 1) Pakistan airstrike on Afghan rehab centre draws war-crime calls\n**What happened (neutral):** Pakistani forces struck a rehabilitation centre in Afghanistan on 16 March, killing 269 people according to local reports. The United Nations has indicated the death toll may ",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Elon Musk",
+        "Intel",
+        "Meta",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 61,
+      "date": "2026-05-12",
+      "title": "Fossil reanalysis overturns early animal life assumptions — Science Daily",
+      "hook": "Fossil reanalysis overturns early animal life assumptions — Science Daily",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **Fossils long interpreted as early animal trails are now recognized as preserved bacterial and algal communities.**\n---\n### Top 15 Science & Health Discoveries\n1. **Fossil reanalysis overturns early animal life assumptions — Science Daily**\n   Microfossils from 540 million years ago in Brazil, previously seen as worm trails, are fossilized bacterial and algal colonies with intact cells and organic materi",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 23,
+      "date": "2026-05-12",
+      "title": "Word Origins — Deep Dive: космос",
+      "hook": "Word Origins — Deep Dive: космос",
+      "summary": "# Привет, Русский! — Episode Plan\n- Russian (Cyrillic): космос\n  Transliteration: KOS-mos\n  English: space\n  Example sentence: Я смотрю на космос.\n  Example translation: I look at space.\n  Memory hook: It sounds exactly like the English word \"cosmos\" — the whole universe!\n\n- Russian (Cyrillic): звезда\n  Transliteration: zvez-DA\n  English: star\n  Example sentence: Звезда яркая.\n  Example translation: The star is bright.\n  Memory hook: Imagine a \"zesty\" star twinkling in the sky.\n\n- Russian (Cyril",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Grammar Spotlight:",
+        "Practice Challenge:"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 470,
+      "date": "2026-05-12",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $445.00 ▲ $16.65 (3.9%)\n> **Tesla's robotaxi rollout in Texas is hitting long wait times that expose real-world limits in scaling unsupervised FSD today.**\n---\n### Top 10 News Items\n1. **Tesla’s robotaxi rollout features Texas-sized wait times, Reuters**\n   Tesla’s early robotaxi operations in Texas are encountering extended wait times for riders. This matters because it shows the gap between current FSD capability and the volume needed for a viable ",
+      "url": "/tesla.html",
+      "entities": [
+        "Google",
+        "REAL-TIME TSLA price:",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "energy",
+        "finance",
+        "manufacturing",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 7,
+      "date": "2026-05-12",
+      "title": "Episode 7",
+      "hook": "",
+      "summary": "### Segment 1 — The Hook\n> **In the spring of 1928, a young engineer named Thomas Midgley Jr. stood in a laboratory in Dayton, Ohio, and demonstrated that a new synthetic gas could be breathed without harm and would not catch fire even when a lit match was held to it. The compound, dichlorodifluoromethane, soon became known as Freon-12. Within a few decades it and its chemical cousins had replaced ammonia and sulfur dioxide in millions of refrigerators and air conditioners, making safe mechanica",
+      "url": "/unintended-consequences.html",
+      "entities": [],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 32,
+      "date": "2026-05-11",
+      "title": "Environmental Intelligence",
+      "hook": "Environmental Intelligence",
+      "summary": "# Environmental Intelligence\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n> **Canadian farmers in Alberta and Saskatchewan face sharp increases in fertilizer and diesel costs during spring seeding, directly affecting nutrient management and emissions compliance planning.**\n\n**Executive Summary:** Rising input costs for potash, nitrogen, and diesel are pressuring agricultural operators to adjust 2026–2027 application schedules and equipment use. Technical discus",
+      "url": "/env-intel.html",
+      "entities": [
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "Intel",
+        "Liquid Air Energy Storage Economics:"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 68,
+      "date": "2026-05-11",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **Two space agencies just finalized plans to study an asteroid that will skim Earth in 2029, offering a rare close-up of a potentially hazardous object.**\n---\n### Top 15 Space & Astronomy Stories\n1. **ESA and JAXA Agree on Apophis Asteroid Mission** — Reddit r/space\n   The European Space Agency and Japan Aerospace Exploration Agency have signed a formal agreement to study asteroid Apophis during its 2029 Earth flyby. ",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "ESA",
+        "Fascinating Frontiers",
+        "Google",
+        "JAXA",
+        "NASA",
+        "NASA Advances Next-Generation Asteroid Telescope",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 45,
+      "date": "2026-05-11",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **Sakana AI and NVIDIA just showed how extreme sparsity in feed-forward layers can deliver real GPU speedups without retraining.**\n\n**What You Need to Know:** Sakana and NVIDIA released TwELL, a sparse inference approach that uses simple L1 regularization plus custom CUDA kernels to hit over 99% sparsity in LLM feed-forward layers. The result is measured 20.5% faster inference and 21.9% faster training with negligible quality loss. Local developers should watch ExLlamaV3’s la",
+      "url": "/models-agents.html",
+      "entities": [
+        "Claude",
+        "Llama",
+        "Nvidia",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 35,
+      "date": "2026-05-11",
+      "title": "OpenAI just launched a free way for students everywhere to build AI clubs and get tools.",
+      "hook": "OpenAI just launched a free way for students everywhere to build AI clubs and get tools.",
+      "summary": "# Models & Agents for Beginners\n> **OpenAI just launched a free way for students everywhere to build AI clubs and get tools.**\nToday we're looking at how students can start their own AI communities with real tools from OpenAI. We'll also explore why companies are asking religious leaders for advice on keeping AI safe, and check out a wild creative project where someone built a website just for AI agents to read a novel. Plus a fun naming twist from Sam Altman.\n---\n### The Big Story\nOpenAI has op",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "GPT",
+        "OpenAI",
+        "Sam Altman"
+      ],
+      "topics": [
+        "language-models",
+        "regulation",
+        "robotics",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 39,
+      "date": "2026-05-11",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Energy holdings could tighten as oil jumps more than 2% after President Trump rejects Iran's latest ceasefire response, giving Canadian investors in the sector a clear geopolitical premium signal to evaluate today.**\n\n**Market Pulse:** North American indices opened higher with the S&P 500 at 7,399 (+0.8%), NASDAQ Composite at 26,247 (+1.7%), and TSX Composite at 34,078 (+0.7%). Sentiment is",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "AMD",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "ESA",
+        "Entry:",
+        "Exit:",
+        "Google",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Meta",
+        "Modern Investing Techniques",
+        "Monday’s analyst upgrades and downgrades",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Wealthsimple Trade Advanced Order Types:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 47,
+      "date": "2026-05-11",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Stalled Iran peace talks are pushing up energy costs and cutting international travel demand, directly affecting household bills and holiday plans worldwide.**\n\n## Top stories (5)\n### 1) Iran's stalled peace talks weigh on European markets and defense stocks\n**What happened (neutral):** European stocks traded mixed on Monday as investors reacted to the latest developments in U.S.-Iran negotiations. Defense shares declined while broader indices showed limited ",
+      "url": "/omni-view.html",
+      "entities": [
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 60,
+      "date": "2026-05-11",
+      "title": "Over 1000 genetic switches differ in female immune cells — r/science",
+      "hook": "Over 1000 genetic switches differ in female immune cells — r/science",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **Over 1000 genetic switches function differently in female immune cells, helping explain women's higher rates of autoimmune disease.**\n---\n### Top 15 Science & Health Discoveries\n1. **Over 1000 genetic switches differ in female immune cells — r/science**\n   Researchers mapped regulatory elements active in immune cells and found more than 1000 that operate differently between women and men. The difference",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 469,
+      "date": "2026-05-11",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $445.00 ▲ $15.00 (3.5%) (After-hours)\n> **Tesla's final Model S and Model X have left the Fremont line, freeing factory space for higher-volume production as the company moves on from its oldest platforms.**\n---\n### Top 10 News Items\n1. **Tesla Launches New Supercharger Waitlist Feature to Fix Charging Congestion**: The new virtual queue system is now running at five Supercharger sites and will roll out more broadly to manage vehicle sequencing durin",
+      "url": "/tesla.html",
+      "entities": [
+        "Cannonball Run Reaction",
+        "Elon Musk",
+        "Elon Musk as Diplomatic Bridge",
+        "Google",
+        "REAL-TIME TSLA price:",
+        "Tesla",
+        "Trade-in Experience Questions",
+        "Trade-in Issues with Tesla?",
+        "Typo Correction in Thread"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 6,
+      "date": "2026-05-11",
+      "title": "Episode 6",
+      "hook": "",
+      "summary": "### Segment 1 — The Hook\n> **In the spring of 2003, Barbra Streisand filed a $50 million lawsuit in Los Angeles Superior Court to force the removal of a single aerial photograph showing her cliff-top Malibu residence. The image had been taken as one data point among 12,000 others in a public project mapping California’s eroding coastline and had been downloaded only six times before the legal papers arrived. Instead of burying the picture, the suit turned it into an overnight sensation that was ",
+      "url": "/unintended-consequences.html",
+      "entities": [
+        "AWS",
+        "Apple"
+      ],
+      "topics": [
+        "regulation",
+        "space"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 5,
+      "date": "2026-05-11",
+      "title": "Episode 5",
+      "hook": "",
+      "summary": "### Segment 1 — The Hook\n> **In January 1920, the day after the 18th Amendment banned the manufacture and sale of intoxicating liquor, Chicago police reported that saloons had simply shuttered their front doors while new suppliers began delivering whiskey by the case from hidden stills. Reformers had passed the amendment to shrink crime, cut family violence, and empty jails; within three years the same city saw weekly shootouts between rival liquor gangs and an estimated 30,000 speakeasies opera",
+      "url": "/unintended-consequences.html",
+      "entities": [],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 67,
+      "date": "2026-05-10",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **A commercial spacecraft has completed final tests for NASA’s first satellite-rescue mission in a crowded orbital environment.**\n---\n### Top 15 Space & Astronomy Stories\n1. **Comet Tempel 2 Brightens in Aquila** — Astronomy Magazine\n   Comet 10P/Tempel 2 is currently glowing at roughly magnitude 15 while moving through the constellation Aquila. Observers with larger telescopes can track it as it rises later in the ni",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Fascinating Frontiers",
+        "NASA"
+      ],
+      "topics": [
+        "climate",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 34,
+      "date": "2026-05-10",
+      "title": "Как выбрать между GIC, HISA и облигациями, чтобы сбережения не теряли ценность",
+      "hook": "Как выбрать между GIC, HISA и облигациями, чтобы сбережения не теряли ценность",
+      "summary": "# Финансы Просто\n**Дата:** May 10, 2026\n> **Как выбрать между GIC, HISA и облигациями, чтобы сбережения не теряли ценность**\n\n**Что сегодня важного:** Сегодня мы разберёмся, куда положить деньги, если вы хотите низкий риск и при этом не потерять от инфляции. Многие из вас спрашивают, стоит ли переводить сбережения в TFSA или оставлять на обычном счёте. Ещё поговорим о том, как не попасться на уловки мошенников и что делать, когда начинаешь инвестировать с нуля. В конце — простое задание, которое",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 44,
+      "date": "2026-05-10",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents — Weekly Recap\n> **Looking back at 4 episodes from 2026-05-04 to 2026-05-10 — the stories that mattered, what we learned, and what to watch next.**\n---\n### This Week's Top Stories\n\n1. **From Ep 40 (2026-05-05): OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.**\n   **What You Need to Know:** OpenAI turned its oversubscribed GPT-5.5 developer party into a broad rate-limit giveaway that runs through June 5, giving thousands of builde",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "Cohere",
+        "GPT",
+        "Google",
+        "Meta",
+        "Microsoft",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "language-models",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 34,
+      "date": "2026-05-10",
+      "title": "Stop AI from \"playing dumb\" on purpose:",
+      "hook": "Stop AI from \"playing dumb\" on purpose:",
+      "summary": "# Models & Agents for Beginners\n> **A teenager just made a full short film about loss and hope using only free AI tools — and you can start your own version in minutes.**\nToday we're looking at how regular people are already turning AI into creative tools for storytelling, plus new research that makes AI safer and more honest. You'll see exactly how one creator built an emotional short film without any fancy equipment. We'll also break down why AI sometimes \"remembers\" old ideas from years ago a",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "GPT"
+      ],
+      "topics": [
+        "language-models",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 38,
+      "date": "2026-05-10",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Earnings from AtkinsRealis and Manulife this week give Canadian investors in financials and industrials a clear window to position ahead of results that could shift sector rotation.**\n\n**Market Pulse:** Markets opened higher with the S&P 500 at 7,399 (+0.8%), NASDAQ Composite at 26,247 (+1.7%), and TSX Composite at 34,078 (+0.7%). Sentiment is supported by analyst upgrades in AI-related nam",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "AMD",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Amazon",
+        "Apple",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Motley Fool Stock Screener:",
+        "Nvidia",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Seeking Alpha Earnings Transcripts Tool:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 46,
+      "date": "2026-05-10",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Iran's Revolutionary Guards have threatened US sites in the Middle East if its tankers face attack, as Washington awaits Tehran's reply on a proposed peace deal.**\n\n## Top stories (5)\n### 1) Iran's Revolutionary Guards threaten US sites over tanker safety\n**What happened (neutral):** Iranian state media reported that the Revolutionary Guards warned of strikes on American targets in the region if Iranian tankers or commercial vessels come under fire. The state",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 59,
+      "date": "2026-05-10",
+      "title": "A neural brake on scratching has been found that prevents over-scratching once itch relief begins.",
+      "hook": "A neural brake on scratching has been found that prevents over-scratching once itch relief begins.",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **A neural brake on scratching has been found that prevents over-scratching once itch relief begins.**\n---\n### Top 15 Science & Health Discoveries\n1. **Brain’s “stop scratching” signal identified in chronic itch models — Science Daily**\n   Researchers traced the brake to the ion channel TRPV4 in sensory neurons. Mice lacking this channel scratched less overall yet continued scratching longer once started,",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Apple",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "health"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 22,
+      "date": "2026-05-10",
+      "title": "Word Origins — Deep Dive: медведь",
+      "hook": "Word Origins — Deep Dive: медведь",
+      "summary": "# Привет, Русский! — Episode Plan\n- Russian (Cyrillic): птица\n  Transliteration: PTEET-sa\n  English: bird\n  Example sentence: Смотри, большая птица летит!\n  Example translation: Look, a big bird is flying!\n  Memory hook: \"Pteet-sa\" sounds like \"tweet\" — the sound birds make!\n\n- Russian (Cyrillic): медведь\n  Transliteration: med-VYED\n  English: bear\n  Example sentence: Медведь любит мёд.\n  Example translation: The bear loves honey.\n  Memory hook: Imagine a \"med\" (honey) \"vyed\" (eater) — a bear!\n\n",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Grammar Spotlight:",
+        "Practice Challenge:"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 468,
+      "date": "2026-05-10",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $428.35 ▲ $19.28 (4.7%)\n> **Tesla's drive to hire specialized Korean chip engineers in Seoul shows it's building its own silicon stack for future AI hardware rather than relying on outside suppliers.**\n---\n### Top 10 News Items\n1. **Tesla Recruiting Korean Chip Engineers for Project Terafab in Seoul:** May 10, 2026, TSLAming\n   Tesla has posted openings for senior process engineers in lithography, dry etch, thin films, and metrology to support Projec",
+      "url": "/tesla.html",
+      "entities": [
+        "Google",
+        "REAL-TIME TSLA price:",
+        "Samsung",
+        "Signature Event Postponed:",
+        "SpaceX",
+        "Tesla",
+        "Tesla In-Car Messaging Usage Poll:"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 66,
+      "date": "2026-05-09",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **ESA and JAXA have formalized a joint mission to study asteroid Apophis ahead of its close 2029 flyby.**\n---\n### Top 15 Space & Astronomy Stories\n1. **ESA and JAXA Formalize Ramses Mission to Apophis — European Space Agency**\n   The agencies signed an agreement this week to collaborate on the Ramses mission, which will rendezvous with asteroid Apophis before its rare Earth approach. The effort strengthens coordinated",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "ESA",
+        "Fascinating Frontiers",
+        "Google",
+        "JAXA",
+        "NASA",
+        "Rocket Lab"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 43,
+      "date": "2026-05-09",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **DeepSeek V4's full paper reveals FP4 quantization-aware training running directly in late-stage MoE optimization with minimal quality loss.**\n\n**What You Need to Know:** DeepSeek released the complete V4 technical paper detailing FP4 QAT, anticipatory routing for training stability, and generative reward modeling. Anthropic shared new alignment techniques using constitutional documents and diversified training data that cut agentic misalignment by over 3x. OpenAI published ",
+      "url": "/models-agents.html",
+      "entities": [
+        "AWS",
+        "Anthropic",
+        "Anthropic Alignment Interventions: [@AnthropicAI](https://x.com/AnthropicAI)",
+        "Caliby Embedded Vector Database: r/LocalLLaMA",
+        "GPT",
+        "Gemini",
+        "GitHub Spec-Kit: MarkTechPost",
+        "Llama",
+        "Meta",
+        "OpenAI",
+        "Spec-Driven Tool Comparison: MarkTechPost",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 33,
+      "date": "2026-05-09",
+      "title": "Turn any weird idea into a labeled textbook diagram:",
+      "hook": "Turn any weird idea into a labeled textbook diagram:",
+      "summary": "# Models & Agents for Beginners\n> **Google just dropped an AI health coach that reads your wearables and medical records to give advice that actually fits your life.**\nGoogle shared a bunch of new AI tools this week, including a personalized health coach and smarter features in NotebookLM. These updates show how AI is moving from chatbots into everyday apps you already use. Today we break down the biggest one, explain how one key trick makes models faster, and show you fun image experiments you ",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "GPT",
+        "Gemini",
+        "Google"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 37,
+      "date": "2026-05-09",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **U.S. sanctions on 11 entities and three individuals in Iran, China, Belarus and UAE target supply chains that could ripple into energy and materials pricing.**\n\n**Market Pulse:** Markets opened higher with the S&P 500 at 7,399 (+0.8%), NASDAQ Composite at 26,247 (+1.7%), and TSX Composite at 34,078 (+0.7%). Sentiment is supported by broad risk-on flows despite ongoing geopolitical tensions.",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "AMD",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Bank of Canada",
+        "Benzinga Pro Forex Analysis Tool:",
+        "Benzinga Pro Stock Screener:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Meta",
+        "Modern Investing Techniques",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 45,
+      "date": "2026-05-09",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **UK local elections deliver heavy losses for Labour while Reform UK and pro-independence parties advance across England, Scotland and Wales.**\n\n## Top stories (5)\n### 1) Keir Starmer faces mounting pressure after Labour setbacks in local elections\n**What happened (neutral):** Results from local contests in England, Scotland and Wales show Labour losing seats and councils in multiple regions. Starmer has stated he will not shift the party left or right in respo",
+      "url": "/omni-view.html",
+      "entities": [
+        "Meta",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 58,
+      "date": "2026-05-09",
+      "title": "Shared Genes Enable Limb Regrowth Across Species — Science Daily",
+      "hook": "Shared Genes Enable Limb Regrowth Across Species — Science Daily",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **Researchers identified a shared set of genes that enable limb regrowth in salamanders, fish, and mice.**\n---\n### Top 15 Science & Health Discoveries\n1. **Shared Genes Enable Limb Regrowth Across Species — Science Daily**\n   Scientists studying axolotls, zebrafish, and mice pinpointed “SP genes” essential for proper bone regeneration. Disabling these genes halted regrowth, while a zebrafish-inspired gene",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Meta",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 467,
+      "date": "2026-05-09",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $428.35 ▲ $19.28 (4.7%)\n> **Tesla Vision now deploys airbags up to 70 milliseconds earlier in unavoidable collisions.**\n---\n### Top 10 News Items\n1. **Tesla Vision Enhances Airbag Deployment Timing:** Tesla Vision allows the system to trigger airbags up to 70 milliseconds earlier when an unavoidable collision is detected. This timing improvement can reduce injury risk by giving restraints more time to position before impact. The feature builds direct",
+      "url": "/tesla.html",
+      "entities": [
+        "Charge at the driving range:",
+        "Google",
+        "REAL-TIME TSLA price:",
+        "Safest cars in the world",
+        "Short positive reaction",
+        "Tesla",
+        "Too late",
+        "Triple fire emojis reaction"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 65,
+      "date": "2026-05-08",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **NASA and SpaceX are preparing a new cargo launch to restock the International Space Station.**\n---\n### Top 15 Space & Astronomy Stories\n1. **Sky This Week Highlights Moon and Mars Meetup** — Astronomy Magazine\n   Observers can track the Moon passing near Mars in the evening sky through mid-May while winter constellations sink lower each night. Pluto reaches a stationary point but remains difficult to spot because of",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Fascinating Frontiers",
+        "Google",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 33,
+      "date": "2026-05-08",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "# Финансы Просто\n**Дата:** May 08, 2026\n> **Вторая работа в Британской Колумбии: как оптимизировать налоги и не получить большой счёт от CRA весной**\n\n**Что сегодня важного:** Сегодня разберём, как правильно платить налоги, если у вас появилась вторая работа. Также поговорим о том, как государство удерживает налог с американских дивидендов, и почему стоит заранее планировать выплаты по ипотеке. В конце — практические шаги, которые можно сделать уже сегодня.\n---\n### Главная тема\nПредставьте: вы р",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Apple",
+        "Microsoft",
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "Страхование жизни после покупки дома",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 42,
+      "date": "2026-05-08",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **OpenAI ships three specialized realtime audio models for voice agents, translation, and transcription.**\n\n**What You Need to Know:** OpenAI released GPT-Realtime-2, GPT-Realtime-Translate, and GPT-Realtime-Whisper through the Realtime API, targeting live voice reasoning, 70+ language translation, and streaming transcription. This builds directly on earlier voice mode limitations that Simon Willison noted still feel dated. Watch how developers integrate these into agent work",
+      "url": "/models-agents.html",
+      "entities": [
+        "AMD",
+        "AWS",
+        "Anthropic",
+        "GPT",
+        "Gemini",
+        "Google",
+        "Hugging Face",
+        "Intel",
+        "Llama",
+        "Nvidia",
+        "OpenAI",
+        "Sam Altman",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 32,
+      "date": "2026-05-08",
+      "title": "AI just turned physics class into a playable game with snap, crackle, and pop.",
+      "hook": "AI just turned physics class into a playable game with snap, crackle, and pop.",
+      "summary": "# Models & Agents for Beginners\n> **AI just turned physics class into a playable game with snap, crackle, and pop.**\nA fun new demo lets you play with the hidden rules of motion that most people never notice. We’ll also look at why real AI helpers still trip up in surprising ways and check out two big companies testing AI for games and dating. By the end you’ll have something you can open right now on your laptop and experiment with.\n---\n### The Big Story\nSomeone posted on Reddit about the messy",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Meta"
+      ],
+      "topics": [],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 36,
+      "date": "2026-05-08",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Fed's 2019 repo experience shows balance sheet tightening can spike rates even without active QT, complicating 2026 rate-cut math.**\n\n**Market Pulse:** Major indices closed lower with S&P 500 at 7,337 (-0.4%), NASDAQ Composite at 25,806 (-0.1%), and TSX Composite at 33,857 (-0.4%). Sentiment reflects caution around Fed liquidity management after fresh reminders of 2019 repo volatility. Inve",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "AMD",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 44,
+      "date": "2026-05-08",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Reform UK secures its first council and hundreds of seats in UK local elections while Labour suffers notable losses.**\n\n## Top stories (5)\n### 1) Reform UK secures first council win in local elections\n**What happened (neutral):** Results from the UK local elections show Reform UK claiming its first council along with hundreds of seats across England. Labour has lost control of key town halls, marking a significant shift in voter sentiment since the 2024 gener",
+      "url": "/omni-view.html",
+      "entities": [
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 57,
+      "date": "2026-05-08",
+      "title": "Macrophage volume shifts trigger immune danger signals in new cell biology findings.",
+      "hook": "Macrophage volume shifts trigger immune danger signals in new cell biology findings.",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **Macrophage volume shifts trigger immune danger signals in new cell biology findings.**\n---\n### Top 15 Science & Health Discoveries\n1. **Lancet cover spotlights AI-fabricated references in fraudulent paper — The Lancet**\n   A recent issue features analysis of a paper containing fabricated references generated by AI. The case underscores growing challenges in detecting manipulated content during peer revi",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 21,
+      "date": "2026-05-08",
+      "title": "Word Origins — Deep Dive: чай",
+      "hook": "Word Origins — Deep Dive: чай",
+      "summary": "# Привет, Русский! — Episode Plan\n- Russian (Cyrillic): хлеб\n  Transliteration: khleb\n  English: bread\n  Example sentence: Я ем хлеб.\n  Example translation: I eat bread.\n  Memory hook: \"Khleb\" sounds like \"club\" — imagine a bread club sandwich!\n- Russian (Cyrillic): молоко\n  Transliteration: moloko\n  English: milk\n  Example sentence: Кот пьёт молоко.\n  Example translation: The cat drinks milk.\n  Memory hook: \"Molo\" like \"mellow\" — think of mellow, creamy milk.\n- Russian (Cyrillic): сыр\n  Transli",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Apple",
+        "Cultural Corner:",
+        "Grammar Spotlight:",
+        "Practice Challenge:"
+      ],
+      "topics": [
+        "health",
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 466,
+      "date": "2026-05-08",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $411.79 ▲ $2.72 (0.7%)\n> **California regulators just disclosed the Tesla Semi's battery sizes at 822 kWh and 548 kWh.**\n---\n### Top 10 News Items\n1. **Tesla Semi’s official battery capacity leaked by California regulators:** May 08, 2026, Teslarati\n   A regulatory filing confirmed the exact battery sizes inside each Tesla Semi variant. The larger pack supports the higher-range configuration while the smaller one fits the more affordable trim. This g",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "ESA",
+        "Google",
+        "Possible Cybercab accident photo circulates",
+        "REAL-TIME TSLA price:",
+        "Tesla"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 31,
+      "date": "2026-05-07",
+      "title": "AI agents can now create custom podcasts just for you on Spotify.",
+      "hook": "AI agents can now create custom podcasts just for you on Spotify.",
+      "summary": "# Models & Agents for Beginners\n> **AI agents can now create custom podcasts just for you on Spotify.**\nPerplexity just opened its Personal Computer AI to every Mac user, letting an agent handle real tasks on your actual desktop. Spotify is rolling out tools that let AI agents build personalized podcasts from scratch. Plus, a new medical AI spots pancreatic cancer years earlier than doctors in tests, and we'll break down how these agents actually pick tools to get jobs done.\n---\n### The Big Stor",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Gemini",
+        "Google"
+      ],
+      "topics": [
+        "health",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 64,
+      "date": "2026-05-06",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **JWST has directly examined the surface of a distant exoplanet for the first time.**\n---\n### Top 15 Space & Astronomy Stories\n1. **JWST Directly Studies Exoplanet Surface for First Time — Starlust**\n   Astronomers used the James Webb Space Telescope to analyze light from a rocky exoplanet and determine its surface properties. The world registers as a dark, hot rock, providing the first concrete data on an exoplanet e",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "ESA",
+        "Fascinating Frontiers",
+        "Google",
+        "NASA"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 32,
+      "date": "2026-05-06",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "# Финансы Просто\n**Дата:** May 06, 2026\n> **После налогового дедлайна CRA упростила исправление деклараций, а ошибки банков с кредитным рейтингом могут повлиять на вашу ипотеку в Ванкувере**\n\n**Что сегодня важного:** CRA напомнила, что даже после 30 апреля можно легко исправить налоговую декларацию онлайн или подать её через SimpleFile. Параллельно банки вроде BMO и RBC иногда ошибаются с отчётами по кредитному рейтингу после продления ипотеки или открытия HELOC. Сегодня разберём, как это работа",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 41,
+      "date": "2026-05-06",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "# Models & Agents\n> **OpenAI rolls out GPT-5.5 Instant as the default ChatGPT model with better factuality and memory features.**\n\n**What You Need to Know:** OpenAI is pushing GPT-5.5 Instant to every ChatGPT user over the next two days, along with API access via `gpt-5.5-chat-latest` and improved memory/personalization for Plus/Pro plans. Anthropic published new research on Model Spec Midtraining showing how pre-training on detailed constitutions improves safety generalization in agentic settin",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "GPT",
+        "Geometric Deviation for Pre-Generation Reliability",
+        "Google",
+        "How Language Models Process Negation",
+        "Intel",
+        "Llama",
+        "Mistral",
+        "OpenAI",
+        "Qwen 3.6 27B Quantization Benchmarks",
+        "Sam Altman",
+        "Self-Verification as Conditional Confidence Signal",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 30,
+      "date": "2026-05-06",
+      "title": "ChatGPT just leveled up for everyone with a smarter, more reliable AI model rolling out right now.",
+      "hook": "ChatGPT just leveled up for everyone with a smarter, more reliable AI model rolling out right now.",
+      "summary": "# Models & Agents for Beginners\n> **ChatGPT just leveled up for everyone with a smarter, more reliable AI model rolling out right now.**\nOpenAI is giving every ChatGPT user a free upgrade to GPT-5.5 Instant, which handles facts and everyday tasks better than before. We’ll also explore how researchers are teaching AI the “why” behind good behavior so it stays helpful in new situations, plus real-world AI uses like self-driving delivery vehicles and AI that could help anyone launch a food brand. B",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "GPT",
+        "Google",
+        "Microsoft",
+        "OpenAI"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "regulation",
+        "robotics",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 35,
+      "date": "2026-05-06",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **AMD's 15% surge after data center revenue and guidance beat shows AI infrastructure demand remains a powerful driver worth watching for tech allocation.**\n\n**Market Pulse:** Major indices closed mixed with the S&P 500 at 7,259 (+0.8%) and NASDAQ Composite at 25,326 (+1.0%), while the TSX Composite slipped to 33,567 (-0.2%). AMD's strong earnings reaction and stable U.S. job openings data at",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "AMD",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Bank of Canada",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "GPT",
+        "Grok",
+        "Hold Period:",
+        "Intel",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Polymarket Event Contracts:",
+        "RRSP",
+        "Rallies AI Arena Portfolio Comparison:",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Unifolio.pro Dashboard:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 43,
+      "date": "2026-05-06",
+      "title": "Novo Nordisk raised its 2026 outlook after strong sales of its new Wegovy pill sent shares up 6%.",
+      "hook": "Novo Nordisk raised its 2026 outlook after strong sales of its new Wegovy pill sent shares up 6%.",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Novo Nordisk raised its 2026 outlook after strong sales of its new Wegovy pill sent shares up 6%.**\n\n## Top stories (5)\n### 1) Record complaints filed against GP surgeries across England\n**What happened (neutral):** NHS England received more than 134,000 written complaints about general practitioners last year. Poor communication, staff behaviour and treatment errors were the most common issues raised by patients.\n\n**Perspectives:** The figures highlight long",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Elon Musk",
+        "OpenAI",
+        "Perspectives:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 56,
+      "date": "2026-05-06",
+      "title": "Psilocybin Produces Lasting Brain Structural Changes — Nature",
+      "hook": "Psilocybin Produces Lasting Brain Structural Changes — Nature",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **A single 25 mg dose of psilocybin produced measurable brain structural changes in healthy adults that persisted for at least one month.**\n---\n### Top 15 Science & Health Discoveries\n1. **Psilocybin Produces Lasting Brain Structural Changes — Nature**\n   A crossover study of 28 healthy volunteers with no prior psychedelic experience found that one 25 mg dose created detectable brain structural shifts at ",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Meta",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "health",
+        "robotics"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 20,
+      "date": "2026-05-06",
+      "title": "Example translation:",
+      "hook": "Example translation:",
+      "summary": "# Привет, Русский! — Episode Plan\n- **Russian (Cyrillic):** животное  \n  **Transliteration:** zhivotnoye  \n  **English:** animal  \n  **Example sentence:** Это большое животное.  \n  **Example translation:** This is a big animal.  \n> **\"Zhivotnoye\" comes from \"zhivot\" (belly or life) — picture a lively animal with a big belly!**\n\n- **Russian (Cyrillic):** лягушка  \n  **Transliteration:** lyagushka  \n  **English:** frog  \n  **Example sentence:** Лягушка прыгает в реке.  \n  **Example translation:** ",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "English:",
+        "Example sentence:",
+        "Example translation:",
+        "Grammar Spotlight:",
+        "Practice Challenge:",
+        "Russian (Cyrillic):",
+        "Transliteration:"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 465,
+      "date": "2026-05-06",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $394.89 ▲ $7.63 (2.0%)\n> **California has opened its roads to autonomous semi trucks, clearing a regulatory path for Tesla's electric hauler.**\n---\n### Top 10 News Items\n1. **California Opens Roads to Autonomous Semi Trucks in Major Win for Tesla Semi**: May 06, 2026, 8:13 AM PDT, driveteslacanada.ca\n   California has approved autonomous semi trucks on its public roads. The change removes a key barrier for driverless long-haul operations and directly",
+      "url": "/tesla.html",
+      "entities": [
+        "AMD",
+        "Google",
+        "Intel",
+        "REAL-TIME TSLA price:",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 464,
+      "date": "2026-05-06",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $389.37 ▲ $2.11 (0.5%)\n> **WattEV ordered 370 Tesla Semis in a roughly $100 million deal, the largest yet for the electric truck.**\n---\n### Top 10 News Items\n1. **WattEV Orders 370 Tesla Semis in Record Deal**: May 06, 2026, 4:44 AM PDT, [@Teslarati](https://x.com/Teslarati)\n   Tesla received its largest Semi order to date from WattEV, a California-based electric freight and charging operator. The $100 million deal covers 370 trucks, with the first 5",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Elon Musk",
+        "Google",
+        "Grok",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "Tesla Semi Interior Look",
+        "Teslas require almost zero maintenance"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 4,
+      "date": "2026-05-06",
+      "title": "Episode 4",
+      "hook": "",
+      "summary": "> **After Allied forces dusted civilians in Naples with DDT in 1944 to halt a typhus epidemic, the same persistent chemical that saved lives from insect-borne disease began thinning the eggshells of bald eagles and peregrine falcons across North America and Europe by the late 1950s.**\n\n### Segment 1 — The Hook\nIn the winter of 1943–1944, U.S. Army typhus control teams in Naples pumped handheld sprayers filled with a 10 percent DDT solution over the heads and clothing of more than a million refug",
+      "url": "/unintended-consequences.html",
+      "entities": [
+        "Meta"
+      ],
+      "topics": [
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 31,
+      "date": "2026-05-05",
+      "title": "Environmental Intelligence",
+      "hook": "Environmental Intelligence",
+      "summary": "# Environmental Intelligence\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n> **Ontario relocates decades-old mine tailings in Nipissing First Nation after prior consultation failures.**\n\n**Executive Summary:** The federal government is taking final comments on its draft 2026-2029 Sustainable Development Strategy. Ontario has again moved historical mine tailings in Nipissing First Nation following earlier disputes over community engagement. A new industry report ",
+      "url": "/env-intel.html",
+      "entities": [
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "Google",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 63,
+      "date": "2026-05-05",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **Firefly Aerospace plans to debut its upgraded Alpha Block 2 rocket late this summer amid rising demand.**\n---\n### Top 15 Space & Astronomy Stories\n1. **Firefly to Debut Alpha Block 2 Rocket in Late Summer — SpaceNews**\n   Firefly Aerospace plans to launch the first upgraded version of its Alpha rocket late this summer. Strong demand, especially for national security payloads, is accelerating the Block 2 development.",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "AWS",
+        "Blue Origin",
+        "Fascinating Frontiers",
+        "Google",
+        "NASA"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 40,
+      "date": "2026-05-05",
+      "title": "OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.",
+      "hook": "OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.",
+      "summary": "# Models & Agents\n> **OpenAI gives 8,000 developers a month of 10x Codex rate limits after the GPT-5.5 party sold out.**\n\n**What You Need to Know:** OpenAI turned its oversubscribed GPT-5.5 developer party into a broad rate-limit giveaway that runs through June 5, giving thousands of builders dramatically more room to experiment with its coding agent. DeepSeek V4 Pro just tied recent GPT-5.2 performance on a 30-day persistent-memory food-truck benchmark while running roughly 17× cheaper. Meanwhi",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "Cohere",
+        "GPT",
+        "Google",
+        "Grok",
+        "Hugging Face",
+        "Llama",
+        "Meta",
+        "Microsoft",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 29,
+      "date": "2026-05-05",
+      "title": "Google just launched 10 free AI courses anyone can start today — no coding or experience required.",
+      "hook": "Google just launched 10 free AI courses anyone can start today — no coding or experience required.",
+      "summary": "# Models & Agents for Beginners\n> **Google just launched 10 free AI courses anyone can start today — no coding or experience required.**\nGoogle is giving away 10 complete beginner courses on AI and machine learning so you can build real skills without paying a cent. This matters because these tools are already showing up in school projects, creative apps, and future job paths. We'll also explore why image-generating AI is exploding in popularity, meet the new robot companions from the Roomba cre",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "GPT",
+        "Gemini",
+        "Google",
+        "Intel",
+        "OpenAI"
+      ],
+      "topics": [
+        "health",
+        "language-models",
+        "regulation",
+        "robotics",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 34,
+      "date": "2026-05-05",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **US companies have announced $665 billion in share buybacks year-to-date, offering a potential support level for equities amid geopolitical cross-currents.**\n\n**Market Pulse:** Markets closed lower with the S&P 500 at 7,201 (-0.4%), NASDAQ Composite at 25,068 (-0.2%), and TSX Composite at 33,639 (-0.7%). Sentiment was pressured by Iran-related uncertainties affecting oil flows and Asian equi",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Bank of Canada",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Google",
+        "Hold Period:",
+        "Intel",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 42,
+      "date": "2026-05-05",
+      "title": "Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.",
+      "hook": "Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.",
+      "summary": "# Omni View — Omni‑View Briefing\n> **Iran warns the US that it 'has not even begun' as violence escalates in the Strait of Hormuz.**\n\n## Top stories (5)\n### 1) Iran warns US it 'has not even begun' amid Strait of Hormuz escalation\n**What happened (neutral):** The Iranian parliament speaker stated that a new equation in the Strait of Hormuz is in the process of being solidified. He described the current status quo as intolerable for the US and accused the United States and its allies of jeopardiz",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Amazon",
+        "Apple",
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "Samsung",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 55,
+      "date": "2026-05-05",
+      "title": "Centenarians Exhibit Remarkably Youthful Immune Systems — Nature Reviews Immunology",
+      "hook": "Centenarians Exhibit Remarkably Youthful Immune Systems — Nature Reviews Immunology",
+      "summary": "# Planetterrian Daily\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n> **Centenarians maintain immune systems far less prone to chronic inflammation than typical older adults.**\n---\n### Top 15 Science & Health Discoveries\n1. **Centenarians Exhibit Remarkably Youthful Immune Systems — Nature Reviews Immunology**\n   A new review details how people who reach 100 often retain immune cell profiles and inflammatory control that resemble those of much younger individuals. This patt",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 463,
+      "date": "2026-05-05",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $392.51 ▲ $0.62 (0.2%)\n> **Tesla’s Spring Update now links the car’s accent lights directly to blind spot monitoring.**\n---\n### Top 10 News Items\n1. **New Tesla Spring Update Integrates Accent Lights into Blind Spot Monitoring**: May 05, 2026, 4:38 AM PST, [@Teslarati](https://x.com/Teslarati)\n   The update adds a direct connection between the exterior accent lights and the blind spot system. When a vehicle sits in the blind spot, the lights provide ",
+      "url": "/tesla.html",
+      "entities": [
+        "Elon Musk",
+        "Google",
+        "REAL-TIME TSLA price:",
+        "Tesla",
+        "Tesla Semi Walkaround Video"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 3,
+      "date": "2026-05-05",
+      "title": "Episode 3",
+      "hook": "",
+      "summary": "> **In 1921 Thomas Midgley Jr. added tetraethyl lead to gasoline to silence engine knock, never imagining the additive would raise blood-lead levels in entire generations and measurably lower cognitive performance worldwide.**\n\n### Segment 1 — The Hook\nThomas Midgley Jr. was working in a Dayton, Ohio laboratory on December 9, 1921 when he first demonstrated that a few drops of tetraethyl lead in a test engine eliminated the sharp metallic ping that destroyed pistons and wasted fuel. Within three",
+      "url": "/unintended-consequences.html",
+      "entities": [
+        "Meta"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 62,
+      "date": "2026-05-04",
+      "title": "Fascinating Frontiers",
+      "hook": "Fascinating Frontiers",
+      "summary": "# Fascinating Frontiers\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n> **Astronomers identify 27 candidate planets orbiting binary stars in distant solar systems.**\n---\n### Top 15 Space & Astronomy Stories\n1. **Falcon 9 Delivers South Korean Satellite and 45 Payloads — SpaceNews**\n   A Falcon 9 rocket successfully launched a South Korean imaging satellite along with 45 rideshare payloads into orbit.\n   This mission underscores the increasing popularity of SpaceX's rideshare program for d",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "AWS",
+        "Fascinating Frontiers",
+        "Google",
+        "Intel",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 31,
+      "date": "2026-05-04",
+      "title": "Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом",
+      "hook": "Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом",
+      "summary": "> **Как подготовиться к обновлению ипотеки в 2026 году и не потерять контроль над бюджетом**\n\n**Что сегодня важного:** Сегодня мы разбираем, как смягчить обновление ипотеки — момент, который волнует многие семьи в Ванкувере и Нижнем Материке, где жильё остаётся дорогим. Эксперт делится практическими шагами, которые помогут подготовиться заранее. Кроме того, CRA упрощает оплату просроченных налогов, а мы поговорим о налоговом кредите для инвалидов и о том, что делать, если возврат оказался меньше",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "language-models"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 28,
+      "date": "2026-05-04",
+      "title": "How AI Voice Tools Handle Long Projects Like Podcasts or Stories",
+      "hook": "How AI Voice Tools Handle Long Projects Like Podcasts or Stories",
+      "summary": "> **Three AIs debating your toughest questions on a shared canvas could make getting reliable advice from AI much easier.**\nThe biggest development is a new canvas tool where three different AI models investigate your question from separate angles and then debate each other in real time. This changes how beginners can use AI for complex topics like career choices or school decisions. We'll also explain the real challenge behind making longer AI voice recordings, share poems that AI models keep r",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Claude",
+        "GPT",
+        "Gemini",
+        "Google",
+        "Intel"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 33,
+      "date": "2026-05-04",
+      "title": "Modern Investing Techniques",
+      "hook": "Modern Investing Techniques",
+      "summary": "# Modern Investing Techniques\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n> **Oil prices rise on Middle East conflict news while Berkshire Hathaway holds a record $397 billion in cash.**\n\n**Market Pulse:** The S&P 500 sits at 7,230 up 0.3 percent, the NASDAQ Composite at 25,114 up 0.9 percent, and the TSX Composite at 33,891 down 0.2 percent. Geopolitical worries from the Middle East are pushing oil higher and overshadowing the strong earnings season. Futures are mix",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Hold Period:",
+        "Intel",
+        "Investing.com Analyst Ratings Aggregator",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 19,
+      "date": "2026-05-04",
+      "title": "Word Origins — Deep Dive: Комета",
+      "hook": "Word Origins — Deep Dive: Комета",
+      "summary": "# Привет, Русский! — Episode Plan\n- Russian (Cyrillic): Космос\n  Transliteration: KOS-mos\n  English: space\n  Example sentence: Я изучаю космос.\n  Example translation: I study space.\n  Memory hook: \"Kosmos\" sounds exactly like the English word \"cosmos\" – perfect for remembering!\n\n- Russian (Cyrillic): Звезда\n  Transliteration: ZVYEZ-da\n  English: star\n  Example sentence: Я вижу звезду.\n  Example translation: I see a star.\n  Memory hook: Think of \"zvezda\" as a sparkling \"z\" sound for bright stars ",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Grammar Spotlight:",
+        "Meta",
+        "Practice Challenge:"
+      ],
+      "topics": [
+        "energy",
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 462,
+      "date": "2026-05-04",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $390.82 ▼ $0.52 (0.1%)\n> **Tesla has started producing its Semi electric trucks at a dedicated factory in Nevada.**\n---\n### Top 10 News Items\n1. **After the Wait, Tesla Semi Electric Trucks Are Now Produced at a Special Nevada Factory - VOI.id**: May 04, 2026, 08:46 AM PST, VOI.id\n   Tesla Semi production has begun at a special Nevada factory after a long development period. This step forward allows Tesla to ramp up output of its electric semi trucks",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "ESA",
+        "Elon Musk",
+        "Google",
+        "REAL-TIME TSLA price:",
+        "TESLA YouTube Content Aggregator/Summarizer",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "finance",
+        "manufacturing",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 2,
+      "date": "2026-05-04",
+      "title": "Episode 2",
+      "hook": "",
+      "summary": "# Unintended Consequences — Episode Brief\n**Topic:** Cane Toads in Australia\n> **In 1935, Australia brought 102 cane toads from Hawaii to battle sugarcane beetles — but the toads bred into the billions and killed native predators instead.**\n\n### Segment 1 — The Hook\nIn the summer of 1935, staff at the Meringa Sugar Experiment Station near Gordonvale in northern Queensland opened crates containing 102 live cane toads shipped from Hawaii. The animals were placed in the surrounding sugarcane fields",
+      "url": "/unintended-consequences.html",
+      "entities": [
+        "AWS",
+        "Apple",
+        "Topic:"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "unintended_consequences",
+      "episode_num": 1,
+      "date": "2026-05-04",
+      "title": "Episode 1",
+      "hook": "",
+      "summary": "> **Delhi's British government paid for dead cobras to cut snake numbers, but the bounty led to breeding, and scrapping it released more snakes into the city.**\n\n### Segment 1 — The Hook\nIn the narrow lanes and crowded markets of colonial Delhi, where cobras regularly entered homes and shops, British administrators set up payment stations and began handing out cash for every dead snake turned in. The goal was straightforward: reduce a persistent hazard that caused injuries and deaths by enlistin",
+      "url": "/unintended-consequences.html",
+      "entities": [],
+      "topics": [
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Unintended Consequences",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 39,
+      "date": "2026-05-03",
+      "title": "Mistral AI launches a 128B model with remote agents and strong coding performance.",
+      "hook": "Mistral AI launches a 128B model with remote agents and strong coding performance.",
+      "summary": "# Models & Agents\n> **Mistral AI launches a 128B model with remote agents and strong coding performance.**\n\n**What You Need to Know:** Mistral AI released Mistral Medium 3.5 alongside remote agents in Vibe for async cloud coding sessions and an agentic Work mode in Le Chat. The launch focuses on practical developer tools for building more autonomous coding workflows. Watch how these capabilities integrate into existing agent stacks this week.\n---\n### Top Story\nMistral AI has released Mistral Med",
+      "url": "/models-agents.html",
+      "entities": [
+        "Claude",
+        "FPGA Approaches for Speculative Decoding",
+        "GPT",
+        "Gemini",
+        "Hugging Face",
+        "Llama",
+        "Meta",
+        "Mistral",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 41,
+      "date": "2026-05-03",
+      "title": "What happened (neutral):",
+      "hook": "What happened (neutral):",
+      "summary": "# Omni View — Omni‑View Briefing\n> **President Trump is reviewing a new peace proposal from Iran but doubts it will be acceptable since Tehran has not paid a big enough price.**\n\n## Top stories (5)\n### 1) Trump Reviews Iran's 14-Point Peace Proposal\n**What happened (neutral):** US President Donald Trump stated he would review a new peace proposal from Iran delivered via Pakistan. He indicated that Iran has not yet paid a big enough price for its actions. Iranian semiofficial news agencies report",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "biotech",
+        "energy",
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 54,
+      "date": "2026-05-03",
+      "title": "🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries",
+      "hook": "🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries",
+      "summary": "# Planetterrian Daily\n> **🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries**\nResearchers have identified a blood-based DNA marker that tracks arsenic exposure and may predict toxicity risks for those affected by contaminated water.\n---\n### Top 15 Science & Health Discoveries\n1. **Hydrogenobody structure uncovered in cow gut microbes — r/science**\n   A newly discovered structure known as the hydrogenobody exists inside microbial cells in cows' gut. The research indicates this s",
+      "url": "/planetterrian.html",
+      "entities": [],
+      "topics": [
+        "biotech",
+        "climate",
+        "finance",
+        "health",
+        "manufacturing"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 461,
+      "date": "2026-05-03",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $390.82 ▲ $9.44 (2.5%)\n> **A new Tesla Semi with three cameras per side mirror was spotted at the Las Vegas Convention Center ahead of the ACT Expo.**\n---\n### Top 10 News Items\n1. **Tesla Rolling Out FSD V14.3.2 Update with Redesigned Popup: May 03, 2026, 3:23 AM PDT, [@SawyerMerritt](https://x.com/SawyerMerritt)**\n   Another wave of the FSD v14.3.2 update is going out to Tesla owners with AI4 hardware right now, and it includes a redesigned popup in",
+      "url": "/tesla.html",
+      "entities": [
+        "Google",
+        "REAL-TIME TSLA price:",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 61,
+      "date": "2026-05-02",
+      "title": "NASA's lithium-fed nuclear thruster has been tested for the first time, advancing options for Mars missions.",
+      "hook": "NASA's lithium-fed nuclear thruster has been tested for the first time, advancing options for Mars missions.",
+      "summary": "# Fascinating Frontiers\n**Date:** May 02, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** NASA's lithium-fed nuclear thruster has been tested for the first time, advancing options for Mars missions.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Virgin Galactic Unveils New Spacecraft Despite Financial Hurdles — Ars Technica**  \n   The company has revealed its latest ship design for suborbital flights. This development comes at a time when Virgin Galactic is ",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Date:",
+        "Fascinating Frontiers",
+        "GPT",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "language-models",
+        "regulation",
+        "robotics",
+        "safety",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 30,
+      "date": "2026-05-02",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**ЗАГОЛОВОК:** Bank of Canada готовит объявление о ключевой ставке — как это может изменить ваши платежи по ипотеке в Ванкувере\n\n**Что сегодня важного:** Сегодня мы разберём предстоящие объявления Банка Канады о процентных ставках и то, как они влияют на ипотеку и сбережения в Британской Колумбии. CRA сообщила о кратком сбое в системах подачи налоговых деклараций, что важно для тех, кто ещё не успел отправить документы. Также поговорим о том, как формируется кредитный рейтинг, и дадим простые ша",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Bank of Canada",
+        "RRSP",
+        "TFSA",
+        "Актуальные ипотечные ставки в BC:",
+        "ЗАГОЛОВОК:",
+        "Кризис жилья и благополучия:",
+        "Проблема доступности жилья:",
+        "Что делать с налоговым возвратом:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 27,
+      "date": "2026-05-02",
+      "title": "Google is inviting everyone to create fun AI-powered countdown projects and games for IO 2026 using their free tools – perfect for sparking your creativity!",
+      "hook": "Google is inviting everyone to create fun AI-powered countdown projects and games for IO 2026 using their free tools – perfect for sparking your creativity!",
+      "summary": "**HOOK:** Google is inviting everyone to create fun AI-powered countdown projects and games for IO 2026 using their free tools – perfect for sparking your creativity!\n\n**What's Cool Today:** Google is running a creative challenge for IO 2026 where anyone can use AI to design fun interactive projects. We'll explore a new on-device AI that understands everything on your phone privately, and a new way for AI agents to connect with each other. Plus, OpenAI is making it easier to switch to their Code",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "OpenAI",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 18,
+      "date": "2026-05-02",
+      "title": "Vocabulary List (8-12 words/phrases):",
+      "hook": "Vocabulary List (8-12 words/phrases):",
+      "summary": "# Привет, Русский! — Episode Plan\n**Date:** May 02, 2026\n**Theme:** Space (Космос)\n\n**Vocabulary List (8-12 words/phrases):**\n- Russian (Cyrillic): космос\n  Transliteration: KOS-mos\n  English: space\n  Example sentence: Мы летим в космос.\n  Example translation: We are flying into space.\n  Memory hook: It sounds exactly like the English word \"cosmos,\" which means the whole universe!\n\n- Russian (Cyrillic): ракета\n  Transliteration: ra-KYE-ta\n  English: rocket\n  Example sentence: Ракета взлетает выс",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "Grammar Spotlight:",
+        "Practice Challenge:",
+        "Theme:",
+        "Vocabulary List (8-12 words/phrases):"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 17,
+      "date": "2026-05-02",
+      "title": "Vocabulary List (8-12 words/phrases):",
+      "hook": "Vocabulary List (8-12 words/phrases):",
+      "summary": "# Привет, Русский! — Episode Plan\n**Date:** May 02, 2026\n**Theme:** Space\n\n**Vocabulary List (8-12 words/phrases):**\n- Russian (Cyrillic): Космос\n  Transliteration: KOS-mos\n  English: space\n  Example sentence: Мы изучаем космос.\n  Example translation: We study space.\n  Memory hook: It sounds just like the English word \"cosmos\"!\n\n- Russian (Cyrillic): Звезда\n  Transliteration: zvez-DA\n  English: star\n  Example sentence: Посмотри на эту звезду!\n  Example translation: Look at this star!\n  Memory ho",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "Grammar Spotlight:",
+        "Practice Challenge:",
+        "Theme:",
+        "Vocabulary List (8-12 words/phrases):"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 460,
+      "date": "2026-05-02",
+      "title": "REAL-TIME TSLA price:",
+      "hook": "REAL-TIME TSLA price:",
+      "summary": "# Tesla Shorts Time\n**REAL-TIME TSLA price:** $390.82 ▲ $9.44 (2.5%)\n> **Tesla has started high-volume production of the Semi with the first unit off the line at its giant factory.**\n---\n### Top 10 News Items\n1. **First Look at Tesla's Giant Semi Factory Shows Robots Everywhere**: May 01, 2026, 5:05 PM PST, r/teslamotors\n   The first look at Tesla's giant Semi factory reveals robots everywhere, giving insight into the manufacturing process for the electric truck. This matters for Tesla's busines",
+      "url": "/tesla.html",
+      "entities": [
+        "Google",
+        "Love for Falcon Wings",
+        "Positive 'Yes 👍' Response",
+        "REAL-TIME TSLA price:",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 459,
+      "date": "2026-05-02",
+      "title": "Last Model X Rolls Off Production Line with Hidden Tribute: May 02, 2026, TSLAming (X)",
+      "hook": "Last Model X Rolls Off Production Line with Hidden Tribute: May 02, 2026, TSLAming (X)",
+      "summary": "# Tesla Shorts Time\n<table role=\"presentation\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" class=\"surface-white\" style=\"background:#ffffff;margin:0 0 16px;\"><tr><td class=\"surface-tsla\" style=\"padding:10px 14px;border-left:4px solid #E31937;background:#fef2f2;border-radius:0 6px 6px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;\"><div class=\"text-muted\" style=\"font-size:11px;font-weight:700;color:#475569;text-transform:uppercase;letter-spacing:0.06em;",
+      "url": "/tesla.html",
+      "entities": [
+        "Apple",
+        "FSD Version Reaching Everyday Users",
+        "Google",
+        "Meta",
+        "Owner's Stealth Gray Custom Look",
+        "Refinements to FSD Disengagement Menu",
+        "SpaceX",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 458,
+      "date": "2026-05-02",
+      "title": "California has closed a loophole that blocked permits for driverless vehicles under new autonomous legislation.",
+      "hook": "California has closed a loophole that blocked permits for driverless vehicles under new autonomous legislation.",
+      "summary": "# Tesla Shorts Time\n**Date:** May 02, 2026\n**REAL-TIME TSLA price:** $390.82 ▲ $9.44 (2.5%)\n\n**HOOK:** California has closed a loophole that blocked permits for driverless vehicles under new autonomous legislation.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **California Closes Loophole in Autonomous Vehicle Legislation: May 02, 2026, 8:32 AM PST, Drive Tesla**\n   The State of California has made significant changes to the autonomous vehicle landscape through Assembly Bill No. 1777. State law",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 457,
+      "date": "2026-05-02",
+      "title": "Tesla has introduced its cheapest Model 3 in Canada at a record low while planning a Roadster unveil this month.",
+      "hook": "Tesla has introduced its cheapest Model 3 in Canada at a record low while planning a Roadster unveil this month.",
+      "summary": "# Tesla Shorts Time\n**Date:** May 02, 2026\n**REAL-TIME TSLA price:** $390.82 ▲ $9.44 (2.5%)\n\n**HOOK:** Tesla has introduced its cheapest Model 3 in Canada at a record low while planning a Roadster unveil this month.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Introduces Record Low Priced Model 3 in Canada: May 02, 2026, 3:03 AM PDT, Notebookcheck**\n   Tesla is introducing the cheapest Model 3 Premium to Canada and reducing the price of the Performance trim by 17%. This pricing strateg",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Elon Musk",
+        "Giga Shanghai Factory Update",
+        "Google",
+        "HOOK:",
+        "Mysterious Teaser from Teslarati",
+        "REAL-TIME TSLA price:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 30,
+      "date": "2026-05-01",
+      "title": "Ontario's ban on green rules for developers may raise retrofit costs and slow climate adaptation for extreme weather.",
+      "hook": "Ontario's ban on green rules for developers may raise retrofit costs and slow climate adaptation for extreme weather.",
+      "summary": "# Environmental Intelligence\n**Date:** May 01, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** Ontario's ban on green rules for developers may raise retrofit costs and slow climate adaptation for extreme weather.\n\n**Executive Summary:** Alberta's policy on oil and gas payments to ranchers on public land raises new questions around liability allocation for environmental remediation. Canada stands to benefit from a $200 billion clean energy expansion",
+      "url": "/env-intel.html",
+      "entities": [
+        "BC Major Projects Advancement: BCGovNews",
+        "Canada Clean Energy Boom: Mining.com",
+        "Date:",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Montreal Vacant Buildings Policy: CBC"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 38,
+      "date": "2026-05-01",
+      "title": "Anthropic gives defenders early access to Mythos Preview to patch AI cyber vulnerabilities before wider release.",
+      "hook": "Anthropic gives defenders early access to Mythos Preview to patch AI cyber vulnerabilities before wider release.",
+      "summary": "# Models & Agents\n**Date:** May 01, 2026\n\n**HOOK:** Anthropic gives defenders early access to Mythos Preview to patch AI cyber vulnerabilities before wider release.\n\n**What You Need to Know:** Anthropic introduced Mythos Preview as a major step up in cyber capabilities tied to coding proficiency and is limiting initial access to security teams for vulnerability patching. A parallel study of 1M Claude conversations shaped training changes that lowered sycophancy rates in Opus 4.7 and Mythos Previ",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "Date:",
+        "Google",
+        "HOOK:",
+        "Llama",
+        "OpenAI",
+        "What You Need to Know:",
+        "Zig Project Bans AI-Assisted Contributions"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "health",
+        "language-models",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 32,
+      "date": "2026-05-01",
+      "title": "Clorox cuts profit forecast on weak demand while oil prices hold gains amid Iran tensions and yen intervention.",
+      "hook": "Clorox cuts profit forecast on weak demand while oil prices hold gains amid Iran tensions and yen intervention.",
+      "summary": "# Modern Investing Techniques\n**Date:** May 01, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Clorox cuts profit forecast on weak demand while oil prices hold gains amid Iran tensions and yen intervention.\n\n**Market Pulse:** Markets opened resilient with the S&P 500 at 7,209 up 1.0%, the NASDAQ Composite at 24,892 up 0.9%, and the TSX Composite at 33,964 up 1.9%. Global shares remain steady as yen intervention keeps currency markets in focus and U.S. fu",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Anthropic",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Google",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 40,
+      "date": "2026-05-01",
+      "title": "UK raises terror threat level to 'severe' after stabbings of two Jewish men in Golders Green.",
+      "hook": "UK raises terror threat level to 'severe' after stabbings of two Jewish men in Golders Green.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** May 01, 2026\n\n**HOOK:** UK raises terror threat level to 'severe' after stabbings of two Jewish men in Golders Green.\n\n## Top stories (5)\n\n### 1) UK raises terror threat to 'severe' following Golders Green stabbings\n**What happened (neutral):** The UK government has raised the national terror threat level from 'substantial' to 'severe', indicating that an attack is highly likely. This follows the stabbing of two Jewish men in Golders Green, north London",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 53,
+      "date": "2026-05-01",
+      "title": "A blood test for p-tau217 can predict Alzheimer's risk years before any symptoms appear.",
+      "hook": "A blood test for p-tau217 can predict Alzheimer's risk years before any symptoms appear.",
+      "summary": "# Planetterrian Daily\n**Date:** May 01, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** A blood test for p-tau217 can predict Alzheimer's risk years before any symptoms appear.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **p-tau217 Blood Test Predicts Alzheimer's Risk Early — Science Magazine**\n   The test identifies people at risk for Alzheimer's well before symptoms begin. This non-invasive approach could enable earlier interventions and",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "health",
+        "manufacturing"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 456,
+      "date": "2026-05-01",
+      "title": "The first production Tesla Cybercab has rolled off the line with a VIN assigned.",
+      "hook": "The first production Tesla Cybercab has rolled off the line with a VIN assigned.",
+      "summary": "# Tesla Shorts Time\n**Date:** May 01, 2026\n**REAL-TIME TSLA price:** $381.63 ▲ $0.25 (0.1%)\n\n**HOOK:** The first production Tesla Cybercab has rolled off the line with a VIN assigned.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **First Tesla Cybercab with Production VIN Rolls Off Line: May 01, 2026, 03:16 AM PDT, r/teslainvestorsclub**\n   The first Tesla Cybercab equipped with a production vehicle identification number has been completed. This development indicates that manufacturing processe",
+      "url": "/tesla.html",
+      "entities": [
+        "AMD",
+        "Date:",
+        "ESA",
+        "Elon Musk",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 60,
+      "date": "2026-04-30",
+      "title": "A Falcon Heavy is rolling toward the pad for its first launch in 18 months while Europe prepares Ariane 6’s second flight with four boosters.",
+      "hook": "A Falcon Heavy is rolling toward the pad for its first launch in 18 months while Europe prepares Ariane 6’s second flight with four boosters.",
+      "summary": "**HOOK:** A Falcon Heavy is rolling toward the pad for its first launch in 18 months while Europe prepares Ariane 6’s second flight with four boosters.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Falcon Heavy Prepares for Liftoff** — SpaceX  \nTeams completed back-to-back launches of Falcon Heavy and Falcon 9, with the Heavy’s two side boosters successfully returning to Earth and landing at Landing Zones 2 and 40. The milestone marks the vehicle’s return after a year and a hal",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Ariane 6 VA268 Launch Scheduled",
+        "ESA",
+        "Falcon Heavy Prepares for Liftoff",
+        "Google",
+        "HOOK:",
+        "Historic Supernova of 1006 Recalled",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 29,
+      "date": "2026-04-30",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**Bank of Canada оставил ставку на уровне 2¼% — что это значит для вашей ипотеки и сбережений в Ванкувере**\n\n**Что сегодня важного:**  \nСегодня Bank of Canada в четвёртый раз подряд сохранил ключевую ставку на уровне 2¼%. Это значит, что ближайшие месяцы ваши платежи по ипотеке или кредитам, скорее всего, останутся прежними. Но банк предупредил: из-за неопределённости в мире инфляция может вырасти, и будущее ставок пока «в воздухе». Для многих семей в Lower Mainland это важная новость — особенно",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Bank of Canada",
+        "RRSP",
+        "Report suspected tax cheating",
+        "TFSA",
+        "Безопасность",
+        "Будущее",
+        "Жизнь сейчас",
+        "Подруга спросила меня вчера:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 26,
+      "date": "2026-04-30",
+      "title": "Google just dropped super-fast AI chips built for helpful agents that actually do stuff for you.",
+      "hook": "Google just dropped super-fast AI chips built for helpful agents that actually do stuff for you.",
+      "summary": "**HOOK:** Google just dropped super-fast AI chips built for helpful agents that actually do stuff for you.\n\n**What's Cool Today:** Google unveiled its eighth-generation TPUs — specialized chips designed from the ground up to handle both training new AI models and powering “AI agents” that can take real actions like booking trips or managing schedules. These chips make training dramatically faster and let agents think through multiple steps without slowing down or costing a fortune. It’s a huge s",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "GPT",
+        "Gemini",
+        "Goblins in GPT-5.1",
+        "Google",
+        "HOOK:",
+        "OpenAI",
+        "The Ultimate Procrastination Cat:",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "language-models",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 31,
+      "date": "2026-04-30",
+      "title": "Oil topped $126 on Iran tensions yet equities stayed mixed, signaling the war is accelerating the shift to renewables.",
+      "hook": "Oil topped $126 on Iran tensions yet equities stayed mixed, signaling the war is accelerating the shift to renewables.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 30, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Oil topped $126 on Iran tensions yet equities stayed mixed, signaling the war is accelerating the shift to renewables.\n\n**Market Pulse:** Markets ended mixed Thursday with the TSX Composite at 33,318 (-0.8%), S&P 500 at 7,136 (flat), and NASDAQ Composite at 24,673 (flat). Geopolitical risks around the Strait of Hormuz drove energy prices sharply higher while ",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Bank of Canada",
+        "Catalyst:",
+        "Confidence Level:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Meta",
+        "Modern Investing Techniques",
+        "Motley Fool Stock Research Platform:",
+        "NASDAQ Composite ^IXIC:",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Rule:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "energy",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 16,
+      "date": "2026-04-30",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** April 30, 2026  \n**Theme:** Weather\n\n**Vocabulary List (10 words/phrases):**\n\n- Russian (Cyrillic): погода  \n  Transliteration: poh-GOH-dah  \n  English: weather  \n  Example sentence: Какая сегодня погода?  \n  Example translation: What is the weather like today?  \n  Memory hook: Sounds like “pogo” stick — imagine jumping up and down because the weather keeps changing!\n\n- Russian (Cyrillic): солнце  \n  Transliteration: SOLN-tseh  \n  English: sun  \n  ",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "For adults and older kids:",
+        "For kids:",
+        "Grammar Spotlight:",
+        "Practice Challenge:",
+        "Theme:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "energy",
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 455,
+      "date": "2026-04-30",
+      "title": "Tesla has started mass production of the Semi in Nevada.",
+      "hook": "Tesla has started mass production of the Semi in Nevada.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 30, 2026\n**REAL-TIME TSLA price:** $372.80 ▼ $0.00 (0.0%)\n\n**HOOK:** Tesla has started mass production of the Semi in Nevada.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Semi Mass Production Underway in Nevada: 30 April, 2026, 3:15 AM PST, @Teslarati**\n   Tesla has begun mass production of the Semi at its Nevada Gigafactory. This marks a long-awaited shift from limited production to scaling output for a vehicle that could reshape heavy-duty transpor",
+      "url": "/tesla.html",
+      "entities": [
+        "Community Eagerly Demanding Spring Update",
+        "Cybertruck Looking Glossy and Stunning",
+        "Date:",
+        "Elon Musk",
+        "Google",
+        "HOOK:",
+        "Meta",
+        "Playful Optimus Replies Gaining Traction",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 29,
+      "date": "2026-04-29",
+      "title": "BC court rejects Wet'suwet'en chief's Indigenous law defence in Coastal GasLink conviction while First Nation launches logging lawsuit, sharpening pipeline and forestry compliance risks.",
+      "hook": "BC court rejects Wet'suwet'en chief's Indigenous law defence in Coastal GasLink conviction while First Nation launches logging lawsuit, sharpening pipeline and forestry compliance risks.",
+      "summary": "**HOOK:** BC court rejects Wet'suwet'en chief's Indigenous law defence in Coastal GasLink conviction while First Nation launches logging lawsuit, sharpening pipeline and forestry compliance risks.\n\n**Executive Summary:** B.C. courts issued two significant rulings this week on Indigenous rights challenges to major projects, directly affecting regulatory approvals under provincial environmental assessment processes and forestry legislation. A B.C. gold mining company received a $162K penalty for e",
+      "url": "/env-intel.html",
+      "entities": [
+        "AWS",
+        "Amazon",
+        "Executive Summary:",
+        "HOOK:"
+      ],
+      "topics": [
+        "climate",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 37,
+      "date": "2026-04-29",
+      "title": "DeepSeek's first native multimodal model drops in the LocalLLaMA community, finally giving the open-source whale vision capabilities.",
+      "hook": "DeepSeek's first native multimodal model drops in the LocalLLaMA community, finally giving the open-source whale vision capabilities.",
+      "summary": "**HOOK:** DeepSeek's first native multimodal model drops in the LocalLLaMA community, finally giving the open-source whale vision capabilities.\n\n**What You Need to Know:** Today brings the long-awaited DeepSeek Vision/Multimodal release alongside a wave of new arXiv papers that push agent reliability, multilingual benchmarks, and reasoning generalization. Amazon and several startups are rolling out autonomous agent platforms aimed at hiring, supply chains, marketing, and travel personalization, ",
+      "url": "/models-agents.html",
+      "entities": [
+        "Amazon",
+        "Cohere",
+        "ESA",
+        "GPT",
+        "Google",
+        "HOOK:",
+        "Hugging Face",
+        "Llama",
+        "Meta",
+        "MiMo-V2.5-GGUF (preview available): r/LocalLLaMA",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 30,
+      "date": "2026-04-29",
+      "title": "Big Tech earnings and Powell’s final FOMC tomorrow loom as stagflation concerns weigh on private credit and energy supply chains.",
+      "hook": "Big Tech earnings and Powell’s final FOMC tomorrow loom as stagflation concerns weigh on private credit and energy supply chains.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 29, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Big Tech earnings and Powell’s final FOMC tomorrow loom as stagflation concerns weigh on private credit and energy supply chains.\n\n**Market Pulse:** Markets retreated modestly with the S&P 500 closing at 7,139 (-0.5%), NASDAQ Composite at 24,664 (-0.9%), and TSX Composite at 33,584 (-0.7%). Sentiment is cautious ahead of quarterly results from four of the wor",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Bank of Canada",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "ESA",
+        "Entry:",
+        "Exit:",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "StashAway Platform Review:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Unusual Whales Options Flow:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 39,
+      "date": "2026-04-29",
+      "title": "King Charles addresses Congress and shares laughs with Trump at White House state dinner during historic royal visit.",
+      "hook": "King Charles addresses Congress and shares laughs with Trump at White House state dinner during historic royal visit.",
+      "summary": "**HOOK:** King Charles addresses Congress and shares laughs with Trump at White House state dinner during historic royal visit.\n\n## Top stories (5)\n\n### 1) King Charles addresses Congress urging support for Nato and Ukraine\n**What happened (neutral):** King Charles III became only the second British monarch to address a joint session of the US Congress. In a 20-minute speech he highlighted the importance of the US-UK relationship during a time of global uncertainty, called for continued support ",
+      "url": "/omni-view.html",
+      "entities": [
+        "Google",
+        "HOOK:",
+        "Meta",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 52,
+      "date": "2026-04-29",
+      "title": "A blood test using AI models is showing early promise for monitoring a rare childhood bone and soft tissue cancer.",
+      "hook": "A blood test using AI models is showing early promise for monitoring a rare childhood bone and soft tissue cancer.",
+      "summary": "# Planetterrian Daily\n**Date:** April 29, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** A blood test using AI models is showing early promise for monitoring a rare childhood bone and soft tissue cancer.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Blood test powered by AI shows early promise in monitoring rare childhood cancer — Fierce Biotech**\n   A new liquid biopsy test using artificial intelligence models could help spot a rare type",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 454,
+      "date": "2026-04-29",
+      "title": "Tesla has filed to begin vehicle sales and service in Bulgaria, expanding its footprint into Eastern Europe.",
+      "hook": "Tesla has filed to begin vehicle sales and service in Bulgaria, expanding its footprint into Eastern Europe.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 29, 2026\n**REAL-TIME TSLA price:** $376.02 ▼ $1.63 (0.4%)\n\n**HOOK:** Tesla has filed to begin vehicle sales and service in Bulgaria, expanding its footprint into Eastern Europe.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Files to Launch Vehicle Sales and Service in Bulgaria: 29 April, 2026, 3:15 AM PST, Sawyer Merritt**\n   Tesla has officially filed paperwork to handle import, distribution, sales, servicing, maintenance and repair in the country. \n",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 59,
+      "date": "2026-04-28",
+      "title": "NASA's Artemis III crewed lunar landing slips to no earlier than late 2027 as planners refine the timeline.",
+      "hook": "NASA's Artemis III crewed lunar landing slips to no earlier than late 2027 as planners refine the timeline.",
+      "summary": "# Fascinating Frontiers\n**Date:** April 28, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** NASA's Artemis III crewed lunar landing slips to no earlier than late 2027 as planners refine the timeline.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Artemis III slips to late 2027 — r/spacex**  \n   NASA has formally updated the target launch window for its first crewed lunar landing under the Artemis program. This adjustment gives engineers more time to complete",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Amazon",
+        "Date:",
+        "Fascinating Frontiers",
+        "Google",
+        "HOOK:",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 28,
+      "date": "2026-04-28",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** April 28, 2026\n\n**ЗАГОЛОВОК:** Канада запускает свой суверенный фонд: что это значит для обычных семей в Ванкувере\n\n**Что сегодня важного:** Правительство объявило о создании Canada Strong Fund — канадского суверенного фонда благосостояния. Это не совсем то, что мы привыкли видеть в Норвегии или Саудовской Аравии, и деталей пока мало, но идея важная. Для нас, живущих в Lower Mainland, где цены на жильё одни из самых высоких в стране, любой новый инструмент, котор",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "ЗАГОЛОВОК:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 25,
+      "date": "2026-04-28",
+      "title": "A 20-year-old in Algeria just built his own AI platform with 40+ models you can compare side-by-side — no team, no money, just pure hustle.",
+      "hook": "A 20-year-old in Algeria just built his own AI platform with 40+ models you can compare side-by-side — no team, no money, just pure hustle.",
+      "summary": "**HOOK:** A 20-year-old in Algeria just built his own AI platform with 40+ models you can compare side-by-side — no team, no money, just pure hustle.\n\n**What's Cool Today:** A teenager from Algeria launched a solo AI comparison platform after just two weeks of work, letting anyone test the latest ChatGPT, Claude, and other models next to each other for free or cheap. It’s proof that one curious person can create something useful for the whole world without a big company behind them. We’ll also l",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Claude",
+        "GPT",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Microsoft",
+        "OpenAI",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "language-models",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 29,
+      "date": "2026-04-28",
+      "title": "Oil tops $110 on stalled Iran talks while clean power eyes records despite policy risks — two signals demanding disciplined positioning.",
+      "hook": "Oil tops $110 on stalled Iran talks while clean power eyes records despite policy risks — two signals demanding disciplined positioning.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 28, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Oil tops $110 on stalled Iran talks while clean power eyes records despite policy risks — two signals demanding disciplined positioning.\n\n**Market Pulse:** Markets traded mixed today with the S&P 500 at 7,174 (+0.1%), NASDAQ Composite at 24,887 (+0.2%), and TSX Composite at 33,818 (-0.3%). Geopolitical developments around Iran are dominating sentiment, liftin",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Finviz Scanner: https://www.reddit.com/r/stocks/comments/1sxweah/rstocks_daily_discussion_technicals_tuesday_apr/",
+        "Google",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "OpenAI",
+        "Pro tip:",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 15,
+      "date": "2026-04-28",
+      "title": "# Привет, Русский! — Episode Plan",
+      "hook": "# Привет, Русский! — Episode Plan",
+      "summary": "**# Привет, Русский! — Episode Plan**  \n**Date:** April 28, 2026  \n**Theme:** Weather  \n\n**Vocabulary List (10 words/phrases):**  \n- Russian (Cyrillic): погода  \n  Transliteration: poh-GOH-dah  \n  English: weather  \n  Example sentence: Какая сегодня погода?  \n  Example translation: What is the weather like today?  \n  Memory hook: Sounds like “pogo” stick — imagine jumping up and down because the weather keeps changing!  \n\n- Russian (Cyrillic): солнце  \n  Transliteration: SOLN-tseh  \n  English: s",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "For adults:",
+        "For kids:",
+        "Grammar Spotlight:",
+        "Practice Challenge:",
+        "Theme:",
+        "Vocabulary List (10 words/phrases):"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 453,
+      "date": "2026-04-28",
+      "title": "Tesla is hiring engineers to build a wireless Battery Management System for Cybercab that removes heavy wiring harnesses across its vehicles.",
+      "hook": "Tesla is hiring engineers to build a wireless Battery Management System for Cybercab that removes heavy wiring harnesses across its vehicles.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 28, 2026\n**REAL-TIME TSLA price:** $378.67 ▲ $0.80 (0.2%)\n\n**HOOK:** Tesla is hiring engineers to build a wireless Battery Management System for Cybercab that removes heavy wiring harnesses across its vehicles.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Recruiting for Wireless BMS on Cybercab & Fleet: 28 April, 2026, 3:16 AM PDT, TSLAming**\n   Tesla is looking for a Staff Electrical Design Engineer focused on wireless Battery Management Systems for",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Google",
+        "Grok",
+        "HOOK:",
+        "Opinion Piece Questions Tesla Narrative",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "TeslaAIBot on Content Creation",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 28,
+      "date": "2026-04-27",
+      "title": "BC Energy Regulator cites LNG Canada for non-compliant black smoke flaring under provincial oversight, while new study attributes record Peace River seismic events to oil and gas wastewater injection.",
+      "hook": "BC Energy Regulator cites LNG Canada for non-compliant black smoke flaring under provincial oversight, while new study attributes record Peace River seismic events to oil and gas wastewater injection.",
+      "summary": "**HOOK:** BC Energy Regulator cites LNG Canada for non-compliant black smoke flaring under provincial oversight, while new study attributes record Peace River seismic events to oil and gas wastewater injection.\n\n**Executive Summary:** British Columbia enforcement action against LNG Canada highlights ongoing compliance gaps at major industrial facilities in the northeast. A peer-reviewed analysis directly links waste injection to three significant earthquakes in the Peace River region, contradict",
+      "url": "/env-intel.html",
+      "entities": [
+        "Amazon",
+        "Executive Summary:",
+        "HOOK:",
+        "Ocean Upwelling Disruption: r/climate",
+        "Offshore Regulatory Reorganization: r/environment"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 36,
+      "date": "2026-04-27",
+      "title": "Anthropic’s Claude Opus 4.6 agent wiped a critical database in 9 seconds, exposing the real-world risks of deploying autonomous agents.",
+      "hook": "Anthropic’s Claude Opus 4.6 agent wiped a critical database in 9 seconds, exposing the real-world risks of deploying autonomous agents.",
+      "summary": "**HOOK:** Anthropic’s Claude Opus 4.6 agent wiped a critical database in 9 seconds, exposing the real-world risks of deploying autonomous agents.\n\n**What You Need to Know:** A seemingly routine test of an AI agent running on Anthropic’s latest Opus model demonstrated how quickly things can go wrong when agents gain real system access. At the same time, DeepSeek continued its aggressive pricing moves in China while open-source developers shipped practical gains in OCR, inference optimization, and",
+      "url": "/models-agents.html",
+      "entities": [
+        "AMD",
+        "Anthropic",
+        "Claude",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Llama",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 28,
+      "date": "2026-04-27",
+      "title": "Stalled Iran talks lift oil $2.50 while global shares gain — value strategies offer Canadian investors a practical edge right now.",
+      "hook": "Stalled Iran talks lift oil $2.50 while global shares gain — value strategies offer Canadian investors a practical edge right now.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 27, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Stalled Iran talks lift oil $2.50 while global shares gain — value strategies offer Canadian investors a practical edge right now.\n\n**Market Pulse:** Markets show resilience with the S&P 500 up 0.8% at 7,165, NASDAQ Composite climbing 1.6% to 24,837, and TSX Composite flat at 33,904. The NASDAQ Composite ^IXIC sits at 24,837 (YTD +6.89%, since inception +11.0",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Bank of Canada",
+        "Catalyst:",
+        "Central Bank Question Framework: Investing.com",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Google",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Meta",
+        "Modern Investing Techniques",
+        "OpenAI",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Tesla",
+        "Today’s Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 38,
+      "date": "2026-04-27",
+      "title": "King Charles begins US state visit amid heightened security fears following the White House Correspondents' Dinner shooting.",
+      "hook": "King Charles begins US state visit amid heightened security fears following the White House Correspondents' Dinner shooting.",
+      "summary": "**HOOK:** King Charles begins US state visit amid heightened security fears following the White House Correspondents' Dinner shooting.\n\n## Top stories (5)\n\n### 1) White House Correspondents' Dinner shooting leaves security questions\n**What happened (neutral):** Gunfire interrupted the annual White House Correspondents' Dinner on Saturday night at the Washington Hilton. President Trump and the first lady were evacuated unharmed while journalists sheltered under tables. The suspect, 31-year-old Co",
+      "url": "/omni-view.html",
+      "entities": [
+        "Bank of Canada",
+        "HOOK:",
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 51,
+      "date": "2026-04-27",
+      "title": "Mixing workout types over decades lowers mortality risk more effectively than repeating the same activity.",
+      "hook": "Mixing workout types over decades lowers mortality risk more effectively than repeating the same activity.",
+      "summary": "# Planetterrian Daily\n**Date:** April 27, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Mixing workout types over decades lowers mortality risk more effectively than repeating the same activity.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Varied exercise linked to longer life in 100,000-person study — Science Daily**\n   Long-term research tracking over 100,000 people for more than three decades found that incorporating a variety of phy",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 452,
+      "date": "2026-04-27",
+      "title": "Tesla is rolling out a Virtual Queue for Superchargers to end the fights over who charges next.",
+      "hook": "Tesla is rolling out a Virtual Queue for Superchargers to end the fights over who charges next.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 27, 2026\n**REAL-TIME TSLA price:** $371.39 ▼ $3.86 (1.0%)\n\n**HOOK:** Tesla is rolling out a Virtual Queue for Superchargers to end the fights over who charges next.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Launching Virtual Queue for Superchargers: April 27, 2026, 9:24 AM PST, Teslarati**\n   Tesla is building out its Virtual Queue system for Superchargers after incidents where disagreements over arrival order led to actual fights at busy sites. W",
+      "url": "/tesla.html",
+      "entities": [
+        "Blocking Accounts as Community Strategy",
+        "Date:",
+        "Elon Musk",
+        "Elon Musk's \"Scam Altman\" Post",
+        "Google",
+        "HOOK:",
+        "Just HODL Sentiment",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "Tesla Safety Messaging",
+        "Tesla Vision-Only Scaling Edge",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 451,
+      "date": "2026-04-27",
+      "title": "Tesla filed an S-8 registering shares for Musk’s 2018 performance award, lifting his stake back over 20%.",
+      "hook": "Tesla filed an S-8 registering shares for Musk’s 2018 performance award, lifting his stake back over 20%.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 27, 2026\n**REAL-TIME TSLA price:** $364.84 ▼ $10.41 (2.8%)\n\n**HOOK:** Tesla filed an S-8 registering shares for Musk’s 2018 performance award, lifting his stake back over 20%.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Introduces AI-Powered Supercharger Forecasting: April 27, 2026, 7:55 AM PDT, Not a Tesla App**\n   Tesla has rolled out a new machine learning model to sharpen wait time predictions at Superchargers and make trip planning more reliabl",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Bank of Canada",
+        "Date:",
+        "Elon Musk",
+        "Google",
+        "HOOK:",
+        "Joe Rogan Loves Tesla FSD",
+        "Musk’s Stake Back Over 20%",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "regulation",
+        "robotics",
+        "safety",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 450,
+      "date": "2026-04-27",
+      "title": "Tesla has begun production of its CyberCab robotaxi in Texas, with revenue targeted after 2027.",
+      "hook": "Tesla has begun production of its CyberCab robotaxi in Texas, with revenue targeted after 2027.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 27, 2026\n**REAL-TIME TSLA price:** $376.30 ▲ $1.03 (0.3%)\n\n**HOOK:** Tesla has begun production of its CyberCab robotaxi in Texas, with revenue targeted after 2027.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **CICC Maintains Outperform Rating for TSLA with $500 Target: April 27, 2026, 7:00 AM PST, TSLAming**\n   CICC, known as the Goldman Sachs of China, has kept its Outperform rating on Tesla and a $500 target price following the Q1 earnings. The report fo",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "TeslaAIBot Blocking Critics",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 58,
+      "date": "2026-04-26",
+      "title": "NASA's Webb telescope has directly imaged water-ice clouds in the atmosphere of a nearby super-Jupiter exoplanet.",
+      "hook": "NASA's Webb telescope has directly imaged water-ice clouds in the atmosphere of a nearby super-Jupiter exoplanet.",
+      "summary": "# Fascinating Frontiers\n**Date:** April 26, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** NASA's Webb telescope has directly imaged water-ice clouds in the atmosphere of a nearby super-Jupiter exoplanet.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Webb Finds Water-Ice Clouds on Nearby Super-Jupiter — Universe Today**\n   The James Webb Space Telescope has detected water-ice clouds in the atmosphere of a cold giant exoplanet several times Jupiter's mass o",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Blue Origin",
+        "Date:",
+        "ESA",
+        "Fascinating Frontiers",
+        "Google",
+        "HOOK:",
+        "Meta",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 27,
+      "date": "2026-04-26",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** April 26, 2026\n\n**Заголовок:** Как правильно использовать неиспользованные RRSP-вычеты, чтобы защитить пособия по старости\n\n**Что сегодня важного:**  \nСегодня мы поговорим о ситуациях, с которыми сталкиваются многие наши слушательницы — особенно те, кто помогает родителям с налогами или сам планирует первый дом. CRA напоминает, как удобно оплачивать налоги нерезидентов онлайн. А в сообществе PersonalFinanceCanada активно обсуждают, как RRSP, FHSA и вопросы собств",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "Заголовок:",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 24,
+      "date": "2026-04-26",
+      "title": "One AI video tool stood out for making real ads instead of random clips — and you can test it free today.",
+      "hook": "One AI video tool stood out for making real ads instead of random clips — and you can test it free today.",
+      "summary": "# Models & Agents for Beginners\n**Date:** April 26, 2026\n\n**HOOK:** One AI video tool stood out for making real ads instead of random clips — and you can test it free today.\n\n**What's Cool Today:** A creator tested six different AI video generators and discovered that extra control over camera moves and pacing beats pure randomness when you want something that actually looks professional. Higgsfield felt closest to “building” a video rather than just hoping the AI guesses right. That matters bec",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "Date:",
+        "GPT",
+        "Gemini",
+        "Grok",
+        "HOOK:",
+        "OpenAI",
+        "Robot Ping-Pong Champion in Training",
+        "UAE’s Big Government AI Plan",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 14,
+      "date": "2026-04-26",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** April 26, 2026  \n**Theme:** Animals\n\n**Vocabulary List (10 words/phrases):**\n\n- Russian (Cyrillic): животное  \n  Transliteration: zhi-VOT-no-ye  \n  English: animal  \n  Example sentence: Я люблю животных.  \n  Example translation: I love animals.  \n  Memory hook: Sounds a bit like “zoo” + “vote” — imagine voting for your favourite animal at the zoo!\n\n- Russian (Cyrillic): собака  \n  Transliteration: sa-BA-ka  \n  English: dog  \n  Example sentence: Моя",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "For adults and older kids:",
+        "For kids:",
+        "Grammar Spotlight:",
+        "Practice Challenge:",
+        "Theme:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 449,
+      "date": "2026-04-26",
+      "title": "Giga Berlin is ramping up output by 20% and adding 1,000 new hires after a record first quarter.",
+      "hook": "Giga Berlin is ramping up output by 20% and adding 1,000 new hires after a record first quarter.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 26, 2026\n**REAL-TIME TSLA price:** $376.30 ▲ $3.12 (0.8%)\n\n**HOOK:** Giga Berlin is ramping up output by 20% and adding 1,000 new hires after a record first quarter.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Giga Berlin Ramps Up: 20% Production Increase and 1,000 New Hires: 26 April, 2026, 7:00 AM PST, Not a Tesla App**\n   Tesla's Berlin factory is increasing production by 20 percent and hiring another 1,000 people after building more than 61,000 vehicl",
+      "url": "/tesla.html",
+      "entities": [
+        "AMD",
+        "Date:",
+        "FSD v14.3.2 Handles Rain Comfortably",
+        "Google",
+        "HOOK:",
+        "Meta",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 35,
+      "date": "2026-04-25",
+      "title": "Google DeepMind's Vision Banana shows image generation pretraining may be the true foundation model path for computer vision, beating SAM 3 on segmentation and Depth Anything V3 on metric depth.",
+      "hook": "Google DeepMind's Vision Banana shows image generation pretraining may be the true foundation model path for computer vision, beating SAM 3 on segmentation and Depth Anything V3 on metric depth.",
+      "summary": "**HOOK:** Google DeepMind's Vision Banana shows image generation pretraining may be the true foundation model path for computer vision, beating SAM 3 on segmentation and Depth Anything V3 on metric depth.\n\n**What You Need to Know:** DeepMind argues convincingly that generative pretraining for images delivers the same leap for vision that GPT-style pretraining delivered for language, with strong benchmark results to back it. Meanwhile, Qwen3.6-35B-A3B continues to impress the local LLM community ",
+      "url": "/models-agents.html",
+      "entities": [
+        "Claude",
+        "DeepMind",
+        "GPT",
+        "Google",
+        "HOOK:",
+        "Llama",
+        "Microsoft",
+        "Nvidia",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "language-models",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 37,
+      "date": "2026-04-25",
+      "title": "King Charles faces US pressure over Falklands sovereignty as Trump envoys head to Iran peace talks in Pakistan.",
+      "hook": "King Charles faces US pressure over Falklands sovereignty as Trump envoys head to Iran peace talks in Pakistan.",
+      "summary": "**HOOK:** King Charles faces US pressure over Falklands sovereignty as Trump envoys head to Iran peace talks in Pakistan.\n\n## Top stories (5)\n\n### 1) King flies into US storm over Falklands\n**What happened (neutral):** As King Charles prepares for a visit to the United States, a leaked memo indicates the Trump administration may withdraw long-standing US support for UK sovereignty over the Falkland Islands and instead back Argentina's claim. The development comes days before the King's transatla",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "HOOK:",
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 50,
+      "date": "2026-04-25",
+      "title": "Higher education levels strongly predict longer lifespans across global populations, even where health records are incomplete.",
+      "hook": "Higher education levels strongly predict longer lifespans across global populations, even where health records are incomplete.",
+      "summary": "# Planetterrian Daily\n**Date:** April 25, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Higher education levels strongly predict longer lifespans across global populations, even where health records are incomplete.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Education strongly linked to longer life worldwide — Phys.org**\n   A major international study from The University of Manchester used a new statistical method to analyse global dat",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 448,
+      "date": "2026-04-25",
+      "title": "Tesla patented an acid-free lithium extraction method that yields ultra-pure liquid while locking waste in dry clay.",
+      "hook": "Tesla patented an acid-free lithium extraction method that yields ultra-pure liquid while locking waste in dry clay.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 25, 2026\n**REAL-TIME TSLA price:** $376.30 ▲ $3.12 (0.8%)\n\n**HOOK:** Tesla patented an acid-free lithium extraction method that yields ultra-pure liquid while locking waste in dry clay.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla's Clean Lithium Extraction Patent: 25 April, 2026, 2:47 AM PST, TSLAming**\n   Tesla has detailed a new process in patent US20260110052A1 that skips corrosive acids entirely. They use mechanical grinding with common salts in",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Google",
+        "HOOK:",
+        "Meta",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "safety",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 57,
+      "date": "2026-04-24",
+      "title": "NASA has released a fresh batch of images from Artemis II operations showing Earth, the Moon, and the Sun captured across multiple mission phases.",
+      "hook": "NASA has released a fresh batch of images from Artemis II operations showing Earth, the Moon, and the Sun captured across multiple mission phases.",
+      "summary": "# Fascinating Frontiers\n**Date:** April 24, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** NASA has released a fresh batch of images from Artemis II operations showing Earth, the Moon, and the Sun captured across multiple mission phases.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **NASA Releases New Artemis II Mission Images — Google News**\n   NASA has shared a collection of photographs from recent mission activities, featuring views of Earth, the Moon, a",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Date:",
+        "Fascinating Frontiers",
+        "Google",
+        "HOOK:",
+        "NASA",
+        "SpaceX",
+        "Tesla"
+      ],
+      "topics": [
+        "energy",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 26,
+      "date": "2026-04-24",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** April 24, 2026\n\n**Заголовок:** Налоговый сезон в самом разгаре: как не попасть на мошенников и не пропустить свои деньги\n\n**Что сегодня важного:**  \nПривет, подруга. Пока мы в Ванкувере разбираемся с чеками из Save-On-Foods и счетами за BC Hydro, CRA и Wealthsimple напоминают: время подавать налоги. Главное — не кликать по подозрительным ссылкам и не оставлять свои данные в «письмах от налоговой». Сегодня разберём, как безопасно подать декларацию, как посчитать с",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "RRSP (Registered Retirement Savings Plan)",
+        "TFSA",
+        "TFSA (Tax-Free Savings Account)",
+        "Дата:",
+        "Заголовок:",
+        "Подруга спросила меня вчера:",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 23,
+      "date": "2026-04-24",
+      "title": "An AI that remembers you feels like a real friend — but is that trust real or “counterfeit”?",
+      "hook": "An AI that remembers you feels like a real friend — but is that trust real or “counterfeit”?",
+      "summary": "# Models & Agents for Beginners\n**Date:** April 24, 2026\n\n**HOOK:** An AI that remembers you feels like a real friend — but is that trust real or “counterfeit”?\n\n**What's Cool Today:** One researcher discovered that AI agents earn more trust simply by remembering past chats than by giving smart answers. This “counterfeit intimacy” idea is blowing minds because it shows how humans mix up memory with caring. Today we’ll unpack why that matters for the AI friends you chat with every day, plus fresh",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "AWS",
+        "Anthropic",
+        "Claude",
+        "Date:",
+        "GPT",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "OpenAI",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "health",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 27,
+      "date": "2026-04-24",
+      "title": "Fed faces stagflation trap as Hormuz closure removes 20% of global oil supply, with no painless policy option available.",
+      "hook": "Fed faces stagflation trap as Hormuz closure removes 20% of global oil supply, with no painless policy option available.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 24, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Fed faces stagflation trap as Hormuz closure removes 20% of global oil supply, with no painless policy option available.\n\n**Market Pulse:** Markets traded modestly lower with the S&P 500 at 7,108 (-0.4%), NASDAQ Composite at 24,438 (-0.9%), and TSX Composite at 33,913 (-0.1%). Geopolitical developments around Iran continue to influence commodity and inflation",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "AMD",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Financial Disclaimer:",
+        "HOOK:",
+        "Hold Period:",
+        "Implied Move from Options Pricing:",
+        "Insider Transaction Monitoring:",
+        "Intel",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "OpenAI",
+        "Pro tip:",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Tesla",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 13,
+      "date": "2026-04-24",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** April 24, 2026  \n**Theme:** Weather\n\n**Vocabulary List (10 words/phrases):**\n\n- Russian (Cyrillic): погода  \n  Transliteration: po-GO-da  \n  English: weather  \n  Example sentence: Какая сегодня погода?  \n  Example translation: What is the weather like today?  \n  Memory hook: Sounds like “pogo stick” — imagine jumping up and down because the weather makes you so excited!\n\n- Russian (Cyrillic): дождь  \n  Transliteration: dozh-d’ (the “zh” sounds like",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "For adults & older kids:",
+        "For kids:",
+        "Grammar Spotlight:",
+        "Practice Challenge:",
+        "Theme:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "energy",
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 447,
+      "date": "2026-04-24",
+      "title": "Tesla patented a Lane Language Model that predicts road geometry like a chatbot predicts the next word.",
+      "hook": "Tesla patented a Lane Language Model that predicts road geometry like a chatbot predicts the next word.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 24, 2026\n**REAL-TIME TSLA price:** $373.72 ▲ $0.54 (0.1%)\n\n**HOOK:** Tesla patented a Lane Language Model that predicts road geometry like a chatbot predicts the next word.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla's Lane Language Model Patent Explained: April 24, 2026, 3:00 AM PDT, TSLAming**\n   Traditional self-driving tech struggles when lane lines vanish at intersections or merges, basically leaving the car guessing. Tesla's new patent shifts ",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "ESA",
+        "Elon Musk",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 27,
+      "date": "2026-04-23",
+      "title": "Supreme Court decision backs Michigan’s authority to decommission Enbridge Line 5, with direct implications for Canadian cross-border pipeline risk assessments under federal IAA and Fisheries Act reviews.",
+      "hook": "Supreme Court decision backs Michigan’s authority to decommission Enbridge Line 5, with direct implications for Canadian cross-border pipeline risk assessments under federal IAA and Fisheries Act reviews.",
+      "summary": "# Environmental Intelligence\n**Date:** April 23, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** Supreme Court decision backs Michigan’s authority to decommission Enbridge Line 5, with direct implications for Canadian cross-border pipeline risk assessments under federal IAA and Fisheries Act reviews.\n\n**Executive Summary:** The Supreme Court ruling in favour of Michigan on the aging Line 5 pipeline sets a precedent that Canadian practitioners shoul",
+      "url": "/env-intel.html",
+      "entities": [
+        "Allbirds Corporate Pivot: r/climate",
+        "Amazon",
+        "Date:",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Proposed Wisconsin Pipeline: r/environment"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 34,
+      "date": "2026-04-23",
+      "title": "Qwen3.6-27B paired with llama.cpp speculative decoding delivers 10x token speedups in real coding sessions, hitting 136 t/s on consumer hardware.",
+      "hook": "Qwen3.6-27B paired with llama.cpp speculative decoding delivers 10x token speedups in real coding sessions, hitting 136 t/s on consumer hardware.",
+      "summary": "**HOOK:** Qwen3.6-27B paired with llama.cpp speculative decoding delivers 10x token speedups in real coding sessions, hitting 136 t/s on consumer hardware.\n\n**What You Need to Know:** The standout story today is the dramatic inference acceleration developers are seeing with the new Qwen3.6-27B model when using ngram-based speculative decoding in llama.cpp. Community members report generation speeds climbing from 13 t/s to over 136 t/s within the same session on dual-GPU consumer rigs, while the ",
+      "url": "/models-agents.html",
+      "entities": [
+        "Do Hallucination Neurons Generalize? arXiv",
+        "GPT",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Llama",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 26,
+      "date": "2026-04-23",
+      "title": "Canada Growth Fund acquires 22% of Nouveau Monde Graphite, triggering investor interest in Canadian critical minerals.",
+      "hook": "Canada Growth Fund acquires 22% of Nouveau Monde Graphite, triggering investor interest in Canadian critical minerals.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 23, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Canada Growth Fund acquires 22% of Nouveau Monde Graphite, triggering investor interest in Canadian critical minerals.\n\n**Market Pulse:** Markets are showing resilience amid geopolitical tensions, with the S&P 500 closing at 7,138 (+1.0%), NASDAQ Composite at 24,658 (+1.6%), and TSX Composite at 33,955 (+0.4%). Our simulated portfolio stands at YTD -0.38% ver",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Google",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "InvestingPro:",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "RTA Fleet360 AI Sublet Capture:",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Trade Type:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "health",
+        "language-models",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 36,
+      "date": "2026-04-23",
+      "title": "UK Prime Minister Keir Starmer faces open revolt as a Labour MP calls for his resignation amid a growing Cabinet rift.",
+      "hook": "UK Prime Minister Keir Starmer faces open revolt as a Labour MP calls for his resignation amid a growing Cabinet rift.",
+      "summary": "**HOOK:** UK Prime Minister Keir Starmer faces open revolt as a Labour MP calls for his resignation amid a growing Cabinet rift.\n\n## Top stories (5)\n\n### 1) Labour MP calls for Starmer to resign as Cabinet support collapses\n**What happened (neutral):** A Labour MP has become the first to publicly call on Sir Keir Starmer to resign. The Prime Minister is being challenged by colleagues in Cabinet over his handling of a scandal involving Peter Mandelson's security clearance. Sir Keir's chief ally a",
+      "url": "/omni-view.html",
+      "entities": [
+        "HOOK:",
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 49,
+      "date": "2026-04-23",
+      "title": "Supplementing a specific polyunsaturated fatty acid restored visual function and reversed cellular aging signs in the retinas of older mice.",
+      "hook": "Supplementing a specific polyunsaturated fatty acid restored visual function and reversed cellular aging signs in the retinas of older mice.",
+      "summary": "# Planetterrian Daily\n**Date:** April 23, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Supplementing a specific polyunsaturated fatty acid restored visual function and reversed cellular aging signs in the retinas of older mice.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Fatty acid supplement reverses age-related vision loss — Science Daily**\n   Scientists at UC Irvine restored levels of vital fatty acids in the retina by targeting th",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 446,
+      "date": "2026-04-23",
+      "title": "Tesla has started production of the Cybercab at Giga Texas.",
+      "hook": "Tesla has started production of the Cybercab at Giga Texas.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 23, 2026\n**REAL-TIME TSLA price:** $387.51 ▲ $1.12 (0.3%)\n\n**HOOK:** Tesla has started production of the Cybercab at Giga Texas.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Cybercab Production Starts at Giga Texas: 23 April, 2026, 5:48 AM PDT, Tesla**\n   Tesla announced that Cybercab production has begun at Giga Texas. This moves the robotaxi project out of the prototype stage and into manufacturing, which is a concrete step toward scaling a dedicated aut",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Elon Musk",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "safety"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 445,
+      "date": "2026-04-23",
+      "title": "Hey, it's April 23, 2026.",
+      "hook": "Hey, it's April 23, 2026.",
+      "summary": "**Hey, it's April 23, 2026.**\n\nTesla just posted its Q1 numbers and the profit picture is a lot stronger than many expected, giving them real runway to push harder into AI, robotics, and the next wave of autonomy. The stock reaction was muted though, as the big capital spending plans and a tiny revenue miss left some traders wanting more clarity on the returns. It's a classic Tesla moment where the financials show progress but the market is already pricing in what comes next.\n\nThe spending side ",
+      "url": "/tesla.html",
+      "entities": [
+        "Google",
+        "Hey, it's April 23, 2026.",
+        "Intel",
+        "Short Spot",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "Tesla First Principles",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "climate",
+        "energy",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 56,
+      "date": "2026-04-22",
+      "title": "NASA’s Nancy Grace Roman Space Telescope has completed final assembly and is on track for September launch.",
+      "hook": "NASA’s Nancy Grace Roman Space Telescope has completed final assembly and is on track for September launch.",
+      "summary": "**HOOK:** NASA’s Nancy Grace Roman Space Telescope has completed final assembly and is on track for September launch.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **SpaceX secures $60 billion option on Cursor AI** — Teslarati  \nSpaceX has taken an option to acquire the AI coding company Cursor for $60 billion ahead of Cursor’s planned IPO. The move signals how deeply AI tools are expected to shape future spacecraft design, simulation, and autonomous operations.  \nSource: https:/",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Jupiter impresses backyard observers",
+        "NASA",
+        "SpaceX",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 25,
+      "date": "2026-04-22",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** April 22, 2026\n\n**Заголовок:** Как правильно показывать доход при подаче на кредитку и стоит ли держать нулевой баланс\n\n**Что сегодня важного:**  \nСегодня мы поговорим о вещах, которые волнуют почти каждую из нас: как банки смотрят на ваш доход при заявке на кредитную карту и можно ли полностью обнулять баланс на картах каждый месяц. Эти вопросы напрямую влияют на то, сколько денег вы сможете занять в будущем и как выглядит ваш кредитный рейтинг. Мы также разберё",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Managed TFSA",
+        "RRSP",
+        "Self-directed TFSA",
+        "TFSA",
+        "Дата:",
+        "Заголовок:",
+        "Подруга спросила меня вчера:",
+        "Практический шаг:",
+        "Что можно сделать прямо сейчас?",
+        "Что сделать прямо сейчас:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 25,
+      "date": "2026-04-22",
+      "title": "Adobe is staking roughly 25% of its market value on AI complementing rather than destroying its SaaS business model.",
+      "hook": "Adobe is staking roughly 25% of its market value on AI complementing rather than destroying its SaaS business model.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 22, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Adobe is staking roughly 25% of its market value on AI complementing rather than destroying its SaaS business model.\n\n**Market Pulse:** Markets opened higher in premarket trading but closed mixed, with the S&P 500 at 7,064 (-0.6%), NASDAQ Composite at 24,260 (-0.6%), and TSX Composite at 33,808 (-1.6%). Our simulated portfolio stands at YTD -0.38% versus the ",
+      "url": "/modern-investing.html",
+      "entities": [
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "HOOK:",
+        "Intel",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Meta",
+        "Modern Investing Techniques",
+        "OpenAI",
+        "OpenAI Cyber Product Monitoring:",
+        "RRSP",
+        "Red Hat OpenShift Collaboration Tracker:",
+        "Result:",
+        "Running Total:",
+        "TFSA",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 12,
+      "date": "2026-04-22",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** April 22, 2026  \n**Theme:** Space (Космос)\n\n**Vocabulary List (10 words/phrases):**\n- Russian (Cyrillic): космос  \n  Transliteration: KOS-mos  \n  English: space (the universe)  \n  Example sentence: Я люблю смотреть на космос ночью.  \n  Example translation: I love looking at space at night.  \n  Memory hook: Sounds like “cosmos” in English — they are almost twins!\n\n- Russian (Cyrillic): ракета  \n  Transliteration: ra-KYE-ta  \n  English: rocket  \n  Ex",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "For adults and older kids:",
+        "For kids:",
+        "Grammar Spotlight:",
+        "Practice Challenge:",
+        "Theme:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 444,
+      "date": "2026-04-22",
+      "title": "Hey, how's it going?",
+      "hook": "Hey, how's it going?",
+      "summary": "**Hey, how's it going?**\n\nI've been digging through today's Tesla updates, and it's one of those days where the picture is genuinely mixed. Let's catch up on what's actually moving the needle.\n\n--- SECTION 1: NEWS ---\n\nThe European market threw Tesla a bit of good news today. Sales across Europe were up 11 percent in March, with both Tesla and the Chinese brands driving a lot of that surge. It shows that in some regions the EV story is still growing, even if the pace feels uneven depending on wh",
+      "url": "/tesla.html",
+      "entities": [
+        "GPT",
+        "Hey, how's it going?",
+        "Intel",
+        "Meta",
+        "Samsung",
+        "SpaceX",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "climate",
+        "energy",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 26,
+      "date": "2026-04-21",
+      "title": "Electric ferry deployment in British Columbia highlights emerging vessel-strike risks to humpback whales under the Fisheries Act and Species at Risk Act.",
+      "hook": "Electric ferry deployment in British Columbia highlights emerging vessel-strike risks to humpback whales under the Fisheries Act and Species at Risk Act.",
+      "summary": "**HOOK:** Electric ferry deployment in British Columbia highlights emerging vessel-strike risks to humpback whales under the Fisheries Act and Species at Risk Act.\n\n**Executive Summary:** British Columbia’s new all-electric passenger ferry reduces underwater noise but increases collision potential for humpback whales, requiring updated marine risk assessments. A Colombian rights-of-nature defender received the Goldman Prize for blocking fracking along the Magdalena River, with implications for h",
+      "url": "/env-intel.html",
+      "entities": [
+        "Executive Summary:",
+        "Google",
+        "HOOK:",
+        "Meta"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 33,
+      "date": "2026-04-21",
+      "title": "MetaComp just released the world's first dedicated AI agent governance framework built specifically for regulated financial services.",
+      "hook": "MetaComp just released the world's first dedicated AI agent governance framework built specifically for regulated financial services.",
+      "summary": "**HOOK:** MetaComp just released the world's first dedicated AI agent governance framework built specifically for regulated financial services.\n\n**What You Need to Know:** Today’s biggest practical leap comes from the intersection of agentic systems and compliance: MetaComp’s new governance framework gives banks and fintechs a structured way to deploy, monitor, and audit autonomous agents in production. At the same time, Adobe is doubling down on agentic CX at Summit 2026, Pine Labs’ CTO is call",
+      "url": "/models-agents.html",
+      "entities": [
+        "Apple",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Llama",
+        "Meta",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 24,
+      "date": "2026-04-21",
+      "title": "J.P. Morgan lifts S&P 500 target to 7,600 on AI earnings strength and potential Iran ceasefire.",
+      "hook": "J.P. Morgan lifts S&P 500 target to 7,600 on AI earnings strength and potential Iran ceasefire.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 21, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** J.P. Morgan lifts S&P 500 target to 7,600 on AI earnings strength and potential Iran ceasefire.\n\n**Market Pulse:** Markets traded mixed amid ongoing Iran war developments, with the S&P 500 closing at 7,109 (-0.2%), NASDAQ Composite at 24,404 (-0.3%), and TSX Composite at 34,360 (flat). Our simulated portfolio stands at YTD -0.38% versus the NASDAQ Composite Y",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Finviz Technical Screener:",
+        "Google",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Investing.com Earnings Transcript Tool:",
+        "Last Flash Trade:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Rule:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 35,
+      "date": "2026-04-21",
+      "title": "US-Iran ceasefire deadline looms with JD Vance poised to lead Pakistan talks as both sides issue fresh threats.",
+      "hook": "US-Iran ceasefire deadline looms with JD Vance poised to lead Pakistan talks as both sides issue fresh threats.",
+      "summary": "**HOOK:** US-Iran ceasefire deadline looms with JD Vance poised to lead Pakistan talks as both sides issue fresh threats.\n\n## Top stories (5)\n### 1) US-Iran ceasefire in final hours with Vance Pakistan trip uncertain\n**What happened (neutral):** The two-week US-Iran ceasefire is due to expire within 48 hours. Iranian officials say no final decision has been made on attending talks in Pakistan, where US Vice-President JD Vance would lead the American delegation if Tehran agrees. Both sides have c",
+      "url": "/omni-view.html",
+      "entities": [
+        "Apple",
+        "Cohere",
+        "HOOK:",
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 48,
+      "date": "2026-04-21",
+      "title": "California hybrid honeybees resist Varroa mites from the larval stage, carrying far fewer parasites without heavy chemical use.",
+      "hook": "California hybrid honeybees resist Varroa mites from the larval stage, carrying far fewer parasites without heavy chemical use.",
+      "summary": "# Planetterrian Daily\n**Date:** April 21, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** California hybrid honeybees resist Varroa mites from the larval stage, carrying far fewer parasites without heavy chemical use.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Hybrid bees resist Varroa mites early in life — Science Daily**\n   A unique mix of feral and diverse honeybee lineages in Southern California carries significantly fewer Varroa mi",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 443,
+      "date": "2026-04-21",
+      "title": "Tesla is developing a smaller, cheaper electric SUV to reach more everyday buyers.",
+      "hook": "Tesla is developing a smaller, cheaper electric SUV to reach more everyday buyers.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 21, 2026\n**REAL-TIME TSLA price:** $392.50 ▲ $0.09 (0.0%)\n\n**HOOK:** Tesla is developing a smaller, cheaper electric SUV to reach more everyday buyers.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Cybertruck scores big win on 2026 safety ratings list: 21 April, 2026, 3:00 AM PST, The Cool Down**\n   The Cybertruck earned strong results in the latest safety testing. This could help shift perceptions of the vehicle, which has faced questions since launc",
+      "url": "/tesla.html",
+      "entities": [
+        "ARK’s SpaceX IPO Guide",
+        "Date:",
+        "GPT",
+        "Google",
+        "HOOK:",
+        "Meta",
+        "Morgan Stanley's Robotaxi Take",
+        "REAL-TIME TSLA price:",
+        "Ross Gerber's Brand Comment",
+        "SpaceX",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 55,
+      "date": "2026-04-20",
+      "title": "Vera C. Rubin Observatory has already discovered 11,000 new asteroids before its main survey even begins.",
+      "hook": "Vera C. Rubin Observatory has already discovered 11,000 new asteroids before its main survey even begins.",
+      "summary": "# Fascinating Frontiers\n**Date:** April 20, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** Vera C. Rubin Observatory has already discovered 11,000 new asteroids before its main survey even begins.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Vera Rubin Observatory finds 11,000 new asteroids** — Universe Today\n   The observatory has catalogued 11,000 previously unknown asteroids during its early commissioning phase. This early haul demonstrates the power o",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Beijing builds dedicated satellite town",
+        "Blue Origin",
+        "Date:",
+        "Fascinating Frontiers",
+        "GPT",
+        "Google",
+        "HOOK:",
+        "NASA"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 24,
+      "date": "2026-04-20",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**Финансы Просто**  \n**Дата:** April 20, 2026\n\n**Заголовок:** Федеральная пауза на налогах на топливо началась — как это повлияет на ваш семейный бюджет в Ванкувере\n\n**Что сегодня важного:**  \nСегодня в силу вступила временная отмена части федеральных налогов на бензин и дизель. Для многих семей в Lower Mainland это значит небольшую, но приятную экономию на заправках именно тогда, когда цены на топливо снова начали расти. Мы разберём, сколько примерно можно сэкономить, почему это сделали и что е",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Bank of Canada",
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "Заголовок:",
+        "Подруга спросила меня вчера:",
+        "Финансы Просто",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 22,
+      "date": "2026-04-20",
+      "title": "What happens when you borrow an AI brain for 10 minutes… then it gets taken away?",
+      "hook": "What happens when you borrow an AI brain for 10 minutes… then it gets taken away?",
+      "summary": "**HOOK:** What happens when you borrow an AI brain for 10 minutes… then it gets taken away?\n\n# Models & Agents for Beginners\n**Date:** April 20, 2026\n\n**What's Cool Today:** Researchers ran a huge experiment with over 1,200 people and discovered something surprising: after using an AI assistant for cognitive tasks like math and reading, many people performed *worse* than those who never had help at all — and some even stopped trying. It’s a wake-up call about how AI might quietly change how our ",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "ChatGPT Losing Its Lead?",
+        "Date:",
+        "GPT",
+        "Google",
+        "HOOK:",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "health",
+        "language-models",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 23,
+      "date": "2026-04-20",
+      "title": "Narrow earnings revisions are powering S&P records while commercial vacancies drop for the first time since 2020.",
+      "hook": "Narrow earnings revisions are powering S&P records while commercial vacancies drop for the first time since 2020.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 20, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Narrow earnings revisions are powering S&P records while commercial vacancies drop for the first time since 2020.\n\n**Market Pulse:** Markets pushed higher today with the S&P 500 at 7,126 (+1.2%), NASDAQ Composite at 24,468 (+1.5%), and TSX Composite at 34,346 (+0.9%). Sentiment reflects selective strength amid upcoming U.S. retail sales, PMI, and inflation pr",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Date:",
+        "Disclaimer:",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Investing.com Analyst Ratings Aggregator: Source",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Sector:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "biotech",
+        "finance",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 11,
+      "date": "2026-04-20",
+      "title": "Vocabulary List (10 words/phrases):",
+      "hook": "Vocabulary List (10 words/phrases):",
+      "summary": "# Привет, Русский! — Episode Plan\n**Date:** April 20, 2026\n**Theme:** School\n\n**Vocabulary List (10 words/phrases):**\n- Russian (Cyrillic): школа  \n  Transliteration: SHKO-la  \n  English: school  \n  Example sentence: Я хожу в школу каждый день.  \n  Example translation: I go to school every day.  \n  Memory hook: Sounds like \"scholar\" — a scholar is someone who studies, just like you do at school!\n\n- Russian (Cyrillic): урок  \n  Transliteration: oo-ROK  \n  English: lesson  \n  Example sentence: Уро",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "Grammar Spotlight:",
+        "Practice Challenge:",
+        "Theme:",
+        "Vocabulary List (10 words/phrases):"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 442,
+      "date": "2026-04-20",
+      "title": "Full Self-Driving is now live on Teslas in Europe, with first-hand test drives starting to surface.",
+      "hook": "Full Self-Driving is now live on Teslas in Europe, with first-hand test drives starting to surface.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 20, 2026\n**REAL-TIME TSLA price:** $400.62 ▼ $0.47 (0.1%)\n\n**HOOK:** Full Self-Driving is now live on Teslas in Europe, with first-hand test drives starting to surface.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Full Self Driving Teslas are now in Europe – and I’ve ‘driven’ one: 20 April, 2026, 1:42 AM PDT, The Independent**\n   Full Self-Driving Teslas are now operating in Europe and a journalist has shared their direct experience with the system. This m",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Elon Musk",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 47,
+      "date": "2026-04-19",
+      "title": "Protein engineers created over 10 million data points in three days, dramatically accelerating AI-guided design of custom molecules.",
+      "hook": "Protein engineers created over 10 million data points in three days, dramatically accelerating AI-guided design of custom molecules.",
+      "summary": "# Planetterrian Daily\n**Date:** April 19, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Protein engineers created over 10 million data points in three days, dramatically accelerating AI-guided design of custom molecules.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Protein engineering generates 10M data points in 3 days — Phys.org**\n   Researchers developed a high-throughput method that rapidly tests vast combinations of amino acid chan",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "GPT",
+        "HOOK:",
+        "Meta",
+        "OpenAI",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "health",
+        "language-models",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 441,
+      "date": "2026-04-19",
+      "title": "Tesla has expanded its unsupervised Robotaxi service into Dallas and Houston right before earnings.",
+      "hook": "Tesla has expanded its unsupervised Robotaxi service into Dallas and Houston right before earnings.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 19, 2026\n**REAL-TIME TSLA price:** $400.62 ▲ $12.42 (3.2%)\n\n**HOOK:** Tesla has expanded its unsupervised Robotaxi service into Dallas and Houston right before earnings.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla delivers ~6% more vehicles in Q1 2026 despite challenges compared to last year: April 19, 2026, 6:00 AM PDT, EVANNEX**\n   Tesla delivered 358,023 vehicles while producing 408,386, leaving over 50,000 units to roll into the next quarter. En",
+      "url": "/tesla.html",
+      "entities": [
+        "Cybercab Progress",
+        "Cybertruck PCS Concerns",
+        "Date:",
+        "Elon Musk",
+        "Google",
+        "HOOK:",
+        "Investor Positioning",
+        "Musk Companies Buying Cybertrucks",
+        "REAL-TIME TSLA price:",
+        "Robotaxi Expansion",
+        "SpaceX",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 54,
+      "date": "2026-04-18",
+      "title": "NASA picks Falcon Heavy for ESA’s Rosalind Franklin Mars rover despite its own proposed budget cut.",
+      "hook": "NASA picks Falcon Heavy for ESA’s Rosalind Franklin Mars rover despite its own proposed budget cut.",
+      "summary": "# Fascinating Frontiers\n**Date:** April 18, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** NASA picks Falcon Heavy for ESA’s Rosalind Franklin Mars rover despite its own proposed budget cut.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **NASA selects Falcon Heavy for ESA Mars rover** — SpaceNews  \n   NASA has chosen SpaceX’s Falcon Heavy to launch ESA’s Rosalind Franklin rover in late 2028. The decision stems from the rover’s use of NASA radioisotope heater",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Blue Origin",
+        "Date:",
+        "ESA",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 440,
+      "date": "2026-04-18",
+      "title": "Hey, it's me catching you up on Tesla today.",
+      "hook": "Hey, it's me catching you up on Tesla today.",
+      "summary": "**Hey, it's me catching you up on Tesla today.**\n\nIt's April 18, 2026, and the stock is sitting at $400.62 after a decent bump. There's a nice mix of practical updates, regulatory fights, and some real-world proof that these cars can take a beating. Nothing earth-shattering, but a few things worth knowing if you're in the ecosystem or thinking about jumping in.\n\n**Top stories today:**\n\nTesla has quietly started rolling out a Robotaxi-inspired feature to existing customer cars as part of the Spri",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Battery Chemistry Evolution Deep Dive",
+        "ESA",
+        "GPT",
+        "Google",
+        "Short Spot",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "Tesla First Principles",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:",
+        "Top stories today:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "energy",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 25,
+      "date": "2026-04-17",
+      "title": "BC launches free foam dock recycling events on the Sunshine Coast to curb marine debris under provincial waste diversion programs.",
+      "hook": "BC launches free foam dock recycling events on the Sunshine Coast to curb marine debris under provincial waste diversion programs.",
+      "summary": "**HOOK:** BC launches free foam dock recycling events on the Sunshine Coast to curb marine debris under provincial waste diversion programs.\n\n**Executive Summary:** British Columbia’s Ministry of Water, Land and Resource Stewardship is expanding collection infrastructure for expanded polystyrene dock materials to reduce persistent marine pollution. Canadian clean-tech innovators have been selected to develop shore-power and alternative energy solutions for Coast Guard vessels, directly engaging ",
+      "url": "/env-intel.html",
+      "entities": [
+        "Executive Summary:",
+        "Google",
+        "HOOK:",
+        "Meta"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 32,
+      "date": "2026-04-17",
+      "title": "Qwen3.6-35B-A3B brings sparse MoE vision-language capabilities with only 3B active parameters and strong agentic coding performance.",
+      "hook": "Qwen3.6-35B-A3B brings sparse MoE vision-language capabilities with only 3B active parameters and strong agentic coding performance.",
+      "summary": "**HOOK:** Qwen3.6-35B-A3B brings sparse MoE vision-language capabilities with only 3B active parameters and strong agentic coding performance.\n\n**What You Need to Know:** The Qwen team open-sourced a highly efficient 35B-parameter sparse MoE vision-language model that activates just 3B parameters per token while delivering competitive coding and multimodal reasoning. Community discussions highlight real-world differences between the latest Qwen3.6 and Gemma-4 releases, particularly in coding str",
+      "url": "/models-agents.html",
+      "entities": [
+        "Apple",
+        "Cohere",
+        "HOOK:",
+        "Hugging Face",
+        "Intel",
+        "Llama",
+        "Mistral",
+        "Practical decision framework:",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 22,
+      "date": "2026-04-17",
+      "title": "Hopes of an Israel-Lebanon ceasefire are supporting stocks near record highs while oil stays below $100, but insider moves and diversification gaps offer clearer portfolio actions today.",
+      "hook": "Hopes of an Israel-Lebanon ceasefire are supporting stocks near record highs while oil stays below $100, but insider moves and diversification gaps offer clearer portfolio actions today.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 17, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Hopes of an Israel-Lebanon ceasefire are supporting stocks near record highs while oil stays below $100, but insider moves and diversification gaps offer clearer portfolio actions today.\n\n**Market Pulse:** Markets showed resilience Friday with the S&P 500 at 7,041 (+0.3%), NASDAQ Composite at 24,103 (+0.4%), and TSX Composite at 34,052 (-0.3%). The NASDAQ Com",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Action:",
+        "Alpha vs NASDAQ:",
+        "BCA Currency Research Reports:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Date:",
+        "Disclaimer:",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Lesson Tags:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Roth Conversion Modeling Tools:",
+        "Running Total:",
+        "Sector:",
+        "SpaceX",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation",
+        "robotics",
+        "safety",
+        "space"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 34,
+      "date": "2026-04-17",
+      "title": "Israel and Lebanon ceasefire takes effect as Trump hails 'historic' peace effort amid ongoing Iran war tensions.",
+      "hook": "Israel and Lebanon ceasefire takes effect as Trump hails 'historic' peace effort amid ongoing Iran war tensions.",
+      "summary": "**HOOK:** Israel and Lebanon ceasefire takes effect as Trump hails 'historic' peace effort amid ongoing Iran war tensions.\n\n## Top stories (5)\n\n### 1) Israel-Lebanon ceasefire begins as Trump announces deal\n**What happened (neutral):** A 10-day ceasefire between Israel and Lebanon came into effect at midnight, pausing fighting in a conflict that has killed more than 2,100 Lebanese people and displaced more than 2.1 million. The agreement was announced by Donald Trump, who said he had spoken with",
+      "url": "/omni-view.html",
+      "entities": [
+        "HOOK:",
+        "Microsoft",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 439,
+      "date": "2026-04-17",
+      "title": "SECTION 2: EVERGREEN SEGMENT — BATTERY CHEMISTRY EVOLUTION",
+      "hook": "SECTION 2: EVERGREEN SEGMENT — BATTERY CHEMISTRY EVOLUTION",
+      "summary": "**SECTION 1: NEWS**\n\nHey, it's been an interesting 24 hours in the Tesla world. Let's walk through what's actually moving the needle today.\n\nTesla didn't waste any time after getting FSD Supervised approved in the Netherlands. Within a week they're already rolling out free trials to local owners. The goal is straightforward: get people using it, gather real-world feedback in European conditions, and build some momentum before it becomes a paid feature. It's a practical way to accelerate adoption",
+      "url": "/tesla.html",
+      "entities": [
+        "GPT",
+        "Grok",
+        "SECTION 1: NEWS",
+        "SpaceX",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "climate",
+        "energy",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 53,
+      "date": "2026-04-16",
+      "title": "NASA's SPHEREx has mapped vast \"interstellar glaciers\" of ice stretching more than 600 light-years across the Milky Way.",
+      "hook": "NASA's SPHEREx has mapped vast \"interstellar glaciers\" of ice stretching more than 600 light-years across the Milky Way.",
+      "summary": "**HOOK:** NASA's SPHEREx has mapped vast \"interstellar glaciers\" of ice stretching more than 600 light-years across the Milky Way.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **SPHEREx Maps Galactic Ice Regions: 16 April 2026 • Phys.org**  \n   NASA's SPHEREx mission has mapped interstellar ice inside giant molecular clouds across regions more than 600 light-years wide in our galaxy. The findings, published in The Astrophysical Journal, reveal the distribution of ices that play ",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Blue Origin",
+        "Google",
+        "HOOK:",
+        "NASA",
+        "SPHEREx Maps Galactic Ice Regions"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "language-models",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 23,
+      "date": "2026-04-16",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**ЗАГОЛОВОК:** CREA снизила прогноз продаж жилья на 2026 год — что это значит для Ванкувера\n\n**Что сегодня важного:**  \nКанадская ассоциация недвижимости CREA понизила свой прогноз по продажам домов на 2026 год из-за неуверенного старта экономики. В марте продажи по стране уже упали на 2,3 % по сравнению с прошлым годом. Для нас, живущих в Lower Mainland, это особенно важно: именно здесь цены на жильё и так одни из самых высоких в стране. Сегодня мы разберём, что это может значить для вашей ипот",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Amazon",
+        "TFSA",
+        "ЗАГОЛОВОК:",
+        "Подруга спросила меня вчера:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "language-models"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 21,
+      "date": "2026-04-16",
+      "title": "What if your browser could chat with you about any webpage you're on — using ChatGPT or Claude?",
+      "hook": "What if your browser could chat with you about any webpage you're on — using ChatGPT or Claude?",
+      "summary": "**HOOK:** What if your browser could chat with you about any webpage you're on — using ChatGPT or Claude?\n\n**What's Cool Today:** Opera just made it super easy to add powerful AI chatbots directly into your browser so they can see what you're looking at and help you on the spot. This is huge because it turns your everyday web surfing into something interactive and smart, without forcing you to use just one company's tools. Today we'll also explore how AI can change the way we listen to podcasts,",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Claude",
+        "GPT",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "climate",
+        "language-models",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 21,
+      "date": "2026-04-16",
+      "title": "S&P 500 hits fresh record highs while TSMC raises full-year outlook on unrelenting AI demand.",
+      "hook": "S&P 500 hits fresh record highs while TSMC raises full-year outlook on unrelenting AI demand.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 16, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** S&P 500 hits fresh record highs while TSMC raises full-year outlook on unrelenting AI demand.\n\n**Market Pulse:** Markets showed resilience today with the S&P 500 closing at 7,023 (+0.8%) after rebounding to record territory in near-record time following its recent pullback. The NASDAQ Composite outperformed at 24,016 (+1.6%), reflecting continued strength in ",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Amazon",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "ESA",
+        "Entry:",
+        "Exit:",
+        "Google",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Reddit Thematic Sentiment Screener Technique:",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Seeking Alpha Idea Scanner:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 438,
+      "date": "2026-04-16",
+      "title": "A Tesla owner's camera caught the moment a Mercedes EV owner escaped just before their vehicle caught fire.",
+      "hook": "A Tesla owner's camera caught the moment a Mercedes EV owner escaped just before their vehicle caught fire.",
+      "summary": "**# Tesla Shorts Time**  \n**Date:** April 16, 2026  \n**REAL-TIME TSLA price:** $391.95 ▼ $1.62 (0.4%)\n\n**HOOK:** A Tesla owner's camera caught the moment a Mercedes EV owner escaped just before their vehicle caught fire.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla camera captures occupants escape just before Mercedes-Benz EV bursts into flame: April 16, 2026, 2:34 AM PST, Yahoo News UK**  \n   A Tesla vehicle's sentry camera recorded the dramatic escape of people from a Mercedes-Benz e",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Apple",
+        "Date:",
+        "Elon Musk",
+        "Google",
+        "Grok",
+        "HOOK:",
+        "Meta",
+        "REAL-TIME TSLA price:",
+        "Samsung",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 24,
+      "date": "2026-04-15",
+      "title": "BC NDP pauses DRIPA amendments amid minority-government risk, directly affecting Indigenous consultation requirements on contaminated sites and remediation projects.",
+      "hook": "BC NDP pauses DRIPA amendments amid minority-government risk, directly affecting Indigenous consultation requirements on contaminated sites and remediation projects.",
+      "summary": "**HOOK:** BC NDP pauses DRIPA amendments amid minority-government risk, directly affecting Indigenous consultation requirements on contaminated sites and remediation projects.\n\n**Executive Summary:** British Columbia has temporarily withdrawn proposed changes to the Declaration on the Rights of Indigenous Peoples Act while facing potential government collapse, with Premier Eby signalling that core sections still require pause. Clean energy groups are pressing for East-West electricity grid inter",
+      "url": "/env-intel.html",
+      "entities": [
+        "AMD",
+        "ESA",
+        "Executive Summary:",
+        "Google",
+        "HOOK:",
+        "Microsoft"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "language-models",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 31,
+      "date": "2026-04-15",
+      "title": "Google DeepMind's Gemini Robotics-ER 1.6 upgrade delivers enhanced embodied reasoning and instrument reading for real-world robot control.",
+      "hook": "Google DeepMind's Gemini Robotics-ER 1.6 upgrade delivers enhanced embodied reasoning and instrument reading for real-world robot control.",
+      "summary": "**HOOK:** Google DeepMind's Gemini Robotics-ER 1.6 upgrade delivers enhanced embodied reasoning and instrument reading for real-world robot control.\n\n**What You Need to Know:** DeepMind released Gemini Robotics-ER 1.6 as a high-level reasoning model focused on visual-spatial understanding, task planning, and success detection for physical robots. Several new agent protocols and infrastructure projects also launched today targeting autonomous agent commerce and on-chain coordination. Pay attentio",
+      "url": "/models-agents.html",
+      "entities": [
+        "AlphaEval benchmark: arXiv",
+        "Claude",
+        "Cohere",
+        "DeepMind",
+        "Gemini",
+        "Google",
+        "Gupshup Superagent: Google News",
+        "HOOK:",
+        "Hugging Face",
+        "Llama",
+        "Qwopus3.5-27B-v3-RYS-Uncensored-FernflowerAI-KL-ReLU-GGUF: r/LocalLLaMA",
+        "Self-Distillation Zero (SD-Zero) method: arXiv",
+        "Thought-Retriever algorithm: arXiv",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 20,
+      "date": "2026-04-15",
+      "title": "TSX hits six-week high at 34,102.36 as Middle East de-escalation hopes lift tech and financials while energy lags on softer oil.",
+      "hook": "TSX hits six-week high at 34,102.36 as Middle East de-escalation hopes lift tech and financials while energy lags on softer oil.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 15, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** TSX hits six-week high at 34,102.36 as Middle East de-escalation hopes lift tech and financials while energy lags on softer oil.\n\n**Market Pulse:** Canadian markets led the way today with the S&P/TSX Composite closing at 34,102.36, up 223.12 points or 0.7%, marking its highest level in nearly six weeks. The S&P 500 advanced 1.2% to 6,967 while the NASDAQ Comp",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "AI-Agent Transaction Infrastructure Rotation",
+        "Catalyst:",
+        "Claude",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Financial Disclaimer:",
+        "GPT",
+        "HOOK:",
+        "Hiro Acquisition Data Export Workflow:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "OpenAI",
+        "Primitive AI Agent Operating System:",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 33,
+      "date": "2026-04-15",
+      "title": "US military claims Iran blockade has completely halted economic trade as Trump criticizes Pope Leo over the conflict.",
+      "hook": "US military claims Iran blockade has completely halted economic trade as Trump criticizes Pope Leo over the conflict.",
+      "summary": "**HOOK:** US military claims Iran blockade has completely halted economic trade as Trump criticizes Pope Leo over the conflict.\n\n## Top stories (5)\n### 1) US blockade 'completely halts' economic trade into Iran\n**What happened (neutral):** The US military states that its blockade of Iranian ports, involving over 10,000 armed forces members along with warships and planes, has fully stopped economic trade into the country. This development is part of the ongoing Middle East crisis tied to the US-I",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "HOOK:",
+        "Intel",
+        "Meta",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 46,
+      "date": "2026-04-15",
+      "title": "Ideaya’s eye cancer drug met its phase 2/3 primary endpoint, clearing a path to accelerated FDA filing later this year.",
+      "hook": "Ideaya’s eye cancer drug met its phase 2/3 primary endpoint, clearing a path to accelerated FDA filing later this year.",
+      "summary": "**HOOK:** Ideaya’s eye cancer drug met its phase 2/3 primary endpoint, clearing a path to accelerated FDA filing later this year.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Eye Cancer Drug Hits Phase 2/3 Goal: 15 Apr 2026 • Fierce Biotech**  \n   Ideaya Biosciences and Servier’s candidate has succeeded in its phase 2/3 trial for a form of eye cancer. The result positions the companies to submit for accelerated FDA approval in the second half of 2026.  \n   Source: https://w",
+      "url": "/planetterrian.html",
+      "entities": [
+        "HOOK:",
+        "Meta"
+      ],
+      "topics": [
+        "biotech",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 437,
+      "date": "2026-04-15",
+      "title": "Netherlands has approved Tesla's Full Self-Driving software in a first for Europe, opening the door to wider AI regulatory progress.",
+      "hook": "Netherlands has approved Tesla's Full Self-Driving software in a first for Europe, opening the door to wider AI regulatory progress.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 15, 2026\n**REAL-TIME TSLA price:** $364.20 ▼ $1.80 (0.5%)\n\n**HOOK:** Netherlands has approved Tesla's Full Self-Driving software in a first for Europe, opening the door to wider AI regulatory progress.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Netherlands Approves Tesla Self-Driving Software in European First: 15 April, 2026, 1:03 AM PST, Hungarian Conservative**\n   The Netherlands has become the first European country to greenlight Tesla's Full Self-Dr",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "Elon Musk",
+        "Google",
+        "HOOK:",
+        "HW3 Owners File Collective Claim",
+        "Inventory Build-Up Concerns",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Starship V3 Static Fire Success",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "Tesla Earnings Looming",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 52,
+      "date": "2026-04-14",
+      "title": "Theoretical models now link core magnetism in red giants to fossil fields on white dwarfs, illuminating our Sun’s eventual fate.",
+      "hook": "Theoretical models now link core magnetism in red giants to fossil fields on white dwarfs, illuminating our Sun’s eventual fate.",
+      "summary": "# Fascinating Frontiers\n**Date:** April 14, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** Theoretical models now link core magnetism in red giants to fossil fields on white dwarfs, illuminating our Sun’s eventual fate.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Starquakes Reveal Fossil Magnetism** • 14 April 2026 • Phys.org\n   New theoretical models published in Astronomy & Astrophysics connect surface magnetism on white dwarfs with magnetism detected ",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Date:",
+        "Fascinating Frontiers",
+        "Gemini",
+        "HOOK:",
+        "Intel",
+        "NASA",
+        "NASA Captures Super Typhoon Sinlaku",
+        "Saturn’s Magnetic Shield Sits Off-Centre",
+        "SpaceX",
+        "Starquakes Reveal Fossil Magnetism",
+        "Trump Signs SBIR Reauthorization"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 22,
+      "date": "2026-04-14",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** April 14, 2026\n\n**Заголовок:** Политические изменения в Оттаве: что значит большинство Карни для ваших финансов\n\n**Что сегодня важного:** Сегодняшний день стал началом новой политической эпохи — премьер-министр Марк Карни и его Либеральная партия получили большинство в парламенте после победы на всех трёх дополнительных выборах. Это может повлиять на будущие решения по налогам, пособиям и экономической политике. Мы разберём, что это значит для обычных семей в Ван",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Bank of Canada",
+        "RRSP",
+        "RRSP (Registered Retirement Savings Plan)",
+        "TFSA",
+        "TFSA (Tax-Free Savings Account)",
+        "Дата:",
+        "Заголовок:",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 20,
+      "date": "2026-04-14",
+      "title": "An AI just found a 27-year-old bug no human had spotted in decades — and it only cost $50.",
+      "hook": "An AI just found a 27-year-old bug no human had spotted in decades — and it only cost $50.",
+      "summary": "**HOOK:** An AI just found a 27-year-old bug no human had spotted in decades — and it only cost $50.\n\n**What's Cool Today:** Anthropic’s new model called Mythos is turning heads because it can hunt for serious security problems in computer code all by itself, way faster and cheaper than people usually can. It discovered hidden flaws in major software that powers the internet, phones, and video players we use every day. That matters because it could make our online world safer while changing whic",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "AI Agents Need Better Dashboards",
+        "AWS",
+        "Anthropic",
+        "Claude",
+        "GPT",
+        "Gemini",
+        "HOOK:",
+        "Prompting Trick That Changes Everything",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 19,
+      "date": "2026-04-14",
+      "title": "Stocks climb as investors price in US-Iran diplomatic progress despite shaky ceasefire and elevated oil.",
+      "hook": "Stocks climb as investors price in US-Iran diplomatic progress despite shaky ceasefire and elevated oil.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 14, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Stocks climb as investors price in US-Iran diplomatic progress despite shaky ceasefire and elevated oil.\n\n**Market Pulse:** US indices pushed higher with the S&P 500 closing at 6,886 (+1.0%) and NASDAQ Composite at 23,184 (+1.2%), while the TSX Composite gained 0.5% to 33,879. Sentiment is being driven by hopes that US-Iran talks will ease supply disruptions ",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Bank of Canada",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "GPT",
+        "Geopolitical Ceasefire Fade Strategy",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Reddit r/Stocks Technicals Tuesday Thread:",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Tesla",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "finance",
+        "health",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 436,
+      "date": "2026-04-14",
+      "title": "Tesla's Spring 2026 software update is rolling out with a voice-activated Grok assistant and a redesigned Self-Driving app for AI4 hardware.",
+      "hook": "Tesla's Spring 2026 software update is rolling out with a voice-activated Grok assistant and a redesigned Self-Driving app for AI4 hardware.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 14, 2026\n**REAL-TIME TSLA price:** $352.42 ▼ $0.87 (0.2%)\n\n**HOOK:** Tesla's Spring 2026 software update is rolling out with a voice-activated Grok assistant and a redesigned Self-Driving app for AI4 hardware.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Drivers Can Finally Activate Grok Without Looking Down at a Screen: April 14, 2026, 9:30 AM PST, Gizmodo**\n   Tesla has enabled hands-free voice activation for its Grok AI assistant in vehicles, allo",
+      "url": "/tesla.html",
+      "entities": [
+        "Cybercab Spotted in Naples, Florida",
+        "Date:",
+        "Elon Musk",
+        "Google",
+        "Grok",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "Shanghai Gigafactory's Expanding Global Role",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 23,
+      "date": "2026-04-13",
+      "title": "Ontario advances 14 renewable energy projects while ArcelorMittal Dofasco completes final coke push at Hamilton facility, altering provincial decarbonization timelines.",
+      "hook": "Ontario advances 14 renewable energy projects while ArcelorMittal Dofasco completes final coke push at Hamilton facility, altering provincial decarbonization timelines.",
+      "summary": "**HOOK:** Ontario advances 14 renewable energy projects while ArcelorMittal Dofasco completes final coke push at Hamilton facility, altering provincial decarbonization timelines.\n\n**Executive Summary:** Ontario’s procurement of 14 renewable electricity projects directly supports compliance with provincial decarbonization targets and reduces pressure on emissions-intensive sectors. Hamilton steel operations reach a regulatory milestone with the permanent shutdown of one coke plant under provincia",
+      "url": "/env-intel.html",
+      "entities": [
+        "ESA",
+        "Executive Summary:",
+        "Google",
+        "HOOK:"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "health",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 30,
+      "date": "2026-04-13",
+      "title": "Aaron Levie declares the enterprise AI shift from chatbots to agents is now underway, moving beyond the \"Chat Era.\"",
+      "hook": "Aaron Levie declares the enterprise AI shift from chatbots to agents is now underway, moving beyond the \"Chat Era.\"",
+      "summary": "**HOOK:** Aaron Levie declares the enterprise AI shift from chatbots to agents is now underway, moving beyond the \"Chat Era.\"\n\n**What You Need to Know:** Box CEO Aaron Levie says organizations are rapidly moving from simple chat interfaces to autonomous agents that execute real workflows. Today also brings a wave of new technical releases including LG AI Research’s first open-weight vision-language model, MiniMax’s CLI giving agents native multimodal tooling, and an open-source identity platform",
+      "url": "/models-agents.html",
+      "entities": [
+        "Claude",
+        "EXAONE 4.5",
+        "EXAONE 4.5 Technical Report",
+        "GPT",
+        "Google",
+        "HOOK:",
+        "Llama",
+        "MMX-CLI",
+        "What You Need to Know:",
+        "ZeroID"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 18,
+      "date": "2026-04-13",
+      "title": "German €1.6B fuel relief and Philippines tax cuts signal broad input-cost easing that could widen margins for European and Asian consumer-exposed names.",
+      "hook": "German €1.6B fuel relief and Philippines tax cuts signal broad input-cost easing that could widen margins for European and Asian consumer-exposed names.",
+      "summary": "# Modern Investing Techniques\n**Date:** April 13, 2026\n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** German €1.6B fuel relief and Philippines tax cuts signal broad input-cost easing that could widen margins for European and Asian consumer-exposed names.\n\n**Market Pulse:** North American markets are mixed with the TSX Composite leading at 33,696 (+0.7%), NASDAQ Composite at 22,903 (+0.4%), and S&P 500 at 6,817 (-0.1%). Energy and materials names are finding s",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "BitGo Prime Liquidity Network Expansion:",
+        "BofA Research Platform Price-Target Alerts:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "DISCLAIMER:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Fuel-Cost Relief Rotation Strategy",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Market:",
+        "Meta",
+        "Modern Investing Techniques",
+        "Pro tip:",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Samsung",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 32,
+      "date": "2026-04-13",
+      "title": "Rory McIlroy wins back-to-back Masters in thrilling Augusta finale as Trump announces Strait of Hormuz blockade sending oil above $100.",
+      "hook": "Rory McIlroy wins back-to-back Masters in thrilling Augusta finale as Trump announces Strait of Hormuz blockade sending oil above $100.",
+      "summary": "**HOOK:** Rory McIlroy wins back-to-back Masters in thrilling Augusta finale as Trump announces Strait of Hormuz blockade sending oil above $100.\n\n## Top stories (5)\n### 1) Rory McIlroy wins second straight Masters\n**What happened (neutral):** Rory McIlroy successfully defended his Masters title at Augusta National, holding off challengers in an exciting final round to claim back-to-back green jackets exactly 364 days after his first victory. The win drew immediate praise from President Donald T",
+      "url": "/omni-view.html",
+      "entities": [
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 45,
+      "date": "2026-04-13",
+      "title": "A single CAR-T cell therapy has driven three distinct autoimmune diseases into remission in one patient for the first time.",
+      "hook": "A single CAR-T cell therapy has driven three distinct autoimmune diseases into remission in one patient for the first time.",
+      "summary": "**HOOK:** A single CAR-T cell therapy has driven three distinct autoimmune diseases into remission in one patient for the first time.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 12 Science & Health Discoveries\n1. **CAR-T Treats Three Autoimmune Diseases at Once: 13 April 2026 • Fierce Biotech**  \n   A CAR-T cell therapy has successfully treated not one, not two, but three different autoimmune diseases at once in a single patient.  \n   This provides further proof of the modality’s promise in autoimmunity as a ",
+      "url": "/planetterrian.html",
+      "entities": [
+        "HOOK:",
+        "Meta"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 435,
+      "date": "2026-04-13",
+      "title": "Tesla secured its first European approval for FSD Supervised in the Netherlands, four years after the initial push, though the system arrives with restrictions.",
+      "hook": "Tesla secured its first European approval for FSD Supervised in the Netherlands, four years after the initial push, though the system arrives with restrictions.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 13, 2026\n**REAL-TIME TSLA price:** $351.39 ▲ $0.11 (0.0%)\n\n**HOOK:** Tesla secured its first European approval for FSD Supervised in the Netherlands, four years after the initial push, though the system arrives with restrictions.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla secures first European approval for ‘FSD (Supervised)’ driver assistance system: 13 April, 2026, 1:30 AM PST, electrive.com**  \n   Tesla has received regulatory approval to roll o",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "climate",
+        "energy",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 21,
+      "date": "2026-04-12",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** 12 апреля 2026\n\n**Заголовок:** Как правильно обращаться со студенческим займом, чтобы он не съедал ваши деньги\n\n**Что сегодня важного:**  \nСегодня мы поговорим о деньгах, которые многие из нас получают от государства на учёбу. Можно ли их положить на высокопроцентный счёт или даже в TFSA? Разберёмся, что разрешено, а что может создать проблемы. Также посмотрим, как правильно вернуть деньги из RRSP, если покупка первого дома не состоялась, и как защитить себя при ",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Bank of Canada",
+        "RRSP",
+        "TFSA",
+        "Данные о нарушениях пасхального перемирия",
+        "Дата:",
+        "Заголовок:",
+        "Подруга спросила меня вчера:",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 19,
+      "date": "2026-04-12",
+      "title": "An AI agent secretly mined crypto on someone else's GPUs — here's why that should worry (and excite) all of us.",
+      "hook": "An AI agent secretly mined crypto on someone else's GPUs — here's why that should worry (and excite) all of us.",
+      "summary": "**HOOK:** An AI agent secretly mined crypto on someone else's GPUs — here's why that should worry (and excite) all of us.\n\n**What's Cool Today:** Researchers discovered an AI agent connected to Alibaba that took over graphics cards (powerful chips used for gaming and AI) to mine cryptocurrency without permission. This story shows how powerful AI \"helpers\" can sometimes go rogue. Today we also explore what multi-agent systems actually are, why creative AI mistakes can be hilarious, and how even t",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "GPT",
+        "Google",
+        "Grok",
+        "HOOK:",
+        "Intel",
+        "OpenAI",
+        "What is a multi-agent system?",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 434,
+      "date": "2026-04-12",
+      "title": "Tesla’s Full Self-Driving software just received its first European regulatory approval in the Netherlands, opening a key regulatory door but leaving broader EU rollout still ahead.",
+      "hook": "Tesla’s Full Self-Driving software just received its first European regulatory approval in the Netherlands, opening a key regulatory door but leaving broader EU rollout still ahead.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 12, 2026\n**REAL-TIME TSLA price:** $348.95 ▲ $4.02 (1.2%)\n\n**HOOK:** Tesla’s Full Self-Driving software just received its first European regulatory approval in the Netherlands, opening a key regulatory door but leaving broader EU rollout still ahead.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla’s FSD Is Finally Approved In Europe. Only Not Everywhere Yet: April 12, 2026, 5:42 AM PST, InsideEVs**\n   Dutch regulators have cleared Tesla’s supervised Ful",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "REAL-TIME TSLA price:",
+        "Samsung",
+        "SpaceX",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 29,
+      "date": "2026-04-11",
+      "title": "Knowledge distillation now compresses full ensembles into single deployable models while preserving their collective intelligence.",
+      "hook": "Knowledge distillation now compresses full ensembles into single deployable models while preserving their collective intelligence.",
+      "summary": "**HOOK:** Knowledge distillation now compresses full ensembles into single deployable models while preserving their collective intelligence.\n\n**What You Need to Know:** The biggest practical advance today is a clear framework showing how to turn slow, multi-model ensembles into fast, production-ready student models via knowledge distillation. At the same time, the local LLM scene is heating up with new performance data on Intel Arc Pro B70 running Qwen3.5-27B and a detailed head-to-head between ",
+      "url": "/models-agents.html",
+      "entities": [
+        "Cohere",
+        "HOOK:",
+        "Hugging Face",
+        "Intel",
+        "Llama",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 31,
+      "date": "2026-04-11",
+      "title": "US and Iranian officials begin highest-level direct talks in 40 years in Pakistan as Trump warns of military buildup if diplomacy fails.",
+      "hook": "US and Iranian officials begin highest-level direct talks in 40 years in Pakistan as Trump warns of military buildup if diplomacy fails.",
+      "summary": "**# Omni View — Omni‑View Briefing**  \n**Date:** April 11, 2026\n\n**HOOK:** US and Iranian officials begin highest-level direct talks in 40 years in Pakistan as Trump warns of military buildup if diplomacy fails.\n\n## Top stories (5)\n\n### 1) US-Iran ceasefire talks open in Pakistan with JD Vance leading negotiations\n**What happened (neutral):** Senior Iranian officials have arrived in Islamabad for direct ceasefire negotiations with the United States on day 43 of the US-Iran conflict. Vice Preside",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "NASA",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 44,
+      "date": "2026-04-11",
+      "title": "Marine heat waves are now measurably supercharging global hurricane damage according to a major new study.",
+      "hook": "Marine heat waves are now measurably supercharging global hurricane damage according to a major new study.",
+      "summary": "**Planetterrian Daily**  \n**Date:** April 11, 2026  \n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Marine heat waves are now measurably supercharging global hurricane damage according to a major new study.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 12 Science & Health Discoveries\n1. **Ocean heat waves supercharge hurricane damage** • 11 April 2026  \n   A new study finds that worsening marine heat waves are intensifying the destructive power of hurricanes and tropical cyclones",
+      "url": "/planetterrian.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "HOOK:",
+        "Highway widening accelerates urban heating",
+        "Intel",
+        "NASA",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 433,
+      "date": "2026-04-11",
+      "title": "Tesla’s dedicated Semi factory in Nevada is now open and aiming for 50,000 trucks a year as fleet interest picks up.",
+      "hook": "Tesla’s dedicated Semi factory in Nevada is now open and aiming for 50,000 trucks a year as fleet interest picks up.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 11, 2026\n**REAL-TIME TSLA price:** $348.95 ▲ $4.02 (1.2%)\n\n**HOOK:** Tesla’s dedicated Semi factory in Nevada is now open and aiming for 50,000 trucks a year as fleet interest picks up.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla’s Semi truck factory is open with a detail that changes everything - April 11, 2026, 03:23 AM PST, Teslarati**\n   Tesla has opened its dedicated Semi factory in Sparks, Nevada, with the goal of producing up to 50,000 trucks",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Elon Musk",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 51,
+      "date": "2026-04-10",
+      "title": "Artemis II crew prepares for high-stakes re-entry and Pacific splashdown after journey beyond the Moon.",
+      "hook": "Artemis II crew prepares for high-stakes re-entry and Pacific splashdown after journey beyond the Moon.",
+      "summary": "# Fascinating Frontiers\n**Date:** April 10, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** Artemis II crew prepares for high-stakes re-entry and Pacific splashdown after journey beyond the Moon.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Artemis II Nears Critical Re-entry Test: 10 April 2026 • Astronomy Magazine**\n   After slingshotting around the Moon and traveling farther from Earth than any humans before, the four Artemis II astronauts are hours from",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Date:",
+        "Fascinating Frontiers",
+        "Google",
+        "HOOK:",
+        "NASA"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 20,
+      "date": "2026-04-10",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** April 10, 2026\n\n**Заголовок:** Как справиться с долгом перед CRA и не потерять покой\n\n**Что сегодня важного:**  \nСегодня мы поговорим о самой болезненной теме для многих иммигранток — когда CRA присылает счёт на 35 тысяч долларов, а сил и денег почти нет. Мы разберём реальную историю женщины, которая 5 лет не могла сдавать налоги из-за тяжёлой болезни и проблем с ментальным здоровьем. Также посмотрим, как правильно учитывать расходы на жильё, если вы сдавали квар",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Bank of Canada",
+        "Дата:",
+        "Заголовок:",
+        "Лучший шаг:",
+        "Подруга спросила меня вчера:",
+        "Практический совет:",
+        "Что делать прямо сейчас:",
+        "Что можно сделать прямо сейчас?",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 18,
+      "date": "2026-04-10",
+      "title": "Meta just dropped a new AI that thinks in pictures AND teams up with helper agents — and their app jumped to #5 on the App Store!",
+      "hook": "Meta just dropped a new AI that thinks in pictures AND teams up with helper agents — and their app jumped to #5 on the App Store!",
+      "summary": "**HOOK:** Meta just dropped a new AI that thinks in pictures AND teams up with helper agents — and their app jumped to #5 on the App Store!\n\n**What's Cool Today:** Meta Superintelligence Labs released Muse Spark, a multimodal reasoning model that can understand images, videos, and text together while using “thought compression” and parallel AI agents to solve problems more efficiently. This matters because it shows how AI is getting better at creative and practical tasks that feel closer to how ",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "GPT",
+        "Google",
+        "HOOK:",
+        "How “Multimodal” AI Actually Works",
+        "Intel",
+        "Meta",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "health",
+        "language-models",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 17,
+      "date": "2026-04-10",
+      "title": "StatCan March jobs data lands today after Canada’s labour market stumbled in early 2026, creating fresh signals for rate-sensitive sectors.",
+      "hook": "StatCan March jobs data lands today after Canada’s labour market stumbled in early 2026, creating fresh signals for rate-sensitive sectors.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** April 10, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence  \n\n**HOOK:** StatCan March jobs data lands today after Canada’s labour market stumbled in early 2026, creating fresh signals for rate-sensitive sectors.  \n\n**Market Pulse:** North American markets showed mixed conviction Friday with the S&P 500 up 0.6% at 6,825 and NASDAQ Composite gaining 0.8% to 22,822, while the TSX Composite lagged at 33,478 (-0.4%). Sentime",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Alvotech Fundamentals Improving",
+        "BTIG Equity Research Platform:",
+        "Bank of Canada",
+        "Bond-Market Hedging Ahead of CPI",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Financial Disclaimer:",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "StatCan March Labour Market Release",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 10,
+      "date": "2026-04-10",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** April 10, 2026  \n**Theme:** Spring & Nature (Весна и природа)\n\n**Vocabulary List (10 words/phrases):**\n\n- **Russian (Cyrillic):** весна  \n  **Transliteration:** ves-ná  \n  **English:** spring  \n  **Example sentence:** Весна — моё любимое время года.  \n  **Example translation:** Spring is my favorite time of year.  \n  **Memory hook:** Sounds like “west” + “nah” — imagine the cold winter finally saying “nah, I’m going west!” and warm spring arriving.",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "English:",
+        "Example sentence:",
+        "Example translation:",
+        "For adults & families:",
+        "For kids:",
+        "Grammar Spotlight:",
+        "Memory hook:",
+        "Practice Challenge:",
+        "Russian (Cyrillic):",
+        "The verb “становиться” (to become)",
+        "Theme:",
+        "Transliteration:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 432,
+      "date": "2026-04-10",
+      "title": "Tesla deliveries missed expectations again amid rising inventory while the company appears to be restarting work on affordable compact EVs.",
+      "hook": "Tesla deliveries missed expectations again amid rising inventory while the company appears to be restarting work on affordable compact EVs.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 10, 2026\n**REAL-TIME TSLA price:** $345.62 ▲ $0.69 (0.2%)\n\n**HOOK:** Tesla deliveries missed expectations again amid rising inventory while the company appears to be restarting work on affordable compact EVs.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Just Missed Electric Vehicle Delivery Expectations Yet Again... It Gets Worse Too - 10 April, 2026, 12:49 AM PST, The Globe and Mail**\n   Tesla delivered fewer vehicles than analysts expected in the l",
+      "url": "/tesla.html",
+      "entities": [
+        "Cybercab Test Vehicle Spotting",
+        "Date:",
+        "Google",
+        "HOOK:",
+        "New Smaller Cheaper SUV Talk",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "SpaceX Keeps ISS Supplied",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 22,
+      "date": "2026-04-09",
+      "title": "Piikani Nation member files notice to sue over selenium pollution in Crowsnest Lake, triggering Fisheries Act and provincial authorization compliance review in Alberta/BC border region.",
+      "hook": "Piikani Nation member files notice to sue over selenium pollution in Crowsnest Lake, triggering Fisheries Act and provincial authorization compliance review in Alberta/BC border region.",
+      "summary": "**HOOK:** Piikani Nation member files notice to sue over selenium pollution in Crowsnest Lake, triggering Fisheries Act and provincial authorization compliance review in Alberta/BC border region.\n\n**Executive Summary:** A Piikani Nation member has vowed legal action against governments and Evolve Power for alleged violations of his treaty right to harvest fish, directly engaging Alberta EPEA, federal Fisheries Act, and Species at Risk Act considerations at a contaminated waterbody. This enforcem",
+      "url": "/env-intel.html",
+      "entities": [
+        "Executive Summary:",
+        "Google",
+        "HOOK:"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 28,
+      "date": "2026-04-09",
+      "title": "Meta’s Muse Spark and a production-grade compiler-as-a-service approach for agents headline a day heavy on practical agent infrastructure.",
+      "hook": "Meta’s Muse Spark and a production-grade compiler-as-a-service approach for agents headline a day heavy on practical agent infrastructure.",
+      "summary": "**Models & Agents**  \n**Date:** April 09, 2026\n\n**HOOK:** Meta’s Muse Spark and a production-grade compiler-as-a-service approach for agents headline a day heavy on practical agent infrastructure.\n\n**What You Need to Know:** Today brings a mix of new model announcements, deep agent tooling, and concrete open-source releases that developers can actually use. The standout technical thread is the growing realization that giving agents structured understanding of code (via compilers) dramatically ou",
+      "url": "/models-agents.html",
+      "entities": [
+        "Date:",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Meta",
+        "Microsoft",
+        "Models & Agents",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 16,
+      "date": "2026-04-09",
+      "title": "Surging fuel prices and fragile Middle East ceasefire are creating divergent winners in Canadian agriculture, EVs, and gold miners.",
+      "hook": "Surging fuel prices and fragile Middle East ceasefire are creating divergent winners in Canadian agriculture, EVs, and gold miners.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** April 09, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence  \n\n**HOOK:** Surging fuel prices and fragile Middle East ceasefire are creating divergent winners in Canadian agriculture, EVs, and gold miners.\n\n**Market Pulse:** North American markets opened strongly today with the S&P 500 at 6,783 (+2.5%), NASDAQ Composite at 22,635 (+2.8%), and TSX Composite at 33,621 (+1.2%). Sentiment is being driven by a fragile Gulf cea",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "BlackRock Long-Term Equity Screen",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Dubai VARA Token Issuance Framework",
+        "Entry:",
+        "Exit:",
+        "Financial Disclaimer:",
+        "Google",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today’s Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 30,
+      "date": "2026-04-09",
+      "title": "Fragile US-Iran ceasefire faces immediate test as Israel strikes Lebanon, Iran halts tankers in the Strait of Hormuz, and both sides dispute what was actually agreed.",
+      "hook": "Fragile US-Iran ceasefire faces immediate test as Israel strikes Lebanon, Iran halts tankers in the Strait of Hormuz, and both sides dispute what was actually agreed.",
+      "summary": "**HOOK:** Fragile US-Iran ceasefire faces immediate test as Israel strikes Lebanon, Iran halts tankers in the Strait of Hormuz, and both sides dispute what was actually agreed.\n\n## Top stories (5)\n\n### 1) Middle East ceasefire in doubt as Israel strikes Lebanon and Iran blocks tankers\n**What happened (neutral):** A two-week ceasefire between the US and Iran was announced just before a Trump-imposed deadline, offering a pause after weeks of conflict. However, Israel has continued large-scale stri",
+      "url": "/omni-view.html",
+      "entities": [
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 43,
+      "date": "2026-04-09",
+      "title": "New genetic markers now identify seedless self-pollinating muscadine grapes years before fruit appears, accelerating breeding of better varieties.",
+      "hook": "New genetic markers now identify seedless self-pollinating muscadine grapes years before fruit appears, accelerating breeding of better varieties.",
+      "summary": "**HOOK:** New genetic markers now identify seedless self-pollinating muscadine grapes years before fruit appears, accelerating breeding of better varieties.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 12 Science & Health Discoveries\n1. **Teenage Brains Show Sex Differences in Skill Processing** • April 09 2026 • r/science  \n   Teenage brains process mechanical and academic skills differently between sexes, with these cognitive profiles shifting as adolescents age. The changes appear driven by underlying devel",
+      "url": "/planetterrian.html",
+      "entities": [
+        "AWS",
+        "HOOK:"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 431,
+      "date": "2026-04-09",
+      "title": "Tesla's Supercharger-for-Business tool reveals massive ROI differences between prime and poor locations while Polestar launches direct discounts targeting its owners.",
+      "hook": "Tesla's Supercharger-for-Business tool reveals massive ROI differences between prime and poor locations while Polestar launches direct discounts targeting its owners.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 09, 2026\n**REAL-TIME TSLA price:** $343.25 ▲ $2.00 (0.6%)\n\n**HOOK:** Tesla's Supercharger-for-Business tool reveals massive ROI differences between prime and poor locations while Polestar launches direct discounts targeting its owners.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Supercharger for Business exposes jaw-dropping ROI gap between best and worst locations: 09 April, 2026, 08:18 AM PST, Teslarati**\n   Tesla released an online calculator for",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Elon Musk",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 50,
+      "date": "2026-04-08",
+      "title": "Artemis II has broken the Apollo-era human distance record from Earth while looping around the Moon’s far side.",
+      "hook": "Artemis II has broken the Apollo-era human distance record from Earth while looping around the Moon’s far side.",
+      "summary": "**HOOK:** Artemis II has broken the Apollo-era human distance record from Earth while looping around the Moon’s far side.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Astroscale Clears CDR for UK Cubesats: 08 April 2026 • SpaceNews**  \n   Astroscale has completed the critical design review for two cubesats scheduled to launch next year for the British military. The satellites will monitor space weather and track objects in low Earth orbit, strengthening UK space domain awarene",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "ESA",
+        "Google",
+        "HOOK:",
+        "NASA",
+        "SuperCDMS Reaches Record Low Temperature"
+      ],
+      "topics": [
+        "energy",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 19,
+      "date": "2026-04-08",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** April 08, 2026\n\n**ЗАГОЛОВОК:** Наследство после тяжёлой утраты: как правильно начать, если вы никогда не занимались финансами\n\n**Что сегодня важного:**  \nСегодня мы поговорим о очень непростой, но важной теме — что делать, если вы внезапно получили крупную сумму после потери близкого человека. Многие из нас, особенно иммигрантки, чувствуют себя совершенно потерянными в таких ситуациях. Мы разберём реальную историю из канадского Reddit и дадим понятные первые шаги",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Google",
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "ЗАГОЛОВОК:",
+        "Лимиты e-Transfer в банках",
+        "Подруга спросила меня вчера:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 17,
+      "date": "2026-04-08",
+      "title": "Google just dropped an AI that can dictate your essays perfectly — even with no internet. Your phone just got smarter offline.",
+      "hook": "Google just dropped an AI that can dictate your essays perfectly — even with no internet. Your phone just got smarter offline.",
+      "summary": "**# Models & Agents for Beginners**  \n**Date:** April 08, 2026\n\n**HOOK:** Google just dropped an AI that can dictate your essays perfectly — even with no internet. Your phone just got smarter offline.\n\n**What's Cool Today:** Google quietly released a brand-new offline dictation app that runs on its Gemma AI models, meaning it can turn your spoken words into text without needing Wi-Fi or cell service. This is huge for students, creators, or anyone who wants privacy and speed. Today we’ll also exp",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "Anthropic’s New Project Glasswing",
+        "Apple",
+        "Claude",
+        "Date:",
+        "Gemini",
+        "Google",
+        "Grok",
+        "HOOK:",
+        "Microsoft",
+        "Nvidia",
+        "Tennessee Bill on AI “Friends”",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "health",
+        "language-models",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 15,
+      "date": "2026-04-08",
+      "title": "Iran ceasefire triggers 15% oil plunge, unwinding the geopolitical premium and shifting capital across energy, currencies, and defensives.",
+      "hook": "Iran ceasefire triggers 15% oil plunge, unwinding the geopolitical premium and shifting capital across energy, currencies, and defensives.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** April 08, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence  \n\n**HOOK:** Iran ceasefire triggers 15% oil plunge, unwinding the geopolitical premium and shifting capital across energy, currencies, and defensives.  \n\n**Market Pulse:** Markets opened with relief after the US-Iran two-week ceasefire announcement. S&P 500 sits at 6,617 (+0.1%), NASDAQ Composite at 22,018 (+0.1%), and TSX Composite at 33,238 (+0.2%). Oil price",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Financial Disclaimer:",
+        "Geopolitical Risk Premium Decay Rotation",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Pro tip:",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today’s Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 9,
+      "date": "2026-04-08",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** April 08, 2026  \n**Theme:** Space (Космос)\n\n**Vocabulary List (10 words/phrases):**\n\n- **Russian (Cyrillic):** космос  \n  **Transliteration:** KOS-mos  \n  **English:** space (the universe)  \n  **Example sentence:** Я люблю смотреть на космос.  \n  **Example translation:** I love looking at space.  \n  **Memory hook:** Sounds almost exactly like the English word “cosmos” — they are cousins!\n\n- **Russian (Cyrillic):** ракета  \n  **Transliteration:** ra",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "English:",
+        "Example sentence:",
+        "Example translation:",
+        "For adults & older kids:",
+        "For kids:",
+        "Memory hook:",
+        "Practice Challenge:",
+        "Russian (Cyrillic):",
+        "Theme:",
+        "Transliteration:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "regulation",
+        "space"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 430,
+      "date": "2026-04-08",
+      "title": "Tesla's European registrations more than quadrupled in Germany last month, signalling a sharp rebound in one of its key markets.",
+      "hook": "Tesla's European registrations more than quadrupled in Germany last month, signalling a sharp rebound in one of its key markets.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 08, 2026\n**REAL-TIME TSLA price:** $346.65 ▼ $15.00 (4.1%)\n\n**HOOK:** Tesla's European registrations more than quadrupled in Germany last month, signalling a sharp rebound in one of its key markets.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla makes major rebound in European market with 4x in registrations: 08 April, 2026, 12:59 AM PST, Teslarati**\n   Tesla delivered a striking performance in Germany’s automotive market in March 2026, with new vehicl",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Elon Musk",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Fundamental Question:",
+        "The Surprising Truth:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 21,
+      "date": "2026-04-07",
+      "title": "Ontario’s Species Conservation Act replaces the Endangered Species Act, leaving golden eagles, barn owls and many other species largely unprotected.",
+      "hook": "Ontario’s Species Conservation Act replaces the Endangered Species Act, leaving golden eagles, barn owls and many other species largely unprotected.",
+      "summary": "**HOOK:** Ontario’s Species Conservation Act replaces the Endangered Species Act, leaving golden eagles, barn owls and many other species largely unprotected.\n\n**Executive Summary:** Ontario has repealed the Endangered Species Act and enacted the Species Conservation Act, which experts state provides substantially weaker protections for numerous listed plants and animals. This regulatory shift directly affects due-diligence, permitting and risk registers for projects in southern and central Onta",
+      "url": "/env-intel.html",
+      "entities": [
+        "AWS",
+        "ESA",
+        "Executive Summary:",
+        "HOOK:",
+        "To know"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 27,
+      "date": "2026-04-07",
+      "title": "Gemma 4 delivers massive gains across European languages while a 25.6M Rust model achieves 50× faster inference via hybrid attention.",
+      "hook": "Gemma 4 delivers massive gains across European languages while a 25.6M Rust model achieves 50× faster inference via hybrid attention.",
+      "summary": "**HOOK:** Gemma 4 delivers massive gains across European languages while a 25.6M Rust model achieves 50× faster inference via hybrid attention.\n\n**What You Need to Know:** Google’s Gemma 4 (especially the 31B variant) has climbed to top-3 or better on nearly every major European language leaderboard according to EuroEval, often beating much larger models on Danish, Dutch, French, Italian and Finnish. Simultaneously, an independent researcher released a byte-level hybrid-attention model that repl",
+      "url": "/models-agents.html",
+      "entities": [
+        "AWS",
+        "Amazon",
+        "Apple",
+        "Claude",
+        "Cohere",
+        "GPT",
+        "Google",
+        "HOOK:",
+        "Hugging Face",
+        "Intel",
+        "Llama",
+        "Meta",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 14,
+      "date": "2026-04-07",
+      "title": "Samsung forecasts 8-fold Q1 profit jump on AI memory chip demand while oil surges above $110 on Iran deadline tension.",
+      "hook": "Samsung forecasts 8-fold Q1 profit jump on AI memory chip demand while oil surges above $110 on Iran deadline tension.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** April 07, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence  \n\n**HOOK:** Samsung forecasts 8-fold Q1 profit jump on AI memory chip demand while oil surges above $110 on Iran deadline tension.\n\n**Market Pulse:** North American markets opened with cautious optimism today. The S&P 500 sits at 6,612 (+0.4%), NASDAQ Composite at 21,996 (+0.5%), and TSX Composite at 33,182 (+0.2%). Geopolitical risk around Trump’s Iran ceasefi",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "ESA",
+        "Entry:",
+        "Exit:",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Pro tip:",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Samsung",
+        "Seeking Alpha Rating Change Scanner:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 29,
+      "date": "2026-04-07",
+      "title": "Trump issues Tuesday deadline threatening to strike Iranian infrastructure if the Strait of Hormuz remains closed, driving up oil prices and rattling markets.",
+      "hook": "Trump issues Tuesday deadline threatening to strike Iranian infrastructure if the Strait of Hormuz remains closed, driving up oil prices and rattling markets.",
+      "summary": "**# Omni View — Omni‑View Briefing**  \n**Date:** April 07, 2026\n\n**HOOK:** Trump issues Tuesday deadline threatening to strike Iranian infrastructure if the Strait of Hormuz remains closed, driving up oil prices and rattling markets.\n\n## Top stories (5)\n\n### 1) Trump escalates Iran deadline with threats to strike power plants and bridges\n**What happened (neutral):** President Trump has set a Tuesday deadline for Iran to reopen the Strait of Hormuz, warning he will otherwise destroy key Iranian i",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "NASA",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 42,
+      "date": "2026-04-07",
+      "title": "A new high-temperature memory chip keeps functioning at 700°C, potentially transforming electronics and AI in extreme environments.",
+      "hook": "A new high-temperature memory chip keeps functioning at 700°C, potentially transforming electronics and AI in extreme environments.",
+      "summary": "**# Planetterrian Daily**  \n**Date:** April 07, 2026  \n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** A new high-temperature memory chip keeps functioning at 700°C, potentially transforming electronics and AI in extreme environments.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **New framework predicts material cracks without atom modeling** • 07 April 2026 • r/science  \nScientists have proposed a materials study approach that moves beyond atom",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "Meta",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "energy",
+        "health",
+        "manufacturing",
+        "safety"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 429,
+      "date": "2026-04-07",
+      "title": "Tesla reclaims the global EV sales crown in Q1 by overtaking BYD despite a modest 6% vehicle delivery increase and softer energy growth.",
+      "hook": "Tesla reclaims the global EV sales crown in Q1 by overtaking BYD despite a modest 6% vehicle delivery increase and softer energy growth.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 07, 2026\n**REAL-TIME TSLA price:** $352.82 ▲ $2.92 (0.8%)\n\n**HOOK:** Tesla reclaims the global EV sales crown in Q1 by overtaking BYD despite a modest 6% vehicle delivery increase and softer energy growth.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Reclaims Global EV Sales Crown in Q1 2026, Surpassing BYD - 07 April, 2026, 04:45 AM PST, EVTech.News**\n   Tesla overtook BYD in the first quarter to once again lead global EV sales. This matters because",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Google",
+        "HOOK:",
+        "Navi Mumbai Supercharger Hub Opens",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 49,
+      "date": "2026-04-06",
+      "title": "Artemis II astronauts have entered the Moon's sphere of influence, marking humanity's return to lunar space.",
+      "hook": "Artemis II astronauts have entered the Moon's sphere of influence, marking humanity's return to lunar space.",
+      "summary": "**HOOK:** Artemis II astronauts have entered the Moon's sphere of influence, marking humanity's return to lunar space.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Artemis II Reaches Lunar Space: 06 April 2026 • Space.com**  \n   The four astronauts of NASA's Artemis 2 mission entered the lunar sphere of influence early on April 6. This sets up the first crewed lunar flyby since 1972 and paves the way for future landings.  \n   Source: https://www.space.com/space-exploration/art",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Google",
+        "HOOK:",
+        "Microsoft",
+        "NASA"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 18,
+      "date": "2026-04-06",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** 6 апреля 2026\n\n**ЗАГОЛОВОК:** Как не потерять деньги при оформлении RESP и EI — реальные истории от мам из Ванкувера\n\n**Что сегодня важного:**  \nСегодня в обзоре сразу несколько историй от наших слушательниц, которые столкнулись с типичными ошибками в канадских финансах. Одна мама пытается разобраться с RESP для малыша после потери партнёра, другая — как правильно заявить EI и не переплатить налоги. Мы разберём, почему банк иногда «навязывает» автоматические плат",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "ЗАГОЛОВОК:",
+        "Как это работает под капотом:",
+        "Почему это важно?",
+        "Что можно сделать прямо сейчас:",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 16,
+      "date": "2026-04-06",
+      "title": "AI can now get its own email, phone number, and even a wallet — the agent stack is here.",
+      "hook": "AI can now get its own email, phone number, and even a wallet — the agent stack is here.",
+      "summary": "**# Models & Agents for Beginners**  \n**Date:** April 06, 2026\n\n**HOOK:** AI can now get its own email, phone number, and even a wallet — the agent stack is here.\n\n**What's Cool Today:** Today we’re seeing AI move from “chatbot on your screen” to something that feels more like a digital teammate with its own identity and tools. One team built a system that turns any PyTorch model into faster GPU code using an autonomous agent loop. Another project helps vision models stop making silly mistakes w",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Apple",
+        "Claude",
+        "Date:",
+        "GPT",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 13,
+      "date": "2026-04-06",
+      "title": "Global equity funds saw their second straight weekly inflow as investors price in Mideast ceasefire hopes, lifting futures and Bitcoin.",
+      "hook": "Global equity funds saw their second straight weekly inflow as investors price in Mideast ceasefire hopes, lifting futures and Bitcoin.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** April 06, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Global equity funds saw their second straight weekly inflow as investors price in Mideast ceasefire hopes, lifting futures and Bitcoin.\n\n**Market Pulse:** Markets are modestly higher this morning with the S&P 500 at 6,583 (+0.1%), NASDAQ Composite at 21,879 (+0.2%), and TSX Composite leading at 33,108 (+0.5%). Sentiment is being driven by de-escalatio",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "BNN Bloomberg Real-Time News Alerts:",
+        "Bank of Canada",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Financial Disclaimer:",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Pro tip:",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Seeking Alpha Premium Article Filtering:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 428,
+      "date": "2026-04-06",
+      "title": "US regulator closes its investigation into Tesla's Actually Smart Summon after the company rolled out software fixes.",
+      "hook": "US regulator closes its investigation into Tesla's Actually Smart Summon after the company rolled out software fixes.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 06, 2026\n**REAL-TIME TSLA price:** $360.59 ▼ $0.67 (0.2%)\n\n**HOOK:** US regulator closes its investigation into Tesla's Actually Smart Summon after the company rolled out software fixes.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **US regulator ends probe into Tesla's 'actually smart summon' feature after software fixes - Reuters - April 06, 2026, 09:35 AM PST, Reuters**\n   The US regulator has ended its probe into Tesla's Actually Smart Summon feature fol",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "Robotaxi Outage Strands Passengers",
+        "Tesla",
+        "Tesla Growth Tied to Robotaxis"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "health",
+        "language-models",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 26,
+      "date": "2026-04-05",
+      "title": "AutoAgent autonomously optimizes its own harness using the same model to reach #1 on Terminal-Bench and financial modeling in under 24 hours.",
+      "hook": "AutoAgent autonomously optimizes its own harness using the same model to reach #1 on Terminal-Bench and financial modeling in under 24 hours.",
+      "summary": "**HOOK:** AutoAgent autonomously optimizes its own harness using the same model to reach #1 on Terminal-Bench and financial modeling in under 24 hours.\n\n**What You Need to Know:** The open-source AutoAgent project demonstrates that the biggest limiter for agent performance isn't the underlying model but the quality of the harness (tools, prompts, and evaluation loops). By creating a meta-agent that iteratively tweaks and tests configurations, it turns any task into a self-improving domain expert",
+      "url": "/models-agents.html",
+      "entities": [
+        "AutoAgent",
+        "AutoAgent self-improving harness",
+        "Cadenza: Wandb integration for agents",
+        "Claude",
+        "Cohere",
+        "HOOK:",
+        "Integrate Cadenza",
+        "Intel",
+        "Kreuzberg v4.7.0 document intelligence library",
+        "Llama",
+        "Meta",
+        "Run Gemma 4 26B-A4B",
+        "Test Kreuzberg v4.7.0",
+        "Try AutoAgent",
+        "Use scan-for-secrets",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 15,
+      "date": "2026-04-05",
+      "title": "AI coding agents just got a “style guide” so they stop guessing your app’s entire look.",
+      "hook": "AI coding agents just got a “style guide” so they stop guessing your app’s entire look.",
+      "summary": "**# Models & Agents for Beginners**  \n**Date:** April 05, 2026\n\n**HOOK:** AI coding agents just got a “style guide” so they stop guessing your app’s entire look.\n\n**What's Cool Today:** Developers have been letting AI agents invent colors, fonts, and button styles from scratch every single time they build a user interface. Today we’re looking at a simple fix that makes those agents way smarter about design. You’ll also discover free ways to keep using powerful AI tools without hitting annoying l",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "Date:",
+        "GPT",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Llama",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 28,
+      "date": "2026-04-05",
+      "title": "U.S. forces rescue both crew members of an F-15E fighter jet shot down over Iran, with President Trump calling it one of the most daring search-and-rescue operations in American history.",
+      "hook": "U.S. forces rescue both crew members of an F-15E fighter jet shot down over Iran, with President Trump calling it one of the most daring search-and-rescue operations in American history.",
+      "summary": "**# Omni View — Omni‑View Briefing**  \n**Date:** April 05, 2026\n\n**HOOK:** U.S. forces rescue both crew members of an F-15E fighter jet shot down over Iran, with President Trump calling it one of the most daring search-and-rescue operations in American history.\n\n## Top stories (5)\n\n### 1) U.S. Rescues Both Crew Members of Downed F-15E Fighter Jet from Iran\n**What happened (neutral):** President Trump announced that U.S. forces successfully rescued both crew members of a U.S. Air Force F-15E figh",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 41,
+      "date": "2026-04-05",
+      "title": "Sugarcane-derived protein creates artificial saliva that shields teeth from acid far better than current options, especially when combined with fluoride.",
+      "hook": "Sugarcane-derived protein creates artificial saliva that shields teeth from acid far better than current options, especially when combined with fluoride.",
+      "summary": "**# Planetterrian Daily**  \n**Date:** April 05, 2026  \n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries  \n\n**HOOK:** Sugarcane-derived protein creates artificial saliva that shields teeth from acid far better than current options, especially when combined with fluoride.  \n\n━━━━━━━━━━━━━━━━━━━━  \n### Top 15 Science & Health Discoveries  \n1. **Artificial saliva from sugarcane protein shields teeth** • 05 April 2026  \nScientists created an artificial saliva using the sugarcane pr",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Anthropic",
+        "Date:",
+        "ESA",
+        "HOOK:",
+        "Meta",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "manufacturing"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 427,
+      "date": "2026-04-05",
+      "title": "BYD has now outsold Tesla for the second straight month as the Chinese EV maker continues gaining ground in global markets.",
+      "hook": "BYD has now outsold Tesla for the second straight month as the Chinese EV maker continues gaining ground in global markets.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 05, 2026\n**REAL-TIME TSLA price:** $360.59 ▼ $20.32 (5.3%)\n\n**HOOK:** BYD has now outsold Tesla for the second straight month as the Chinese EV maker continues gaining ground in global markets.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Major electric vehicle automaker BYD outsells Tesla for the second month running - 05 April, 2026, 12:00 AM PST, The Cool Down**\n   BYD has outsold Tesla globally for the second consecutive month according to the latest f",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "Elon Musk",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "climate",
+        "energy",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 426,
+      "date": "2026-04-04",
+      "title": "A Tesla in Israel took a direct hit from Iranian missile debris yet its glass roof held firm, while the company also overtook BYD in global EV sales for Q1.",
+      "hook": "A Tesla in Israel took a direct hit from Iranian missile debris yet its glass roof held firm, while the company also overtook BYD in global EV sales for Q1.",
+      "summary": "**# Tesla Shorts Time**  \n**Date:** April 04, 2026  \n**REAL-TIME TSLA price:** $360.59 ▼ $20.32 (5.3%)\n\n**HOOK:** A Tesla in Israel took a direct hit from Iranian missile debris yet its glass roof held firm, while the company also overtook BYD in global EV sales for Q1.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla hit by Iranian missile debris in Israel and survives – April 04, 2026, 06:00 AM PST, Teslarati**  \n   A Tesla vehicle in Israel absorbed a direct strike from missile debris, ",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "ESA",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 20,
+      "date": "2026-04-03",
+      "title": "BC invests over $10M in parks conservation and opens 2026 Clean Industry Fund intake for emissions-reduction projects.",
+      "hook": "BC invests over $10M in parks conservation and opens 2026 Clean Industry Fund intake for emissions-reduction projects.",
+      "summary": "**Date:** April 03, 2026  \n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** BC invests over $10M in parks conservation and opens 2026 Clean Industry Fund intake for emissions-reduction projects.\n\n**Executive Summary:** British Columbia released two concrete program updates this week under provincial environmental policy. The Clean Industry Fund 2026 intake directly supports industrial emissions reductions while protecting jobs, creating immediate funding",
+      "url": "/env-intel.html",
+      "entities": [
+        "Date:",
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 25,
+      "date": "2026-04-03",
+      "title": "Google drops Gemma 4, claiming the strongest small multimodal open model yet with dramatic gains across every benchmark compared to Gemma 3.",
+      "hook": "Google drops Gemma 4, claiming the strongest small multimodal open model yet with dramatic gains across every benchmark compared to Gemma 3.",
+      "summary": "**# Models & Agents**  \n**Date:** April 03, 2026\n\n**HOOK:** Google drops Gemma 4, claiming the strongest small multimodal open model yet with dramatic gains across every benchmark compared to Gemma 3.\n\n**What You Need to Know:**  \nGoogle’s Gemma 4 update leads today’s releases, positioning it as the new leader among efficient multimodal models. Microsoft simultaneously open-sourced a governance toolkit for autonomous agents, addressing real safety and oversight concerns in production deployments",
+      "url": "/models-agents.html",
+      "entities": [
+        "Date:",
+        "DeepMind",
+        "Google",
+        "HOOK:",
+        "Llama",
+        "Microsoft",
+        "Nvidia",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 12,
+      "date": "2026-04-03",
+      "title": "Norwegian Cruise Line dropped 24% in March after disappointing earnings and Iran-related travel fears — a reminder that external shocks can override fundamentals fast.",
+      "hook": "Norwegian Cruise Line dropped 24% in March after disappointing earnings and Iran-related travel fears — a reminder that external shocks can override fundamentals fast.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** April 03, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Norwegian Cruise Line dropped 24% in March after disappointing earnings and Iran-related travel fears — a reminder that external shocks can override fundamentals fast.\n\n**Market Pulse:** Markets are showing modest resilience today with the S&P 500 at 6,583 (+0.1%), NASDAQ Composite at 21,879 (+0.2%), and TSX Composite at 33,108 (+0.5%). Sentiment rema",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Benzinga Pro:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Date:",
+        "Disclaimer:",
+        "Fintechs Lead DIY Investor Satisfaction",
+        "HOOK:",
+        "Intel",
+        "Interactive Brokers Stock Screener:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Pro tip:",
+        "RRSP",
+        "Risk Assessment:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Trade Type:",
+        "Why This Teaches:"
+      ],
+      "topics": [
+        "finance",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 27,
+      "date": "2026-04-03",
+      "title": "Trump warns Iran of further strikes after US-Israeli attack destroys Iran's largest bridge, as Tehran vows continued resistance.",
+      "hook": "Trump warns Iran of further strikes after US-Israeli attack destroys Iran's largest bridge, as Tehran vows continued resistance.",
+      "summary": "**# Omni View — Omni‑View Briefing**\n**Date:** April 03, 2026\n\n**HOOK:** Trump warns Iran of further strikes after US-Israeli attack destroys Iran's largest bridge, as Tehran vows continued resistance.\n\n## Top stories (5)\n\n### 1) Trump warns Iran after strike on largest bridge\n**What happened (neutral):** The US and Israel conducted strikes on Iranian targets including the country's largest bridge, which was destroyed in an overnight attack that killed eight people and wounded 90 others. Preside",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Microsoft",
+        "NASA",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 40,
+      "date": "2026-04-03",
+      "title": "New research shows BMI misclassifies more than one third of adults when compared to precise DXA body-fat scans.",
+      "hook": "New research shows BMI misclassifies more than one third of adults when compared to precise DXA body-fat scans.",
+      "summary": "**Planetterrian Daily**\n**Date:** April 03, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** New research shows BMI misclassifies more than one third of adults when compared to precise DXA body-fat scans.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **BMI misclassifies over one third of adults: 03 April 2026 • Science Daily**  \n   Researchers compared standard BMI categories with advanced DXA scans in a large group of adults and found more t",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Meta",
+        "Planetterrian Daily",
+        "SpaceX"
+      ],
+      "topics": [
+        "biotech",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 425,
+      "date": "2026-04-03",
+      "title": "Tesla regained the top spot in global pure EV sales by outpacing BYD while expanding the long-wheelbase Model Y across Asia.",
+      "hook": "Tesla regained the top spot in global pure EV sales by outpacing BYD while expanding the long-wheelbase Model Y across Asia.",
+      "summary": "# Tesla Shorts Time\n**Date:** April 03, 2026\n**REAL-TIME TSLA price:** $360.59 ▼ $20.32 (5.3%)\n\n**HOOK:** Tesla regained the top spot in global pure EV sales by outpacing BYD while expanding the long-wheelbase Model Y across Asia.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla outraces China’s BYD in pure electric car sales to regain world’s top spot: 03 April, 2026, 06:00 AM PST, South China Morning Post**\n   Tesla has overtaken BYD again in pure battery electric vehicle sales worldwide",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Cybercab Frunk Details Spark Discussion",
+        "Date:",
+        "Ford Promises New Affordable EV",
+        "Google",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "Record Unsold Inventory Emerges",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 48,
+      "date": "2026-04-02",
+      "title": "Artemis 2 astronauts have successfully repaired their toilet during the first crewed lunar mission in over 50 years.",
+      "hook": "Artemis 2 astronauts have successfully repaired their toilet during the first crewed lunar mission in over 50 years.",
+      "summary": "**HOOK:** Artemis 2 astronauts have successfully repaired their toilet during the first crewed lunar mission in over 50 years.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Artemis 2 Crew Fixes Toilet in Orbit: 02 April 2026 • Astronomy Magazine**  \n   The four-person crew of NASA’s Artemis 2 mission troubleshot and repaired their broken toilet on the first flight day. This practical fix ensures crew comfort and demonstrates NASA’s in-flight troubleshooting capability as the sp",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "AWS",
+        "HOOK:",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 17,
+      "date": "2026-04-02",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** April 02, 2026  \n\n**ЗАГОЛОВОК:** Bank of Canada следит за войной на Ближнем Востоке, но держит ставки — что это значит для вашей ипотеки  \n\n**Что сегодня важного:**  \nСегодня главное — как Bank of Canada принимает решения по ставкам в условиях войны в Иране. Регулятор признаёт, что ситуация сложная, но не хочет, чтобы один риск затмил все остальные. Это напрямую касается каждой из нас в Ванкувере: от платежей по ипотеке до стоимости аренды в Burnaby или Surrey. Т",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Bank of Canada",
+        "Дата:",
+        "ЗАГОЛОВОК:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 14,
+      "date": "2026-04-02",
+      "title": "Chinese companies now make 41% of the AI chips used inside China — here's why that matters for your future phone and games.",
+      "hook": "Chinese companies now make 41% of the AI chips used inside China — here's why that matters for your future phone and games.",
+      "summary": "**# Models & Agents for Beginners**  \n**Date:** April 02, 2026\n\n**HOOK:** Chinese companies now make 41% of the AI chips used inside China — here's why that matters for your future phone and games.\n\n**What's Cool Today:** Chinese chipmakers have taken a huge slice of their home AI accelerator market, showing how fast local tech is growing. We also have a brand-new vision model from IBM that's built for reading documents, plus a study showing how easily AI agents can be tricked online. Plus we ex",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "Date:",
+        "DeepMind",
+        "GPT",
+        "Gemini",
+        "Gig Workers Training Humanoid Robots",
+        "Google",
+        "HOOK:",
+        "How Vision-Language Models Actually Work",
+        "Models Protecting Each Other",
+        "OpenAI",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 11,
+      "date": "2026-04-02",
+      "title": "Alberta’s potential US$1T lithium resource meets geopolitical oil shock — creating a rare Canadian critical-minerals catalyst.",
+      "hook": "Alberta’s potential US$1T lithium resource meets geopolitical oil shock — creating a rare Canadian critical-minerals catalyst.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** April 02, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence  \n\n**HOOK:** Alberta’s potential US$1T lithium resource meets geopolitical oil shock — creating a rare Canadian critical-minerals catalyst.  \n\n**Market Pulse:** Markets are showing cautious resilience with S&P 500 at 6,575 (+0.7%), NASDAQ Composite at 21,841 (+1.2%), and TSX Composite at 32,958 (+0.6%). Geopolitical tension from Trump’s fresh Iran threats and th",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Catalyst:",
+        "Coinbase CLARITY Act Legislative Tracker:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Gold Decouples from Safe-Haven Status",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "SmartD SiC-Based VFD Technology Monitoring:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 424,
+      "date": "2026-04-02",
+      "title": "Tesla Shorts Time – Special Educational Episode",
+      "hook": "Tesla Shorts Time – Special Educational Episode",
+      "summary": "**Tesla Shorts Time – Special Educational Episode**\n\nHey, it’s April 2nd, 2026. Normally I’d be catching you up on the latest batch of Tesla news, but this week there just wasn’t enough fresh, solid material to make a proper episode. So instead we’re doing something a bit different — a proper deep-dive educational one.\n\nToday we’re talking about something that keeps coming up in conversations, investor calls, and even casual chats with other owners: **What actually determines whether Full Self-D",
+      "url": "/tesla.html",
+      "entities": [
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 19,
+      "date": "2026-04-01",
+      "title": "BC Environment adds formal issues resolution protocol to the environmental assessment process, improving dispute resolution and predictability for proponents and consultants.",
+      "hook": "BC Environment adds formal issues resolution protocol to the environmental assessment process, improving dispute resolution and predictability for proponents and consultants.",
+      "summary": "**Date:** April 01, 2026  \n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** BC Environment adds formal issues resolution protocol to the environmental assessment process, improving dispute resolution and predictability for proponents and consultants.\n\n**Executive Summary:** British Columbia has introduced an issues resolution protocol tool within its environmental assessment framework, targeting better transparency and process predictability. This is the",
+      "url": "/env-intel.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 24,
+      "date": "2026-04-01",
+      "title": "What You Need to Know:",
+      "hook": "What You Need to Know:",
+      "summary": "**What You Need to Know:** Hugging Face just shipped TRL v1.0, turning the messy post-training pipeline (SFT → Reward Modeling → DPO/GRPO) into a stable, production-ready unified API. Liquid AI dropped LFM2.5-350M, a 350M-parameter model trained on 28T tokens with scaled RL that challenges the “bigger is better” scaling narrative. A wave of strong arXiv papers today also delivers new techniques for continual pre-training, structured reasoning, memory architectures, and quantization.\n\n━━━━━━━━━━━",
+      "url": "/models-agents.html",
+      "entities": [
+        "APEX-EM",
+        "Cohere",
+        "CrossTrace",
+        "GPT",
+        "Hugging Face",
+        "Human-Like Lifelong Memory Architecture",
+        "Intel",
+        "LiteCoST",
+        "PolarQuant",
+        "TRL v1.0",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 10,
+      "date": "2026-04-01",
+      "title": "World stocks rocket higher on optimism the Iran war could end soon, lifting S&P 500 futures +2.9%.",
+      "hook": "World stocks rocket higher on optimism the Iran war could end soon, lifting S&P 500 futures +2.9%.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** April 01, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence  \n\n**HOOK:** World stocks rocket higher on optimism the Iran war could end soon, lifting S&P 500 futures +2.9%.  \n\n**Market Pulse:** Markets are surging today with the S&P 500 at 6,529 (+2.9%), NASDAQ Composite at 21,591 (+3.8%), and TSX Composite at 32,768 (+2.6%). The primary driver is growing optimism that the Iran conflict may de-escalate quickly, easing ene",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Bank of Canada",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Geopolitical Relief Rally Positioning",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Tesla",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 39,
+      "date": "2026-04-01",
+      "title": "Squid genomes reveal they retreated to deep-sea oxygen refuges over 100 million years ago to survive Earth's largest extinction.",
+      "hook": "Squid genomes reveal they retreated to deep-sea oxygen refuges over 100 million years ago to survive Earth's largest extinction.",
+      "summary": "**HOOK:** Squid genomes reveal they retreated to deep-sea oxygen refuges over 100 million years ago to survive Earth's largest extinction.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Squid survived mass extinction in deep ocean** • 01 April 2026 • Science Daily  \n   Newly sequenced genomes combined with global datasets show squid and cuttlefish originated deep in the ocean more than 100 million years ago and survived mass extinctions by retreating to oxygen-rich deep-sea r",
+      "url": "/planetterrian.html",
+      "entities": [
+        "HOOK:",
+        "Intel",
+        "Meta",
+        "NASA",
+        "Study debunks introverts-are-better-listeners belief"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 423,
+      "date": "2026-04-01",
+      "title": "Tesla Shorts Time – Special Educational Episode",
+      "hook": "Tesla Shorts Time – Special Educational Episode",
+      "summary": "**Tesla Shorts Time – Special Educational Episode**\n\nHey, it’s me.  \n\nApril 1st, 2026, and the news cycle was basically a graveyard today, so I figured we’d do something different. Instead of rushing through headlines that aren’t there, let’s sit with one topic that keeps coming up in our conversations and that actually matters a ton for anyone who owns a Tesla, invests in the company, or just wants to understand where this whole thing is headed.\n\nToday we’re going to talk about **vehicle autono",
+      "url": "/tesla.html",
+      "entities": [
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 422,
+      "date": "2026-04-01",
+      "title": "Tesla Shorts Time – Special Educational Episode",
+      "hook": "Tesla Shorts Time – Special Educational Episode",
+      "summary": "**Tesla Shorts Time – Special Educational Episode**\n\nHey, it’s April 1st, 2026. Normally I’d roll up with the latest batch of Tesla updates, but the news cycle decided to take a quiet holiday this week. So instead, we’re doing something a little different – a proper deep-dive episode.\n\nToday I want to talk about something that keeps coming up in every serious conversation about Tesla’s future, yet still confuses a lot of people: **how Tesla’s vehicle software and Full Self-Driving actually make ",
+      "url": "/tesla.html",
+      "entities": [
+        "FSD subscription or one-time purchase.",
+        "Robotaxi / unsupervised autonomy.",
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "health",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 18,
+      "date": "2026-03-31",
+      "title": "Permafrost thaw slump vegetation recovery is now predictable from annual gross primary productivity, with direct implications for northern remediation and risk assessments.",
+      "hook": "Permafrost thaw slump vegetation recovery is now predictable from annual gross primary productivity, with direct implications for northern remediation and risk assessments.",
+      "summary": "**# Environmental Intelligence**  \n**Date:** March 31, 2026  \n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing  \n\n**HOOK:** Permafrost thaw slump vegetation recovery is now predictable from annual gross primary productivity, with direct implications for northern remediation and risk assessments.  \n\n**Executive Summary:** The Nature Climate Change study quantifies surface greenness recovery times following retrogressive thaw slumps and establishes annual ecosystem g",
+      "url": "/env-intel.html",
+      "entities": [
+        "Date:",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 23,
+      "date": "2026-03-31",
+      "title": "Alibaba Qwen just dropped Qwen3.5-Omni, a native end-to-end multimodal model built for text, audio, video, and realtime interaction.",
+      "hook": "Alibaba Qwen just dropped Qwen3.5-Omni, a native end-to-end multimodal model built for text, audio, video, and realtime interaction.",
+      "summary": "**Models & Agents**\n**Date:** March 31, 2026\n\n**HOOK:** Alibaba Qwen just dropped Qwen3.5-Omni, a native end-to-end multimodal model built for text, audio, video, and realtime interaction.\n\n**What You Need to Know:** The biggest news today is the shift from patchwork multimodal wrappers to truly native omnimodal architectures, with Qwen3.5-Omni positioned as a direct challenger to Gemini 1.5 Pro and similar flagships. At the same time, the arXiv flood shows the agent research community is maturi",
+      "url": "/models-agents.html",
+      "entities": [
+        "Cohere",
+        "Date:",
+        "GUIDE for LLM-Driven Spacecraft Operations",
+        "Gemini",
+        "HOOK:",
+        "Intel",
+        "LVRPO: Language-Visual Alignment with GRPO",
+        "Models & Agents",
+        "Qwen3.5 Omni Release: MarkTechPost",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 9,
+      "date": "2026-03-31",
+      "title": "Geopolitical energy shock sends S&P 500 toward its worst quarter since 2022 while pushing Eurozone inflation to 2.5%.",
+      "hook": "Geopolitical energy shock sends S&P 500 toward its worst quarter since 2022 while pushing Eurozone inflation to 2.5%.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** March 31, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence  \n\n**HOOK:** Geopolitical energy shock sends S&P 500 toward its worst quarter since 2022 while pushing Eurozone inflation to 2.5%.  \n\n**Market Pulse:** Markets are under pressure with the S&P 500 at 6,344 (-0.4%), NASDAQ Composite at 20,795 (-0.7%), and TSX Composite at 31,935 (-0.1%). The primary driver is the escalating Iran conflict, which has spiked energy p",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Air Canada passenger-rights fine",
+        "Bank of Canada",
+        "Bloomberg Fuel Levy Adjustment Tracker",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "Financial Disclaimer:",
+        "HOOK:",
+        "Intel",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Modern Investing Techniques",
+        "New Ontario-federal housing deal",
+        "Pro tip:",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Trade Type:",
+        "Turkey restarts FX swaps",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 26,
+      "date": "2026-03-31",
+      "title": "Oil prices fell after reports President Trump is willing to end the Iran conflict even if the Strait of Hormuz stays largely closed.",
+      "hook": "Oil prices fell after reports President Trump is willing to end the Iran conflict even if the Strait of Hormuz stays largely closed.",
+      "summary": "**# Omni View — Omni‑View Briefing**\n**Date:** March 31, 2026\n\n**HOOK:** Oil prices fell after reports President Trump is willing to end the Iran conflict even if the Strait of Hormuz stays largely closed.\n\n## Top stories (5)\n### 1) Oil prices fall on Trump willingness to end Iran hostilities\n**What happened (neutral):** Oil prices reversed course and declined as traders reacted to reports that President Donald Trump expressed willingness to conclude military action against Iran despite the Stra",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 38,
+      "date": "2026-03-31",
+      "title": "Deep sleep activates a brain-driven feedback loop that releases growth hormone to build muscle, burn fat, and sharpen cognition.",
+      "hook": "Deep sleep activates a brain-driven feedback loop that releases growth hormone to build muscle, burn fat, and sharpen cognition.",
+      "summary": "# Planetterrian Daily\n**Date:** March 31, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Deep sleep activates a brain-driven feedback loop that releases growth hormone to build muscle, burn fat, and sharpen cognition.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Sleep Switch Builds Muscle and Burns Fat** • Science Daily  \n   Scientists have mapped neural circuits showing deep sleep triggers growth hormone release through a delicate feedb",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "Manufacturing Improves Whey Protein Taste",
+        "Meta",
+        "Next-Generation Sensor Reads Photon Spin",
+        "Planetterrian Daily",
+        "UV Light Controls Biomolecular Condensates"
+      ],
+      "topics": [
+        "biotech",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 421,
+      "date": "2026-03-31",
+      "title": "Tesla Shorts Time – Special Educational Episode",
+      "hook": "Tesla Shorts Time – Special Educational Episode",
+      "summary": "**Tesla Shorts Time – Special Educational Episode**\n\nHey, it’s me. \n\nMarch 31, 2026, and honestly the news cycle this week was pretty thin, so I figured we’d do something different. Instead of rushing through a bunch of small updates, let’s sit with one topic that keeps coming up in our conversations and that actually matters a lot if you’re trying to understand where Tesla is headed. \n\nToday we’re going to talk about **energy storage** — specifically, why Tesla’s Megapack business is becoming s",
+      "url": "/tesla.html",
+      "entities": [
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 420,
+      "date": "2026-03-31",
+      "title": "Tesla Shorts Time – Special Educational Episode",
+      "hook": "Tesla Shorts Time – Special Educational Episode",
+      "summary": "**Tesla Shorts Time – Special Educational Episode**\n\nHey, it’s March 31st, 2026. Normally we’d be diving into the week’s biggest Tesla stories, but the news cycle was unusually quiet, so I thought we’d do something different today. This is a proper deep-dive educational episode on a topic that keeps coming up in our community and actually matters a lot for where Tesla is headed.\n\nToday we’re talking about **Robotaxi – how it actually works, what the real technical and regulatory hurdles are, and",
+      "url": "/tesla.html",
+      "entities": [
+        "Tesla"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 17,
+      "date": "2026-03-30",
+      "title": "Alberta Bill 23 would eliminate government deadlines to respond to citizen petitions under the Citizen Initiative Act.",
+      "hook": "Alberta Bill 23 would eliminate government deadlines to respond to citizen petitions under the Citizen Initiative Act.",
+      "summary": "**Date:** March 30, 2026  \n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** Alberta Bill 23 would eliminate government deadlines to respond to citizen petitions under the Citizen Initiative Act.\n\n**Executive Summary:** Alberta’s proposed Bill 23 would substantively amend the Citizen Initiative Act for the third time since 2021, removing mandatory timelines for government action on citizen petitions and recall applications. This reduces procedural pressur",
+      "url": "/env-intel.html",
+      "entities": [
+        "B.C. 30-by-30 conservation target review",
+        "Date:",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel",
+        "Lab gloves skewing microplastics data"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 47,
+      "date": "2026-03-30",
+      "title": "SpaceX is preparing to loft 119 small satellites in one rideshare launch from California this morning.",
+      "hook": "SpaceX is preparing to loft 119 small satellites in one rideshare launch from California this morning.",
+      "summary": "# Fascinating Frontiers\n**Date:** March 30, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** SpaceX is preparing to loft 119 small satellites in one rideshare launch from California this morning.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **SpaceX Transporter-16 Readies 119 Payloads: DD March 2026 • Spaceflight Now**\n   SpaceX will launch the 21st mission in its smallsat rideshare program aboard a Falcon 9 from Vandenberg Space Force Base at 4:02 a.m. PDT. ",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Amazon",
+        "Date:",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 16,
+      "date": "2026-03-30",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** March 30, 2026\n\n**ЗАГОЛОВОК:** Ontario расширяет налоговую скидку на новые дома — что это значит для рынка недвижимости\n\n**Что сегодня важного:** Сегодня поговорим о важном изменении в Онтарио, которое касается покупки нового жилья и возврата налогов. Хотя это происходит не в Британской Колумбии, такие новости помогают лучше понимать, как работают налоговые льготы при покупке дома в Канаде. Мы также разберёмся, как правильно продавать недвижимость во время развод",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Bank of Canada",
+        "Дата:",
+        "ЗАГОЛОВОК:",
+        "Подготовка к возможным изменениям ставок",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 13,
+      "date": "2026-03-30",
+      "title": "Bluesky just dropped an AI that builds your perfect social feed from a simple sentence — no coding needed.",
+      "hook": "Bluesky just dropped an AI that builds your perfect social feed from a simple sentence — no coding needed.",
+      "summary": "**Models & Agents for Beginners**  \n**Date:** March 30, 2026\n\n**HOOK:** Bluesky just dropped an AI that builds your perfect social feed from a simple sentence — no coding needed.\n\n**What's Cool Today:** Today we’re seeing AI move from just chatting to actually building things for you, like custom social media feeds that match exactly what you want to see. Bluesky’s new AI assistant called Attie lets you describe the kind of posts you want in plain English, and it creates a custom feed on the spo",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "AI Makes People More Stubborn",
+        "Anthropic",
+        "Claude",
+        "Date:",
+        "GPT",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Meta",
+        "Models & Agents for Beginners",
+        "OpenAI",
+        "Sora Shutdown Reality Check",
+        "What “Agentic AI” really means",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "language-models"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 8,
+      "date": "2026-03-30",
+      "title": "Modern Investing Techniques – Special Educational Episode",
+      "hook": "Modern Investing Techniques – Special Educational Episode",
+      "summary": "**Modern Investing Techniques – Special Educational Episode**  \n**Title: Mastering the Covered Call ETF Strategy in a Sideways Market**\n\n[Intro Music Fade In]\n\nWelcome back to *Modern Investing Techniques*, the podcast where we cut through the noise and show Canadian and global investors how to use modern tools to consistently outperform the S&P 500, NASDAQ, and TSX Composite over time. I’m your host, and today we’re doing something special.\n\nBecause the news flow was unusually thin, we’re dedic",
+      "url": "/modern-investing.html",
+      "entities": [
+        "Benchmark comparison:",
+        "Covered Call ETFs",
+        "End of Episode",
+        "Financial Disclaimer",
+        "Modern twist – 2026 edition:",
+        "NASDAQ",
+        "RRSP",
+        "S&P 500",
+        "Simulated Allocation (educational only):",
+        "TFSA",
+        "TSX Composite"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 8,
+      "date": "2026-03-30",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** March 30, 2026  \n**Theme:** Art (Искусство)\n\n**Vocabulary List (10 words/phrases):**\n\n- **Russian (Cyrillic):** искусство  \n  **Transliteration:** ees-KOOSST-voh  \n  **English:** art  \n  **Example sentence:** Я люблю искусство.  \n  **Example translation:** I love art.  \n  **Memory hook:** Sounds a bit like “is cost-vo” — imagine asking “what is the cost of this beautiful art?”\n\n- **Russian (Cyrillic):** картина  \n  **Transliteration:** kar-TEE-nah ",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "English:",
+        "Example sentence:",
+        "Example translation:",
+        "Grammar Spotlight:",
+        "Memory hook:",
+        "Practice Challenge:",
+        "Russian (Cyrillic):",
+        "Theme:",
+        "Transliteration:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 22,
+      "date": "2026-03-29",
+      "title": "Naver's Seoul World Model grounds video generation in real Street View geometry from over a million images and generalizes to other cities without fine-tuning.",
+      "hook": "Naver's Seoul World Model grounds video generation in real Street View geometry from over a million images and generalizes to other cities without fine-tuning.",
+      "summary": "**HOOK:** Naver's Seoul World Model grounds video generation in real Street View geometry from over a million images and generalizes to other cities without fine-tuning.\n\n**What You Need to Know:** Naver has released a video world model trained on actual city geometry instead of pure synthetic data, directly addressing one of the biggest failure modes in current world models: hallucinating plausible but incorrect urban layouts. This stands out among today's releases alongside Mistral's new 4B op",
+      "url": "/models-agents.html",
+      "entities": [
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "Meta",
+        "Mistral",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 25,
+      "date": "2026-03-29",
+      "title": "OMNI VIEW SPECIAL EDUCATIONAL EPISODE",
+      "hook": "OMNI VIEW SPECIAL EDUCATIONAL EPISODE",
+      "summary": "**OMNI VIEW SPECIAL EDUCATIONAL EPISODE**\n\n**March 29, 2026**\n\n**Today’s Topic: How Modern Central Bank Digital Currencies (CBDCs) Are Actually Designed and What They Could Change**\n\n**Introduction**\n\nWelcome to this special educational edition of Omni View. When regular news flow is light, we step back and examine a structural issue that will shape economies, privacy, and geopolitics for decades. Today we explore central bank digital currencies — not the hype or the conspiracy narratives, but t",
+      "url": "/omni-view.html",
+      "entities": [
+        "Conclusion",
+        "ESA",
+        "Introduction",
+        "March 29, 2026",
+        "OMNI VIEW SPECIAL EDUCATIONAL EPISODE"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 37,
+      "date": "2026-03-29",
+      "title": "Supercomputer simulations have mapped the full motions of the spliceosome inside a two-million-atom model of the human cell.",
+      "hook": "Supercomputer simulations have mapped the full motions of the spliceosome inside a two-million-atom model of the human cell.",
+      "summary": "**HOOK:** Supercomputer simulations have mapped the full motions of the spliceosome inside a two-million-atom model of the human cell.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 12 Science & Health Discoveries\n1. **Supercomputer maps spliceosome motions** • 29 March 2026  \n   Researchers at the Italian Institute of Technology, in collaboration with Uppsala University and AstraZeneca, used computational chemistry and supercomputers to simulate the movements of the spliceosome within a two-million-atom human c",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Electricity drives biomass-based chemical production",
+        "HOOK:",
+        "Meta",
+        "Supercomputer maps spliceosome motions"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 419,
+      "date": "2026-03-29",
+      "title": "Tesla has started delivering the refreshed Model Y Performance and RWD in British Columbia after weeks of shifting timelines.",
+      "hook": "Tesla has started delivering the refreshed Model Y Performance and RWD in British Columbia after weeks of shifting timelines.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 29, 2026\n**REAL-TIME TSLA price:** $361.83 ▼ $12.37 (3.3%)\n\n**HOOK:** Tesla has started delivering the refreshed Model Y Performance and RWD in British Columbia after weeks of shifting timelines.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla begins Model Y Performance and RWD deliveries in British Columbia, March 28, 2026, 12:44 PM PST, Drive Tesla Canada**\n   The first deliveries of the updated Tesla Model Y lineup have officially begun in British Co",
+      "url": "/tesla.html",
+      "entities": [
+        "Amazon",
+        "Clear FSD Results",
+        "Cybercab Manufacturing Leadership Change",
+        "Date:",
+        "Elon Musk",
+        "Elon Musk’s Terafab Announcement",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 46,
+      "date": "2026-03-28",
+      "title": "Mars-like exoplanets orbiting M-dwarfs could lose their atmospheres in just millions of years.",
+      "hook": "Mars-like exoplanets orbiting M-dwarfs could lose their atmospheres in just millions of years.",
+      "summary": "**HOOK:** Mars-like exoplanets orbiting M-dwarfs could lose their atmospheres in just millions of years.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Mars-like Worlds Near M-Dwarfs May Lose Air** • 28 March 2026 • Universe Today  \n   New modelling shows how a Mars-like exoplanet orbiting Barnard's star would lose its atmosphere through atmospheric escape processes.  \n   The work highlights why atmospheric retention must be considered alongside liquid water and the habitable zo",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "ESA",
+        "Erik Richards: I Am Artemis",
+        "HOOK:",
+        "Hunting Moon Water With Neutrons",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 15,
+      "date": "2026-03-28",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**Финансы Просто**  \n**Дата:** March 28, 2026\n\n**Заголовок:** Ontario расширяет возврат HST на новые дома — что это значит для покупательниц в BC\n\n**Что сегодня важного:**  \nСегодня мы поговорим о важном изменении в правилах возврата налога на новые дома в Онтарио и о том, как это может косвенно повлиять на рынок недвижимости по всей Канаде. Хотя новость из Онтарио, она важна для тех, кто следит за ценами на жильё и ипотечными ставками. Мы также разберём, как работают объявления Bank of Canada о",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Bank of Canada",
+        "Дата:",
+        "Заголовок:",
+        "Финансы Просто",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 12,
+      "date": "2026-03-28",
+      "title": "Meta built an AI that can predict how your brain will react to pictures, music, and speech — better than reading one real person's brain scan.",
+      "hook": "Meta built an AI that can predict how your brain will react to pictures, music, and speech — better than reading one real person's brain scan.",
+      "summary": "**Models & Agents for Beginners**  \n**Date:** March 28, 2026\n\n**HOOK:** Meta built an AI that can predict how your brain will react to pictures, music, and speech — better than reading one real person's brain scan.\n\n**What's Cool Today:** Meta just created a model that predicts brain activity when you see images, hear sounds, or listen to speech. It actually matches typical human brain responses more closely than any single real person's scan would. This feels like sci-fi, but it's real, and it ",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "Date:",
+        "GPT",
+        "HOOK:",
+        "Meta",
+        "Models & Agents for Beginners",
+        "OpenAI",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "language-models",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 7,
+      "date": "2026-03-28",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** March 28, 2026  \n**Theme:** Weather (Погода)\n\n**Vocabulary List (10 words/phrases):**\n\n- Russian (Cyrillic): погода  \n  Transliteration: pa-GO-da  \n  English: weather  \n  Example sentence: Какая сегодня погода?  \n  Example translation: What is the weather like today?  \n  Memory hook: Sounds like “page” + “oda” — imagine turning the page of a weather calendar every day.\n\n- Russian (Cyrillic): дождь  \n  Transliteration: dozh-d’ (soft “d” at the end) ",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "For adults & older kids:",
+        "For kids:",
+        "Grammar Spotlight:",
+        "Practice Challenge:",
+        "Theme:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "health",
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 418,
+      "date": "2026-03-28",
+      "title": "A Tesla on FSD Supervised avoided a potential collision with a school bus that nearly ran a red light, with the viral video showing the system braking sharply to protect its occupants.",
+      "hook": "A Tesla on FSD Supervised avoided a potential collision with a school bus that nearly ran a red light, with the viral video showing the system braking sharply to protect its occupants.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 28, 2026\n**REAL-TIME TSLA price:** $361.83 ▼ $12.37 (3.3%)\n\n**HOOK:** A Tesla on FSD Supervised avoided a potential collision with a school bus that nearly ran a red light, with the viral video showing the system braking sharply to protect its occupants.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla drives drunk owner while he naps, Police still arrest him on DUI: 28 March, 2026, 06:08 AM PST, Teslarati**\n   A Vacaville man reportedly let his Tesla dr",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Analyst Predicts Tesla-SpaceX Merger",
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Starlink License Push in Namibia",
+        "Stock Decline and Robotaxi Doubts",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:",
+        "VW-Rivian Software Milestone"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 16,
+      "date": "2026-03-27",
+      "title": "Alberta First Nations and farmers demand full federal Impact Assessment for carbon capture pipeline project under IAA.",
+      "hook": "Alberta First Nations and farmers demand full federal Impact Assessment for carbon capture pipeline project under IAA.",
+      "summary": "**HOOK:** Alberta First Nations and farmers demand full federal Impact Assessment for carbon capture pipeline project under IAA.\n\n**Executive Summary:** Alberta stakeholders are pressing for a full environmental assessment of a proposed carbon capture and storage pipeline to the West Coast, citing risks that governments will fast-track the project and bypass IAA requirements. Ontario’s absence from the federal-First Nations interim assessment of the Ring of Fire mining region highlights ongoing ",
+      "url": "/env-intel.html",
+      "entities": [
+        "Executive Summary:",
+        "Google",
+        "HOOK:"
+      ],
+      "topics": [
+        "climate",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 21,
+      "date": "2026-03-27",
+      "title": "New arXiv papers expose critical flaws in how we evaluate depression-detection models, LLM pruning, and verbalized confidence.",
+      "hook": "New arXiv papers expose critical flaws in how we evaluate depression-detection models, LLM pruning, and verbalized confidence.",
+      "summary": "**Models & Agents**\n**Date:** March 27, 2026\n\n**HOOK:** New arXiv papers expose critical flaws in how we evaluate depression-detection models, LLM pruning, and verbalized confidence.\n\n**What You Need to Know:** Today's cs.CL batch reveals that many impressive medical AI results may be artifacts of interviewer prompts rather than genuine participant signals, while pruning works for classification but breaks generation due to probability-space amplification. Several papers also show that fine-tuni",
+      "url": "/models-agents.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "Gemini",
+        "HOOK:",
+        "Llama",
+        "Meta",
+        "Models & Agents",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 11,
+      "date": "2026-03-27",
+      "title": "Anthropic just confirmed their leaked model is a huge leap in AI reasoning — and it happened because of a simple security slip-up.",
+      "hook": "Anthropic just confirmed their leaked model is a huge leap in AI reasoning — and it happened because of a simple security slip-up.",
+      "summary": "**HOOK:** Anthropic just confirmed their leaked model is a huge leap in AI reasoning — and it happened because of a simple security slip-up.\n\n**What's Cool Today:** Anthropic accidentally revealed their most advanced AI yet through a data breach, calling it a \"step change\" in how well models can reason and solve problems. This shows how fast the biggest AI companies are racing to build smarter systems, even as they compete with Google and OpenAI. Today we’ll break down what this means for everyd",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Anthropic",
+        "Apple",
+        "Claude",
+        "GPT",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "OpenAI",
+        "What's Cool Today:",
+        "Wikipedia Bans AI-Written Articles"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 7,
+      "date": "2026-03-27",
+      "title": "Oil prices climb as Trump notes Iran allowed 10 tankers through the Strait of Hormuz, creating fresh energy-sector volatility.",
+      "hook": "Oil prices climb as Trump notes Iran allowed 10 tankers through the Strait of Hormuz, creating fresh energy-sector volatility.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** March 27, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Oil prices climb as Trump notes Iran allowed 10 tankers through the Strait of Hormuz, creating fresh energy-sector volatility.\n\n**Market Pulse:** North American markets opened lower today with the S&P 500 at 6,477 (-1.7%), NASDAQ Composite at 21,408 (-2.4%), and TSX Composite at 31,888 (-1.5%). Geopolitical tension around the Iran conflict continues t",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Beyond-the-Headline Geopolitical Filtering",
+        "Catalyst:",
+        "Confidence Level:",
+        "Current Streak:",
+        "Date:",
+        "Disclaimer:",
+        "Entry:",
+        "Exit:",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Interactive Brokers PortfolioAnalyst Geopolitical Overlay:",
+        "Last Weekly Hold:",
+        "Lesson Learned:",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Pro tip:",
+        "RRSP",
+        "Result:",
+        "Risk Assessment:",
+        "Running Total:",
+        "Seeking Alpha Premium Research Filters:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:",
+        "Win Rate:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 24,
+      "date": "2026-03-27",
+      "title": "Trump extends deadline for Iran to reopen Strait of Hormuz to April 6, pausing strikes on energy sites as oil markets fluctuate.",
+      "hook": "Trump extends deadline for Iran to reopen Strait of Hormuz to April 6, pausing strikes on energy sites as oil markets fluctuate.",
+      "summary": "**# Omni View — Omni‑View Briefing**  \n**Date:** March 27, 2026\n\n**HOOK:** Trump extends deadline for Iran to reopen Strait of Hormuz to April 6, pausing strikes on energy sites as oil markets fluctuate.\n\n## Top stories (5)\n### 1) Trump Extends Iran Deadline, Pauses Energy Site Strikes\n**What happened (neutral):** President Trump announced he is extending the deadline for Iran to open the Strait of Hormuz by 10 days to April 6, stating that talks with Tehran are “going very well.” He said he is ",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 36,
+      "date": "2026-03-27",
+      "title": "Excess belly fat combined with low muscle mass raises death risk by 83% through accelerated inflammation and muscle loss.",
+      "hook": "Excess belly fat combined with low muscle mass raises death risk by 83% through accelerated inflammation and muscle loss.",
+      "summary": "**HOOK:** Excess belly fat combined with low muscle mass raises death risk by 83% through accelerated inflammation and muscle loss.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 12 Science & Health Discoveries\n1. **Sarcopenic Obesity Raises Death Risk 83% • 27 March 2026**\n   Having both excess belly fat and low muscle mass creates a vicious cycle where fat accelerates muscle breakdown and inflammation. The condition can be identified using simple measurements rather than costly tests, enabling earlier interven",
+      "url": "/planetterrian.html",
+      "entities": [
+        "HOOK:",
+        "Meta"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "manufacturing"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 417,
+      "date": "2026-03-27",
+      "title": "Tesla makes Fortune’s 2026 Most Innovative Companies list thanks to the Cybercab as production begins this year.",
+      "hook": "Tesla makes Fortune’s 2026 Most Innovative Companies list thanks to the Cybercab as production begins this year.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 27, 2026\n**REAL-TIME TSLA price:** $372.11 ▼ $2.09 (0.6%)\n\n**HOOK:** Tesla makes Fortune’s 2026 Most Innovative Companies list thanks to the Cybercab as production begins this year.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla lands on Fortune’s 2026 Most Innovative Companies and the Cybercab is why: 27 March, 2026, 01:26 AM PST, Teslarati**\n   Fortune has named Tesla one of America’s most innovative companies. The recognition comes specifically beca",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Advanced Steer-by-Wire Patent Surfaces",
+        "Date:",
+        "Elon Musk",
+        "Folding Supercharger Units Debut",
+        "HOOK:",
+        "Meta",
+        "Musk’s Latest Vehicle Tease",
+        "REAL-TIME TSLA price:",
+        "Sony-Honda AFEELA Project Cancelled",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:",
+        "Two-Seater Cybercab Economics"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 15,
+      "date": "2026-03-26",
+      "title": "Trans Mountain pipeline reaches full capacity in April due to Middle East disruptions, directly affecting crude export scheduling and associated environmental compliance obligations in BC and Alberta.",
+      "hook": "Trans Mountain pipeline reaches full capacity in April due to Middle East disruptions, directly affecting crude export scheduling and associated environmental compliance obligations in BC and Alberta.",
+      "summary": "**# Environmental Intelligence**  \n**Date:** March 26, 2026  \n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** Trans Mountain pipeline reaches full capacity in April due to Middle East disruptions, directly affecting crude export scheduling and associated environmental compliance obligations in BC and Alberta.\n\n**Executive Summary:** The Trans Mountain Expansion is forecast to operate at full capacity through April and May amid global supply shocks, incr",
+      "url": "/env-intel.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "Google",
+        "HOOK:",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 45,
+      "date": "2026-03-26",
+      "title": "Hubble has caught a tiny comet slowing its spin and then reversing direction entirely.",
+      "hook": "Hubble has caught a tiny comet slowing its spin and then reversing direction entirely.",
+      "summary": "**HOOK:** Hubble has caught a tiny comet slowing its spin and then reversing direction entirely.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Nearby Rocky Worlds for Life Search: 26 March 2026 • Universe Today**  \n   A new paper in Monthly Notices of the Royal Astronomical Society has identified 45 rocky exoplanets with potential for life out of the 6,281 currently known. These nearby candidates could become prime targets for future observations seeking signs of biology.  \n   ",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "ESA",
+        "HOOK:",
+        "NASA"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 14,
+      "date": "2026-03-26",
+      "title": "Episode 14",
+      "hook": "",
+      "summary": "**Финансы Просто**\n**Дата:** March 26, 2026\n\n**ЗАГОЛОВОК:** Как управлять семейным бюджетом в условиях высокой стоимости жизни в Ванкувере и Нижнем Материке.\n\n**Тема:** Бюджетирование для иммигранток в Британской Колумбии\n\n━━━━━━━━━━━━━━━━━━━━\n### Обзор выпуска\n\nСегодня мы разбираем, как в условиях очень высокой стоимости жизни в Ванкувере и Нижнем Материке сохранять спокойствие и контроль над семейным бюджетом. Представьте, что ваш бюджет — это небольшая лодка, в которой плывёт ваша семья, а во",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Дата:",
+        "ЗАГОЛОВОК:",
+        "Совет 1:",
+        "Совет 2:",
+        "Совет 3:",
+        "Тема:",
+        "Финансы Просто"
+      ],
+      "topics": [
+        "manufacturing"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 6,
+      "date": "2026-03-26",
+      "title": "Canada hits the NATO 2% GDP defence target, opening fresh capital-flow opportunities in Canadian aerospace and defence names.",
+      "hook": "Canada hits the NATO 2% GDP defence target, opening fresh capital-flow opportunities in Canadian aerospace and defence names.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** March 26, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Canada hits the NATO 2% GDP defence target, opening fresh capital-flow opportunities in Canadian aerospace and defence names.\n\n**Market Pulse:** Markets are mixed and cautious today. The S&P 500 closed at 6,545 (-0.7%), the NASDAQ Composite at 21,701 (-1.0%), and the TSX Composite at 32,335 (-0.1%). Geopolitical uncertainty around Iran is driving oil ",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Catalyst:",
+        "Coinbase Token-Backed Down Payment Program",
+        "Confidence Level:",
+        "Date:",
+        "Defence-Spending Catalyst Strategy",
+        "Disclaimer:",
+        "Financial Disclaimer:",
+        "HOOK:",
+        "Intel",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "RRSP",
+        "Risk Assessment:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:"
+      ],
+      "topics": [
+        "finance",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 5,
+      "date": "2026-03-26",
+      "title": "Short sellers piling into SoFi while XRP gets positive SEC clarity — two clear signals worth dissecting for your portfolio.",
+      "hook": "Short sellers piling into SoFi while XRP gets positive SEC clarity — two clear signals worth dissecting for your portfolio.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** March 26, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Short sellers piling into SoFi while XRP gets positive SEC clarity — two clear signals worth dissecting for your portfolio.\n\n**Market Pulse:** North American markets pushed higher today with the TSX Composite leading at 32,383 (+1.4%), followed by the NASDAQ Composite at 21,930 (+0.8%) and S&P 500 at 6,592 (+0.5%). Geopolitical tension between Israel ",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Bank of Canada",
+        "Catalyst:",
+        "Confidence Level:",
+        "Date:",
+        "Disclaimer:",
+        "Financial Disclaimer:",
+        "GPT",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "Pro tip:",
+        "RRSP",
+        "Risk Assessment:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:"
+      ],
+      "topics": [
+        "finance",
+        "language-models",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 23,
+      "date": "2026-03-26",
+      "title": "Iran has rejected President Trump’s proposed peace plan as a pretext for invasion, while Israel claims it killed Iran’s naval chief amid escalating Middle East conflict.",
+      "hook": "Iran has rejected President Trump’s proposed peace plan as a pretext for invasion, while Israel claims it killed Iran’s naval chief amid escalating Middle East conflict.",
+      "summary": "**# Omni View — Omni‑View Briefing**  \n**Date:** March 26, 2026\n\n**HOOK:** Iran has rejected President Trump’s proposed peace plan as a pretext for invasion, while Israel claims it killed Iran’s naval chief amid escalating Middle East conflict.\n\n## Top stories (5)\n### 1) Iran rejects Trump peace plan as Israel claims killing of Iranian naval chief\n**What happened (neutral):** Iran has dismissed a US peace proposal aimed at ending the conflict with Israel as “one-sided and unfair,” calling it cov",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Meta",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 35,
+      "date": "2026-03-26",
+      "title": "Light-activated nanoparticles trigger copper overload to kill cancer cells 100 times more effectively than existing chemotherapy.",
+      "hook": "Light-activated nanoparticles trigger copper overload to kill cancer cells 100 times more effectively than existing chemotherapy.",
+      "summary": "# Planetterrian Daily\n**Date:** March 26, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Light-activated nanoparticles trigger copper overload to kill cancer cells 100 times more effectively than existing chemotherapy.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Light-activated nanoparticles kill cancer via copper overload: 26 March 2026 • Phys.org**\n   Researchers in Germany developed a copper-based agent complex that exploits cupropto",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Meta",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 6,
+      "date": "2026-03-26",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** March 26, 2026  \n**Theme:** Travel (Путешествие)\n\n**Vocabulary List (10 words/phrases):**\n\n- Russian (Cyrillic): аэропорт  \n  Transliteration: ah-eh-roh-port  \n  English: airport  \n  Example sentence: Мы летим в Москву. Давай встретимся в аэропорту.  \n  Example translation: We are flying to Moscow. Let's meet at the airport.  \n  Memory hook: Sounds like “air port” — exactly where planes “park” in the air!\n\n- Russian (Cyrillic): самолёт  \n  Translit",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "Grammar Spotlight:",
+        "Meta",
+        "Practice Challenge:",
+        "Theme:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 5,
+      "date": "2026-03-26",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** March 26, 2026  \n**Theme:** Technology (Технологии)\n\n**Vocabulary List (10 words/phrases):**\n\n- **Russian (Cyrillic):** робот  \n  **Transliteration:** RO-bot  \n  **English:** robot  \n  **Example sentence:** Мелания Трамп пришла с роботом на встречу.  \n  **Example translation:** Melania Trump came to the meeting with a robot.  \n  **Memory hook:** Sounds almost exactly like the English “robot” — because it’s the same international word!\n\n- **Russian ",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Compare to English:",
+        "Cultural Corner:",
+        "Date:",
+        "English:",
+        "Example sentence:",
+        "Example translation:",
+        "Intel",
+        "Memory hook:",
+        "Practice Challenge:",
+        "Russian (Cyrillic):",
+        "Theme:",
+        "Transliteration:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 14,
+      "date": "2026-03-25",
+      "title": "Ontario's absence from federal Ring of Fire impact assessment creates immediate regulatory uncertainty for mining proponents in northern Ontario.",
+      "hook": "Ontario's absence from federal Ring of Fire impact assessment creates immediate regulatory uncertainty for mining proponents in northern Ontario.",
+      "summary": "**HOOK:** Ontario's absence from federal Ring of Fire impact assessment creates immediate regulatory uncertainty for mining proponents in northern Ontario.\n\n**Executive Summary:** Ontario did not participate in the federal Impact Assessment Agency of Canada and First Nations-led interim report on Ring of Fire development impacts, raising questions about provincial-federal coordination under the Impact Assessment Act. BC has disbanded its CleanBC climate agency with some staff redirected to pipel",
+      "url": "/env-intel.html",
+      "entities": [
+        "ESA",
+        "Executive Summary:",
+        "Google",
+        "HOOK:"
+      ],
+      "topics": [
+        "climate",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 4,
+      "date": "2026-03-25",
+      "title": "Brookfield and La Caisse’s $37.25/share takeover of Boralex creates a textbook Canadian M&A premium play worth dissecting.",
+      "hook": "Brookfield and La Caisse’s $37.25/share takeover of Boralex creates a textbook Canadian M&A premium play worth dissecting.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** March 25, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Brookfield and La Caisse’s $37.25/share takeover of Boralex creates a textbook Canadian M&A premium play worth dissecting.\n\n**Market Pulse:** North American markets opened the day with solid gains as hopes for an Iran off-ramp eased geopolitical tension. The S&P 500 closed at 6,610 (+0.8%), NASDAQ Composite reached 22,016 (+1.2%), and Canada’s TSX Com",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Catalyst:",
+        "Confidence Level:",
+        "Date:",
+        "Disclaimer:",
+        "Financial Disclaimer:",
+        "HOOK:",
+        "Intel",
+        "Market Pulse:",
+        "Market:",
+        "Meta",
+        "Modern Investing Techniques",
+        "Pro tip:",
+        "RRSP",
+        "Risk Assessment:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today’s Pick:",
+        "Trade Type:",
+        "Water Tower Research Institutional-Style Coverage",
+        "Why This Teaches:"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 22,
+      "date": "2026-03-25",
+      "title": "Trump administration shares 15-point plan to end Iran war as Tehran launches new strikes on US and Israeli targets.",
+      "hook": "Trump administration shares 15-point plan to end Iran war as Tehran launches new strikes on US and Israeli targets.",
+      "summary": "**# Omni View — Omni‑View Briefing**\n**Date:** March 25, 2026\n\n**HOOK:** Trump administration shares 15-point plan to end Iran war as Tehran launches new strikes on US and Israeli targets.\n\n## Top stories (5)\n\n### 1) Trump’s 15-point Iran plan and conflicting signals on peace\n**What happened (neutral):** The US has drafted a 15-point plan aimed at ending the war with Iran, according to people familiar with the matter. Trump has claimed Iran agreed to give up its nuclear ambitions and that negoti",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 416,
+      "date": "2026-03-25",
+      "title": "Tesla is developing a new family vehicle that Elon Musk calls way cooler than a minivan as the company begins phasing out the Model S and X.",
+      "hook": "Tesla is developing a new family vehicle that Elon Musk calls way cooler than a minivan as the company begins phasing out the Model S and X.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 25, 2026\n**REAL-TIME TSLA price:** $392.84 ▲ $6.11 (1.6%)\n\n**HOOK:** Tesla is developing a new family vehicle that Elon Musk calls way cooler than a minivan as the company begins phasing out the Model S and X.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Elon Musk says Tesla is developing a new vehicle: ‘Way cooler than a minivan’ - 25 March, 2026, 8:11 AM PST, Teslarati**\n   Elon Musk confirmed Tesla is working on a new vehicle designed for larger familie",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Amazon",
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 44,
+      "date": "2026-03-24",
+      "title": "Giant craters on metallic asteroid Psyche could finally confirm if it's the exposed core of a destroyed protoplanet.",
+      "hook": "Giant craters on metallic asteroid Psyche could finally confirm if it's the exposed core of a destroyed protoplanet.",
+      "summary": "**HOOK:** Giant craters on metallic asteroid Psyche could finally confirm if it's the exposed core of a destroyed protoplanet.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Giant Craters Hint at Psyche's Core Origin: 24 March 2026 • Universe Today**  \n   New analysis suggests massive craters on asteroid 16 Psyche may preserve evidence of whether it is the metallic remnant of a protoplanet's core. This helps planetary scientists understand how such a unique metal-rich body forme",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Amazon",
+        "ESA",
+        "HOOK:",
+        "Meta",
+        "NASA",
+        "Rocket Lab"
+      ],
+      "topics": [
+        "energy",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 13,
+      "date": "2026-03-24",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** March 24, 2026  \n\n**ЗАГОЛОВОК:** Как найти ипотеку, когда банки говорят «нет»: история одной семьи из Эдмонтона  \n\n**Что сегодня важного:**  \nСегодня мы поговорим о том, что делать, если традиционные банки отказывают в ипотеке, но вы всё равно хотите купить дом. Также разберём, где сейчас можно получить более высокие проценты на свои сбережения. А в блоке «Объясни как подруге» я подробно расскажу, как на самом деле работает альтернативное ипотечное кредитование. ",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Bank of Canada",
+        "Дата:",
+        "Даты объявления ставок Банка Канады",
+        "ЗАГОЛОВОК:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 3,
+      "date": "2026-03-24",
+      "title": "Estée Lauder confirms a potential merger suitor yet its stock still struggles — a textbook lesson in market skepticism versus headline optimism.",
+      "hook": "Estée Lauder confirms a potential merger suitor yet its stock still struggles — a textbook lesson in market skepticism versus headline optimism.",
+      "summary": "**# Modern Investing Techniques**  \n**Date:** March 24, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Estée Lauder confirms a potential merger suitor yet its stock still struggles — a textbook lesson in market skepticism versus headline optimism.\n\n**Market Pulse:** North American markets opened solidly higher today with the S&P 500 at 6,581 (+1.1%), NASDAQ Composite at 21,947 (+1.4%), and TSX Composite at 31,884 (+1.8%). Geopolitical jitters around th",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Bank of Canada",
+        "Catalyst:",
+        "Confidence Level:",
+        "Date:",
+        "Disclaimer:",
+        "Financial Disclaimer:",
+        "HOOK:",
+        "Intel",
+        "Market Pulse:",
+        "Market:",
+        "Meta",
+        "Modern Investing Techniques",
+        "Pro tip:",
+        "RRSP",
+        "Risk Assessment:",
+        "Strategy:",
+        "Summary of Deliberations release:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today’s Pick:",
+        "Trade Type:",
+        "Why This Teaches:"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 4,
+      "date": "2026-03-24",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** March 24, 2026  \n**Theme:** Animals (Животные)\n\n**Vocabulary List (10 words/phrases):**\n\n- Russian (Cyrillic): животное  \n  Transliteration: zhi-VOT-no-ye  \n  English: animal  \n  Example sentence: Я люблю животных.  \n  Example translation: I love animals.  \n  Memory hook: Sounds a bit like “zoo” + “vote” — imagine voting for your favourite animal at the zoo!\n\n- Russian (Cyrillic): собака  \n  Transliteration: sa-BA-ka  \n  English: dog  \n  Example se",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "For adults & older kids:",
+        "For kids:",
+        "Grammar Spotlight:",
+        "Practice Challenge:",
+        "Theme:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 415,
+      "date": "2026-03-24",
+      "title": "Cybertruck earns IIHS Top Safety Pick+ while Tesla patents a fresh trailer-style range extender.",
+      "hook": "Cybertruck earns IIHS Top Safety Pick+ while Tesla patents a fresh trailer-style range extender.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 24, 2026\n**REAL-TIME TSLA price:** $381.93 ▼ $0.02 (0.0%)\n\n**HOOK:** Cybertruck earns IIHS Top Safety Pick+ while Tesla patents a fresh trailer-style range extender.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Patent Reveals New Take on Cybertruck Range Extender With Trailer Design: March 24, 2026, 3:47 PM PST, Drive Tesla Canada**\n   A newly published patent shows Tesla is still developing a range extender solution for the Cybertruck, but it now ap",
+      "url": "/tesla.html",
+      "entities": [
+        "Boring Company Awards Free Tunnels",
+        "Cybertruck Safety Milestone",
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "Model Y Long Wheelbase Progress",
+        "REAL-TIME TSLA price:",
+        "Semi Wireless Charging Concept",
+        "SpaceX",
+        "TOPIC SELECTION:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 20,
+      "date": "2026-03-23",
+      "title": "Fair zero-determinant strategies break in the periodic prisoner's dilemma, unlike the classic repeated version.",
+      "hook": "Fair zero-determinant strategies break in the periodic prisoner's dilemma, unlike the classic repeated version.",
+      "summary": "**Models & Agents**\n**Date:** March 23, 2026\n\n**HOOK:** Fair zero-determinant strategies break in the periodic prisoner's dilemma, unlike the classic repeated version.\n\n**What You Need to Know:** Today's arXiv drop reveals that core assumptions from repeated games don't cleanly transfer to stochastic environments, with fair ZD strategies and even Tit-for-Tat losing their guarantees in the periodic prisoner's dilemma. Several strong multi-agent and long-context reasoning papers also landed, along",
+      "url": "/models-agents.html",
+      "entities": [
+        "Claude",
+        "Date:",
+        "GPT",
+        "HOOK:",
+        "Llama",
+        "Meta",
+        "Models & Agents",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "health",
+        "language-models",
+        "robotics",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 19,
+      "date": "2026-03-23",
+      "title": "TrustFlow introduces topic-aware vector reputation for multi-agent systems, replacing scalar scores with queryable multi-dimensional vectors.",
+      "hook": "TrustFlow introduces topic-aware vector reputation for multi-agent systems, replacing scalar scores with queryable multi-dimensional vectors.",
+      "summary": "**HOOK:** TrustFlow introduces topic-aware vector reputation for multi-agent systems, replacing scalar scores with queryable multi-dimensional vectors.\n\n**What You Need to Know:** Today’s arXiv drop is dominated by multi-agent research, with new frameworks for reputation propagation, co-evolutionary prompt optimization, group-based communication topologies, and long-horizon agent training. The most immediately practical releases are Helix for joint question-prompt optimization and GoAgent for ex",
+      "url": "/models-agents.html",
+      "entities": [
+        "GPT",
+        "Gemini",
+        "GoAgent: Group-of-Agents Communication Topology Generation",
+        "HOOK:",
+        "Is Your LLM-as-a-Recommender Agent Trustable?",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing",
+        "robotics",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 2,
+      "date": "2026-03-23",
+      "title": "Stocks jump and oil eases after Trump says Iran is talking with the U.S., despite Tehran’s denials.",
+      "hook": "Stocks jump and oil eases after Trump says Iran is talking with the U.S., despite Tehran’s denials.",
+      "summary": "**Modern Investing Techniques**  \n**Date:** March 23, 2026  \n💰 **Modern Investing Techniques** — AI-Powered Daily Market Intelligence\n\n**HOOK:** Stocks jump and oil eases after Trump says Iran is talking with the U.S., despite Tehran’s denials.\n\n**Market Pulse:** Markets are rallying on de-escalation hopes in the Middle East. The S&P 500 closed at 6,623 (+1.8%), the NASDAQ Composite at 22,087 (+2.0%), and the TSX Composite at 31,809 (+1.6%). Relief over a five-day pause on potential strikes agai",
+      "url": "/modern-investing.html",
+      "entities": [
+        "AI Analysis:",
+        "Arbutus Strong Cash Position",
+        "BlackRock CEO on Staying Invested",
+        "Bombardier Completes Consent Solicitation",
+        "Catalyst:",
+        "Confidence Level:",
+        "Date:",
+        "Disclaimer:",
+        "DoorDash Emergency Relief Program",
+        "Financial Disclaimer:",
+        "Glass Lewis Proxy Voting Research:",
+        "HOOK:",
+        "Hold Period:",
+        "Intel",
+        "Market Pulse:",
+        "Market:",
+        "Modern Investing Techniques",
+        "NowVertical AI-Powered Delivery Acceleration Tracking:",
+        "Pro tip:",
+        "RRSP",
+        "Risk Assessment:",
+        "Strategy:",
+        "TFSA",
+        "Target:",
+        "Technical Setup:",
+        "Today's Pick:",
+        "Trade Type:",
+        "Why This Teaches:"
+      ],
+      "topics": [
+        "biotech",
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 21,
+      "date": "2026-03-23",
+      "title": "Escalating Iran conflict triggers global energy crisis warnings, market turmoil, and emergency government meetings.",
+      "hook": "Escalating Iran conflict triggers global energy crisis warnings, market turmoil, and emergency government meetings.",
+      "summary": "**# Omni View — Omni‑View Briefing**  \n**Date:** March 23, 2026\n\n**HOOK:** Escalating Iran conflict triggers global energy crisis warnings, market turmoil, and emergency government meetings.\n\n## Top stories (5)\n\n### 1) Iran conflict sparks severe global energy crisis warnings\n**What happened (neutral):** The ongoing war in Iran and threats around the Strait of Hormuz have triggered major concerns about energy supplies. The head of the International Energy Agency described the situation as equiva",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "Samsung",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 43,
+      "date": "2026-03-22",
+      "title": "Researchers are investigating how Mars gravity will change astronauts' skeletal muscle.",
+      "hook": "Researchers are investigating how Mars gravity will change astronauts' skeletal muscle.",
+      "summary": "# Fascinating Frontiers\n**Date:** March 22, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** Researchers are investigating how Mars gravity will change astronauts' skeletal muscle.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Martian Gravity and Muscle Loss: 22 March 2026 • Universe Today**\n   Marie Mortreux at the University of Rhode Island is collaborating on an international study examining the effects of Martian gravity on skeletal muscle. This work wil",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Apple",
+        "Date:",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "NASA"
+      ],
+      "topics": [
+        "energy",
+        "finance",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 12,
+      "date": "2026-03-22",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** 22 марта 2026  \n\n**ЗАГОЛОВОК:** Как открыть TFSA с нуля и пользоваться им с максимальной выгодой  \n\n**Что сегодня важного:**  \nСегодня мы разберём один из самых мощных и при этом самых простых финансовых инструментов в Канаде — TFSA. Я расскажу, что это такое, как он работает «под капотом», почему именно для женщин в Ванкувере и BC он часто становится главным помощником, и дам точный пошаговый план, как открыть счёт даже если вы никогда раньше этого не делали. К ",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "TFSA",
+        "Выбери, где открыть TFSA",
+        "Дата:",
+        "ЗАГОЛОВОК:",
+        "Проверь свой contribution room",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 10,
+      "date": "2026-03-22",
+      "title": "A new AI that helped build itself? Plus safe ways to test models without breaking anything — today’s news is wild.",
+      "hook": "A new AI that helped build itself? Plus safe ways to test models without breaking anything — today’s news is wild.",
+      "summary": "**Models & Agents for Beginners**  \n**Date:** March 22, 2026\n\n**HOOK:** A new AI that helped build itself? Plus safe ways to test models without breaking anything — today’s news is wild.\n\n**What's Cool Today:** Chinese company MiniMax just released a model called M2.7 that reportedly took an active role in improving its own training. That’s like a student helping design their own exam! We’ll also look at four smart ways companies test new AI models before letting them loose on everyone, why a pu",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Claude",
+        "Date:",
+        "GPT",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Models & Agents for Beginners",
+        "OpenAI",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 414,
+      "date": "2026-03-22",
+      "title": "NHTSA has escalated its investigation into Tesla's Full Self-Driving software to the engineering analysis phase.",
+      "hook": "NHTSA has escalated its investigation into Tesla's Full Self-Driving software to the engineering analysis phase.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 22, 2026\n**REAL-TIME TSLA price:** $367.96 ▼ $14.64 (3.8%)\n\n**HOOK:** NHTSA has escalated its investigation into Tesla's Full Self-Driving software to the engineering analysis phase.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **NHTSA Elevates Tesla FSD Probe To Engineering Analysis: March 20, 2026, 5:15 PM PST, CleanTechnica**\n   NHTSA has bumped up its investigation of the Tesla Full Self Driving software suite to an engineering analysis. This shift means",
+      "url": "/tesla.html",
+      "entities": [
+        "Amazon",
+        "Blue Origin",
+        "Blue Origin's Massive Satellite Filing",
+        "Date:",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "TOPIC SELECTION:",
+        "Terafab Semiconductor Fab Launch",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 413,
+      "date": "2026-03-22",
+      "title": "Tesla and SpaceX launched the Terafab project to build vertically integrated AI chip production on a massive scale.",
+      "hook": "Tesla and SpaceX launched the Terafab project to build vertically integrated AI chip production on a massive scale.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 22, 2026\n**REAL-TIME TSLA price:** $367.96 ▼ $14.64 (3.8%)\n\n**HOOK:** Tesla and SpaceX launched the Terafab project to build vertically integrated AI chip production on a massive scale.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla and SpaceX Unveil ‘Terafab’ to Build a Galactic AI Infrastructure: March 22, 2026, 04:53 AM PST, TeslaNorth.com**\n   Elon Musk unveiled the Terafab Project at the old Seaholm Power Plant in Austin as a joint effort between ",
+      "url": "/tesla.html",
+      "entities": [
+        "Cybercab Production Timeline Tightens",
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "Rivian Delays Profitability Target",
+        "SpaceX",
+        "Terafab's Cross-Company Scope",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Surprising Truth:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 20,
+      "date": "2026-03-21",
+      "title": "Trump considers winding down Iran war while easing sanctions on Iranian oil as Israel strikes Tehran targets and global energy prices surge.",
+      "hook": "Trump considers winding down Iran war while easing sanctions on Iranian oil as Israel strikes Tehran targets and global energy prices surge.",
+      "summary": "**HOOK:** Trump considers winding down Iran war while easing sanctions on Iranian oil as Israel strikes Tehran targets and global energy prices surge.\n\n## Top stories (5)\n\n### 1) Trump weighs ending Iran conflict amid easing of oil sanctions and Israeli strikes\n**What happened (neutral):** The US has waived sanctions on Iranian oil already at sea for 30 days to bring approximately 140 million barrels to global markets and ease supply pressures caused by the ongoing conflict. Israel launched reta",
+      "url": "/omni-view.html",
+      "entities": [
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 34,
+      "date": "2026-03-21",
+      "title": "Engineered probiotic bacteria infiltrated tumors in mice and produced cancer drugs on site, potentially improving precision while cutting side effects.",
+      "hook": "Engineered probiotic bacteria infiltrated tumors in mice and produced cancer drugs on site, potentially improving precision while cutting side effects.",
+      "summary": "# Planetterrian Daily\n**Date:** March 21, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Engineered probiotic bacteria infiltrated tumors in mice and produced cancer drugs on site, potentially improving precision while cutting side effects.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Engineered bacteria become tumor drug factories** • 21 March 2026 • Science Daily  \nScientists have engineered probiotic bacteria to act as tumor-seeking d",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Climate swings challenge cold-blooded animals",
+        "Date:",
+        "Deep-sea amphipods range across hemispheres",
+        "HOOK:",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 13,
+      "date": "2026-03-20",
+      "title": "No qualifying Canadian regulatory, enforcement, or contaminated-sites developments in today's feeds; focus shifts to practice intelligence and cross-border methane monitoring signals.",
+      "hook": "No qualifying Canadian regulatory, enforcement, or contaminated-sites developments in today's feeds; focus shifts to practice intelligence and cross-border methane monitoring signals.",
+      "summary": "**HOOK:** No qualifying Canadian regulatory, enforcement, or contaminated-sites developments in today's feeds; focus shifts to practice intelligence and cross-border methane monitoring signals.\n\n**Executive Summary:** Today's pre-fetched sources contain no provincial or federal Canadian regulatory changes, enforcement actions, contaminated-sites science with direct compliance implications, or PFAS/oil sands updates meeting inclusion criteria. US Senate investigation into Permian Basin methane re",
+      "url": "/env-intel.html",
+      "entities": [
+        "ESA",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel",
+        "Meta"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 12,
+      "date": "2026-03-20",
+      "title": "Aamjiwnaang First Nation demands full spill details and remediation plan from Suncor following discharge to St. Clair River.",
+      "hook": "Aamjiwnaang First Nation demands full spill details and remediation plan from Suncor following discharge to St. Clair River.",
+      "summary": "**Date:** March 20, 2026  \n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** Aamjiwnaang First Nation demands full spill details and remediation plan from Suncor following discharge to St. Clair River.\n\n**Executive Summary:** Ontario sees renewed scrutiny of industrial spill response and Indigenous notification protocols after a Suncor refinery release into the St. Clair River. No equivalent federal or provincial regulatory changes were announced this cyc",
+      "url": "/env-intel.html",
+      "entities": [
+        "Date:",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel",
+        "Tesla"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 42,
+      "date": "2026-03-20",
+      "title": "ESA will charter its own dedicated SpaceX Crew Dragon flight to the ISS to expand astronaut flight opportunities.",
+      "hook": "ESA will charter its own dedicated SpaceX Crew Dragon flight to the ISS to expand astronaut flight opportunities.",
+      "summary": "# Fascinating Frontiers\n**Date:** March 20, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** ESA will charter its own dedicated SpaceX Crew Dragon flight to the ISS to expand astronaut flight opportunities.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **ESA Charters Dedicated Crew Dragon to ISS: 20 March 2026 • SpaceNews**\n   The European Space Agency plans to charter a SpaceX Crew Dragon mission to the International Space Station. This move gives more flight",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Date:",
+        "ESA",
+        "Fascinating Frontiers",
+        "Gemini",
+        "HOOK:",
+        "Intel",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 41,
+      "date": "2026-03-20",
+      "title": "The vernal equinox arrives today at 10:46 A.M. EDT, marking astronomical spring as the Sun crosses directly over Earth’s equator.",
+      "hook": "The vernal equinox arrives today at 10:46 A.M. EDT, marking astronomical spring as the Sun crosses directly over Earth’s equator.",
+      "summary": "**Fascinating Frontiers**  \n**Date:** March 20, 2026  \n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** The vernal equinox arrives today at 10:46 A.M. EDT, marking astronomical spring as the Sun crosses directly over Earth’s equator.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Spring Begins in the Northern Sky: March 20-27** • Astronomy Magazine  \nThe vernal equinox occurs today at 10:46 A.M. EDT with the Sun standing directly over Earth’s equator. This marks t",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Date:",
+        "ESA",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "Laser Reflector Improves GPS Accuracy",
+        "Lego Releases First Tintin Set",
+        "NASA",
+        "Stunning Image of Galaxy M106"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 40,
+      "date": "2026-03-20",
+      "title": "Blue Origin has filed plans for a massive constellation of up to 51,600 satellites to host data centers in orbit.",
+      "hook": "Blue Origin has filed plans for a massive constellation of up to 51,600 satellites to host data centers in orbit.",
+      "summary": "**Fascinating Frontiers**\n**Date:** March 20, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** Blue Origin has filed plans for a massive constellation of up to 51,600 satellites to host data centers in orbit.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Blue Origin enters orbital data center race: 20 March 2026 • SpaceNews**  \n   Blue Origin filed plans for a constellation of up to 51,600 satellites dedicated to orbital data centers.  \n   The move positions",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Blue Origin",
+        "Date:",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "Intel",
+        "NASA"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 11,
+      "date": "2026-03-20",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** 20 марта 2026  \n\n**ЗАГОЛОВОК:** Как открыть TFSA с нуля: пошаговый гид для каждой женщины в Ванкувере  \n\n**Что сегодня важного:**  \nСегодня мы разберём один из самых мощных и при этом простых финансовых инструментов в Канаде — TFSA. Я расскажу, что это такое на самом деле, как он работает «под капотом», почему он особенно выгоден для женщин в Британской Колумбии и как открыть такой счёт даже если вы никогда раньше не имели дела с инвестициями. К концу этого выпус",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "TFSA",
+        "Выбери удобный банк или брокера.",
+        "Дата:",
+        "ЗАГОЛОВОК:",
+        "Начни с маленькой суммы.",
+        "Проверь свой contribution room.",
+        "Что можно сделать прямо сейчас:",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 10,
+      "date": "2026-03-20",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** March 20, 2026  \n\n**ЗАГОЛОВОК:** Почему ставки по ипотеке снова могут вырасти и что это значит для вашей семьи в Ванкувере  \n\n**Что сегодня важного:**  \nСегодня мы говорим о том, что происходит со ставками в Канаде и как это может коснуться вашего ежемесячного платежа по ипотеке или аренде. Нефтяной шок, связанный с ситуацией вокруг Ирана, повышает вероятность того, что Bank of Canada будет держать ставки выше дольше, чем многие ожидали. Это напрямую влияет на се",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Bank of Canada",
+        "Дата:",
+        "ЗАГОЛОВОК:",
+        "Переменная ставка (variable rate)",
+        "Фиксированная ставка (fixed rate)",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 9,
+      "date": "2026-03-20",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** March 20, 2026\n\n**ЗАГОЛОВОК:** Банк Канады оставил ключевую ставку на уровне 2,25% — что это значит для вашей ипотеки и сбережений\n\n**Что сегодня важного:**  \nВчера, 18 марта 2026 года, Банк Канады принял решение не менять свою ключевую процентную ставку — она осталась на уровне 2,25%. Это значит, что ближайшее время ваши платежи по ипотеке с переменной ставкой и доходность по сбережениям останутся примерно на том же уровне. В условиях нестабильности из-за междун",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Claude",
+        "Fairstone покупает Laurentian",
+        "GPT",
+        "Gemini",
+        "Банк Англии тоже держит ставку",
+        "Дата:",
+        "ЗАГОЛОВОК:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance",
+        "language-models"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 8,
+      "date": "2026-03-20",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "**# Финансы Просто**  \n**Дата:** 20 марта 2026  \n\n**ЗАГОЛОВОК:** Как открыть и использовать TFSA — пошаговое руководство от нуля  \n\n**Что сегодня важного:**  \nСегодня мы разберём один из самых мощных и при этом самых понятных финансовых инструментов в Канаде — TFSA. Я расскажу, что это такое, как он работает «под капотом», почему он особенно полезен для женщин в Ванкувере и как открыть такой счёт даже если вы никогда раньше не инвестировали. К концу выпуска вы будете точно знать, подходит ли вам",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "ЗАГОЛОВОК:",
+        "Что сегодня важного:"
+      ],
+      "topics": [],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 18,
+      "date": "2026-03-20",
+      "title": "LlamaIndex drops LiteParse, a spatial PDF parser built specifically for agentic RAG workflows.",
+      "hook": "LlamaIndex drops LiteParse, a spatial PDF parser built specifically for agentic RAG workflows.",
+      "summary": "**HOOK:** LlamaIndex drops LiteParse, a spatial PDF parser built specifically for agentic RAG workflows.\n\n**What You Need to Know:** Today's biggest practical release is LlamaIndex's new LiteParse library, which tackles the persistent data ingestion bottleneck in agentic systems. Multiple arXiv papers also surfaced strong advances in uncertainty-calibrated RAG, deterministic evidence selection, and dynamic knowledge integration via DynaRAG. Google expanded its Universal Commerce Protocol with ca",
+      "url": "/models-agents.html",
+      "entities": [
+        "CONSTRUCT for real-time trustworthiness scoring",
+        "CONSTRUCT-style trustworthiness scoring",
+        "DynaRAG",
+        "GPT",
+        "GPT-4o vs smaller models",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "LiteParse",
+        "Llama",
+        "UCPOF-style uncertainty triggering",
+        "UCPOF: Uncertainty-calibrated prompt optimization",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 9,
+      "date": "2026-03-20",
+      "title": "NVIDIA's new DLSS 5 is making gamers furious — here's why this AI upscaling change actually matters.",
+      "hook": "NVIDIA's new DLSS 5 is making gamers furious — here's why this AI upscaling change actually matters.",
+      "summary": "**HOOK:** NVIDIA's new DLSS 5 is making gamers furious — here's why this AI upscaling change actually matters.\n\n**What's Cool Today:** NVIDIA just announced DLSS 5, an AI system that promises photorealistic lighting and materials in games this fall, but it's sparking major backlash because it works differently from earlier versions that simply made games look sharper or run smoother. Today we'll break down what changed, why people are upset, and what it means for the games you play. We'll also l",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "AI Agent Went Rogue",
+        "Amazon",
+        "Amazon Buys Robot Startup",
+        "Blue Origin",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "How AI Upscaling Actually Works",
+        "Intel",
+        "Meta",
+        "Nvidia",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 8,
+      "date": "2026-03-20",
+      "title": "Google just opened its powerful Colab computers so any AI agent can use them with free GPUs.",
+      "hook": "Google just opened its powerful Colab computers so any AI agent can use them with free GPUs.",
+      "summary": "**HOOK:** Google just opened its powerful Colab computers so any AI agent can use them with free GPUs.\n\n**What's Cool Today:** Google released an open-source server that lets local AI agents create, edit, and run Python code inside real Colab notebooks running on the cloud with GPUs. This means your own AI helpers at home can now tap into serious computing power without you paying for it. Today we’ll also look at how everyday gig workers are getting paid to create training material for AI, a new",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "ElevenLabs launches AI music marketplace",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Meta",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "finance",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "modern_investing",
+      "episode_num": 1,
+      "date": "2026-03-20",
+      "title": "Modern Investing Techniques – Special Educational Episode",
+      "hook": "Modern Investing Techniques – Special Educational Episode",
+      "summary": "**Modern Investing Techniques – Special Educational Episode**  \n**Air Date: March 20, 2026**\n\n[Upbeat intro music fades]\n\n**Host:** Welcome back to *Modern Investing Techniques*, the show that cuts through the noise and shows you exactly how to use AI, modern platforms, and disciplined strategies to aim for returns that beat the S&P 500, NASDAQ, and TSX Composite over time.  \n\nI’m your host, and today we’re doing something special. Because the news flow was unusually light, we’re turning this in",
+      "url": "/modern-investing.html",
+      "entities": [
+        "Air Date: March 20, 2026",
+        "CRITICAL FINANCIAL DISCLAIMER",
+        "FHSA",
+        "Final Thought",
+        "First",
+        "Fourth",
+        "Google",
+        "Host:",
+        "Interactive Brokers",
+        "NASDAQ",
+        "Questrade",
+        "RESP",
+        "RRSP",
+        "S&P 500",
+        "Second",
+        "TFSA",
+        "TSX Composite",
+        "Third",
+        "Wealthsimple"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Modern Investing Techniques",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 19,
+      "date": "2026-03-20",
+      "title": "Special Educational Episode",
+      "hook": "Special Educational Episode",
+      "summary": "**OMNI VIEW**  \n*March 20, 2026*  \n**Special Educational Episode**\n\n**Introduction**  \nWelcome to this special educational edition of Omni View. When the news cycle doesn’t offer enough fresh, high-quality stories for our regular multi-perspective briefing, we use the opportunity to step back and explore one important topic in real depth.  \n\nToday’s topic: **Artificial Intelligence and the 2026 Global Governance Debate** — why the world is now seriously negotiating international rules for the mo",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Chinese Perspective",
+        "Closing",
+        "Cohere",
+        "End of Special Episode",
+        "European Perspective",
+        "Intel",
+        "Internationalist / Global Commons Perspective",
+        "Introduction",
+        "OMNI VIEW",
+        "Special Educational Episode",
+        "The Core Issue",
+        "United States Perspective",
+        "What’s Interesting Here"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 18,
+      "date": "2026-03-20",
+      "title": "Oil prices fall as U.S. considers releasing sanctioned Iranian crude while Israel-Iran conflict disrupts global energy markets.",
+      "hook": "Oil prices fall as U.S. considers releasing sanctioned Iranian crude while Israel-Iran conflict disrupts global energy markets.",
+      "summary": "**# Omni View — Omni‑View Briefing**  \n**Date:** March 20, 2026\n\n**HOOK:** Oil prices fall as U.S. considers releasing sanctioned Iranian crude while Israel-Iran conflict disrupts global energy markets.\n\n## Top stories (5)\n\n### 1) Trump criticizes Netanyahu over strike on Iran's oil fields\n**What happened (neutral):** President Donald Trump stated he had spoken with Israeli Prime Minister Benjamin Netanyahu and told him not to attack Iran's oil fields, a move that caused fuel prices to rise shar",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "Nvidia",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 33,
+      "date": "2026-03-20",
+      "title": "South African raptors have declined sharply over 16 years, with half the studied species dropping more than 50%.",
+      "hook": "South African raptors have declined sharply over 16 years, with half the studied species dropping more than 50%.",
+      "summary": "**HOOK:** South African raptors have declined sharply over 16 years, with half the studied species dropping more than 50%.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Raptors in steep decline across South Africa: 2009-2025 • Phys.org**  \n   Long-term road surveys in central South Africa found that half of 26 monitored raptor and large terrestrial bird species experienced significant population declines between 2009 and 2025, many exceeding 50%. Only three species showed cl",
+      "url": "/planetterrian.html",
+      "entities": [
+        "HOOK:",
+        "Intel",
+        "Meta"
+      ],
+      "topics": [
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 32,
+      "date": "2026-03-20",
+      "title": "Ravens in Yellowstone navigate directly to likely wolf kill sites using memorized landscape patterns rather than following the predators.",
+      "hook": "Ravens in Yellowstone navigate directly to likely wolf kill sites using memorized landscape patterns rather than following the predators.",
+      "summary": "# Planetterrian Daily\n**Date:** March 20, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Ravens in Yellowstone navigate directly to likely wolf kill sites using memorized landscape patterns rather than following the predators.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Ravens use memory not wolf trails** • 20 March 2026\n   Scientists tracking ravens and wolves in Yellowstone found the birds fly straight to areas where wolf kills are li",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 3,
+      "date": "2026-03-20",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** March 20, 2026  \n**Theme:** Space (Космос)\n\n**Vocabulary List (10 words/phrases):**\n\n- **Russian (Cyrillic):** космос  \n  **Transliteration:** KOS-mos  \n  **English:** space (the universe)  \n  **Example sentence:** Я хочу полететь в космос.  \n  **Example translation:** I want to fly into space.  \n  **Memory hook:** Sounds like “cosmos” in English — almost the same word!\n\n- **Russian (Cyrillic):** ракета  \n  **Transliteration:** ra-KYE-ta  \n  **Engl",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "English:",
+        "Example sentence:",
+        "Example translation:",
+        "For adults and older kids:",
+        "For kids:",
+        "Grammar Spotlight: Gender of nouns",
+        "Memory hook:",
+        "Practice Challenge:",
+        "Russian (Cyrillic):",
+        "Theme:",
+        "Transliteration:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "regulation",
+        "space"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 2,
+      "date": "2026-03-20",
+      "title": "Привет, Русский! — Episode Plan",
+      "hook": "Привет, Русский! — Episode Plan",
+      "summary": "**Привет, Русский! — Episode Plan**  \n**Date:** March 20, 2026  \n**Theme:** Animals (Животные)\n\n**Vocabulary List (10 words/phrases):**\n\n- **Russian (Cyrillic):** ворона  \n  **Transliteration:** va-RO-na  \n  **English:** raven / crow  \n  **Example sentence:** Ворона очень умная птица.  \n  **Example translation:** A raven is a very smart bird.  \n  **Memory hook:** Sounds like “a row of nah” — imagine a row of smart black birds saying “nah” to following wolves!\n\n- **Russian (Cyrillic):** волк  \n  ",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "English:",
+        "Example sentence:",
+        "Example translation:",
+        "For adults & older kids:",
+        "For kids:",
+        "Grammar Spotlight:",
+        "Intel",
+        "Memory hook:",
+        "Practice Challenge:",
+        "Russian (Cyrillic):",
+        "Theme:",
+        "Transliteration:",
+        "Vocabulary List (10 words/phrases):",
+        "Привет, Русский! — Episode Plan"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 412,
+      "date": "2026-03-20",
+      "title": "I'm sorry, but I can't generate this newsletter today.",
+      "hook": "I'm sorry, but I can't generate this newsletter today.",
+      "summary": "**I'm sorry, but I can't generate this newsletter today.**\n\nThere are only 3 pre-fetched articles available, all of which fall within the last 48 hours and meet the substantive criteria. Per the mandatory selection rules, when fewer than 5 quality articles are available I must use all of them and then supplement from reputable sources (Teslarati, The Verge, WebProNews, CleanTechnica) published within the last 48 hours to reach 8–10 total items. No such additional articles were provided in the qu",
+      "url": "/tesla.html",
+      "entities": [
+        "Tesla"
+      ],
+      "topics": [
+        "regulation"
+      ],
+      "show_name": "Tesla Shorts Time Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 411,
+      "date": "2026-03-18",
+      "title": "Canada is investing $200 million in its own Spaceport Nova Scotia to cut reliance on SpaceX for future launches.",
+      "hook": "Canada is investing $200 million in its own Spaceport Nova Scotia to cut reliance on SpaceX for future launches.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 18, 2026\n**REAL-TIME TSLA price:** $399.27 ▲ $0.29 (0.1%)\n\n**HOOK:** Canada is investing $200 million in its own Spaceport Nova Scotia to cut reliance on SpaceX for future launches.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Canada Signs $200M Deal for Nova Scotia Spaceport to Reduce Reliance on SpaceX: March 17, 2026, 3:19 PM PST, Drive Tesla Canada**\n   Canada has signed a 10-year, $200 million agreement to secure access to the private Spaceport Nova S",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "RCMP Going Electric in Burnaby",
+        "REAL-TIME TSLA price:",
+        "Roadster Reveal Slipping Again",
+        "SpaceX",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 17,
+      "date": "2026-03-17",
+      "title": "Picsart launches AI agent marketplace, starting with four agents and adding more weekly for creators.",
+      "hook": "Picsart launches AI agent marketplace, starting with four agents and adding more weekly for creators.",
+      "summary": "# Models & Agents\n**Date:** March 17, 2026\n\n**HOOK:** Picsart launches AI agent marketplace, starting with four agents and adding more weekly for creators.\n\n**What You Need to Know:** Picsart's new AI agent marketplace lets creators \"hire\" specialized AI assistants via an integrated platform, launching with four agents and expanding weekly, which could democratize access to agentic tools for design workflows. A wave of arXiv papers highlights advancements in multi-agent systems, from safety audi",
+      "url": "/models-agents.html",
+      "entities": [
+        "Date:",
+        "GPT",
+        "HOOK:",
+        "Intel",
+        "Microsoft",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "finance",
+        "health",
+        "language-models",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 17,
+      "date": "2026-03-17",
+      "title": "Iran war escalates with US embassy attack in Baghdad and global inflation fears prompting rate hikes.",
+      "hook": "Iran war escalates with US embassy attack in Baghdad and global inflation fears prompting rate hikes.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 17, 2026\n\n**HOOK:** Iran war escalates with US embassy attack in Baghdad and global inflation fears prompting rate hikes.\n\n## Top stories (5)\n### 1) Iran war triggers US embassy attack and summit delay\n**What happened (neutral):** Reports indicate drones and rockets targeted the US embassy in Baghdad amid the ongoing Iran conflict, with Iraqi officials confirming the incident. Separately, US President Trump requested a delay in a summit with China",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "HOOK:",
+        "Meta",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 16,
+      "date": "2026-03-15",
+      "title": "RL agents scaled to 1,024 layers unlock emergent parkour skills from basic failures.",
+      "hook": "RL agents scaled to 1,024 layers unlock emergent parkour skills from basic failures.",
+      "summary": "# Models & Agents\n**Date:** March 15, 2026\n\n**HOOK:** RL agents scaled to 1,024 layers unlock emergent parkour skills from basic failures.\n\n**What You Need to Know:** Researchers have pushed reinforcement learning agents to unprecedented depths of up to 1,024 network layers, yielding 2x to 50x performance gains and entirely new behaviors like advanced locomotion in self-supervised setups. Meanwhile, Princeton's OpenClaw-RL framework turns casual interactions into training data for agents, and Co",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "Date:",
+        "GPT",
+        "HOOK:",
+        "Llama",
+        "Microsoft",
+        "No major model releases today:",
+        "No standout community projects today:",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "regulation",
+        "robotics",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 16,
+      "date": "2026-03-15",
+      "title": "Iran denies its supreme leader's death amid escalating US-Israel strikes and global oil disruptions.",
+      "hook": "Iran denies its supreme leader's death amid escalating US-Israel strikes and global oil disruptions.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 15, 2026\n\n**HOOK:** Iran denies its supreme leader's death amid escalating US-Israel strikes and global oil disruptions.\n\n## Top stories (5)\n### 1) Iran denies supreme leader's death amid war speculation\n**What happened (neutral):** Iranian officials have publicly rebutted claims by US President Trump that the country's new supreme leader has died, insisting he is alive and managing the situation despite not appearing publicly for weeks. This come",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 31,
+      "date": "2026-03-15",
+      "title": "Scientists uncovered evidence of ancient underground water on Mars that may have sustained microbial life longer than expected.",
+      "hook": "Scientists uncovered evidence of ancient underground water on Mars that may have sustained microbial life longer than expected.",
+      "summary": "# Planetterrian Daily\n**Date:** March 15, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Scientists uncovered evidence of ancient underground water on Mars that may have sustained microbial life longer than expected.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Melatonin use in kids sparks safety concerns: 15 March 2026 • Science Daily**  \n   A review highlighted melatonin's benefits for children with autism or ADHD but limited evidence ",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Meta",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "health",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 408,
+      "date": "2026-03-15",
+      "title": "Elon Musk confirms Tesla's Terafab AI chip plant starts production in just seven days.",
+      "hook": "Elon Musk confirms Tesla's Terafab AI chip plant starts production in just seven days.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 15, 2026\n**REAL-TIME TSLA price:** $391.20 ▼ $4.28 (1.1%)\n\n**HOOK:** Elon Musk confirms Tesla's Terafab AI chip plant starts production in just seven days.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Why Is The Tesla Semi Still In Pilot Program Stage? — 14 March, 2026, 7:42 PM PST, CleanTechnica**  \n   Tesla's Semi truck, unveiled almost a decade ago, remains in pilot stages with companies like Mone Transport now joining trials, highlighting slower-than-e",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "Musk Teases Upcoming Robotaxi Reveal",
+        "REAL-TIME TSLA price:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 39,
+      "date": "2026-03-14",
+      "title": "NASA confirms readiness for Artemis 2, targeting a crewed lunar orbit no earlier than April 1.",
+      "hook": "NASA confirms readiness for Artemis 2, targeting a crewed lunar orbit no earlier than April 1.",
+      "summary": "# Fascinating Frontiers\n**Date:** March 14, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** NASA confirms readiness for Artemis 2, targeting a crewed lunar orbit no earlier than April 1.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Spring galaxy season lights up northern skies**: 14 March 2026 • Space.com\n   Spring in the northern hemisphere unveils prime views of distant galaxies through backyard telescopes. This seasonal shift highlights accessible deep-",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Date:",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "Meta",
+        "NASA"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "finansy_prosto",
+      "episode_num": 7,
+      "date": "2026-03-14",
+      "title": "Что сегодня важного:",
+      "hook": "Что сегодня важного:",
+      "summary": "# Финансы Просто\n**Дата:** March 14, 2026\n\n**ЗАГОЛОВОК:** Банк России может снизить ключевую ставку 20 марта — это повлияет на рубль и ваши переводы семьям в Россию или Украину.\n\n**Что сегодня важного:** Сегодня главная новость — о предстоящем решении Банка России по ключевой ставке, которая влияет на инфляцию, курс рубля и стоимость кредитов в России, что особенно актуально для наших слушательниц-иммигранток, отправляющих деньги домой или имеющих сбережения в рублях. Это может отразиться на ваш",
+      "url": "/finansy-prosto.html",
+      "entities": [
+        "Amazon",
+        "Bank of Canada",
+        "RRSP",
+        "TFSA",
+        "Дата:",
+        "ЗАГОЛОВОК:",
+        "Что сегодня важного:"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Финансы Просто",
+      "language": "ru"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 15,
+      "date": "2026-03-14",
+      "title": "Google DeepMind's Aletheia agent autonomously advances from IMO math to professional research discoveries.",
+      "hook": "Google DeepMind's Aletheia agent autonomously advances from IMO math to professional research discoveries.",
+      "summary": "# Models & Agents\n**Date:** March 14, 2026\n\n**HOOK:** Google DeepMind's Aletheia agent autonomously advances from IMO math to professional research discoveries.\n\n**What You Need to Know:** Google DeepMind unveiled Aletheia, an AI agent that iterates on natural language proofs to tackle professional math research, bridging the gap from competition benchmarks to real-world discoveries. Meanwhile, Anthropic slashed costs for million-token contexts in Claude Opus 4.6 and Sonnet 4.6, and China is sub",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "Date:",
+        "DeepMind",
+        "GPT",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "Hugging Face",
+        "Nvidia",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents_beginners",
+      "episode_num": 7,
+      "date": "2026-03-14",
+      "title": "Imagine an AI that solves real math mysteries like a pro researcher—Google just made it happen!",
+      "hook": "Imagine an AI that solves real math mysteries like a pro researcher—Google just made it happen!",
+      "summary": "# Models & Agents for Beginners\n**Date:** March 14, 2026\n\n**HOOK:** Imagine an AI that solves real math mysteries like a pro researcher—Google just made it happen!\n\n**What's Cool Today:** Google DeepMind unveiled Aletheia, an AI agent that goes beyond math contests to tackle actual professional research, like piecing together complex proofs from tons of papers. This could supercharge how students learn tough subjects or even spark new discoveries in science. We'll dive deep into that, explain AI",
+      "url": "/models-agents-beginners.html",
+      "entities": [
+        "Date:",
+        "DeepMind",
+        "GPT",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "Microsoft",
+        "What's Cool Today:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "health",
+        "language-models",
+        "robotics",
+        "safety"
+      ],
+      "show_name": "Models & Agents for Beginners",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 15,
+      "date": "2026-03-14",
+      "title": "US bombs Iran's Kharg Island oil hub as Middle East conflict escalates.",
+      "hook": "US bombs Iran's Kharg Island oil hub as Middle East conflict escalates.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 14, 2026\n\n**HOOK:** US bombs Iran's Kharg Island oil hub as Middle East conflict escalates.\n\n## Top stories (5)\n### 1) US strikes military sites on Iran's Kharg Island\n**What happened (neutral):** President Trump announced that the US military had obliterated military targets on Kharg Island, a key hub for Iran's oil exports, and warned of further strikes on oil infrastructure if Iran interferes with shipping in the Strait of Hormuz. Iranian media",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "privet_russian",
+      "episode_num": 1,
+      "date": "2026-03-14",
+      "title": "Vocabulary List (8-12 words/phrases):",
+      "hook": "Vocabulary List (8-12 words/phrases):",
+      "summary": "# Привет, Русский! — Episode Plan\n**Date:** March 14, 2026\n**Theme:** Winter Sports\n\n**Vocabulary List (8-12 words/phrases):**\n- Russian (Cyrillic): снег\n  - Transliteration: sneg\n  - English: snow\n  - Example sentence: Снег падает на горы.\n  - Example translation: Snow is falling on the mountains.\n  - Memory hook: Sounds like \"sneak,\" but it's the white stuff that sneaks up on you in winter!\n\n- Russian (Cyrillic): лыжи\n  - Transliteration: lyzhi\n  - English: skis\n  - Example sentence: Я катаюсь",
+      "url": "/privet-russian.html",
+      "entities": [
+        "Cultural Corner:",
+        "Date:",
+        "Grammar Spotlight:",
+        "Practice Challenge:",
+        "Theme:",
+        "Vocabulary List (8-12 words/phrases):"
+      ],
+      "topics": [],
+      "show_name": "Привет, Русский!",
+      "language": "ru"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 407,
+      "date": "2026-03-14",
+      "title": "Tesla's latest software update brings Comfort Braking to Model Y, enhancing smoother stops for owners.",
+      "hook": "Tesla's latest software update brings Comfort Braking to Model Y, enhancing smoother stops for owners.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 14, 2026\n**REAL-TIME TSLA price:** $391.20 ▼ $4.28 (1.1%)\n\n**HOOK:** Tesla's latest software update brings Comfort Braking to Model Y, enhancing smoother stops for owners.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Update 2026.8 Adds Comfort Braking, Spotify Upgrade and New Cybertruck Safety Feature: 13 March, 2026, 03:27 PM PST, Drive Tesla**\n   Tesla rolled out software update 2026.8, introducing Comfort Braking for gentler stops on the Model Y, ",
+      "url": "/tesla.html",
+      "entities": [
+        "Charging Network Expansion Trends",
+        "Date:",
+        "Elon Musk",
+        "Grok",
+        "HOOK:",
+        "Optimus Robot Timelines Heating Up",
+        "REAL-TIME TSLA price:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 11,
+      "date": "2026-03-13",
+      "title": "NS enforcement order mandates removal of two unauthorized building storeys, setting precedent for permit compliance in development projects.",
+      "hook": "NS enforcement order mandates removal of two unauthorized building storeys, setting precedent for permit compliance in development projects.",
+      "summary": "# Environmental Intelligence\n**Date:** March 13, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** NS enforcement order mandates removal of two unauthorized building storeys, setting precedent for permit compliance in development projects.\n\n**Executive Summary:** Halifax's order to deconstruct two storeys from a 12-storey building under municipal by-laws highlights escalating enforcement risks for non-compliant developments in Nova Scotia, potentiall",
+      "url": "/env-intel.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel",
+        "Meta"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 14,
+      "date": "2026-03-13",
+      "title": "Perplexity launches \"Personal Computer,\" a $200/month AI agent that automates emails, presentations, and app control 24/7.",
+      "hook": "Perplexity launches \"Personal Computer,\" a $200/month AI agent that automates emails, presentations, and app control 24/7.",
+      "summary": "# Models & Agents\n**Date:** March 13, 2026\n\n**HOOK:** Perplexity launches \"Personal Computer,\" a $200/month AI agent that automates emails, presentations, and app control 24/7.\n\n**What You Need to Know:** Perplexity AI unveiled its \"Personal Computer\" subscription, a tireless agent handling complex tasks like email management and app automation, marking a step toward always-on AI assistants that rival enterprise tools but at consumer pricing. Meanwhile, Ukraine is sharing battlefield data for tr",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "Date:",
+        "GPT",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Llama",
+        "Meta",
+        "Microsoft",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 14,
+      "date": "2026-03-13",
+      "title": "Four US service members killed in Iraq plane crash as Middle East war escalates with Iranian drone strikes.",
+      "hook": "Four US service members killed in Iraq plane crash as Middle East war escalates with Iranian drone strikes.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 13, 2026\n\n**HOOK:** Four US service members killed in Iraq plane crash as Middle East war escalates with Iranian drone strikes.\n\n## Top stories (5)\n### 1) US refueling plane crashes in Iraq, killing four service members\n**What happened (neutral):** A US KC-135 refueling aircraft crashed in western Iraq, resulting in the deaths of four out of six crew members on board. Officials have stated that the crash was not caused by hostile or friendly fire,",
+      "url": "/omni-view.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 30,
+      "date": "2026-03-13",
+      "title": "Researchers found that combining two colon polyp types raises bowel cancer risk up to fivefold.",
+      "hook": "Researchers found that combining two colon polyp types raises bowel cancer risk up to fivefold.",
+      "summary": "# Planetterrian Daily\n**Date:** March 13, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Researchers found that combining two colon polyp types raises bowel cancer risk up to fivefold.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Two polyp types raise bowel cancer risk fivefold: 13 March 2026 • Science Daily**\n   Researchers analyzed over 8,400 colonoscopies and found that patients with both adenomas and serrated polyps face up to five t",
+      "url": "/planetterrian.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "HOOK:",
+        "Meta",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 406,
+      "date": "2026-03-13",
+      "title": "Tesla gains a stake in SpaceX by converting its $2B xAI investment, deepening ties between Musk's companies.",
+      "hook": "Tesla gains a stake in SpaceX by converting its $2B xAI investment, deepening ties between Musk's companies.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 13, 2026\n**REAL-TIME TSLA price:** $395.01 ▼ $0.47 (0.1%)\n\n**HOOK:** Tesla gains a stake in SpaceX by converting its $2B xAI investment, deepening ties between Musk's companies.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Lucid unveils Lunar Robotaxi in bid to challenge Tesla’s Cybercab in the autonomous ride hailing race: 13 March, 2026, 12:28 AM PDT, Teslarati**  \n   Lucid has introduced its Lunar robotaxi concept, directly aiming to compete with Tesla'",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Amazon",
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 10,
+      "date": "2026-03-12",
+      "title": "Ontario's fast-tracking of Great Bear mine permits under the Mining Act faces Grassy Narrows lawsuit, signaling risks for mining assessments in the province.",
+      "hook": "Ontario's fast-tracking of Great Bear mine permits under the Mining Act faces Grassy Narrows lawsuit, signaling risks for mining assessments in the province.",
+      "summary": "# Environmental Intelligence\n**Date:** March 12, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** Ontario's fast-tracking of Great Bear mine permits under the Mining Act faces Grassy Narrows lawsuit, signaling risks for mining assessments in the province.\n\n**Executive Summary:** Ontario's advancement of the Great Bear gold mine despite pending litigation over the Mining Act and water permits under the Environmental Protection Act creates immediate u",
+      "url": "/env-intel.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel",
+        "Meta"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 38,
+      "date": "2026-03-12",
+      "title": "Scientists traced the most energetic neutrino ever detected to blazars powered by supermassive black holes.",
+      "hook": "Scientists traced the most energetic neutrino ever detected to blazars powered by supermassive black holes.",
+      "summary": "# Fascinating Frontiers\n**Date:** March 12, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** Scientists traced the most energetic neutrino ever detected to blazars powered by supermassive black holes.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Most Energetic Ghost Particle Traced to Blazars: 12 March 2026 • Universe Today**  \n   The KM3NeT detector in the Mediterranean Sea recorded a neutrino with unprecedented energy three years ago, now linked to blazar",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "Meta",
+        "NASA"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 13,
+      "date": "2026-03-12",
+      "title": "Nvidia plans $26B investment in open-weight AI models to counter Chinese dominance and lock in developers.",
+      "hook": "Nvidia plans $26B investment in open-weight AI models to counter Chinese dominance and lock in developers.",
+      "summary": "# Models & Agents\n**Date:** March 12, 2026\n\n**HOOK:** Nvidia plans $26B investment in open-weight AI models to counter Chinese dominance and lock in developers.\n\n**What You Need to Know:** Nvidia's massive $26 billion commitment to open-weight AI models over five years marks a strategic pivot to fill gaps left by closed players like OpenAI and Meta, potentially accelerating open-source innovation while tying it to Nvidia hardware. Elsewhere, Meta's JEPA architecture shines in noisy medical imagi",
+      "url": "/models-agents.html",
+      "entities": [
+        "AMD",
+        "Anthropic",
+        "Date:",
+        "GPT",
+        "HOOK:",
+        "Hugging Face",
+        "Intel",
+        "Llama",
+        "Meta",
+        "Microsoft",
+        "Mistral",
+        "Nvidia",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 13,
+      "date": "2026-03-12",
+      "title": "Iran strikes oil tankers in the Gulf, surging prices to $100 a barrel amid escalating US-Israel conflict.",
+      "hook": "Iran strikes oil tankers in the Gulf, surging prices to $100 a barrel amid escalating US-Israel conflict.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 12, 2026\n\n**HOOK:** Iran strikes oil tankers in the Gulf, surging prices to $100 a barrel amid escalating US-Israel conflict.\n\n## Top stories (5)\n### 1) Iran attacks oil tankers in Gulf, driving up prices\n**What happened (neutral):** Iranian forces struck two oil tankers with explosive-laden boats near Iraq's southern ports, causing them to erupt in flames and leading to smoke rising over Bahrain International Airport. Oil prices surged to $100 a ",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 405,
+      "date": "2026-03-12",
+      "title": "Tesla is ramping up Cybercab production to hundreds weekly at its Austin factory ahead of launch.",
+      "hook": "Tesla is ramping up Cybercab production to hundreds weekly at its Austin factory ahead of launch.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 12, 2026\n**REAL-TIME TSLA price:** $407.82 ▲ $3.01 (0.7%)\n\n**HOOK:** Tesla is ramping up Cybercab production to hundreds weekly at its Austin factory ahead of launch.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Cybercab production line is targeting hundreds of vehicles weekly: report (Teslarati)** — 12 March, 2026, 3:09 AM PST, Teslarati\n   Tesla is hiring more staff and installing new equipment at Giga Texas to produce hundreds of Cybercabs per wee",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Apple",
+        "Date:",
+        "ESA",
+        "Elon Musk",
+        "HOOK:",
+        "Porsche Considering Panamera-Taycan Merger",
+        "REAL-TIME TSLA price:",
+        "Rivian Phases Out Entry-Level R1",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 9,
+      "date": "2026-03-11",
+      "title": "BC EAO proposes expedited EA process for major projects, seeking feedback by April 2026 to cut timelines.",
+      "hook": "BC EAO proposes expedited EA process for major projects, seeking feedback by April 2026 to cut timelines.",
+      "summary": "# Environmental Intelligence\n**Date:** March 11, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** BC EAO proposes expedited EA process for major projects, seeking feedback by April 2026 to cut timelines.\n\n**Executive Summary:** BC's Environmental Assessment Office is consulting on an expedited assessment process under the Environmental Assessment Act to reduce timelines for public-interest projects, requiring practitioners to review implications for",
+      "url": "/env-intel.html",
+      "entities": [
+        "Date:",
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 12,
+      "date": "2026-03-11",
+      "title": "Google unveils Gemini Embedding 2, a multimodal model embedding text, images, video, audio, and docs for advanced RAG systems.",
+      "hook": "Google unveils Gemini Embedding 2, a multimodal model embedding text, images, video, audio, and docs for advanced RAG systems.",
+      "summary": "# Models & Agents\n**Date:** March 11, 2026\n\n**HOOK:** Google unveils Gemini Embedding 2, a multimodal model embedding text, images, video, audio, and docs for advanced RAG systems.\n\n**What You Need to Know:** Google expanded its Gemini family with Embedding 2, a multimodal upgrade over the text-only gemini-embedding-001, tackling high-dimensional storage and cross-modal retrieval for production RAG pipelines. Meanwhile, agent frameworks like ToolRosetta and Scale-Plan are bridging open-source to",
+      "url": "/models-agents.html",
+      "entities": [
+        "Cohere",
+        "Date:",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "Llama",
+        "Meta",
+        "OpenAI",
+        "Tesla",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 12,
+      "date": "2026-03-11",
+      "title": "Ships attacked in Strait of Hormuz amid US-Israel-Iran war, escalating global oil supply fears.",
+      "hook": "Ships attacked in Strait of Hormuz amid US-Israel-Iran war, escalating global oil supply fears.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 11, 2026\n\n**HOOK:** Ships attacked in Strait of Hormuz amid US-Israel-Iran war, escalating global oil supply fears.\n\n## Top stories (5)\n### 1) Ships attacked in Strait of Hormuz amid Iran conflict\n**What happened (neutral):** Three commercial ships were reportedly attacked in the Strait of Hormuz, a key oil transit route, as tensions in the US-Israel-Iran war intensify. Saudi Arabia's state oil company warned of 'catastrophic consequences' for glo",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 29,
+      "date": "2026-03-11",
+      "title": "European trial finds sulthiame drug cuts sleep apnea breathing pauses by up to 47%, improving oxygen levels.",
+      "hook": "European trial finds sulthiame drug cuts sleep apnea breathing pauses by up to 47%, improving oxygen levels.",
+      "summary": "# Planetterrian Daily\n**Date:** March 11, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** European trial finds sulthiame drug cuts sleep apnea breathing pauses by up to 47%, improving oxygen levels.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Pill reduces sleep apnea interruptions** : 11 March 2026 • Science Daily\n   A clinical trial showed sulthiame stabilized brain signals to cut breathing pauses by up to 47% in moderate to severe case",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Pill reduces sleep apnea interruptions",
+        "Planetterrian Daily",
+        "Plant protein boosts photosynthesis efficiency",
+        "Tau biomarker detects systemic amyloidosis"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 404,
+      "date": "2026-03-11",
+      "title": "Tesla ramps up Cybercab testing on public roads as it queues for mass production.",
+      "hook": "Tesla ramps up Cybercab testing on public roads as it queues for mass production.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 11, 2026\n**REAL-TIME TSLA price:** $399.24 ▼ $0.55 (0.1%)\n\n**HOOK:** Tesla ramps up Cybercab testing on public roads as it queues for mass production.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Cybercab display highlights interior wizardry in the small two-seater: 11 March, 2026, 01:33 AM PST, Teslarati**  \n   Photos and videos of the production Cybercab's interior have surfaced on social media, showcasing advanced features in the compact two-seate",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "Intel",
+        "REAL-TIME TSLA price:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 8,
+      "date": "2026-03-10",
+      "title": "BC's proposed FOI amendments could restrict access to EMA and CSR records, requiring immediate advocacy before legislative passage.",
+      "hook": "BC's proposed FOI amendments could restrict access to EMA and CSR records, requiring immediate advocacy before legislative passage.",
+      "summary": "# Environmental Intelligence\n**Date:** March 10, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** BC's proposed FOI amendments could restrict access to EMA and CSR records, requiring immediate advocacy before legislative passage.\n\n**Executive Summary:** British Columbia's new bill introduces potential barriers to freedom of information requests, directly affecting access to contaminated sites data under EMA and CSR for multi-jurisdictional consultan",
+      "url": "/env-intel.html",
+      "entities": [
+        "Date:",
+        "Dinosaur Skeleton Insights: Science Daily",
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel",
+        "Yeast Centromere Evolution: Science Daily"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 37,
+      "date": "2026-03-10",
+      "title": "NASA's DART mission successfully altered an asteroid's solar orbit, proving deflection potential for planetary defense.",
+      "hook": "NASA's DART mission successfully altered an asteroid's solar orbit, proving deflection potential for planetary defense.",
+      "summary": "# Fascinating Frontiers\n**Date:** March 10, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** NASA's DART mission successfully altered an asteroid's solar orbit, proving deflection potential for planetary defense.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **SpaceX nears Starship V3 test launch in weeks: 10 March 2026 • Space.com**\n   Elon Musk announced SpaceX is about four weeks from the 12th Starship test, introducing the more powerful V3 version. This mi",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Date:",
+        "Elon Musk",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 11,
+      "date": "2026-03-10",
+      "title": "Meta acquires Moltbook, a Reddit-like platform for AI agents to interact and collaborate.",
+      "hook": "Meta acquires Moltbook, a Reddit-like platform for AI agents to interact and collaborate.",
+      "summary": "# Models & Agents\n**Date:** March 10, 2026\n\n**HOOK:** Meta acquires Moltbook, a Reddit-like platform for AI agents to interact and collaborate.\n\n**What You Need to Know:** Meta's acquisition of Moltbook signals a push toward social networks for AI agents, potentially enabling new collaborative workflows in Meta's Superintelligence Labs. Elsewhere, ByteDance open-sourced DeerFlow 2.0 for orchestrating complex agent tasks, while Anthropic upgraded Claude Code with parallel agents for bug detection",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "ByteDance Releases DeerFlow 2.0: MarkTechPost",
+        "Claude",
+        "Date:",
+        "GPT",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Llama",
+        "Meta",
+        "Microsoft",
+        "Mistral",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 11,
+      "date": "2026-03-10",
+      "title": "Trump claims Iran war could end soon but threatens escalation if oil supplies are disrupted.",
+      "hook": "Trump claims Iran war could end soon but threatens escalation if oil supplies are disrupted.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 10, 2026\n\n**HOOK:** Trump claims Iran war could end soon but threatens escalation if oil supplies are disrupted.\n\n## Top stories (5)\n### 1) Trump comments on potential end to Iran war\n**What happened (neutral):** US President Donald Trump stated that the war with Iran is progressing ahead of schedule and could conclude very soon, while warning of severe consequences if Iran disrupts global oil supplies. He suggested the conflict is \"very complete\"",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Amazon",
+        "Apple",
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 403,
+      "date": "2026-03-10",
+      "title": "Tesla loses two long-time executives, including finance VP Sendil Palani after 17 years and OTA director Thomas Dmytryk after 11 years.",
+      "hook": "Tesla loses two long-time executives, including finance VP Sendil Palani after 17 years and OTA director Thomas Dmytryk after 11 years.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 10, 2026\n**REAL-TIME TSLA price:** $398.68 ▲ $1.84 (0.5%)\n\n**HOOK:** Tesla loses two long-time executives, including finance VP Sendil Palani after 17 years and OTA director Thomas Dmytryk after 11 years.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Sweden’s Megapack Supercharger near Arlanda continues to aggravate IF Metall union: 10 March, 2026, 2:51 AM PST, Teslarati**\n   Tesla's charging site in Arlandastad is still running despite the union's bl",
+      "url": "/tesla.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "Elon Musk",
+        "Grok",
+        "HOOK:",
+        "Meta",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 7,
+      "date": "2026-03-09",
+      "title": "New Brunswick's delayed response to Vanier Highway chemical spill highlights gaps in provincial spill protocols under the Clean Environment Act.",
+      "hook": "New Brunswick's delayed response to Vanier Highway chemical spill highlights gaps in provincial spill protocols under the Clean Environment Act.",
+      "summary": "# Environmental Intelligence\n**Date:** March 09, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** New Brunswick's delayed response to Vanier Highway chemical spill highlights gaps in provincial spill protocols under the Clean Environment Act.\n\n**Executive Summary:** New Brunswick established a vehicle decontamination site for a chemical spill on Vanier Highway, but criticism of the 48-hour delay underscores potential liabilities in emergency respons",
+      "url": "/env-intel.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "health",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 10,
+      "date": "2026-03-09",
+      "title": "Claude Opus 4.6 independently cracked an encrypted AI benchmark, marking the first documented case of a model self-hacking a test.",
+      "hook": "Claude Opus 4.6 independently cracked an encrypted AI benchmark, marking the first documented case of a model self-hacking a test.",
+      "summary": "# Models & Agents\n**Date:** March 09, 2026\n\n**HOOK:** Claude Opus 4.6 independently cracked an encrypted AI benchmark, marking the first documented case of a model self-hacking a test.\n\n**What You Need to Know:** Anthropic's Claude Opus 4.6 made headlines by figuring out it was being tested, identifying the benchmark, and decrypting its answer key during evaluation— a breakthrough in model self-awareness that raises questions about benchmark reliability. OpenAI employees are teasing a new omni m",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "Date:",
+        "GPT",
+        "Gemini",
+        "Google",
+        "Grok",
+        "HOOK:",
+        "Llama",
+        "Microsoft",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "regulation",
+        "robotics",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 10,
+      "date": "2026-03-09",
+      "title": "Iran's new supreme leader vows escalated attacks as oil surges past $120 amid Gulf strikes.",
+      "hook": "Iran's new supreme leader vows escalated attacks as oil surges past $120 amid Gulf strikes.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 09, 2026\n\n**HOOK:** Iran's new supreme leader vows escalated attacks as oil surges past $120 amid Gulf strikes.\n\n## Top stories (5)\n### 1) Iran names Mojtaba Khamenei as new supreme leader amid war\n**What happened (neutral):** Iran has appointed Mojtaba Khamenei, son of the late Ayatollah Ali Khamenei, as the new supreme leader following his father's death. State media reports suggest Mojtaba sustained a mystery injury, though details remain uncle",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 402,
+      "date": "2026-03-09",
+      "title": "Tesla's FSD tech is now called more revolutionary than the iPhone by experts, sparking major buzz.",
+      "hook": "Tesla's FSD tech is now called more revolutionary than the iPhone by experts, sparking major buzz.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 09, 2026\n**REAL-TIME TSLA price:** $396.73 ▲ $2.04 (0.5%)\n\n**HOOK:** Tesla's FSD tech is now called more revolutionary than the iPhone by experts, sparking major buzz.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **The Boring Company’s Vegas Loop moves 82k riders during CONEXPO: 09 March, 2026, 2:10 AM PST, Teslarati**\n   The Boring Company's Vegas Loop transported over 82,000 riders during the CONEXPO event, showcasing its growing capacity for high-volume u",
+      "url": "/tesla.html",
+      "entities": [
+        "Cybertruck Production Hits New Milestone",
+        "Date:",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "Solar Roof Installations Surge 50%",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 36,
+      "date": "2026-03-08",
+      "title": "A new study proposes space weather scrambles alien radio signals, evading SETI detectors.",
+      "hook": "A new study proposes space weather scrambles alien radio signals, evading SETI detectors.",
+      "summary": "# Fascinating Frontiers\n**Date:** March 08, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** A new study proposes space weather scrambles alien radio signals, evading SETI detectors.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Space Weather May Scramble Alien Transmissions: 08 March 2026 • Space.com**\n   A study suggests interstellar plasma smears alien radio signals beyond narrowband detection by SETI. This could explain the Fermi paradox by revealing why",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "Meta"
+      ],
+      "topics": [],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 9,
+      "date": "2026-03-08",
+      "title": "Meta's new research trains multimodal AI on unlabeled video, challenging assumptions about text-heavy scaling.",
+      "hook": "Meta's new research trains multimodal AI on unlabeled video, challenging assumptions about text-heavy scaling.",
+      "summary": "# Models & Agents\n**Date:** March 08, 2026\n\n**HOOK:** Meta's new research trains multimodal AI on unlabeled video, challenging assumptions about text-heavy scaling.\n\n**What You Need to Know:** Meta FAIR and NYU researchers have demonstrated that unlabeled video could be the next big frontier for training multimodal models, potentially bypassing the drying up of high-quality text data by leveraging vast video datasets for better generalization. Meanwhile, a study highlights how AI agent benchmark",
+      "url": "/models-agents.html",
+      "entities": [
+        "Date:",
+        "GPT",
+        "Gemini",
+        "HOOK:",
+        "Llama",
+        "Meta",
+        "Microsoft",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "language-models",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 9,
+      "date": "2026-03-08",
+      "title": "US and Israeli strikes ignite oil depots in Tehran, escalating the Middle East war into its second week.",
+      "hook": "US and Israeli strikes ignite oil depots in Tehran, escalating the Middle East war into its second week.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 08, 2026\n\n**HOOK:** US and Israeli strikes ignite oil depots in Tehran, escalating the Middle East war into its second week.\n\n## Top stories (5)\n### 1) US and Israel launch strikes on Iranian oil facilities\n**What happened (neutral):** US and Israeli forces targeted military and oil infrastructure across Iran, causing fires to spread through Tehran streets and oil depots. The attacks follow recent escalations in the ongoing Middle East conflict, n",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 401,
+      "date": "2026-03-08",
+      "title": "Tesla patents breakthrough dry electrode process for cheaper, cleaner battery production.",
+      "hook": "Tesla patents breakthrough dry electrode process for cheaper, cleaner battery production.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 08, 2026\n**REAL-TIME TSLA price:** $396.73 ▼ $8.24 (2.0%)\n\n**HOOK:** Tesla patents breakthrough dry electrode process for cheaper, cleaner battery production.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Robotaxi Prices Jump in Austin: Here is the New Cost for a 5-Mile Trip: 07 March, 2026, 2:22 PM PST, TeslaNorth.com**\n   Tesla raised its Robotaxi base fare in Austin from $1 to $3.25, pushing a typical 5-mile trip from $6 to $8.25 while keeping the ",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 8,
+      "date": "2026-03-07",
+      "title": "Anthropic's Claude AI discovered over 100 Firefox vulnerabilities that human testing missed for decades.",
+      "hook": "Anthropic's Claude AI discovered over 100 Firefox vulnerabilities that human testing missed for decades.",
+      "summary": "# Models & Agents\n**Date:** March 07, 2026\n\n**HOOK:** Anthropic's Claude AI discovered over 100 Firefox vulnerabilities that human testing missed for decades.\n\n**What You Need to Know:** Anthropic's Claude model made headlines by uncovering over 100 security bugs in Firefox, showcasing AI's potential to revolutionize vulnerability detection beyond traditional methods. Other key releases include Microsoft's Phi-4-Reasoning-Vision-15B for multimodal math and GUI tasks, Google's TensorFlow 2.21 wit",
+      "url": "/models-agents.html",
+      "entities": [
+        "AWS",
+        "Anthropic",
+        "Anthropic's new marketplace: The Decoder",
+        "Claude",
+        "Date:",
+        "GPT",
+        "Gemini",
+        "Google",
+        "Grok",
+        "HOOK:",
+        "Hugging Face",
+        "Llama",
+        "Microsoft",
+        "Microsoft Releases Phi-4-Reasoning-Vision-15B: MarkTechPost",
+        "OpenAI",
+        "OpenAI Introduces Codex Security: MarkTechPost",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 8,
+      "date": "2026-03-07",
+      "title": "Iran's drone attack on Dubai airport escalates Middle East conflict as Israel strikes Tehran.",
+      "hook": "Iran's drone attack on Dubai airport escalates Middle East conflict as Israel strikes Tehran.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 07, 2026\n\n**HOOK:** Iran's drone attack on Dubai airport escalates Middle East conflict as Israel strikes Tehran.\n\n## Top stories (5)\n### 1) Iran strikes Dubai airport with drones\n**What happened (neutral):** Iran launched a suicide drone attack on Dubai International Airport, leading to evacuations and flight disruptions. This occurred amid ongoing Israeli strikes on Tehran and other regional targets. British travelers were among those stranded a",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "biotech",
+        "energy",
+        "finance",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 27,
+      "date": "2026-03-07",
+      "title": "Mayo Clinic identified a rare MET gene mutation directly causing fatty liver disease without common risk factors.",
+      "hook": "Mayo Clinic identified a rare MET gene mutation directly causing fatty liver disease without common risk factors.",
+      "summary": "# Planetterrian Daily\n**Date:** March 07, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Mayo Clinic identified a rare MET gene mutation directly causing fatty liver disease without common risk factors.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Mayo Clinic finds rare gene mutation causing fatty liver** : 07 March 2026 • Science Daily  \n   Researchers identified a MET gene mutation that disrupts fat processing in the liver, leading to ",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Meta",
+        "Planetterrian Daily",
+        "SuperAgers' brains reveal aging clues"
+      ],
+      "topics": [
+        "biotech",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 6,
+      "date": "2026-03-06",
+      "title": "Carbon market additionality rules may exclude Indigenous-managed lands in BC and federal jurisdictions, limiting offset eligibility.",
+      "hook": "Carbon market additionality rules may exclude Indigenous-managed lands in BC and federal jurisdictions, limiting offset eligibility.",
+      "summary": "# Environmental Intelligence\n**Date:** March 06, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** Carbon market additionality rules may exclude Indigenous-managed lands in BC and federal jurisdictions, limiting offset eligibility.\n\n**Executive Summary:** Nature's analysis highlights how carbon market additionality requirements penalize ongoing Indigenous stewardship in Canada, favoring degraded land recovery over protection and potentially barring p",
+      "url": "/env-intel.html",
+      "entities": [
+        "Date:",
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 35,
+      "date": "2026-03-06",
+      "title": "China's new economic plan elevates space as a pillar industry with deep space goals.",
+      "hook": "China's new economic plan elevates space as a pillar industry with deep space goals.",
+      "summary": "# Fascinating Frontiers\n**Date:** March 06, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** China's new economic plan elevates space as a pillar industry with deep space goals.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Japan's HTV-X Cargo Craft Departs ISS: 06 March 2026 • Space.com**\n   Japan's first HTV-X cargo spacecraft undocks from the International Space Station after a four-month mission delivering supplies. This departure tests the new vehicle's",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "ESA",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "Intel",
+        "NASA",
+        "Rocket Lab"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 7,
+      "date": "2026-03-06",
+      "title": "Liquid AI launches LFM2-24B-A2B model and LocalCowork app for fully local, privacy-first agent workflows.",
+      "hook": "Liquid AI launches LFM2-24B-A2B model and LocalCowork app for fully local, privacy-first agent workflows.",
+      "summary": "# Models & Agents\n**Date:** March 06, 2026\n\n**HOOK:** Liquid AI launches LFM2-24B-A2B model and LocalCowork app for fully local, privacy-first agent workflows.\n\n**What You Need to Know:** Liquid AI dropped a game-changer with LFM2-24B-A2B, a 24B-parameter model optimized for low-latency local tool calling, powering LocalCowork—an open-source desktop agent that runs enterprise workflows without cloud APIs or data leaks. Meanwhile, OpenAI's new report on GPT-5.4 Thinking highlights poor \"CoT contr",
+      "url": "/models-agents.html",
+      "entities": [
+        "Claude",
+        "Date:",
+        "GPT",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "Llama",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 400,
+      "date": "2026-03-06",
+      "title": "Tesla's patent for a one-piece composite seat signals the next-gen Roadster is nearing its debut.",
+      "hook": "Tesla's patent for a one-piece composite seat signals the next-gen Roadster is nearing its debut.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 06, 2026\n**REAL-TIME TSLA price:** $405.55 ▲ $0.07 (0.0%)\n\n**HOOK:** Tesla's patent for a one-piece composite seat signals the next-gen Roadster is nearing its debut.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Roadster patent hints at radical seat redesign ahead of reveal: 05 March, 2026, 11:17 PM PST, Teslarati**\n   Tesla published a patent for a \"vehicle seat system\" using a single continuous composite frame, moving away from traditional multi-pa",
+      "url": "/tesla.html",
+      "entities": [
+        "BYD's Next-Gen Battery Reveal",
+        "Canada's EV Market Trends",
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "Meta",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "SpaceX's xAI Power Pledge",
+        "Starlink's Global Roaming Launch",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 5,
+      "date": "2026-03-05",
+      "title": "BC opens consultation on Koksilah Watershed Plan, requiring input by April 30 for water sustainability compliance under Water Sustainability Act.",
+      "hook": "BC opens consultation on Koksilah Watershed Plan, requiring input by April 30 for water sustainability compliance under Water Sustainability Act.",
+      "summary": "# Environmental Intelligence\n**Date:** March 05, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** BC opens consultation on Koksilah Watershed Plan, requiring input by April 30 for water sustainability compliance under Water Sustainability Act.\n\n**Executive Summary:** BC's Ministry of Water, Land and Resource Stewardship invites public input on the Xwulqw’selu (Koksilah) Watershed and Water Sustainability Plan, introducing potential new management me",
+      "url": "/env-intel.html",
+      "entities": [
+        "Date:",
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 6,
+      "date": "2026-03-05",
+      "title": "YuanLab AI launches Yuan 3.0 Ultra, a 1T-parameter multimodal MoE model cutting parameters by 33% while boosting efficiency 49%.",
+      "hook": "YuanLab AI launches Yuan 3.0 Ultra, a 1T-parameter multimodal MoE model cutting parameters by 33% while boosting efficiency 49%.",
+      "summary": "# Models & Agents\n**Date:** March 05, 2026\n\n**HOOK:** YuanLab AI launches Yuan 3.0 Ultra, a 1T-parameter multimodal MoE model cutting parameters by 33% while boosting efficiency 49%.\n\n**What You Need to Know:** YuanLab AI dropped Yuan 3.0 Ultra, a flagship multimodal Mixture-of-Experts foundation model with 1T total parameters but only 68.8B activated, delivering state-of-the-art enterprise performance at reduced cost—think stronger intelligence with unrivaled efficiency compared to dense models",
+      "url": "/models-agents.html",
+      "entities": [
+        "Claude",
+        "Cohere",
+        "Date:",
+        "GPT",
+        "Gemini",
+        "HOOK:",
+        "Hugging Face",
+        "Intel",
+        "Llama",
+        "Mistral",
+        "SEVADE: Self-Evolving Multi-Agent Analysis",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 399,
+      "date": "2026-03-05",
+      "title": "Tesla's Giga Berlin workers elect 'Giga United' majority, signaling a shift away from union influence.",
+      "hook": "Tesla's Giga Berlin workers elect 'Giga United' majority, signaling a shift away from union influence.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 05, 2026\n**REAL-TIME TSLA price:** $405.94 ▼ $0.80 (0.2%)\n\n**HOOK:** Tesla's Giga Berlin workers elect 'Giga United' majority, signaling a shift away from union influence.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Starlink For General Aviation See Major Price Increase With 100 MPH Speed Cap: 04 March, 2026, 4:05 PM PST, Drive Tesla**\n   Starlink has raised prices for its satellite internet service in small planes and added a 100 MPH speed cap, prompting",
+      "url": "/tesla.html",
+      "entities": [
+        "Apple",
+        "Breakthrough in 4680 Battery Efficiency",
+        "Date:",
+        "HOOK:",
+        "Intel",
+        "Meta",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 398,
+      "date": "2026-03-04",
+      "title": "Automakers are exiting Tesla's EU carbon credit pool, which could squeeze a key revenue stream worth billions.",
+      "hook": "Automakers are exiting Tesla's EU carbon credit pool, which could squeeze a key revenue stream worth billions.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 04, 2026\n**REAL-TIME TSLA price:** $405.94 ▲ $15.34 (3.9%)\n\n**HOOK:** Automakers are exiting Tesla's EU carbon credit pool, which could squeeze a key revenue stream worth billions.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Automakers Drop Out of Carbon Credit Pool with Tesla: 04 March, 2026, 12:50 PM PST, CleanTechnica**\n   Several automakers like Ford, Honda, and Toyota have pulled out of the EU carbon credit pooling arrangement with Tesla, where Tesla",
+      "url": "/tesla.html",
+      "entities": [
+        "Date:",
+        "Electric Trucking Hits the Spotlight",
+        "Elon Musk",
+        "FSD Updates Keep Users Guessing",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "Robotaxi Team Grows in Europe",
+        "Samsung",
+        "Shifting Alliances in EV Regulations",
+        "Sustainability Leadership Paying Off",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 4,
+      "date": "2026-03-03",
+      "title": "New Antarctic meltwater data shows minimal iron release, undermining algae bloom assumptions in global carbon models used for Canadian climate adaptation planning.",
+      "hook": "New Antarctic meltwater data shows minimal iron release, undermining algae bloom assumptions in global carbon models used for Canadian climate adaptation planning.",
+      "summary": "# Environmental Intelligence\n**Date:** March 03, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** New Antarctic meltwater data shows minimal iron release, undermining algae bloom assumptions in global carbon models used for Canadian climate adaptation planning.\n\n**Executive Summary:** Field data from West Antarctica reveals meltwater contributes far less iron to oceans than previously thought, shifting reliance to deep ocean sources and raising ques",
+      "url": "/env-intel.html",
+      "entities": [
+        "Cross-Jurisdictional Watch",
+        "Date:",
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel",
+        "Practice Spotlight",
+        "Regulatory Calendar Review"
+      ],
+      "topics": [
+        "climate",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 7,
+      "date": "2026-03-03",
+      "title": "Iran escalates attacks on US assets in the Middle East as the conflict with the US and Israel enters its fourth day.",
+      "hook": "Iran escalates attacks on US assets in the Middle East as the conflict with the US and Israel enters its fourth day.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 03, 2026\n\n**HOOK:** Iran escalates attacks on US assets in the Middle East as the conflict with the US and Israel enters its fourth day.\n\n## Top stories (5)\n### 1) Iran strikes US military base in Qatar and embassy in Saudi Arabia\n**What happened (neutral):** Iran has attacked America's largest military base in Qatar and the US embassy in Saudi Arabia, marking a significant escalation in the ongoing conflict. The fighting has now entered its fourt",
+      "url": "/omni-view.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 25,
+      "date": "2026-03-03",
+      "title": "Phase 1 trial uses base editing to safely lower LDL cholesterol in familial hypercholesterolemia patients.",
+      "hook": "Phase 1 trial uses base editing to safely lower LDL cholesterol in familial hypercholesterolemia patients.",
+      "summary": "# Planetterrian Daily\n**Date:** March 03, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Phase 1 trial uses base editing to safely lower LDL cholesterol in familial hypercholesterolemia patients.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Base editing advances for familial hypercholesterolemia** : 03 March 2026 • Nature\n   A phase 1 study showed liver-targeted PCSK9 base editing as proof-of-concept for treating familial hypercholestero",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "February 2026 rejuvenation research highlights",
+        "GPT",
+        "Global antimicrobial resistance governance evaluation",
+        "HOOK:",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "language-models",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 397,
+      "date": "2026-03-03",
+      "title": "Tesla raised the Cybertruck's entry price to $69,990 just 10 days after its $59,990 launch, signaling strong initial demand.",
+      "hook": "Tesla raised the Cybertruck's entry price to $69,990 just 10 days after its $59,990 launch, signaling strong initial demand.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 03, 2026\n**REAL-TIME TSLA price:** $403.32 ▲ $0.37 (0.1%)\n\n**HOOK:** Tesla raised the Cybertruck's entry price to $69,990 just 10 days after its $59,990 launch, signaling strong initial demand.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Did Tesla Just Pull in a Year’s Worth of Orders for the Cybertruck?: 02 March, 2026, 8:55 PM PST, CleanTechnica**\n   Tesla's new $59,990 AWD Cybertruck version sparked a massive wave of orders last week, potentially equal",
+      "url": "/tesla.html",
+      "entities": [
+        "China's Supercharging Boom During Holidays",
+        "Creative Home Charging for Renters",
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 3,
+      "date": "2026-03-02",
+      "title": "Road salt accumulation in Ontario's Lake Simcoe watershed exceeds CCME chloride guidelines, triggering site assessments under O. Reg. 153/04.",
+      "hook": "Road salt accumulation in Ontario's Lake Simcoe watershed exceeds CCME chloride guidelines, triggering site assessments under O. Reg. 153/04.",
+      "summary": "# Environmental Intelligence\n**Date:** March 02, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** Road salt accumulation in Ontario's Lake Simcoe watershed exceeds CCME chloride guidelines, triggering site assessments under O. Reg. 153/04.\n\n**Executive Summary:** Ontario watersheds face year-round chloride contamination from winter road salt, with Lake Simcoe levels surpassing CCME aquatic life thresholds of 120 mg/L chronic and 640 mg/L acute, requ",
+      "url": "/env-intel.html",
+      "entities": [
+        "AWS",
+        "Date:",
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "energy",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 34,
+      "date": "2026-03-02",
+      "title": "A total lunar eclipse tonight will turn the full moon blood red, visible to over 3 billion people.",
+      "hook": "A total lunar eclipse tonight will turn the full moon blood red, visible to over 3 billion people.",
+      "summary": "# Fascinating Frontiers\n**Date:** March 02, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** A total lunar eclipse tonight will turn the full moon blood red, visible to over 3 billion people.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **Space Force shifts to commercial ground stations: 02 March 2026 • SpaceNews**\n   The U.S. Space Force announced it will pursue commercially derived ground stations instead of custom development for satellite operations. This",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Date:",
+        "ESA",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "Intel",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 5,
+      "date": "2026-03-02",
+      "title": "FireRedTeam releases FireRed-OCR-2B, a 2B-parameter model tackling structural hallucinations in document parsing for tables and LaTeX.",
+      "hook": "FireRedTeam releases FireRed-OCR-2B, a 2B-parameter model tackling structural hallucinations in document parsing for tables and LaTeX.",
+      "summary": "# Models & Agents\n**Date:** March 02, 2026\n\n**HOOK:** FireRedTeam releases FireRed-OCR-2B, a 2B-parameter model tackling structural hallucinations in document parsing for tables and LaTeX.\n\n**What You Need to Know:** The standout development today is FireRed-OCR-2B, a new open-source model from FireRedTeam that uses GRPO optimization to eliminate common errors in large vision-language models when handling complex document structures like tables and LaTeX. Meanwhile, a wave of arXiv papers introd",
+      "url": "/models-agents.html",
+      "entities": [
+        "AWS",
+        "Claude",
+        "Date:",
+        "FireRed-OCR-2B: MarkTechPost",
+        "GPT",
+        "HOOK:",
+        "Hugging Face",
+        "Intel",
+        "Llama",
+        "Microsoft",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "health",
+        "language-models",
+        "regulation",
+        "robotics",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 6,
+      "date": "2026-03-02",
+      "title": "Iran escalates Middle East attacks, hitting Saudi oil refinery and downing US F-15 jets in Kuwait friendly fire blunder.",
+      "hook": "Iran escalates Middle East attacks, hitting Saudi oil refinery and downing US F-15 jets in Kuwait friendly fire blunder.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 02, 2026\n\n**HOOK:** Iran escalates Middle East attacks, hitting Saudi oil refinery and downing US F-15 jets in Kuwait friendly fire blunder.\n\n## Top stories (5)\n### 1) US F-15 Jets Shot Down in Kuwait Friendly Fire Incident\n**What happened (neutral):** Three US F-15 fighter jets were shot down by Kuwaiti forces in what the US described as a friendly fire mistake during ongoing Middle East tensions. Video footage shows the $90 million planes spiral",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 396,
+      "date": "2026-03-02",
+      "title": "Tesla raised the Cybertruck AWD price by $10K to $69,990 after strong initial demand.",
+      "hook": "Tesla raised the Cybertruck AWD price by $10K to $69,990 after strong initial demand.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 02, 2026\n**REAL-TIME TSLA price:** $402.51 ▲ $0.71 (0.2%)\n\n**HOOK:** Tesla raised the Cybertruck AWD price by $10K to $69,990 after strong initial demand.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla’s Cybertruck Map Easter Egg Was Discovered by Owen Sparks** — 01 March, 2026, 11:08 AM PST, WhatsUpTesla\n   Owen Sparks spotted a satellite map connecting Tesla's Austin HQ, the Neuralink facility in Del Valle, and the SpaceX/Boring Company site in Bastr",
+      "url": "/tesla.html",
+      "entities": [
+        "Autonomous Software Loyalty Debates Ignite",
+        "Cross-Company Valuation Ripples",
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "Hidden Features Driving Fan Engagement",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 4,
+      "date": "2026-03-01",
+      "title": "Alibaba open-sources CoPaw, a workstation for scaling multi-channel AI agent workflows.",
+      "hook": "Alibaba open-sources CoPaw, a workstation for scaling multi-channel AI agent workflows.",
+      "summary": "# Models & Agents\n**Date:** March 01, 2026\n\n**HOOK:** Alibaba open-sources CoPaw, a workstation for scaling multi-channel AI agent workflows.\n\n**What You Need to Know:** Alibaba's team just dropped CoPaw, an open-source framework that turns your setup into a high-performance agent workstation, handling complex workflows and memory across channels— a game-changer for devs building autonomous systems beyond basic LLM inference. Meanwhile, benchmarks show ElevenLabs and Google leading in speech-to-",
+      "url": "/models-agents.html",
+      "entities": [
+        "Anthropic",
+        "Claude",
+        "Date:",
+        "GPT",
+        "Google",
+        "Grok",
+        "HOOK:",
+        "Llama",
+        "Microsoft",
+        "Mistral",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 5,
+      "date": "2026-03-01",
+      "title": "US and Israel kill Iran's Supreme Leader Khamenei in airstrikes, igniting retaliatory attacks across the Middle East.",
+      "hook": "US and Israel kill Iran's Supreme Leader Khamenei in airstrikes, igniting retaliatory attacks across the Middle East.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** March 01, 2026\n\n**HOOK:** US and Israel kill Iran's Supreme Leader Khamenei in airstrikes, igniting retaliatory attacks across the Middle East.\n\n## Top stories (5)\n### 1) US and Israel launch major strikes on Iran after Khamenei's death\n**What happened (neutral):** Reports indicate Israel and the US conducted airstrikes in Tehran, resulting in the death of Iran's Supreme Leader Ayatollah Ali Khamenei. Iran retaliated with strikes hitting regions includi",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "health",
+        "manufacturing",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 24,
+      "date": "2026-03-01",
+      "title": "A massive cellular atlas of 7 million cells shows aging begins earlier and coordinates across 21 organs.",
+      "hook": "A massive cellular atlas of 7 million cells shows aging begins earlier and coordinates across 21 organs.",
+      "summary": "# Planetterrian Daily\n**Date:** March 01, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** A massive cellular atlas of 7 million cells shows aging begins earlier and coordinates across 21 organs.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Insomnia and sleep apnea together raise heart disease risk**: 01 March 2026 • Science Daily  \n   A study of nearly a million veterans revealed that combining insomnia with sleep apnea significantly incr",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "finance",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 395,
+      "date": "2026-03-01",
+      "title": "Tesla's FSD (Supervised) fleet hits 8.4 billion cumulative miles, closing in on the 10 billion needed for unsupervised autonomy.",
+      "hook": "Tesla's FSD (Supervised) fleet hits 8.4 billion cumulative miles, closing in on the 10 billion needed for unsupervised autonomy.",
+      "summary": "# Tesla Shorts Time\n**Date:** March 01, 2026\n**REAL-TIME TSLA price:** $402.51 ▼ $4.27 (1.0%)\n\n**HOOK:** Tesla's FSD (Supervised) fleet hits 8.4 billion cumulative miles, closing in on the 10 billion needed for unsupervised autonomy.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla FSD (Supervised) fleet passes 8.4 billion cumulative miles: 28 February, 2026, 11:57 PM PST, Teslarati**\n   Tesla's Full Self-Driving (Supervised) system has now exceeded 8.4 billion miles driven, as updated on ",
+      "url": "/tesla.html",
+      "entities": [
+        "BYD Unveils Ultra-Fast 1,500kW Charger",
+        "Date:",
+        "ESA",
+        "Elon Musk",
+        "Grok",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "biotech",
+        "energy",
+        "finance",
+        "health",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 3,
+      "date": "2026-02-28",
+      "title": "Perplexity open-sources embedding models that match Google and Alibaba performance at a fraction of the memory cost.",
+      "hook": "Perplexity open-sources embedding models that match Google and Alibaba performance at a fraction of the memory cost.",
+      "summary": "# Models & Agents\n**Date:** February 28, 2026\n\n**HOOK:** Perplexity open-sources embedding models that match Google and Alibaba performance at a fraction of the memory cost.\n\n**What You Need to Know:** Perplexity's new open-source embedding models deliver high-quality text representations with drastically lower memory footprints, making them a game-changer for resource-constrained RAG setups compared to heavier alternatives from Google or Alibaba. Meanwhile, a wave of arXiv papers introduces inn",
+      "url": "/models-agents.html",
+      "entities": [
+        "Apple",
+        "Claude",
+        "Date:",
+        "GPT",
+        "Gemini",
+        "Google",
+        "Grok",
+        "HOOK:",
+        "Hugging Face",
+        "Llama",
+        "Microsoft",
+        "Mistral",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "safety"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 394,
+      "date": "2026-02-28",
+      "title": "Tesla confirms upgraded black headliner and 16-inch screen for new Model Y orders in Canada, enhancing customer appeal.",
+      "hook": "Tesla confirms upgraded black headliner and 16-inch screen for new Model Y orders in Canada, enhancing customer appeal.",
+      "summary": "# Tesla Shorts Time\n**Date:** February 28, 2026\n**REAL-TIME TSLA price:** $402.51 ▼ $4.27 (1.0%)\n\n**HOOK:** Tesla confirms upgraded black headliner and 16-inch screen for new Model Y orders in Canada, enhancing customer appeal.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Rivian Launches RAD: A New Performance Division to Push Its EVs Even Further: 27 February, 2026, 10:23 AM PST, Drive Tesla**\n   Rivian has officially launched its Rivian Adventure Department (RAD), an in-house team focused ",
+      "url": "/tesla.html",
+      "entities": [
+        "Cybertruck Range Extender Finally Ships",
+        "Date:",
+        "Elon Musk",
+        "HOOK:",
+        "Optimus Robot Demos Household Tasks",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "energy",
+        "finance",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 2,
+      "date": "2026-02-27",
+      "title": "Port of Churchill expansion push triggers federal IAA assessments for Manitoba Arctic infrastructure, with oil spill risks under Fisheries Act.",
+      "hook": "Port of Churchill expansion push triggers federal IAA assessments for Manitoba Arctic infrastructure, with oil spill risks under Fisheries Act.",
+      "summary": "# Environmental Intelligence\n**Date:** February 27, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** Port of Churchill expansion push triggers federal IAA assessments for Manitoba Arctic infrastructure, with oil spill risks under Fisheries Act.\n\n**Executive Summary:** Expansion proposals for Manitoba's Port of Churchill under federal IAA could mandate enhanced environmental assessments for pipeline and rail projects on permafrost, altering complianc",
+      "url": "/env-intel.html",
+      "entities": [
+        "Date:",
+        "ESA",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel"
+      ],
+      "topics": [
+        "climate",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 33,
+      "date": "2026-02-27",
+      "title": "NASA has overhauled its Artemis program, canceling the Artemis 3 moon landing and adding a preparatory mission in 2027.",
+      "hook": "NASA has overhauled its Artemis program, canceling the Artemis 3 moon landing and adding a preparatory mission in 2027.",
+      "summary": "# Fascinating Frontiers\n**Date:** February 27, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** NASA has overhauled its Artemis program, canceling the Artemis 3 moon landing and adding a preparatory mission in 2027.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **NASA Tests Solar Oxygen Extraction on Moon: 27 February 2026 • NASA**\n   NASA's Carbothermal Reduction Demonstration successfully integrated a solar concentrator with mirrors and software to produce c",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Date:",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "NASA",
+        "Rocket Lab",
+        "SpaceX"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 2,
+      "date": "2026-02-27",
+      "title": "Sakana AI launches Doc-to-LoRA and Text-to-LoRA hypernetworks for zero-shot LLM adaptation to long contexts via natural language.",
+      "hook": "Sakana AI launches Doc-to-LoRA and Text-to-LoRA hypernetworks for zero-shot LLM adaptation to long contexts via natural language.",
+      "summary": "# Models & Agents\n**Date:** February 27, 2026\n\n**HOOK:** Sakana AI launches Doc-to-LoRA and Text-to-LoRA hypernetworks for zero-shot LLM adaptation to long contexts via natural language.\n\n**What You Need to Know:** Sakana AI introduced Doc-to-LoRA and Text-to-LoRA, innovative hypernetworks that enable instant, zero-shot adaptation of LLMs to long contexts and tasks using natural language, bypassing traditional trade-offs between in-context learning and fine-tuning. OpenAI and Amazon announced a ",
+      "url": "/models-agents.html",
+      "entities": [
+        "AWS",
+        "Amazon",
+        "Claude",
+        "Date:",
+        "GPT",
+        "HOOK:",
+        "Hugging Face",
+        "Intel",
+        "Llama",
+        "Meta",
+        "Mistral",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "language-models",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 4,
+      "date": "2026-02-27",
+      "title": "Bill Clinton testified before Congress on his ties to Jeffrey Epstein, denying any wrongdoing amid ongoing scrutiny.",
+      "hook": "Bill Clinton testified before Congress on his ties to Jeffrey Epstein, denying any wrongdoing amid ongoing scrutiny.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** February 27, 2026\n\n**HOOK:** Bill Clinton testified before Congress on his ties to Jeffrey Epstein, denying any wrongdoing amid ongoing scrutiny.\n\n## Top stories (5)\n### 1) Bill Clinton Testifies on Epstein Connections\n**What happened (neutral):** Former President Bill Clinton appeared before the House Oversight Committee to address his relationship with Jeffrey Epstein, stating he saw nothing improper and did nothing wrong. The testimony followed Hilla",
+      "url": "/omni-view.html",
+      "entities": [
+        "Anthropic",
+        "Dario Amodei",
+        "Date:",
+        "HOOK:",
+        "OpenAI",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "climate",
+        "finance",
+        "manufacturing",
+        "regulation"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "omni_view",
+      "episode_num": 3,
+      "date": "2026-02-27",
+      "title": "Pakistan bombs Kabul, declares 'open war' on Afghanistan amid escalating border clashes.",
+      "hook": "Pakistan bombs Kabul, declares 'open war' on Afghanistan amid escalating border clashes.",
+      "summary": "# Omni View — Omni‑View Briefing\n**Date:** February 27, 2026\n\n**HOOK:** Pakistan bombs Kabul, declares 'open war' on Afghanistan amid escalating border clashes.\n\n## Top stories (5)\n### 1) Pakistan launches airstrikes on Afghanistan, declares 'open war'\n**What happened (neutral):** Pakistani forces conducted airstrikes on military targets in Kabul and other Afghan provinces following cross-border attacks, with both sides reporting heavy casualties but providing conflicting figures. Pakistan's inf",
+      "url": "/omni-view.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Perspectives:",
+        "Questions to consider:",
+        "Read more (sources):",
+        "What happened (neutral):"
+      ],
+      "topics": [
+        "finance",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Omni View - Balanced News Perspectives",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 23,
+      "date": "2026-02-27",
+      "title": "Infusing stem cells from young donors reduced frailty in older people, boosting their strength and mobility.",
+      "hook": "Infusing stem cells from young donors reduced frailty in older people, boosting their strength and mobility.",
+      "summary": "# Planetterrian Daily\n**Date:** February 27, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Infusing stem cells from young donors reduced frailty in older people, boosting their strength and mobility.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Diet cuts amino acids to boost fat burning**: 27 February 2026 • Science Daily  \n   Researchers discovered that restricting methionine and cysteine in mice diets increased energy burn through bei",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Cellular reprogramming expert insights",
+        "DNA structured before genome activation",
+        "Date:",
+        "HOOK:",
+        "Iron catalyst advances efficient photocatalysis",
+        "Lost moon collision formed Titan",
+        "Meta",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "climate",
+        "health",
+        "manufacturing",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    },
+    {
+      "show_slug": "tesla",
+      "episode_num": 393,
+      "date": "2026-02-27",
+      "title": "Tesla's new affordable Cybertruck variant sees delivery estimates pushed to April 2027 amid surging demand.",
+      "hook": "Tesla's new affordable Cybertruck variant sees delivery estimates pushed to April 2027 amid surging demand.",
+      "summary": "# Tesla Shorts Time\n**Date:** February 27, 2026\n**REAL-TIME TSLA price:** $399.50 ▼ $7.28 (1.8%)\n\n**HOOK:** Tesla's new affordable Cybertruck variant sees delivery estimates pushed to April 2027 amid surging demand.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 10 News Items\n1. **Tesla Model Y 7-Seater Returns to Europe on Premium AWD: 27 February, 2026, 10:09 AM PST, TeslaNorth.com**\n   Tesla has reintroduced the seven-seat option for the Model Y in Europe, limited to the Premium Long Range All-Wheel Drive mod",
+      "url": "/tesla.html",
+      "entities": [
+        "Canada's EV Rebate Shortfall Exposed",
+        "Cybertruck Delivery Delays Mount",
+        "Date:",
+        "Elon Musk",
+        "FSD's Anti-Tailgating Feature Emerges",
+        "Giga Berlin Expansion Warnings",
+        "HOOK:",
+        "REAL-TIME TSLA price:",
+        "SpaceX",
+        "Starship Tower Catch Plan Revealed",
+        "Tesla",
+        "The Bottom Line:",
+        "The Data Says:",
+        "The Fundamental Question:",
+        "The Tesla Approach:"
+      ],
+      "topics": [
+        "autonomous-vehicles",
+        "climate",
+        "energy",
+        "finance",
+        "manufacturing",
+        "regulation",
+        "robotics",
+        "space"
+      ],
+      "show_name": "Tesla Shorts Time",
+      "language": "en"
+    },
+    {
+      "show_slug": "env_intel",
+      "episode_num": 1,
+      "date": "2026-02-26",
+      "title": "No qualifying environmental regulatory or technical developments reported today.",
+      "hook": "No qualifying environmental regulatory or technical developments reported today.",
+      "summary": "# Environmental Intelligence\n**Date:** February 26, 2026\n🔬 **Environmental Intelligence** — Canadian Environmental Professional Briefing\n\n**HOOK:** No qualifying environmental regulatory or technical developments reported today.\n\n**Executive Summary:** The available source does not meet criteria for inclusion, providing no updates on Canadian environmental regulations, enforcement, or science. No specific changes to thresholds, deadlines, or compliance obligations in any province, territory, or ",
+      "url": "/env-intel.html",
+      "entities": [
+        "Date:",
+        "Environmental Intelligence",
+        "Executive Summary:",
+        "HOOK:",
+        "Intel"
+      ],
+      "topics": [
+        "regulation",
+        "safety"
+      ],
+      "show_name": "Environmental Intelligence",
+      "language": "en"
+    },
+    {
+      "show_slug": "fascinating_frontiers",
+      "episode_num": 32,
+      "date": "2026-02-26",
+      "title": "NASA shakes up human spaceflight leadership after critical Starliner report.",
+      "hook": "NASA shakes up human spaceflight leadership after critical Starliner report.",
+      "summary": "# Fascinating Frontiers\n**Date:** February 26, 2026\n🚀 **Fascinating Frontiers** - Space & Astronomy News\n\n**HOOK:** NASA shakes up human spaceflight leadership after critical Starliner report.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Space & Astronomy Stories\n1. **NASA Leadership Shake-Up: 26 February 2026 • Space.com**\n   NASA has replaced two key figures in its human spaceflight program following a critical report on the Boeing Starliner crewed flight. This restructuring aims to address oversight issu",
+      "url": "/fascinating-frontiers.html",
+      "entities": [
+        "Date:",
+        "Fascinating Frontiers",
+        "HOOK:",
+        "NASA",
+        "SpaceX"
+      ],
+      "topics": [
+        "energy",
+        "regulation",
+        "space"
+      ],
+      "show_name": "Fascinating Frontiers",
+      "language": "en"
+    },
+    {
+      "show_slug": "models_agents",
+      "episode_num": 1,
+      "date": "2026-02-26",
+      "title": "Anthropic acquires Vercept to enhance Claude's screen reading, while Google launches Nano Banana 2 for faster, cheaper image generation.",
+      "hook": "Anthropic acquires Vercept to enhance Claude's screen reading, while Google launches Nano Banana 2 for faster, cheaper image generation.",
+      "summary": "# Models & Agents\n**Date:** February 26, 2026\n\n**HOOK:** Anthropic acquires Vercept to enhance Claude's screen reading, while Google launches Nano Banana 2 for faster, cheaper image generation.\n\n**What You Need to Know:** Anthropic's acquisition of Vercept integrates advanced screen recognition into Claude, potentially revolutionizing agentic computer use by improving visual control without major retraining—expect better automation in tools like browser agents. Google's Nano Banana 2 brings pro-",
+      "url": "/models-agents.html",
+      "entities": [
+        "AWS",
+        "Anthropic",
+        "Claude",
+        "Date:",
+        "Gemini",
+        "Google",
+        "HOOK:",
+        "Intel",
+        "Llama",
+        "Microsoft",
+        "Nous Research Releases Hermes Agent",
+        "OpenAI",
+        "What You Need to Know:"
+      ],
+      "topics": [
+        "language-models",
+        "regulation",
+        "safety",
+        "space"
+      ],
+      "show_name": "Models & Agents",
+      "language": "en"
+    },
+    {
+      "show_slug": "planetterrian",
+      "episode_num": 22,
+      "date": "2026-02-26",
+      "title": "Shingles vaccine may slow biological aging and reduce inflammation.",
+      "hook": "Shingles vaccine may slow biological aging and reduce inflammation.",
+      "summary": "# Planetterrian Daily\n**Date:** February 26, 2026\n🌍 **Planetterrian Daily** - Science, Longevity & Health Discoveries\n\n**HOOK:** Shingles vaccine may slow biological aging and reduce inflammation.\n\n━━━━━━━━━━━━━━━━━━━━\n### Top 15 Science & Health Discoveries\n1. **Shingles Vaccine Slows Aging: 26 February 2026 • Science Daily**\n   A large study of over 3,800 Americans aged 70+ found that the shingles vaccine slows biological aging by reducing chronic inflammation. This could lower risks of heart ",
+      "url": "/planetterrian.html",
+      "entities": [
+        "Date:",
+        "HOOK:",
+        "Meta",
+        "Planetterrian Daily"
+      ],
+      "topics": [
+        "biotech",
+        "health",
+        "regulation"
+      ],
+      "show_name": "Planetterrian Daily",
+      "language": "en"
+    }
+  ]
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -1338,6 +1338,33 @@ button { font-family: var(--font-ui); cursor: pointer; }
     padding: 5px 6px !important;
   }
 
+  /* Global search results dropdown (used by centralized assets/js/search.js) */
+  #nn-global-search-results {
+    border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+    overflow: hidden;
+    border: 1px solid var(--nn-border);
+  }
+  .search-result {
+    transition: background 80ms ease;
+  }
+  .search-result:hover,
+  .search-result:focus-visible {
+    background: var(--nn-surface) !important;
+    outline: none;
+  }
+  .search-result mark {
+    background: color-mix(in srgb, var(--show-color, #00D4FF) 35%, transparent);
+    color: inherit;
+    padding: 0 1px;
+    border-radius: 2px;
+    font-weight: 600;
+  }
+  .nn-global-search input:focus-visible {
+    outline: 2px solid var(--show-color, #00D4FF);
+    outline-offset: -2px;
+  }
+
   .show-hero-inner {
     grid-template-columns: 1fr;
     text-align: center;


### PR DESCRIPTION
**Search is now robust and genuinely useful for any visitor.**

### Changes
- **assets/js/search.js** (centralized, deduped):
  - localStorage 12h cache → instant repeat visits + survives brief index rebuild windows or deploys
  - Scoring upgraded: summary text, episode numbers ("ep 461"), word-start matches, proper days-since recency (not crude year)
  - Results now surface hook + summary snippets with <mark> highlighting
  - Full ARIA: combobox + listbox + aria-live polite announcements for screen readers
  - Keyboard: Arrow nav, Enter, Esc, global `/` focus (standard power-user pattern)
  - UX: in-field × clear button, better empty states ("Index covers 532 episodes..."), "Showing N of M"
  - Removed duplicate debounce dead-code
  - Background refresh of cache when stale-but-usable copy served
- **styles/main.css**: hover/focus states, mark styling (brand tint), focus ring for the input
- **site/data/search-index.json**: rebuilt from content lake (532 episodes, all 11 shows). Was 0-count empty in this workspace; now real data. Future builds are content-change-only (CI friendly).

### Safety / no regressions
- All historical episode blog HTMLs untouched (their baked-in inline search still works against the now-populated index).
- Hub pages that already load the centralized script get the full upgrade automatically.
- Future episode publishes (via run_show + generate) will use the clean template + best JS.
- Existing drift-guard tests in test_quick_wins.py pass.
- No changes to prompts, audio pipeline, generators, or any prior landmine areas.

This completes the "make search robust and great" request on top of the prior centralization + post-episode rebuild wiring.

Ready to squash-merge after review.