### PR TITLE
hotfix: fix SyntaxError in weekly_recap.py blocking all show runs

### DIFF
--- a/engine/weekly_recap.py
+++ b/engine/weekly_recap.py
@@ -120,7 +120,7 @@ def build_weekly_recap_digest(
             f"   {body}"
         )
 
-    return "\n\n".join([
+    recap = "\n\n".join([
         title,
         hook,
         "━━━━━━━━━━━━━━━━━━━━",
@@ -139,7 +139,10 @@ def build_weekly_recap_digest(
         ),
     ])
 
-    # TST-specific enhancement: inject narrative memory framing when available
+    # TST-specific enhancement: inject narrative memory framing when available.
+    # This is intentionally best-effort (the narrative tracker lives in the
+    # gitignored content lake + digests/ on the runner). If anything fails we
+    # just ship the plain recap.
     if show_slug == "tesla":
         try:
             from engine import tesla_memory
@@ -149,9 +152,12 @@ def build_weekly_recap_digest(
             )
             narrative_block = tesla_memory.build_narrative_status_block(tracker)
             if narrative_block:
-                base += "\n\n" + narrative_block + "\n\nUse the narrative status above to highlight meaningful progress or open questions across the week."
+                recap += (
+                    "\n\n" + narrative_block +
+                    "\n\nUse the narrative status above to highlight meaningful "
+                    "progress or open questions across the week."
+                )
         except Exception:
             pass
 
-    return base
-    ])
+    return recap


### PR DESCRIPTION
**Critical hotfix** — unblocks CI for every show.

### Problem
`engine/weekly_recap.py` had a `SyntaxError: unmatched ']'` at import time.

This was caused by a copy-paste error during the Tesla narrative memory work: the enhancement block was left after an early `return` along with a stray `])`.

Because the smoke tests in `run-show.yml` do:

```bash
python -m pytest tests/test_config.py tests/test_schedule.py ... -q
```

...and `test_schedule.py::TestWeeklyRecapHelper` imports `weekly_recap`, **every single show run** (Tesla, OV, FF, PT, M&A, etc.) was failing the "Run smoke tests" step before the pipeline even started.

### Fix
- Moved the Tesla-specific narrative injection to the correct place (after building the recap string, before the final return).
- Made it properly best-effort / non-breaking.
- Removed dead code and the syntax error.

All 266 smoke tests now pass cleanly (verified locally + the three previously red `TestWeeklyRecapHelper` tests are green).

This is a pure hotfix with no behavior change for non-Tesla shows and graceful degradation when the narrative tracker is unavailable on the runner.

Ready for immediate squash-merge.