### PR TITLE
Per-episode deep-dive mode + SpaceX IPO deep dive for Modern Investing

### DIFF
--- a/editorial.html
+++ b/editorial.html
@@ -190,6 +190,16 @@
                 <span class="gradient-text">Nerra</span> Network
             </a>
 
+            
+            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.5rem;max-width:180px;flex:1 1 auto;min-width:120px;">
+                <input type="search" id="nn-global-search-input"
+                       placeholder="Search…"
+                       style="width:100%;padding:6px 8px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.85rem;"
+                       aria-label="Search all episodes across the network">
+                <div id="nn-global-search-results"
+                     style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:340px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
+            </div>
+
             <ul class="nn-nav-links">
                 <li class="nn-nav-dropdown">
                     <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
@@ -763,6 +773,8 @@
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>
+                    <span style="opacity:0.5;">&middot;</span>
+                    <span style="font-size:0.7rem;opacity:0.6;">Automation: reliable nightly + post-publish pipeline</span>
                 </div>
             </div>
         </div>
@@ -792,5 +804,8 @@
     }
     </script>
     
+
+    <!-- Centralized, improved global search -->
+    <script src="assets/js/search.js" defer></script>
 </body>
 </html>

--- a/engine/config.py
+++ b/engine/config.py
@@ -301,6 +301,34 @@ class SlowNewsConfig:
 
 
 @dataclass
+class DeepDiveConfig:
+    """Per-episode deep-dive override (May 2026).
+
+    Lets a normally news-driven show (e.g. Modern Investing) produce an
+    occasional standalone single-subject deep-dive episode without
+    permanently switching to ``narrative_mode``. The runner checks
+    ``queue_file`` at the start of each run; if a topic is scheduled for
+    today (``date: YYYY-MM-DD``) or flagged ``when: next``, that single
+    episode bypasses the news fetch + slow-news + digest-validation path
+    and runs off the topic with the deep-dive prompt files, then
+    auto-reverts to the normal daily pipeline. A specific topic can also
+    be forced on demand via ``run_show.py <show> --deep-dive <id>``,
+    regardless of schedule. Queue entries share the
+    ``shows/topic_queues`` schema (id / title / brief / produced /
+    episode_number / produced_date) plus the optional ``date`` / ``when``
+    scheduling keys.
+    """
+    enabled: bool = False
+    queue_file: str = ""            # e.g. "shows/deep_dives/modern_investing.yaml"
+    # Prompt overrides used only on a deep-dive run. Empty = fall back to
+    # the show's normal llm.*_prompt_file (rarely what you want — a deep
+    # dive has a different shape than a daily news episode).
+    digest_prompt_file: str = ""    # outline / brief expansion prompt
+    podcast_prompt_file: str = ""   # full-script prompt
+    system_prompt_file: str = ""    # optional system-prompt override
+
+
+@dataclass
 class ContentFreshnessConfig:
     """Per-show article freshness filter overrides."""
     lookback_days: int = 0          # 0 = use pipeline default (1 or 3 based on episode count)
@@ -487,6 +515,10 @@ class ShowConfig:
     # depend on daily news cycles.
     narrative_mode: bool = False
     topic_queue_file: str = ""
+    # Per-episode deep-dive override (see DeepDiveConfig). Distinct from
+    # narrative_mode: the show stays news-driven by default and only a
+    # scheduled / forced episode runs as a standalone deep dive.
+    deep_dive: DeepDiveConfig = field(default_factory=DeepDiveConfig)
     # Recursive narrative-memory (Phase 3). When true, the show's pre_fetch
     # hook injects a {narrative_memory_section} block (programs + open
     # questions + mined themes) into the digest/podcast prompts, and its
@@ -664,6 +696,7 @@ def load_config(yaml_path: str | Path) -> ShowConfig:
         weekly_recap_on_sunday=bool(data.get("weekly_recap_on_sunday", False)),
         narrative_mode=bool(data.get("narrative_mode", False)),
         topic_queue_file=str(data.get("topic_queue_file", "") or ""),
+        deep_dive=_build_nested(DeepDiveConfig, data.get("deep_dive")),
         memory_enabled=bool(data.get("memory_enabled", False)),
     )
     logger.info("Loaded config for '%s' from %s", config.name, path)

--- a/engine/topic_queue.py
+++ b/engine/topic_queue.py
@@ -82,6 +82,67 @@ def pick_next_topic(queue_path: Path) -> Optional[Dict[str, Any]]:
     return None
 
 
