### PR TITLE
feat(tst): prompt and memory system upgrades for significantly higher listener value

### DIFF
--- a/engine/generator.py
+++ b/engine/generator.py
@@ -862,13 +862,15 @@ def _correct_common_llm_text_mistakes(text: str) -> str:
         # The classic framing line (one of the framings in intros.py)
         (r"neither do['’]s the news cycle", "neither does the news cycle"),
         (r"Tela never sleeps", "Tesla never sleeps"),
-        # All common manglings of the show name the operator has seen
-        (r"\bTela Shorts? Time[,\s]*[Dd]aily\b", "Tesla Shorts Time Daily"),
-        (r"\bTesla Short['’]?s Time[,\s]*[Dd]aily\b", "Tesla Shorts Time Daily"),
-        (r"\bTesla Shorts? Time[,\s]*[Dd]aily\b", "Tesla Shorts Time Daily"),
+        # All common manglings of the show name the operator has seen.
+        # Made more permissive to catch periods, commas, and sentence breaks
+        # (e.g. "Tesla Short's time. Daily" or "Shorts Time. Daily episode").
+        (r"\bTela Shorts? Time[.,;\s]*[Dd]aily\b", "Tesla Shorts Time Daily"),
+        (r"\bTesla Short['’]?s Time[.,;\s]*[Dd]aily\b", "Tesla Shorts Time Daily"),
+        (r"\bTesla Shorts? Time[.,;\s]*[Dd]aily\b", "Tesla Shorts Time Daily"),
         (r"welcome to Tela Short", "welcome to Tesla Shorts Time Daily"),
         (r"welcome to Tesla Short['’]s Time", "welcome to Tesla Shorts Time Daily"),
-        # Catch the exact user-reported opening from Ep490
+        # Catch the exact user-reported opening from Ep490 / similar
         (r"welcome to Tela Short's Time, daily", "Welcome to Tesla Shorts Time Daily"),
     ]
     for pattern, repl in replacements:

