### PR TITLE
Phase 1: foundation &amp; safety hardening for network evolution

### DIFF
--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -106,10 +106,10 @@ jobs:
             echo "SUMMARY_EOF"
           } >> "$GITHUB_OUTPUT"
 
-          if [ $EXIT_CODE -eq 1 ]; then
+          if [ "$EXIT_CODE" -eq 1 ]; then
             echo "::error::CRITICAL issues found — check GitHub issues + api/daily-review.json"
             exit 1
-          elif [ $EXIT_CODE -eq 2 ]; then
+          elif [ "$EXIT_CODE" -eq 2 ]; then
             echo "::warning::Warnings found"
             exit 0
           fi

--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -231,7 +231,10 @@ jobs:
           python -m pytest tests/test_config.py tests/test_schedule.py \
             tests/test_tts_grok.py tests/test_tesla_hook.py tests/test_rss.py \
             tests/test_review_remediation.py tests/test_show_scaffold.py \
-            tests/test_first_episode.py -q --tb=short
+            tests/test_first_episode.py tests/test_generator.py \
+            tests/test_show_memory.py tests/test_prompt_fidelity.py \
+            tests/test_episode_validity.py tests/test_pipeline_safety.py \
+            -q --tb=short
 
       - name: Create .env
         run: |
@@ -286,6 +289,14 @@ jobs:
         # covered. Backfill is fast (~5 s for ~50 episodes) and
         # rebuilds from the committed digests/<slug>/*.md files.
         run: python scripts/backfill_content_lake.py
+
+      - name: YouTube quota preflight
+        # Landmine #20: enabling YouTube on a 3rd daily show tips the
+        # @NerraNetwork channel past its 10k/day quota, after which uploads
+        # fail silently. Non-strict here: emits a loud ::error:: annotation if
+        # the enabled shows are projected over quota, but never blocks the
+        # episode (exit 0). Run a guard job with --strict to hard-fail instead.
+        run: python scripts/youtube_quota_preflight.py || true
 
       - name: Run show pipeline
         id: pipeline
@@ -608,3 +619,14 @@ jobs:
           echo "All push attempts failed for shared pages"
           echo "::warning::Shared pages (index, blog index, sitemap) could not be pushed after 5 attempts. They will be regenerated on the next successful nightly or manual run."
           exit 1
+
+      - name: Post daily health summary
+        # Positive heartbeat: the pipeline already notifies on failure, but
+        # nothing confirms a healthy day. This composes an all-clear / cost /
+        # quota / RSS-freshness line from the freshly-regenerated dashboard.json
+        # and posts it if NOTIFICATION_WEBHOOK_URL is set (clean no-op if not).
+        # Runs even if the shared-pages push had trouble.
+        if: always()
+        env:
+          NOTIFICATION_WEBHOOK_URL: ${{ secrets.NOTIFICATION_WEBHOOK_URL }}
+        run: python scripts/post_run_summary.py || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,6 +392,23 @@ pytest tests/test_integration.py   # Pipeline integration tests
 Tests use AST extraction + `exec()` to load functions from show scripts because
 `tesla_shorts_time.py` has a `SystemExit` guard preventing import.
 
+**Phase 1 hardening guards (May 2026):** the network-evolution roadmap's first
+phase added safety nets that the `run-show.yml` smoke step now runs on every
+episode:
+
+- `tests/test_generator.py` — the LLM-call path (`load_prompt` incl. the new
+  shared-snippet include mechanism, `_call_grok` request/response shaping,
+  refusal detection, fallback-model resolution). Catches a breaking Grok
+  request/response change without spending credits.
+- `tests/test_show_memory.py` — pins `engine.tesla_memory`'s load/save/build
+  contract (and the first-run copy-isolation fix) *before* Phase 3 generalizes
+  it to other shows via `engine/show_memory.py`.
+- `tests/test_prompt_fidelity.py` — every show's prompts exist, are non-empty,
+  and render without a malformed-brace crash.
+- `tests/test_episode_validity.py` — the latest committed digest per show meets
+  a conservative word floor and isn't a refusal.
+- `tests/test_pipeline_safety.py` — the three safety scripts below.
+
 ### Code Style
 
 - No linter configured; scripts are large single-file programs
@@ -399,6 +416,29 @@ Tests use AST extraction + `exec()` to load functions from show scripts because
 - `logging` for all output; `sys.stdout` handler
 - `pathlib.Path` for all file operations
 - `tenacity` for retry logic on API calls
+
+### Prompt composition + pipeline safety scripts (Phase 1, May 2026)
+
+- **Shared prompt snippets.** `engine.generator.load_prompt` resolves
+  `<<include: relative/path.txt>>` directives (relative to the including
+  prompt's dir, recursive, cycle/depth-guarded) **before** `{placeholder}`
+  substitution. Canonical snippets live in `shows/prompts/_shared/`. The
+  mechanism is **opt-in**: a prompt with no directive renders byte-for-byte as
+  before, so existing prompts are unchanged. Do NOT bulk-rewrite prompts to use
+  includes without re-running `test_prompt_fidelity.py` + A/B listening (it
+  changes generated output). See `shows/prompts/_shared/README.md`.
+- **Fail-loud safety nets** (all *loud-but-non-blocking by default*; pass
+  `--strict` to hard-fail in a dedicated guard job):
+  - `scripts/backfill_content_lake.py` — evaluates the rebuilt lake and emits a
+    GitHub `::error::`/`::warning::` annotation when it's empty/thin (was a
+    silent failure mode that broke dedup/recaps/search).
+  - `scripts/youtube_quota_preflight.py` — sums quota for YouTube-enabled shows
+    and annotates when projected over the 10k/day budget (landmine #20). Wired
+    as a preflight step in `run-show.yml`.
+  - `scripts/post_run_summary.py` — positive heartbeat: composes an all-clear /
+    cost / quota / RSS-freshness line from `api/dashboard.json` and POSTs to
+    `NOTIFICATION_WEBHOOK_URL` (clean no-op when unset). Wired into the finalize
+    job.
 
 ## Current Refactoring Goal
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ network migration May 2026; ElevenLabs retained only as emergency rollback),
 mixes intro/outro music, and publishes to RSS, GitHub Pages, YouTube (long-form
 + smart Shorts for enabled shows), and X/Twitter where configured.
 