+def pick_deep_dive_topic(
+    queue_path: Path,
+    today_iso: str,
+    force_id: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Select a deep-dive topic for this run, or ``None`` for a normal
+    (news) episode.
+
+    Unlike ``pick_next_topic`` (which always returns the first unproduced
+    entry), deep dives only fire when explicitly scheduled or forced, so
+    a news-driven show isn't hijacked by a stale queue. Among entries that
+    are not yet ``produced``:
+
+      1. ``force_id`` given (``--deep-dive <id>``) — the matching entry,
+         regardless of its schedule. Returns ``None`` if the id is unknown
+         or already produced (caller decides whether to skip or fall back).
+      2. an entry whose ``date`` equals *today_iso* (a scheduled deep dive).
+      3. an entry flagged ``when: next`` (fires on the very next run).
+
+    The returned dict is a shallow copy; use ``mark_topic_produced`` to
+    record completion.
+    """
+    data = _load_queue(queue_path)
+    queue = data.get("queue", [])
+
+    def _valid_unproduced() -> list:
+        out = []
+        for entry in queue:
+            if not isinstance(entry, dict) or entry.get("produced") is True:
+                continue
+            if not all(entry.get(k) for k in ("id", "title", "brief")):
+                logger.error(
+                    "Deep-dive queue entry missing id/title/brief — skipping: %s",
+                    entry,
+                )
+                continue
+            out.append(entry)
+        return out
+
+    candidates = _valid_unproduced()
+
+    if force_id:
+        for entry in candidates:
+            if entry.get("id") == force_id:
+                return dict(entry)
+        logger.warning(
+            "pick_deep_dive_topic: forced id %r not found among unproduced "
+            "entries in %s", force_id, queue_path,
+        )
+        return None
+
+    # Scheduled-for-today wins over a generic "next" flag.
+    for entry in candidates:
+        if str(entry.get("date", "")) == today_iso:
+            return dict(entry)
+    for entry in candidates:
+        if str(entry.get("when", "")).lower() == "next":
+            return dict(entry)
+    return None
+
+
 def mark_topic_produced(
     queue_path: Path,
     topic_id: str,

--- a/run_show.py
+++ b/run_show.py
@@ -132,6 +132,18 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="YouTube only: MP3 + digest on disk, rebuild/upload videos (skips TTS/RSS/X)",
     )
+    parser.add_argument(
+        "--deep-dive",
+        metavar="TOPIC_ID",
+        default=None,
+        help=(
+            "Force this run to produce a standalone deep-dive episode for the "
+            "given topic id from the show's deep_dive.queue_file, bypassing the "
+            "news fetch. Without this flag, deep dives still fire automatically "
+            "when a queue entry is scheduled for today (date:) or flagged "
+            "when: next."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -655,11 +667,73 @@ def run(args: argparse.Namespace) -> None:
             metrics.record("narrative_topic_id", narrative_topic.get("id", ""))
             # Skip the fetch threadpool entirely — articles stays [].
 
+        # Deep-dive override (May 2026). A normally news-driven show can
+        # produce an occasional standalone single-subject episode without
+        # permanently switching to narrative_mode. Resolve up-front (like
+        # narrative_mode) so this run bypasses the news fetch + slow-news +
+        # digest-validation path. Fires when a queue entry is scheduled for
+        # today / flagged when: next, or forced via --deep-dive <id>.
+        deep_dive_topic: dict = {}
+        is_deep_dive = False
+        _dd_cfg = getattr(config, "deep_dive", None)
+        _forced_dd = getattr(args, "deep_dive", None)
+        if _forced_dd or (_dd_cfg and _dd_cfg.enabled and _dd_cfg.queue_file):
+            if not (_dd_cfg and _dd_cfg.queue_file):
+                _skip_episode(
+                    "deep_dive_unconfigured",
+                    f"--deep-dive {_forced_dd!r} given but show has no "
+                    f"deep_dive.queue_file configured.",
+                )
+                return
+            from engine.topic_queue import pick_deep_dive_topic
+            _dd_queue = PROJECT_ROOT / _dd_cfg.queue_file
+            deep_dive_topic = pick_deep_dive_topic(
+                _dd_queue, today.isoformat(), force_id=_forced_dd,
+            ) or {}
+            if _forced_dd and not deep_dive_topic:
+                _skip_episode(
+                    "deep_dive_not_found",
+                    f"--deep-dive {_forced_dd!r} matched no unproduced entry "
+                    f"in {_dd_cfg.queue_file}.",
+                )
+                return
+            if deep_dive_topic:
+                is_deep_dive = True
+                # Swap in the deep-dive prompts for this run only (config is a
+                # per-run object, so this doesn't leak to other shows/days).
+                if _dd_cfg.digest_prompt_file:
+                    config.llm.digest_prompt_file = _dd_cfg.digest_prompt_file
+                if _dd_cfg.podcast_prompt_file:
+                    config.llm.podcast_prompt_file = _dd_cfg.podcast_prompt_file
+                if _dd_cfg.system_prompt_file:
+                    config.llm.system_prompt_file = _dd_cfg.system_prompt_file
+                logger.info(
+                    "Deep-dive mode: topic %r (%s)%s",
+                    deep_dive_topic.get("id"), deep_dive_topic.get("title"),
+                    " [forced]" if _forced_dd else "",
+                )
+                metrics.record("deep_dive_mode", True)
+                metrics.record("deep_dive_topic_id", deep_dive_topic.get("id", ""))
+                # Skip the fetch threadpool entirely — articles stays [].
+
+        # Either alternate-content mode bypasses the news-fetch / slow-news /
+        # validation machinery and feeds a single topic straight into the
+        # digest+podcast chain.
+        _topic_driven = bool(
+            getattr(config, "narrative_mode", False) or is_deep_dive
+        )
+        _active_topic = narrative_topic or deep_dive_topic
+
         with metrics.stage("fetch_and_dedup"):
             with ThreadPoolExecutor(max_workers=3) as executor:
                 hook_future = executor.submit(_run_hook)
-                fetch_future = executor.submit(_run_fetch)
-                x_fetch_future = executor.submit(_run_x_fetch)
+                # Topic-driven runs (narrative mode + deep dives) take their
+                # input from a curated topic, not the news cycle — skip the RSS
+                # and X fetches entirely. (Narrative shows like UC also have no
+                # sources, but deep-dive shows like MIT do, so the guard must be
+                # explicit, not rely on an empty feed list.)
+                fetch_future = None if _topic_driven else executor.submit(_run_fetch)
+                x_fetch_future = None if _topic_driven else executor.submit(_run_x_fetch)
 
                 try:
                     extra_context = hook_future.result(timeout=60)
@@ -670,24 +744,26 @@ def run(args: argparse.Namespace) -> None:
                     )
                     extra_context = {}
 
-                try:
-                    articles = fetch_future.result(timeout=120)
-                except Exception as exc:
-                    logger.error("RSS fetch failed: %s", exc)
-                    articles = []
-                    # Distinguish a structural fetch failure from a genuine
-                    # slow-news day. Without this flag, slow_news mode would
-                    # happily ship an evergreen-only episode when feeds are
-                    # actually broken, masking the outage from operators.
-                    rss_fetch_failed = True
+                if fetch_future is not None:
+                    try:
+                        articles = fetch_future.result(timeout=120)
+                    except Exception as exc:
+                        logger.error("RSS fetch failed: %s", exc)
+                        articles = []
+                        # Distinguish a structural fetch failure from a genuine
+                        # slow-news day. Without this flag, slow_news mode would
+                        # happily ship an evergreen-only episode when feeds are
+                        # actually broken, masking the outage from operators.
+                        rss_fetch_failed = True
 
-                try:
-                    x_posts = x_fetch_future.result(timeout=120)
-                    if x_posts:
-                        tracker["services"]["x_api"]["search_calls"] = len(x_posts)
-                except Exception as exc:
-                    logger.warning("X account fetch failed: %s — continuing with RSS only", exc)
-                    x_posts = []
+                if x_fetch_future is not None:
+                    try:
+                        x_posts = x_fetch_future.result(timeout=120)
+                        if x_posts:
+                            tracker["services"]["x_api"]["search_calls"] = len(x_posts)
+                    except Exception as exc:
+                        logger.warning("X account fetch failed: %s — continuing with RSS only", exc)
+                        x_posts = []
 
         if rss_fetch_failed and not articles and not x_posts:
             _skip_episode(
@@ -768,7 +844,7 @@ def run(args: argparse.Namespace) -> None:
         )
         metrics.record("article_count", len(articles))
 
-        if not articles and not getattr(config, "narrative_mode", False):
+        if not articles and not _topic_driven:
             logger.warning("No articles found even after expanded search. Skipping episode.")
             _skip_episode("no_articles", "No articles found even after expanded search.")
 
@@ -797,7 +873,7 @@ def run(args: argparse.Namespace) -> None:
 
         if (
             len(articles) < skip_threshold
-            and not getattr(config, "narrative_mode", False)
+            and not _topic_driven
         ):
             from engine.slow_news import is_slow_news_day, load_segment_library, select_segments
 
@@ -951,17 +1027,17 @@ def run(args: argparse.Namespace) -> None:
             "recent_content_summary": content_tracker_summary,
             "recent_deep_dive_topics": deep_dive_topics_text,
         }
-        # Narrative-mode shows feed a topic from the queue into the digest
-        # prompt instead of news articles. Stage the topic vars here so the
-        # downstream digest prompt template can resolve ``{topic_title}``,
-        # ``{topic_brief}``, and ``{topic_category}``. (The actual queue
-        # pick + skip-when-empty happens further up — see narrative_mode
-        # branch around the fetch stage.)
-        if getattr(config, "narrative_mode", False):
-            narrative_topic = locals().get("narrative_topic") or {}
-            template_vars["topic_title"] = narrative_topic.get("title", "")
-            template_vars["topic_brief"] = narrative_topic.get("brief", "")
-            template_vars["topic_category"] = narrative_topic.get("category", "")
+        # Topic-driven runs (narrative-mode shows + deep-dive episodes) feed a
+        # single curated topic into the digest prompt instead of news articles.
+        # Stage the topic vars here so the downstream digest prompt template can
+        # resolve ``{topic_title}``, ``{topic_brief}``, and ``{topic_category}``.
+        # (The actual queue pick + skip-when-empty happens further up — see the
+        # narrative_mode / deep-dive branch around the fetch stage.)
+        if _topic_driven:
+            _topic = _active_topic or {}
+            template_vars["topic_title"] = _topic.get("title", "")
+            template_vars["topic_brief"] = _topic.get("brief", "")
+            template_vars["topic_category"] = _topic.get("category", "")
         # Slow news day context injection
         if slow_news_mode and selected_segs:
             from engine.slow_news import build_slow_news_prompt_context
@@ -1123,7 +1199,11 @@ def run(args: argparse.Namespace) -> None:
         _val_factory = SHOW_VALIDATION_CONFIGS.get(config.slug)
         _exact_dups: list = []  # Populated by validate_digest for 100% cross-episode matches
         _empty_section_issues: list = []  # Mandatory sections that came back empty (0 items)
-        if _val_factory and not is_weekly_recap:
+        # Deep-dive digests have a different shape than the show's normal news
+        # format, so the daily-format validator (and the structural-integrity
+        # gate below) would false-positive on them — skip both for deep dives,
+        # as we already do for weekly recaps.
+        if _val_factory and not is_weekly_recap and not is_deep_dive:
             _val_config = _val_factory()
             _recent = content_tracker.get_recent_headlines(days=7)
             _val_passed, _val_issues, _exact_dups = _validate_digest(
@@ -1488,8 +1568,9 @@ def run(args: argparse.Namespace) -> None:
         #     the podcast LLM call — gives the episode a structurally sound
         #     digest to expand. Gated on a daily-format validation config
         #     (narrative / weekly-recap shows have their own fixed shape and
-        #     may legitimately have no HOOK label).
-        if _val_factory and not is_weekly_recap:
+        #     may legitimately have no HOOK label). Deep dives are skipped too
+        #     — their digest shape isn't the daily news format.
+        if _val_factory and not is_weekly_recap and not is_deep_dive:
             _struct_defects: list = []
             if not _extract_hook(x_thread):
                 _struct_defects.append("the **HOOK:** line is missing")
@@ -1628,8 +1709,28 @@ def run(args: argparse.Namespace) -> None:
                     "Failed to mark topic as produced (non-fatal): %s", exc,
                 )
 
-        # Post-generation hook (e.g. extract trade picks for Modern Investing tracker)
-        if hook_module and hasattr(hook_module, "post_generate"):
+        # Deep-dive episodes: mark the topic produced in the deep-dive queue so
+        # a ``when: next`` entry doesn't fire again on tomorrow's news episode.
+        if is_deep_dive and deep_dive_topic:
+            try:
+                from engine.topic_queue import mark_topic_produced
+                _dd_queue = PROJECT_ROOT / config.deep_dive.queue_file
+                mark_topic_produced(
+                    _dd_queue,
+                    topic_id=deep_dive_topic.get("id", ""),
+                    episode_num=episode_num,
+                    produced_date=today.isoformat(),
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to mark deep-dive topic as produced (non-fatal): %s",
+                    exc,
+                )
+
+        # Post-generation hook (e.g. extract trade picks for Modern Investing
+        # tracker). Skipped on deep dives — a standalone deep dive has no daily
+        # trade pick / portfolio segment for the hook to parse.
+        if hook_module and hasattr(hook_module, "post_generate") and not is_deep_dive:
             try:
                 hook_module.post_generate(config, digest_text=x_thread, episode_num=episode_num)
             except Exception as exc:
@@ -1714,17 +1815,17 @@ def run(args: argparse.Namespace) -> None:
 
             if hook:
                 effective_hook = hook
-            elif getattr(config, "narrative_mode", False):
-                # Narrative-mode shows shouldn't fall back to a news framing.
-                # The hook is the topic title (or show name) so the LLM has
-                # something concrete to anchor the opening to. Logged as a
-                # warning so the operator can investigate why digest hook
-                # extraction returned empty for a topic-queue-driven show.
-                _topic = locals().get("narrative_topic") or {}
+            elif _topic_driven:
+                # Topic-driven runs (narrative mode + deep dives) shouldn't fall
+                # back to a news framing. The hook is the topic title (or show
+                # name) so the LLM has something concrete to anchor the opening
+                # to. Logged as a warning so the operator can investigate why
+                # digest hook extraction returned empty for a topic-driven run.
+                _topic = _active_topic or {}
                 effective_hook = (_topic.get("title") if isinstance(_topic, dict)
                                   else "") or config.name
                 logger.warning(
-                    "Narrative-mode show %s has no extractable hook — using "
+                    "Topic-driven run for %s has no extractable hook — using "
                     "topic title (%r) as the {hook} fallback. Investigate the "
                     "digest output if this happens repeatedly.",
                     config.slug, effective_hook,

--- a/run_show.py
+++ b/run_show.py
@@ -1109,9 +1109,10 @@ def run(args: argparse.Namespace) -> None:
         # content lake. The rest of the pipeline (podcast script gen,
         # TTS, publish) runs unchanged on this synthetic digest, so
         # listeners get the same narrative quality as a daily episode.
-        is_weekly_recap = (
-            bool(getattr(config, "weekly_recap_on_sunday", False))
-            and today.weekday() == 6
+        is_weekly_recap = _resolve_weekly_recap(
+            getattr(config, "weekly_recap_on_sunday", False),
+            today,
+            is_deep_dive,
         )
         from engine.generator import generate_digest, LLMRefusalError
         if is_weekly_recap:
@@ -3032,6 +3033,28 @@ def _empty_mandatory_section_issues(item_count_issues: list) -> list:
     long digest and is deliberately NOT treated as structural.
     """
     return [i for i in item_count_issues if re.search(r":\s*0\s+items", i)]
+
+
+def _resolve_weekly_recap(
+    weekly_recap_on_sunday: bool,
+    today: "datetime.date",
+    is_deep_dive: bool,
+) -> bool:
+    """Whether this run is a Sunday weekly-recap episode.
+
+    True when the show opts into Sunday recaps and today is Sunday — UNLESS a
+    deep dive has already claimed this run. A deep dive is an explicit operator
+    action (scheduled / ``when: next`` / ``--deep-dive``) and takes precedence
+    over the automatic recap, so a deep dive that lands on a Sunday still airs
+    as the deep dive instead of being silently turned into a recap (which would
+    also burn the deep-dive queue slot). The monthly MIT episode is a separate
+    entry point (scripts/run_monthly_mit_episode.py) and does not interact here.
+    """
+    return (
+        bool(weekly_recap_on_sunday)
+        and today.weekday() == 6  # Monday=0 … Sunday=6
+        and not is_deep_dive
+    )
 
 
 def _extract_hook(digest: str) -> str | None:

--- a/shows/deep_dives/README.md
+++ b/shows/deep_dives/README.md
@@ -1,0 +1,90 @@
+# Deep-dive episodes
+
+A **deep dive** is a special, standalone, single-subject episode of an
+otherwise news-driven show. Unlike `narrative_mode` (which permanently turns a
+show into a topic-queue show, e.g. Unintended Consequences), a deep dive is a
+**per-episode override**: the show stays a daily news show, and only a
+scheduled or forced episode runs as a deep dive — then it auto-reverts to the
+normal daily pipeline.
+
+When a deep dive fires, that one run:
+
+- **bypasses** the RSS/X news fetch, slow-news fallback, and the daily-format
+  digest validation,
+- feeds the queued topic (`title` + `brief`) into the show's deep-dive prompts,
+- runs the normal digest → outline → podcast → TTS → publish pipeline,
+- marks the topic `produced` in the queue, and
+- skips the show's `post_generate` hook (so a standalone deep dive doesn't try
+  to advance, e.g., Modern Investing's simulated-trade tracker).
+
+## How a deep dive is triggered
+
+For a show with a `deep_dive:` block, the runner checks its `queue_file` at the
+start of **every** run and fires a deep dive when one of these is true:
+
+1. **`when: next`** on an unproduced entry — fires on the very next run.
+2. **`date: YYYY-MM-DD`** equals the run date — a scheduled deep dive.
+   (A `date` match for today wins over a generic `when: next`.)
+3. **Forced**: `python run_show.py <show> --deep-dive <id>` — produces that
+   entry now, regardless of schedule. (Skips the episode with a clear message
+   if the id is unknown or already produced.)
+
+If none match, it's a normal news episode.
+
+## Adding a deep dive (existing deep-dive show, e.g. Modern Investing)
+
+Append an entry to `shows/deep_dives/<show>.yaml`:
+
+```yaml
+  - id: my-topic-slug              # unique; also the --deep-dive argument
+    title: "Episode Title Phrase"  # → {topic_title}
+    brief: >                        # → {topic_brief}: EXACTLY what to cover
+      Spell out precisely what the episode must explain. The more concrete the
+      brief (specific angles, the framework to teach, what to hedge as
+      speculative), the better the episode. Two-part briefs ("PART ONE … PART
+      TWO …") work well for a specific case + a reusable technique.
+    when: next                      # OR: date: 2026-06-15
+    produced: false
+    episode_number: null            # runner fills these in
+    produced_date: null
+```
+
+Leave `produced: false` until it runs. The next matching run produces it and
+flips `produced: true` with the episode number and date.
+
+## Enabling deep dives for another show
+
+1. Add a `deep_dive:` block to the show's YAML:
+
+   ```yaml
+   deep_dive:
+     enabled: true
+     queue_file: shows/deep_dives/<show>.yaml
+     digest_prompt_file: shows/prompts/<show>_deep_dive.txt
+     podcast_prompt_file: shows/prompts/<show>_deep_dive_podcast.txt
+     # system_prompt_file: optional override
+   ```
+
+2. Create `shows/deep_dives/<show>.yaml` with a `queue:` list (schema above).
+
+3. Create the two prompts. Model them on
+   `shows/prompts/modern_investing_deep_dive*.txt`:
+   - the **digest/brief** prompt must consume `{topic_title}` / `{topic_brief}`
+     / `{topic_category}` and emit a `**HOOK:**` line (it becomes the episode
+     title), and
+   - the **podcast** prompt must consume `{digest}` (the brief) + `{hook}` and
+     produce the spoken script in the show's host voice.
+
+Both prompt files are required overrides — a deep dive has a different shape
+than a daily news episode, so falling back to the show's normal prompts is
+almost never what you want.
+
+## Notes
+
+- Deep dives still publish normally (RSS, newsletter, X if enabled). YouTube
+  follows the show's existing `youtube.enabled`.
+- Chapter markers are best-effort; a deep-dive script won't match the show's
+  news-format section patterns, so it may produce only Introduction/Closing
+  chapters. That's expected.
+- The `deep_dive_mode` / `deep_dive_topic_id` metrics fire per episode so the
+  dashboard can tell deep dives apart from daily episodes.

--- a/shows/deep_dives/modern_investing.yaml
+++ b/shows/deep_dives/modern_investing.yaml
@@ -1,0 +1,58 @@
+# Deep-dive queue for Modern Investing Techniques.
+#
+# These are SPECIAL standalone single-subject episodes, distinct from the
+# daily markets show. The runner (run_show.py) checks this queue at the start
+# of every MIT run via the show's ``deep_dive:`` config block. A deep-dive
+# episode fires when:
+#   1. an entry's ``date:`` equals today's date (a scheduled deep dive), OR
+#   2. an entry is flagged ``when: next`` (fires on the very next MIT run), OR
+#   3. it's forced: ``python run_show.py modern_investing --deep-dive <id>``.
+# When one fires, that single episode bypasses the news fetch and runs off the
+# topic using the deep-dive prompts; the show auto-reverts to daily news after.
+#
+# To schedule a future deep dive: add an entry with a ``date: YYYY-MM-DD`` (the
+# date MIT runs that day) OR ``when: next``. Keep ``produced: false`` until it
+# runs — the runner flips it to true and records the episode number + date.
+#
+# Entry schema (shares shows/topic_queues schema + scheduling keys):
+#   id:             unique slug (also the --deep-dive argument)
+#   title:          episode title-ish phrase ({topic_title} in the prompt)
+#   brief:          EXACTLY what the episode must cover ({topic_brief})
+#   when:           "next" to fire on the next run (optional)
+#   date:           YYYY-MM-DD to fire on a specific run date (optional)
+#   produced:       false until produced
+#   episode_number: null until produced (runner fills in)
+#   produced_date:  null until produced (runner fills in)
+
+queue:
+  - id: spacex-ipo
+    title: "The SpaceX IPO and How to Invest in IPOs"
+    when: next
+    brief: >
+      A two-part deep dive. PART ONE — the SpaceX IPO question: walk through
+      where SpaceX actually stands as a private company (its scale, Starlink as
+      the cash-generative engine versus the launch business, its most recent
+      private-market / tender-offer valuation, and why Musk has historically
+      kept it private). Be explicit that, as of recording, there is NO formally
+      announced or priced SpaceX IPO — treat any IPO as speculative and explain
+      the realistic paths a retail investor has today to get exposure to
+      SpaceX-adjacent value (private-market platforms and their high minimums
+      and accreditation rules, funds/holding companies that carry SpaceX
+      stakes, and the caveats of each), versus simply waiting for a public
+      listing. PART TWO — the reusable framework for investing in IPOs in
+      general: how the traditional IPO process works (underwriters, the roadshow,
+      pricing, the first-day "pop"), how a direct listing and an SPAC differ,
+      why retail investors rarely get allocation at the offer price and what
+      that means, the role and danger of the post-IPO lock-up expiry, how to
+      read an S-1 / prospectus (what actually matters — revenue quality, path to
+      profitability, share structure and dilution, insider selling), the
+      historical base rates on IPO performance (the well-documented tendency to
+      underperform over the first one-to-three years), and a disciplined
+      checklist a Canadian or US retail investor can apply before buying any
+      newly public company — including which account (TFSA / RRSP / FHSA /
+      taxable) and the case for simply waiting a few quarters. Keep it
+      educational, balanced, and explicit that none of it is financial advice.
+    category: special
+    produced: false
+    episode_number: null
+    produced_date: null

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -247,6 +247,18 @@ slow_news:
   max_segments: 2
   cooldown_days: 30
 
+# Special standalone single-subject episodes (May 2026). When a topic in the
+# queue is scheduled for today (date:) or flagged when: next — or forced via
+# `python run_show.py modern_investing --deep-dive <id>` — that one episode
+# bypasses the daily news fetch and runs as a deep dive using the prompts
+# below, then auto-reverts to the normal daily markets show. Add future deep
+# dives by appending entries to shows/deep_dives/modern_investing.yaml.
+deep_dive:
+  enabled: true
+  queue_file: shows/deep_dives/modern_investing.yaml
+  digest_prompt_file: shows/prompts/modern_investing_deep_dive.txt
+  podcast_prompt_file: shows/prompts/modern_investing_deep_dive_podcast.txt
+
 youtube:
   podcast_playlist_id: PLRHMnzNNXPYCnD0HJiNss4SZPLBsH7z6v
   enabled: false                # Phase 2 — flip after quota raise

--- a/shows/prompts/modern_investing_deep_dive.txt
+++ b/shows/prompts/modern_investing_deep_dive.txt
@@ -1,0 +1,53 @@
+[PRODUCTION NOTES — DO NOT COPY INTO OUTPUT]
+This stage produces the EPISODE BRIEF for a SPECIAL standalone DEEP-DIVE episode of Modern Investing Techniques. It is NOT a daily news episode: there is no Market Pulse, no Practice Investment of the Day, no portfolio tracker, no Quick Hits. The whole episode is one subject, explored in depth. The brief is structured like a written essay with section markers; the downstream podcast prompt turns those sections into flowing narration. Do not include this production-notes block in your output.
+[END PRODUCTION NOTES]
+
+# Modern Investing Techniques — Deep-Dive Episode Brief
+
+**Date:** {today_str}
+**Topic:** {topic_title}
+
+**HOOK:** [One sentence under 130 characters that captures why this deep dive matters to an investor right now. Lead with the stake, then the subject. Plain prose, no blockquote, no emoji. This becomes the RSS / Apple / Spotify episode title.]
+
+━━━━━━━━━━━━━━━━━━━━
+
+ABOUT THE HOOK LINE (CRITICAL — read before writing anything):
+The ``**HOOK:**`` line above is the episode title in podcast apps. It is a SEPARATE field from Segment 1. Both must appear:
+  • ``**HOOK:**`` — one sentence, under 130 characters, plain prose, on its own line BEFORE the ━━━ divider.
+  • ``### Segment 1 — The Open`` — the spoken opening, 2–3 sentences.
+Do NOT merge them, do NOT omit the ``**HOOK:**`` label. An episode with no extractable HOOK ships with a generic "Episode N" title — bad for discovery.
+
+You are writing today's deep-dive brief for "Modern Investing Techniques," hosted by Patrick in Vancouver. The audience is intermediate Canadian and US retail investors. Use the topic information below as your scope and expand it with verifiable, concrete detail — real mechanisms, real numbers where you are confident, real institutions and instruments. This is education, not advice.
+
+TOPIC TITLE: {topic_title}
+TOPIC BRIEF (this defines exactly what to cover — follow it): {topic_brief}
+TOPIC CATEGORY: {topic_category}
+
+Produce a written, essay-style brief covering all six segments below. Keep the tone explanatory and prose-driven, not bullet-pointed. The downstream podcast prompt will turn this into ~13–18 minutes of spoken narration, so give it real substance to work with.
+
+### Segment 1 — The Open
+2–3 sentences. Open with a specific, concrete detail that frames why this subject is worth a full episode right now. State the promise of the episode plainly: by the end, the listener will understand X and have a framework for Y. This is the spoken opening — separate from the ``**HOOK:**`` title line.
+
+### Segment 2 — The Background
+5–8 sentences. The context a smart listener needs before the analysis lands. If the topic has a specific case at its centre (a company, an event, a product), establish the facts: who, what, when, the numbers that matter, where things stand today. Define any term the audience might not know on first use.
+
+### Segment 3 — The Core Analysis
+10–16 sentences. The heart of the episode. Explain the actual mechanics — how the thing works, why it is structured the way it is, what drives the outcomes, what the data shows. Walk through the cause-and-effect. Use concrete figures, comparisons, and worked reasoning rather than vague characterization. This is where the listener learns something they could not get from a headline.
+
+### Segment 4 — The Framework (How to Think About It / How to Act)
+8–12 sentences. Turn the analysis into a reusable, actionable framework the listener can apply themselves. Be specific and practical for Canadian and US retail investors: which account types apply (TFSA, RRSP, FHSA, taxable), what to check before committing capital, what platforms or instruments are realistically available to a retail investor, the questions a disciplined investor asks before acting, and the common mistakes to avoid. Generalize beyond the specific case so the framework is reusable.
+
+### Segment 5 — The Risks & The Other Side
+5–8 sentences. The strongest honest counterpoints. What can go wrong, what the bull and bear cases each get right, what the historical base rates actually are, where the hype diverges from the evidence. Never one-sided. If something is uncertain or speculative, say so plainly.
+
+### Segment 6 — The Takeaways
+4–6 sentences. Two to four crisp, durable principles the listener should leave with — phrased as general rules, each stated once. Close with a specific forward-looking question or a concrete "what to watch next," not a generic platitude.
+
+CRITICAL CONSTRAINTS:
+- This is educational and for entertainment — never financial advice, never a promise of returns, never a recommendation to buy or sell a specific security. Frame actionable content as "how a disciplined investor might think about this," not "you should buy this."
+- Do NOT fabricate statistics, dates, prices, valuations, or quotes. When you are not confident of a precise figure, hedge naturally ("estimates put it around…", "as of the most recent reporting…", "exact figures vary, but…") or speak to the mechanism rather than inventing a number. Speculative or rumoured items (e.g. an unannounced or unpriced IPO) must be flagged as speculative.
+- Keep all section markers in THIS brief so the podcast writer can see the structure, but write each segment as prose paragraphs.
+- Canadian-first framing where relevant (TSX, CRA account rules, CAD), with US context alongside. Acronyms in standard written form (TFSA, RRSP, FHSA, IPO, ETF, S&P, SEC, NASDAQ).
+- Length target: 1500–2200 words for the brief. The podcast prompt will expand it to ~2200–2900 spoken words.
+
+Output the brief now.

--- a/shows/prompts/modern_investing_deep_dive_podcast.txt
+++ b/shows/prompts/modern_investing_deep_dive_podcast.txt
@@ -1,0 +1,68 @@
+[PRODUCTION NOTES — DO NOT READ ALOUD]
+CRITICAL: The following block is for you (the writer). Never narrate, read aloud, reference, or echo any of it. Your script must contain ONLY the words spoken aloud to listeners. Specifically NEVER include:
+- Word counts, sentence counts, or script length targets
+- Segment length targets (e.g. "2–3 minutes")
+- Production note headers, bracketed labels, or self-references like "this deep dive"
+- Segment labels like "Segment 3:", "[The Framework]" — flow into content naturally
+- Instructions or directives from this prompt
+If you find yourself about to write any of the above, stop and rewrite that line as pure spoken content.
+
+PRONUNCIATION GUIDE:
+- Keep ALL acronyms in their standard written form (IPO, ETF, TFSA, RRSP, FHSA, SEC, NASDAQ, TSX, S&P, NYSE, etc.)
+- Keep ALL proper nouns in their standard spelling (SpaceX, Wealthsimple, Questrade, Musk, etc.)
+- DO NOT attempt phonetic spellings
+- DO spell out numbers as words ("four hundred twenty" not "420"); spell out currency ("thirty-nine billion dollars", not "$39B")
+- Expand an acronym on first use, then use the acronym ("an initial public offering, or IPO")
+[END PRODUCTION NOTES]
+
+You are writing a special standalone DEEP-DIVE episode of "Modern Investing Techniques," Episode {episode_num}. This is NOT a daily markets episode — there is no Market Pulse, no Practice Investment of the Day, and no portfolio tracker. The entire episode is one subject, explored with depth and a reusable takeaway.
+
+HOST: Patrick — an experienced investor and technology enthusiast based in Vancouver. Quiet confidence, genuine enthusiasm for democratizing investing through modern tools. Conversational but precise with numbers. Speaks to a capable, intermediate audience. Never preachy, never vague about risk, never promising returns.
+
+TARGET: a focused 13–18 minute episode. Reach the length by teaching the subject thoroughly — explaining mechanisms, walking through the numbers, building the framework — not by padding. If you finish early, you have under-explained: go deeper on the core analysis and the framework rather than adding filler.
+
+RULES:
+- Start every line with "Patrick:"
+- Use ONLY information from the episode brief below — do NOT invent statistics, dates, valuations, or quotes that are not in the brief.
+- Write SHORT paragraphs — 1 to 2 sentences per "Patrick:" line. Each thought its own line. This creates natural pauses in the audio.
+- Frame everything as education and entertainment, never financial advice. When you describe how to act, phrase it as "how a disciplined investor might think about this," not "you should buy this."
+- Flag speculative or unconfirmed items as speculative (e.g. an IPO that has not been formally announced or priced). Hedge uncertain figures ("estimates put it around…").
+- Do NOT include URLs, datelines, source-only lines, emoji, markdown, or section headers. Mention sources conversationally.
+- Maintain clear pronoun antecedents — every "it / they / this" must point to a clear noun in the same or immediately preceding line.
+
+SCRIPT STRUCTURE (do NOT announce these as labelled sections — flow naturally):
+
+[Intro — ~15 seconds]
+Patrick: Open by welcoming listeners to a special deep-dive episode of Modern Investing Techniques, and name today's subject in one sentence.
+
+[Disclaimer — immediately after the intro]
+Patrick: Quick reminder — everything in this episode is for education and entertainment. I'm not a licensed financial advisor and this isn't financial advice. Nothing here is a recommendation to buy or sell any security. Always do your own research before putting real money to work.
+
+[Hook — one sentence right after the disclaimer]
+Patrick: {hook}
+Then transition naturally into the open.
+
+[The Open] Set up why this subject is worth a full episode and what the listener will walk away understanding.
+
+[The Background] Give the listener the context and facts they need before the analysis — who/what/when, the numbers that matter, where things stand now. Define terms on first use.
+
+[The Core Analysis] The heart of the episode. Explain the real mechanics and the cause-and-effect, walking through concrete figures and comparisons. Let it build with a sense of discovery — this is the part listeners came for.
+
+[The Framework] Turn the analysis into a reusable, practical framework. Be concrete for Canadian and US retail investors — relevant account types (TFSA, RRSP, FHSA, taxable), what to check before committing capital, what's realistically accessible to a retail investor, and the common mistakes to avoid. Generalize so it applies beyond today's specific case.
+
+[The Risks & The Other Side] The strongest honest counterpoints — what can go wrong, what the bull and bear cases each get right, what the base rates actually are. Be balanced and candid about uncertainty.
+
+[The Takeaways] Two to four durable principles, each stated once.
+
+[Tomorrow Teaser — one sentence] Briefly note that the show returns to its regular daily markets coverage next episode.
+
+[Closing] Sign off warmly as Modern Investing Techniques.
+
+CROSS-PROMO (optional, single sentence, ONLY in the close, ONLY if it genuinely fits the subject):
+- AI / tech angle → "For daily AI news, check out Models & Agents on the Nerra Network."
+- Tesla / TSLA angle → "Tesla Shorts Time covers Tesla daily on the Nerra Network."
+If nothing fits naturally, omit it.
+
+Here is today's deep-dive brief. Use ONLY this content:
+
+{digest}

--- a/tests/test_deep_dive.py
+++ b/tests/test_deep_dive.py
@@ -176,3 +176,36 @@ class TestShippedMITDeepDive:
         }
         load_prompt("shows/prompts/modern_investing_deep_dive.txt", v)
         load_prompt("shows/prompts/modern_investing_deep_dive_podcast.txt", v)
