### PR TITLE
Fix deep-dive skip: lower MIT word floor + mark-produced only after thin gate

### DIFF
--- a/run_show.py
+++ b/run_show.py
@@ -1753,23 +1753,11 @@ def run(args: argparse.Namespace) -> None:
                     "Failed to mark topic as produced (non-fatal): %s", exc,
                 )
 
-        # Deep-dive episodes: mark the topic produced in the deep-dive queue so
-        # a ``when: next`` entry doesn't fire again on tomorrow's news episode.
-        if is_deep_dive and deep_dive_topic:
-            try:
-                from engine.topic_queue import mark_topic_produced
-                _dd_queue = PROJECT_ROOT / config.deep_dive.queue_file
-                mark_topic_produced(
-                    _dd_queue,
-                    topic_id=deep_dive_topic.get("id", ""),
-                    episode_num=episode_num,
-                    produced_date=today.isoformat(),
-                )
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "Failed to mark deep-dive topic as produced (non-fatal): %s",
-                    exc,
-                )
+        # Deep-dive topics are marked produced LATER — only after the
+        # podcast script clears the thin-script gate (see step 8b) — so a
+        # skipped deep dive (e.g. the script came out too thin) does NOT burn
+        # the queue slot. Marking here, before generation, would consume the
+        # topic even on a skip.
 
         # Post-generation hook (e.g. extract trade picks for Modern Investing
         # tracker). Skipped on deep dives — a standalone deep dive has no daily
@@ -2067,6 +2055,27 @@ def run(args: argparse.Namespace) -> None:
                     )
                     save_usage(tracker, digests_dir)
                     sys.exit(1)
+
+            # Deep-dive episodes: NOW that the script has cleared the thin-script
+            # gate (8b) and the pre-TTS duration gate (8c), mark the topic
+            # produced in the deep-dive queue. Done here (not before generation)
+            # so a skipped deep dive never burns its queue slot — a ``when: next``
+            # entry that skipped on a thin script will correctly fire again.
+            if is_deep_dive and deep_dive_topic:
+                try:
+                    from engine.topic_queue import mark_topic_produced
+                    _dd_queue = PROJECT_ROOT / config.deep_dive.queue_file
+                    mark_topic_produced(
+                        _dd_queue,
+                        topic_id=deep_dive_topic.get("id", ""),
+                        episode_num=episode_num,
+                        produced_date=today.isoformat(),
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "Failed to mark deep-dive topic as produced (non-fatal): %s",
+                        exc,
+                    )
 
             # Update Content Lake with podcast script (non-fatal)
             if _lake_record is not None:

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -259,9 +259,14 @@ deep_dive:
   digest_prompt_file: shows/prompts/modern_investing_deep_dive.txt
   podcast_prompt_file: shows/prompts/modern_investing_deep_dive_podcast.txt
   # Deep dives are full-length explainers, not daily-sized episodes. Push the
-  # word floor well above MIT's daily 1300 so the length gate + expansion retry
-  # drive a ~16-19 min episode (Ep059 shipped only 1252 words against 1300).
-  min_podcast_words: 2400
+  # word floor above MIT's daily 1300 so the expansion retry fires and a fuller
+  # episode ships — but NOT so high it skips a good-content episode. Ep060
+  # (SpaceX, excellent live-sourced content) produced ~1320 words after the
+  # retry; a 2400 target skipped it at the 1440 soft floor. 1700 → soft floor
+  # 1020, so a ~1300-word deep dive ships while the retry still pushes depth.
+  # (Single-pass generation caps ~1300-1400 words for this content; a true
+  # 16-20 min deep dive needs section-by-section generation — see backlog.)
+  min_podcast_words: 1700
 
 youtube:
   podcast_playlist_id: PLRHMnzNNXPYCnD0HJiNss4SZPLBsH7z6v

--- a/tests/test_deep_dive.py
+++ b/tests/test_deep_dive.py
@@ -130,10 +130,14 @@ class TestDeepDiveConfig:
         assert c.deep_dive.podcast_prompt_file.endswith(
             "modern_investing_deep_dive_podcast.txt"
         )
