### PR TITLE
fix: May 2026 pipeline stability improvements

### DIFF
--- a/.github/actions/safe-commit-push/action.yml
+++ b/.github/actions/safe-commit-push/action.yml
@@ -60,8 +60,8 @@ runs:
         # word-splitting and stops paths from being misinterpreted as
         # executable commands (the cause of "Permission denied" on .json files).
         cat > /tmp/paths-to-add.txt << 'EOL'
-${{ inputs.add-paths }}
-EOL
+        ${{ inputs.add-paths }}
+        EOL
 
         # Drop blank lines and add the rest
         grep -v '^[[:space:]]*$' /tmp/paths-to-add.txt > /tmp/paths-clean.txt || true

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -1630,12 +1630,13 @@ def generate_podcast_script(
         )
         retry_prompt = (
             f"The script you just wrote is only {word_count} words. "
-            f"Please rewrite it with more substance:\n"
-            f"- Add one missing element per story only if useful: a brief "
-            f"listener takeaway, a transition, or a one-sentence why-it-matters\n"
-            f"- Do NOT pad existing stories with filler or repeat content\n"
-            f"- Do NOT add new stories \u2014 just deepen the existing ones\n"
-            f"- Better to stay short than to repeat yourself\n\n"
+            f"Please rewrite it with significantly more substance and natural flow while "
+            f"staying strictly faithful to the provided stories:\n"
+            f"- For each story, add 1-2 listener takeaways, implications, a smooth transition, "
+            f"or a concrete 'why this matters' sentence drawn from the details already present\n"
+            f"- Expand the narrative voice with conversational bridges between stories\n"
+            f"- Do NOT invent new facts, new stories, or repeat any sentence verbatim\n"
+            f"- Aim for at least {min_words} words of real spoken content\n\n"
             f"Here is your short script to expand:\n\n{text}"
         )
         text2, meta2 = _call_grok(

--- a/review_episodes.py
+++ b/review_episodes.py
@@ -114,7 +114,7 @@ SHOW_REGISTRY = {
         "min_audio_s": 240,
         "max_audio_s": 1500,
         "required_sections": [],
-        "schedule": "odd",
+        "schedule": "daily",
     },
     "fascinating_frontiers": {
         "name": "Fascinating Frontiers",
@@ -126,7 +126,7 @@ SHOW_REGISTRY = {
         "min_audio_s": 240,
         "max_audio_s": 1500,
         "required_sections": [],
-        "schedule": "even",
+        "schedule": "daily",
     },
     "planetterrian": {
         "name": "Planetterrian Daily",
@@ -138,7 +138,7 @@ SHOW_REGISTRY = {
         "min_audio_s": 240,
         "max_audio_s": 1500,
         "required_sections": [],
-        "schedule": "odd",
+        "schedule": "daily",
     },
     "env_intel": {
         "name": "Environmental Intelligence",
@@ -162,7 +162,7 @@ SHOW_REGISTRY = {
         "min_audio_s": 240,
         "max_audio_s": 1500,
         "required_sections": [],
-        "schedule": "odd",
+        "schedule": "daily",
     },
     "models_agents_beginners": {
         "name": "Models & Agents for Beginners",
@@ -174,7 +174,7 @@ SHOW_REGISTRY = {
         "min_audio_s": 180,
         "max_audio_s": 1500,
         "required_sections": [],
-        "schedule": "even",
+        "schedule": "daily",
     },
     "finansy_prosto": {
         "name": "Finansy Prosto",
@@ -198,7 +198,7 @@ SHOW_REGISTRY = {
         "min_audio_s": 300,
         "max_audio_s": 1800,
         "required_sections": ["Strategy Spotlight", "Practice Investment"],
-        "schedule": "weekday",
+        "schedule": "daily",
     },
     "privet_russian": {
         "name": "Privet Russian",
@@ -211,6 +211,18 @@ SHOW_REGISTRY = {
         "max_audio_s": 1200,
         "required_sections": [],
         "schedule": "even",
+    },
+    "unintended_consequences": {
+        "name": "Unintended Consequences",
+        "output_dir": "digests/unintended_consequences",
+        "prefix": "Unintended_Consequences_Ep",
+        "min_digest_chars": 2000,
+        "max_digest_chars": 20000,
+        "min_tts_words": 1300,
+        "min_audio_s": 300,
+        "max_audio_s": 1200,
+        "required_sections": [],
+        "schedule": "weekday",
     },
 }
 

--- a/run_show.py
+++ b/run_show.py
@@ -1739,13 +1739,36 @@ def run(args: argparse.Namespace) -> None:
             _HARD_FLOOR = max(_FLOOR_FIELD, int(_TARGET_WORDS * 0.4))
             _script_word_count = len(podcast_script.split())
             if _script_word_count < _HARD_FLOOR:
-                logger.error(
-                    "Podcast script is clearly broken (%d words, hard floor %d) — "
-                    "aborting episode.",
+                logger.warning(
+                    "Podcast script too thin after dedup + retries (%d words, hard floor %d) — "
+                    "skipping episode for today (fresh material was insufficient for a full show).",
                     _script_word_count, _HARD_FLOOR,
                 )
+                # Write skip marker so daily review treats this as intentional thin-day skip
+                # rather than a crash (consistent with min_articles_skip and other content gates).
+                try:
+                    marker_path = digests_dir / f".skip_{today.strftime('%Y%m%d')}.json"
+                    marker_path.parent.mkdir(parents=True, exist_ok=True)
+                    marker_data = {
+                        "date": today.isoformat(),
+                        "show": config.slug,
+                        "show_name": config.name,
+                        "reason": "podcast_script_too_thin",
+                        "detail": (
+                            f"Script only {_script_word_count} words after all dedup, "
+                            f"validation, and length retries (hard floor {_HARD_FLOOR}). "
+                            f"Insufficient fresh synthesizable material on this cycle."
+                        ),
+                        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                        "word_count": _script_word_count,
+                        "hard_floor": _HARD_FLOOR,
+                    }
+                    marker_path.write_text(json.dumps(marker_data, indent=2))
+                    logger.info("Skip marker written for thin podcast script: %s", marker_path.name)
+                except Exception as exc:
+                    logger.warning("Failed to write thin-script skip marker: %s", exc)
                 save_usage(tracker, digests_dir)
-                sys.exit(1)
+                sys.exit(2)  # Graceful skip (like insufficient articles) so matrix job stays green for other shows.
             elif _script_word_count < _TARGET_WORDS:
                 logger.warning(
                     "Podcast script below target (%d words, target %d) — "
@@ -2815,7 +2838,20 @@ def _clean_digest_for_podcast(digest: str) -> str:
         line = re.sub(r"  +", " ", line).strip()
         lines.append(line)
 
-    return "\n".join(lines)
+    cleaned = "\n".join(lines)
+
+    # Collapse repetitive source citation footers that the LLM sometimes echoes
+    # multiple times (e.g. "**— phys.org**", "**— r/science**" appearing 4x).
+    # This reduces the "suspicious repetition" warnings and gives the podcast
+    # stage cleaner material on thin news days.
+    cleaned = re.sub(
+        r'(\*\*?[-–—]\s*(phys\.org|Science Daily|bioRxiv|r/science|Nature|MIT Technology Review|Fierce Biotech|STAT News|Ars Technica|Harvard|Google News|Quanta|Science News|Lifespan\.io)\*\*?\s*){2,}',
+        r'\1',
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+
+    return cleaned
 
 
 def _clean_podcast_script(script: str, host_name: str = "Patrick") -> str:

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1274,6 +1274,37 @@ def build_network_rollup(
 # ---------------------------------------------------------------------------
 
 
+def _normalize_mit_monthly_snapshots(snapshots: list) -> list:
+    """Ensure every monthly snapshot dict has the keys expected by the
+    public show page template and management.html, using safe defaults.
+
+    This protects against historical snapshots written by the daily hook
+    (which used a different/minimal schema) or any future writer drift.
+    The three comparison percentages default to None (rendered as "—").
+    """
+    if not snapshots:
+        return []
+    normalized = []
+    for s in snapshots:
+        if not isinstance(s, dict):
+            continue
+        normalized.append({
+            "month": s.get("month"),
+            "trades": s.get("trades") if s.get("trades") is not None else s.get("total_trades", 0),
+            "win_rate": s.get("win_rate") if s.get("win_rate") is not None else s.get("win_rate_pct", 0.0),
+            "portfolio_pct": s.get("portfolio_pct"),
+            "nasdaq_pct": s.get("nasdaq_pct"),
+            "alpha_pct": s.get("alpha_pct"),
+            "portfolio_pnl": s.get("portfolio_pnl") if s.get("portfolio_pnl") is not None else s.get("cumulative_pnl", 0.0),
+            # preserve any extra fields
+            **{k: v for k, v in s.items() if k not in {
+                "month", "trades", "total_trades", "win_rate", "win_rate_pct",
+                "portfolio_pct", "nasdaq_pct", "alpha_pct", "portfolio_pnl", "cumulative_pnl"
+            }},
+        })
+    return normalized
+
+
 def aggregate_mit_performance(root: Path) -> Dict[str, Any]:
     """Read the Modern Investing trackers and return a dashboard-ready dict.
 
@@ -1422,7 +1453,7 @@ def aggregate_mit_performance(root: Path) -> Dict[str, Any]:
         "benchmark": benchmark,
         "alpha": alpha,
         "sectors": sectors,
-        "monthly_snapshots": tracker.get("monthly_snapshots") or [],
+        "monthly_snapshots": _normalize_mit_monthly_snapshots(tracker.get("monthly_snapshots") or []),
         "trades": trades_normalised,
         "lessons_learned": lessons_active,
         "taught_lessons_hot": taught_hot,

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -1712,8 +1712,21 @@ def _maybe_record_monthly_snapshot(tracker: dict, today: "datetime.date") -> Non
     if snapshots and snapshots[-1].get("month") == current_month:
         return
     summary = tracker.get("summary", {})
+    # Emit a snapshot shape compatible with the public show page template
+    # (which expects portfolio_pct / nasdaq_pct / alpha_pct / trades / win_rate)
+    # and the richer snapshots produced by scripts/run_monthly_mit_episode.py.
+    # Daily hook snapshots (written on month rollover during a regular episode)
+    # don't have the full per-month closed-trade aggregation, so the three
+    # comparison percentages are left as None (template shows "—").
     snapshot = {
         "month": current_month,
+        "trades": summary.get("total_trades", 0),
+        "win_rate": summary.get("win_rate_pct", 0.0),
+        "portfolio_pct": None,
+        "nasdaq_pct": None,
+        "alpha_pct": None,
+        "portfolio_pnl": summary.get("cumulative_pnl", 0.0),
+        # Legacy keys kept for any direct consumers of the raw tracker
         "total_trades": summary.get("total_trades", 0),
         "win_rate_pct": summary.get("win_rate_pct", 0.0),
         "cumulative_pnl": summary.get("cumulative_pnl", 0.0),

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -354,9 +354,9 @@
                             <td style="padding:6px 12px;font-weight:600;">{{ m.month }}</td>
                             <td style="padding:6px 12px;text-align:right;">{{ m.trades or 0 }}</td>
                             <td style="padding:6px 12px;text-align:right;">{{ "{:.0f}".format(m.win_rate or 0) }}%</td>
-                            <td style="padding:6px 12px;text-align:right;font-variant-numeric:tabular-nums;">{% if m.portfolio_pct is not none %}{{ "{:+.2f}".format(m.portfolio_pct) }}%{% else %}—{% endif %}</td>
-                            <td style="padding:6px 12px;text-align:right;font-variant-numeric:tabular-nums;color:var(--nn-text-muted);">{% if m.nasdaq_pct is not none %}{{ "{:+.2f}".format(m.nasdaq_pct) }}%{% else %}—{% endif %}</td>
-                            <td style="padding:6px 12px;text-align:right;font-variant-numeric:tabular-nums;font-weight:600;color:{% if (m.alpha_pct or 0) >= 0 %}#10b981{% else %}#ef4444{% endif %};">{% if m.alpha_pct is not none %}{{ "{:+.2f}".format(m.alpha_pct) }}%{% else %}—{% endif %}</td>
+                            <td style="padding:6px 12px;text-align:right;font-variant-numeric:tabular-nums;">{% if m.portfolio_pct is defined and m.portfolio_pct is not none %}{{ "{:+.2f}".format(m.portfolio_pct) }}%{% else %}—{% endif %}</td>
+                            <td style="padding:6px 12px;text-align:right;font-variant-numeric:tabular-nums;color:var(--nn-text-muted);">{% if m.nasdaq_pct is defined and m.nasdaq_pct is not none %}{{ "{:+.2f}".format(m.nasdaq_pct) }}%{% else %}—{% endif %}</td>
+                            <td style="padding:6px 12px;text-align:right;font-variant-numeric:tabular-nums;font-weight:600;color:{% if (m.alpha_pct or 0) >= 0 %}#10b981{% else %}#ef4444{% endif %};">{% if m.alpha_pct is defined and m.alpha_pct is not none %}{{ "{:+.2f}".format(m.alpha_pct) }}%{% else %}—{% endif %}</td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/tests/test_skip_markers.py
+++ b/tests/test_skip_markers.py
@@ -255,8 +255,8 @@ class TestCheckMissedEpisodes:
 
     def test_not_scheduled_not_flagged(self):
         """A show not scheduled for the target date should not be flagged."""
-        # Day 14 is even — omni_view (odd schedule) should not be flagged
-        target = datetime.date(2026, 4, 14)
+        # Day 13 is odd — finansy_prosto (even schedule) should not be flagged
+        target = datetime.date(2026, 4, 13)
         found: list[EpisodeReview] = []
-        issues = check_missed_episodes(target, found, show_filter="omni_view")
+        issues = check_missed_episodes(target, found, show_filter="finansy_prosto")
         assert len(issues) == 0


### PR DESCRIPTION
### Summary
Bundle of fixes addressing several pipeline and publishing reliability issues observed around late May 2026 (including TST missing runs, PT hard failures on thin days, MIT public page crashes, and composite action load failures).

### Changes
- **Graceful thin-script handling** (`run_show.py` + `engine/generator.py`): When podcast scripts fall below the hard floor after dedup/retries (common on quiet science days for PT/M&A etc.), we now write a proper `.skip_*.json` marker and exit 2 instead of hard-crashing the job. Matches the philosophy of "fresh > perfect length".
- **Better length retry prompt**: Removed self-defeating language that was causing the expansion retry to produce *shorter* output.
- **Review / monitoring fixes** (`review_episodes.py`): Updated `SHOW_REGISTRY` schedules to match the post-May-2026 daily cadence overhaul. Added the missing `unintended_consequences` entry. Fixed a test that was hard-coded to the old schema.
- **MIT show page crash** (`templates/show_page.html.j2`, `shows/hooks/modern_investing.py`, `scripts/generate_dashboard.py`): The daily hook was writing minimal `monthly_snapshots` entries missing `portfolio_pct` / `nasdaq_pct` / `alpha_pct`. Template + dashboard aggregator now handle mixed shapes safely via normalization + defensive Jinja guards.
- **safe-commit-push YAML parse error** (`.github/actions/safe-commit-push/action.yml`): The heredoc for multi-line `add-paths` had unindented content, causing the action manifest loader to fail with "scanning a simple key... expected ':'". Fixed indentation so the composite action can be loaded again.

### Why this matters
These issues were causing (or could cause):
- Entire daily matrix runs to appear as failures even when most shows succeeded.
- Public pages (modern-investing.html) to 500 on render.
- Nightly / post-episode publishing steps to be blocked by the safe-commit-push composite failing to load.

All changes are low-risk, well-tested (existing test suites pass), and defensive.

CI-friendly note: no unnecessary regeneration of large generated files (search index, etc.) was forced.