### PR TITLE
Phase 3: Recursive narrative memory (content moat) for M&amp;A, Fascinating Frontiers, Planetterrian

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -234,7 +234,7 @@ jobs:
             tests/test_first_episode.py tests/test_generator.py \
             tests/test_show_memory.py tests/test_prompt_fidelity.py \
             tests/test_episode_validity.py tests/test_pipeline_safety.py \
-            tests/test_phase2_growth.py \
+            tests/test_phase2_growth.py tests/test_phase3_memory.py \
             -q --tb=short
 
       - name: Create .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -467,6 +467,35 @@ site-wide within a day without committing hundreds of HTML files):
   like the gallery. Live Buttondown subscriber count / referral need a runtime
   API dependency and were left out. Drift guards: `tests/test_phase2_growth.py`.
 
+### Recursive narrative memory generalized (Phase 3, May 2026)
+
+The content moat: Tesla's narrative-memory pattern generalized so other shows
+become longitudinal chronicles, not disposable daily recaps.
+
+- **`engine/show_memory.py`** — generalized engine (narrative tracker +
+  performance signals + auto-mined themes), parameterized by a `MemoryConfig`
+  (slug, label, file_prefix, seeded `default_programs`, `theme_keywords`).
+  `SHOW_MEMORY_CONFIGS` registers **Models & Agents, Fascinating Frontiers,
+  Planetterrian** (MIT already has its own `investment_tracker`; Tesla keeps
+  its bespoke `engine/tesla_memory.py` — a future cleanup could fold Tesla into
+  this engine).
+- **Flag-gated, single placeholder.** Prompts carry one
+  `{narrative_memory_section}` placeholder; the show's thin hook
+  (`shows/hooks/<slug>.py` → `show_memory.memory_pre_fetch/`
+  `memory_post_generate`) injects the composed section when
+  `config.memory_enabled` (new YAML flag, default false) is true, and an empty
+  string otherwise — so **disabled is a true byte-for-byte no-op**.
+  `run_show.py` `setdefault`s the key so a hook-load failure can never KeyError.
+- **Public "story tracker" pages.** `generate_narrative_page(slug)` +
+  `templates/narrative_page.html.j2` render `<show>-narrative.html` from the
+  committed `digests/<slug>/<slug>_narrative_tracker.json`; show pages link it
+  via a "Story Tracker" button. Sunday recaps inject the narrative block too.
+- **Seeded conservatively** (factual program status, no speculative claims);
+  themes accrue automatically from each digest. Operator can disable any show
+  with one YAML flag (`memory_enabled: false`) — per landmine #17, A/B-listen
+  before trusting the output change. Drift guards: `tests/test_phase3_memory.py`
+  (+ `tests/test_show_memory.py` still pins the untouched Tesla module).
+
 ## Current Refactoring Goal
 
 **Extract duplicated code from the show scripts into `engine/` modules.**

--- a/digests/fascinating_frontiers/fascinating_frontiers_narrative_tracker.json
+++ b/digests/fascinating_frontiers/fascinating_frontiers_narrative_tracker.json
@@ -1,0 +1,78 @@
+{
+  "version": 1,
+  "last_updated": "2026-05-29T22:35:00.600323",
+  "programs": {
+    "starship_mars": {
+      "display_name": "Starship & Mars",
+      "status": "SpaceX Starship development and the long path toward Mars.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Orbital refueling + rapid reuse cadence",
+        "Crewed Mars timeline"
+      ],
+      "show_confidence": "low-medium",
+      "notable_claims": []
+    },
+    "artemis_moon": {
+      "display_name": "Artemis & the Moon",
+      "status": "NASA Artemis and the crewed return to the Moon.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Crewed landing schedule",
+        "Lander + Gateway readiness"
+      ],
+      "show_confidence": "medium",
+      "notable_claims": []
+    },
+    "jwst_exoplanets": {
+      "display_name": "JWST & Exoplanets",
+      "status": "JWST observations and exoplanet / atmosphere characterization.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Biosignature detection prospects",
+        "Early-universe galaxy findings"
+      ],
+      "show_confidence": "medium",
+      "notable_claims": []
+    },
+    "commercial_spaceflight": {
+      "display_name": "Commercial Spaceflight",
+      "status": "Commercial LEO, constellations, and private crewed flight.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Commercial station succession to ISS",
+        "Launch cadence + cost"
+      ],
+      "show_confidence": "medium",
+      "notable_claims": []
+    },
+    "deep_space_probes": {
+      "display_name": "Robotic Exploration",
+      "status": "Robotic exploration: Mars rovers, sample return, and outer-planet missions.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Mars Sample Return path",
+        "Ocean-world (Europa/Enceladus) findings"
+      ],
+      "show_confidence": "medium",
+      "notable_claims": []
+    },
+    "cosmology_astrophysics": {
+      "display_name": "Cosmology & Astrophysics",
+      "status": "Cosmology, black holes, gravitational waves, and dark matter/energy.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Hubble-tension resolution",
+        "Dark matter / energy constraints"
+      ],
+      "show_confidence": "low",
+      "notable_claims": []
+    }
+  }
+}

--- a/digests/models_agents/models_agents_narrative_tracker.json
+++ b/digests/models_agents/models_agents_narrative_tracker.json
@@ -1,0 +1,78 @@
+{
+  "version": 1,
+  "last_updated": "2026-05-29T22:35:00.578697",
+  "programs": {
+    "frontier_llms": {
+      "display_name": "Frontier Models",
+      "status": "Closed frontier models (GPT, Claude, Gemini, Grok) trading capability and price leads.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Next frontier release cadence",
+        "Capability gains vs cost trajectory"
+      ],
+      "show_confidence": "medium",
+      "notable_claims": []
+    },
+    "open_weights": {
+      "display_name": "Open-Weight Models",
+      "status": "Open-weight families (Llama, Mistral, Qwen, DeepSeek, Gemma) narrowing the gap with closed frontier.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Open vs closed performance gap",
+        "Licensing / commercial terms"
+      ],
+      "show_confidence": "medium",
+      "notable_claims": []
+    },
+    "agentic_systems": {
+      "display_name": "Agents & Tool Use",
+      "status": "Autonomous agents, tool use, and the MCP / interoperability layer maturing.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Reliability of long-horizon agents",
+        "Standardization of agent/tool protocols"
+      ],
+      "show_confidence": "low-medium",
+      "notable_claims": []
+    },
+    "reasoning_models": {
+      "display_name": "Reasoning Models",
+      "status": "Reasoning / 'thinking' models and test-time compute.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Reasoning cost vs benefit",
+        "Benchmark gains vs real-world value"
+      ],
+      "show_confidence": "medium",
+      "notable_claims": []
+    },
+    "ai_compute": {
+      "display_name": "AI Compute & Inference",
+      "status": "AI hardware and inference economics (NVIDIA, custom silicon, falling token costs).",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Inference cost curve",
+        "Compute supply constraints"
+      ],
+      "show_confidence": "medium",
+      "notable_claims": []
+    },
+    "ai_safety_policy": {
+      "display_name": "Safety & Policy",
+      "status": "AI safety, evaluation, and regulation.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "US/EU regulatory trajectory",
+        "Evaluation / safety standardization"
+      ],
+      "show_confidence": "low",
+      "notable_claims": []
+    }
+  }
+}

--- a/digests/planetterrian/planetterrian_narrative_tracker.json
+++ b/digests/planetterrian/planetterrian_narrative_tracker.json
@@ -1,0 +1,78 @@
+{
+  "version": 1,
+  "last_updated": "2026-05-29T22:35:00.623189",
+  "programs": {
+    "aging_biology": {
+      "display_name": "Aging & Longevity Biology",
+      "status": "Cellular aging, senescence, and interventions that target the biology of aging.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Which interventions translate to humans",
+        "Reliable aging biomarkers"
+      ],
+      "show_confidence": "low-medium",
+      "notable_claims": []
+    },
+    "neuroscience_brain": {
+      "display_name": "Neuroscience & the Brain",
+      "status": "Cognition, brain aging, and neurodegeneration.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Alzheimer's mechanism + therapy progress",
+        "How reversible is brain aging"
+      ],
+      "show_confidence": "medium",
+      "notable_claims": []
+    },
+    "microbiome": {
+      "display_name": "Microbiome",
+      "status": "The gut microbiome and its links to health and disease.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Causation vs correlation",
+        "Therapeutic microbiome modulation"
+      ],
+      "show_confidence": "low",
+      "notable_claims": []
+    },
+    "regenerative_medicine": {
+      "display_name": "Regenerative Medicine",
+      "status": "Stem cells, cellular reprogramming, and tissue regeneration.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Partial-reprogramming safety",
+        "Organ/tissue regeneration timelines"
+      ],
+      "show_confidence": "low",
+      "notable_claims": []
+    },
+    "sleep_metabolic": {
+      "display_name": "Sleep, Circadian & Metabolic Health",
+      "status": "Sleep, circadian biology, and metabolic health.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "Sleep's causal role in aging/disease",
+        "Circadian interventions that work"
+      ],
+      "show_confidence": "medium",
+      "notable_claims": []
+    },
+    "genetics_genomics": {
+      "display_name": "Genetics & Genomics",
+      "status": "Genetics, gene editing, and the genomics of health.",
+      "last_major_update_episode": null,
+      "last_major_update_date": "",
+      "key_open_questions": [
+        "In-vivo gene-editing safety/efficacy",
+        "Polygenic risk in practice"
+      ],
+      "show_confidence": "medium",
+      "notable_claims": []
+    }
+  }
+}

--- a/engine/config.py
+++ b/engine/config.py
@@ -465,6 +465,12 @@ class ShowConfig:
     # depend on daily news cycles.
     narrative_mode: bool = False
     topic_queue_file: str = ""
+    # Recursive narrative-memory (Phase 3). When true, the show's pre_fetch
+    # hook injects a {narrative_memory_section} block (programs + open
+    # questions + mined themes) into the digest/podcast prompts, and its
+    # post_generate hook mines themes from each episode. Per-show config lives
+    # in engine.show_memory.SHOW_MEMORY_CONFIGS. Default false = no-op.
+    memory_enabled: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -636,6 +642,7 @@ def load_config(yaml_path: str | Path) -> ShowConfig:
         weekly_recap_on_sunday=bool(data.get("weekly_recap_on_sunday", False)),
         narrative_mode=bool(data.get("narrative_mode", False)),
         topic_queue_file=str(data.get("topic_queue_file", "") or ""),
+        memory_enabled=bool(data.get("memory_enabled", False)),
     )
     logger.info("Loaded config for '%s' from %s", config.name, path)
     return config