+
+
+# ---------------------------------------------------------------------------
+# Deep-dive vs Sunday weekly-recap precedence
+# ---------------------------------------------------------------------------
+
+class TestDeepDiveVsWeeklyRecap:
+    """A deep dive scheduled onto a Sunday must win over the automatic Sunday
+    weekly recap — otherwise the run builds a recap digest but uses the
+    deep-dive podcast prompt (a broken hybrid) AND marks the deep-dive topic
+    produced, burning the slot. The monthly MIT episode is a separate entry
+    point and is intentionally not involved."""
+
+    import datetime as _dt
+
+    SUNDAY = _dt.date(2026, 5, 31)   # the next MIT run after the SpaceX merge
+    WEEKDAY = _dt.date(2026, 5, 29)  # a Friday
+
+    def test_recap_fires_on_sunday_normally(self):
+        from run_show import _resolve_weekly_recap
+        assert _resolve_weekly_recap(True, self.SUNDAY, is_deep_dive=False) is True
+
+    def test_deep_dive_suppresses_sunday_recap(self):
+        from run_show import _resolve_weekly_recap
+        assert _resolve_weekly_recap(True, self.SUNDAY, is_deep_dive=True) is False
+
+    def test_no_recap_on_weekday(self):
+        from run_show import _resolve_weekly_recap
+        assert _resolve_weekly_recap(True, self.WEEKDAY, is_deep_dive=False) is False
+
+    def test_opt_out_show_never_recaps(self):
+        from run_show import _resolve_weekly_recap
+        assert _resolve_weekly_recap(False, self.SUNDAY, is_deep_dive=False) is False

