### PR TITLE
Multi-platform Shorts (Instagram Reels / TikTok): safe-zone variant + per-platform metadata + posting scaffold

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -235,7 +235,7 @@ jobs:
             tests/test_show_memory.py tests/test_prompt_fidelity.py \
             tests/test_episode_validity.py tests/test_pipeline_safety.py \
             tests/test_phase2_growth.py tests/test_phase3_memory.py \
-            tests/test_phase4_repositioning.py \
+            tests/test_phase4_repositioning.py tests/test_social_distribution.py \
             -q --tb=short
 
       - name: Create .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -527,6 +527,24 @@ generated output; per landmine #17, A/B-listen and revert via git if needed):
 - **Operator tooling:** `scripts/update_tesla_narrative.py` now takes `--slug`
   (default tesla) for any memory show.
 
+### Multi-platform Shorts distribution (Instagram Reels / TikTok, May 2026)
+
+Opt-in per show (`youtube.multi_platform_enabled`, default false → no-op). When
+on, each published Short also gets: a **safe-zone variant MP4** (drops the
+bottom URL pill + end-card and lifts captions via
+`build_short_video(drop_url_pill=, caption_margin_v=)` so overlays clear the
+IG/TikTok UI bands), a **`.social.json` sidecar** with per-platform
+caption/hashtags (`engine/social_metadata.py`), optional **R2 hosting**
+(`social_r2_prefix`; needed for IG's URL-based API), and best-effort
+**auto-posting** (`engine/social_publisher.py` — IG Graph + TikTok Content
+Posting; a clean no-op until `IG_ACCESS_TOKEN`/`IG_USER_ID` /
+`TIKTOK_ACCESS_TOKEN` are set, and requires the operator's developer-app
+approval). Orchestrated by `engine/social_distribution.py`, called once per
+Short from `run_show.py`'s YouTube stage (additive, non-fatal). YouTube uploads
+use the original Short, unchanged. Full setup + limitations:
+[`docs/social_distribution.md`](docs/social_distribution.md). Drift guards:
+`tests/test_social_distribution.py`.
+
 ## Current Refactoring Goal
 
 **Extract duplicated code from the show scripts into `engine/` modules.**

--- a/docs/social_distribution.md
+++ b/docs/social_distribution.md
@@ -1,0 +1,94 @@
+# Multi-platform Shorts distribution (Instagram Reels / TikTok)
+
+The Shorts pipeline can cross-post each Short to Instagram Reels and TikTok (and
+leave a ready-to-post bundle for anywhere else). This is **opt-in per show** and
+a **clean no-op until you finish the one-time account/app setup** below — so the
+code can ship and sit dormant safely.
+
+## What the pipeline produces
+
+When `youtube.multi_platform_enabled: true` for a show, every Short it publishes
+to YouTube *also* gets:
+
+1. **A safe-zone variant MP4** (`<episode>_short[_N]_social.mp4`). It's the same
+   clip but with overlays moved out of the bands Instagram Reels & TikTok cover
+   with their own UI: the bottom URL pill and the end-card are dropped, and the
+   burned-in captions are lifted (`MarginV` 340 → `social_caption_margin_v`,
+   default 480). The top brand pill and centred hook stay. YouTube uploads still
+   use the original (unchanged) Short — this variant is for the vertical-social
+   platforms whose UI is more aggressive.
+2. **A `.social.json` sidecar** with ready-to-post copy per platform:
+   ```json
+   {
+     "youtube":        {"title": "...", "description": "...", "tags": [...]},
+     "instagram_reels":{"caption": "<hook> … #Tag #Reels #podcast", "hashtags": [...]},
+     "tiktok":         {"caption": "<hook> #Tag #podcast #fyp",       "hashtags": [...]}
+   }
+   ```
+   Captions lead with the episode hook and reuse the same entity-derived hashtags
+   as the YouTube Short (`engine/shorts_hashtags.py`).
+3. **(Optional) R2 hosting** — if `youtube.social_r2_prefix` is set and the
+   gallery R2 env is configured, the variant is uploaded so it has a stable
+   public URL (required for Instagram's URL-based API, and handy for grabbing the
+   asset to post manually).
+4. **Auto-posting** to the platforms you've enabled + credentialed (below).
+
+Even with **no** credentials, you still get the variant MP4 + sidecar, so you can
+post manually with one paste.
+
+## Enabling it (per show YAML)
+
+```yaml
+youtube:
+  enabled: true            # YouTube must be on (Shorts are produced there)
+  multi_platform_enabled: true
+  instagram_enabled: true  # attempt IG auto-post (needs creds below)
+  tiktok_enabled: true     # attempt TikTok auto-post (needs creds below)
+  social_r2_prefix: "social/tesla"   # host variants here (needed for IG)
+  # optional tuning:
+  # social_caption_margin_v: 480   # px from bottom for captions on the variant
+  # social_drop_url_pill: true
+  # social_drop_end_card: true
+```
+
+Default is everything off → YouTube-only, byte-for-byte unchanged.
+
+## One-time credential / app setup (operator)
+
+These require **your** accounts and developer apps; they can't be scripted blind.
+
+### Instagram Reels (Graph API)
+- Convert the IG account to **Business/Creator** and link it to a **Facebook Page**.
+- Create a **Meta app**, add **Instagram Graph API**, request the
+  `instagram_content_publish` + `instagram_basic` permissions (App Review).
+- Generate a long-lived **IG access token** and find the **IG user id**.
+- Set env / GitHub secrets: `IG_ACCESS_TOKEN`, `IG_USER_ID`.
+- IG is **URL-based**: the Short must be at a public URL → set `social_r2_prefix`
+  and the gallery R2 env (`R2_ENDPOINT_URL`, `R2_ACCESS_KEY_ID`,
+  `R2_SECRET_ACCESS_KEY`, `R2_GALLERY_BUCKET`, `R2_GALLERY_PUBLIC_BASE_URL`).
+
+### TikTok (Content Posting API)
+- Register a **TikTok developer app**, request the **`video.publish`** scope
+  (requires app review/audit).
+- Complete user OAuth and store a user **access token**: `TIKTOK_ACCESS_TOKEN`.
+- Until the app passes audit, posts are created as `SELF_ONLY` (the publisher
+  sets this deliberately); flip to public in `engine/social_publisher.py`
+  (`privacy_level`) once approved.
+
+## Where it lives
+
+- `engine/social_metadata.py` — pure per-platform caption/hashtag builder.
+- `engine/social_publisher.py` — credential-gated IG/TikTok API calls (no-op
+  without creds; never raises).
+- `engine/social_distribution.py` — orchestrator (variant + sidecar + R2 + post),
+  called once per Short from `run_show.py`'s YouTube publish stage.
+- `engine/video.py` — `build_short_video(..., drop_url_pill=, caption_margin_v=)`
+  renders the safe-zone variant.
+
+## Status / limitations
+
+- The IG/TikTok API flows are implemented against the documented endpoints but
+  have **not** been run against live apps here — verify on the first real post.
+- Posting is best-effort and non-fatal: a failure never blocks the episode.
+- Other platforms (YouTube Shorts already covered; Facebook Reels, etc.) can
+  reuse the same safe-zone MP4 + sidecar.

--- a/engine/config.py
+++ b/engine/config.py
@@ -419,6 +419,28 @@ class YouTubeConfig:
     # offset so they ignore this knob and always produce 1 Short.
     shorts_per_episode: int = 1
 
+    # ---- Multi-platform distribution (Instagram Reels / TikTok / etc.) ----
+    # When true, each published Short additionally gets (1) a "safe-zone"
+    # variant MP4 with overlays lifted out of the bottom/right bands that IG
+    # Reels and TikTok draw their own UI (caption + action rail) over, and
+    # (2) a "<short>.social.json" sidecar carrying per-platform caption +
+    # hashtags. Actual posting is handled by engine.social_publisher, which is
+    # a clean no-op until the platform API credentials are configured. Default
+    # false → YouTube-only behaviour is byte-for-byte unchanged.
+    multi_platform_enabled: bool = False
+    instagram_enabled: bool = False
+    tiktok_enabled: bool = False
+    # Safe-zone overlay tuning for the social variant (1080×1920). IG/TikTok
+    # cover the bottom ~16% (caption + CTA) and right ~12% (like/share rail).
+    # Captions are bottom-centre, so only the vertical margin needs lifting;
+    # the URL pill + end-card are dropped (the caption text carries the link).
+    social_caption_margin_v: int = 480     # ASS MarginV (px from bottom)
+    social_drop_url_pill: bool = True
+    social_drop_end_card: bool = True
+    # R2 bucket key prefix for ready-to-post social assets (video + sidecar).
+    # Empty = keep assets local only (no upload).
+    social_r2_prefix: str = ""
+
 
 @dataclass
 class ShowConfig:

--- a/engine/social_distribution.py
+++ b/engine/social_distribution.py
@@ -1,0 +1,134 @@
+"""Cross-platform distribution for a single Short (orchestrator).
+
+For each YouTube Short the pipeline publishes, this (when
+``config.youtube.multi_platform_enabled``) additionally:
+
+  1. renders a **safe-zone variant** MP4 — overlays lifted out of the bottom/
+     right bands that Instagram Reels & TikTok draw their own UI over (drops the
+     bottom URL pill + end-card, raises the captions);
+  2. writes a **``<short>.social.json`` sidecar** with per-platform caption +
+     hashtags (``engine.social_metadata``);
+  3. optionally **hosts the MP4 on R2** (needed so Instagram's URL-based Graph
+     API — and the operator — can fetch a non-ephemeral asset);
+  4. **posts** to the enabled platforms via ``engine.social_publisher`` (a
+     no-op until credentials are configured).
+
+Every step is best-effort and non-fatal: a distribution failure must never
+block the episode. The whole thing is a no-op unless the show opts in.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+def _maybe_upload_r2(local_path: Path, key_prefix: str) -> str:
+    """Upload to the gallery R2 bucket and return a public URL, or "" if R2
+    isn't configured (clean fall-through)."""
+    try:
+        from engine.gallery_uploader import gallery_config_from_env
+        from engine.storage import upload_to_r2
+        cfg = gallery_config_from_env()
+        if not (cfg.is_configured and cfg.public_base_url):
+            return ""
+        key = f"{key_prefix.strip('/')}/{local_path.name}"
+        return upload_to_r2(
+            local_path, key,
+            bucket=cfg.bucket, endpoint_url=cfg.endpoint_url,
+            access_key=cfg.access_key, secret_key=cfg.secret_key,
+            public_base_url=cfg.public_base_url, content_type="video/mp4",
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Social R2 upload failed (non-fatal): %s", exc)
+        return ""
+
+
+def distribute_short(
+    config,
+    *,
+    audio_path: Path,
+    cover_path: Path,
+    work_dir: Path,
+    base_name: str,
+    short_suffix: str = "",
+    start_offset: float = 0.0,
+    duration: float = 55.0,
+    hook: str = "",
+    show_name: str = "",
+    show_url: str = "",
+    scene_paths: Optional[Sequence[Path]] = None,
+    subtitles_path: Optional[Path] = None,
+    long_form_url: str = "",
+    short_youtube_url: str = "",
+    show_keywords: Optional[Sequence[str]] = None,
+    is_ru: bool = False,
+) -> Dict:
+    """Produce + (optionally) post the social variant of one Short.
+
+    Returns a summary dict (paths + per-platform post status). No-op (returns
+    ``{}``) unless ``config.youtube.multi_platform_enabled``.
+    """
+    yt = getattr(config, "youtube", None)
+    if not getattr(yt, "multi_platform_enabled", False):
+        return {}
+
+    result: Dict = {}
+    social_mp4 = work_dir / f"{base_name}_short{short_suffix}_social.mp4"
+
+    # 1) Safe-zone variant MP4 (no URL pill, no end-card, captions lifted).
+    try:
+        from engine.video import build_short_video
+        build_short_video(
+            audio_path, cover_path, social_mp4,
+            start_offset=start_offset, duration=duration,
+            hook=hook, scene_paths=scene_paths, show_name=show_name,
+            subtitles_path=subtitles_path,
+            end_card=False,
+            drop_url_pill=getattr(yt, "social_drop_url_pill", True),
+            caption_margin_v=getattr(yt, "social_caption_margin_v", 480),
+        )
+        result["video"] = str(social_mp4)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Social safe-zone Short render failed (non-fatal): %s", exc)
+        return result
+
+    # 2) Per-platform metadata sidecar.
+    try:
+        from engine.social_metadata import build_social_metadata
+        meta = build_social_metadata(
+            hook=hook, show_name=show_name, show_url=show_url,
+            long_form_url=long_form_url, short_youtube_url=short_youtube_url,
+            show_keywords=show_keywords, is_ru=is_ru,
+        )
+        sidecar = social_mp4.with_suffix(".social.json")
+        sidecar.write_text(json.dumps(meta, indent=2, ensure_ascii=False), encoding="utf-8")
+        result["sidecar"] = str(sidecar)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Social metadata sidecar failed (non-fatal): %s", exc)
+        return result
+
+    # 3) Host on R2 (so IG can fetch it + the operator can grab it).
+    public_url = ""
+    prefix = getattr(yt, "social_r2_prefix", "") or ""
+    if prefix:
+        public_url = _maybe_upload_r2(social_mp4, prefix)
+        if public_url:
+            result["public_url"] = public_url
+
+    # 4) Post to enabled platforms (no-op without credentials).
+    try:
+        from engine.social_publisher import publish_short
+        result["posted"] = publish_short(
+            video_path=social_mp4, metadata=meta, video_public_url=public_url,
+            instagram=getattr(yt, "instagram_enabled", False),
+            tiktok=getattr(yt, "tiktok_enabled", False),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Social publish dispatch failed (non-fatal): %s", exc)
+
+    return result

--- a/engine/social_metadata.py
+++ b/engine/social_metadata.py
@@ -1,0 +1,121 @@
+"""Per-platform post metadata for Shorts (YouTube / Instagram Reels / TikTok).
+
+The video pipeline already builds YouTube title/description/tags
+(``engine.video_metadata``). Instagram Reels and TikTok don't take a
+title/tags field — they take a single *caption* with hashtags inline, and each
+has its own conventions (caption length, how many hashtags read well, what CTA
+makes sense). This module produces a ready-to-post caption + hashtag list per
+platform from the episode hook + show info, reusing the same entity-derived
+hashtags as the YouTube Shorts (``engine.shorts_hashtags``).
+
+It's a pure builder (no I/O, no config import) so it's trivially testable; the
+caller passes the show-derived values and persists the result as a
+``<short>.social.json`` sidecar.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence
+
+from engine.shorts_hashtags import extract_hashtags
+
+# Conservative caption ceilings (both platforms allow ~2200; keep margin).
+_CAPTION_MAX = 2000
+# Universal discovery tags appended per platform (deduped against entity tags).
+_YT_SUFFIX = ["Shorts", "podcast"]
+_IG_SUFFIX = ["Reels", "podcast"]
+_TIKTOK_SUFFIX = ["podcast", "fyp"]
+
+
+def _fmt_tags(tags: Sequence[str]) -> str:
+    return " ".join(f"#{t}" for t in tags)
+
+
+def _merge_tags(entity_tags: Sequence[str], suffix: Sequence[str], cap: int = 8) -> List[str]:
+    """Entity tags first, then platform suffix tags, de-duped case-insensitively."""
+    out: List[str] = []
+    seen = set()
+    for t in list(entity_tags) + list(suffix):
+        key = t.lower().lstrip("#")
+        if key and key not in seen:
+            seen.add(key)
+            out.append(t.lstrip("#"))
+        if len(out) >= cap:
+            break
+    return out
+
+
+def _clip(text: str, limit: int = _CAPTION_MAX) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def build_social_metadata(
+    *,
+    hook: str,
+    show_name: str,
+    show_url: str,
+    long_form_url: str = "",
+    short_youtube_url: str = "",
+    show_keywords: Optional[Sequence[str]] = None,
+    is_ru: bool = False,
+) -> Dict[str, dict]:
+    """Return ready-to-post metadata keyed by platform.
+
+    Keys: ``youtube`` (title/description/tags), ``instagram_reels`` and
+    ``tiktok`` (each ``caption`` + ``hashtags``). Captions lead with the hook
+    (the unique, attention-grabbing line) so the visible preview is strong.
+    """
+    hook = (hook or "").strip()
+    entity_tags = extract_hashtags(hook, show_keywords=show_keywords, max_hashtags=6)
+
+    listen = long_form_url or short_youtube_url or show_url
+    # Localised CTA copy for the Russian shows.
+    if is_ru:
+        full = "🎧 Полный выпуск и другие серии"
+        more = "Слушайте"
+    else:
+        full = "🎧 Full episode + more"
+        more = "Listen"
+
+    # --- Instagram Reels: hook, CTA, then hashtags on their own line ---
+    ig_tags = _merge_tags(entity_tags, _IG_SUFFIX, cap=10)
+    ig_caption = _clip(
+        f"{hook}\n\n{full}: {show_url}\n\n{_fmt_tags(ig_tags)}"
+    )
+
+    # --- TikTok: punchier; a few hashtags inline after the hook ---
+    tt_tags = _merge_tags(entity_tags, _TIKTOK_SUFFIX, cap=6)
+    tt_caption = _clip(f"{hook} {_fmt_tags(tt_tags)}".strip())
+
+    # --- YouTube Shorts: title + description + tags (mirrors video_metadata) ---
+    yt_tags = _merge_tags(entity_tags, _YT_SUFFIX, cap=12)
+    yt_title = _clip(f"{hook} | {show_name} #Shorts", limit=100)
+    yt_desc_lines = [hook, "", f"{more}: {listen}", f"🌐 {show_url}"]
+    if long_form_url:
+        yt_desc_lines.insert(2, f"▶ Full episode: {long_form_url}")
+    yt_description = _clip("\n".join(yt_desc_lines), limit=4500)
+
+    return {
+        "youtube": {
+            "title": yt_title,
+            "description": yt_description,
+            "tags": yt_tags,
+        },
+        "instagram_reels": {
+            "caption": ig_caption,
+            "hashtags": ig_tags,
+        },
+        "tiktok": {
+            "caption": tt_caption,
+            "hashtags": tt_tags,
+        },
+        "_meta": {
+            "hook": hook,
+            "show_name": show_name,
+            "show_url": show_url,
+            "long_form_url": long_form_url,
+            "short_youtube_url": short_youtube_url,
+        },
+    }

--- a/engine/social_publisher.py
+++ b/engine/social_publisher.py
@@ -1,0 +1,185 @@
+"""Publish a Short to Instagram Reels / TikTok (credential-gated, no-op by default).
+
+This is the integration seam for cross-posting the safe-zone Short MP4 produced
+by the pipeline. It is a **clean no-op until the platform credentials are set**
+(via env vars), so wiring it in is safe before the operator has finished the
+one-time developer-app setup. Each call returns a structured status dict
+(``posted`` / ``skipped`` / ``error``) and never raises — distribution must
+never block an episode.
+
+Reality check (why this needs operator setup, not just code):
+  * **Instagram Reels** uses the Instagram Graph API, which requires a
+    Business/Creator account linked to a Facebook Page + an approved Meta app
+    with ``instagram_content_publish``. It is **URL-based**: you create a media
+    container pointing at a *publicly reachable* video URL, then publish it —
+    so the Short must be hosted first (e.g. the gallery R2 bucket). Env:
+    ``IG_ACCESS_TOKEN``, ``IG_USER_ID``.
+  * **TikTok** uses the Content Posting API, which requires a registered TikTok
+    developer app with the ``video.publish`` scope (app review) and a user
+    OAuth access token. Supports direct file upload. Env:
+    ``TIKTOK_ACCESS_TOKEN``.
+
+See ``docs/social_distribution.md`` for the full setup. Until then, the
+pipeline still emits a ``<short>.social.json`` sidecar + safe-zone MP4 so the
+operator can post manually.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_GRAPH_BASE = "https://graph.facebook.com/v21.0"
+_TIKTOK_BASE = "https://open.tiktokapis.com/v2"
+
+
+def _status(platform: str, state: str, **extra) -> Dict:
+    out = {"platform": platform, "status": state}
+    out.update(extra)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Instagram Reels (Graph API — container then publish; needs a public video URL)
+# ---------------------------------------------------------------------------
+
+def publish_to_instagram(
+    *,
+    video_public_url: str,
+    caption: str,
+    access_token: Optional[str] = None,
+    ig_user_id: Optional[str] = None,
+    timeout: int = 60,
+) -> Dict:
+    access_token = access_token or os.getenv("IG_ACCESS_TOKEN", "").strip()
+    ig_user_id = ig_user_id or os.getenv("IG_USER_ID", "").strip()
+    if not access_token or not ig_user_id:
+        return _status("instagram_reels", "skipped", reason="IG_ACCESS_TOKEN / IG_USER_ID not set")
+    if not video_public_url:
+        return _status("instagram_reels", "skipped", reason="no public video URL (host the MP4 first, e.g. R2)")
+    try:
+        import requests
+        # 1) create a REELS media container pointing at the hosted MP4
+        r = requests.post(
+            f"{_GRAPH_BASE}/{ig_user_id}/media",
+            data={
+                "media_type": "REELS",
+                "video_url": video_public_url,
+                "caption": caption,
+                "access_token": access_token,
+            },
+            timeout=timeout,
+        )
+        r.raise_for_status()
+        creation_id = r.json().get("id")
+        if not creation_id:
+            return _status("instagram_reels", "error", detail="no creation id returned")
+        # 2) publish the container (the operator should poll container status
+        #    for large videos; small Reels are usually ready quickly).
+        pub = requests.post(
+            f"{_GRAPH_BASE}/{ig_user_id}/media_publish",
+            data={"creation_id": creation_id, "access_token": access_token},
+            timeout=timeout,
+        )
+        pub.raise_for_status()
+        return _status("instagram_reels", "posted", media_id=pub.json().get("id"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Instagram publish failed (non-fatal): %s", exc)
+        return _status("instagram_reels", "error", detail=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# TikTok (Content Posting API — direct file upload)
+# ---------------------------------------------------------------------------
+
+def publish_to_tiktok(
+    *,
+    video_path: Path,
+    caption: str,
+    access_token: Optional[str] = None,
+    timeout: int = 120,
+) -> Dict:
+    access_token = access_token or os.getenv("TIKTOK_ACCESS_TOKEN", "").strip()
+    if not access_token:
+        return _status("tiktok", "skipped", reason="TIKTOK_ACCESS_TOKEN not set")
+    video_path = Path(video_path)
+    if not video_path.exists():
+        return _status("tiktok", "error", detail=f"video not found: {video_path}")
+    try:
+        import requests
+        size = video_path.stat().st_size
+        headers = {"Authorization": f"Bearer {access_token}"}
+        # 1) init a direct-post upload (single chunk for a short clip)
+        init = requests.post(
+            f"{_TIKTOK_BASE}/post/publish/video/init/",
+            headers={**headers, "Content-Type": "application/json; charset=UTF-8"},
+            json={
+                "post_info": {"title": caption[:2200], "privacy_level": "SELF_ONLY"},
+                "source_info": {
+                    "source": "FILE_UPLOAD",
+                    "video_size": size,
+                    "chunk_size": size,
+                    "total_chunk_count": 1,
+                },
+            },
+            timeout=timeout,
+        )
+        init.raise_for_status()
+        data = (init.json() or {}).get("data", {})
+        upload_url = data.get("upload_url")
+        publish_id = data.get("publish_id")
+        if not upload_url:
+            return _status("tiktok", "error", detail="no upload_url returned")
+        # 2) upload the bytes
+        with video_path.open("rb") as fh:
+            up = requests.put(
+                upload_url,
+                headers={
+                    "Content-Type": "video/mp4",
+                    "Content-Range": f"bytes 0-{size - 1}/{size}",
+                },
+                data=fh.read(),
+                timeout=timeout,
+            )
+        up.raise_for_status()
+        # NOTE: privacy_level is SELF_ONLY until the app passes TikTok review;
+        # operator flips it to PUBLIC_TO_EVERYONE after audit. Status can be
+        # polled via /post/publish/status/fetch/ with publish_id.
+        return _status("tiktok", "posted", publish_id=publish_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("TikTok publish failed (non-fatal): %s", exc)
+        return _status("tiktok", "error", detail=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+def publish_short(
+    *,
+    video_path: Path,
+    metadata: Dict,
+    video_public_url: str = "",
+    instagram: bool = False,
+    tiktok: bool = False,
+) -> Dict[str, Dict]:
+    """Post a Short to the enabled platforms. Returns {platform: status}.
+
+    Each platform is independent and best-effort: a failure or missing
+    credential on one never affects the others or the episode. ``metadata`` is
+    the dict from ``engine.social_metadata.build_social_metadata``.
+    """
+    results: Dict[str, Dict] = {}
+    if instagram:
+        cap = (metadata.get("instagram_reels") or {}).get("caption", "")
+        results["instagram_reels"] = publish_to_instagram(
+            video_public_url=video_public_url, caption=cap,
+        )
+    if tiktok:
+        cap = (metadata.get("tiktok") or {}).get("caption", "")
+        results["tiktok"] = publish_to_tiktok(video_path=Path(video_path), caption=cap)
+    return results

--- a/engine/video.py
+++ b/engine/video.py
@@ -576,6 +576,19 @@ _SHORTS_SUBTITLES_FORCE_STYLE = (
 )
 
 
+def _shorts_subtitle_style(margin_v: Optional[int] = None) -> str:
+    """Shorts caption ``force_style``, optionally overriding ``MarginV`` (px
+    from the bottom edge).
+
+    The default 340 is tuned for YouTube Shorts. Instagram Reels / TikTok draw
+    their caption + CTA UI over the bottom ~16% of the frame, so the social
+    variant lifts captions higher (a larger MarginV) to keep them readable.
+    """
+    if margin_v is None:
+        return _SHORTS_SUBTITLES_FORCE_STYLE
+    return _SHORTS_SUBTITLES_FORCE_STYLE.replace("MarginV=340", f"MarginV={int(margin_v)}")
+
+
 def _long_form_filter_graph(*, width: int = 1920, height: int = 1080,
                             fps: int = 30,
                             bg_is_video: bool = False,
@@ -663,7 +676,8 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
                              total_duration: float = 55.0,
                              end_card_main_text: str = "WATCH FULL EPISODE",
                              end_card_sub_text: str = "Tap Subscribe ↗",
-                             end_card_image_input_label: Optional[str] = None) -> str:
+                             end_card_image_input_label: Optional[str] = None,
+                             caption_margin_v: Optional[int] = None) -> str:
     """filter_complex for the 1080x1920 Shorts build.
 
     Inputs:
@@ -788,7 +802,7 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
         sub_label = "[capted]" if end_card else "[v]"
         chain += (
             f";{post_brand_label}subtitles='{escaped_sub}'"
-            f":force_style='{_SHORTS_SUBTITLES_FORCE_STYLE}'{sub_label}"
+            f":force_style='{_shorts_subtitle_style(caption_margin_v)}'{sub_label}"
         )
         post_brand_label = sub_label
         if not end_card:
@@ -937,7 +951,8 @@ def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
                     end_card_main_text: str = "WATCH FULL EPISODE",
                     end_card_sub_text: str = "Tap Subscribe ↗",
                     end_card_duration: float = 3.0,
-                    end_card_image_in: Optional[str] = None) -> List[str]:
+                    end_card_image_in: Optional[str] = None,
+                    caption_margin_v: Optional[int] = None) -> List[str]:
     """ffmpeg command for the 1080x1920 Shorts build.
 
     When *bg_is_video* is True, *bg_in* is a pre-rendered vertical
@@ -998,7 +1013,8 @@ def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
                                  total_duration=duration,
                                  end_card_main_text=end_card_main_text,
                                  end_card_sub_text=end_card_sub_text,
-                                 end_card_image_input_label=end_card_image_input_label),
+                                 end_card_image_input_label=end_card_image_input_label,
+                                 caption_margin_v=caption_margin_v),
         "-map", "[v]", "-map", "1:a",
         *_VIDEO_ENCODE,
         "-r", str(fps),
@@ -1143,8 +1159,15 @@ def build_short_video(audio_path: Path, cover_path: Path,
                       end_card_main_text: str = "WATCH FULL EPISODE",
                       end_card_sub_text: str = "Tap Subscribe ↗",
                       end_card_duration: float = 3.0,
-                      end_card_image_path: Optional[Path] = None) -> Path:
+                      end_card_image_path: Optional[Path] = None,
+                      drop_url_pill: bool = False,
+                      caption_margin_v: Optional[int] = None) -> Path:
     """Render a 1080x1920 vertical YouTube Shorts video.
+
+    ``drop_url_pill`` / ``caption_margin_v`` support the multi-platform
+    "safe-zone" variant: dropping the bottom-centre URL pill and lifting the
+    captions (larger MarginV) keeps content clear of the bottom UI band that
+    Instagram Reels and TikTok draw over. They default to YouTube behaviour.
 
     Parameters
     ----------
@@ -1195,6 +1218,11 @@ def build_short_video(audio_path: Path, cover_path: Path,
         _make_show_pill(show_name, brand_path)
         url_pill_path = work_dir / "_url_pill_v1.png"
         _make_url_pill(url_pill_path)
+        if drop_url_pill:
+            # Social safe-zone variant: keep the top brand pill, drop the
+            # bottom-centre URL pill (the caption carries the link, and the
+            # bottom band is covered by IG/TikTok UI anyway).
+            url_pill_path = None
     else:
         brand_path = work_dir / "_brand_pill_v2.png"
         _make_brand_pill(brand_path)
@@ -1235,6 +1263,7 @@ def build_short_video(audio_path: Path, cover_path: Path,
             if end_card_image_path and Path(end_card_image_path).exists()
             else None
         ),
+        caption_margin_v=caption_margin_v,
     )
     logger.info(
         "Building Shorts video (%.1fs from %.1fs) → %s "

--- a/run_show.py
+++ b/run_show.py
@@ -3914,6 +3914,36 @@ def _publish_youtube(
                                 "Playlist add failed for short #%d: %s",
                                 short_idx + 1, exc,
                             )
+                    # Multi-platform distribution (Instagram Reels / TikTok).
+                    # No-op unless config.youtube.multi_platform_enabled; renders
+                    # a safe-zone variant + social.json sidecar, optionally hosts
+                    # on R2, and posts where credentialed. Best-effort.
+                    try:
+                        from engine.social_distribution import distribute_short
+                        dist = distribute_short(
+                            config,
+                            audio_path=final_mp3, cover_path=cover_path,
+                            work_dir=work_dir, base_name=base_name, short_suffix=suffix,
+                            start_offset=this_offset, duration=duration,
+                            hook=this_hook or "", show_name=config.name,
+                            show_url="https://nerranetwork.com",
+                            scene_paths=(
+                                short_scene_paths if len(short_scene_paths) >= 2 else None
+                            ),
+                            subtitles_path=this_srt_path,
+                            long_form_url=long_url,
+                            short_youtube_url=this_upload.watch_url,
+                            show_keywords=getattr(config, "keywords", None),
+                            is_ru=(config.slug in ("finansy_prosto", "privet_russian")),
+                        )
+                        if dist.get("posted"):
+                            result.setdefault("social_posted", []).append(dist["posted"])
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "Social distribution #%d failed (non-fatal): %s",
+                            short_idx + 1, exc,
+                        )
+
                     # Best-effort cleanup of this Short's MP4 now
                     # that YouTube has the canonical copy.
                     try:

--- a/tests/test_social_distribution.py
+++ b/tests/test_social_distribution.py
@@ -1,0 +1,195 @@
+"""Tests for the multi-platform (Instagram Reels / TikTok) Shorts distribution.
+
+Covers: per-platform metadata, the safe-zone Short filter graph, the
+credential-gated publisher (no-op without creds), and the distribute_short
+orchestrator (no-op unless opted in; renders variant + sidecar when on).
+ffmpeg / R2 / platform APIs are mocked — none run here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import types
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Per-platform metadata
+# ---------------------------------------------------------------------------
+
+class TestSocialMetadata:
+    def _build(self, **kw):
+        from engine.social_metadata import build_social_metadata
+        base = dict(
+            hook="Tesla Cybercab hits 500k preorders in 48 hours",
+            show_name="Tesla Shorts Time",
+            show_url="https://nerranetwork.com",
+            long_form_url="https://youtu.be/abc",
+            short_youtube_url="https://youtube.com/shorts/xyz",
+            show_keywords=["tesla", "ev"],
+        )
+        base.update(kw)
+        return build_social_metadata(**base)
+
+    def test_has_all_platforms(self):
+        m = self._build()
+        for key in ("youtube", "instagram_reels", "tiktok"):
+            assert key in m
+
+    def test_captions_lead_with_hook(self):
+        m = self._build()
+        assert m["instagram_reels"]["caption"].startswith("Tesla Cybercab")
+        assert m["tiktok"]["caption"].startswith("Tesla Cybercab")
+
+    def test_hashtags_present_and_formatted(self):
+        m = self._build()
+        assert m["instagram_reels"]["hashtags"], "expected IG hashtags"
+        assert "#" in m["instagram_reels"]["caption"]
+        # TikTok adds discovery tags
+        assert any(t.lower() == "fyp" for t in m["tiktok"]["hashtags"])
+        # IG adds Reels tag
+        assert any(t.lower() == "reels" for t in m["instagram_reels"]["hashtags"])
+
+    def test_youtube_title_capped(self):
+        m = self._build(hook="X" * 300)
+        assert len(m["youtube"]["title"]) <= 100
+
+    def test_caption_capped(self):
+        m = self._build(hook="word " * 1000)
+        assert len(m["instagram_reels"]["caption"]) <= 2000
+        assert len(m["tiktok"]["caption"]) <= 2000
+
+    def test_russian_localised_cta(self):
+        m = self._build(is_ru=True)
+        assert "Полный выпуск" in m["instagram_reels"]["caption"]
+
+
+# ---------------------------------------------------------------------------
+# Safe-zone Short filter graph
+# ---------------------------------------------------------------------------
+
+class TestSafeZoneFilterGraph:
+    def test_default_youtube_unchanged(self):
+        from engine.video import _short_form_filter_graph
+        g = _short_form_filter_graph(subtitles_path="x.srt", with_url_pill=True)
+        assert "MarginV=340" in g
+        assert "urlpill" in g
+
+    def test_safe_zone_lifts_captions_and_drops_url_pill(self):
+        from engine.video import _short_form_filter_graph
+        g = _short_form_filter_graph(
+            subtitles_path="x.srt", with_url_pill=False, caption_margin_v=480,
+        )
+        assert "MarginV=480" in g
+        assert "MarginV=340" not in g
+        assert "urlpill" not in g
+
+    def test_style_helper(self):
+        from engine.video import _shorts_subtitle_style
+        assert _shorts_subtitle_style().endswith("MarginV=340")
+        assert _shorts_subtitle_style(480).endswith("MarginV=480")
+
+
+# ---------------------------------------------------------------------------
+# Credential-gated publisher
+# ---------------------------------------------------------------------------
+
+class TestPublisherGating:
+    def _clear_creds(self, monkeypatch):
+        for k in ("IG_ACCESS_TOKEN", "IG_USER_ID", "TIKTOK_ACCESS_TOKEN"):
+            monkeypatch.delenv(k, raising=False)
+
+    def test_instagram_skips_without_creds(self, monkeypatch):
+        self._clear_creds(monkeypatch)
+        from engine.social_publisher import publish_to_instagram
+        r = publish_to_instagram(video_public_url="https://x/v.mp4", caption="hi")
+        assert r["status"] == "skipped"
+
+    def test_tiktok_skips_without_creds(self, monkeypatch):
+        self._clear_creds(monkeypatch)
+        from engine.social_publisher import publish_to_tiktok
+        r = publish_to_tiktok(video_path=Path("/tmp/none.mp4"), caption="hi")
+        assert r["status"] == "skipped"
+
+    def test_instagram_skips_without_public_url(self, monkeypatch):
+        monkeypatch.setenv("IG_ACCESS_TOKEN", "t")
+        monkeypatch.setenv("IG_USER_ID", "1")
+        from engine.social_publisher import publish_to_instagram
+        r = publish_to_instagram(video_public_url="", caption="hi")
+        assert r["status"] == "skipped"
+
+    def test_dispatcher_only_requested_platforms(self, monkeypatch):
+        self._clear_creds(monkeypatch)
+        from engine.social_publisher import publish_short
+        r = publish_short(video_path=Path("/tmp/x.mp4"), metadata={}, instagram=True, tiktok=False)
+        assert set(r) == {"instagram_reels"}
+        assert r["instagram_reels"]["status"] == "skipped"
+
+    def test_dispatcher_never_raises(self, monkeypatch):
+        self._clear_creds(monkeypatch)
+        from engine.social_publisher import publish_short
+        # metadata missing keys must not crash
+        assert publish_short(video_path=Path("/tmp/x.mp4"), metadata={}, tiktok=True)
+
+
+# ---------------------------------------------------------------------------
+# distribute_short orchestrator
+# ---------------------------------------------------------------------------
+
+def _fake_config(enabled: bool):
+    yt = types.SimpleNamespace(
+        multi_platform_enabled=enabled,
+        social_drop_url_pill=True,
+        social_caption_margin_v=480,
+        social_r2_prefix="",
+        instagram_enabled=False,
+        tiktok_enabled=False,
+    )
+    return types.SimpleNamespace(youtube=yt, name="Tesla Shorts Time", slug="tesla", keywords=["tesla"])
+
+
+class TestDistributeShort:
+    def test_noop_when_disabled(self, tmp_path):
+        from engine.social_distribution import distribute_short
+        out = distribute_short(
+            _fake_config(False),
+            audio_path=tmp_path / "a.mp3", cover_path=tmp_path / "c.jpg",
+            work_dir=tmp_path, base_name="Ep1", hook="A hook", show_name="Tesla",
+            show_url="https://nerranetwork.com",
+        )
+        assert out == {}
+
+    def test_enabled_renders_variant_and_sidecar(self, tmp_path, monkeypatch):
+        # Mock the ffmpeg render to just create the file.
+        import engine.video as video
+
+        def _fake_build(audio_path, cover_path, output_path, **kw):
+            Path(output_path).write_bytes(b"\x00")
+            # safe-zone kwargs must be passed through
+            assert kw.get("end_card") is False
+            assert kw.get("drop_url_pill") is True
+            assert kw.get("caption_margin_v") == 480
+            return output_path
+
+        monkeypatch.setattr(video, "build_short_video", _fake_build)
+
+        from engine.social_distribution import distribute_short
+        out = distribute_short(
+            _fake_config(True),
+            audio_path=tmp_path / "a.mp3", cover_path=tmp_path / "c.jpg",
+            work_dir=tmp_path, base_name="Ep1", short_suffix="_1",
+            hook="A unique hook line", show_name="Tesla Shorts Time",
+            show_url="https://nerranetwork.com", show_keywords=["tesla"],
+        )
+        assert out.get("video", "").endswith("Ep1_short_1_social.mp4")
+        sidecar = Path(out["sidecar"])
+        assert sidecar.exists()
+        meta = json.loads(sidecar.read_text())
+        assert "instagram_reels" in meta and "tiktok" in meta
+        # Posting was attempted but skipped (no creds / flags off).
+        assert out.get("posted") == {} or all(
+            v["status"] == "skipped" for v in out.get("posted", {}).values()
+        )


### PR DESCRIPTION
## Multi-platform Shorts (Instagram Reels / TikTok) + YouTube pipeline review

### Review finding
The Shorts pipeline is well-built and YouTube-compatible, but its overlays are tuned for the **YouTube Shorts** player. **Instagram Reels** and **TikTok** draw their own UI over the bottom ~16% (caption + CTA) and right ~12% (like/comment/share rail) of the frame — which would **obscure the bottom URL pill and clip the burned-in captions** (`MarginV=340` baseline ≈ y1580, inside the IG/TikTok caption band). Encoding (H.264/yuv420p/AAC/`+faststart`) is already cross-platform-compatible; the gap is overlay placement + per-platform post copy + a posting path.

### What this adds (opt-in, default off → YouTube output byte-for-byte unchanged)
- **Safe-zone Short variant** — `build_short_video(..., drop_url_pill=, caption_margin_v=)` renders a variant with the bottom URL pill + end-card dropped and captions lifted (`MarginV` 340→480) so nothing sits under the IG/TikTok UI. YouTube still uploads the original Short.
- **`.social.json` sidecar** per Short — ready-to-post `caption` + `hashtags` for `instagram_reels` / `tiktok` (hook-first, length-capped, platform discovery tags), plus the YouTube title/desc/tags. Reuses `engine.shorts_hashtags`; RU-localised CTA.
- **Optional R2 hosting** (`social_r2_prefix`) so the variant has a stable public URL — required for Instagram's URL-based API and handy for grabbing the asset to post manually.
- **Credential-gated auto-posting** (`engine/social_publisher.py`): IG Graph (Reels container→publish) + TikTok Content Posting (direct upload). **Clean no-op** ("skipped") until `IG_ACCESS_TOKEN`/`IG_USER_ID` / `TIKTOK_ACCESS_TOKEN` are set; never raises.
- Orchestrated by `engine/social_distribution.py`, called once per Short from `run_show.py`'s YouTube stage (additive, best-effort, non-fatal).

### Honest limitations (operator setup required)
Actual TikTok/IG auto-posting needs **your developer apps + API approval** (Meta App Review for `instagram_content_publish`; TikTok app audit for `video.publish`) and accounts — these can't be wired up blind, and I have no ffmpeg locally so the video is validated by **command structure** (like the existing `test_video_commands.py`), not a real render. **Until you complete that setup, the pipeline still emits the safe-zone MP4 + sidecar so every Short is one-paste ready to post manually.** The API flows are implemented against the documented endpoints but unverified against live apps. Full steps: [`docs/social_distribution.md`](docs/social_distribution.md).

### To turn it on (per show)
```yaml
youtube:
  multi_platform_enabled: true
  tiktok_enabled: true        # + TIKTOK_ACCESS_TOKEN
  instagram_enabled: true     # + IG_ACCESS_TOKEN/IG_USER_ID + social_r2_prefix
  social_r2_prefix: "social/tesla"
```

### Verification
- `tests/test_social_distribution.py` (**16 tests**: metadata, safe-zone filter graph, publisher no-op gating, orchestrator) added to the smoke set.
- Existing `test_video_commands.py` (**79**) confirms the YouTube Short command is unchanged.
- Full suite: **2401 passed, 3 skipped**. `ruff` + `actionlint` (with shellcheck) clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gedt496vNmp6wkqbi1ix4d)_