### PR TITLE
Persist deep-dive queue marks (stop SpaceX deep dive re-firing)

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -450,6 +450,12 @@ jobs:
           # checkout. (Bug caught May 2026 when UC Ep001 was about to
           # ship Cobra Effect twice.)
           git add -A shows/topic_queues/ || true
+          # Deep-dive queues — same persistence requirement as topic_queues.
+          # A deep-dive run marks its entry produced in shows/deep_dives/<show>.yaml;
+          # without committing it the entry stays ``when: next`` and the deep dive
+          # RE-FIRES on the next run (caught May 2026: SpaceX Ep059/Ep060 each
+          # re-queued because this directory wasn't staged).
+          git add -A shows/deep_dives/ || true
 
           # Exclude MP3 files (hosted on R2, not in git)
           git reset HEAD -- '*.mp3' 2>/dev/null || true

--- a/shows/deep_dives/modern_investing.yaml
+++ b/shows/deep_dives/modern_investing.yaml
@@ -68,7 +68,11 @@ queue:
   # and the brief instructs the host to report it with attribution.
   - id: spacex-ipo-current
     title: "The SpaceX IPO: How Retail Investors Can Get Ready"
-    when: next
+    # Produced as Ep060 on 2026-05-30 (deep_dive_topic_id confirmed in metrics;
+    # hook: "SpaceX filed its S-1 on May 20 targeting a June 12 Nasdaq listing
+    # at roughly $1.8 trillion"). Recorded by hand because the runner's
+    # mark-produced wasn't committed (shows/deep_dives/ wasn't staged — fixed in
+    # .github/workflows/run-show.yml). Marked produced so it can't re-fire.
     # Live research the runner pulls (web + X) before generation; results are
     # injected into the brief prompt's {current_research} block.
     web_search_queries:
@@ -148,6 +152,6 @@ queue:
       three horizons. Keep it balanced (genuine bull AND bear), precise with
       attributed numbers, and explicit that none of it is financial advice.
     category: special
-    produced: false
-    episode_number: null
-    produced_date: null
+    produced: true
+    episode_number: 60
+    produced_date: '2026-05-30'

--- a/tests/test_deep_dive.py
+++ b/tests/test_deep_dive.py
@@ -156,21 +156,23 @@ class TestDeepDiveConfig:
 
 class TestShippedMITDeepDive:
 
-    def test_current_spacex_entry_is_next_and_research_grounded(self):
+    def test_spacex_entries_are_retired_and_research_grounded(self):
         data = yaml.safe_load(
             Path("shows/deep_dives/modern_investing.yaml").read_text()
         )
-        # The original spacex-ipo entry is retired (produced) so it can't
-        # re-fire; the replacement is the live one.
-        old = next(e for e in data["queue"] if e["id"] == "spacex-ipo")
-        assert old["produced"] is True
-        assert "when" not in old  # must not re-fire
+        # BOTH SpaceX entries are produced (Ep059 + the live-research Ep060) and
+        # carry no ``when`` — neither may re-fire. The runner's mark-produced
+        # didn't persist because shows/deep_dives/ wasn't staged in the commit
+        # step (now fixed), so they're recorded here by hand.
+        for slug, ep in (("spacex-ipo", 59), ("spacex-ipo-current", 60)):
+            e = next(x for x in data["queue"] if x["id"] == slug)
+            assert e["produced"] is True, f"{slug} must be produced (no re-fire)"
+            assert e.get("episode_number") == ep
+            assert "when" not in e, f"{slug} must not carry when: (would re-fire)"
 
         entry = next(e for e in data["queue"] if e["id"] == "spacex-ipo-current")
-        assert entry["when"] == "next"
-        assert entry["produced"] is False
-        # Time-sensitive topic MUST carry live-research queries (the whole
-        # point of the v2 episode — Ep059 was stale without them).
+        # Time-sensitive topic carries live-research queries (the whole point of
+        # the v2 episode — Ep059 was stale without them).
         assert entry["web_search_queries"], "SpaceX deep dive needs live research queries"
         brief = entry["brief"].lower()
         assert "spacex" in brief and "ipo" in brief
@@ -179,6 +181,16 @@ class TestShippedMITDeepDive:
         assert "short-term" in brief and "medium-term" in brief and "long-term" in brief
         # And set the current market backdrop, not just the company.
         assert "market backdrop" in brief or "ipo environment" in brief
+
+    def test_run_show_workflow_commits_deep_dive_queue(self):
+        """The run-show workflow MUST stage shows/deep_dives/ so a deep dive's
+        mark-produced persists. Without it the entry stays ``when: next`` and
+        re-fires (SpaceX Ep059 + Ep060 both re-queued before this fix)."""
+        wf = Path(".github/workflows/run-show.yml").read_text()
+        assert "git add -A shows/deep_dives/" in wf, (
+            "run-show.yml must stage shows/deep_dives/ in the commit step, "
+            "alongside shows/topic_queues/, or deep dives re-fire."
+        )
 
     def test_deep_dive_prompts_exist_and_reference_topic(self):
         digest = Path("shows/prompts/modern_investing_deep_dive.txt").read_text()


### PR DESCRIPTION
## What needed doing

Ep060 (the SpaceX deep dive) **shipped correctly** — current, sourced, three-horizon (hook: *"SpaceX filed its S-1 on May 20 targeting a June 12 Nasdaq listing at roughly $1.8 trillion… a concrete plan across three time horizons"*). But two loose ends remained:

1. **The queue still said `spacex-ipo-current: when: next, produced: false`** on `main`, so the deep dive would **re-fire and produce a duplicate** on the next MIT run.
2. **Root cause:** `run-show.yml`'s commit step stages `shows/topic_queues/` (so narrative shows persist) but **never `shows/deep_dives/`** — so a deep dive marks its entry produced on the runner and that change is discarded on the next checkout. Ep059 and Ep060 *both* re-queued for this reason. (PR #496 fixed the mark *ordering* + word floor, but missed this staging gap, so the marks still couldn't persist.)

## Fix

- **`.github/workflows/run-show.yml`** — stage `shows/deep_dives/` in the commit step, next to `shows/topic_queues/`. This is the durable fix: future deep dives mark-and-persist with no manual cleanup.
- **`shows/deep_dives/modern_investing.yaml`** — mark `spacex-ipo-current` produced (Ep060, 2026‑05‑30) by hand, since the runner's mark never persisted. Both SpaceX entries are now retired.
- **Drift guard** — test asserts the workflow stages `shows/deep_dives/`; updated the SpaceX-entry test to expect both entries retired.

(The word-floor skip was already addressed in #496: MIT deep-dive `min_podcast_words` is 1700, and mark-produced now runs after the thin-script gate.)

## Net effect

The next MIT run is a **normal news episode** (the deep-dive queue is fully produced), and deep dives no longer re-fire. Full suite green (2338 passed).

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_