### PR TITLE
Daily audit: page only on missed episodes / stale feeds, not editorial quality

### DIFF
--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -106,17 +106,23 @@ jobs:
             echo "SUMMARY_EOF"
           } >> "$GITHUB_OUTPUT"
 
+          # Exit 1 = OPERATIONAL problem only (a due episode is missing) — page.
+          # Exit 2 = editorial-quality notes + warnings — recorded in the GitHub
+          # issue + api/daily-review.json, but must NOT fail the run (otherwise
+          # the audit pages daily for routine quality notes). Operator decision,
+          # May 2026.
           if [ "$EXIT_CODE" -eq 1 ]; then
-            echo "::error::CRITICAL issues found — check GitHub issues + api/daily-review.json"
+            echo "::error::Operational problem — a due episode is missing. See GitHub issue + api/daily-review.json"
             exit 1
           elif [ "$EXIT_CODE" -eq 2 ]; then
-            echo "::warning::Warnings found"
+            echo "::warning::Quality notes recorded (non-paging) — see GitHub issue + api/daily-review.json"
             exit 0
           fi
 
       - name: RSS Feed Freshness Health Check
         shell: python3 {0}
         run: |
+          import sys
           import xml.etree.ElementTree as ET
           from email.utils import parsedate_to_datetime
           from datetime import datetime, timezone
@@ -161,8 +167,15 @@ jobs:
                   stale.append(f"{name}: error {e}")
 
           if stale:
+              # A feed not updating past its (cadence-aware) limit is an
+              # OPERATIONAL problem — episodes aren't reaching subscribers — so
+              # this fails the job and pages the operator, same tier as a missed
+              # episode. (Editorial-quality notes do NOT fail the run; see the
+              # review step above.) Thresholds already tolerate alt-cadence /
+              # weekend gaps, so a trip here means multiple missed cycles.
               print("::error::STALE RSS FEEDS: " + "; ".join(stale))
               with open("has_stale_rss", "w") as f: f.write("\n".join(stale))
+              sys.exit(1)
           else:
               print("RSS freshness: all feeds OK")
 
@@ -191,9 +204,13 @@ jobs:
             git push origin main || echo "Push of audit artifacts failed (non-blocking)"
           fi
 
-          # Webhook notification on problems
-          if [ -n "$DAILY_REVIEW_WEBHOOK_URL" ] && [ "$EXIT_CODE" != "0" ]; then
+          # Webhook notification ONLY on operational problems (exit 1 = a
+          # missed episode). Editorial-quality notes (exit 2) are recorded in
+          # the GitHub issue + JSON and must not ping — that daily noise is
+          # exactly what the May 2026 operator change removed. (A stale RSS
+          # feed fails its own step, which red-X's the run separately.)
+          if [ -n "$DAILY_REVIEW_WEBHOOK_URL" ] && [ "$EXIT_CODE" = "1" ]; then
             curl -s -X POST "$DAILY_REVIEW_WEBHOOK_URL" \
               -H "Content-Type: application/json" \
-              -d "{\"text\":\"Nerra Daily Audit finished with exit $EXIT_CODE\\n$RUN_URL\"}" || true
+              -d "{\"text\":\"Nerra Daily Audit: a due episode is missing (operational) — $RUN_URL\"}" || true
           fi

--- a/review_episodes.py
+++ b/review_episodes.py
@@ -20,8 +20,14 @@ Checks performed:
 
 Exit codes:
     0 — all episodes OK (or no episodes today)