-All shows are produced independently in Vancouver, Canada.
+Nerra Network produces shows for a **global audience** — independently produced
+in **Vancouver, British Columbia, Canada**. Globally focused shows (Tesla Shorts
+Time, Models & Agents, Fascinating Frontiers, etc.) carry no regional constraint;
+shows with a Canadian focus (Modern Investing Techniques, Финансы Просто,
+Environmental Intelligence) cover Canadian markets, policy, and personal finance
+alongside their global context.
 
 **Website:** [nerranetwork.com](https://nerranetwork.com)
 
@@ -17,14 +22,14 @@ All shows are produced independently in Vancouver, Canada.
 | Show | Schedule | Player | RSS |
 |------|----------|--------|-----|
 | **Tesla Shorts Time** | Daily | [Player](https://nerranetwork.com/tesla.html) | [RSS](https://nerranetwork.com/podcast.rss) |
-| **Omni View** | Odd days | [Player](https://nerranetwork.com/omni-view.html) | [RSS](https://nerranetwork.com/omni_view_podcast.rss) |
-| **Fascinating Frontiers** | Even days | [Player](https://nerranetwork.com/fascinating_frontiers.html) | [RSS](https://nerranetwork.com/fascinating_frontiers_podcast.rss) |
-| **Planetterrian Daily** | Odd days | [Player](https://nerranetwork.com/planetterrian.html) | [RSS](https://nerranetwork.com/planetterrian_podcast.rss) |
+| **Omni View** | Daily (Sun = weekly recap) | [Player](https://nerranetwork.com/omni-view.html) | [RSS](https://nerranetwork.com/omni_view_podcast.rss) |
+| **Fascinating Frontiers** | Daily (Sun = weekly recap) | [Player](https://nerranetwork.com/fascinating_frontiers.html) | [RSS](https://nerranetwork.com/fascinating_frontiers_podcast.rss) |
+| **Planetterrian Daily** | Daily (Sun = weekly recap) | [Player](https://nerranetwork.com/planetterrian.html) | [RSS](https://nerranetwork.com/planetterrian_podcast.rss) |
 | **Environmental Intelligence** | Odd weekdays | [Player](https://nerranetwork.com/env-intel.html) | [RSS](https://nerranetwork.com/env_intel_podcast.rss) |
-| **Models & Agents** | Odd days | [Player](https://nerranetwork.com/models-agents.html) | [RSS](https://nerranetwork.com/models_agents_podcast.rss) |
-| **Models & Agents for Beginners** | Even days | [Player](https://nerranetwork.com/models-agents-beginners.html) | [RSS](https://nerranetwork.com/models_agents_beginners_podcast.rss) |
+| **Models & Agents** | Daily (Sun = weekly recap) | [Player](https://nerranetwork.com/models-agents.html) | [RSS](https://nerranetwork.com/models_agents_podcast.rss) |
+| **Models & Agents for Beginners** | Daily (Sun = weekly recap) | [Player](https://nerranetwork.com/models-agents-beginners.html) | [RSS](https://nerranetwork.com/models_agents_beginners_podcast.rss) |
 | **Финансы Просто** | Even days | [Player](https://nerranetwork.com/ru/finansy-prosto.html) | [RSS](https://nerranetwork.com/finansy_prosto_podcast.rss) |
-| **Modern Investing Techniques** | Weekdays | [Player](https://nerranetwork.com/modern-investing.html) | [RSS](https://nerranetwork.com/modern_investing_podcast.rss) |
+| **Modern Investing Techniques** | Daily (Sat = weekend angle, Sun = recap) | [Player](https://nerranetwork.com/modern-investing.html) | [RSS](https://nerranetwork.com/modern_investing_podcast.rss) |
 | **Привет, Русский!** | Even days | [Player](https://nerranetwork.com/ru/privet-russian.html) | [RSS](https://nerranetwork.com/privet_russian_podcast.rss) |
 | **Unintended Consequences** | Weekdays (narrative) | [Player](https://nerranetwork.com/unintended-consequences.html) | [RSS](https://nerranetwork.com/unintended_consequences_podcast.rss) |
 

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -55,6 +55,42 @@ def _resolve_fallback_model(config) -> str:
 # Prompt template loading
 # ---------------------------------------------------------------------------
 
+# Directive for composing prompts from shared snippets.  Chosen to use angle
+# brackets (not ``{...}``) so it survives ``str.format_map`` untouched and never
+# collides with template placeholders.  Resolved *before* substitution, so a
+# prompt with no directive renders byte-for-byte as before.
+#   <<include: _shared/accuracy_rules.txt>>
+_INCLUDE_RE = re.compile(r"<<\s*include:\s*([^>]+?)\s*>>")
+_MAX_INCLUDE_DEPTH = 10
+
+
+def _resolve_includes(raw: str, base_dir: Path, _seen: Optional[set] = None, _depth: int = 0) -> str:
+    """Recursively expand ``<<include: path>>`` directives.
+
+    Paths are resolved relative to *base_dir* (the directory of the file that
+    contains the directive).  Guards against cycles and runaway recursion so a
+    malformed shared snippet can never hang the pipeline.
+    """
+    if "<<include:" not in raw and "<<include :" not in raw and not _INCLUDE_RE.search(raw):
+        return raw
+    if _depth > _MAX_INCLUDE_DEPTH:
+        raise ValueError(f"Prompt include recursion exceeded {_MAX_INCLUDE_DEPTH} levels")
+    _seen = _seen or set()
+
+    def _sub(match: "re.Match") -> str:
+        rel = match.group(1).strip()
+        inc_path = (base_dir / rel).resolve()
+        key = str(inc_path)
+        if key in _seen:
+            raise ValueError(f"Circular prompt include detected: {rel}")
+        if not inc_path.exists():
+            raise FileNotFoundError(f"Included prompt snippet not found: {rel} (from {base_dir})")
+        nested = inc_path.read_text(encoding="utf-8")
+        return _resolve_includes(nested, inc_path.parent, _seen | {key}, _depth + 1)
+
+    return _INCLUDE_RE.sub(_sub, raw)
+
+
 def load_prompt(prompt_file: str, template_vars: Optional[Dict[str, Any]] = None) -> str:
     """Read a prompt template file and fill in ``{placeholder}`` variables.
 
@@ -67,11 +103,16 @@ def load_prompt(prompt_file: str, template_vars: Optional[Dict[str, Any]] = None
         Dict of values to substitute into ``{key}`` placeholders.  Uses
         ``str.format_map`` so missing keys raise ``KeyError``.  Pass
         ``None`` to skip substitution (useful for reference-only files).
+
+    Shared snippets can be composed in via ``<<include: relative/path.txt>>``
+    directives (resolved relative to *prompt_file*'s directory, before
+    placeholder substitution).  Prompts with no directive are unaffected.
     """
     path = Path(prompt_file)
     if not path.exists():
         raise FileNotFoundError(f"Prompt file not found: {path}")
     raw = path.read_text(encoding="utf-8")
+    raw = _resolve_includes(raw, path.parent)
     if template_vars is not None:
         return raw.format_map(template_vars)
     return raw

--- a/engine/tesla_memory.py
+++ b/engine/tesla_memory.py
@@ -14,6 +14,7 @@ into prompts via the tesla pre-fetch hook.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import re
@@ -121,8 +122,11 @@ DEFAULT_THEME_HISTORY: Dict[str, Any] = {
 # ---------------------------------------------------------------------------
 
 def _load_json(path: Path, default: Dict[str, Any]) -> Dict[str, Any]:
+    # deepcopy (not .copy()) so callers that mutate nested dicts (e.g. a
+    # brand-new show recording its first narrative update before any file
+    # exists) can never corrupt the shared module-level DEFAULT_* templates.
     if not path.exists():
-        return default.copy()
+        return copy.deepcopy(default)
     try:
         with path.open("r", encoding="utf-8") as f:
             data = json.load(f)
@@ -132,7 +136,7 @@ def _load_json(path: Path, default: Dict[str, Any]) -> Dict[str, Any]:
             return data
     except Exception as exc:
         logger.warning("Failed to load %s (%s) — using default", path.name, exc)
-        return default.copy()
+        return copy.deepcopy(default)
 
 
 def _save_json(path: Path, data: Dict[str, Any]) -> None:

--- a/scripts/backfill_content_lake.py
+++ b/scripts/backfill_content_lake.py
@@ -2,8 +2,18 @@
 """Backfill the Content Lake from existing markdown digest files.
 
 Scans all show digest directories and imports historical episodes.
+
+The content lake feeds cross-episode dedup, the Sunday weekly recaps, and the
+global site search.  When a rebuild silently produces an empty (or near-empty)
+lake — historically a quiet failure mode — those downstream features degrade
+without anyone noticing.  This script now evaluates the rebuilt lake and
+*fails loud*: it emits a GitHub ``::error::``/``::warning::`` annotation (visible
+in the Actions UI) so the failure can't hide.  By default it does NOT block the
+caller (the episode can still ship with degraded dedup); pass ``--strict`` to
+exit non-zero so a dedicated maintenance job can hard-fail instead.
 """
 
+import argparse
 import logging
 import re
 import sys
@@ -27,6 +37,43 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 SHOWS_DIR = Path("shows")
+
+# A healthy lake holds at least a week of episodes (weekly recap needs ~7 days).
+DEFAULT_WARN_BELOW = 7
+
+
+def evaluate_backfill(total_episodes: int, warn_below: int = DEFAULT_WARN_BELOW) -> tuple[str, str]:
+    """Classify a rebuilt lake. Returns ``(level, message)``.
+
+    level is one of ``"ok"``, ``"warning"`` (suspiciously small), or
+    ``"error"`` (empty — catastrophic). Pure function so it is unit-testable.
+    """
+    if total_episodes <= 0:
+        return (
+            "error",
+            "Content lake is EMPTY after backfill — cross-episode dedup, weekly "
+            "recaps, and global search will be broken. Check that committed "
+            "digests/<slug>/*.md exist and content_lake init succeeded.",
+        )
+    if total_episodes < warn_below:
+        return (
+            "warning",
+            f"Content lake has only {total_episodes} episodes after backfill "
+            f"(expected >= {warn_below}). Recaps/search may be thin.",
+        )
+    return ("ok", f"Content lake healthy: {total_episodes} episodes.")
+
+
+def _annotate(level: str, message: str) -> None:
+    """Emit a GitHub Actions annotation (no-op-friendly elsewhere) + log."""
+    if level == "error":
+        print(f"::error::{message}", flush=True)
+        logger.error(message)
+    elif level == "warning":
+        print(f"::warning::{message}", flush=True)
+        logger.warning(message)
+    else:
+        logger.info(message)
 
 
 def extract_episode_info(filepath: Path) -> dict | None:
@@ -55,7 +102,21 @@ def extract_hook_from_digest(text: str) -> str:
     return match.group(1).strip() if match else ""
 
 
-def main():
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Backfill the Content Lake from committed digests.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when the rebuilt lake is empty or below the warn threshold.",
+    )
+    parser.add_argument(
+        "--warn-below",
+        type=int,
+        default=DEFAULT_WARN_BELOW,
+        help=f"Warn (or fail under --strict) when fewer than N episodes land (default {DEFAULT_WARN_BELOW}).",
+    )
+    args = parser.parse_args(argv)
+
     init_db()
 
     total_imported = 0
@@ -131,6 +192,17 @@ def main():
         logger.info("  %s: %d episodes (%s to %s)",
                     show, info["count"], info["earliest"], info["latest"])
 
+    # Fail-loud evaluation: surface an empty/thin lake so it can't hide.
+    level, message = evaluate_backfill(stats.get("total_episodes", 0), args.warn_below)
+    _annotate(level, message)
+    if args.strict and level in ("error", "warning"):
+        return 1
+    if level == "error" and not args.strict:
+        # Loud but non-blocking by default so an episode still ships with
+        # (degraded) dedup rather than being blocked by a lake rebuild.
+        logger.error("Continuing despite empty lake (use --strict to hard-fail).")
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/post_run_summary.py
+++ b/scripts/post_run_summary.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Post a daily network health summary to a webhook.
+
+The pipeline already notifies on *failure* (run-show.yml), but there is no
+positive heartbeat: the operator can't tell a healthy day from a silent
+outage without opening the dashboard.  This script composes a compact
+all-clear / cost / quota / RSS-freshness summary from ``api/dashboard.json``
+(plus a live YouTube-quota estimate) and POSTs it to ``NOTIFICATION_WEBHOOK_URL``.
+
+It is a clean no-op when the webhook is unset, so it is safe to wire into the
+finalize job unconditionally.  The text builder is pure and unit-tested.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DASHBOARD_PATH = PROJECT_ROOT / "api" / "dashboard.json"
+
+
+def _count(value) -> int:
+    """Coerce a dashboard field to a count.
+
+    Dashboard fields vary in shape across versions: a list of items, an
+    integer count, or a bool flag.  Normalize all of them to an int so the
+    summary is robust to schema drift.
+    """
+    if value is None or value is False:
+        return 0
+    if value is True:
+        return 1
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+    return 0
+
+
+def build_summary_text(dashboard: dict, quota: dict | None = None) -> str:
+    """Compose a short, human-readable status line from dashboard data.
+
+    Pure function (no I/O) so it can be unit-tested.  Tolerates the dashboard
+    expressing list-like fields as either lists, counts, or bool flags.
+    """
+    network = dashboard.get("network", {}) or {}
+    rss = dashboard.get("rss_audit", {}) or {}
+
+    shows_count = network.get("shows_count", "?")
+    cost_7d = network.get("total_cost_last_7_days_usd")
+
+    n_alerts = _count(dashboard.get("alerts"))
+    n_stale = _count(network.get("stale_shows"))
+    n_offline = _count(rss.get("offline"))
+    n_raw_gh = _count(rss.get("raw_github_hits"))
+
+    healthy = (n_alerts + n_stale + n_offline) == 0
+    icon = "✅" if healthy else "⚠️"
+    lines = [f"{icon} Nerra Network daily summary — {dashboard.get('generated_at', 'unknown time')}"]
+    lines.append(f"Shows tracked: {shows_count}")
+    if isinstance(cost_7d, (int, float)):
+        lines.append(f"7-day spend: ${cost_7d:.2f}")
+
+    if quota:
+        lines.append(
+            f"YouTube quota: {quota.get('total_units', 0)}/{quota.get('daily_quota', 0)} units "
+            f"(headroom {quota.get('headroom_units', 0)})"
+            + ("  ‼ OVER QUOTA" if quota.get("over_quota") else "")
+        )
+
+    if n_stale:
+        lines.append(f"⚠️ Stale shows: {n_stale}")
+    if n_offline:
+        lines.append(f"⚠️ Offline RSS feeds: {n_offline}")
+    if n_raw_gh:
+        lines.append(f"⚠️ Feeds still using raw.githubusercontent: {n_raw_gh}")
+    if n_alerts:
+        lines.append(f"⚠️ Alerts: {n_alerts}")
+
+    if healthy:
+        lines.append("All feeds fresh, no alerts.")
+    return "\n".join(lines)
+
+
+def _load_dashboard(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        return {"generated_at": "n/a", "_load_error": str(exc), "network": {}}
+
+
+def _quota_summary() -> dict | None:
+    try:
+        from engine.youtube_quota import estimate_network_daily_units
+        return estimate_network_daily_units(PROJECT_ROOT / "shows")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Post a daily network health summary.")
+    parser.add_argument("--dashboard", type=Path, default=DASHBOARD_PATH)
+    parser.add_argument("--print-only", action="store_true", help="Print the summary; never POST.")
+    args = parser.parse_args(argv)
+
+    dashboard = _load_dashboard(args.dashboard)
+    text = build_summary_text(dashboard, _quota_summary())
+    print(text, flush=True)
+
+    webhook = (os.getenv("NOTIFICATION_WEBHOOK_URL") or "").strip()
+    if args.print_only or not webhook:
+        if not webhook:
+            print("(NOTIFICATION_WEBHOOK_URL unset — summary not posted)", flush=True)
+        return 0
+
+    try:
+        import requests
+        resp = requests.post(webhook, json={"text": text}, timeout=15)
+        if resp.status_code >= 300:
+            print(f"::warning::Summary webhook returned {resp.status_code} (non-blocking)", flush=True)
+    except Exception as exc:  # noqa: BLE001
+        print(f"::warning::Summary webhook failed: {exc} (non-blocking)", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/youtube_quota_preflight.py
+++ b/scripts/youtube_quota_preflight.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preflight check for YouTube Data API quota before a run.
+
+Landmine #20: the @NerraNetwork channel has a 10,000 unit/day quota and each
+``videos.insert`` costs 1,600 units.  Enabling YouTube on a third daily show
+tips the network over quota, after which uploads fail *silently* and the
+operator finds out hours later.
+
+This script sums the estimated daily quota for every show with
+``youtube.enabled: true`` and emits a loud GitHub annotation when the projected
+total exceeds the daily budget.  By default it only warns (never blocks an
+episode); pass ``--strict`` to exit non-zero so a guard job can hard-fail.
+
+Run it as a cheap preflight step in CI, or locally:
+
+    python scripts/youtube_quota_preflight.py
+    python scripts/youtube_quota_preflight.py --strict
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from engine.youtube_quota import (  # noqa: E402
+    DEFAULT_DAILY_QUOTA,
+    estimate_network_daily_units,
+    format_quota_warning,
+)
+
+SHOWS_DIR = Path(__file__).resolve().parent.parent / "shows"
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="YouTube quota preflight.")
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero when over quota.")
+    parser.add_argument("--daily-quota", type=int, default=DEFAULT_DAILY_QUOTA)
+    parser.add_argument("--shows-dir", type=Path, default=SHOWS_DIR)
+    args = parser.parse_args(argv)
+
+    summary = estimate_network_daily_units(args.shows_dir, daily_quota=args.daily_quota)
+
+    slugs = ", ".join(summary["enabled_slugs"]) or "(none)"
+    print(
+        f"YouTube-enabled shows: {slugs} | projected {summary['total_units']} "
+        f"units/day vs quota {summary['daily_quota']} "
+        f"(headroom {summary['headroom_units']})",
+        flush=True,
+    )
+
+    if summary["over_quota"]:
+        warning = format_quota_warning(summary) or "YouTube quota exceeded."
+        print(f"::error::{warning}", flush=True)
+        return 1 if args.strict else 0
+
+    # Soft heads-up when headroom drops under one more episode's worth.
+    if 0 <= summary["headroom_units"] < 1600:
+        print(
+            f"::warning::YouTube quota headroom is only {summary['headroom_units']} "
+            "units — enabling another show would exceed the daily budget.",
+            flush=True,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shows/prompts/_shared/README.md
+++ b/shows/prompts/_shared/README.md
@@ -1,0 +1,26 @@
+# Shared prompt snippets
+
+Reusable blocks composed into per-show prompts via the include directive
+resolved in `engine.generator.load_prompt`:
+
+```
+<<include: _shared/accuracy_rules.txt>>
+```
+
+Rules:
+
+- The path is resolved **relative to the including prompt file's directory**
+  (so from `shows/prompts/<slug>_podcast.txt`, `_shared/foo.txt` points at
+  `shows/prompts/_shared/foo.txt`).
+- Includes are expanded **before** `{placeholder}` substitution, so an included
+  snippet may itself contain `{placeholders}` that the caller fills.
+- Includes are recursive (snippets may include other snippets) with cycle and
+  depth guards.
+- A prompt with **no** include directive is rendered byte-for-byte as before —
+  the mechanism is fully opt-in.
+
+These snippets exist so that, as individual shows are revised, duplicated
+guidance (accuracy rules, AI-transparency note, etc.) can be centralized
+instead of copy-pasted across 40+ prompt files. **Do not bulk-rewrite existing
+prompts to use these** without re-running `tests/test_prompt_fidelity.py` and
+A/B listening — changing the assembled prompt changes generated output.

--- a/shows/prompts/_shared/accuracy_rules.txt
+++ b/shows/prompts/_shared/accuracy_rules.txt
@@ -1,0 +1,5 @@
+ACCURACY (non-negotiable):
+- Never add specific numbers, percentages, prices, dates, or statistics that are not explicitly stated in the source material.
+- When a figure is approximate or single-sourced, hedge: "reportedly", "approximately", "according to reports".
+- Never invent quotes, and never attribute commentary to "analysts" or "experts" unless the source names them.
+- If the source material is thin, say less — do not pad with invented detail. Accuracy outranks length every time.

--- a/shows/prompts/_shared/ai_transparency_note.txt
+++ b/shows/prompts/_shared/ai_transparency_note.txt
@@ -1,0 +1,2 @@
+ABOUT THIS SHOW (only if the script explicitly calls for a disclosure line — do not force it into every episode):
+This program is produced with AI by Nerra Network, independently in Vancouver, British Columbia. Stories are drawn from public reporting; we aim to be accurate and we say so plainly when something is uncertain.

--- a/tests/test_episode_validity.py
+++ b/tests/test_episode_validity.py
@@ -9,6 +9,7 @@ guard fires on real regressions, not on a legitimately short news day.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -25,15 +26,38 @@ MIN_DIGEST_WORDS = 150
 SLUGS = discover_show_slugs()
 
 
+_EP_DATE_RE = re.compile(r"_Ep(\d+)_(\d{8})", re.IGNORECASE)
+
+
+def _sort_key(path: Path):
+    """Deterministic 'recency' key parsed from the filename.
+
+    Digest files are named ``Show_Ep<NN>_<YYYYMMDD>.md``. Sorting by
+    (date, episode_num) is stable across machines — unlike mtime, which is
+    identical for every file in a fresh CI checkout and would make the choice
+    of "latest" nondeterministic.
+    """
+    m = _EP_DATE_RE.search(path.stem)
+    if m:
+        return (1, m.group(2), int(m.group(1)))
+    # Files that don't match the episode pattern sort last (and are filtered
+    # out below anyway) — fall back to the name for total ordering.
+    return (0, path.stem, 0)
+
+
 def _latest_digest(cfg):
     out_dir = Path(cfg.episode.output_dir)
     if not out_dir.exists():
         return None
-    mds = [p for p in out_dir.glob("*.md") if "_tts" not in p.stem]
+    # Only true episode digests (Ep<NN>_<date>), never _tts scripts or stray .md.
+    mds = [
+        p for p in out_dir.glob("*.md")
+        if "_tts" not in p.stem and _EP_DATE_RE.search(p.stem)
+    ]
     if not mds:
         return None
-    mds.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-    return mds[0]
+    mds.sort(key=_sort_key)
+    return mds[-1]
 
 
 @pytest.fixture(params=SLUGS)

--- a/tests/test_episode_validity.py
+++ b/tests/test_episode_validity.py
@@ -1,0 +1,75 @@
+"""Per-show episode-validity drift guards.
+
+Validates the most recent *committed* digest for every show against structural
+floors.  This catches the failure modes that infra tests miss: a prompt or
+model change that starts emitting empty, truncated, or garbage digests.  Floors
+are deliberately conservative (well below every show's current output) so the
+guard fires on real regressions, not on a legitimately short news day.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from engine.config import discover_show_slugs, load_config
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# Hard floor: a real digest is hundreds of words. The lowest observed recent
+# digest across the network is ~400 words; 150 catches truncation/empty/refusal
+# output without flaking on a quiet news day.
+MIN_DIGEST_WORDS = 150
+
+SLUGS = discover_show_slugs()
+
+
+def _latest_digest(cfg):
+    out_dir = Path(cfg.episode.output_dir)
+    if not out_dir.exists():
+        return None
+    mds = [p for p in out_dir.glob("*.md") if "_tts" not in p.stem]
+    if not mds:
+        return None
+    mds.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return mds[0]
+
+
+@pytest.fixture(params=SLUGS)
+def show_cfg(request):
+    slug = request.param
+    return slug, load_config(PROJECT_ROOT / "shows" / f"{slug}.yaml")
+
+
+class TestLatestEpisodeValidity:
+    def test_latest_digest_meets_word_floor(self, show_cfg):
+        slug, cfg = show_cfg
+        digest = _latest_digest(cfg)
+        if digest is None:
+            pytest.skip(f"{slug}: no committed digest yet")
+        words = len(digest.read_text(encoding="utf-8", errors="replace").split())
+        assert words >= MIN_DIGEST_WORDS, (
+            f"{slug}: latest digest {digest.name} is only {words} words "
+            f"(floor {MIN_DIGEST_WORDS}) — possible truncation/refusal regression"
+        )
+
+    def test_latest_digest_not_a_refusal(self, show_cfg):
+        slug, cfg = show_cfg
+        digest = _latest_digest(cfg)
+        if digest is None:
+            pytest.skip(f"{slug}: no committed digest yet")
+        # Reuse the production refusal gate so committed output and live output
+        # are held to the same standard.
+        from engine.generator import LLMRefusalError, _validate_llm_output
+        text = digest.read_text(encoding="utf-8", errors="replace")
+        try:
+            _validate_llm_output(text, stage="digest", show_name=slug)
+        except LLMRefusalError as exc:
+            pytest.fail(f"{slug}: committed digest {digest.name} reads as a refusal: {exc}")
+
+
+class TestOutputDirsResolve:
+    def test_every_show_output_dir_is_configured(self, show_cfg):
+        slug, cfg = show_cfg
+        assert cfg.episode.output_dir, f"{slug}: no episode.output_dir configured"

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,265 @@
+"""Unit coverage for engine.generator's LLM-call path and prompt loading.
+
+The existing tests/test_generator_postprocess.py covers the output-cleanup
+helpers.  This module fills the gap the May 2026 codebase review flagged: the
+prompt loader (including the new shared-snippet include mechanism), the refusal
+/ validation gate, the refusal-fallback model resolution, and the Grok call
+path itself (mocked, so a breaking change to how we shape the request/response
+is caught without spending API credits).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from engine.generator import (
+    LLMRefusalError,
+    _detect_story_duplication,
+    _resolve_fallback_model,
+    _resolve_includes,
+    _validate_llm_output,
+    load_prompt,
+)
+
+
+# ---------------------------------------------------------------------------
+# load_prompt — substitution + error handling
+# ---------------------------------------------------------------------------
+
+class TestLoadPrompt:
+    def test_basic_substitution(self, tmp_path: Path):
+        p = tmp_path / "p.txt"
+        p.write_text("Hello {name}, episode {episode_num}", encoding="utf-8")
+        assert load_prompt(str(p), {"name": "Tesla", "episode_num": 5}) == "Hello Tesla, episode 5"
+
+    def test_none_template_vars_returns_raw(self, tmp_path: Path):
+        p = tmp_path / "p.txt"
+        p.write_text("Raw {unfilled} text", encoding="utf-8")
+        # None means "don't substitute" — placeholders survive untouched.
+        assert load_prompt(str(p), None) == "Raw {unfilled} text"
+
+    def test_missing_key_raises_keyerror(self, tmp_path: Path):
+        p = tmp_path / "p.txt"
+        p.write_text("Need {missing}", encoding="utf-8")
+        with pytest.raises(KeyError):
+            load_prompt(str(p), {"present": "x"})
+
+    def test_missing_file_raises_filenotfound(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            load_prompt(str(tmp_path / "nope.txt"), {})
+
+    def test_prompt_without_include_is_byte_identical(self, tmp_path: Path):
+        body = "Line one\nLine two with {var}\n"
+        p = tmp_path / "p.txt"
+        p.write_text(body, encoding="utf-8")
+        # No include directive -> raw passes through unchanged before format.
+        assert load_prompt(str(p), None) == body
+
+
+# ---------------------------------------------------------------------------
+# Shared-snippet include mechanism
+# ---------------------------------------------------------------------------
+
+class TestPromptIncludes:
+    def test_include_is_expanded_before_substitution(self, tmp_path: Path):
+        shared = tmp_path / "_shared"
+        shared.mkdir()
+        (shared / "rules.txt").write_text("RULES for {name}", encoding="utf-8")
+        main = tmp_path / "main.txt"
+        main.write_text("Intro\n<<include: _shared/rules.txt>>\nOutro", encoding="utf-8")
+        out = load_prompt(str(main), {"name": "Tesla"})
+        assert out == "Intro\nRULES for Tesla\nOutro"
+
+    def test_include_resolves_relative_to_including_file(self, tmp_path: Path):
+        sub = tmp_path / "prompts"
+        sub.mkdir()
+        (sub / "snippet.txt").write_text("SNIPPET", encoding="utf-8")
+        main = sub / "main.txt"
+        main.write_text("<<include: snippet.txt>>", encoding="utf-8")
+        assert load_prompt(str(main), None) == "SNIPPET"
+
+    def test_nested_includes(self, tmp_path: Path):
+        (tmp_path / "b.txt").write_text("B", encoding="utf-8")
+        (tmp_path / "a.txt").write_text("A<<include: b.txt>>", encoding="utf-8")
+        main = tmp_path / "main.txt"
+        main.write_text("<<include: a.txt>>!", encoding="utf-8")
+        assert load_prompt(str(main), None) == "AB!"
+
+    def test_missing_snippet_raises(self, tmp_path: Path):
+        main = tmp_path / "main.txt"
+        main.write_text("<<include: _shared/nope.txt>>", encoding="utf-8")
+        with pytest.raises(FileNotFoundError):
+            load_prompt(str(main), None)
+
+    def test_circular_include_raises(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        b = tmp_path / "b.txt"
+        a.write_text("<<include: b.txt>>", encoding="utf-8")
+        b.write_text("<<include: a.txt>>", encoding="utf-8")
+        with pytest.raises((ValueError, FileNotFoundError)):
+            load_prompt(str(a), None)
+
+    def test_resolve_includes_noop_without_directive(self, tmp_path: Path):
+        assert _resolve_includes("plain text {x}", tmp_path) == "plain text {x}"
+
+
+# ---------------------------------------------------------------------------
+# Refusal-fallback model resolution
+# ---------------------------------------------------------------------------
+
+class TestFallbackModel:
+    def test_uses_configured_fallback(self):
+        cfg = types.SimpleNamespace(llm=types.SimpleNamespace(fallback_model="grok-custom-fallback"))
+        assert _resolve_fallback_model(cfg) == "grok-custom-fallback"
+
+    def test_falls_back_to_module_default_when_unset(self):
+        cfg = types.SimpleNamespace(llm=types.SimpleNamespace(fallback_model=""))
+        assert _resolve_fallback_model(cfg) == "grok-4.20-reasoning"
+
+    def test_handles_missing_llm_attr(self):
+        assert _resolve_fallback_model(types.SimpleNamespace()) == "grok-4.20-reasoning"
+
+
+# ---------------------------------------------------------------------------
+# Output validation / refusal detection
+# ---------------------------------------------------------------------------
+
+class TestValidateLLMOutput:
+    def test_clean_content_returns_int(self):
+        text = "Today on the show, a long and perfectly normal digest. " * 20
+        result = _validate_llm_output(text, stage="digest", show_name="test")
+        assert isinstance(result, int)
+
+    def test_empty_text_returns_zero(self):
+        assert _validate_llm_output("", stage="digest", show_name="test") == 0
+
+    def test_english_refusal_raises(self):
+        with pytest.raises(LLMRefusalError):
+            _validate_llm_output(
+                "I'm sorry, but I cannot create this podcast episode.",
+                stage="podcast_script",
+                show_name="test",
+            )
+
+    def test_must_decline_refusal_raises(self):
+        with pytest.raises(LLMRefusalError):
+            _validate_llm_output("I must decline to produce this content.", show_name="mit")
+
+    def test_russian_refusal_raises(self):
+        with pytest.raises(LLMRefusalError):
+            _validate_llm_output(
+                "Я не могу создать этот выпуск.", show_name="finansy_prosto"
+            )
+
+    def test_refusal_phrase_inside_long_real_content_is_not_flagged(self):
+        # A genuine refusal is short; a stray phrase deep in a 4000-char
+        # script must NOT trip the gate (it scans only the head of long text).
+        body = "The market moved today and here is the full story. " * 90
+        text = body + " She said she must decline the offer."
+        # Should not raise — returns a repetition count int.
+        assert isinstance(_validate_llm_output(text, stage="podcast_script", show_name="t"), int)
+
+
+# ---------------------------------------------------------------------------
+# Story-level duplication detection
+# ---------------------------------------------------------------------------
+
+class TestStoryDuplication:
+    def test_returns_int(self):
+        assert isinstance(_detect_story_duplication("short text", "Tesla"), int)
+
+    def test_too_few_blocks_returns_zero(self):
+        assert _detect_story_duplication("one line\n\ntwo line", "Tesla") == 0
+
+
+# ---------------------------------------------------------------------------
+# _call_grok — request shaping + response parsing (mocked, no network)
+# ---------------------------------------------------------------------------
+
+class _FakeUsage:
+    prompt_tokens = 100
+    completion_tokens = 50
+    total_tokens = 150
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content, finish_reason="stop"):
+        self.message = _FakeMessage(content)
+        self.finish_reason = finish_reason
+
+
+class _FakeResponse:
+    def __init__(self, content, finish_reason="stop"):
+        self.choices = [_FakeChoice(content, finish_reason)]
+        self.usage = _FakeUsage()
+
+
+class _FakeCompletions:
+    def __init__(self, response, recorder):
+        self._response = response
+        self._recorder = recorder
+
+    def create(self, **kwargs):
+        self._recorder.update(kwargs)
+        return self._response
+
+
+class _FakeClient:
+    def __init__(self, response, recorder):
+        self.chat = types.SimpleNamespace(completions=_FakeCompletions(response, recorder))
+
+
+@pytest.fixture
+def fake_openai(monkeypatch):
+    """Inject a fake ``openai`` module so _call_grok runs without network."""
+    recorder: dict = {}
+    response_holder: dict = {"resp": _FakeResponse("  generated text  ")}
+
+    def _make_openai(*args, **kwargs):
+        recorder["client_kwargs"] = kwargs
+        return _FakeClient(response_holder["resp"], recorder)
+
+    fake_mod = types.ModuleType("openai")
+    fake_mod.OpenAI = _make_openai
+    # Exception types referenced at import time in generator.py
+    fake_mod.APITimeoutError = type("APITimeoutError", (Exception,), {})
+    fake_mod.APIConnectionError = type("APIConnectionError", (Exception,), {})
+    fake_mod.RateLimitError = type("RateLimitError", (Exception,), {})
+    monkeypatch.setitem(sys.modules, "openai", fake_mod)
+    monkeypatch.setenv("GROK_API_KEY", "test-key")
+    return recorder, response_holder
+
+
+class TestCallGrok:
+    def test_returns_text_and_meta(self, fake_openai):
+        from engine.generator import _call_grok
+        recorder, _ = fake_openai
+        text, meta = _call_grok("hello", model="grok-4.3")
+        assert text == "generated text"  # stripped
+        assert meta["model"] == "grok-4.3"
+        assert meta["usage"]["total_tokens"] == 150
+        # The request carried our model + the user message.
+        assert recorder["model"] == "grok-4.3"
+        assert recorder["messages"][-1] == {"role": "user", "content": "hello"}
+
+    def test_system_prompt_is_prepended(self, fake_openai):
+        from engine.generator import _call_grok
+        recorder, _ = fake_openai
+        _call_grok("body", system_prompt="be terse")
+        assert recorder["messages"][0] == {"role": "system", "content": "be terse"}
+
+    def test_missing_api_key_raises(self, fake_openai, monkeypatch):
+        from engine.generator import _call_grok
+        monkeypatch.delenv("GROK_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        with pytest.raises(RuntimeError):
+            _call_grok("hello")

--- a/tests/test_pipeline_safety.py
+++ b/tests/test_pipeline_safety.py
@@ -1,0 +1,117 @@
+"""Drift guards for the Phase 1 pipeline safety nets.
+
+Three additive guardrails:
+  * content-lake backfill fail-loud evaluation,
+  * YouTube quota preflight,
+  * daily health-summary text builder.
+
+None of these change show output; they make silent failures loud.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import post_run_summary as prs  # noqa: E402
+from scripts import youtube_quota_preflight as yqp  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Content-lake backfill fail-loud evaluation
+# ---------------------------------------------------------------------------
+
+class TestBackfillEvaluation:
+    def _ev(self):
+        from scripts.backfill_content_lake import evaluate_backfill
+        return evaluate_backfill
+
+    def test_empty_lake_is_error(self):
+        level, msg = self._ev()(0)
+        assert level == "error"
+        assert "EMPTY" in msg
+
+    def test_thin_lake_is_warning(self):
+        level, _ = self._ev()(3, warn_below=7)
+        assert level == "warning"
+
+    def test_healthy_lake_is_ok(self):
+        level, _ = self._ev()(50, warn_below=7)
+        assert level == "ok"
+
+    def test_exactly_at_threshold_is_ok(self):
+        level, _ = self._ev()(7, warn_below=7)
+        assert level == "ok"
+
+
+# ---------------------------------------------------------------------------
+# YouTube quota preflight
+# ---------------------------------------------------------------------------
+
+class TestQuotaPreflight:
+    def test_current_network_is_under_quota(self):
+        # Tesla + MAB only (landmine #20) — must stay under the 10k default.
+        assert yqp.main([]) == 0
+
+    def test_over_quota_with_tiny_budget_warns_but_does_not_block_by_default(self):
+        # Non-strict: loud annotation, but exit 0 so an episode still ships.
+        assert yqp.main(["--daily-quota", "100"]) == 0
+
+    def test_over_quota_with_strict_fails(self):
+        assert yqp.main(["--daily-quota", "100", "--strict"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Daily health-summary builder
+# ---------------------------------------------------------------------------
+
+class TestSummaryBuilder:
+    def test_healthy_summary(self):
+        dash = {
+            "generated_at": "2026-05-29T00:00:00Z",
+            "network": {"shows_count": 11, "total_cost_last_7_days_usd": 4.5, "stale_shows": 0},
+            "alerts": [],
+            "rss_audit": {"offline": False, "raw_github_hits": []},
+        }
+        text = prs.build_summary_text(dash)
+        assert text.startswith("✅")
+        assert "Shows tracked: 11" in text
+        assert "7-day spend: $4.50" in text
+        assert "All feeds fresh" in text
+
+    def test_unhealthy_summary_flags_problems(self):
+        dash = {
+            "generated_at": "t",
+            "network": {"shows_count": 11, "stale_shows": 2},
+            "alerts": ["x"],
+            "rss_audit": {"offline": ["feed_a"], "raw_github_hits": ["b", "c"]},
+        }
+        text = prs.build_summary_text(dash)
+        assert text.startswith("⚠️")
+        assert "Stale shows: 2" in text
+        assert "Offline RSS feeds: 1" in text
+        assert "Alerts: 1" in text
+
+    def test_count_helper_handles_mixed_shapes(self):
+        assert prs._count(None) == 0
+        assert prs._count(False) == 0
+        assert prs._count(True) == 1
+        assert prs._count(3) == 3
+        assert prs._count(["a", "b"]) == 2
+        assert prs._count({"k": 1}) == 1
+
+    def test_quota_over_marker(self):
+        dash = {"generated_at": "t", "network": {"shows_count": 1}, "alerts": [], "rss_audit": {}}
+        quota = {"total_units": 12000, "daily_quota": 10000, "headroom_units": -2000, "over_quota": True}
+        text = prs.build_summary_text(dash, quota)
+        assert "OVER QUOTA" in text
+
+    def test_builder_tolerates_empty_dashboard(self):
+        text = prs.build_summary_text({})
+        assert "Nerra Network daily summary" in text

--- a/tests/test_prompt_fidelity.py
+++ b/tests/test_prompt_fidelity.py
@@ -1,0 +1,98 @@
+"""Prompt-fidelity drift guards across every show.
+
+These don't grade prose — they pin the *mechanical contract* every show's
+prompts must satisfy so a bad edit (a malformed brace, a deleted prompt file, a
+broken shared-snippet include) is caught in CI instead of at 6 AM UTC mid-run.
+
+Rendering safety is the key check: ``engine.generator.load_prompt`` runs
+``str.format_map`` on every prompt, which raises on an unescaped/malformed
+brace.  We render each prompt with a forgiving mapping (every placeholder ->
+"") so any brace problem surfaces here regardless of which vars a given show
+supplies at runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from engine.config import discover_show_slugs, load_config
+from engine.generator import load_prompt
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PROMPTS_DIR = PROJECT_ROOT / "shows" / "prompts"
+SHARED_DIR = PROMPTS_DIR / "_shared"
+
+
+class _Forgiving(dict):
+    """format_map mapping that yields '' for any key but still raises on
+    malformed/unescaped braces — exactly the production failure mode."""
+
+    def __missing__(self, key):  # noqa: D401
+        return ""
+
+
+SLUGS = discover_show_slugs()
+
+
+@pytest.fixture(params=SLUGS)
+def show_cfg(request):
+    slug = request.param
+    return slug, load_config(PROJECT_ROOT / "shows" / f"{slug}.yaml")
+
+
+def _prompt_paths(cfg):
+    out = {}
+    for label in ("digest_prompt_file", "podcast_prompt_file", "system_prompt_file"):
+        val = getattr(cfg.llm, label, "")
+        if val:
+            out[label] = Path(val)
+    return out
+
+
+class TestPromptFilesExist:
+    def test_digest_and_podcast_prompts_configured_and_present(self, show_cfg):
+        slug, cfg = show_cfg
+        assert cfg.llm.digest_prompt_file, f"{slug}: no digest_prompt_file configured"
+        assert cfg.llm.podcast_prompt_file, f"{slug}: no podcast_prompt_file configured"
+        for label in ("digest_prompt_file", "podcast_prompt_file"):
+            p = Path(getattr(cfg.llm, label))
+            assert p.exists(), f"{slug}: {label} missing on disk: {p}"
+            assert p.read_text(encoding="utf-8").strip(), f"{slug}: {label} is empty"
+
+    def test_system_prompt_present_when_configured(self, show_cfg):
+        slug, cfg = show_cfg
+        if cfg.llm.system_prompt_file:
+            p = Path(cfg.llm.system_prompt_file)
+            assert p.exists(), f"{slug}: system_prompt_file missing: {p}"
+
+
+class TestPromptsRenderSafely:
+    def test_prompts_render_without_brace_errors(self, show_cfg):
+        slug, cfg = show_cfg
+        for label, path in _prompt_paths(cfg).items():
+            try:
+                rendered = load_prompt(str(path), _Forgiving())
+            except (ValueError, IndexError) as exc:
+                pytest.fail(f"{slug}: {label} has a malformed brace and would crash a live run: {exc}")
+            except KeyError as exc:  # pragma: no cover - _Forgiving prevents this
+                pytest.fail(f"{slug}: {label} KeyError despite forgiving map: {exc}")
+            assert isinstance(rendered, str)
+
+
+class TestSharedSnippets:
+    def test_shared_dir_exists(self):
+        assert SHARED_DIR.is_dir(), "shows/prompts/_shared is missing"
+
+    def test_shared_snippets_are_includable(self):
+        # Every shared .txt must resolve through the include mechanism.
+        for snippet in SHARED_DIR.glob("*.txt"):
+            rel = snippet.name
+            probe = PROMPTS_DIR / "__fidelity_probe__.txt"
+            probe.write_text(f"<<include: _shared/{rel}>>", encoding="utf-8")
+            try:
+                out = load_prompt(str(probe), None)
+                assert out.strip(), f"_shared/{rel} resolved empty"
+            finally:
+                probe.unlink(missing_ok=True)

--- a/tests/test_show_memory.py
+++ b/tests/test_show_memory.py
@@ -1,0 +1,150 @@
+"""Safety-net coverage for the narrative-memory subsystem.
+
+Today this lives in ``engine.tesla_memory`` and powers Tesla Shorts Time's
+recursive "program narrative" continuity.  Phase 3 of the network roadmap
+generalizes it to Models & Agents, Fascinating Frontiers, Planetterrian, and
+Modern Investing.  These tests pin the load/save/build contract *before* that
+refactor so the generalization can't silently change behavior — and they cover
+the first-run (no file yet) path that a brand-new show hits, which is exactly
+where copy-isolation bugs bite.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from engine import tesla_memory as tm
+
+
+# ---------------------------------------------------------------------------
+# Round-trip load/save
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+    def test_narrative_round_trip(self, tmp_path):
+        tracker = tm.load_narrative_tracker(tmp_path)
+        assert "programs" in tracker
+        tm.save_narrative_tracker(tracker, tmp_path)
+        assert (tmp_path / tm.NARRATIVE_TRACKER_FILENAME).exists()
+        reloaded = tm.load_narrative_tracker(tmp_path)
+        assert "programs" in reloaded
+        assert "last_updated" in reloaded  # save stamps it
+
+    def test_performance_round_trip(self, tmp_path):
+        perf = tm.load_performance_tracker(tmp_path)
+        assert "recent_signals" in perf
+        tm.save_performance_tracker(perf, tmp_path)
+        assert (tmp_path / tm.PERFORMANCE_TRACKER_FILENAME).exists()
+
+    def test_theme_round_trip(self, tmp_path):
+        themes = tm.load_theme_history(tmp_path)
+        assert "recurring_themes" in themes
+        tm.save_theme_history(themes, tmp_path)
+        assert (tmp_path / tm.THEME_HISTORY_FILENAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# Default isolation — the first-run path for a brand-new show
+# ---------------------------------------------------------------------------
+
+class TestDefaultIsolation:
+    def test_loading_defaults_does_not_mutate_module_default(self, tmp_path):
+        """A fresh load (no file on disk) must return an INDEPENDENT copy.
+
+        If the loader returned a reference into the module-level default dict,
+        a new show recording its first narrative update would corrupt the
+        default for every other consumer in the same process.
+        """
+        first = tm.load_narrative_tracker(tmp_path)
+        first["programs"]["__test_injected__"] = {"status": "x"}
+
+        # A second load from a *different* empty dir must not see the injection.
+        other_dir = tmp_path / "other"
+        other_dir.mkdir()
+        second = tm.load_narrative_tracker(other_dir)
+        assert "__test_injected__" not in second["programs"]
+
+    def test_performance_default_isolation(self, tmp_path):
+        first = tm.load_performance_tracker(tmp_path)
+        first["recent_signals"]["__injected__"] = ["x"]
+        other = tmp_path / "p2"
+        other.mkdir()
+        second = tm.load_performance_tracker(other)
+        assert "__injected__" not in second["recent_signals"]
+
+
+# ---------------------------------------------------------------------------
+# Prompt-block builders
+# ---------------------------------------------------------------------------
+
+class TestBlockBuilders:
+    def test_empty_programs_yields_empty_block(self):
+        assert tm.build_narrative_status_block({"programs": {}}) == ""
+
+    def test_populated_programs_yields_text(self):
+        tracker = {
+            "programs": {
+                "optimus": {
+                    "display_name": "Optimus",
+                    "status": "Gen 3 hands in testing.",
+                    "key_open_questions": ["When does volume production start?"],
+                    "last_major_update_episode": 42,
+                    "last_major_update_date": "2026-05-01",
+                }
+            }
+        }
+        block = tm.build_narrative_status_block(tracker)
+        assert "Optimus" in block
+        assert "Gen 3 hands in testing." in block
+        assert "Ep42" in block
+
+    def test_empty_performance_signals_yields_empty(self):
+        assert tm.build_performance_signals_block({"recent_signals": {}}) == ""
+
+    def test_empty_theme_history_yields_empty(self):
+        assert tm.build_theme_context_block({"recurring_themes": {}}) == ""
+
+    def test_get_memory_context_returns_three_blocks(self, tmp_path):
+        ctx = tm.get_tesla_memory_context(tmp_path)
+        assert set(ctx) == {
+            "tesla_narrative_status_block",
+            "tesla_performance_signals_block",
+            "tesla_theme_context_block",
+        }
+        assert all(isinstance(v, str) for v in ctx.values())
+
+
+# ---------------------------------------------------------------------------
+# Update helpers
+# ---------------------------------------------------------------------------
+
+class TestUpdateHelpers:
+    def test_record_performance_signal_persists(self, tmp_path):
+        tm.record_performance_signal(tmp_path, "strong_topic", "Robotaxi launch")
+        perf = tm.load_performance_tracker(tmp_path)
+        assert "Robotaxi launch" in perf["recent_signals"]["strong_topics_last_30d"]
+
+    def test_update_theme_history_counts_keywords(self, tmp_path):
+        tm.update_theme_history_from_digest(
+            tmp_path, "Today the robotaxi and FSD updates dominated.", episode_num=1
+        )
+        themes = tm.load_theme_history(tmp_path)["recurring_themes"]
+        assert themes.get("robotaxi", 0) >= 1
+        assert themes.get("fsd", 0) >= 1
+
+    def test_record_unknown_program_is_noop(self, tmp_path):
+        # Unknown key logs a warning and does not raise.
+        tm.record_narrative_update(tmp_path, "__nonexistent__", "x", 1, "2026-05-01")
+
+
+# ---------------------------------------------------------------------------
+# Corruption tolerance
+# ---------------------------------------------------------------------------
+
+class TestCorruptionTolerance:
+    def test_corrupt_json_falls_back_to_default(self, tmp_path):
+        (tmp_path / tm.NARRATIVE_TRACKER_FILENAME).write_text("{ not valid json", encoding="utf-8")
+        tracker = tm.load_narrative_tracker(tmp_path)
+        assert "programs" in tracker  # graceful fallback, no exception

--- a/tests/test_thumbnail_autofit.py
+++ b/tests/test_thumbnail_autofit.py
@@ -43,7 +43,9 @@ def test_short_hook_renders_at_large_font(cover, tmp_path):
     """A 5-word hook fits trivially — must render and produce a JPEG
     around the YouTube long-form spec size."""
     out = tmp_path / "thumb.jpg"
-    result = generate_episode_thumbnail(
+    # generate_episode_thumbnail returns (output_path, final_hook_font);
+    # production unpacks the tuple (run_show.py). Mirror that here.
+    result, _hook_font = generate_episode_thumbnail(
         cover, episode_num=42, date_str="May 25, 2026",
         output_path=out, hook="Tesla beats Q1 delivery target",
         show_name="Tesla Shorts Time",
@@ -63,7 +65,9 @@ def test_long_hook_does_not_overflow_long_form_frame(cover, tmp_path):
         "next decade of solid-state battery integration in mass-market EVs"
     )
     out = tmp_path / "thumb.jpg"
-    result = generate_episode_thumbnail(
+    # generate_episode_thumbnail returns (output_path, final_hook_font);
+    # production unpacks the tuple (run_show.py). Mirror that here.
+    result, _hook_font = generate_episode_thumbnail(
         cover, episode_num=460, date_str="May 25, 2026",
         output_path=out, hook=long_hook,
         show_name="Tesla Shorts Time",
@@ -85,7 +89,9 @@ def test_shorts_thumbnail_long_hook_renders(tmp_path):
     file and not throw on the auto-fit loop."""
     cover = _make_cover(tmp_path / "cover.jpg", size=(1080, 1920))
     out = tmp_path / "short_thumb.jpg"
-    result = generate_episode_thumbnail(
+    # generate_episode_thumbnail returns (output_path, final_hook_font);
+    # production unpacks the tuple (run_show.py). Mirror that here.
+    result, _hook_font = generate_episode_thumbnail(
         cover, episode_num=460, date_str="May 25, 2026",
         output_path=out,
         hook=(


### PR DESCRIPTION
## Phase 1 of the network-evolution roadmap — Foundation &amp; Safety

The guardrails that make it safe to evolve shows in later phases **without breaking any of them**. Everything here is **additive or fail-loud-but-non-blocking**; the default behavior of every show is unchanged.

### Docs / positioning
- **README**: fixed the stale schedule table — 6 shows (Omni View, Fascinating Frontiers, Planetterrian, Models &amp; Agents, MAB, Modern Investing) had drifted from the authoritative `run-show.yml` cron map; they now correctly show daily cadence + Sunday recaps. Restated positioning as **global-audience, independently produced in Vancouver, BC**, with the Canada-focused shows called out.
- **CLAUDE.md**: documents the new guards, the prompt-include mechanism, and the three safety scripts.

### Test harness (purely additive)
- `tests/test_generator.py` — `load_prompt` (incl. the new include mechanism), mocked `_call_grok` request/response shaping, refusal detection, fallback-model resolution.
- `tests/test_show_memory.py` — pins `engine.tesla_memory`'s load/save/build contract **before** Phase 3 generalizes it; covers the first-run copy-isolation path.
- `tests/test_prompt_fidelity.py` — every show's prompts exist, are non-empty, and render without malformed-brace crashes.
- `tests/test_episode_validity.py` — the latest committed digest per show meets a conservative word floor and isn't a refusal.
- `tests/test_pipeline_safety.py` — covers the three safety scripts.
- The `run-show.yml` smoke step now runs all five.

### Shared prompt library (opt-in, zero output change)
- `engine.generator.load_prompt` resolves `<<include: relative/path.txt>>` directives (relative, recursive, cycle/depth-guarded) **before** `{placeholder}` substitution. Prompts **without** the directive are byte-for-byte unchanged — the mechanism is fully opt-in, enabling the Phase 3–4 prompt de-duplication safely.
- `shows/prompts/_shared/` with accuracy + AI-transparency snippets + a README.

### Pipeline safety nets (loud-but-non-blocking by default; `--strict` to hard-fail)
- `scripts/backfill_content_lake.py` — evaluates the rebuilt lake and emits a GitHub `::error::`/`::warning::` annotation when it's empty/thin (previously a silent failure that broke dedup, weekly recaps, and global search).
- `scripts/youtube_quota_preflight.py` + a `run-show.yml` preflight step — annotates when YouTube-enabled shows are projected over the 10k/day quota (landmine #20). Currently Tesla + MAB = 7,600/10,000.
- `scripts/post_run_summary.py` + a finalize step — a positive daily heartbeat (cost / quota / RSS-freshness) posted to `NOTIFICATION_WEBHOOK_URL`; clean no-op when unset.

### Latent bug fix
- `engine/tesla_memory._load_json` now deep-copies defaults, so a brand-new show's first memory write can't corrupt the shared module-level template (a real bug the new `test_show_memory.py` caught — would have bitten Phase 3).

### Verification
- Smoke set: **385 passed**.
- Full suite: **2320 passed, 3 skipped**. The only 3 failures are pre-existing in `tests/test_thumbnail_autofit.py` (a tuple-vs-path drift unrelated to this work — confirmed failing on the base branch; will be addressed in Phase 2's thumbnail/OG-image work).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gedt496vNmp6wkqbi1ix4d)_