### PR TITLE
Drive listeners back to the site: richer RSS show notes + spoken network promo

### DIFF
--- a/engine/network_promo.py
+++ b/engine/network_promo.py
@@ -1,0 +1,122 @@
+"""Spoken network cross-promo for the end of each podcast.
+
+Every English show's spoken closing gets a short plug for the Nerra Network
+plus ONE rotating sibling show. The featured sibling is chosen deterministically
+from the date, so:
+
+  - it varies every day for every show,
+  - different shows feature different siblings on the same day, and
+  - over a full rotation each show's closing eventually features every other
+    English show (no sibling is left unadvertised).
+
+Russian shows (Финансы Просто, Привет Русский!) are intentionally excluded:
+they neither receive a promo nor get advertised by the English shows (operator
+decision — keep the cross-promo English-only for now).
+
+The promo is appended to the resolved ``closing_block`` in
+``engine.pipeline.run_generation_phase`` so it covers every English show
+including ones whose hook supplies its own closing (e.g. Tesla) and episode 1.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# English shows only. ``spoken_name`` avoids the ``&`` ampersand (Models &
+# Agents → "Models and Agents") so TTS never reads a stray symbol; ``tagline``
+# is a short spoken fragment that reads naturally after "give X a listen:".
+# Order is fixed (used as the per-show rotation offset) — append new shows at
+# the end rather than reordering, so existing rotations stay stable.
+ENGLISH_SHOWS: dict[str, dict[str, str]] = {
+    "tesla": {
+        "spoken_name": "Tesla Shorts Time",
+        "tagline": "your daily deep dive into everything Tesla",
+    },
+    "omni_view": {
+        "spoken_name": "Omni View",
+        "tagline": "a balanced daily world-news briefing that takes every side seriously",
+    },
+    "fascinating_frontiers": {
+        "spoken_name": "Fascinating Frontiers",
+        "tagline": "the most fascinating news from space and science",
+    },
+    "planetterrian": {
+        "spoken_name": "Planetterrian Daily",
+        "tagline": "daily breakthroughs in science, health, and longevity",
+    },
+    "env_intel": {
+        "spoken_name": "Environmental Intelligence",
+        "tagline": "the environment and climate-policy brief for Canada",
+    },
+    "models_agents": {
+        "spoken_name": "Models and Agents",
+        "tagline": "your daily briefing on AI models and agents",
+    },
+    "models_agents_beginners": {
+        "spoken_name": "Models and Agents for Beginners",
+        "tagline": "artificial intelligence explained simply, for beginners and curious teens",
+    },
+    "modern_investing": {
+        "spoken_name": "Modern Investing Techniques",
+        "tagline": "modern strategies for Canadian and U.S. investors",
+    },
+    "unintended_consequences": {
+        "spoken_name": "Unintended Consequences",
+        "tagline": "true stories of good intentions that backfired",
+    },
+}
+
+# Fixed rotation order (insertion order of the dict above).
+ENGLISH_ORDER: list[str] = list(ENGLISH_SHOWS.keys())
+
+# Shows that must never receive or appear in the cross-promo.
+RUSSIAN_SHOWS = ("finansy_prosto", "privet_russian")
+
+
+def pick_featured_show(show_slug: str, date: _dt.date) -> Optional[str]:
+    """Return the sibling English show to feature in *show_slug*'s closing on
+    *date*, or ``None`` if there is no eligible sibling / the show is not an
+    English show.
+
+    Deterministic and coverage-complete: the candidate list is every English
+    show except ``show_slug``, indexed by ``date.toordinal()`` plus a per-show
+    offset. The daily ordinal increment walks the whole candidate list over
+    consecutive days (so every sibling is eventually featured), and the per-show
+    offset means two shows airing the same day feature different siblings.
+    """
+    if show_slug not in ENGLISH_SHOWS:
+        return None
+    candidates = [s for s in ENGLISH_ORDER if s != show_slug]
+    if not candidates:
+        return None
+    offset = ENGLISH_ORDER.index(show_slug)
+    idx = (date.toordinal() + offset) % len(candidates)
+    return candidates[idx]
+
+
+def build_network_promo(
+    show_slug: str,
+    date: _dt.date,
+    episode_num: Optional[int] = None,
+) -> str:
+    """Build the spoken network cross-promo sentence(s) for *show_slug* on
+    *date*, or ``""`` for Russian / unknown shows (which get no promo).
+
+    The returned text carries no host prefix — it is appended to an already
+    host-prefixed ``closing_block``.
+    """
+    featured = pick_featured_show(show_slug, date)
+    if not featured:
+        return ""
+    name = ENGLISH_SHOWS[featured]["spoken_name"]
+    tagline = ENGLISH_SHOWS[featured]["tagline"]
+    return (
+        "And before you go — this show is part of the Nerra Network, "
+        "a family of daily podcasts covering tech, science, markets, and more. "
+        f"If you enjoyed today's episode, give {name} a listen: {tagline}. "
+        "You can explore the whole lineup at nerranetwork.com."
+    )

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -24,8 +24,11 @@ incrementally in follow-up PRs.
 from __future__ import annotations
 
 import datetime
+import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
 
 # Placeholder for future phase result types
 PublishResult = Dict[str, Any]
@@ -292,6 +295,28 @@ def run_generation_phase(
             pod_vars.setdefault("closing_block", "Thanks for listening.")
 
     pod_vars.setdefault("tone_hint", "natural and conversational")
+
+    # Append the rotating Nerra Network cross-promo to the spoken closing.
+    # Done HERE (after closing_block is resolved from any source) so it covers
+    # every path: build_closing_block, the episode-1 closing, AND shows whose
+    # pre-fetch hook supplied closing_block via extra_context (e.g. Tesla). The
+    # promo is English-only and varies by day + show so every English sibling
+    # eventually gets advertised. Russian shows get "" → no change.
+    _promo_date = datetime.date.today()
+    _show_slug = getattr(config, "slug", "") or (
+        getattr(args, "show", "") if args is not None else ""
+    )
+    if _show_slug:
+        try:
+            from engine.network_promo import build_network_promo
+            _promo = build_network_promo(_show_slug, _promo_date, episode_num)
+            if _promo:
+                _close = str(pod_vars.get("closing_block", "")).rstrip()
+                # Idempotent — don't double-append if already present.
+                if "nerranetwork.com" not in _close.lower():
+                    pod_vars["closing_block"] = f"{_close} {_promo}".strip()
+        except Exception as exc:  # noqa: BLE001 — promo must never break a run
+            logger.warning("Network promo append failed (non-fatal): %s", exc)
 
     # Merge pod_vars into the main template_vars for the podcast prompt
     # (the podcast prompt expects many of the same keys + digest, etc.)

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -117,6 +117,49 @@ def _markdown_to_rss_html(md: str) -> str:
     return "\n\n".join(paragraphs)
 
 
+def build_show_notes_footer(
+    base_url: str,
+    show_slug: str,
+    episode_num: int,
+    *,
+    has_blog: bool,
+    blog_path_prefix: str = "blog",
+) -> str:
+    """Build the website + per-episode blog-post footer appended to an RSS
+    episode description, so listeners on Apple / Spotify / Amazon / YouTube
+    can click back to the site for the full transcript and sources.
+
+    Returns markdown (rendered to ``<a>`` anchors by
+    :func:`_markdown_to_rss_html`):
+
+      - a per-episode blog link (full show notes / transcript / sources) when
+        ``has_blog`` is true (the show actually publishes a blog page for this
+        episode — i.e. it is in ``NETWORK_SHOWS``), and
+      - always the network home-page link.
+
+    Returns ``""`` when ``base_url`` is empty so callers can append
+    unconditionally without emitting a dangling footer.
+    """
+    site = (base_url or "").rstrip("/")
+    if not site:
+        return ""
+    parts: list[str] = []
+    if has_blog and show_slug:
+        blog_url = (
+            f"{site}/{blog_path_prefix.strip('/')}/{show_slug}/ep{episode_num:03d}.html"
+        )
+        parts.append(
+            "📝 Full show notes, transcript & sources: "
+            f"[read the episode page]({blog_url})"
+        )
+    domain = site.split("//", 1)[-1]
+    parts.append(
+        "🌐 Part of the Nerra Network — explore every show at "
+        f"[{domain}]({site})."
+    )
+    return "\n\n".join(parts)
+
+
 def _add_existing_entry_to_feed(fg, ep_data: dict, channel_image: str = "") -> None:
     """Re-add a parsed existing episode to the feed generator."""
     entry = fg.add_entry()

--- a/run_show.py
+++ b/run_show.py
@@ -2668,6 +2668,27 @@ def run(args: argparse.Namespace) -> None:
         if youtube_long_url:
             episode_desc += f"\n\n🎬 Watch on YouTube: {youtube_long_url}"
 
+        # Drive listeners from the podcast apps back to the website: link the
+        # network home page plus this episode's blog page (full show notes,
+        # transcript, and sources). The blog page only exists for shows in
+        # NETWORK_SHOWS, so gate the per-episode link on membership and fall
+        # back to the network home page otherwise. The footer is markdown;
+        # publisher._markdown_to_rss_html renders it to real <a> anchors.
+        try:
+            from generate_html import NETWORK_SHOWS as _NETWORK_SHOWS_RSS
+            _has_blog = config.slug in _NETWORK_SHOWS_RSS
+        except Exception:  # noqa: BLE001 — never let show-notes linking break RSS
+            _has_blog = False
+        from engine.publisher import build_show_notes_footer
+        _notes_footer = build_show_notes_footer(
+            config.publishing.base_url,
+            config.slug,
+            episode_num,
+            has_blog=_has_blog,
+        )
+        if _notes_footer:
+            episode_desc += "\n\n" + _notes_footer
+
         # If no R2 URL but analytics is enabled, build URL and prefix it
         feed_audio_url = rss_audio_url
         if not feed_audio_url and config.analytics.enabled:

--- a/tests/test_network_promo.py
+++ b/tests/test_network_promo.py
@@ -1,0 +1,76 @@
+"""Drift guards for the spoken Nerra Network cross-promo (engine.network_promo).
+
+Every English show's spoken closing gets a short network plug + ONE rotating
+sibling show, chosen deterministically from the date so it varies daily, differs
+across shows on the same day, and eventually advertises every English sibling.
+Russian shows are excluded entirely.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from engine.network_promo import (
+    ENGLISH_ORDER,
+    RUSSIAN_SHOWS,
+    build_network_promo,
+    pick_featured_show,
+)
+
+_DAY = dt.date(2026, 6, 1)
+
+
+def test_never_features_itself():
+    for slug in ENGLISH_ORDER:
+        assert pick_featured_show(slug, _DAY) != slug
+
+
+def test_featured_is_always_an_english_show():
+    for slug in ENGLISH_ORDER:
+        assert pick_featured_show(slug, _DAY) in ENGLISH_ORDER
+
+
+def test_russian_shows_get_no_promo():
+    for slug in RUSSIAN_SHOWS:
+        assert pick_featured_show(slug, _DAY) is None
+        assert build_network_promo(slug, _DAY) == ""
+
+
+def test_unknown_show_gets_no_promo():
+    assert build_network_promo("does_not_exist", _DAY) == ""
+    assert pick_featured_show("does_not_exist", _DAY) is None
+
+
+def test_promo_varies_by_day():
+    """The featured sibling for a given show changes across consecutive days
+    (so listeners don't hear the same plug every episode)."""
+    feats = [pick_featured_show("tesla", _DAY + dt.timedelta(days=i)) for i in range(4)]
+    assert len(set(feats)) > 1
+
+
+def test_full_coverage_over_rotation():
+    """Over enough days, every show features every English sibling — no
+    sibling is permanently left unadvertised."""
+    for slug in ENGLISH_ORDER:
+        seen = {
+            pick_featured_show(slug, _DAY + dt.timedelta(days=i))
+            for i in range(40)
+        }
+        assert seen == set(ENGLISH_ORDER) - {slug}
+
+
+def test_promo_text_mentions_network_and_featured_show():
+    promo = build_network_promo("tesla", _DAY)
+    assert "Nerra Network" in promo
+    assert "nerranetwork.com" in promo
+    featured = pick_featured_show("tesla", _DAY)
+    from engine.network_promo import ENGLISH_SHOWS
+    assert ENGLISH_SHOWS[featured]["spoken_name"] in promo
+
+
+def test_promo_text_has_no_ampersand():
+    """TTS must never read a stray '&' — Models & Agents → 'Models and Agents'."""
+    for slug in ENGLISH_ORDER:
+        for i in range(len(ENGLISH_ORDER) + 1):
+            promo = build_network_promo(slug, _DAY + dt.timedelta(days=i))
+            assert "&" not in promo

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -20,7 +20,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from engine.publisher import (
+    _markdown_to_rss_html,
     apply_op3_prefix,
+    build_show_notes_footer,
     format_digest_for_x,
     format_tst_digest_for_x,
     get_next_episode_number,
@@ -1141,3 +1143,57 @@ class TestFormatTstDigestForX:
 
         # Within default char limit
         assert len(result) <= 25000
+
+# ---------------------------------------------------------------------------
+# build_show_notes_footer — RSS description footer driving listeners to site
+# ---------------------------------------------------------------------------
+
+class TestBuildShowNotesFooter:
+    """The RSS episode description gains a footer linking the network home
+    page (always) and the per-episode blog page (when the show publishes a
+    blog page for the episode). Lets podcast-app / YouTube listeners reach
+    the full transcript + sources and discover the rest of the network."""
+
+    BASE = "https://nerranetwork.com"
+
+    def test_blog_link_present_when_has_blog(self):
+        out = build_show_notes_footer(self.BASE, "tesla", 461, has_blog=True)
+        assert f"{self.BASE}/blog/tesla/ep461.html" in out
+        assert "transcript" in out.lower()
+
+    def test_blog_link_zero_padded_to_three_digits(self):
+        out = build_show_notes_footer(self.BASE, "omni_view", 7, has_blog=True)
+        assert "/blog/omni_view/ep007.html" in out
+
+    def test_no_blog_link_when_not_a_network_show(self):
+        out = build_show_notes_footer(self.BASE, "some_show", 12, has_blog=False)
+        assert "/blog/" not in out
+        # The network home-page link is still always present.
+        assert self.BASE in out
+
+    def test_network_home_link_always_present(self):
+        for has_blog in (True, False):
+            out = build_show_notes_footer(self.BASE, "tesla", 1, has_blog=has_blog)
+            assert "Nerra Network" in out
+            assert f"]({self.BASE})" in out
+            assert "nerranetwork.com" in out
+
+    def test_empty_base_url_returns_empty(self):
+        """Caller can append unconditionally without a dangling footer."""
+        assert build_show_notes_footer("", "tesla", 1, has_blog=True) == ""
+
+    def test_trailing_slash_in_base_url_is_normalised(self):
+        out = build_show_notes_footer("https://nerranetwork.com/", "tesla", 5, has_blog=True)
+        assert "https://nerranetwork.com//" not in out
+        assert "https://nerranetwork.com/blog/tesla/ep005.html" in out
+
+    def test_footer_renders_to_anchors_through_rss_html(self):
+        """The footer is markdown; _markdown_to_rss_html must turn its links
+        into real <a> anchors so podcast apps show clickable links, not raw
+        markdown brackets."""
+        footer = build_show_notes_footer(self.BASE, "tesla", 461, has_blog=True)
+        rendered = _markdown_to_rss_html("Episode body.\n\n" + footer)
+        assert f'<a href="{self.BASE}/blog/tesla/ep461.html">' in rendered
+        assert f'<a href="{self.BASE}">' in rendered
+        # No leftover markdown link brackets.
+        assert "](" not in rendered


### PR DESCRIPTION
Two additions that point podcast-app / YouTube listeners back to **nerranetwork.com** and cross-promote the rest of the network.

## 1. Richer RSS show notes (text-only — safe)
`engine/publisher.build_show_notes_footer()` appends a footer to every episode's RSS `<description>` / `<itunes:summary>`:

- 📝 a **per-episode blog-post link** (full show notes, transcript, sources) — gated on `NETWORK_SHOWS` membership so only shows that actually publish a blog page get the deep link;
- 🌐 the **network home-page link** (always).

Written as markdown and rendered to real `<a>` anchors by the existing `_markdown_to_rss_html` path. Wired into `run_show.py`'s RSS stage right after the existing YouTube-watch line. Clean no-op when `base_url` is empty. **This only affects show-notes text — no audio changes.**

## 2. Spoken end-of-show network cross-promo (⚠️ changes audio)
`engine/network_promo.py` — every **English** show's spoken closing now ends with a short Nerra Network plug + **one rotating sibling show**, chosen deterministically from the date so it:

- varies every day for each show,
- features a different sibling across shows on the same day, and
- over a full rotation advertises **every** English sibling (no show left unadvertised).

Appended to the resolved `closing_block` in `engine/pipeline.py` so it covers **all** paths — `build_closing_block`, the episode-1 closing, and hook-supplied closings (e.g. Tesla). Idempotent (won't double-append) and wrapped in try/except so it can never break a run. **Russian shows (Финансы Просто, Привет Русский!) are excluded entirely** — they neither receive a promo nor get advertised.

> **Operator note (re: landmine #17):** Part 2 adds ~4 spoken sentences to the closing of all 9 English shows, so it *does* change generated audio. It's deterministic (not an LLM prompt change), but please A/B-listen one episode before merging. If you'd prefer it behind a per-show / network YAML kill-switch instead of always-on, say so and I'll add the flag — I kept it flag-free for now since the draft PR itself is the review gate.

## Tests
- `tests/test_network_promo.py` — 8 drift guards: full-rotation coverage, never-features-itself, Russian exclusion, daily variation, no stray `&` for TTS.
- `tests/test_publisher.py::TestBuildShowNotesFooter` — blog-link gating, 3-digit zero-padding, home-link always present, trailing-slash normalisation, and end-to-end anchor rendering through `_markdown_to_rss_html`.
- Full suite: **2345 passed, 6 skipped** (skips are the pre-existing `feedgen`-gated RSS tests; unavailable to build in this sandbox but present in CI).

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_