-    1 — critical issues found (episodes that should be considered for removal)
-    2 — warnings only (fixable for future episodes)
+    1 — OPERATIONAL problem that should page the operator: a missed episode
+        (a show that was due but produced no output and has no skip marker).
+        The daily-audit workflow red-X's / notifies on this.
+    2 — non-paging notices only: editorial-quality criticals (short script,
+        repetition, garbles) AND warnings. These are recorded in the GitHub
+        issue + api/daily-review.json for review, but do NOT fail the run —
+        otherwise the audit pages daily for routine quality notes. (Operator
+        decision, May 2026.)
 """
 
 from __future__ import annotations
@@ -1818,6 +1824,31 @@ def format_for_claude(
 # Main
 # ---------------------------------------------------------------------------
 
+def _review_exit_code(
+    operational_critical: int,
+    editorial_critical: int,
+    total_warnings: int,
+) -> int:
+    """Map review tallies to a process exit code.
+
+    Operator decision (May 2026): the daily audit should PAGE (red-X /
+    notify) only for OPERATIONAL problems — a show that was due but produced
+    no episode (``operational_critical``). Editorial-quality criticals
+    (short script, repetition, garbles) and warnings are recorded in the
+    GitHub issue + ``api/daily-review.json`` but must NOT fail the run, or
+    the audit pages daily for routine notes.
+
+      1 — operational problem (missed episode): page.
+      2 — editorial criticals and/or warnings only: recorded, non-paging.
+      0 — clean.
+    """
+    if operational_critical > 0:
+        return 1
+    if editorial_critical > 0 or total_warnings > 0:
+        return 2
+    return 0
+
+
 def run_review(
     target_date: datetime.date,
     create_issues: bool = False,
@@ -1886,14 +1917,22 @@ def run_review(
     else:
         logger.info("Skipping AI review (no GROK_API_KEY)")
 
-    # Report
-    total_critical = sum(1 for i in missed_issues if i.severity == "critical")
+    # Report. Two buckets of "critical":
+    #   - operational_critical: a show that was due but didn't ship (missed
+    #     episode, no skip marker). This is the only thing that should PAGE
+    #     the operator (exit 1) — an episode is actually missing.
+    #   - editorial_critical: content-quality problems on episodes that DID
+    #     ship (short script, repetition, garbles). Recorded in the issue +
+    #     JSON, but does NOT page (exit 2) — otherwise the audit fails daily
+    #     for routine notes. (Operator decision, May 2026.)
+    operational_critical = sum(1 for i in missed_issues if i.severity == "critical")
+    editorial_critical = 0
     total_warnings = sum(1 for i in missed_issues if i.severity == "warning")
     for ep in episodes:
         n_crit = sum(1 for i in ep.issues if i.severity == "critical")
         n_warn = sum(1 for i in ep.issues if i.severity == "warning")
         n_info = sum(1 for i in ep.issues if i.severity == "info")
-        total_critical += n_crit
+        editorial_critical += n_crit
         total_warnings += n_warn
 
         if ep.issues:
@@ -1907,6 +1946,8 @@ def run_review(
                            "  [%s] %s: %s", issue.severity.upper(), issue.title, issue.detail)
         else:
             logger.info("%s Ep%03d: OK", ep.show_name, ep.episode_num)
+
+    total_critical = operational_critical + editorial_critical
 
     # Claude Code output
     if output_format == "claude":
@@ -1947,11 +1988,10 @@ def run_review(
     parts.extend([f"{total_critical} critical", f"{total_warnings} warning(s)"])
     logger.info("=== Review complete: %s ===", ", ".join(parts))
 
-    if total_critical > 0:
-        return 1
-    elif total_warnings > 0:
-        return 2
-    return 0
+    # Exit 1 ONLY for operational problems (a missed episode) so the daily
+    # audit pages the operator when something genuinely didn't ship. Editorial
+    # criticals + warnings return 2 (recorded, non-paging). See module docstring.
+    return _review_exit_code(operational_critical, editorial_critical, total_warnings)
 
 
 def write_review_json(

--- a/tests/test_daily_audit_notify_policy.py
+++ b/tests/test_daily_audit_notify_policy.py
@@ -1,0 +1,50 @@
+"""Drift guard for the daily-audit notification policy (May 2026).
+
+Operator decision: the daily Episode Review / audit workflow should PAGE
+(red-X the run + notify) only for OPERATIONAL problems — a show that was due
+but produced no episode. Editorial-quality criticals (short script,
+repetition, ``nay-toe`` / ``nassa`` garbles) plus warnings are recorded in
+the GitHub issue + api/daily-review.json, but must NOT fail the run —
+otherwise the audit emailed a failure daily for routine quality notes.
+
+These tests pin ``review_episodes._review_exit_code`` so a future change
+that re-couples editorial findings to the paging exit code (1) trips here.
+"""
+
+from __future__ import annotations
+
+from review_episodes import _review_exit_code
+
+
+def test_missed_episode_pages():
+    """An operational problem (a due episode is missing) returns 1 → the
+    workflow red-X's / notifies."""
+    assert _review_exit_code(operational_critical=1, editorial_critical=0, total_warnings=0) == 1
+
+
+def test_editorial_criticals_do_not_page():
+    """Short-script / repetition / garble criticals on episodes that DID
+    ship are editorial — return 2 (recorded, non-paging), NOT 1."""
+    assert _review_exit_code(operational_critical=0, editorial_critical=4, total_warnings=15) == 2
+
+
+def test_warnings_only_do_not_page():
+    assert _review_exit_code(operational_critical=0, editorial_critical=0, total_warnings=3) == 2
+
+
+def test_clean_run_is_zero():
+    assert _review_exit_code(operational_critical=0, editorial_critical=0, total_warnings=0) == 0
+
+
+def test_operational_wins_even_with_editorial():
+    """If a real episode is missing AND others have editorial notes, the
+    operational signal dominates — still page (1)."""
+    assert _review_exit_code(operational_critical=1, editorial_critical=9, total_warnings=20) == 1
+
+
+def test_todays_real_tally_would_not_page():
+    """The 2026-05-30 run had 4 critical / 15 warnings, ALL editorial (no
+    missed episodes). Under the new policy that's a non-paging exit 2 —
+    exactly the daily failure email the operator asked to stop."""
+    # All 4 criticals were editorial (short script + repetition), 0 missed.
+    assert _review_exit_code(operational_critical=0, editorial_critical=4, total_warnings=15) == 2