-        # Deep dives push a fuller word target than the daily show (Ep059 was
-        # only 1252 words) so the length gate drives a real deep dive.
-        assert c.deep_dive.min_podcast_words >= 2000
+        # Deep dives push a fuller word target than the daily show so the
+        # expansion retry fires — but tuned so a ~1300-word deep dive still
+        # SHIPS (a 2400 target skipped the strong Ep060 at its 1440 soft floor).
         assert c.deep_dive.min_podcast_words > c.llm.min_podcast_words
+        assert 1500 <= c.deep_dive.min_podcast_words <= 2000
+        # Soft floor (0.6 x target) must sit below the ~1300 words this content
+        # reliably produces, so a good-content episode ships rather than skips.
+        assert int(c.deep_dive.min_podcast_words * 0.6) <= 1100
 
     def test_deep_dive_min_words_defaults_to_inherit(self):
         from engine.config import DeepDiveConfig
@@ -198,6 +202,27 @@ class TestShippedMITDeepDive:
         }
         load_prompt("shows/prompts/modern_investing_deep_dive.txt", v)
         load_prompt("shows/prompts/modern_investing_deep_dive_podcast.txt", v)
+
+
+class TestDeepDiveMarkProducedAfterThinGate:
+    """A deep-dive topic must be marked produced ONLY after the podcast script
+    clears the thin-script gate — otherwise a skipped deep dive (script too
+    thin) burns its queue slot and a ``when: next`` entry never re-fires.
+    (Regression: SpaceX Ep060 skipped at the soft floor; the mark must come
+    after that skip, not at digest-save before generation.)"""
+
+    def test_mark_produced_comes_after_thin_script_skip(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parent.parent / "run_show.py").read_text()
+        thin_skip = src.index("Podcast script too thin for publication")
+        # The deep-dive mark_topic_produced must appear AFTER the thin-script
+        # skip in source order.
+        dd_mark = src.index(
+            "Failed to mark deep-dive topic as produced", thin_skip
+        )
+        assert dd_mark > thin_skip
+        # And there must be no deep-dive mark BEFORE the thin gate.
+        assert "Failed to mark deep-dive topic as produced" not in src[:thin_skip]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What the Ep060 run told us

The rebuilt SpaceX deep dive **works** — the live research did exactly its job:

```
Deep-dive: running live web+X research (10 queries) ...
retrieved 4842 chars of current context
Hook: With SpaceX's S-1 now public and a June 12 Nasdaq debut targeted at a
roughly $1.8 trillion valuation, this episode walks through exactly how retail
investors can prepare across short-, medium-, and long-term horizons.
```

Real S‑1 (filed May 20, with an SEC.gov citation), the June 12 Nasdaq date, the ~$1.8T valuation, and the short/medium/long-term framing. The stale-content problem is fully solved.

**But the episode skipped.** The script came in at **1,315 words**, under the **1,440 soft floor** that my `min_podcast_words: 2400` created. The model caps at ~1,300–1,400 words for this content *even when asked for 2,400* (the expansion retry only got 1,065 → 1,323), so the aggressive target just converted a strong episode into a skip.

## Fixes

1. **`shows/modern_investing.yaml`** — `deep_dive.min_podcast_words` **2400 → 1700**. The expansion retry still fires (first draft < 1,122 → retry) and pushes depth, but the soft floor (1,020) now sits below the ~1,300 words this content reliably produces, so the episode **ships** instead of skipping.

2. **`run_show.py`** — moved the deep-dive `mark_topic_produced` to **after** the thin-script + pre-TTS gates (it was at digest-save, *before* generation). A skipped deep dive no longer **burns its queue slot**, so a `when: next` entry that skipped will correctly re-fire. (On Ep060 the slot happened not to persist on `main`, so `spacex-ipo-current` is still `when: next` and will fire again — this just makes it robust.)

## Drift guards
Source-order test (mark must come after the thin gate) + tuned word-target bounds in `tests/test_deep_dive.py`. Full suite green (2337 passed).

## Important: this ships a ~10-minute episode, not a 16–20 min epic

Single-pass generation caps this deep dive at ~1,300 words (~9–10 min) regardless of the target — the model writes a tight treatment and resists padding. The **content** is excellent and current; the **length** is the limit. A genuinely full 16–20 min deep dive needs **section-by-section generation** (generate each of the four parts / each holding horizon as its own call, then concatenate — reliably 2,500–3,500 words). That's a real engine change I've flagged as follow-up.

**So: merge this to ship the strong ~10-min episode now, or hold and I build the section-based long-form generator first.** Your call — see my chat message.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_