### PR TITLE
Fix monthly MIT episode TTS crash (legacy speak() → synthesize())

### DIFF
--- a/scripts/run_monthly_mit_episode.py
+++ b/scripts/run_monthly_mit_episode.py
@@ -39,6 +39,7 @@ import calendar
 import datetime as _dt
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Any, Iterable
@@ -432,7 +433,7 @@ def run(
         return 0
 
     # TTS -> audio mix -> upload -> RSS update
-    from engine.tts import speak
+    from engine.tts import synthesize
     from engine.audio import mix_with_music, get_audio_duration
     from engine.storage import upload_episode
     from engine.publisher import (
@@ -447,16 +448,36 @@ def run(
     voice_mp3 = mit_dir / f"{mp3_basename}_voice.mp3"
     final_mp3 = mit_dir / f"{mp3_basename}.mp3"
 
-    speak(
-        text=script,
-        output_path=voice_mp3,
-        voice_id=config.tts.voice_id,
-        model=config.tts.model,
+    # Resolve TTS provider + API key the same way run_show.py does (the whole
+    # network is on Grok TTS — the legacy speak() ElevenLabs path took different
+    # kwargs, which is why this used to crash).
+    tts_provider = (config.tts.provider or "elevenlabs").lower()
+    if tts_provider == "grok":
+        tts_api_key = (os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY") or "").strip()
+    else:
+        tts_api_key = (os.getenv("ELEVENLABS_API_KEY") or "").strip()
+    if not tts_api_key:
+        raise RuntimeError(
+            f"No TTS API key for provider '{tts_provider}' "
+            "(set GROK_API_KEY/XAI_API_KEY, or ELEVENLABS_API_KEY)."
+        )
+
+    synthesize(
+        script,
+        config.tts.voice_id,
+        voice_mp3,
+        api_key=tts_api_key,
+        provider=tts_provider,
+        max_chars=config.tts.max_chars,
+        model_id=config.tts.model,
         stability=config.tts.stability,
         similarity_boost=config.tts.similarity_boost,
         style=config.tts.style,
-        use_speaker_boost=config.tts.use_speaker_boost,
-        max_chars=config.tts.max_chars,
+        language_code=config.tts.language_code,
+        speed=config.tts.speed,
+        apply_text_normalization=config.tts.apply_text_normalization,
+        speech_wrap_open=config.tts.speech_wrap_open,
+        speech_wrap_close=config.tts.speech_wrap_close,
     )
     logger.info("Voice synthesised: %s", voice_mp3)
 

--- a/tests/test_monthly_mit_episode.py
+++ b/tests/test_monthly_mit_episode.py
@@ -22,6 +22,45 @@ import run_monthly_mit_episode as monthly  # type: ignore
 
 
 # ---------------------------------------------------------------------------
+# TTS call-signature guard (regression for the speak(output_path=...) crash)
+# ---------------------------------------------------------------------------
+
+class TestTtsCallSignature:
+    """The monthly episode used to call the legacy ElevenLabs ``speak()`` with
+    stale kwargs (``output_path=``, ``model=``) and no ``api_key``, crashing the
+    monthly-report workflow. Guard that it calls the canonical ``synthesize()``
+    dispatcher with only real parameters."""
+
+    _SCRIPT = _REPO_ROOT / "scripts" / "run_monthly_mit_episode.py"
+
+    def test_uses_synthesize_not_legacy_speak(self):
+        src = self._SCRIPT.read_text(encoding="utf-8")
+        assert "from engine.tts import synthesize" in src
+        assert "output_path=voice_mp3" not in src  # the old buggy kwarg
+
+    def test_synthesize_call_kwargs_are_all_valid(self):
+        import ast
+        import inspect
+        from engine.tts import synthesize
+
+        valid = set(inspect.signature(synthesize).parameters)
+        tree = ast.parse(self._SCRIPT.read_text(encoding="utf-8"))
+        calls = [
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            and n.func.id == "synthesize"
+        ]
+        assert calls, "expected a synthesize() call in the monthly episode script"
+        for call in calls:
+            for kw in call.keywords:
+                if kw.arg is None:  # **kwargs spread — skip
+                    continue
+                assert kw.arg in valid, (
+                    f"synthesize() has no parameter {kw.arg!r} — stale TTS call"
+                )
+
+
+# ---------------------------------------------------------------------------
 # is_last_trading_day_of_month
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Fix: monthly MIT episode TTS crash

The `monthly-report` workflow was failing:

```
File "scripts/run_monthly_mit_episode.py", line 450, in run
    speak(
TypeError: speak() got an unexpected keyword argument 'output_path'
```

### Root cause
`scripts/run_monthly_mit_episode.py` called the **legacy ElevenLabs `speak()`** with stale kwargs (`output_path=`, `model=`, `use_speaker_boost=`) and **no `api_key`** — a signature that predates the Grok-TTS migration and the `speak()` refactor. The whole network runs on Grok TTS now, so the monthly episode must go through the canonical provider-aware **`engine.tts.synthesize()`** dispatcher, exactly like `run_show.py` does. (Not caused by recent PRs — pre-existing staleness in a monthly-only script that only runs near month-end, so it surfaced now.)

### Fix
- Switch the import + call to `synthesize()`; resolve provider + `api_key` the same way `run_show.py` does (`GROK_API_KEY`/`XAI_API_KEY` for grok, else `ELEVENLABS_API_KEY`) and fail loudly if unset.
- Add the missing `import os`.
- **Regression guard** (`tests/test_monthly_mit_episode.py`): AST-parses the script's `synthesize()` call and asserts every kwarg is a real parameter of `engine.tts.synthesize`, and that the legacy `speak(output_path=)` call is gone. This catches any future TTS-signature drift in the script.

### Verification
- Confirmed there are **no other stale `speak()` callers** (the two in `engine/tts.py` are the correct internal ElevenLabs dispatch inside `synthesize()`).
- Full suite: **2385 passed, 3 skipped**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gedt496vNmp6wkqbi1ix4d)_