### PR DESCRIPTION
## Problem

The daily **Episode Review** (`daily-audit.yml` → `review_episodes.py`) red-X's the run and emails a failure whenever **any** of the ~9 shows has a CRITICAL finding. Across that many shows there's almost always an *editorial-quality* note — a slightly short script, a repeated paragraph, a `nay-toe` / `nassa` garble — so it sends a failure email **every day** for routine notes. (Today's 2026-05-30 run: 4 critical / 15 warnings, **all editorial, zero missed episodes** → still failed + emailed + opened issue #491.)

## Change — page only on operational problems

Per operator decision, the audit now pages (red-X + notify) **only when something operationally didn't ship**, and treats editorial quality as recorded-but-non-paging.

**`review_episodes.py`**
- Split criticals into **operational** (a *missed episode* — a due show produced no output and has no skip marker) vs **editorial** (quality issues on episodes that *did* ship).
- Exit **1** (page) only for operational; editorial criticals **and** warnings → exit **2** (recorded in the GitHub issue + `api/daily-review.json`, non-paging).
- Extracted `_review_exit_code()` so the policy is unit-pinned.

**`daily-audit.yml`**
- **Stale RSS now fails its step** — a feed not updating past its cadence-aware limit means episodes aren't reaching subscribers (operational). Previously it only printed a `::error::` annotation and *never actually failed*, so you weren't alerted to it at all.
- Webhook fires only on operational failures (exit 1), not editorial (exit 2).
- Clearer step messages.

## Net effect

| Situation | Before | After |
|---|---|---|
| A due episode is missing | fail + email | **fail + email** (unchanged) |
| A feed went stale | annotation only (no alert) | **fail + email** (now alerts) |
| Short script / repetition / garble | fail + email **daily** | recorded in issue + JSON, **no email** |
| Warnings only | no email | no email |

Editorial findings still land in the daily GitHub issue and `api/daily-review.json` for when you want to review them — they just stop paging you.

## Tests

`tests/test_daily_audit_notify_policy.py` pins the exit-code policy (operational → 1, editorial/warnings → 2, operational dominates, clean → 0, and today's real all-editorial tally → non-paging). Full suite green (2330 passed).

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_