### PR TITLE
Fix Tesla thin-script skips: cover all stories, regen broken digests, close retry dead band

### DIFF
--- a/engine/generator.py
+++ b/engine/generator.py
@@ -780,6 +780,25 @@ def _retry_word_count_ok(orig_words: int, retry_words: int,
     return retry_words >= threshold
 
 
+def _podcast_expansion_retry_threshold(min_words: int) -> int:
+    """Word count below which ``generate_podcast_script`` triggers a
+    one-shot expansion retry.
+
+    This MUST stay at or above ``run_show.py``'s publication soft floor
+    (``int(min_words * 0.6)``) so the two checks can't open a dead band:
+    a script that clears this bar but falls under the soft floor would be
+    accepted here and then silently skipped by the runner, never getting
+    an expansion attempt (Tesla Ep493, 2026-05-30 — 874 words cleared the
+    old 50%/800-word bar but fell under the 60%/960 soft floor and the
+    episode was skipped). The ~10% margin above the soft floor covers the
+    dedup pass that runs between generation and the skip check and trims a
+    few percent off the count (Ep493 went 874 → 818). ``600`` is the
+    network-wide absolute floor.
+    """
+    soft_floor = int(min_words * 0.6)
+    return max(600, int(soft_floor * 1.1))
+
+
 def _sanitize_podcast_script(text: str) -> str:
     """Strip known LLM artifacts that break TTS quality.
 
@@ -1660,11 +1679,19 @@ def generate_podcast_script(
                                               show_name=config.name,
                                               min_podcast_words=min_words)
 
-    # Retry once if podcast script is catastrophically short (< 50% of
-    # target).  Above that, accept the shorter script — fresh content
-    # matters more than hitting a word count.
+    # Retry once if the podcast script is below the publication soft floor.
+    # run_show.py skips any episode under 60% of the target word count
+    # (its _SOFT_FLOOR), so a script in that band is unpublishable anyway —
+    # we should always attempt an expansion rather than accept it and let
+    # the runner silently skip the episode. The threshold sits ~10% *above*
+    # the soft floor because a dedup pass runs between here and the skip
+    # check, trimming a few percent off the count (Tesla Ep493 went
+    # 874 → 818 and was skipped without ever getting an expansion attempt —
+    # it cleared the old 50%/800-word retry bar but fell under the 60%/960
+    # soft floor). Expanding here gives the episode a real chance to clear
+    # the floor instead of being thrown away.
     word_count = len(text.split())
-    _retry_threshold = max(600, int(min_words * 0.5))
+    _retry_threshold = _podcast_expansion_retry_threshold(min_words)
     if word_count < _retry_threshold:
         logger.warning(
             "Podcast script for '%s' is very short (%d words, retry threshold %d). "

--- a/run_show.py
+++ b/run_show.py
@@ -1122,6 +1122,7 @@ def run(args: argparse.Namespace) -> None:
         from engine.validation import validate_digest as _validate_digest, SHOW_VALIDATION_CONFIGS
         _val_factory = SHOW_VALIDATION_CONFIGS.get(config.slug)
         _exact_dups: list = []  # Populated by validate_digest for 100% cross-episode matches
+        _empty_section_issues: list = []  # Mandatory sections that came back empty (0 items)
         if _val_factory and not is_weekly_recap:
             _val_config = _val_factory()
             _recent = content_tracker.get_recent_headlines(days=7)
@@ -1237,6 +1238,14 @@ def run(args: argparse.Namespace) -> None:
                         if "has only" in i.lower() or "below minimum" in i.lower()
                            or ("item" in i.lower() and "minimum" in i.lower())
                     ]
+                    # A mandatory section that came back with ZERO items is a
+                    # structural defect (vs. a soft "8 of 10" shortfall): it
+                    # guts the downstream podcast even when the digest is long.
+                    # Captured here and acted on by the structural-integrity
+                    # gate below (7d).
+                    _empty_section_issues = _empty_mandatory_section_issues(
+                        _item_count_issues
+                    )
                     if _item_count_issues:
                         _digest_char_count = len(x_thread.strip())
                         if _digest_char_count < 1500:
@@ -1467,6 +1476,79 @@ def run(args: argparse.Namespace) -> None:
                 )
                 save_usage(tracker, digests_dir)
                 sys.exit(1)
+
+        # 7d. Structural-integrity gate — a digest can clear the char floor
+        #     above yet still be broken in ways that gut the downstream
+        #     podcast: a missing **HOOK:** line and/or a mandatory section
+        #     that came back empty. Tesla Ep493 (2026-05-30) shipped a
+        #     12.7k-char digest with no HOOK and an empty "First Principles"
+        #     section; the podcast stage then dropped the whole main-news
+        #     body and the episode was skipped as too thin. One targeted
+        #     regeneration with a corrective suffix here — before we spend
+        #     the podcast LLM call — gives the episode a structurally sound
+        #     digest to expand. Gated on a daily-format validation config
+        #     (narrative / weekly-recap shows have their own fixed shape and
+        #     may legitimately have no HOOK label).
+        if _val_factory and not is_weekly_recap:
+            _struct_defects: list = []
+            if not _extract_hook(x_thread):
+                _struct_defects.append("the **HOOK:** line is missing")
+            if _empty_section_issues:
+                _struct_defects.append(
+                    "these mandatory sections came back empty: "
+                    + "; ".join(_empty_section_issues)
+                )
+            if _struct_defects:
+                logger.warning(
+                    "Digest is structurally broken (%s) — regenerating once "
+                    "before the podcast stage ...",
+                    "; ".join(_struct_defects),
+                )
+                metrics.record("digest_structural_regen", True)
+                _struct_suffix = (
+                    "\n\nCRITICAL: Your previous attempt was structurally "
+                    "invalid: " + "; ".join(_struct_defects) + ". You MUST "
+                    "output a one-sentence **HOOK:** line right after the "
+                    "date/price block, AND fill EVERY mandatory section "
+                    "(Top 12 News Items, Tesla X Takeover, Short Spot, Tesla "
+                    "First Principles) with real content. Do NOT leave any "
+                    "mandatory section empty and do NOT omit the HOOK. Use the "
+                    "available articles to write any thin section with extra "
+                    "depth rather than leaving it blank."
+                )
+                try:
+                    with metrics.stage("generate_digest_structural_retry"):
+                        _x_struct = generate_digest(
+                            template_vars, config, tracker=tracker,
+                            prompt_suffix=_struct_suffix,
+                        )
+                    # Only swap in the retry if it restored the HOOK (the most
+                    # reliable structural signal) and isn't shorter garbage.
+                    if (
+                        _extract_hook(_x_struct)
+                        and len(_x_struct.strip()) >= _MIN_DIGEST_CHARS
+                    ):
+                        logger.info(
+                            "Structural retry produced a digest with a HOOK "
+                            "(%d chars) — using it",
+                            len(_x_struct.strip()),
+                        )
+                        x_thread = _x_struct
+                    else:
+                        logger.warning(
+                            "Structural retry did not restore a usable HOOK — "
+                            "keeping original (podcast prompt will still be told "
+                            "to cover all stories).",
+                        )
+                except LLMRefusalError:
+                    logger.error(
+                        "Structural digest retry refused by LLM — keeping original",
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Structural digest retry failed: %s — keeping original",
+                        exc,
+                    )
 
         # Extract the daily hook (headline) from the digest
         hook = _extract_hook(x_thread)
@@ -2834,6 +2916,21 @@ def _extract_segment_summaries(
             if summary:
                 summaries[seg["id"]] = summary
     return summaries
+
+
+def _empty_mandatory_section_issues(item_count_issues: list) -> list:
+    """From a digest validator's item-count issues, return only those that
+    report a mandatory section with ZERO items (e.g.
+    ``Section 'First Principles': 0 items (minimum 1)``).
+
+    A 0-item section is a structural defect: it guts the downstream podcast
+    even when the digest clears the character floor (Tesla Ep493 shipped a
+    12.7k-char digest with an empty First Principles section, and the
+    podcast then dropped the whole main-news body). A soft shortfall like
+    ``has only 8 items (minimum 10)`` is usually a formatting mismatch on a
+    long digest and is deliberately NOT treated as structural.
+    """
+    return [i for i in item_count_issues if re.search(r":\s*0\s+items", i)]
 
 
 def _extract_hook(digest: str) -> str | None:

--- a/shows/prompts/tesla_podcast.txt
+++ b/shows/prompts/tesla_podcast.txt
@@ -31,6 +31,7 @@ HOST: Patrick in Vancouver — Canadian, scientist, newscaster. Think Rob Maurer
 STRUCTURAL REQUIREMENTS (these determine episode length — NON-NEGOTIABLE):
 - You are writing a 13–17 minute episode. Target 110–140 "Patrick:" lines.
 - Cover ALL stories from the Top 12 News section (give each 5–7 spoken sentences) plus 3–4 from the X Takeover section.
+- The Top 12 main-news body is the LARGEST part of the episode. Never skip it, never compress it into a sentence or two, and never jump straight from the intro to the editorial segments (Counterpoint / First Principles / teaser). Dropping or gutting the main-news body is the single most common failure mode and it produces an unpublishably thin episode.
 - Add: natural intro + hook + Counterpoint segment + First Principles segment (5–7 sentences) + tomorrow teaser + closing.
 - If the provided digest is missing sections or is thin, you **must still expand** every available story to the required depth using the facts that *are* present. Do not produce a short or rushed script.
 - A script under ~950 words is unacceptable for publication. Expand, add necessary context from the supplied digest + memory blocks, and deliver a full-length episode.
@@ -107,8 +108,9 @@ PACING, RHYTHM, AND LISTENER ENGAGEMENT (CRITICAL FOR RETENTION):
 - Every story must deliver clear value. Prioritize concrete specifics (numbers, mechanisms, quotes, before/after comparisons) over vague summary.
 - Use the memory blocks to create "ongoing story" moments: "This is the first time we've seen public numbers on [program] since we last discussed it in [recent context]."
 - Transitions should feel conversational and purposeful, not mechanical. Vary them. Good examples: "On the regulatory front...", "Meanwhile in another part of the business...", "This connects directly to something we've been watching with [program]..."
-- Never pad for length. If the real news is thin, let the episode run shorter rather than adding empty sentences. Quality and momentum matter more than hitting an arbitrary word count.
-- Cover the strongest stories thoroughly rather than rushing through every single item at equal depth.
+- Do not pad with empty commentary, filler, or rephrased points — every sentence must carry a concrete fact, number, name, quote, or genuine "why this matters" drawn from the digest or memory blocks.
+- This is NOT a license to drop stories. On a normal news day, cover EVERY item in the Top 12 block at the full 5–7 spoken sentences each. "Covering the strongest stories thoroughly" means going deeper on the biggest ones — not silently skipping the rest.
+- The ONLY time the episode may run shorter is a genuine slow-news day where the digest itself contains few real stories. In that case, go deeper on the stories that ARE present rather than inventing filler — but still cover all of them.
 
 === EPISODE 1 SPECIAL INTRODUCTION (ONLY FOR EPISODE 1) ===
 If this is Episode 1, replace the standard intro with a special 90-120 second introduction that:
@@ -162,7 +164,7 @@ WHAT TO SKIP (do not read aloud):
 - Section headers and separators — skip entirely
 
 LENGTH TARGET:
-Your script must be at least 2800 words (70+ sentences). If you find yourself finishing early, COVER MORE STORIES from the digest — pull additional items from the X Takeover section, or add more concrete details from the sources of stories you've already covered. Do NOT pad existing stories with commentary, implications, or rephrased points. If the digest is genuinely short on news, let the episode be shorter rather than fill space with editorial padding.
+Your script must be at least 2800 words (70+ sentences) on any normal news day — and it must reach that length by COVERING STORIES, never by padding. The reliable path: cover every Top 12 item at 5–7 fact-bearing sentences, then 3–4 X Takeover items at similar depth, then the Counterpoint and First Principles segments. If you find yourself finishing early, you have UNDER-COVERED the news — go back and add the concrete facts, numbers, names, quotes, and source attributions for stories you summarized too quickly, and pull in additional Top 12 / X Takeover items you skipped. Do NOT pad existing stories with generic commentary, implications, or rephrased points. The ONLY acceptable reason to finish under 2800 words is a genuine slow-news day where the digest truly contains only a handful of stories — and even then, cover every story that IS present at full depth.
 
 CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with another Nerra Network show, and ONLY in the closing or final lesson segment, single sentence max):
 - AI / tech topics → "For daily AI news, check out Models & Agents on the Nerra Network."

--- a/tests/test_digest_structural_gate.py
+++ b/tests/test_digest_structural_gate.py
@@ -1,0 +1,54 @@
+"""Drift guards for the digest structural-integrity gate (run_show 7d).
+
+Tesla Ep493 (2026-05-30) shipped a 12,904-char digest that cleared the
+800-char length floor but was structurally broken: it had no **HOOK:** line
+and an empty "First Principles" section. Because the digest was long, the
+empty-section issue was logged as a non-blocking "formatting mismatch" and
+the broken digest was handed to the podcast stage — which then dropped the
+entire main-news body, producing an 818-word script that was skipped as too
+thin.
+
+The gate now distinguishes a *0-item* mandatory section (a structural defect
+worth one corrective regeneration) from a soft item-count shortfall (a
+formatting mismatch that should not trigger a regen). These tests pin that
+distinction.
+"""
+
+from __future__ import annotations
+
+from run_show import _empty_mandatory_section_issues
+
+
+class TestEmptyMandatorySectionIssues:
+
+    def test_ep493_empty_first_principles_is_flagged(self):
+        """The exact Ep493 validator message for an empty section must be
+        recognized as structural."""
+        issues = ["Section 'First Principles': 0 items (minimum 1)"]
+        assert _empty_mandatory_section_issues(issues) == issues
+
+    def test_soft_shortfall_is_not_flagged(self):
+        """A non-zero shortfall ("8 of 10") is a formatting mismatch on a
+        long digest, NOT a structural defect — it must not trigger a regen."""
+        issues = ["Section 'Top 12 News Items' has only 8 items (minimum 10)"]
+        assert _empty_mandatory_section_issues(issues) == []
+
+    def test_mixed_returns_only_empty_sections(self):
+        issues = [
+            "Section 'Top 12 News Items' has only 9 items (minimum 10)",
+            "Section 'First Principles': 0 items (minimum 1)",
+            "Section 'Short Spot': 0 items (minimum 1)",
+        ]
+        assert _empty_mandatory_section_issues(issues) == [
+            "Section 'First Principles': 0 items (minimum 1)",
+            "Section 'Short Spot': 0 items (minimum 1)",
+        ]
+
+    def test_empty_input_returns_empty(self):
+        assert _empty_mandatory_section_issues([]) == []
+
+    def test_does_not_false_match_ten_items(self):
+        """A regex that matched a bare '0' could catch '10 items'. Ensure the
+        word-boundary on the count keeps '10 items' out."""
+        issues = ["Section 'Top 12 News Items': 10 items (minimum 10)"]
+        assert _empty_mandatory_section_issues(issues) == []

--- a/tests/test_generator_postprocess.py
+++ b/tests/test_generator_postprocess.py
@@ -219,6 +219,52 @@ class TestRetryWordCountOk:
 
 
 # ---------------------------------------------------------------------------
+# _podcast_expansion_retry_threshold — no dead band vs run_show's soft floor
+# ---------------------------------------------------------------------------
+
+class TestPodcastExpansionRetryThreshold:
+    """Tesla Ep493 (2026-05-30) was skipped without an expansion attempt:
+    the script came in at 874 words (→818 after dedup). The old retry bar
+    was ``max(600, min_words * 0.5)`` = 800 words for Tesla (min_words=1600),
+    so 874 cleared it and no expansion ran — but run_show.py's publication
+    soft floor is ``int(min_words * 0.6)`` = 960, so the runner skipped the
+    episode. Any script in the 800–960 band was neither rescued nor
+    published. The retry threshold must stay at or above that soft floor so
+    the two checks can't open a dead band."""
+
+    # Mirror of run_show.py's _SOFT_FLOOR computation. If that formula
+    # changes, this test (and the helper's docstring) must be revisited.
+    @staticmethod
+    def _run_show_soft_floor(min_words: int) -> int:
+        return int(min_words * 0.6)
+
+    def test_tesla_ep493_word_count_now_triggers_retry(self):
+        """874 words at Tesla's min_words=1600 must now trigger the
+        expansion retry (it cleared the old 800-word bar and was skipped
+        at the 960 soft floor)."""
+        from engine.generator import _podcast_expansion_retry_threshold
+        threshold = _podcast_expansion_retry_threshold(1600)
+        assert 874 < threshold
+
+    @pytest.mark.parametrize("min_words", [1000, 1200, 1500, 1600, 2000, 2800])
+    def test_threshold_never_below_soft_floor(self, min_words):
+        """For every plausible target the retry threshold must be >= the
+        runner's soft floor, so a script that would be skipped always gets
+        an expansion attempt first."""
+        from engine.generator import _podcast_expansion_retry_threshold
+        assert (
+            _podcast_expansion_retry_threshold(min_words)
+            >= self._run_show_soft_floor(min_words)
+        )
+
+    def test_absolute_floor_of_600(self):
+        """Very small targets still keep the network-wide 600-word
+        absolute retry floor."""
+        from engine.generator import _podcast_expansion_retry_threshold
+        assert _podcast_expansion_retry_threshold(100) == 600
+
+
+# ---------------------------------------------------------------------------
 # _correct_common_llm_text_mistakes (TST Ep489/Ep490 branding + grammar slips)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What happened

Tesla **Ep493 (2026-05-30)** was skipped as "too thin" despite a **healthy news day** — 40 articles, a 12,904-char digest. The script came in at 818 words. The parsed chapters tell the story:

```
['Introduction', 'The Counterpoint', 'Tomorrow Teaser', 'Introduction']
```

The model **dropped the entire Top 12 main-news body and X Takeover** — the bulk of the show — and jumped from the intro straight to the editorial segments. So 40 articles collapsed into a skeleton. This addresses all three layers of the failure.

## 1. Podcast prompt: push fuller story coverage (`shows/prompts/tesla_podcast.txt`)

The prompt had directly conflicting length guidance — *"cover ALL Top 12 stories / must be 2800 words"* alongside *"never pad, let it run shorter / don't cover every item."* On a messy digest the model took the permission-to-minimize path.

- The **Top 12 main-news body is now explicitly mandatory**; dropping or gutting it is called out as the single most common failure mode.
- Removed the unconditional *"let it run shorter / don't cover every item"* escape hatch and **scoped it to genuine slow-news days only**.
- Reframed the length target as something reached by **covering stories at depth, never by padding** — finishing early means the news was *under-covered*, not that the script is done.

## 2. Digest structural-integrity gate (`run_show.py`, step 7d)

The Ep493 digest cleared the 800-char length floor but was structurally broken — **no HOOK line** and an **empty "First Principles" section** — which the validator logged as a non-blocking "formatting mismatch" because the digest was long. That broken digest was then handed to the podcast stage.

- New gate detects a **missing HOOK** and/or a **0-item mandatory section** and **regenerates the digest once** with a corrective suffix *before* the podcast LLM call. The retry is only swapped in if it restores a usable HOOK and isn't shorter garbage.
- A **0-item section** is now distinguished from a soft *"8 of 10"* shortfall (still treated as a harmless formatting mismatch — no regen).
- Extracted `_empty_mandatory_section_issues()` so the distinction is unit-tested.

## 3. Close the podcast retry dead band (`engine/generator.py`)

Even with a good digest, two length gates were misaligned and could silently skip a recoverable script:

| Check | Value for Tesla (`min_podcast_words=1600`) |
|---|---|
| Old expansion-retry bar (`max(600, min_words*0.5)`) | **800** |
| Publication soft floor / skip (`int(min_words*0.6)`) | **960** |

A script in the **800–960** band cleared the retry bar (no expansion attempt) but fell under the soft floor (skipped). Ep493's 874-word script (→818 after dedup) hit it exactly. Extracted `_podcast_expansion_retry_threshold(min_words)` and raised it to ~10% above the soft floor (margin covers the dedup pass), so anything the runner would skip now gets an expansion attempt first.

**This affected every show targeting ≳1,000 words** (Tesla 800–960, default-1500 shows 750–900, Fascinating Frontiers 675–810, Modern Investing / Unintended Consequences 650–780, Planetterrian 625–750). The 900-and-below shows (Omni View, Env Intel, Финансы Просто, MAB, Привет) were never exposed and are unchanged.

## How the layers compose

Slow-news mode (upstream) pads thin *input* with evergreen segments. These fixes address thin *output*: the prompt makes coverage mandatory, the digest gate ensures the podcast stage receives a sound digest, and the retry net is the final mechanical safety catch before a skip.

## Note on landmine #17

The prompt change alters generated output, which per landmine #17 warrants an A/B listen on the custom voice before it's fully trusted. It was made as an explicit operator directive ("give the audience more of the information"). The mechanical changes (retry threshold, digest regen) don't change audio on a healthy day.

## Tests

- `tests/test_generator_postprocess.py::TestPodcastExpansionRetryThreshold` — no dead band vs the runner's soft floor, for every target
- `tests/test_digest_structural_gate.py` — 0-item section flagged, soft shortfall and "10 items" not
- `test_prompt_fidelity.py` confirms the edited prompt still renders

```
test_generator.py (25) · test_generator_postprocess.py (29) ·
test_digest_structural_gate.py (5) · test_prompt_fidelity.py (35) ·
test_integration.py (114) — all green
```

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC