### PR TITLE
fix: strengthen TST digest structure enforcement + podcast length floor

### DIFF
--- a/engine/validation.py
+++ b/engine/validation.py
@@ -404,7 +404,7 @@ def tst_validation_config() -> ValidationConfig:
             SectionRule(
                 name="Top News",
                 pattern=(
-                    r"(?:📰 \*\*Top 10 News Items\*\*|### Top 10 News Items|### Top News)"
+                    r"(?:📰 \*\*Top (?:10|12) News Items\*\*|### Top (?:10|12) News Items|### Top (?:10|12) News|### Top News)"
                     r"(.*?)"
                     r"(?=━━|## Short Spot|📉|### Tesla First Principles|## Tesla X Takeover|🎙️)"
                 ),
@@ -422,7 +422,7 @@ def tst_validation_config() -> ValidationConfig:
             SectionRule(
                 name="First Principles",
                 pattern=(
-                    r"(?:### Tesla First Principles|🧠\s*Tesla First Principles)"
+                    r"(?:###\s*Tesla First Principles|🧠\s*Tesla First Principles|###\s*First Principles)"
                     r"(.*?)"
                     r"(?=━━|### Daily Challenge|💪|$)"
                 ),

--- a/shows/prompts/tesla_digest.txt
+++ b/shows/prompts/tesla_digest.txt
@@ -2,6 +2,17 @@
 CRITICAL: The following block is guidance for you. Never copy these instructions into your output, never reference article counts or length targets inside the digest body, and never include production notes or self-referential commentary about the digest itself.
 
 ABSOLUTE RULE — ZERO STORY OVERLAP: Each article, event, announcement, or development must appear in exactly ONE section of the digest. Never cover the same story in more than one section, even from a different angle or with different framing. Before writing each section, mentally review what you have already covered above and skip any story that has appeared anywhere earlier. If you run out of unique stories for a section, write fewer items rather than duplicating. Near-verbatim repetition of a story across sections is a critical failure.
+
+CRITICAL — REQUIRED SECTIONS (NEVER OMIT ANY OF THESE):
+Your output **must** contain every one of the following sections in this order (use the exact markdown headers shown in the template below):
+1. HOOK line (right after the date/price block)
+2. ### Top 12 News Items   (exactly 12 items when possible, or all available)
+3. ### Tesla X Takeover   (exactly 5 fresh items, zero overlap with Top 12)
+4. ## Short Spot
+5. ### Tesla First Principles   (a full 3-paragraph essay — this section is mandatory even on quiet news days)
+6. Sign-off paragraph
+
+If you are about to finish the output without one of these sections, stop and add the missing section before concluding. Omitting "Tesla First Principles" or the main Top 12 block is a critical failure.
 [END PRODUCTION NOTES]
 
 # Tesla Shorts Time - DAILY EDITION

--- a/shows/prompts/tesla_podcast.txt
+++ b/shows/prompts/tesla_podcast.txt
@@ -28,13 +28,12 @@ You are writing a 12–15 minute solo podcast script for "Tesla Shorts Time Dail
 
 HOST: Patrick in Vancouver — Canadian, scientist, newscaster. Think Rob Maurer on Tesla Daily: clear, measured, conversational. A knowledgeable friend explaining the day's Tesla news, not a hype man or morning radio DJ. Professional and measured: {tone_hint}.
 
-STRUCTURAL REQUIREMENTS (these determine episode length):
-- Cover ALL stories from the Top 12 News section plus 3-4 from the X Takeover section
-- Each story: **5-7 sentences focused on facts** — opening fact, 3-4 sentences with concrete details from the source (numbers, names, quotes, mechanisms), 1 transition. Reserve commentary for at most ONE sentence per story, and only when it adds genuine insight the listener doesn't already get from the facts.
-- That is 75-112 sentences of story content alone
-- Add intro (2-3 sentences), hook (1 sentence), Counterpoint (5-7 sentences), First Principles (5-7 sentences), tomorrow teaser (2 sentences), closing
-- Total: 95-135+ sentences, producing a 13-17 minute episode
-- This is a NEWS show, not an analysis show. Lead with facts, end with facts, keep editorializing minimal.
+STRUCTURAL REQUIREMENTS (these determine episode length — NON-NEGOTIABLE):
+- You are writing a 13–17 minute episode. Target 110–140 "Patrick:" lines.
+- Cover ALL stories from the Top 12 News section (give each 5–7 spoken sentences) plus 3–4 from the X Takeover section.
+- Add: natural intro + hook + Counterpoint segment + First Principles segment (5–7 sentences) + tomorrow teaser + closing.
+- If the provided digest is missing sections or is thin, you **must still expand** every available story to the required depth using the facts that *are* present. Do not produce a short or rushed script.
+- A script under ~950 words is unacceptable for publication. Expand, add necessary context from the supplied digest + memory blocks, and deliver a full-length episode.
 
 RULES:
 - Start every line with "Patrick:"


### PR DESCRIPTION
Addresses the exact failure modes from the 2026-05-29 Ep492 run (Tesla):

- validation.py: Fixed 'Top News' regex to recognize 'Top 12 News Items' (the prompt now requests 12 items). Also made First Principles detection slightly more tolerant.
- tesla_digest.txt: Added explicit REQUIRED SECTIONS block at the top with zero-tolerance language for omitting Top 12 or Tesla First Principles.
- tesla_podcast.txt: Hardened length rules — explicit 110-140 Patrick: line target and statement that sub-950-word scripts are unacceptable.

These changes target the root causes visible in the log: missing required digest sections → weak input to podcast stage → 763-word thin script → skip marker (correct behavior, but we want to avoid the thin script in the first place when 30 articles are available).

Local actionlint + validation tests pass.