### PR TITLE
chore: extract daily-audit remediation to external script (finally kill SC2086 noise)

### DIFF
--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -170,35 +170,7 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # shellcheck disable=SC2086
-          if [ ! -f api/daily-review.json ]; then
-            echo "No structured audit output — skipping auto-remediation"
-            exit 0
-          fi
-
-          RETRY_SHOWS=$(python3 - <<'PY'
-          import json
-          try:
-              data = json.load(open("api/daily-review.json"))
-              print(" ".join(data.get("remediation", {}).get("auto_retry_shows", [])))
-          except Exception:
-              print("")
-          PY
-          )
-
-          if [ -z "$RETRY_SHOWS" ]; then
-            echo "No auto-retries needed"
-            exit 0
-          fi
-
-          # shellcheck disable=SC2086
-          echo "Auto-dispatching recovery for: $RETRY_SHOWS"
-          # shellcheck disable=SC2086
-          read -ra SHOWS <<< "$RETRY_SHOWS"
-          for s in "${SHOWS[@]}"; do
-            gh workflow run run-show.yml -f show="$s" --ref main || echo "Dispatch failed for $s"
-          done
+        run: python scripts/dispatch_audit_retries.py
 
       - name: Notify + Persist Audit Artifacts
         if: always()

--- a/scripts/dispatch_audit_retries.py
+++ b/scripts/dispatch_audit_retries.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Automated remediation for the Daily Audit workflow.
+
+Reads api/daily-review.json (produced by review_episodes.py) and dispatches
+`gh workflow run run-show.yml` for any shows listed under
+`remediation.auto_retry_shows`.
+
+This script exists so the complex shell + heredoc logic lives outside the
+workflow YAML. This completely avoids noisy SC2086 reports from actionlint's
+embedded shellcheck when processing large `run: |` blocks.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    review_path = Path("api/daily-review.json")
+
+    if not review_path.exists():
+        print("No structured audit output — skipping auto-remediation")
+        return
+
+    try:
+        data = json.loads(review_path.read_text())
+    except Exception as exc:
+        print(f"Failed to parse {review_path}: {exc}")
+        sys.exit(0)
+
+    shows = data.get("remediation", {}).get("auto_retry_shows", []) or []
+    if not shows:
+        print("No auto-retries needed")
+        return
+
+    print(f"Auto-dispatching recovery for: {' '.join(shows)}")
+
+    gh_token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not gh_token:
+        print("No GH_TOKEN / GITHUB_TOKEN found in environment — cannot dispatch")
+        sys.exit(0)
+
+    failed = []
+    for show in shows:
+        cmd = [
+            "gh", "workflow", "run", "run-show.yml",
+            "-f", f"show={show}",
+            "--ref", "main",
+        ]
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True)
+            print(f"Dispatched recovery run for {show}")
+        except subprocess.CalledProcessError as exc:
+            print(f"Dispatch failed for {show}: {exc.stderr.strip() or exc}")
+            failed.append(show)
+
+    if failed:
+        # Non-fatal: we still want the rest of the audit to complete.
+        print(f"Some dispatches failed: {', '.join(failed)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The persistent SC2086 reports in the actionlint job came from the non-trivial shell + heredoc inside the 'Automated Remediation' step.

This PR extracts the logic to `scripts/dispatch_audit_retries.py` (clean Python). The workflow step is now just:

    run: python scripts/dispatch_audit_retries.py

This is the same pattern that previously solved the equivalent problem for the 'Validate output' step (extracting the Python heredocs to validate_*.py).

Local actionlint now reports zero issues. This should be the final fix for the daily-audit actionlint failures.