--- a/tests/test_deep_dive.py
+++ b/tests/test_deep_dive.py
@@ -1,0 +1,178 @@
+"""Drift guards for per-episode deep-dive episodes (May 2026).
+
+Modern Investing Techniques (and any future show) can produce an occasional
+standalone single-subject deep-dive episode without permanently switching to
+``narrative_mode``. Covered here:
+
+  - ``engine.topic_queue.pick_deep_dive_topic`` selection priority:
+    forced id > scheduled date == today > ``when: next`` > nothing.
+  - ``DeepDiveConfig`` loads from a show YAML.
+  - The shipped MIT deep-dive queue + prompts are wired correctly so the
+    SpaceX IPO episode fires on the next run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _write_queue(path: Path, entries: list) -> None:
+    path.write_text(yaml.safe_dump({"queue": entries}, sort_keys=False))
+
+
+# ---------------------------------------------------------------------------
+# pick_deep_dive_topic — selection priority
+# ---------------------------------------------------------------------------
+
+class TestPickDeepDiveTopic:
+
+    def test_fires_on_when_next(self, tmp_path: Path):
+        from engine.topic_queue import pick_deep_dive_topic
+        q = tmp_path / "q.yaml"
+        _write_queue(q, [
+            {"id": "a", "title": "A", "brief": "b", "when": "next",
+             "produced": False},
+        ])
+        # Any date — "next" is date-agnostic.
+        t = pick_deep_dive_topic(q, "2026-05-31")
+        assert t and t["id"] == "a"
+
+    def test_fires_on_scheduled_date(self, tmp_path: Path):
+        from engine.topic_queue import pick_deep_dive_topic
+        q = tmp_path / "q.yaml"
+        _write_queue(q, [
+            {"id": "a", "title": "A", "brief": "b", "date": "2026-06-15",
+             "produced": False},
+        ])
+        assert pick_deep_dive_topic(q, "2026-06-15")["id"] == "a"
+        # Wrong day → no deep dive (normal news episode).
+        assert pick_deep_dive_topic(q, "2026-06-14") is None
+
+    def test_no_fire_without_schedule_or_next(self, tmp_path: Path):
+        """A plain unproduced entry with neither date nor when must NOT
+        hijack a news show — otherwise every run would be a deep dive."""
+        from engine.topic_queue import pick_deep_dive_topic
+        q = tmp_path / "q.yaml"
+        _write_queue(q, [
+            {"id": "a", "title": "A", "brief": "b", "produced": False},
+        ])
+        assert pick_deep_dive_topic(q, "2026-05-31") is None
+        # ...but it can still be forced explicitly.
+        assert pick_deep_dive_topic(q, "2026-05-31", force_id="a")["id"] == "a"
+
+    def test_date_today_wins_over_when_next(self, tmp_path: Path):
+        from engine.topic_queue import pick_deep_dive_topic
+        q = tmp_path / "q.yaml"
+        _write_queue(q, [
+            {"id": "later", "title": "L", "brief": "b", "when": "next",
+             "produced": False},
+            {"id": "today", "title": "T", "brief": "b", "date": "2026-05-31",
+             "produced": False},
+        ])
+        assert pick_deep_dive_topic(q, "2026-05-31")["id"] == "today"
+
+    def test_forced_id_overrides_schedule(self, tmp_path: Path):
+        from engine.topic_queue import pick_deep_dive_topic
+        q = tmp_path / "q.yaml"
+        _write_queue(q, [
+            {"id": "sched", "title": "S", "brief": "b", "date": "2026-05-31",
+             "produced": False},
+            {"id": "forced", "title": "F", "brief": "b", "produced": False},
+        ])
+        assert pick_deep_dive_topic(
+            q, "2026-05-31", force_id="forced")["id"] == "forced"
+
+    def test_forced_unknown_or_produced_returns_none(self, tmp_path: Path):
+        from engine.topic_queue import pick_deep_dive_topic
+        q = tmp_path / "q.yaml"
+        _write_queue(q, [
+            {"id": "done", "title": "D", "brief": "b", "when": "next",
+             "produced": True},
+        ])
+        assert pick_deep_dive_topic(q, "2026-05-31", force_id="missing") is None
+        # Already-produced entries are never re-selected (even forced).
+        assert pick_deep_dive_topic(q, "2026-05-31", force_id="done") is None
+        assert pick_deep_dive_topic(q, "2026-05-31") is None
+
+    def test_skips_produced_entries(self, tmp_path: Path):
+        from engine.topic_queue import pick_deep_dive_topic
+        q = tmp_path / "q.yaml"
+        _write_queue(q, [
+            {"id": "old", "title": "O", "brief": "b", "when": "next",
+             "produced": True},
+            {"id": "new", "title": "N", "brief": "b", "when": "next",
+             "produced": False},
+        ])
+        assert pick_deep_dive_topic(q, "2026-05-31")["id"] == "new"
+
+
+# ---------------------------------------------------------------------------
+# DeepDiveConfig loading
+# ---------------------------------------------------------------------------
+
+class TestDeepDiveConfig:
+
+    def test_defaults_disabled(self):
+        from engine.config import DeepDiveConfig
+        dd = DeepDiveConfig()
+        assert dd.enabled is False
+        assert dd.queue_file == ""
+
+    def test_mit_yaml_wires_deep_dive(self):
+        from engine.config import load_config
+        c = load_config("shows/modern_investing.yaml")
+        assert c.deep_dive.enabled is True
+        assert c.deep_dive.queue_file == "shows/deep_dives/modern_investing.yaml"
+        assert c.deep_dive.digest_prompt_file.endswith("modern_investing_deep_dive.txt")
+        assert c.deep_dive.podcast_prompt_file.endswith(
+            "modern_investing_deep_dive_podcast.txt"
+        )
+
+    def test_news_shows_default_to_no_deep_dive(self):
+        """A show without a deep_dive: block must stay news-driven."""
+        from engine.config import load_config
+        c = load_config("shows/omni_view.yaml")
+        assert c.deep_dive.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Shipped MIT deep-dive assets
+# ---------------------------------------------------------------------------
+
+class TestShippedMITDeepDive:
+
+    def test_spacex_ipo_is_next_and_unproduced(self):
+        data = yaml.safe_load(
+            Path("shows/deep_dives/modern_investing.yaml").read_text()
+        )
+        entry = next(e for e in data["queue"] if e["id"] == "spacex-ipo")
+        assert entry["when"] == "next"
+        assert entry["produced"] is False
+        # Brief must mention both the specific case and the general framework.
+        brief = entry["brief"].lower()
+        assert "spacex" in brief
+        assert "ipo" in brief
+
+    def test_deep_dive_prompts_exist_and_reference_topic(self):
+        digest = Path("shows/prompts/modern_investing_deep_dive.txt").read_text()
+        podcast = Path(
+            "shows/prompts/modern_investing_deep_dive_podcast.txt"
+        ).read_text()
+        # Brief prompt must consume the queue topic + emit a HOOK line.
+        assert "{topic_title}" in digest and "{topic_brief}" in digest
+        assert "**HOOK:**" in digest
+        # Podcast prompt must consume the brief + the extracted hook.
+        assert "{digest}" in podcast and "{hook}" in podcast
+
+    def test_deep_dive_prompts_render(self):
+        from engine.generator import load_prompt
+        v = {
+            "today_str": "May 31, 2026", "topic_title": "T",
+            "topic_brief": "B", "topic_category": "special",
+            "episode_num": 7, "hook": "H", "digest": "D",
+        }
+        load_prompt("shows/prompts/modern_investing_deep_dive.txt", v)
+        load_prompt("shows/prompts/modern_investing_deep_dive_podcast.txt", v)

--- a/tests/test_weekly_recap_validator_gate.py
+++ b/tests/test_weekly_recap_validator_gate.py
@@ -46,8 +46,11 @@ def test_validator_block_gated_on_not_weekly_recap():
     source = _RUN_SHOW.read_text(encoding="utf-8")
     # The gate must reference both the validator factory AND the
     # ``is_weekly_recap`` flag so a daily-format check doesn't fire
-    # on a recap digest.
-    assert "if _val_factory and not is_weekly_recap:" in source, (
+    # on a recap digest. (May 2026: the gate also carries a trailing
+    # ``and not is_deep_dive`` so standalone deep-dive episodes — which
+    # have their own non-daily shape — skip the daily validator too. We
+    # match the prefix so either tail is accepted.)
+    assert "if _val_factory and not is_weekly_recap" in source, (
         "Daily-format validator block in run_show.py must be gated on "
         "``not is_weekly_recap``. Without the gate, recap digests get "
         "overwritten with daily content on Sundays. See May 10 2026 "


### PR DESCRIPTION
## What this adds

A reusable **deep-dive episode** mechanism: a normally news-driven show can run an occasional *standalone single-subject* episode without permanently becoming a topic-queue show (`narrative_mode`). The show stays a daily news show — only a **scheduled or forced** episode runs as a deep dive, and it **auto-reverts** to the normal pipeline afterward.

First use: **Modern Investing Techniques** ships a **SpaceX IPO** deep dive that fires on its **next run** (`when: next`), covering both the SpaceX IPO question *and* a reusable framework for investing in IPOs in general.

## How a deep dive fires

For any show with a `deep_dive:` block, the runner checks its queue at the start of every run:

1. **`when: next`** on an unproduced entry → fires on the very next run.
2. **`date: YYYY-MM-DD`** == run date → a scheduled deep dive (a date match for today beats a generic `when: next`).
3. **Forced**: `python run_show.py modern_investing --deep-dive spacex-ipo` → produces it now, regardless of schedule.

A plain unproduced entry with *neither* `date` nor `when` never fires automatically — so a news show can't be hijacked by a stale queue. When one fires, that episode bypasses the news fetch + slow-news + daily-format digest validation, runs off the topic via the deep-dive prompts, marks the topic `produced`, and skips the show's `post_generate` hook (so a standalone deep dive doesn't advance MIT's simulated-trade tracker).

## Files

**Mechanism (generic, reuses `topic_queue` infra):**
- `engine/config.py` — new `DeepDiveConfig` (`enabled`, `queue_file`, prompt overrides).
- `engine/topic_queue.py` — `pick_deep_dive_topic()` with the selection priority above.
- `run_show.py` — up-front deep-dive resolution (alongside `narrative_mode`), `--deep-dive <id>` flag, and a single `_topic_driven` gate that handles narrative + deep-dive modes uniformly across the fetch-skip / validation-skip / topic-injection / hook-fallback / mark-produced points. All references live inside the generation `else` block, so resume-publish paths are unaffected.

**Modern Investing wiring:**
- `shows/modern_investing.yaml` — `deep_dive:` block (standalone shape: no Market Pulse / Practice Investment / portfolio segments).
- `shows/prompts/modern_investing_deep_dive.txt` + `..._deep_dive_podcast.txt` — dedicated educational deep-dive prompts (brief → spoken script), with a spoken "not financial advice" disclaimer, Canadian-first framing (TFSA/RRSP/FHSA), and explicit "hedge unconfirmed figures / flag speculation."
- `shows/deep_dives/modern_investing.yaml` — seeded with the SpaceX IPO topic.
- `shows/deep_dives/README.md` — documents the pattern and how to add future deep dives / enable it for other shows.

## Tests

`tests/test_deep_dive.py` (13) — selection priority (forced > date-today > `when: next` > none), config wiring, the shipped SpaceX entry, and prompt rendering. Broad sweep green:

```
468 passed, 3 skipped  (config, deep_dive, topic, narrative, unintended,
prompt_fidelity, validation, schedule, generator, integration, tts_grok)
```

## Notes / heads-up

- **Verify before the live run:** since deep dives skip the news fetch and run off the LLM with the `brief`, please skim the generated SpaceX episode once before it's trusted — the prompt forbids fabricated figures and forces speculation to be flagged (there is no formally announced/priced SpaceX IPO), but a financial-topic deep dive warrants a read of episode one. You can dry-run with `python run_show.py modern_investing --deep-dive spacex-ipo --test` (fetch+digest only).
- Deep dives still publish normally (RSS, newsletter, X). YouTube follows the show's existing `youtube.enabled` (off for MIT).
- `deep_dive_mode` / `deep_dive_topic_id` metrics fire per episode so the dashboard can distinguish deep dives from daily episodes.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_