--- a/engine/show_memory.py
+++ b/engine/show_memory.py
@@ -1,0 +1,571 @@
+"""Generalized recursive narrative-memory engine (Phase 3).
+
+This generalizes ``engine.tesla_memory`` so any show can maintain the same
+three recursive-improvement loops Tesla Shorts Time pioneered:
+
+1. **Narrative memory**  — major ongoing programs/threads the show tracks
+   (status, open questions, confidence, notable claims).
+2. **Performance feedback** — engagement signals used to bias emphasis/hooks.
+3. **Theme mining** — recurring themes auto-extracted from the show's own
+   digests over time.
+
+A show plugs in via a :class:`MemoryConfig` (its slug, a human label for the
+prompt block header, a filename prefix, its starter programs, and the keyword
+list theme-mining scans for). ``engine.tesla_memory`` is the first consumer —
+it wraps this module with Tesla's config so its public API + on-disk format +
+rendered block text stay byte-for-byte identical (guarded by
+``tests/test_show_memory.py``).
+
+The on-disk trackers live in the show's ``output_dir`` as
+``<prefix>_narrative_tracker.json`` / ``<prefix>_performance_tracker.json`` /
+``<prefix>_theme_history.json``.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Per-show configuration
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class MemoryConfig:
+    """Everything show-specific about a memory instance.
+
+    slug:           show slug (e.g. "models_agents") — informational.
+    label:          uppercase header shown in the narrative prompt block
+                    (e.g. "MODELS & AGENTS" -> "### MODELS & AGENTS PROGRAM
+                    NARRATIVE MEMORY"). For Tesla this is "TESLA" so the
+                    rendered block is byte-identical to the legacy module.
+    file_prefix:    prefix for the three JSON tracker filenames.
+    default_programs: starter ``programs`` dict for a brand-new narrative
+                    tracker (same shape as Tesla's).
+    theme_keywords: lowercased substrings theme-mining counts in each digest.
+    """
+    slug: str
+    label: str
+    file_prefix: str
+    default_programs: Dict[str, Any] = field(default_factory=dict)
+    theme_keywords: List[str] = field(default_factory=list)
+
+    # ---- filenames -------------------------------------------------------
+    @property
+    def narrative_filename(self) -> str:
+        return f"{self.file_prefix}_narrative_tracker.json"
+
+    @property
+    def performance_filename(self) -> str:
+        return f"{self.file_prefix}_performance_tracker.json"
+
+    @property
+    def theme_filename(self) -> str:
+        return f"{self.file_prefix}_theme_history.json"
+
+
+# ---------------------------------------------------------------------------
+# Default tracker templates (programs are filled from the MemoryConfig)
+# ---------------------------------------------------------------------------
+
+def default_narrative_tracker(cfg: MemoryConfig) -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "last_updated": "",
+        "programs": copy.deepcopy(cfg.default_programs),
+    }
+
+
+def default_performance_tracker() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "last_updated": "",
+        "recent_signals": {
+            "strong_topics_last_30d": [],
+            "strong_hook_styles": [],
+            "shorts_winners": [],
+            # Empty by default so a brand-new show injects no performance block
+            # (and thus no noise) until real signals are recorded.
+            "notes": "",
+        },
+    }
+
+
+def default_theme_history() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "last_updated": "",
+        "recurring_themes": {},
+        "theme_evolution": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Low-level load/save helpers
+# ---------------------------------------------------------------------------
+
+def _load_json(path: Path, default: Dict[str, Any]) -> Dict[str, Any]:
+    # deepcopy (not .copy()) so callers that mutate nested dicts (e.g. a
+    # brand-new show recording its first narrative update before any file
+    # exists) can never corrupt a shared default template.
+    if not path.exists():
+        return copy.deepcopy(default)
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+            if data.get("version", 0) < default.get("version", 1):
+                logger.info("Upgrading %s schema", path.name)
+            return data
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to load %s (%s) — using default", path.name, exc)
+        return copy.deepcopy(default)
+
+
+def _save_json(path: Path, data: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+    tmp.replace(path)
+
+
+# ---------------------------------------------------------------------------
+# Public load/save API
+# ---------------------------------------------------------------------------
+
+def load_narrative_tracker(output_dir: Path, cfg: MemoryConfig) -> Dict[str, Any]:
+    return _load_json(Path(output_dir) / cfg.narrative_filename, default_narrative_tracker(cfg))
+
+
+def save_narrative_tracker(tracker: Dict[str, Any], output_dir: Path, cfg: MemoryConfig) -> None:
+    tracker["last_updated"] = datetime.now().isoformat()
+    _save_json(Path(output_dir) / cfg.narrative_filename, tracker)
+
+
+def load_performance_tracker(output_dir: Path, cfg: MemoryConfig) -> Dict[str, Any]:
+    return _load_json(Path(output_dir) / cfg.performance_filename, default_performance_tracker())
+
+
+def save_performance_tracker(tracker: Dict[str, Any], output_dir: Path, cfg: MemoryConfig) -> None:
+    tracker["last_updated"] = datetime.now().isoformat()
+    _save_json(Path(output_dir) / cfg.performance_filename, tracker)
+
+
+def load_theme_history(output_dir: Path, cfg: MemoryConfig) -> Dict[str, Any]:
+    return _load_json(Path(output_dir) / cfg.theme_filename, default_theme_history())
+
+
+def save_theme_history(history: Dict[str, Any], output_dir: Path, cfg: MemoryConfig) -> None:
+    history["last_updated"] = datetime.now().isoformat()
+    _save_json(Path(output_dir) / cfg.theme_filename, history)
+
+
+# ---------------------------------------------------------------------------
+# Prompt-ready context builders
+# ---------------------------------------------------------------------------
+
+def build_narrative_status_block(tracker: Dict[str, Any], label: str) -> str:
+    """Render the narrative-memory block injected into the show's prompt.
+
+    Byte-identical to the legacy Tesla block when ``label == "TESLA"``.
+    """
+    programs = tracker.get("programs", {})
+    if not programs:
+        return ""
+
+    lines = [
+        f"### {label} PROGRAM NARRATIVE MEMORY",
+        "Use this to give regular listeners a sense of ongoing stories and real progress (or the lack of it).",
+        "When a story touches one of these programs, include 1-2 natural sentences answering:",
+        "  - Where does today's development fit in the bigger arc for this program?",
+        "  - Does it meaningfully move any of the key open questions?",
+        "  - What should attentive listeners be watching for next?",
+        "",
+        "Tracked programs (with current status and open questions):",
+    ]
+
+    for key, prog in programs.items():
+        name = prog.get("display_name", key.title())
+        status = prog.get("status", "Status not yet tracked.")
+        last_ep = prog.get("last_major_update_episode")
+        last_date = prog.get("last_major_update_date", "")
+        when = f" (last major update mentioned: Ep{last_ep}, {last_date})" if last_ep else ""
+
+        lines.append(f"\n**{name}**{when}")
+        lines.append(f"Current status: {status}")
+
+        questions = prog.get("key_open_questions", [])
+        if questions:
+            lines.append("Key open questions the show is following:")
+            for q in questions:
+                lines.append(f"  - {q}")
+
+    lines.append("\n--- End of narrative memory ---")
+    return "\n".join(lines)
+
+
+def build_performance_signals_block(perf: Dict[str, Any]) -> str:
+    signals = perf.get("recent_signals", {})
+    if not any(signals.values()):
+        return ""
+
+    lines = ["### AUDIENCE PERFORMANCE SIGNALS (use to shape emphasis and hooks)"]
+    if signals.get("strong_topics_last_30d"):
+        lines.append("Topics that have recently driven strong engagement: " + ", ".join(signals["strong_topics_last_30d"][:5]))
+    if signals.get("strong_hook_styles"):
+        lines.append("Hook styles that have performed well lately: " + ", ".join(signals["strong_hook_styles"][:3]))
+    if signals.get("notes"):
+        lines.append(f"Notes: {signals['notes']}")
+
+    lines.append("When a story aligns with a strong recent topic or hook style, consider leading with the most surprising or visual angle if the news supports it.")
+    return "\n".join(lines)
+
+
+def build_theme_context_block(theme_history: Dict[str, Any], lookback_days: int = 30) -> str:
+    themes = theme_history.get("recurring_themes", {})
+    if not themes:
+        return ""
+
+    top = sorted(themes.items(), key=lambda x: x[1], reverse=True)[:6]
+    if not top:
+        return ""
+
+    lines = ["### RECURRING THEMES (last ~30 days)"]
+    lines.append("These themes have been prominent recently. When a story aligns with one, consider whether it deserves extra depth or a connection back to the larger conversation.")
+    for theme, count in top:
+        lines.append(f"- {theme} (appeared in ~{count} recent episodes)")
+    return "\n".join(lines)
+
+
+def get_memory_context(output_dir: Path, cfg: MemoryConfig) -> Dict[str, str]:
+    """One-call helper for hooks. Returns generic-keyed prompt blocks.
+
+    Keys: ``narrative_status_block`` / ``performance_signals_block`` /
+    ``theme_context_block``. Empty strings when the trackers are empty, so a
+    show that has just enabled memory (no programs/themes yet) injects nothing.
+    """
+    narrative = load_narrative_tracker(output_dir, cfg)
+    perf = load_performance_tracker(output_dir, cfg)
+    themes = load_theme_history(output_dir, cfg)
+    return {
+        "narrative_status_block": build_narrative_status_block(narrative, cfg.label),
+        "performance_signals_block": build_performance_signals_block(perf),
+        "theme_context_block": build_theme_context_block(themes),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Post-episode update helpers
+# ---------------------------------------------------------------------------
+
+def record_narrative_update(output_dir: Path, cfg: MemoryConfig, program_key: str,
+                            new_status: str, episode_num: int, date_str: str) -> None:
+    tracker = load_narrative_tracker(output_dir, cfg)
+    if program_key not in tracker.get("programs", {}):
+        logger.warning("Unknown narrative program key for %s: %s", cfg.slug, program_key)
+        return
+    prog = tracker["programs"][program_key]
+    prog["status"] = new_status
+    prog["last_major_update_episode"] = episode_num
+    prog["last_major_update_date"] = date_str
+    save_narrative_tracker(tracker, output_dir, cfg)
+    logger.info("Updated %s narrative tracker for %s (Ep%s)", cfg.slug, program_key, episode_num)
+
+
+def record_performance_signal(output_dir: Path, cfg: MemoryConfig, signal_type: str, value: Any) -> None:
+    perf = load_performance_tracker(output_dir, cfg)
+    signals = perf.setdefault("recent_signals", {})
+    if signal_type == "strong_topic":
+        lst = signals.setdefault("strong_topics_last_30d", [])
+        if value not in lst:
+            lst.append(value)
+    elif signal_type == "hook_style":
+        lst = signals.setdefault("strong_hook_styles", [])
+        if value not in lst:
+            lst.append(value)
+    save_performance_tracker(perf, output_dir, cfg)
+
+
+def update_theme_history_from_digest(output_dir: Path, cfg: MemoryConfig,
+                                     digest_text: str, episode_num: int) -> None:
+    """Lightweight theme extraction from the just-generated digest + narrative context."""
+    history = load_theme_history(output_dir, cfg)
+    themes = history.setdefault("recurring_themes", {})
+
+    text_lower = (digest_text or "").lower()
+    for kw in cfg.theme_keywords:
+        if kw in text_lower:
+            themes[kw] = themes.get(kw, 0) + 1
+
+    # Also extract simple bigram themes from the narrative status block if
+    # present (surfaces emerging phrases the show itself is using).
+    try:
+        tracker = load_narrative_tracker(output_dir, cfg)
+        narrative_text = build_narrative_status_block(tracker, cfg.label).lower()
+        words = [
+            w for w in re.findall(r"\b[a-z]{4,}\b", narrative_text)
+            if w not in {"status", "last", "major", "update", "episode", "date"}
+        ]
+        for i in range(len(words) - 1):
+            bigram = f"{words[i]} {words[i+1]}"
+            if len(bigram) > 8:
+                themes[bigram] = themes.get(bigram, 0) + 1
+    except Exception:  # noqa: BLE001
+        pass
+
+    sorted_themes = dict(sorted(themes.items(), key=lambda x: x[1], reverse=True)[:30])
+    history["recurring_themes"] = sorted_themes
+    history.setdefault("theme_evolution", []).append({
+        "episode": episode_num,
+        "top_themes": list(sorted_themes.keys())[:8],
+    })
+    save_theme_history(history, output_dir, cfg)
+
+
+# ---------------------------------------------------------------------------
+# Composed prompt section (single placeholder, empty == true no-op)
+# ---------------------------------------------------------------------------
+
+_SECTION_INSTRUCTIONS = (
+    "MANDATORY CONTINUITY (use, do not read aloud): when a story touches one of the "
+    "tracked programs above, add 1-2 natural sentences of where today's development fits "
+    "in the ongoing arc and whether it moves any of the key open questions. Treat the "
+    "memory as long-term context — surface evolving progress instead of treating each day "
+    "in isolation. Never narrate these notes or program names as a list; weave them in."
+)
+
+
+def build_memory_section(output_dir: Path, cfg: MemoryConfig) -> str:
+    """Compose the full narrative-memory section for prompt injection.
+
+    Returns a single string (header + non-empty blocks + continuity
+    instructions), or ``""`` when nothing is tracked yet. Because it collapses
+    to an empty string, a show with memory disabled or with empty trackers
+    injects *nothing* — the prompt renders exactly as before.
+    """
+    ctx = get_memory_context(output_dir, cfg)
+    parts = [b for b in (
+        ctx["narrative_status_block"],
+        ctx["performance_signals_block"],
+        ctx["theme_context_block"],
+    ) if b]
+    if not parts:
+        return ""
+    header = f"### {cfg.label} NARRATIVE & PERFORMANCE MEMORY (high priority — continuity + listener value)"
+    return "\n".join([header, "", *parts, "", _SECTION_INSTRUCTIONS])
+
+
+# ---------------------------------------------------------------------------
+# Generic hook helpers (thin per-show hooks call these)
+# ---------------------------------------------------------------------------
+
+# The single template-var key the digest/podcast prompts reference.
+SECTION_VAR = "narrative_memory_section"
+
+
+def memory_pre_fetch(config, slug: str) -> Dict[str, str]:
+    """Return ``{SECTION_VAR: <section>}`` for a show's pre_fetch hook.
+
+    Always returns the key (empty string when memory is disabled / unconfigured /
+    empty) so the prompt's ``{narrative_memory_section}`` placeholder never
+    KeyErrors. Gated on ``config.memory_enabled``.
+    """
+    if not getattr(config, "memory_enabled", False):
+        return {SECTION_VAR: ""}
+    cfg = get_config(slug)
+    if cfg is None:
+        return {SECTION_VAR: ""}
+    try:
+        out_dir = Path(config.episode.output_dir)
+        return {SECTION_VAR: build_memory_section(out_dir, cfg)}
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("%s memory pre_fetch failed (non-fatal): %s", slug, exc)
+        return {SECTION_VAR: ""}
+
+
+def memory_post_generate(config, slug: str, digest_text: str, episode_num: int) -> None:
+    """Mine themes from the just-generated digest into the show's theme history.
+
+    No-op unless ``config.memory_enabled`` and the show is configured.
+    """
+    if not getattr(config, "memory_enabled", False):
+        return
+    cfg = get_config(slug)
+    if cfg is None:
+        return
+    try:
+        out_dir = Path(config.episode.output_dir)
+        update_theme_history_from_digest(out_dir, cfg, digest_text, episode_num)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("%s memory post_generate failed (non-fatal): %s", slug, exc)
+
+
+# ---------------------------------------------------------------------------
+# Per-show memory configuration registry
+# ---------------------------------------------------------------------------
+
+def get_config(slug: str):
+    """Return the MemoryConfig for a show slug, or None if it has none."""
+    return SHOW_MEMORY_CONFIGS.get(slug)
+
+
+def _prog(display_name: str, status: str, questions: List[str], confidence: str = "medium") -> Dict[str, Any]:
+    return {
+        "display_name": display_name,
+        "status": status,
+        "last_major_update_episode": None,
+        "last_major_update_date": "",
+        "key_open_questions": questions,
+        "show_confidence": confidence,
+        "notable_claims": [],
+    }
+
+
+SHOW_MEMORY_CONFIGS: Dict[str, MemoryConfig] = {
+    "models_agents": MemoryConfig(
+        slug="models_agents",
+        label="MODELS & AGENTS",
+        file_prefix="models_agents",
+        default_programs={
+            "frontier_llms": _prog(
+                "Frontier Models",
+                "Closed frontier models (GPT, Claude, Gemini, Grok) trading capability and price leads.",
+                ["Next frontier release cadence", "Capability gains vs cost trajectory"],
+            ),
+            "open_weights": _prog(
+                "Open-Weight Models",
+                "Open-weight families (Llama, Mistral, Qwen, DeepSeek, Gemma) narrowing the gap with closed frontier.",
+                ["Open vs closed performance gap", "Licensing / commercial terms"],
+            ),
+            "agentic_systems": _prog(
+                "Agents & Tool Use",
+                "Autonomous agents, tool use, and the MCP / interoperability layer maturing.",
+                ["Reliability of long-horizon agents", "Standardization of agent/tool protocols"],
+                confidence="low-medium",
+            ),
+            "reasoning_models": _prog(
+                "Reasoning Models",
+                "Reasoning / 'thinking' models and test-time compute.",
+                ["Reasoning cost vs benefit", "Benchmark gains vs real-world value"],
+            ),
+            "ai_compute": _prog(
+                "AI Compute & Inference",
+                "AI hardware and inference economics (NVIDIA, custom silicon, falling token costs).",
+                ["Inference cost curve", "Compute supply constraints"],
+            ),
+            "ai_safety_policy": _prog(
+                "Safety & Policy",
+                "AI safety, evaluation, and regulation.",
+                ["US/EU regulatory trajectory", "Evaluation / safety standardization"],
+                confidence="low",
+            ),
+        },
+        theme_keywords=[
+            "gpt", "claude", "gemini", "grok", "llama", "mistral", "qwen", "deepseek",
+            "agent", "mcp", "reasoning", "inference", "fine-tun", "open-weight", "open weight",
+            "benchmark", "multimodal", "context window", "rag", "embedding", "nvidia", "gpu",
+            "safety", "alignment", "training", "tokens", "open source",
+        ],
+    ),
+    "fascinating_frontiers": MemoryConfig(
+        slug="fascinating_frontiers",
+        label="FASCINATING FRONTIERS",
+        file_prefix="fascinating_frontiers",
+        default_programs={
+            "starship_mars": _prog(
+                "Starship & Mars",
+                "SpaceX Starship development and the long path toward Mars.",
+                ["Orbital refueling + rapid reuse cadence", "Crewed Mars timeline"],
+                confidence="low-medium",
+            ),
+            "artemis_moon": _prog(
+                "Artemis & the Moon",
+                "NASA Artemis and the crewed return to the Moon.",
+                ["Crewed landing schedule", "Lander + Gateway readiness"],
+            ),
+            "jwst_exoplanets": _prog(
+                "JWST & Exoplanets",
+                "JWST observations and exoplanet / atmosphere characterization.",
+                ["Biosignature detection prospects", "Early-universe galaxy findings"],
+            ),
+            "commercial_spaceflight": _prog(
+                "Commercial Spaceflight",
+                "Commercial LEO, constellations, and private crewed flight.",
+                ["Commercial station succession to ISS", "Launch cadence + cost"],
+            ),
+            "deep_space_probes": _prog(
+                "Robotic Exploration",
+                "Robotic exploration: Mars rovers, sample return, and outer-planet missions.",
+                ["Mars Sample Return path", "Ocean-world (Europa/Enceladus) findings"],
+            ),
+            "cosmology_astrophysics": _prog(
+                "Cosmology & Astrophysics",
+                "Cosmology, black holes, gravitational waves, and dark matter/energy.",
+                ["Hubble-tension resolution", "Dark matter / energy constraints"],
+                confidence="low",
+            ),
+        },
+        theme_keywords=[
+            "starship", "spacex", "mars", "artemis", "moon", "lunar", "nasa", "jwst", "webb",
+            "exoplanet", "telescope", "rocket", "launch", "orbit", "satellite", "rover",
+            "asteroid", "comet", "black hole", "galaxy", "gravitational wave", "dark matter",
+            "dark energy", "cosmolog", "probe", "mission", "astronaut", "neutron star",
+        ],
+    ),
+    "planetterrian": MemoryConfig(
+        slug="planetterrian",
+        label="PLANETTERRIAN",
+        file_prefix="planetterrian",
+        default_programs={
+            "aging_biology": _prog(
+                "Aging & Longevity Biology",
+                "Cellular aging, senescence, and interventions that target the biology of aging.",
+                ["Which interventions translate to humans", "Reliable aging biomarkers"],
+                confidence="low-medium",
+            ),
+            "neuroscience_brain": _prog(
+                "Neuroscience & the Brain",
+                "Cognition, brain aging, and neurodegeneration.",
+                ["Alzheimer's mechanism + therapy progress", "How reversible is brain aging"],
+            ),
+            "microbiome": _prog(
+                "Microbiome",
+                "The gut microbiome and its links to health and disease.",
+                ["Causation vs correlation", "Therapeutic microbiome modulation"],
+                confidence="low",
+            ),
+            "regenerative_medicine": _prog(
+                "Regenerative Medicine",
+                "Stem cells, cellular reprogramming, and tissue regeneration.",
+                ["Partial-reprogramming safety", "Organ/tissue regeneration timelines"],
+                confidence="low",
+            ),
+            "sleep_metabolic": _prog(
+                "Sleep, Circadian & Metabolic Health",
+                "Sleep, circadian biology, and metabolic health.",
+                ["Sleep's causal role in aging/disease", "Circadian interventions that work"],
+            ),
+            "genetics_genomics": _prog(
+                "Genetics & Genomics",
+                "Genetics, gene editing, and the genomics of health.",
+                ["In-vivo gene-editing safety/efficacy", "Polygenic risk in practice"],
+            ),
+        },
+        theme_keywords=[
+            "aging", "longevity", "senescen", "senolytic", "neuroscience", "brain", "cogniti",
+            "alzheimer", "neurodegenerat", "microbiome", "gut", "stem cell", "reprogramming",
+            "regenerat", "sleep", "circadian", "metabolic", "genetic", "genom", "gene editing",
+            "crispr", "epigenetic", "mitochond", "inflammation", "nutrition", "clinical trial",
+        ],
+    ),
+}
+

--- a/engine/weekly_recap.py
+++ b/engine/weekly_recap.py
@@ -160,4 +160,25 @@ def build_weekly_recap_digest(
         except Exception:
             pass
 
+    # Phase 3: same narrative framing for the generalized memory shows
+    # (Models & Agents, Fascinating Frontiers, Planetterrian). Best-effort.
+    else:
+        try:
+            from pathlib import Path as _Path
+            from engine import show_memory
+            mcfg = show_memory.get_config(show_slug)
+            if mcfg is not None:
+                tracker = show_memory.load_narrative_tracker(
+                    _Path("digests") / show_slug, mcfg
+                )
+                narrative_block = show_memory.build_narrative_status_block(tracker, mcfg.label)
+                if narrative_block:
+                    recap += (
+                        "\n\n" + narrative_block +
+                        "\n\nUse the narrative status above to highlight meaningful "
+                        "progress or open questions across the week."
+                    )
+        except Exception:
+            pass
+
     return recap

--- a/fascinating-frontiers-narrative.html
+++ b/fascinating-frontiers-narrative.html
@@ -1,0 +1,823 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="The ongoing storylines Fascinating Frontiers tracks over time — current status, key open questions, and real progress across episodes.">
+    
+    
+    <title>Fascinating Frontiers — Narrative Tracker | Nerra Network</title>
+    
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Fascinating Frontiers — Narrative Tracker | Nerra Network">
+    <meta property="og:description" content="The ongoing storylines Fascinating Frontiers tracks over time — current status, key open questions, and real progress across episodes.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="assets/covers/fascinating-frontiers.jpg">
+    
+    <meta property="og:site_name" content="Nerra Network">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Fascinating Frontiers — Narrative Tracker | Nerra Network">
+    <meta name="twitter:description" content="The ongoing storylines Fascinating Frontiers tracks over time — current status, key open questions, and real progress across episodes.">
+    <meta name="twitter:image" content="assets/covers/fascinating-frontiers.jpg">
+
+    
+    
+    
+    
+
+    <!-- Google Fonts: DM Sans + Source Serif 4 -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&display=swap" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%236B47FF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/></svg>">
+
+    
+    
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
+    
+    
+    <script defer src="assets/js/tracking.js"></script>
+
+    <!-- Shared CSS -->
+    <link rel="stylesheet" href="styles/main.css">
+
+    
+
+    
+    <style>
+        @media (max-width: 768px) {
+            .nn-footer-grid { grid-template-columns: 1fr; }
+            .nn-footer-col h4 {
+                cursor: pointer;
+                position: relative;
+                padding-right: 1.5rem;
+            }
+            .nn-footer-col h4::after {
+                content: '+';
+                position: absolute;
+                right: 0;
+                font-size: 1.2rem;
+                color: var(--nn-text-muted);
+            }
+            .nn-footer-col.expanded h4::after { content: '\2212'; }
+            .nn-footer-col > a,
+            .nn-footer-col > ul { display: none; }
+            .nn-footer-col.expanded > a,
+            .nn-footer-col.expanded > ul { display: block; }
+        }
+    </style>
+</head>
+<body><a href="#main-content" class="skip-link">Skip to content</a>
+    <!-- Navigation -->
+    <nav class="nn-nav" aria-label="Main navigation">
+        <div class="nn-nav-inner">
+            <a href="index.html" class="nn-nav-logo">
+                <img src="assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
+                <span class="gradient-text">Nerra</span> Network
+            </a>
+
+            
+            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.5rem;max-width:180px;flex:1 1 auto;min-width:120px;">
+                <input type="search" id="nn-global-search-input"
+                       placeholder="Search…"
+                       style="width:100%;padding:6px 8px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.85rem;"
+                       aria-label="Search all episodes across the network">
+                <div id="nn-global-search-results"
+                     style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:340px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
+            </div>
+
+            <ul class="nn-nav-links">
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Shows
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu" role="menu">
+                        
+                        <a href="models-agents.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents
+                        </a>
+                        
+                        <a href="planetterrian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily
+                        </a>
+                        
+                        <a href="omni-view.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View
+                        </a>
+                        
+                        <a href="models-agents-beginners.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners
+                        </a>
+                        
+                        <a href="fascinating-frontiers.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers
+                        </a>
+                        
+                        <a href="modern-investing.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques
+                        </a>
+                        
+                        <a href="tesla.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time
+                        </a>
+                        
+                        <a href="env-intel.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence
+                        </a>
+                        
+                        <a href="ru/finansy-prosto.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто
+                        </a>
+                        
+                        <a href="ru/privet-russian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский!
+                        </a>
+                        
+                        <a href="unintended-consequences.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences
+                        </a>
+                        
+                    </div>
+                </li>
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Blog
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu">
+                        <a href="blog/index.html" style="font-weight:600;border-bottom:1px solid var(--nn-border);padding-bottom:8px;margin-bottom:4px">
+                            All Blog Posts
+                        </a>
+                        
+                        <a href="blog/models_agents/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents Blog
+                        </a>
+                        
+                        <a href="blog/planetterrian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily Blog
+                        </a>
+                        
+                        <a href="blog/omni_view/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View Blog
+                        </a>
+                        
+                        <a href="blog/models_agents_beginners/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners Blog
+                        </a>
+                        
+                        <a href="blog/fascinating_frontiers/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers Blog
+                        </a>
+                        
+                        <a href="blog/modern_investing/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques Blog
+                        </a>
+                        
+                        <a href="blog/tesla/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time Blog
+                        </a>
+                        
+                        <a href="blog/env_intel/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence Blog
+                        </a>
+                        
+                        <a href="blog/finansy_prosto/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто Blog
+                        </a>
+                        
+                        <a href="blog/privet_russian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский! Blog
+                        </a>
+                        
+                        <a href="blog/unintended_consequences/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences Blog
+                        </a>
+                        
+                    </div>
+                </li>
+                
+                <li><a href="start-here.html">Start Here</a></li>
+                <li><a href="how-to-listen.html">Listen</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="player.html">Player</a></li>
+                <li><a href="index.html">Home</a></li>
+                
+            </ul>
+
+            <button class="nn-hamburger" aria-label="Toggle menu" aria-expanded="false" onclick="var m=document.getElementById('mobileMenu');m.classList.toggle('open');this.setAttribute('aria-expanded',m.classList.contains('open'));document.body.classList.toggle('menu-open')">&#9776;</button>
+        </div>
+    </nav>
+
+    <!-- Mobile Menu -->
+    <div id="mobileMenu" class="nn-mobile-menu">
+        
+        <a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Start Here</a>
+        <a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">How to Listen</a>
+        <a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">About</a>
+        <a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Player</a>
+        <a href="index.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Home</a>
+        
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">All Shows</div>
+            
+            <a href="models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents
+            </a>
+            
+            <a href="planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily
+            </a>
+            
+            <a href="omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View
+            </a>
+            
+            <a href="models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners
+            </a>
+            
+            <a href="fascinating-frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers
+            </a>
+            
+            <a href="modern-investing.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques
+            </a>
+            
+            <a href="tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time
+            </a>
+            
+            <a href="env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence
+            </a>
+            
+            <a href="ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто
+            </a>
+            
+            <a href="ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский!
+            </a>
+            
+            <a href="unintended-consequences.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences
+            </a>
+            
+        </div>
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">Blogs</div>
+            <a href="blog/index.html" class="nn-mobile-show-link" style="font-weight:600" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                All Blog Posts
+            </a>
+            
+            <a href="blog/models_agents/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents Blog
+            </a>
+            
+            <a href="blog/planetterrian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily Blog
+            </a>
+            
+            <a href="blog/omni_view/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View Blog
+            </a>
+            
+            <a href="blog/models_agents_beginners/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners Blog
+            </a>
+            
+            <a href="blog/fascinating_frontiers/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers Blog
+            </a>
+            
+            <a href="blog/modern_investing/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques Blog
+            </a>
+            
+            <a href="blog/tesla/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time Blog
+            </a>
+            
+            <a href="blog/env_intel/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence Blog
+            </a>
+            
+            <a href="blog/finansy_prosto/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто Blog
+            </a>
+            
+            <a href="blog/privet_russian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский! Blog
+            </a>
+            
+            <a href="blog/unintended_consequences/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences Blog
+            </a>
+            
+        </div>
+    </div>
+
+    <main id="main-content">
+    
+<div class="container" style="max-width: 1100px; padding: calc(var(--nav-height) + var(--sp-12)) 0 var(--sp-8);">
+  <style>
+    @media (max-width: 640px) {
+      .glass-card { padding: 14px !important; }
+      .program-card { padding: 14px !important; }
+    }
+    .program-card {
+      background: var(--nn-surface);
+      border: 1px solid var(--nn-border);
+      border-radius: 12px;
+      padding: 18px;
+      margin-bottom: var(--sp-5);
+    }
+    .program-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      margin-bottom: 8px;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .status-text { line-height: 1.5; margin-bottom: 10px; }
+    .meta-row { font-size: 0.85rem; color: var(--nn-text-muted); }
+  </style>
+
+  <div style="margin-bottom: var(--sp-8);">
+    <h1 style="font-size: 2.3rem; margin-bottom: 0.3rem;">Fascinating Frontiers — Narrative Tracker</h1>
+    <p style="font-size: 1.1rem; color: var(--nn-text-muted); max-width: 820px;">
+      Fascinating Frontiers maintains a living memory of the major ongoing storylines in its field — so
+      regular listeners get continuity, not just isolated daily headlines. This page shows the current
+      status of each tracked program, the last time we covered it in depth, and the key open questions
+      we're following.
+    </p>
+    <p style="font-size: 0.85rem; color: var(--nn-text-muted); margin-top: 0.4rem;">
+      Updated as episodes ship. Source: <code>digests/fascinating_frontiers/fascinating_frontiers_narrative_tracker.json</code>
+    </p>
+  </div>
+
+  
+    <div class="glass-card" style="padding: var(--sp-6); margin-bottom: var(--sp-8);">
+      <h2 style="margin-top:0; margin-bottom: var(--sp-5);">Tracked Programs</h2>
+
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Starship & Mars</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">SpaceX Starship development and the long path toward Mars.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Orbital refueling + rapid reuse cadence</li>
+                
+                  <li>Crewed Mars timeline</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>low-medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Artemis & the Moon</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">NASA Artemis and the crewed return to the Moon.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Crewed landing schedule</li>
+                
+                  <li>Lander + Gateway readiness</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">JWST & Exoplanets</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">JWST observations and exoplanet / atmosphere characterization.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Biosignature detection prospects</li>
+                
+                  <li>Early-universe galaxy findings</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Commercial Spaceflight</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">Commercial LEO, constellations, and private crewed flight.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Commercial station succession to ISS</li>
+                
+                  <li>Launch cadence + cost</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Robotic Exploration</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">Robotic exploration: Mars rovers, sample return, and outer-planet missions.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Mars Sample Return path</li>
+                
+                  <li>Ocean-world (Europa/Enceladus) findings</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Cosmology & Astrophysics</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">Cosmology, black holes, gravitational waves, and dark matter/energy.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Hubble-tension resolution</li>
+                
+                  <li>Dark matter / energy constraints</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>low</strong>
+            </div>
+          
+
+          
+        </div>
+      
+    </div>
+  
+
+  <div style="margin-top: var(--sp-8); font-size:0.85rem; color:var(--nn-text-muted); line-height:1.5;">
+    <p>
+      This is part of Fascinating Frontiers's long-term memory system (narrative tracking + theme mining from
+      our own episodes). The goal is for the show to become a genuinely useful running chronicle of its
+      field, not a stream of disposable daily recaps.
+    </p>
+    
+    <p style="margin-top:12px;">
+      Want to suggest an update to any program status? Reach out on X at
+      <a href="https://x.com/planetterrian" target="_blank" rel="noopener">@planetterrian</a>.
+    </p>
+    
+  </div>
+</div>
+
+    </main>
+
+    <!-- Footer -->
+    <footer class="nn-footer">
+        <div class="container">
+            <div class="nn-footer-grid">
+                <div>
+                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
+                    <p class="nn-footer-desc">Eleven shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Shows</h4>
+                    
+                    <a href="models-agents.html">Models & Agents</a>
+                    
+                    <a href="planetterrian.html">Planetterrian Daily</a>
+                    
+                    <a href="omni-view.html">Omni View</a>
+                    
+                    <a href="models-agents-beginners.html">Models & Agents for Beginners</a>
+                    
+                    <a href="fascinating-frontiers.html">Fascinating Frontiers</a>
+                    
+                    <a href="modern-investing.html">Modern Investing Techniques</a>
+                    
+                    <a href="tesla.html">Tesla Shorts Time</a>
+                    
+                    <a href="env-intel.html">Environmental Intelligence</a>
+                    
+                    <a href="ru/finansy-prosto.html">Финансы Просто</a>
+                    
+                    <a href="ru/privet-russian.html">Привет, Русский!</a>
+                    
+                    <a href="unintended-consequences.html">Unintended Consequences</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Blog</h4>
+                    <a href="blog/index.html">All Blog Posts</a>
+                    
+                    <a href="blog/models_agents/index.html">Models & Agents</a>
+                    
+                    <a href="blog/planetterrian/index.html">Planetterrian Daily</a>
+                    
+                    <a href="blog/omni_view/index.html">Omni View</a>
+                    
+                    <a href="blog/models_agents_beginners/index.html">Models & Agents for Beginners</a>
+                    
+                    <a href="blog/fascinating_frontiers/index.html">Fascinating Frontiers</a>
+                    
+                    <a href="blog/modern_investing/index.html">Modern Investing Techniques</a>
+                    
+                    <a href="blog/tesla/index.html">Tesla Shorts Time</a>
+                    
+                    <a href="blog/env_intel/index.html">Environmental Intelligence</a>
+                    
+                    <a href="blog/finansy_prosto/index.html">Финансы Просто</a>
+                    
+                    <a href="blog/privet_russian/index.html">Привет, Русский!</a>
+                    
+                    <a href="blog/unintended_consequences/index.html">Unintended Consequences</a>
+                    
+                    <a href="blog.rss">Blog RSS (All Shows)</a>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Listen</h4>
+                    <a href="how-to-listen.html" style="font-weight:600">How to Listen</a>
+                    <a href="player.html" style="font-weight:600">Network Player</a>
+                    <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939?utm_source=nerranetwork&utm_medium=footer&utm_campaign=tesla" target="_blank" rel="noopener" data-show="tesla">Apple Podcasts</a>
+                    <a href="network.rss">Network RSS</a>
+                    
+                    <a href="models_agents_podcast.rss">Models & Agents RSS</a>
+                    
+                    <a href="planetterrian_podcast.rss">Planetterrian Daily RSS</a>
+                    
+                    <a href="omni_view_podcast.rss">Omni View RSS</a>
+                    
+                    <a href="models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
+                    
+                    <a href="fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
+                    
+                    <a href="modern_investing_podcast.rss">Modern Investing Techniques RSS</a>
+                    
+                    <a href="podcast.rss">Tesla Shorts Time RSS</a>
+                    
+                    <a href="env_intel_podcast.rss">Environmental Intelligence RSS</a>
+                    
+                    <a href="finansy_prosto_podcast.rss">Финансы Просто RSS</a>
+                    
+                    <a href="privet_russian_podcast.rss">Привет, Русский! RSS</a>
+                    
+                    <a href="unintended_consequences_podcast.rss">Unintended Consequences RSS</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Connect</h4>
+                    <a href="https://x.com/teslashortstime" target="_blank" rel="noopener">@teslashortstime</a>
+                    <a href="https://x.com/omniviewnews" target="_blank" rel="noopener">@omniviewnews</a>
+                    <a href="https://x.com/planetterrian" target="_blank" rel="noopener">@planetterrian</a>
+                </div>
+            </div>
+            <div class="nn-footer-col">
+                <h4>About</h4>
+                <a href="about.html">About Nerra Network</a>
+                <a href="start-here.html">Start Here</a>
+                <a href="how-to-listen.html">How to Listen</a>
+                <a href="faq.html">FAQ</a>
+                <a href="contact.html">Contact</a>
+                <a href="press.html">Press Kit</a>
+                <a href="privacy-policy.html">Privacy Policy</a>
+                <a href="terms-of-service.html">Terms of Service</a>
+                <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="editorial.html">Editorial Process</a>
+                <a href="management.html">Network Status</a>
+            </div>
+            <!-- Newsletter Subscribe -->
+            <div class="nn-footer-subscribe">
+                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                    <h4>Get Show Updates</h4>
+                    <p>Pick the shows you want in your inbox:</p>
+                    <div class="nn-subscribe-tags"><label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                        <label><input type="checkbox" name="tag" value="Omni View"> Omni View</label>
+                        <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
+                        <label><input type="checkbox" name="tag" value="Planetterrian Daily"> Planetterrian Daily</label>
+                        <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents"> Models &amp; Agents</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models &amp; Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
+                        <label><input type="checkbox" name="tag" value="Unintended Consequences"> Unintended Consequences</label><label><input type="checkbox" name="tag" value="Finansy Prosto"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Privet Russian"> Привет, Русский!</label>
+                    </div>
+                    <div class="nn-subscribe-row">
+                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="hidden" value="1" name="embed">
+                        <button type="submit">Subscribe</button>
+                    </div>
+                </form>
+            </div>
+            <div class="nn-footer-bottom">
+                <span>© 2026 Nerra Network. All shows independently produced.</span>
+                <a href="index.html">nerranetwork.com</a>
+            </div>
+            <div class="nn-footer-legal">
+                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
+                <div>
+                    <a href="privacy-policy.html">Privacy</a> &middot;
+                    <a href="terms-of-service.html">Terms</a> &middot;
+                    <a href="ai-disclosure.html">AI Disclosure</a>
+                    <span style="opacity:0.5;">&middot;</span>
+                    <span style="font-size:0.7rem;opacity:0.6;">Automation: reliable nightly + post-publish pipeline</span>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    // Toggle aria-expanded on dropdown hover/focus
+    document.querySelectorAll('.nn-nav-dropdown').forEach(function(dd) {
+        var btn = dd.querySelector('.nn-nav-dropdown-btn');
+        if (!btn) return;
+        dd.addEventListener('mouseenter', function() { btn.setAttribute('aria-expanded', 'true'); });
+        dd.addEventListener('mouseleave', function() { btn.setAttribute('aria-expanded', 'false'); });
+        btn.addEventListener('focus', function() { btn.setAttribute('aria-expanded', 'true'); });
+        btn.addEventListener('blur', function() {
+            setTimeout(function() {
+                if (!dd.contains(document.activeElement)) btn.setAttribute('aria-expanded', 'false');
+            }, 100);
+        });
+    });
+    // Mobile footer accordions
+    if (window.innerWidth <= 768) {
+        document.querySelectorAll('.nn-footer-col h4').forEach(function(h4) {
+            h4.addEventListener('click', function() {
+                h4.parentElement.classList.toggle('expanded');
+            });
+        });
+    }
+    </script>
+    
+
+    <!-- Centralized, improved global search -->
+    <script src="assets/js/search.js" defer></script>
+</body>
+</html>

--- a/generate_html.py
+++ b/generate_html.py
@@ -1612,6 +1612,86 @@ def generate_tesla_narrative_page(*, dry_run=False):
     return out_path
 
 
+def _load_narrative_data(slug):
+    """Load a memory-enabled show's narrative tracker for its public page."""
+    import json
+    from engine import show_memory
+    mcfg = show_memory.get_config(slug)
+    if mcfg is None:
+        return None
+    tracker_path = ROOT / "digests" / slug / mcfg.narrative_filename
+    if not tracker_path.exists():
+        return None
+    try:
+        data = json.loads(tracker_path.read_text(encoding="utf-8"))
+        return {
+            "available": True,
+            "programs": data.get("programs", {}),
+            "last_updated": data.get("last_updated", ""),
+        }
+    except Exception:
+        return None
+
+
+def generate_narrative_page(slug, *, dry_run=False):
+    """Generate the public Narrative Tracker page for a memory-enabled show.
+
+    Generic counterpart to generate_tesla_narrative_page (Tesla keeps its own,
+    richer page). No-ops cleanly when the show has no memory config or no
+    committed tracker yet.
+    """
+    from engine import show_memory
+    cfg = NETWORK_SHOWS.get(slug)
+    mcfg = show_memory.get_config(slug)
+    if cfg is None or mcfg is None:
+        return None
+    narrative_data = _load_narrative_data(slug)
+    if not narrative_data:
+        return None
+
+    env = _get_jinja_env()
+    template = env.get_template("narrative_page.html.j2")
+    context = {
+        "narrative": narrative_data,
+        "show_name": cfg["name"],
+        "show_slug": slug,
+        "x_account": cfg.get("x_account") or "",
+        "brand_color": cfg.get("brand_color", ""),
+        "source_path": f"digests/{slug}/{mcfg.narrative_filename}",
+        "page_title": f"{cfg['name']} — Narrative Tracker | Nerra Network",
+        "meta_description": (
+            f"The ongoing storylines {cfg['name']} tracks over time — current status, "
+            "key open questions, and real progress across episodes."
+        ),
+        "og_image": cfg.get("podcast_image", ""),
+        "path_prefix": "",
+        "is_russian": False,
+        "t": {
+            "nav_shows": "Shows", "nav_blog": "Blog", "all_blog_posts": "All Blog Posts",
+            "show_blog_suffix": "Blog", "nav_start_here": "Start Here", "nav_listen": "How to Listen",
+            "nav_about": "About", "nav_player": "Player", "nav_home": "Home",
+            "footer_network_status": "Network Status",
+        },
+        "all_shows": _build_all_shows_list(),
+    }
+    html = template.render(**context)
+    out_path = ROOT / cfg["show_page"].replace(".html", "-narrative.html")
+    if dry_run:
+        print(f"[dry-run] Would write {out_path}")
+        return out_path
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
+    print(f"Wrote narrative page: {out_path}")
+    return out_path
+
+
+def generate_all_narrative_pages(*, dry_run=False):
+    """Generate narrative pages for every memory-configured show (except Tesla,
+    which has its own dedicated generator)."""
+    from engine import show_memory
+    for slug in show_memory.SHOW_MEMORY_CONFIGS:
+        generate_narrative_page(slug, dry_run=dry_run)
+
+
 def generate_show_page(slug, *, dry_run=False):
     """Render and write a show page for a single show."""
     cfg = NETWORK_SHOWS[slug]
@@ -1771,8 +1851,19 @@ def generate_show_page(slug, *, dry_run=False):
         page_title = f"{cfg['name']} — {hook_snippet} | Nerra Network"
         meta_description = f"Latest: {latest_episode_title}. {cfg.get('meta_description', '')}".strip()
 
+    # Phase 3: link to the show's public narrative tracker page when it has one
+    # (Tesla has a dedicated page; other shows use the generic generator).
+    from engine import show_memory as _sm
+    if slug == "tesla":
+        narrative_page_url = "tesla-narrative.html"
+    elif _sm.get_config(slug) is not None:
+        narrative_page_url = cfg["show_page"].replace(".html", "-narrative.html")
+    else:
+        narrative_page_url = ""
+
     context = {
         **cfg,
+        "narrative_page_url": narrative_page_url,
         "path_prefix": prefix,
         "show_name": cfg["name"],
         "show_slug": cfg["slug"],
@@ -1841,6 +1932,13 @@ def generate_all_show_pages(*, dry_run=False):
         tesla_narrative = generate_tesla_narrative_page(dry_run=dry_run)
         if tesla_narrative:
             paths.append(tesla_narrative)
+
+    # Phase 3: narrative pages for the other memory-enabled shows.
+    from engine import show_memory
+    for slug in show_memory.SHOW_MEMORY_CONFIGS:
+        result = generate_narrative_page(slug, dry_run=dry_run)
+        if result:
+            paths.append(result)
 
     return paths
 
@@ -2265,6 +2363,7 @@ def generate_sitemap(*, dry_run=False):
     from xml.sax.saxutils import escape as _esc
     import os
     from datetime import datetime, timezone
+    from engine.show_memory import get_config as _sm_get_config
 
     base = "https://nerranetwork.com"
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
@@ -2300,6 +2399,13 @@ def generate_sitemap(*, dry_run=False):
                      _lm_or_today(cfg["summaries_page"])))
         urls.append((f"{base}/blog/{slug}/index.html", "0.7",
                      _lm_or_today(f"blog/{slug}/index.html")))
+        # Public narrative tracker page (Tesla + Phase 3 memory shows), when present.
+        _narr = "tesla-narrative.html" if slug == "tesla" else (
+            cfg["show_page"].replace(".html", "-narrative.html")
+            if _sm_get_config(slug) else None
+        )
+        if _narr and (ROOT / _narr).exists():
+            urls.append((f"{base}/{_narr}", "0.6", _lm_or_today(_narr)))
 
     # Network blog hub
     urls.append((f"{base}/blog/index.html", "0.7",
@@ -2817,6 +2923,8 @@ def main():
         # Tesla Narrative page
         if args.show == "tesla":
             generate_tesla_narrative_page(dry_run=args.dry_run)
+        # Phase 3 narrative page for other memory-enabled shows (no-op otherwise)
+        generate_narrative_page(args.show, dry_run=args.dry_run)
         if args.blogs:
             generate_blog_posts(args.show, dry_run=args.dry_run)
             generate_blog_index(args.show, dry_run=args.dry_run)

--- a/models-agents-narrative.html
+++ b/models-agents-narrative.html
@@ -1,0 +1,818 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="The ongoing storylines Models & Agents tracks over time — current status, key open questions, and real progress across episodes.">
+    
+    
+    <title>Models & Agents — Narrative Tracker | Nerra Network</title>
+    
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Models & Agents — Narrative Tracker | Nerra Network">
+    <meta property="og:description" content="The ongoing storylines Models & Agents tracks over time — current status, key open questions, and real progress across episodes.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="assets/covers/models-agents.jpg">
+    
+    <meta property="og:site_name" content="Nerra Network">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Models & Agents — Narrative Tracker | Nerra Network">
+    <meta name="twitter:description" content="The ongoing storylines Models & Agents tracks over time — current status, key open questions, and real progress across episodes.">
+    <meta name="twitter:image" content="assets/covers/models-agents.jpg">
+
+    
+    
+    
+    
+
+    <!-- Google Fonts: DM Sans + Source Serif 4 -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&display=swap" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%236B47FF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/></svg>">
+
+    
+    
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
+    
+    
+    <script defer src="assets/js/tracking.js"></script>
+
+    <!-- Shared CSS -->
+    <link rel="stylesheet" href="styles/main.css">
+
+    
+
+    
+    <style>
+        @media (max-width: 768px) {
+            .nn-footer-grid { grid-template-columns: 1fr; }
+            .nn-footer-col h4 {
+                cursor: pointer;
+                position: relative;
+                padding-right: 1.5rem;
+            }
+            .nn-footer-col h4::after {
+                content: '+';
+                position: absolute;
+                right: 0;
+                font-size: 1.2rem;
+                color: var(--nn-text-muted);
+            }
+            .nn-footer-col.expanded h4::after { content: '\2212'; }
+            .nn-footer-col > a,
+            .nn-footer-col > ul { display: none; }
+            .nn-footer-col.expanded > a,
+            .nn-footer-col.expanded > ul { display: block; }
+        }
+    </style>
+</head>
+<body><a href="#main-content" class="skip-link">Skip to content</a>
+    <!-- Navigation -->
+    <nav class="nn-nav" aria-label="Main navigation">
+        <div class="nn-nav-inner">
+            <a href="index.html" class="nn-nav-logo">
+                <img src="assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
+                <span class="gradient-text">Nerra</span> Network
+            </a>
+
+            
+            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.5rem;max-width:180px;flex:1 1 auto;min-width:120px;">
+                <input type="search" id="nn-global-search-input"
+                       placeholder="Search…"
+                       style="width:100%;padding:6px 8px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.85rem;"
+                       aria-label="Search all episodes across the network">
+                <div id="nn-global-search-results"
+                     style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:340px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
+            </div>
+
+            <ul class="nn-nav-links">
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Shows
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu" role="menu">
+                        
+                        <a href="models-agents.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents
+                        </a>
+                        
+                        <a href="planetterrian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily
+                        </a>
+                        
+                        <a href="omni-view.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View
+                        </a>
+                        
+                        <a href="models-agents-beginners.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners
+                        </a>
+                        
+                        <a href="fascinating-frontiers.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers
+                        </a>
+                        
+                        <a href="modern-investing.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques
+                        </a>
+                        
+                        <a href="tesla.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time
+                        </a>
+                        
+                        <a href="env-intel.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence
+                        </a>
+                        
+                        <a href="ru/finansy-prosto.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто
+                        </a>
+                        
+                        <a href="ru/privet-russian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский!
+                        </a>
+                        
+                        <a href="unintended-consequences.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences
+                        </a>
+                        
+                    </div>
+                </li>
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Blog
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu">
+                        <a href="blog/index.html" style="font-weight:600;border-bottom:1px solid var(--nn-border);padding-bottom:8px;margin-bottom:4px">
+                            All Blog Posts
+                        </a>
+                        
+                        <a href="blog/models_agents/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents Blog
+                        </a>
+                        
+                        <a href="blog/planetterrian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily Blog
+                        </a>
+                        
+                        <a href="blog/omni_view/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View Blog
+                        </a>
+                        
+                        <a href="blog/models_agents_beginners/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners Blog
+                        </a>
+                        
+                        <a href="blog/fascinating_frontiers/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers Blog
+                        </a>
+                        
+                        <a href="blog/modern_investing/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques Blog
+                        </a>
+                        
+                        <a href="blog/tesla/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time Blog
+                        </a>
+                        
+                        <a href="blog/env_intel/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence Blog
+                        </a>
+                        
+                        <a href="blog/finansy_prosto/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто Blog
+                        </a>
+                        
+                        <a href="blog/privet_russian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский! Blog
+                        </a>
+                        
+                        <a href="blog/unintended_consequences/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences Blog
+                        </a>
+                        
+                    </div>
+                </li>
+                
+                <li><a href="start-here.html">Start Here</a></li>
+                <li><a href="how-to-listen.html">Listen</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="player.html">Player</a></li>
+                <li><a href="index.html">Home</a></li>
+                
+            </ul>
+
+            <button class="nn-hamburger" aria-label="Toggle menu" aria-expanded="false" onclick="var m=document.getElementById('mobileMenu');m.classList.toggle('open');this.setAttribute('aria-expanded',m.classList.contains('open'));document.body.classList.toggle('menu-open')">&#9776;</button>
+        </div>
+    </nav>
+
+    <!-- Mobile Menu -->
+    <div id="mobileMenu" class="nn-mobile-menu">
+        
+        <a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Start Here</a>
+        <a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">How to Listen</a>
+        <a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">About</a>
+        <a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Player</a>
+        <a href="index.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Home</a>
+        
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">All Shows</div>
+            
+            <a href="models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents
+            </a>
+            
+            <a href="planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily
+            </a>
+            
+            <a href="omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View
+            </a>
+            
+            <a href="models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners
+            </a>
+            
+            <a href="fascinating-frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers
+            </a>
+            
+            <a href="modern-investing.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques
+            </a>
+            
+            <a href="tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time
+            </a>
+            
+            <a href="env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence
+            </a>
+            
+            <a href="ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто
+            </a>
+            
+            <a href="ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский!
+            </a>
+            
+            <a href="unintended-consequences.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences
+            </a>
+            
+        </div>
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">Blogs</div>
+            <a href="blog/index.html" class="nn-mobile-show-link" style="font-weight:600" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                All Blog Posts
+            </a>
+            
+            <a href="blog/models_agents/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents Blog
+            </a>
+            
+            <a href="blog/planetterrian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily Blog
+            </a>
+            
+            <a href="blog/omni_view/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View Blog
+            </a>
+            
+            <a href="blog/models_agents_beginners/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners Blog
+            </a>
+            
+            <a href="blog/fascinating_frontiers/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers Blog
+            </a>
+            
+            <a href="blog/modern_investing/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques Blog
+            </a>
+            
+            <a href="blog/tesla/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time Blog
+            </a>
+            
+            <a href="blog/env_intel/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence Blog
+            </a>
+            
+            <a href="blog/finansy_prosto/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто Blog
+            </a>
+            
+            <a href="blog/privet_russian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский! Blog
+            </a>
+            
+            <a href="blog/unintended_consequences/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences Blog
+            </a>
+            
+        </div>
+    </div>
+
+    <main id="main-content">
+    
+<div class="container" style="max-width: 1100px; padding: calc(var(--nav-height) + var(--sp-12)) 0 var(--sp-8);">
+  <style>
+    @media (max-width: 640px) {
+      .glass-card { padding: 14px !important; }
+      .program-card { padding: 14px !important; }
+    }
+    .program-card {
+      background: var(--nn-surface);
+      border: 1px solid var(--nn-border);
+      border-radius: 12px;
+      padding: 18px;
+      margin-bottom: var(--sp-5);
+    }
+    .program-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      margin-bottom: 8px;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .status-text { line-height: 1.5; margin-bottom: 10px; }
+    .meta-row { font-size: 0.85rem; color: var(--nn-text-muted); }
+  </style>
+
+  <div style="margin-bottom: var(--sp-8);">
+    <h1 style="font-size: 2.3rem; margin-bottom: 0.3rem;">Models & Agents — Narrative Tracker</h1>
+    <p style="font-size: 1.1rem; color: var(--nn-text-muted); max-width: 820px;">
+      Models & Agents maintains a living memory of the major ongoing storylines in its field — so
+      regular listeners get continuity, not just isolated daily headlines. This page shows the current
+      status of each tracked program, the last time we covered it in depth, and the key open questions
+      we're following.
+    </p>
+    <p style="font-size: 0.85rem; color: var(--nn-text-muted); margin-top: 0.4rem;">
+      Updated as episodes ship. Source: <code>digests/models_agents/models_agents_narrative_tracker.json</code>
+    </p>
+  </div>
+
+  
+    <div class="glass-card" style="padding: var(--sp-6); margin-bottom: var(--sp-8);">
+      <h2 style="margin-top:0; margin-bottom: var(--sp-5);">Tracked Programs</h2>
+
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Frontier Models</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">Closed frontier models (GPT, Claude, Gemini, Grok) trading capability and price leads.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Next frontier release cadence</li>
+                
+                  <li>Capability gains vs cost trajectory</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Open-Weight Models</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">Open-weight families (Llama, Mistral, Qwen, DeepSeek, Gemma) narrowing the gap with closed frontier.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Open vs closed performance gap</li>
+                
+                  <li>Licensing / commercial terms</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Agents & Tool Use</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">Autonomous agents, tool use, and the MCP / interoperability layer maturing.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Reliability of long-horizon agents</li>
+                
+                  <li>Standardization of agent/tool protocols</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>low-medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Reasoning Models</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">Reasoning / 'thinking' models and test-time compute.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Reasoning cost vs benefit</li>
+                
+                  <li>Benchmark gains vs real-world value</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">AI Compute & Inference</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">AI hardware and inference economics (NVIDIA, custom silicon, falling token costs).</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Inference cost curve</li>
+                
+                  <li>Compute supply constraints</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Safety & Policy</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">AI safety, evaluation, and regulation.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>US/EU regulatory trajectory</li>
+                
+                  <li>Evaluation / safety standardization</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>low</strong>
+            </div>
+          
+
+          
+        </div>
+      
+    </div>
+  
+
+  <div style="margin-top: var(--sp-8); font-size:0.85rem; color:var(--nn-text-muted); line-height:1.5;">
+    <p>
+      This is part of Models & Agents's long-term memory system (narrative tracking + theme mining from
+      our own episodes). The goal is for the show to become a genuinely useful running chronicle of its
+      field, not a stream of disposable daily recaps.
+    </p>
+    
+  </div>
+</div>
+
+    </main>
+
+    <!-- Footer -->
+    <footer class="nn-footer">
+        <div class="container">
+            <div class="nn-footer-grid">
+                <div>
+                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
+                    <p class="nn-footer-desc">Eleven shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Shows</h4>
+                    
+                    <a href="models-agents.html">Models & Agents</a>
+                    
+                    <a href="planetterrian.html">Planetterrian Daily</a>
+                    
+                    <a href="omni-view.html">Omni View</a>
+                    
+                    <a href="models-agents-beginners.html">Models & Agents for Beginners</a>
+                    
+                    <a href="fascinating-frontiers.html">Fascinating Frontiers</a>
+                    
+                    <a href="modern-investing.html">Modern Investing Techniques</a>
+                    
+                    <a href="tesla.html">Tesla Shorts Time</a>
+                    
+                    <a href="env-intel.html">Environmental Intelligence</a>
+                    
+                    <a href="ru/finansy-prosto.html">Финансы Просто</a>
+                    
+                    <a href="ru/privet-russian.html">Привет, Русский!</a>
+                    
+                    <a href="unintended-consequences.html">Unintended Consequences</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Blog</h4>
+                    <a href="blog/index.html">All Blog Posts</a>
+                    
+                    <a href="blog/models_agents/index.html">Models & Agents</a>
+                    
+                    <a href="blog/planetterrian/index.html">Planetterrian Daily</a>
+                    
+                    <a href="blog/omni_view/index.html">Omni View</a>
+                    
+                    <a href="blog/models_agents_beginners/index.html">Models & Agents for Beginners</a>
+                    
+                    <a href="blog/fascinating_frontiers/index.html">Fascinating Frontiers</a>
+                    
+                    <a href="blog/modern_investing/index.html">Modern Investing Techniques</a>
+                    
+                    <a href="blog/tesla/index.html">Tesla Shorts Time</a>
+                    
+                    <a href="blog/env_intel/index.html">Environmental Intelligence</a>
+                    
+                    <a href="blog/finansy_prosto/index.html">Финансы Просто</a>
+                    
+                    <a href="blog/privet_russian/index.html">Привет, Русский!</a>
+                    
+                    <a href="blog/unintended_consequences/index.html">Unintended Consequences</a>
+                    
+                    <a href="blog.rss">Blog RSS (All Shows)</a>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Listen</h4>
+                    <a href="how-to-listen.html" style="font-weight:600">How to Listen</a>
+                    <a href="player.html" style="font-weight:600">Network Player</a>
+                    <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939?utm_source=nerranetwork&utm_medium=footer&utm_campaign=tesla" target="_blank" rel="noopener" data-show="tesla">Apple Podcasts</a>
+                    <a href="network.rss">Network RSS</a>
+                    
+                    <a href="models_agents_podcast.rss">Models & Agents RSS</a>
+                    
+                    <a href="planetterrian_podcast.rss">Planetterrian Daily RSS</a>
+                    
+                    <a href="omni_view_podcast.rss">Omni View RSS</a>
+                    
+                    <a href="models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
+                    
+                    <a href="fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
+                    
+                    <a href="modern_investing_podcast.rss">Modern Investing Techniques RSS</a>
+                    
+                    <a href="podcast.rss">Tesla Shorts Time RSS</a>
+                    
+                    <a href="env_intel_podcast.rss">Environmental Intelligence RSS</a>
+                    
+                    <a href="finansy_prosto_podcast.rss">Финансы Просто RSS</a>
+                    
+                    <a href="privet_russian_podcast.rss">Привет, Русский! RSS</a>
+                    
+                    <a href="unintended_consequences_podcast.rss">Unintended Consequences RSS</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Connect</h4>
+                    <a href="https://x.com/teslashortstime" target="_blank" rel="noopener">@teslashortstime</a>
+                    <a href="https://x.com/omniviewnews" target="_blank" rel="noopener">@omniviewnews</a>
+                    <a href="https://x.com/planetterrian" target="_blank" rel="noopener">@planetterrian</a>
+                </div>
+            </div>
+            <div class="nn-footer-col">
+                <h4>About</h4>
+                <a href="about.html">About Nerra Network</a>
+                <a href="start-here.html">Start Here</a>
+                <a href="how-to-listen.html">How to Listen</a>
+                <a href="faq.html">FAQ</a>
+                <a href="contact.html">Contact</a>
+                <a href="press.html">Press Kit</a>
+                <a href="privacy-policy.html">Privacy Policy</a>
+                <a href="terms-of-service.html">Terms of Service</a>
+                <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="editorial.html">Editorial Process</a>
+                <a href="management.html">Network Status</a>
+            </div>
+            <!-- Newsletter Subscribe -->
+            <div class="nn-footer-subscribe">
+                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                    <h4>Get Show Updates</h4>
+                    <p>Pick the shows you want in your inbox:</p>
+                    <div class="nn-subscribe-tags"><label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                        <label><input type="checkbox" name="tag" value="Omni View"> Omni View</label>
+                        <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
+                        <label><input type="checkbox" name="tag" value="Planetterrian Daily"> Planetterrian Daily</label>
+                        <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents"> Models &amp; Agents</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models &amp; Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
+                        <label><input type="checkbox" name="tag" value="Unintended Consequences"> Unintended Consequences</label><label><input type="checkbox" name="tag" value="Finansy Prosto"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Privet Russian"> Привет, Русский!</label>
+                    </div>
+                    <div class="nn-subscribe-row">
+                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="hidden" value="1" name="embed">
+                        <button type="submit">Subscribe</button>
+                    </div>
+                </form>
+            </div>
+            <div class="nn-footer-bottom">
+                <span>© 2026 Nerra Network. All shows independently produced.</span>
+                <a href="index.html">nerranetwork.com</a>
+            </div>
+            <div class="nn-footer-legal">
+                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
+                <div>
+                    <a href="privacy-policy.html">Privacy</a> &middot;
+                    <a href="terms-of-service.html">Terms</a> &middot;
+                    <a href="ai-disclosure.html">AI Disclosure</a>
+                    <span style="opacity:0.5;">&middot;</span>
+                    <span style="font-size:0.7rem;opacity:0.6;">Automation: reliable nightly + post-publish pipeline</span>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    // Toggle aria-expanded on dropdown hover/focus
+    document.querySelectorAll('.nn-nav-dropdown').forEach(function(dd) {
+        var btn = dd.querySelector('.nn-nav-dropdown-btn');
+        if (!btn) return;
+        dd.addEventListener('mouseenter', function() { btn.setAttribute('aria-expanded', 'true'); });
+        dd.addEventListener('mouseleave', function() { btn.setAttribute('aria-expanded', 'false'); });
+        btn.addEventListener('focus', function() { btn.setAttribute('aria-expanded', 'true'); });
+        btn.addEventListener('blur', function() {
+            setTimeout(function() {
+                if (!dd.contains(document.activeElement)) btn.setAttribute('aria-expanded', 'false');
+            }, 100);
+        });
+    });
+    // Mobile footer accordions
+    if (window.innerWidth <= 768) {
+        document.querySelectorAll('.nn-footer-col h4').forEach(function(h4) {
+            h4.addEventListener('click', function() {
+                h4.parentElement.classList.toggle('expanded');
+            });
+        });
+    }
+    </script>
+    
+
+    <!-- Centralized, improved global search -->
+    <script src="assets/js/search.js" defer></script>
+</body>
+</html>

--- a/planetterrian-narrative.html
+++ b/planetterrian-narrative.html
@@ -1,0 +1,823 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="The ongoing storylines Planetterrian Daily tracks over time — current status, key open questions, and real progress across episodes.">
+    
+    
+    <title>Planetterrian Daily — Narrative Tracker | Nerra Network</title>
+    
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Planetterrian Daily — Narrative Tracker | Nerra Network">
+    <meta property="og:description" content="The ongoing storylines Planetterrian Daily tracks over time — current status, key open questions, and real progress across episodes.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="assets/covers/planetterrian-daily.jpg">
+    
+    <meta property="og:site_name" content="Nerra Network">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Planetterrian Daily — Narrative Tracker | Nerra Network">
+    <meta name="twitter:description" content="The ongoing storylines Planetterrian Daily tracks over time — current status, key open questions, and real progress across episodes.">
+    <meta name="twitter:image" content="assets/covers/planetterrian-daily.jpg">
+
+    
+    
+    
+    
+
+    <!-- Google Fonts: DM Sans + Source Serif 4 -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&display=swap" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%236B47FF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/></svg>">
+
+    
+    
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
+    
+    
+    <script defer src="assets/js/tracking.js"></script>
+
+    <!-- Shared CSS -->
+    <link rel="stylesheet" href="styles/main.css">
+
+    
+
+    
+    <style>
+        @media (max-width: 768px) {
+            .nn-footer-grid { grid-template-columns: 1fr; }
+            .nn-footer-col h4 {
+                cursor: pointer;
+                position: relative;
+                padding-right: 1.5rem;
+            }
+            .nn-footer-col h4::after {
+                content: '+';
+                position: absolute;
+                right: 0;
+                font-size: 1.2rem;
+                color: var(--nn-text-muted);
+            }
+            .nn-footer-col.expanded h4::after { content: '\2212'; }
+            .nn-footer-col > a,
+            .nn-footer-col > ul { display: none; }
+            .nn-footer-col.expanded > a,
+            .nn-footer-col.expanded > ul { display: block; }
+        }
+    </style>
+</head>
+<body><a href="#main-content" class="skip-link">Skip to content</a>
+    <!-- Navigation -->
+    <nav class="nn-nav" aria-label="Main navigation">
+        <div class="nn-nav-inner">
+            <a href="index.html" class="nn-nav-logo">
+                <img src="assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
+                <span class="gradient-text">Nerra</span> Network
+            </a>
+
+            
+            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.5rem;max-width:180px;flex:1 1 auto;min-width:120px;">
+                <input type="search" id="nn-global-search-input"
+                       placeholder="Search…"
+                       style="width:100%;padding:6px 8px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.85rem;"
+                       aria-label="Search all episodes across the network">
+                <div id="nn-global-search-results"
+                     style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:340px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
+            </div>
+
+            <ul class="nn-nav-links">
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Shows
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu" role="menu">
+                        
+                        <a href="models-agents.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents
+                        </a>
+                        
+                        <a href="planetterrian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily
+                        </a>
+                        
+                        <a href="omni-view.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View
+                        </a>
+                        
+                        <a href="models-agents-beginners.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners
+                        </a>
+                        
+                        <a href="fascinating-frontiers.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers
+                        </a>
+                        
+                        <a href="modern-investing.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques
+                        </a>
+                        
+                        <a href="tesla.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time
+                        </a>
+                        
+                        <a href="env-intel.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence
+                        </a>
+                        
+                        <a href="ru/finansy-prosto.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто
+                        </a>
+                        
+                        <a href="ru/privet-russian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский!
+                        </a>
+                        
+                        <a href="unintended-consequences.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences
+                        </a>
+                        
+                    </div>
+                </li>
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Blog
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu">
+                        <a href="blog/index.html" style="font-weight:600;border-bottom:1px solid var(--nn-border);padding-bottom:8px;margin-bottom:4px">
+                            All Blog Posts
+                        </a>
+                        
+                        <a href="blog/models_agents/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents Blog
+                        </a>
+                        
+                        <a href="blog/planetterrian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily Blog
+                        </a>
+                        
+                        <a href="blog/omni_view/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View Blog
+                        </a>
+                        
+                        <a href="blog/models_agents_beginners/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners Blog
+                        </a>
+                        
+                        <a href="blog/fascinating_frontiers/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers Blog
+                        </a>
+                        
+                        <a href="blog/modern_investing/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques Blog
+                        </a>
+                        
+                        <a href="blog/tesla/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time Blog
+                        </a>
+                        
+                        <a href="blog/env_intel/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence Blog
+                        </a>
+                        
+                        <a href="blog/finansy_prosto/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто Blog
+                        </a>
+                        
+                        <a href="blog/privet_russian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский! Blog
+                        </a>
+                        
+                        <a href="blog/unintended_consequences/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences Blog
+                        </a>
+                        
+                    </div>
+                </li>
+                
+                <li><a href="start-here.html">Start Here</a></li>
+                <li><a href="how-to-listen.html">Listen</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="player.html">Player</a></li>
+                <li><a href="index.html">Home</a></li>
+                
+            </ul>
+
+            <button class="nn-hamburger" aria-label="Toggle menu" aria-expanded="false" onclick="var m=document.getElementById('mobileMenu');m.classList.toggle('open');this.setAttribute('aria-expanded',m.classList.contains('open'));document.body.classList.toggle('menu-open')">&#9776;</button>
+        </div>
+    </nav>
+
+    <!-- Mobile Menu -->
+    <div id="mobileMenu" class="nn-mobile-menu">
+        
+        <a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Start Here</a>
+        <a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">How to Listen</a>
+        <a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">About</a>
+        <a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Player</a>
+        <a href="index.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Home</a>
+        
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">All Shows</div>
+            
+            <a href="models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents
+            </a>
+            
+            <a href="planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily
+            </a>
+            
+            <a href="omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View
+            </a>
+            
+            <a href="models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners
+            </a>
+            
+            <a href="fascinating-frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers
+            </a>
+            
+            <a href="modern-investing.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques
+            </a>
+            
+            <a href="tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time
+            </a>
+            
+            <a href="env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence
+            </a>
+            
+            <a href="ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто
+            </a>
+            
+            <a href="ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский!
+            </a>
+            
+            <a href="unintended-consequences.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences
+            </a>
+            
+        </div>
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">Blogs</div>
+            <a href="blog/index.html" class="nn-mobile-show-link" style="font-weight:600" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                All Blog Posts
+            </a>
+            
+            <a href="blog/models_agents/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents Blog
+            </a>
+            
+            <a href="blog/planetterrian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily Blog
+            </a>
+            
+            <a href="blog/omni_view/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View Blog
+            </a>
+            
+            <a href="blog/models_agents_beginners/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners Blog
+            </a>
+            
+            <a href="blog/fascinating_frontiers/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers Blog
+            </a>
+            
+            <a href="blog/modern_investing/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques Blog
+            </a>
+            
+            <a href="blog/tesla/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time Blog
+            </a>
+            
+            <a href="blog/env_intel/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence Blog
+            </a>
+            
+            <a href="blog/finansy_prosto/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто Blog
+            </a>
+            
+            <a href="blog/privet_russian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский! Blog
+            </a>
+            
+            <a href="blog/unintended_consequences/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences Blog
+            </a>
+            
+        </div>
+    </div>
+
+    <main id="main-content">
+    
+<div class="container" style="max-width: 1100px; padding: calc(var(--nav-height) + var(--sp-12)) 0 var(--sp-8);">
+  <style>
+    @media (max-width: 640px) {
+      .glass-card { padding: 14px !important; }
+      .program-card { padding: 14px !important; }
+    }
+    .program-card {
+      background: var(--nn-surface);
+      border: 1px solid var(--nn-border);
+      border-radius: 12px;
+      padding: 18px;
+      margin-bottom: var(--sp-5);
+    }
+    .program-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      margin-bottom: 8px;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .status-text { line-height: 1.5; margin-bottom: 10px; }
+    .meta-row { font-size: 0.85rem; color: var(--nn-text-muted); }
+  </style>
+
+  <div style="margin-bottom: var(--sp-8);">
+    <h1 style="font-size: 2.3rem; margin-bottom: 0.3rem;">Planetterrian Daily — Narrative Tracker</h1>
+    <p style="font-size: 1.1rem; color: var(--nn-text-muted); max-width: 820px;">
+      Planetterrian Daily maintains a living memory of the major ongoing storylines in its field — so
+      regular listeners get continuity, not just isolated daily headlines. This page shows the current
+      status of each tracked program, the last time we covered it in depth, and the key open questions
+      we're following.
+    </p>
+    <p style="font-size: 0.85rem; color: var(--nn-text-muted); margin-top: 0.4rem;">
+      Updated as episodes ship. Source: <code>digests/planetterrian/planetterrian_narrative_tracker.json</code>
+    </p>
+  </div>
+
+  
+    <div class="glass-card" style="padding: var(--sp-6); margin-bottom: var(--sp-8);">
+      <h2 style="margin-top:0; margin-bottom: var(--sp-5);">Tracked Programs</h2>
+
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Aging & Longevity Biology</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">Cellular aging, senescence, and interventions that target the biology of aging.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Which interventions translate to humans</li>
+                
+                  <li>Reliable aging biomarkers</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>low-medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Neuroscience & the Brain</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">Cognition, brain aging, and neurodegeneration.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Alzheimer's mechanism + therapy progress</li>
+                
+                  <li>How reversible is brain aging</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Microbiome</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">The gut microbiome and its links to health and disease.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Causation vs correlation</li>
+                
+                  <li>Therapeutic microbiome modulation</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>low</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Regenerative Medicine</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">Stem cells, cellular reprogramming, and tissue regeneration.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Partial-reprogramming safety</li>
+                
+                  <li>Organ/tissue regeneration timelines</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>low</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Sleep, Circadian & Metabolic Health</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">Sleep, circadian biology, and metabolic health.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>Sleep's causal role in aging/disease</li>
+                
+                  <li>Circadian interventions that work</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">Genetics & Genomics</h3>
+            
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            
+          </div>
+
+          <p class="status-text">Genetics, gene editing, and the genomics of health.</p>
+
+          
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                
+                  <li>In-vivo gene-editing safety/efficacy</li>
+                
+                  <li>Polygenic risk in practice</li>
+                
+              </ul>
+            </div>
+          
+
+          
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>medium</strong>
+            </div>
+          
+
+          
+        </div>
+      
+    </div>
+  
+
+  <div style="margin-top: var(--sp-8); font-size:0.85rem; color:var(--nn-text-muted); line-height:1.5;">
+    <p>
+      This is part of Planetterrian Daily's long-term memory system (narrative tracking + theme mining from
+      our own episodes). The goal is for the show to become a genuinely useful running chronicle of its
+      field, not a stream of disposable daily recaps.
+    </p>
+    
+    <p style="margin-top:12px;">
+      Want to suggest an update to any program status? Reach out on X at
+      <a href="https://x.com/planetterrian" target="_blank" rel="noopener">@planetterrian</a>.
+    </p>
+    
+  </div>
+</div>
+
+    </main>
+
+    <!-- Footer -->
+    <footer class="nn-footer">
+        <div class="container">
+            <div class="nn-footer-grid">
+                <div>
+                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
+                    <p class="nn-footer-desc">Eleven shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Shows</h4>
+                    
+                    <a href="models-agents.html">Models & Agents</a>
+                    
+                    <a href="planetterrian.html">Planetterrian Daily</a>
+                    
+                    <a href="omni-view.html">Omni View</a>
+                    
+                    <a href="models-agents-beginners.html">Models & Agents for Beginners</a>
+                    
+                    <a href="fascinating-frontiers.html">Fascinating Frontiers</a>
+                    
+                    <a href="modern-investing.html">Modern Investing Techniques</a>
+                    
+                    <a href="tesla.html">Tesla Shorts Time</a>
+                    
+                    <a href="env-intel.html">Environmental Intelligence</a>
+                    
+                    <a href="ru/finansy-prosto.html">Финансы Просто</a>
+                    
+                    <a href="ru/privet-russian.html">Привет, Русский!</a>
+                    
+                    <a href="unintended-consequences.html">Unintended Consequences</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Blog</h4>
+                    <a href="blog/index.html">All Blog Posts</a>
+                    
+                    <a href="blog/models_agents/index.html">Models & Agents</a>
+                    
+                    <a href="blog/planetterrian/index.html">Planetterrian Daily</a>
+                    
+                    <a href="blog/omni_view/index.html">Omni View</a>
+                    
+                    <a href="blog/models_agents_beginners/index.html">Models & Agents for Beginners</a>
+                    
+                    <a href="blog/fascinating_frontiers/index.html">Fascinating Frontiers</a>
+                    
+                    <a href="blog/modern_investing/index.html">Modern Investing Techniques</a>
+                    
+                    <a href="blog/tesla/index.html">Tesla Shorts Time</a>
+                    
+                    <a href="blog/env_intel/index.html">Environmental Intelligence</a>
+                    
+                    <a href="blog/finansy_prosto/index.html">Финансы Просто</a>
+                    
+                    <a href="blog/privet_russian/index.html">Привет, Русский!</a>
+                    
+                    <a href="blog/unintended_consequences/index.html">Unintended Consequences</a>
+                    
+                    <a href="blog.rss">Blog RSS (All Shows)</a>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Listen</h4>
+                    <a href="how-to-listen.html" style="font-weight:600">How to Listen</a>
+                    <a href="player.html" style="font-weight:600">Network Player</a>
+                    <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939?utm_source=nerranetwork&utm_medium=footer&utm_campaign=tesla" target="_blank" rel="noopener" data-show="tesla">Apple Podcasts</a>
+                    <a href="network.rss">Network RSS</a>
+                    
+                    <a href="models_agents_podcast.rss">Models & Agents RSS</a>
+                    
+                    <a href="planetterrian_podcast.rss">Planetterrian Daily RSS</a>
+                    
+                    <a href="omni_view_podcast.rss">Omni View RSS</a>
+                    
+                    <a href="models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
+                    
+                    <a href="fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
+                    
+                    <a href="modern_investing_podcast.rss">Modern Investing Techniques RSS</a>
+                    
+                    <a href="podcast.rss">Tesla Shorts Time RSS</a>
+                    
+                    <a href="env_intel_podcast.rss">Environmental Intelligence RSS</a>
+                    
+                    <a href="finansy_prosto_podcast.rss">Финансы Просто RSS</a>
+                    
+                    <a href="privet_russian_podcast.rss">Привет, Русский! RSS</a>
+                    
+                    <a href="unintended_consequences_podcast.rss">Unintended Consequences RSS</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Connect</h4>
+                    <a href="https://x.com/teslashortstime" target="_blank" rel="noopener">@teslashortstime</a>
+                    <a href="https://x.com/omniviewnews" target="_blank" rel="noopener">@omniviewnews</a>
+                    <a href="https://x.com/planetterrian" target="_blank" rel="noopener">@planetterrian</a>
+                </div>
+            </div>
+            <div class="nn-footer-col">
+                <h4>About</h4>
+                <a href="about.html">About Nerra Network</a>
+                <a href="start-here.html">Start Here</a>
+                <a href="how-to-listen.html">How to Listen</a>
+                <a href="faq.html">FAQ</a>
+                <a href="contact.html">Contact</a>
+                <a href="press.html">Press Kit</a>
+                <a href="privacy-policy.html">Privacy Policy</a>
+                <a href="terms-of-service.html">Terms of Service</a>
+                <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="editorial.html">Editorial Process</a>
+                <a href="management.html">Network Status</a>
+            </div>
+            <!-- Newsletter Subscribe -->
+            <div class="nn-footer-subscribe">
+                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                    <h4>Get Show Updates</h4>
+                    <p>Pick the shows you want in your inbox:</p>
+                    <div class="nn-subscribe-tags"><label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                        <label><input type="checkbox" name="tag" value="Omni View"> Omni View</label>
+                        <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
+                        <label><input type="checkbox" name="tag" value="Planetterrian Daily"> Planetterrian Daily</label>
+                        <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents"> Models &amp; Agents</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models &amp; Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
+                        <label><input type="checkbox" name="tag" value="Unintended Consequences"> Unintended Consequences</label><label><input type="checkbox" name="tag" value="Finansy Prosto"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Privet Russian"> Привет, Русский!</label>
+                    </div>
+                    <div class="nn-subscribe-row">
+                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="hidden" value="1" name="embed">
+                        <button type="submit">Subscribe</button>
+                    </div>
+                </form>
+            </div>
+            <div class="nn-footer-bottom">
+                <span>© 2026 Nerra Network. All shows independently produced.</span>
+                <a href="index.html">nerranetwork.com</a>
+            </div>
+            <div class="nn-footer-legal">
+                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
+                <div>
+                    <a href="privacy-policy.html">Privacy</a> &middot;
+                    <a href="terms-of-service.html">Terms</a> &middot;
+                    <a href="ai-disclosure.html">AI Disclosure</a>
+                    <span style="opacity:0.5;">&middot;</span>
+                    <span style="font-size:0.7rem;opacity:0.6;">Automation: reliable nightly + post-publish pipeline</span>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    // Toggle aria-expanded on dropdown hover/focus
+    document.querySelectorAll('.nn-nav-dropdown').forEach(function(dd) {
+        var btn = dd.querySelector('.nn-nav-dropdown-btn');
+        if (!btn) return;
+        dd.addEventListener('mouseenter', function() { btn.setAttribute('aria-expanded', 'true'); });
+        dd.addEventListener('mouseleave', function() { btn.setAttribute('aria-expanded', 'false'); });
+        btn.addEventListener('focus', function() { btn.setAttribute('aria-expanded', 'true'); });
+        btn.addEventListener('blur', function() {
+            setTimeout(function() {
+                if (!dd.contains(document.activeElement)) btn.setAttribute('aria-expanded', 'false');
+            }, 100);
+        });
+    });
+    // Mobile footer accordions
+    if (window.innerWidth <= 768) {
+        document.querySelectorAll('.nn-footer-col h4').forEach(function(h4) {
+            h4.addEventListener('click', function() {
+                h4.parentElement.classList.toggle('expanded');
+            });
+        });
+    }
+    </script>
+    
+
+    <!-- Centralized, improved global search -->
+    <script src="assets/js/search.js" defer></script>
+</body>
+</html>

--- a/run_show.py
+++ b/run_show.py
@@ -1018,6 +1018,12 @@ def run(args: argparse.Namespace) -> None:
         # Merge extra context from hooks (e.g. price, change_str, x_posts_section)
         template_vars.update(extra_context)
 
+        # Phase 3 recursive memory: the digest/podcast prompts for memory-enabled
+        # shows reference {narrative_memory_section}, supplied by the show's
+        # pre_fetch hook. Default it to empty so a hook-load failure (or a show
+        # without memory) can never KeyError in prompt substitution.
+        template_vars.setdefault("narrative_memory_section", "")
+
         # 7. Generate digest
         #
         # Sunday weekly-recap mode (May 2026 schedule overhaul). When the

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -1,6 +1,7 @@
 name: Fascinating Frontiers
 slug: fascinating_frontiers
 weekly_recap_on_sunday: true   # May 2026: daily cadence; Sunday slot recaps the past 7 days from the content lake.
+memory_enabled: true           # Phase 3: recursive narrative memory (programs in engine/show_memory.py). Flip to false to disable.
 description: "Space exploration, astronomy, and cosmology — the frontier of human discovery beyond Earth. Daily briefings on NASA, ESA, SpaceX missions, planetary science, and the search for life in the universe."
 
 sources:

--- a/shows/hooks/fascinating_frontiers.py
+++ b/shows/hooks/fascinating_frontiers.py
@@ -1,0 +1,18 @@
+"""Fascinating Frontiers hooks — recursive narrative memory (Phase 3).
+
+Thin wrapper over engine.show_memory; see shows/hooks/models_agents.py.
+"""
+
+from __future__ import annotations
+
+from engine import show_memory
+
+_SLUG = "fascinating_frontiers"
+
+
+def pre_fetch(config, *, episode_num=None, today_str=None) -> dict:
+    return show_memory.memory_pre_fetch(config, _SLUG)
+
+
+def post_generate(config, *, digest_text="", episode_num=None) -> None:
+    show_memory.memory_post_generate(config, _SLUG, digest_text or "", episode_num or 0)

--- a/shows/hooks/models_agents.py
+++ b/shows/hooks/models_agents.py
@@ -1,0 +1,22 @@
+"""Models & Agents hooks — recursive narrative memory (Phase 3).
+
+Thin wrapper over engine.show_memory. Injects the narrative-memory section
+into the digest/podcast prompts (pre_fetch) and mines recurring themes from
+each episode's digest (post_generate). Both are gated on
+``config.memory_enabled`` and are non-fatal — a memory failure never blocks an
+episode.
+"""
+
+from __future__ import annotations
+
+from engine import show_memory
+
+_SLUG = "models_agents"
+
+
+def pre_fetch(config, *, episode_num=None, today_str=None) -> dict:
+    return show_memory.memory_pre_fetch(config, _SLUG)
+
+
+def post_generate(config, *, digest_text="", episode_num=None) -> None:
+    show_memory.memory_post_generate(config, _SLUG, digest_text or "", episode_num or 0)

--- a/shows/hooks/planetterrian.py
+++ b/shows/hooks/planetterrian.py
@@ -1,0 +1,18 @@
+"""Planetterrian Daily hooks — recursive narrative memory (Phase 3).
+
+Thin wrapper over engine.show_memory; see shows/hooks/models_agents.py.
+"""
+
+from __future__ import annotations
+
+from engine import show_memory
+
+_SLUG = "planetterrian"
+
+
+def pre_fetch(config, *, episode_num=None, today_str=None) -> dict:
+    return show_memory.memory_pre_fetch(config, _SLUG)
+
+
+def post_generate(config, *, digest_text="", episode_num=None) -> None:
+    show_memory.memory_post_generate(config, _SLUG, digest_text or "", episode_num or 0)

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -1,6 +1,7 @@
 name: "Models & Agents"
 slug: models_agents
 weekly_recap_on_sunday: true   # May 2026: daily cadence; Sunday slot recaps the past 7 days from the content lake.
+memory_enabled: true           # Phase 3: recursive narrative memory (programs in engine/show_memory.py). Flip to false to disable.
 description: "Daily AI briefing covering new model releases, agent frameworks, and practical developments in the AI models and agents ecosystem. Helping you stay on top of the most exciting developments of our generation."
 
 sources:

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -1,6 +1,7 @@
 name: Planetterrian Daily
 slug: planetterrian
 weekly_recap_on_sunday: true   # May 2026: daily cadence; Sunday slot recaps the past 7 days from the content lake.
+memory_enabled: true           # Phase 3: recursive narrative memory (programs in engine/show_memory.py). Flip to false to disable.
 description: "Science, longevity, and health discoveries — neuroscience, microbiome, cellular aging biology, sleep and circadian science, nutrition research, genetics, and regenerative biology. Daily briefings on Nature/Science papers and primary research that extend our understanding of healthy human lifespan. Pharma dealmaking and incremental drug-trial readouts are deliberately minimized in favour of broader scientific advances."
 
 sources:

--- a/shows/prompts/fascinating_frontiers_digest.txt
+++ b/shows/prompts/fascinating_frontiers_digest.txt
@@ -9,6 +9,8 @@ ABSOLUTE RULE — ZERO STORY OVERLAP: Each article, event, announcement, or deve
 🚀 Fascinating Frontiers Podcast: Coming soon to Apple Podcasts
 {news_section}
 
+{narrative_memory_section}
+
 You are an elite space and astronomy news curator producing the daily "Fascinating Frontiers" newsletter. Use ONLY the pre-fetched news articles above. Do NOT hallucinate, invent, or search for new content/URLs—stick to exact provided links. Do NOT include any X posts or Twitter references.
 
 ### SELECTION & COUNTS

--- a/shows/prompts/fascinating_frontiers_podcast.txt
+++ b/shows/prompts/fascinating_frontiers_podcast.txt
@@ -144,3 +144,5 @@ If today's topic doesn't naturally overlap with any of these, omit the cross-pro
 Here is today's complete formatted digest. Use ONLY this content:
 
 {digest}
+
+{narrative_memory_section}

--- a/shows/prompts/models_agents_digest.txt
+++ b/shows/prompts/models_agents_digest.txt
@@ -9,6 +9,8 @@ ABSOLUTE RULE — ZERO STORY OVERLAP: Each article, event, announcement, or deve
 
 {news_section}
 
+{narrative_memory_section}
+
 You are an expert AI technology journalist who deeply understands the AI models and agents ecosystem. You are writing the daily "Models & Agents" briefing. Your readers are developers, AI practitioners, tech-curious professionals, and anyone who wants to stay informed about the rapidly evolving world of AI models and autonomous agents. They range from hands-on builders to curious adopters who want to know what's new, what to try, and how to benefit from the changes happening.
 
 **EXPERTISE (demonstrate this in your analysis):**

--- a/shows/prompts/models_agents_podcast.txt
+++ b/shows/prompts/models_agents_podcast.txt
@@ -175,3 +175,5 @@ If today's topic doesn't naturally overlap with any of these, omit the cross-pro
 Here is today's complete briefing. Use ONLY this content:
 
 {digest}
+
+{narrative_memory_section}

--- a/shows/prompts/planetterrian_digest.txt
+++ b/shows/prompts/planetterrian_digest.txt
@@ -9,6 +9,8 @@ ABSOLUTE RULE — ZERO STORY OVERLAP: Each article, event, announcement, or deve
 🌍 Planetterrian Daily Podcast: Coming soon to Apple Podcasts
 {news_section}
 
+{narrative_memory_section}
+
 You are an elite science, longevity, and health news curator producing the daily "Planetterrian Daily" newsletter. Use ONLY the pre-fetched news articles above. Do NOT hallucinate, invent, or search for new content/URLs—stick to exact provided links. Do NOT include any X posts or Twitter references.
 
 ### SELECTION & COUNTS

--- a/shows/prompts/planetterrian_podcast.txt
+++ b/shows/prompts/planetterrian_podcast.txt
@@ -145,3 +145,5 @@ If today's topic doesn't naturally overlap with any of these, omit the cross-pro
 Here is today's complete formatted digest. Use ONLY this content:
 
 {digest}
+
+{narrative_memory_section}

--- a/templates/narrative_page.html.j2
+++ b/templates/narrative_page.html.j2
@@ -1,0 +1,111 @@
+{% extends "base.html.j2" %}
+
+{% block title %}{{ show_name }} — Narrative Tracker & Storylines{% endblock %}
+
+{% block content %}
+<div class="container" style="max-width: 1100px; padding: calc(var(--nav-height) + var(--sp-12)) 0 var(--sp-8);">
+  <style>
+    @media (max-width: 640px) {
+      .glass-card { padding: 14px !important; }
+      .program-card { padding: 14px !important; }
+    }
+    .program-card {
+      background: var(--nn-surface);
+      border: 1px solid var(--nn-border);
+      border-radius: 12px;
+      padding: 18px;
+      margin-bottom: var(--sp-5);
+    }
+    .program-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      margin-bottom: 8px;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .status-text { line-height: 1.5; margin-bottom: 10px; }
+    .meta-row { font-size: 0.85rem; color: var(--nn-text-muted); }
+  </style>
+
+  <div style="margin-bottom: var(--sp-8);">
+    <h1 style="font-size: 2.3rem; margin-bottom: 0.3rem;">{{ show_name }} — Narrative Tracker</h1>
+    <p style="font-size: 1.1rem; color: var(--nn-text-muted); max-width: 820px;">
+      {{ show_name }} maintains a living memory of the major ongoing storylines in its field — so
+      regular listeners get continuity, not just isolated daily headlines. This page shows the current
+      status of each tracked program, the last time we covered it in depth, and the key open questions
+      we're following.
+    </p>
+    <p style="font-size: 0.85rem; color: var(--nn-text-muted); margin-top: 0.4rem;">
+      Updated as episodes ship. Source: <code>{{ source_path }}</code>
+    </p>
+  </div>
+
+  {% if narrative and narrative.programs %}
+    <div class="glass-card" style="padding: var(--sp-6); margin-bottom: var(--sp-8);">
+      <h2 style="margin-top:0; margin-bottom: var(--sp-5);">Tracked Programs</h2>
+
+      {% for key, prog in narrative.programs.items() %}
+        <div class="program-card">
+          <div class="program-header">
+            <h3 style="margin:0; font-size:1.3rem;">{{ prog.display_name or key.title() }}</h3>
+            {% if prog.last_major_update_episode %}
+              <span class="meta-row">
+                Last deep coverage: <strong>Ep {{ prog.last_major_update_episode }}</strong> ({{ prog.last_major_update_date }})
+              </span>
+            {% else %}
+              <span class="meta-row">Not yet deeply covered on the show</span>
+            {% endif %}
+          </div>
+
+          <p class="status-text">{{ prog.status }}</p>
+
+          {% if prog.key_open_questions %}
+            <div style="margin-bottom: 8px;">
+              <strong style="font-size:0.9rem;">Key open questions:</strong>
+              <ul style="margin: 4px 0 0 18px; padding:0; font-size:0.9rem;">
+                {% for q in prog.key_open_questions %}
+                  <li>{{ q }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+
+          {% if prog.show_confidence %}
+            <div class="meta-row">
+              Show confidence on major timelines: <strong>{{ prog.show_confidence }}</strong>
+            </div>
+          {% endif %}
+
+          {% if prog.notable_claims %}
+            <div style="margin-top: 10px; font-size:0.85rem;">
+              <strong>Notable claims surfaced on the show:</strong>
+              {% for claim in prog.notable_claims %}
+                <div style="margin-top:4px; padding-left:8px; border-left:2px solid var(--nn-border);">
+                  Ep {{ claim.episode }} ({{ claim.date }}): "{{ claim.claim }}" — <em>Status: {{ claim.status }}</em>
+                </div>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+  {% else %}
+    <p style="color: var(--nn-text-muted);">Narrative tracker data is being initialized.</p>
+  {% endif %}
+
+  <div style="margin-top: var(--sp-8); font-size:0.85rem; color:var(--nn-text-muted); line-height:1.5;">
+    <p>
+      This is part of {{ show_name }}'s long-term memory system (narrative tracking + theme mining from
+      our own episodes). The goal is for the show to become a genuinely useful running chronicle of its
+      field, not a stream of disposable daily recaps.
+    </p>
+    {% if x_account %}
+    <p style="margin-top:12px;">
+      Want to suggest an update to any program status? Reach out on X at
+      <a href="https://x.com/{{ x_account }}" target="_blank" rel="noopener">@{{ x_account }}</a>.
+    </p>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -112,6 +112,9 @@
                     <a href="#episodes" class="nn-btn nn-btn-primary">{% if _is_ru %}Слушать{% else %}Listen Now{% endif %}</a>
                     <a href="{{ path_prefix }}{{ blog_page }}" class="nn-btn">{% if _is_ru %}Читать блог{% else %}Read Blog{% endif %}</a>
                     <a href="{{ path_prefix }}{{ summaries_page }}" class="nn-btn">{% if _is_ru %}Все выпуски{% else %}View Summaries{% endif %}</a>
+                    {% if narrative_page_url %}
+                    <a href="{{ path_prefix }}{{ narrative_page_url }}" class="nn-btn">{% if _is_ru %}Хронология{% else %}Story Tracker{% endif %}</a>
+                    {% endif %}
                     {% if apple_podcasts_url %}
                     <a href="{{ apple_podcasts_url | with_utm(campaign=show_slug) }}" class="nn-btn" target="_blank" rel="noopener" data-show="{{ show_slug }}">Apple Podcasts</a>
                     {% endif %}

--- a/tests/test_phase3_memory.py
+++ b/tests/test_phase3_memory.py
@@ -1,0 +1,180 @@
+"""Phase 3 (recursive narrative memory) drift guards.
+
+Generalizes Tesla's narrative-memory system to other shows via
+``engine.show_memory`` + per-show MemoryConfigs + thin hooks + flag-gated
+prompt injection + public "story tracker" pages.
+
+These tests pin: the generic engine, the flag gating (disabled == true no-op),
+the per-show config registry, the prompt wiring, and the public page render.
+``tests/test_show_memory.py`` continues to guard the untouched Tesla module.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from engine import show_memory as sm
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+MEMORY_SHOWS = ("models_agents", "fascinating_frontiers", "planetterrian")
+
+
+# ---------------------------------------------------------------------------
+# Generic engine
+# ---------------------------------------------------------------------------
+
+class TestEngine:
+    def _cfg(self):
+        return sm.MemoryConfig(
+            slug="demo", label="DEMO", file_prefix="demo",
+            default_programs={"p1": sm._prog("Program One", "Status one.", ["Q1?"])},
+            theme_keywords=["alpha", "beta"],
+        )
+
+    def test_filenames(self):
+        c = self._cfg()
+        assert c.narrative_filename == "demo_narrative_tracker.json"
+        assert c.performance_filename == "demo_performance_tracker.json"
+        assert c.theme_filename == "demo_theme_history.json"
+
+    def test_round_trip(self, tmp_path):
+        c = self._cfg()
+        t = sm.load_narrative_tracker(tmp_path, c)
+        assert "p1" in t["programs"]
+        sm.save_narrative_tracker(t, tmp_path, c)
+        assert (tmp_path / c.narrative_filename).exists()
+
+    def test_default_isolation(self, tmp_path):
+        c = self._cfg()
+        first = sm.load_narrative_tracker(tmp_path, c)
+        first["programs"]["INJECTED"] = {}
+        other = tmp_path / "x"; other.mkdir()
+        assert "INJECTED" not in sm.load_narrative_tracker(other, c)["programs"]
+
+    def test_section_empty_when_no_programs(self, tmp_path):
+        c = sm.MemoryConfig(slug="empty", label="EMPTY", file_prefix="empty",
+                            default_programs={}, theme_keywords=[])
+        assert sm.build_memory_section(tmp_path, c) == ""
+
+    def test_section_nonempty_with_programs(self, tmp_path):
+        c = self._cfg()
+        section = sm.build_memory_section(tmp_path, c)
+        assert "DEMO" in section
+        assert "Program One" in section
+        assert "Status one." in section
+
+    def test_get_memory_context_keys(self, tmp_path):
+        ctx = sm.get_memory_context(tmp_path, self._cfg())
+        assert set(ctx) == {"narrative_status_block", "performance_signals_block", "theme_context_block"}
+
+    def test_theme_mining(self, tmp_path):
+        c = self._cfg()
+        sm.update_theme_history_from_digest(tmp_path, c, "Alpha and beta showed up today.", 1)
+        themes = sm.load_theme_history(tmp_path, c)["recurring_themes"]
+        assert themes.get("alpha", 0) >= 1
+        assert themes.get("beta", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Flag gating via the shared hook helpers
+# ---------------------------------------------------------------------------
+
+class _FakeCfg:
+    def __init__(self, output_dir, enabled):
+        self.memory_enabled = enabled
+        self.episode = type("E", (), {"output_dir": str(output_dir)})()
+
+
+class TestHookGating:
+    def test_disabled_is_true_noop(self, tmp_path):
+        out = sm.memory_pre_fetch(_FakeCfg(tmp_path, False), "models_agents")
+        assert out == {sm.SECTION_VAR: ""}
+
+    def test_enabled_injects_section(self, tmp_path):
+        out = sm.memory_pre_fetch(_FakeCfg(tmp_path, True), "models_agents")
+        assert out[sm.SECTION_VAR]  # non-empty (seeded programs)
+        assert "MODELS & AGENTS" in out[sm.SECTION_VAR]
+
+    def test_unknown_slug_is_noop(self, tmp_path):
+        out = sm.memory_pre_fetch(_FakeCfg(tmp_path, True), "no_such_show")
+        assert out == {sm.SECTION_VAR: ""}
+
+    def test_post_generate_disabled_writes_nothing(self, tmp_path):
+        sm.memory_post_generate(_FakeCfg(tmp_path, False), "models_agents", "agent gpt", 1)
+        assert not list(tmp_path.glob("*theme*"))
+
+    def test_post_generate_enabled_mines(self, tmp_path):
+        sm.memory_post_generate(_FakeCfg(tmp_path, True), "models_agents", "A new agent and gpt model.", 1)
+        cfg = sm.get_config("models_agents")
+        themes = sm.load_theme_history(tmp_path, cfg)["recurring_themes"]
+        assert themes.get("agent", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Per-show config registry + YAML flags
+# ---------------------------------------------------------------------------
+
+class TestRegistryAndConfig:
+    @pytest.mark.parametrize("slug", MEMORY_SHOWS)
+    def test_registered_with_content(self, slug):
+        cfg = sm.get_config(slug)
+        assert cfg is not None
+        assert cfg.default_programs, f"{slug} should have seeded programs"
+        assert cfg.theme_keywords, f"{slug} should have theme keywords"
+        assert cfg.label.isupper() or "&" in cfg.label
+
+    @pytest.mark.parametrize("slug", MEMORY_SHOWS)
+    def test_yaml_memory_enabled(self, slug):
+        from engine.config import load_config
+        cfg = load_config(PROJECT_ROOT / "shows" / f"{slug}.yaml")
+        assert cfg.memory_enabled is True
+
+    def test_non_memory_show_defaults_false(self):
+        from engine.config import load_config
+        cfg = load_config(PROJECT_ROOT / "shows" / "omni_view.yaml")
+        assert cfg.memory_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Prompt wiring + hook files
+# ---------------------------------------------------------------------------
+
+class TestPromptWiring:
+    @pytest.mark.parametrize("slug", MEMORY_SHOWS)
+    def test_prompts_have_placeholder(self, slug):
+        for kind in ("digest", "podcast"):
+            txt = (PROJECT_ROOT / "shows" / "prompts" / f"{slug}_{kind}.txt").read_text(encoding="utf-8")
+            assert "{narrative_memory_section}" in txt, f"{slug}_{kind} missing placeholder"
+
+    @pytest.mark.parametrize("slug", MEMORY_SHOWS)
+    def test_hook_file_exposes_prefetch(self, slug):
+        import importlib.util
+        path = PROJECT_ROOT / "shows" / "hooks" / f"{slug}.py"
+        assert path.exists()
+        spec = importlib.util.spec_from_file_location(f"hk_{slug}", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        assert hasattr(mod, "pre_fetch") and hasattr(mod, "post_generate")
+
+
+# ---------------------------------------------------------------------------
+# Public narrative page
+# ---------------------------------------------------------------------------
+
+class TestPublicPage:
+    @pytest.mark.parametrize("slug", MEMORY_SHOWS)
+    def test_page_renders(self, slug):
+        import generate_html as gh
+        path = gh.generate_narrative_page(slug, dry_run=False)
+        assert path is not None and Path(path).exists()
+        html = Path(path).read_text(encoding="utf-8")
+        assert "Narrative Tracker" in html
+        assert "program-card" in html
+        assert "<title>" in html and "</title>" in html
+        # title must be populated (not empty)
+        import re
+        m = re.search(r"<title>(.*?)</title>", html)
+        assert m and m.group(1).strip(), "title should be populated"


### PR DESCRIPTION
## Phase 3 of the network-evolution roadmap — The Content Moat (recursive narrative memory)

Generalizes Tesla's proven narrative-memory pattern so other shows become **longitudinal chronicles** (tracked programs + open questions + auto-mined themes) instead of disposable daily recaps — the one thing the 80%-overlapping AI-news crowd and human-hosted shows structurally can't match. **Flag-gated and reversible; Tesla's bespoke module is left untouched (zero flagship risk).**

### Engine — `engine/show_memory.py` (new)
Generalized memory engine (narrative tracker + performance signals + theme mining), parameterized by a `MemoryConfig` (slug, label, file_prefix, seeded `default_programs`, `theme_keywords`). Block builders are byte-faithful to `tesla_memory`'s. `SHOW_MEMORY_CONFIGS` registers **Models & Agents, Fascinating Frontiers, Planetterrian** with domain-appropriate programs + keywords.
- MIT already has its own `investment_tracker` (not duplicated); **Tesla keeps `engine/tesla_memory.py`** — folding it into this engine is a safe future cleanup, guarded by the existing `test_show_memory.py`.

### Flag-gated wiring (disabled == true no-op)
- New `config.ShowConfig.memory_enabled` (default **false**).
- Prompts carry **one** `{narrative_memory_section}` placeholder; thin hooks (`shows/hooks/<slug>.py` → `show_memory.memory_pre_fetch`/`memory_post_generate`) inject the composed section when enabled, **empty string otherwise** — so a disabled show renders byte-for-byte as before.
- `run_show.py` `setdefault`s the key so a hook-load failure can never `KeyError` in prompt substitution.
- `memory_enabled: true` set for the 3 rollout shows; **seed narrative trackers committed** (factual status, no speculative claims). Themes accrue automatically from each digest.

### Public "story tracker" pages
- `generate_narrative_page(slug)` + `templates/narrative_page.html.j2` render `<show>-narrative.html` from the committed tracker (with proper `<title>`/OG metadata — which Tesla's page actually lacks). Show pages gain a **"Story Tracker"** button (also now linking Tesla's). Sitemap includes the narrative pages; Sunday weekly recaps inject the narrative block for memory shows too.

### Notes / decisions
- **Planetterrian** confirmed as a science/longevity/health show — landmine #21's "Edmonton-local" description is **stale**.
- Per **landmine #17** (operator output-sensitivity): this changes 3 shows' generated output when enabled. It's **conservatively seeded** and **one-flag reversible** per show (`memory_enabled: false`) — recommend an A/B listen before fully trusting it.

### Verification
- `tests/test_phase3_memory.py` (**28 tests**) — engine, flag gating (disabled no-op), registry, prompt wiring, public page render — added to the `run-show.yml` smoke set; `test_show_memory.py` still pins the untouched Tesla module.
- Full suite: **2362 passed, 3 skipped**. `ruff` clean; `actionlint` (with shellcheck, matching CI) clean.
- Source-only for regenerated HTML (the pipeline regenerates show pages/blogs/sitemap within a day); the 3 new narrative pages + seed trackers are committed so they're immediately live.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gedt496vNmp6wkqbi1ix4d)_