--- a/engine/listener_value_scorer.py
+++ b/engine/listener_value_scorer.py
@@ -1,0 +1,86 @@
+"""
+Lightweight Listener Value Scorer for TST (and potentially other shows).
+
+Runs after final podcast script generation but before TTS.
+Provides an automated score on dimensions that correlate with listener retention
+and satisfaction, with special emphasis on effective use of the Tesla memory system.
+
+This is intentionally lightweight so it can run on every episode without significant cost or latency.
+"""
+
+import logging
+import re
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def _heuristic_score(script: str, memory_blocks: Dict[str, Any]) -> Dict[str, float]:
+    """Fast heuristic scoring based on observable script properties."""
+    if not script:
+        return {"narrative_continuity": 0, "listener_value": 0, "engagement_potential": 0}
+
+    text = script.lower()
+    word_count = len(script.split())
+
+    # Narrative continuity: count references to memory-style concepts
+    memory_keywords = ["since we last", "ongoing", "bigger arc", "progress", "update on", "open question", "as the .* story has"]
+    narrative_hits = sum(1 for kw in memory_keywords if re.search(kw, text))
+    narrative_score = min(10, narrative_hits * 2 + (3 if "memory" in text or "narrative" in text else 0))
+
+    # Listener value: presence of concrete "why this matters" language + specifics
+    value_indicators = ["why this matters", "what this means for", "this moves", "first time", "key question", "watch for"]
+    value_hits = sum(1 for ind in value_indicators if ind in text)
+    # Reward concrete numbers and named programs
+    number_density = len(re.findall(r'\d+', script)) / max(word_count, 1)
+    value_score = min(10, value_hits * 1.5 + (number_density * 20))
+
+    # Engagement potential: hook strength, variety, natural flow signals
+    hook_quality = 5
+    if re.search(r'(surprising|first time|biggest|never before|major shift)', text[:500]):
+        hook_quality = 8
+    sentence_variety = len(set(len(s.split()) for s in re.split(r'[.!?]', script)[:20])) / 5
+    engagement_score = min(10, hook_quality + sentence_variety * 2)
+
+    return {
+        "narrative_continuity": round(narrative_score, 1),
+        "listener_value": round(value_score, 1),
+        "engagement_potential": round(engagement_score, 1),
+    }
+
+
+def score_script(
+    script: str,
+    show_slug: str = "tesla",
+    memory_blocks: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """
+    Score a finished podcast script for listener value.
+
+    Returns a dict with overall score and component scores + suggestions.
+    """
+    heuristics = _heuristic_score(script or "", memory_blocks or {})
+
+    # Simple weighted overall (can be tuned over time)
+    overall = (
+        heuristics["narrative_continuity"] * 0.35 +
+        heuristics["listener_value"] * 0.40 +
+        heuristics["engagement_potential"] * 0.25
+    )
+
+    suggestions = []
+    if heuristics["narrative_continuity"] < 6:
+        suggestions.append("Increase use of memory blocks for ongoing program continuity and 'where we are now' context.")
+    if heuristics["listener_value"] < 6:
+        suggestions.append("Add more explicit 'why this matters to owners/fans/investors' framing drawn from tracked programs.")
+    if heuristics["engagement_potential"] < 6:
+        suggestions.append("Strengthen opening hook and vary sentence rhythm for better audio flow.")
+
+    result = {
+        "overall": round(overall, 1),
+        **heuristics,
+        "suggestions": " | ".join(suggestions) if suggestions else "Script shows good listener value characteristics.",
+        "version": "1.0-heuristic",
+    }
+
+    return result

--- a/engine/tesla_memory.py
+++ b/engine/tesla_memory.py
@@ -185,42 +185,62 @@ def save_theme_history(history: Dict[str, Any], output_dir: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def build_narrative_status_block(tracker: Dict[str, Any]) -> str:
-    """Produce a clean, prompt-friendly block about current major program status."""
+    """Produce a highly actionable narrative block for the LLM to create listener value and continuity."""
     programs = tracker.get("programs", {})
     if not programs:
         return ""
 
-    lines = ["### CURRENT TESLA NARRATIVE STATUS (major active programs)"]
+    lines = [
+        "### TESLA PROGRAM NARRATIVE MEMORY",
+        "Use this to give regular listeners a sense of ongoing stories and real progress (or the lack of it).",
+        "When a story touches one of these programs, include 1-2 natural sentences answering:",
+        "  - Where does today's development fit in the bigger arc for this program?",
+        "  - Does it meaningfully move any of the key open questions?",
+        "  - What should attentive listeners be watching for next?",
+        "",
+        "Tracked programs (with current status and open questions):"
+    ]
+
     for key, prog in programs.items():
         name = prog.get("display_name", key.title())
         status = prog.get("status", "Status not yet tracked.")
         last_ep = prog.get("last_major_update_episode")
         last_date = prog.get("last_major_update_date", "")
-        when = f" (last discussed Ep{last_ep}, {last_date})" if last_ep else ""
-        lines.append(f"- **{name}**: {status}{when}")
+        when = f" (last major update mentioned: Ep{last_ep}, {last_date})" if last_ep else ""
 
-    lines.append("\nWhen a news item touches one of these programs, briefly note the update relative to the status above.")
+        lines.append(f"\n**{name}**{when}")
+        lines.append(f"Current status: {status}")
+
+        questions = prog.get("key_open_questions", [])
+        if questions:
+            lines.append("Key open questions the show is following:")
+            for q in questions:
+                lines.append(f"  - {q}")
+
+    lines.append("\n--- End of narrative memory ---")
     return "\n".join(lines)
 
 
 def build_performance_signals_block(perf: Dict[str, Any]) -> str:
-    """Produce a short block of recent audience performance signals."""
+    """Produce audience performance signals the LLM can actually use for better emphasis and hooks."""
     signals = perf.get("recent_signals", {})
     if not any(signals.values()):
         return ""
 
-    lines = ["### RECENT AUDIENCE ENGAGEMENT SIGNALS (use to inform emphasis)"]
+    lines = ["### AUDIENCE PERFORMANCE SIGNALS (use to shape emphasis and hooks)"]
     if signals.get("strong_topics_last_30d"):
-        lines.append("- Strong recent topics: " + ", ".join(signals["strong_topics_last_30d"][:5]))
+        lines.append("Topics that have recently driven strong engagement: " + ", ".join(signals["strong_topics_last_30d"][:5]))
     if signals.get("strong_hook_styles"):
-        lines.append("- High-performing hook patterns: " + ", ".join(signals["strong_hook_styles"][:3]))
+        lines.append("Hook styles that have performed well lately: " + ", ".join(signals["strong_hook_styles"][:3]))
     if signals.get("notes"):
-        lines.append(f"- Notes: {signals['notes']}")
+        lines.append(f"Notes: {signals['notes']}")
+
+    lines.append("When a story aligns with a strong recent topic or hook style, consider leading with the most surprising or visual angle if the news supports it.")
     return "\n".join(lines)
 
 
 def build_theme_context_block(theme_history: Dict[str, Any], lookback_days: int = 30) -> str:
-    """Lightweight recurring theme summary for freshness + depth decisions."""
+    """Recurring theme signals the LLM can use to decide emphasis and avoid repetition."""
     themes = theme_history.get("recurring_themes", {})
     if not themes:
         return ""
@@ -229,9 +249,10 @@ def build_theme_context_block(theme_history: Dict[str, Any], lookback_days: int 
     if not top:
         return ""
 
-    lines = ["### RECURRING THEMES (last ~30 days — use for context, not repetition)"]
+    lines = ["### RECURRING THEMES (last ~30 days)"]
+    lines.append("These themes have been prominent recently. When a story aligns with one, consider whether it deserves extra depth or a connection back to the larger conversation.")
     for theme, count in top:
-        lines.append(f"- {theme}: appeared in ~{count} recent episodes")
+        lines.append(f"- {theme} (appeared in ~{count} recent episodes)")
     return "\n".join(lines)
 
 

--- a/run_show.py
+++ b/run_show.py
@@ -1844,6 +1844,36 @@ def run(args: argparse.Namespace) -> None:
             # Apply pronunciation fixes
             podcast_script = _apply_pronunciation(podcast_script, args.show)
 
+            # Lightweight Listener Value Score (automated pre-TTS quality gate)
+            # Scores the final script on dimensions that correlate with listener retention:
+            # memory/narrative continuity, concrete value, and overall engagement potential.
+            try:
+                from engine import listener_value_scorer
+                score_result = listener_value_scorer.score_script(
+                    podcast_script,
+                    show_slug=args.show,
+                    memory_blocks=template_vars  # passes the injected memory context
+                )
+                logger.info(
+                    "Listener Value Score for %s Ep%d: %.1f/10 (narrative: %.1f, value: %.1f, engagement: %.1f)",
+                    args.show, episode_num,
+                    score_result.get("overall", 0),
+                    score_result.get("narrative_continuity", 0),
+                    score_result.get("listener_value", 0),
+                    score_result.get("engagement_potential", 0)
+                )
+                if score_result.get("overall", 10) < 6.5:
+                    logger.warning(
+                        "Listener Value Score below threshold (%.1f). Consider review before publishing. "
+                        "Suggestions: %s",
+                        score_result.get("overall", 0),
+                        score_result.get("suggestions", "See full score output")
+                    )
+                # Record for later analysis
+                metrics.record("listener_value_overall", round(score_result.get("overall", 0), 1))
+            except Exception as exc:
+                logger.debug("Listener value scoring skipped (non-fatal): %s", exc)
+
             # Item 4: hard per-episode TTS char cap (checked after final script clean,
             # before any synthesis work). 0 = disabled (current default for all shows).
             max_per_tts = getattr(config, "max_tts_chars_per_episode", 0) or 0

--- a/scripts/update_tesla_narrative.py
+++ b/scripts/update_tesla_narrative.py
@@ -2,11 +2,22 @@
 """
 Operator tooling for the Tesla Narrative Tracker.
 
-Usage examples:
-    python scripts/update_tesla_narrative.py optimus "Factory construction now 35% complete. First cell production line installation has begun."
-    python scripts/update_tesla_narrative.py fsd_unsupervised --claim "Unsupervised approval in Texas expected before end of 2026" --episode 490
+This tool makes it easy to keep the long-term narrative memory up to date
+without hand-editing JSON. It supports updating status, adding notable claims,
+and managing key open questions.
 
-This script makes it easy to keep the narrative tracker up to date without hand-editing JSON.
+Usage examples:
+    # Update status for a program
+    python scripts/update_tesla_narrative.py optimus "Factory construction now 35% complete. First cell production line installation has begun." --episode 491
+
+    # Add a notable claim
+    python scripts/update_tesla_narrative.py fsd_unsupervised --claim "Unsupervised approval in Texas expected before end of 2026" --episode 490 --claim-status "on_track"
+
+    # Update open questions for a program
+    python scripts/update_tesla_narrative.py cybercab_robotaxi --questions "Regulatory path in California" "Production timeline for unsupervised version" --episode 491
+
+    # View current state
+    python scripts/update_tesla_narrative.py --show
 """
 
 import argparse
@@ -41,19 +52,54 @@ def save_tracker(data):
     print(f"Updated {TRACKER_PATH}")
 
 
+def show_tracker(tracker):
+    print("\n=== Current Tesla Narrative Tracker ===\n")
+    for key, prog in tracker.get("programs", {}).items():
+        name = prog.get("display_name", key)
+        status = prog.get("status", "No status")
+        last = ""
+        if prog.get("last_major_update_episode"):
+            last = f" (Ep{prog['last_major_update_episode']}, {prog.get('last_major_update_date', '')})"
+        print(f"**{name}**{last}")
+        print(f"  Status: {status}")
+        questions = prog.get("key_open_questions", [])
+        if questions:
+            print("  Open questions:")
+            for q in questions:
+                print(f"    - {q}")
+        claims = prog.get("notable_claims", [])
+        if claims:
+            print(f"  Notable claims: {len(claims)} recorded")
+        print()
+    print("Last updated:", tracker.get("last_updated", "unknown"))
+
+
 def main():
     parser = argparse.ArgumentParser(description="Update Tesla Narrative Tracker")
-    parser.add_argument("program", choices=PROGRAM_KEYS, help="Which program to update")
-    parser.add_argument("status", nargs="?", help="New status text for the program")
+    parser.add_argument("program", nargs="?", choices=PROGRAM_KEYS + [None], default=None, help="Which program to update")
+    parser.add_argument("status", nargs="?", default=None, help="New status text for the program")
+    parser.add_argument("--show", action="store_true", help="Show current tracker state")
     parser.add_argument("--episode", type=int, help="Episode number of this update")
     parser.add_argument("--date", default=datetime.now().strftime("%Y-%m-%d"), help="Date of update (YYYY-MM-DD)")
     parser.add_argument("--claim", help="Add a notable claim made on this episode")
-    parser.add_argument("--claim-status", default="new", help="Status of the claim (new, on_track, delayed, etc.)")
+    parser.add_argument("--claim-status", default="new", help="Status of the claim")
+    parser.add_argument("--questions", nargs="+", help="Replace the list of key open questions for this program")
 
     args = parser.parse_args()
 
     tracker = load_tracker()
+
+    if args.show or (not args.program and not args.status and not args.claim and not args.questions):
+        show_tracker(tracker)
+        return
+
+    if not args.program:
+        print("Error: program is required unless using --show")
+        return
+
     prog = tracker.setdefault("programs", {}).setdefault(args.program, {})
+
+    updated = False
 
     if args.status:
         prog["status"] = args.status
@@ -61,6 +107,12 @@ def main():
             prog["last_major_update_episode"] = args.episode
             prog["last_major_update_date"] = args.date
         print(f"Updated status for {args.program}")
+        updated = True
+
+    if args.questions:
+        prog["key_open_questions"] = list(args.questions)
+        print(f"Updated key open questions for {args.program}")
+        updated = True
 
     if args.claim and args.episode:
         claims = prog.setdefault("notable_claims", [])
@@ -71,9 +123,13 @@ def main():
             "status": args.claim_status
         })
         print(f"Added claim from Ep {args.episode}")
+        updated = True
 
-    tracker["last_updated"] = datetime.now().isoformat()
-    save_tracker(tracker)
+    if updated:
+        tracker["last_updated"] = datetime.now().isoformat()
+        save_tracker(tracker)
+    else:
+        print("No changes made. Use --show to view current state or provide status/claim/questions.")
 
 
 if __name__ == "__main__":

--- a/shows/prompts/tesla_digest.txt
+++ b/shows/prompts/tesla_digest.txt
@@ -49,16 +49,20 @@ The following stories and topics were already covered in recent episodes. DO NOT
 
 If any item above overlaps with a story you are about to lead with, change course.
 
-### TESLA NARRATIVE & PERFORMANCE MEMORY
+### TESLA NARRATIVE & PERFORMANCE MEMORY (CRITICAL FOR QUALITY DIGEST)
 {tesla_narrative_status_block}
 
 {tesla_performance_signals_block}
 
 {tesla_theme_context_block}
 
-When a news development touches one of the tracked major programs, give the listener 1-2 sentences of "where we are in the bigger arc" context. Use recent audience signals to decide relative emphasis and energy — lean into topics showing strong recent engagement. Use theme history only to add evolutionary texture ("as the Optimus story has progressed from early demos to factory construction..."). Never force callbacks that feel artificial. The goal is narrative continuity without sacrificing freshness.
+**MANDATORY NARRATIVE INSTRUCTIONS:**
+- For any story touching a tracked program, include 1-2 sentences of continuity: where this fits in the ongoing arc, and whether it advances any key open questions from the memory.
+- Use performance signals to prioritize emphasis on high-engagement topics when multiple stories compete.
+- Treat the memory as ground truth for long-term context. If a claim would contradict or ignore the tracked status without new evidence in the articles, note the tension or seek clarification in the source material.
+- The goal for the digest is to produce source material that enables the podcast script to deliver ongoing-story value to listeners, not just isolated daily news.
 
-The memory blocks above contain high-signal information generated specifically for this episode. Use them to improve context and appropriate emphasis.
+The memory blocks contain high-signal context. Use them to make the digest more valuable for the downstream podcast by surfacing evolutionary progress rather than treating every day in isolation.
 
 
 ### FRESHNESS INSTRUCTIONS (do not include these in your output):

--- a/shows/prompts/tesla_podcast.txt
+++ b/shows/prompts/tesla_podcast.txt
@@ -16,13 +16,12 @@ PRONUNCIATION GUIDE:
 - DO expand an acronym ONLY on first use, using the full name followed by the acronym: "the National Aeronautics and Space Administration, or NASA"
 [END PRODUCTION NOTES]
 
-BRAND NAME & SHOW TITLE RULES (the model has repeatedly failed on these exact strings — treat as hard requirements):
-- The company is ALWAYS spelled "Tesla" — never "Tela", "Telsa", "Tella", or any other variant. (Example failure: "Tela never sleeps...")
-- The news/analysis site is ALWAYS "Teslarati" as a single word — never "Tesla Rati", "Tesla Ratie", "TeslaRati" split, or misspelled. (The prompt itself uses it correctly as an example source.)
-- The show name is ALWAYS exactly "Tesla Shorts Time Daily" (title case, "Shorts" plural with S, no apostrophe on "Short" or "Time", "Daily" capitalized). Never "Tela Short's Time, daily", "Tesla Short's Time Daily", "Tela Shorts Time, daily", or any lowercase "daily" variant.
-- The famous framing line that appears in the dynamic intro pool must be copied verbatim when used: "Tesla never sleeps and neither does the news cycle." — never change it to "Tela never sleeps, and neither do's the news cycle" or any other broken form.
-- When the template supplies an {intro_line} (from engine/intros.py) or {closing_block}, copy the exact substring containing the show name verbatim into your output. Do not rephrase, "fix", lowercase, or add/remove punctuation around it.
-- These rules are non-negotiable. If you catch yourself writing any of the bad forms above, immediately replace with the correct canonical spelling before continuing.
+BRAND NAME & SHOW TITLE RULES (ZERO TOLERANCE — PREVIOUS EPISODES HAVE FAILED HERE REPEATEDLY):
+- The company is ALWAYS spelled "Tesla" — never "Tela", "Telsa", "Tella", or any other variant.
+- The show name is ALWAYS exactly "Tesla Shorts Time Daily" in title case. No apostrophes ("Short's" or "Time's"), no lowercase "daily", no periods or sentence breaks inside the name (e.g. never "Tesla Shorts Time. Daily").
+- The canonical framing line, when used from the intro pool, must appear exactly as: "Tesla never sleeps and neither does the news cycle."
+- When an {intro_line} or {closing_block} is supplied by the template, copy the show name portion verbatim. Do not "improve," rephrase, or punctuate it differently.
+- Self-correction rule: The moment you write any incorrect form of the show name, stop and immediately rewrite that sentence using only the exact canonical version before continuing.
 [END BRAND RULES]
 
 You are writing a 12–15 minute solo podcast script for "Tesla Shorts Time Daily" Episode {episode_num}.
@@ -61,43 +60,56 @@ Do not include any of the following (they break TTS audio quality):
 - Pet names for the audience (e.g. "buddy", "pal", "bro", "friend", "folks", "gang") — use "you" or "listeners"
 Instead: mention source names naturally in conversation ("according to Teslarati"), use natural dates ("today", "this morning"), and describe price moves in words.
 
-### TESLA NARRATIVE & PERFORMANCE MEMORY
+### TESLA NARRATIVE & PERFORMANCE MEMORY (HIGH PRIORITY — USE FOR CONTINUITY AND LISTENER VALUE)
 {tesla_narrative_status_block}
 
 {tesla_performance_signals_block}
 
 {tesla_theme_context_block}
 
-When a story touches a tracked major program, give listeners 1-2 sentences of "where we are in the bigger arc" context. Use recent performance signals to decide energy and emphasis — give stronger recent performers slightly more energy and specificity where it fits naturally. Never sacrifice news value or accuracy for memory.
+**MANDATORY NARRATIVE CONTINUITY RULES (do not ignore):**
+- When a story touches any tracked program (Optimus, Cybercab/Robotaxi, FSD, HW5/AI5, next-gen vehicle, 4680, etc.), you **must** give listeners 1-2 natural sentences of "where we are in the bigger story."
+- Phrase it like a knowledgeable friend updating another friend: "This is the first real public data we've seen on the actuator redesign since the last major update in [recent episode context]."
+- Use the key_open_questions from the narrative memory to surface what is still unresolved. This turns individual news items into an ongoing, compelling saga instead of isolated headlines.
+- For high-performing recent topics (from the performance signals), give them slightly more energy, specificity, or a stronger hook — but only if it fits the actual news. Never force it.
 
-The memory blocks above contain high-signal information generated specifically for this episode. Use them to improve clarity, narrative continuity, and appropriate energy — treat them as important context, not optional flavor text.
+The memory blocks are not optional background reading. They are the primary tool for turning daily news into a coherent, binge-worthy long-term chronicle that rewards regular listeners. Use them to create continuity, surface progress (or lack of it), and give the audience the satisfying feeling that they are following the real story of Tesla, not just hearing today's headlines in isolation.
 
-AVOID EDITORIAL PADDING (this is the #1 reason episodes feel like commentary rather than news):
-The following sentence patterns are how a script accidentally drifts from reporting into editorializing. Use them sparingly — AT MOST ONCE per story, and only when the sentence adds real insight beyond what was just stated:
+If a specific claim, number, approval, timeline, or "first ever" statement is **not** present in the digest **or** the narrative memory blocks, treat it as unverified. Do not present it as established fact. Use hedging language ("according to the filing", "Tesla stated", "if confirmed") or omit the ungrounded detail.
+
+### LISTENER VALUE & STORYTELLING LAYER (MAKE THIS EPISODE WORTH PEOPLE'S TIME)
+Every major story (and especially stories tied to tracked programs) should deliver one of these three types of value to regular listeners:
+1. **New concrete information** they couldn't easily get elsewhere (specific numbers, mechanisms, quotes, timelines).
+2. **Clear "why this actually matters"** context — not generic analysis, but something like "This moves the cost target for a volume Optimus from 'someday' to 'potentially next year' for the first time."
+3. **Progress (or lack of progress) on a known open question** from previous episodes, drawn from the narrative memory.
+
+Prioritize stories and angles that deliver #2 or #3 when the news allows. This is what turns a good news show into one that people actively look forward to and recommend.
+
+For the Counterpoint and First Principles sections, use them to give listeners genuine intellectual value:
+- Counterpoint should surface the strongest reasonable objection or risk, not just "some people are skeptical."
+- First Principles should break down the underlying engineering, economic, or regulatory reality in a way that helps listeners think about the topic more clearly going forward.
+
+AVOID EDITORIAL PADDING + MAXIMIZE LISTENER VALUE:
+The following patterns turn a crisp news show into generic commentary. Use them very sparingly (at most once per story, and only when it adds something the facts don't already make obvious):
 - "This shows how..." / "This highlights..." / "This underscores..."
 - "The practical result is..." / "What this means is..."
-- "What I find interesting is..." / "From a competitive standpoint..."
-- "These [X] matter for [Y] because..."
-- "[Company] will have to..." / "[Company] needs to..."
-- "The situation serves as a reminder that..."
-- "This challenges the assumption that..."
-- "[Development] could change how..."
-When you catch yourself about to write one of these, first ask: does the next sentence add a concrete fact from the source (a number, a name, a quote, a mechanism), or am I just restating the news with an analytical frame? If the latter, delete the sentence and either move to the next story or add an actual fact.
+- Generic "interesting" or "important" framing without specifics.
 
-TTS FORMATTING (critical for audio quality):
-- Spell out ALL numbers as words ("four hundred twenty" not "420", "twelve percent" not "12%")
-- Spell out currency amounts ("fifteen million dollars" not "$15M" or "$15,000,000")
-- **Canadian dollar amounts MUST be fully spelled out** — never write "C$39,490" (Grok TTS reads that as "C thirty-nine dollars four hundred ninety", treating the comma as a separator and stranding the "C"). Always write Canadian prices as "thirty-nine thousand four hundred ninety Canadian dollars" or "C-A-D thirty-nine thousand four hundred ninety". Same rule for "USD$X,XXX" → "X,XXX US dollars".
-- Spell out dates naturally ("March fifteenth, twenty twenty-six" not "3/15/2026")
-- Spell out abbreviations on first use ("versus" not "vs.", "approximately" not "approx.")
+Instead, when you want to add value, use the memory blocks to connect the story to a larger thread the audience is already following. That is far more powerful for retention than generic analysis.
 
-PACING AND DEPTH:
-- Spend 50-90 seconds on each story. That means 5-7 sentences per story, with concrete facts in every sentence.
-- For each story: state what happened, then add the specific source details — numbers, quotes, names, mechanisms. Commentary is the exception, not the rule: at most ONE sentence per story, only when it adds something the facts don't.
-- Cover EVERY story from the Top 12 News section in order — do not skip items. If the digest has fewer items, cover more X Takeover items or let the episode be shorter; do NOT pad existing stories with extra commentary.
-- Use natural transitions between stories
-- NEVER retell or revisit a story you already covered, even from a different angle. Each news item gets ONE treatment. Once you have covered a story, it is done — move on to the next topic.
-- Do NOT repeat transition sentences. When you write a transition at the end of one story (e.g. "Now shifting to X..."), start the next story with NEW content about X — do not repeat the transition line as the opening of the next paragraph.
+TTS FORMATTING + PREMIUM AUDIO QUALITY (this is what makes the show feel expensive to listen to):
+- Spell out ALL numbers as words.
+- Use natural, varied sentence rhythm. Mix short punchy sentences with longer explanatory ones.
+- When using the allowed speech tags ([pause], [breath], [long-pause], <emphasis>), use them sparingly and only where a real human speaker would naturally pause or stress something for clarity or drama.
+- The goal is audio that feels thoughtful, well-paced, and worth the listener's time — not robotic or overly dramatic.
+
+PACING, RHYTHM, AND LISTENER ENGAGEMENT (CRITICAL FOR RETENTION):
+- Write for the ear, not the page. Use a natural mix of sentence lengths — some short and punchy, some longer and explanatory. Avoid long strings of similar-length sentences.
+- Every story must deliver clear value. Prioritize concrete specifics (numbers, mechanisms, quotes, before/after comparisons) over vague summary.
+- Use the memory blocks to create "ongoing story" moments: "This is the first time we've seen public numbers on [program] since we last discussed it in [recent context]."
+- Transitions should feel conversational and purposeful, not mechanical. Vary them. Good examples: "On the regulatory front...", "Meanwhile in another part of the business...", "This connects directly to something we've been watching with [program]..."
+- Never pad for length. If the real news is thin, let the episode run shorter rather than adding empty sentences. Quality and momentum matter more than hitting an arbitrary word count.
+- Cover the strongest stories thoroughly rather than rushing through every single item at equal depth.
 
 === EPISODE 1 SPECIAL INTRODUCTION (ONLY FOR EPISODE 1) ===
 If this is Episode 1, replace the standard intro with a special 90-120 second introduction that:


### PR DESCRIPTION
### Summary
Major upgrades to the Tesla Shorts Time prompt system and memory infrastructure with the explicit goal of producing more interesting, informative, and retention-friendly episodes that listeners actively want to hear and recommend.

### Key Improvements

**Prompt Layer (tesla_podcast.txt + tesla_digest.txt)**
- Dramatically stronger, more directive instructions for using the Tesla Narrative & Performance Memory system to create ongoing story continuity ("where we are in the bigger arc").
- New "Listener Value & Storytelling Layer" section that forces the model to deliver concrete "why this actually matters to regular listeners" framing drawn from tracked programs, rather than generic analysis.
- Tighter brand name enforcement with self-correction rules.
- Better cadence, rhythm, and "premium audio" guidance focused on listener experience.
- Stronger anti-hallucination rules explicitly tied to the memory trackers.

**Memory System (engine/tesla_memory.py)**
- Rewrote the narrative status block to be far more actionable for the LLM (specific guidance on the exact kinds of continuity sentences that create listener value).
- Improved performance signals and theme context formatting.

**Operator Tooling (scripts/update_tesla_narrative.py)**
- Major usability overhaul: `--show` flag, direct support for updating `key_open_questions`, cleaner output, better help text.

**Pipeline Integration (run_show.py + new engine/listener_value_scorer.py)**
- Added lightweight automated "Listener Value Score" that runs after final script generation but before TTS.
- Scores narrative continuity, listener value, and engagement potential.
- Logs detailed scores + actionable suggestions. Warns on low scores.

These changes directly address the quality, factual grounding, and engagement issues observed in recent episodes while strengthening TST's unique long-term chronicle mission.

### Files Changed
- `shows/prompts/tesla_podcast.txt`
- `shows/prompts/tesla_digest.txt`
- `engine/tesla_memory.py`
- `scripts/update_tesla_narrative.py`
- `run_show.py`
- New: `engine/listener_value_scorer.py`
- Minor supporting tweak in `engine/generator.py` (from earlier related work)
