### PR TITLE
Review polish: consolidate PodcastEpisode JSON-LD, Sunday narrative dedup, title-fallback tightening

### DIFF
--- a/engine/blog.py
+++ b/engine/blog.py
@@ -516,7 +516,8 @@ def convert_md_to_blog_html(md_text: str) -> tuple[str, list[dict]]:
 # ---------------------------------------------------------------------------
 
 def _build_jsonld(metadata: dict, show_name: str, blog_url: str,
-                   show_config: dict | None = None) -> str:
+                   show_config: dict | None = None,
+                   *, transcript_url: str = "", audio_url: str = "") -> str:
     """Build Schema.org JSON-LD: BlogPosting + PodcastEpisode (as array).
 
     PodcastEpisode enables Google's podcast features in Search results, links
@@ -570,6 +571,14 @@ def _build_jsonld(metadata: dict, show_name: str, blog_url: str,
         }
         if show_config.get("podcast_image"):
             podcast_episode["image"] = f"https://nerranetwork.com/{show_config['podcast_image']}"
+
+    # Transcript + audio (supplied by generate_blog_post_html once the TTS
+    # transcript has been loaded). Emitted only when present so the JSON stays
+    # tight. This is the single canonical PodcastEpisode for the page.
+    if transcript_url:
+        podcast_episode["transcript"] = transcript_url
+    if audio_url:
+        podcast_episode["associatedMedia"] = {"@type": "MediaObject", "contentUrl": audio_url}
 
     # ``ensure_ascii=False`` so Cyrillic show names ("Финансы Просто",
     # "Привет, Русский!") render as readable Unicode in the page source
@@ -627,19 +636,20 @@ def generate_blog_post_html(
     _extracted = (metadata.get("title") or "").strip()
     _hook = (metadata.get("hook") or "").strip()
     _show = show_config["name"]
+    # Match the show-name fallback without over-reaching: equality or a
+    # leading "# <Show Name> — subtitle" heading. Deliberately NOT a bare
+    # substring check, so a genuinely unique title that merely *mentions* the
+    # show name mid-sentence keeps its own title.
     _is_show_name = (
         not _extracted
         or _extracted == _show
         or _extracted.startswith(_show)
-        or _show in _extracted
     )
     if _is_show_name and _hook:
         clipped = _hook[:100].rstrip(" .,;:—-")
         metadata["title"] = clipped + ("…" if len(_hook) > 100 else "")
     elif not _extracted:
         metadata["title"] = _show
-
-    jsonld = _build_jsonld(metadata, show_config["name"], blog_url, show_config)
 
     # Source domains for display
     source_domains = []
@@ -668,6 +678,15 @@ def generate_blog_post_html(
                 transcript_text = strip_speech_tags(_raw)
     except Exception:
         pass  # Non-fatal — transcript is optional
+
+    # Build JSON-LD now that the transcript is known, so the (single, canonical)
+    # PodcastEpisode block can carry the transcript + audio links.
+    _transcript_url = f"{blog_url}#transcript" if transcript_text else ""
+    _audio_url = metadata.get("audio_url", "")
+    jsonld = _build_jsonld(
+        metadata, show_config["name"], blog_url, show_config,
+        transcript_url=_transcript_url, audio_url=_audio_url,
+    )
 
     template = template_env.get_template("blog_post.html.j2")
 

--- a/run_show.py
+++ b/run_show.py
@@ -1052,6 +1052,12 @@ def run(args: argparse.Namespace) -> None:
                 is_weekly_recap = False
             else:
                 metrics.record("weekly_recap_mode", True)
+                # The Sunday recap text already embeds the narrative-memory
+                # block (engine.weekly_recap appends it), so clear the prompt's
+                # {narrative_memory_section} to avoid injecting the same content
+                # twice into the podcast prompt on recap days.
+                if template_vars.get("narrative_memory_section"):
+                    template_vars["narrative_memory_section"] = ""
         if not is_weekly_recap:
             logger.info("Generating digest ...")
             try:

--- a/templates/blog_post.html.j2
+++ b/templates/blog_post.html.j2
@@ -24,30 +24,9 @@
   ]
 }
     </script>
-
-    {# Richer PodcastEpisode structured data (supplements the BlogPosting
-       JSON-LD above). Built as a dict piped through tojson so the output is
-       always valid JSON even when a title contains quotes, and optional
-       members (audio, transcript) are emitted only when actually present. #}
-    {%- set _episode_ld = {
-        "@context": "https://schema.org",
-        "@type": "PodcastEpisode",
-        "name": (episode_title if (episode_title and episode_title != show_name) else (hook or episode_title or page_title)),
-        "url": (page_url or canonical_url),
-        "datePublished": (date or episode_date_iso),
-        "description": (summary or ""),
-        "inLanguage": ("ru" if _is_ru else "en"),
-        "isPartOf": {
-            "@type": "PodcastSeries",
-            "name": show_name,
-            "url": ("https://nerranetwork.com/" ~ show_page)
-        }
-    } -%}
-    {%- if audio_url %}{% set _ = _episode_ld.update({"associatedMedia": {"@type": "MediaObject", "contentUrl": audio_url}}) %}{% endif -%}
-    {%- if transcript_url %}{% set _ = _episode_ld.update({"transcript": transcript_url}) %}{% endif -%}
-    <script type="application/ld+json">
-{{ _episode_ld | tojson }}
-    </script>
+    {# PodcastEpisode JSON-LD is emitted once, in the {{ jsonld }} array above
+       (engine/blog.py _build_jsonld) — including transcript + audio links —
+       so there is no duplicate PodcastEpisode block here. #}
 
     <style>
         .blog-hero {

--- a/tests/test_phase2_growth.py
+++ b/tests/test_phase2_growth.py
@@ -137,9 +137,20 @@ class TestBlogPostRender:
         assert ep["url"].startswith("https://nerranetwork.com/blog/tesla/")
         assert ep["datePublished"], "datePublished must not be empty"
         assert ep["name"], "name must not be empty"
-        assert ep["isPartOf"]["@type"] == "PodcastSeries"
+        # Single canonical PodcastEpisode (from engine/blog.py _build_jsonld)
+        # links to its series and carries the transcript.
+        series = ep.get("partOfSeries") or ep.get("isPartOf")
+        assert series and series["@type"] == "PodcastSeries"
         assert ep["inLanguage"] == "en"
         assert ep["transcript"].endswith("#transcript")
+
+    def test_only_one_podcastepisode_block(self, html):
+        # Consolidation: exactly one PodcastEpisode across all JSON-LD on the page.
+        eps = []
+        for b in _ld_json_blocks(html):
+            items = b if isinstance(b, list) else [b]
+            eps += [x for x in items if x.get("@type") == "PodcastEpisode"]
+        assert len(eps) == 1, f"expected exactly one PodcastEpisode, found {len(eps)}"
 
     def test_share_row_has_facebook_email_and_utm(self, html):
         assert "facebook.com/sharer" in html


### PR DESCRIPTION
## Post-phase review polish (3 optional cleanups)

A full codebase review of the four-phase work found **no bugs** — the one "critical" audit finding (a `--resume-publish` `NameError` on `hook_module`) was a **verified false positive**: that call lives inside the non-resume `else` block (spans `run_show.py:579→2284`), so it's unreachable on the resume path. These are the three low-priority improvements the review surfaced:

1. **Consolidated duplicate `PodcastEpisode` JSON-LD.** `engine/blog.py`'s `_build_jsonld` already emits a `PodcastEpisode` in the `{{ jsonld }}` array, and the blog template emitted a *second* standalone one. I enriched `_build_jsonld`'s `PodcastEpisode` with the `transcript` + `associatedMedia` links (moving the call to after the transcript loads) and removed the standalone block. Now exactly **one** canonical `PodcastEpisode` per page (verified on a real post).

2. **Sunday narrative dedup.** On the Sunday weekly recap the narrative block is already embedded in the synthesized digest (`engine.weekly_recap`), so `run_show.py` now clears `{narrative_memory_section}` on recap days — avoiding injecting the same content twice into the podcast prompt for the memory shows. (Tesla uses a different key and is unchanged.)

3. **Tightened the per-episode title fallback.** Dropped the broad `_show in _extracted` substring check so a unique title that merely *mentions* the show name keeps its own title; `==` and `"# Show — subtitle"` `startswith` still catch the show-name fallback.

### Verification
- Updated `tests/test_phase2_growth.py` (asserts exactly one `PodcastEpisode`, accepts `partOfSeries`).
- Full suite: **2383 passed, 3 skipped**. `ruff` + `actionlint` (with shellcheck) clean.
- Source-only (pipeline regenerates HTML).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gedt496vNmp6wkqbi1ix4d)_