### PR TITLE
Fix the newsletter pipeline: weekly arg crash + tag-filter rejected by Buttondown

### DIFF
--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -63,18 +63,18 @@ jobs:
           INPUT_SHOW: ${{ github.event.inputs.show || '' }}
           INPUT_DRY_RUN: ${{ github.event.inputs.dry_run || '' }}
         run: |
-          ARGS=""
+          ARGS=()
           if [ "$INPUT_SHOW" != "" ] && [ "$INPUT_SHOW" != "all" ]; then
-            ARGS="--show $INPUT_SHOW"
+            ARGS+=(--show "$INPUT_SHOW")
           fi
           # Scheduled runs (cron) actually send; manual dispatch respects the dry_run input.
           if [ "${{ github.event_name }}" = "schedule" ]; then
             echo "Scheduled run — sending for real"
           elif [ "$INPUT_DRY_RUN" != "false" ]; then
-            ARGS="$ARGS --dry-run"
+            ARGS+=(--dry-run)
             echo "Manual dispatch — dry run mode"
           fi
-          python scripts/run_weekly_newsletters.py "$ARGS"
+          python scripts/run_weekly_newsletters.py "${ARGS[@]}"
 
       - name: Generate cross-network intelligence briefing
         # Editorial synthesis across all 11 shows for the past 7 days.

--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -166,6 +166,55 @@ def validate_api_key(api_key: str) -> bool:
 _VALID_STATUSES = {"about_to_send", "draft", "scheduled"}
 
 
+# Buttondown tag display-name -> tag identifier (TypeID) cache. Populated
+# lazily from GET /v1/tags the first time a name is needed in a process.
+_TAG_ID_CACHE: Dict[str, str] = {}
+
+
+def _resolve_tag_ids(tag_names: List[str], api_key: str) -> Dict[str, str]:
+    """Resolve Buttondown tag display names to their tag identifiers.
+
+    Buttondown's email ``filters`` require tag *identifiers* (TypeIDs like
+    ``tag_…``); passing a display name returns HTTP 422 ``"Tag filters must
+    be valid tag identifiers."`` (this silently blocked every show's
+    newsletter network-wide — see send_newsletter). Subscribers still carry
+    tag *names* in their ``tags`` array, so we map name -> id via the
+    paginated ``GET /v1/tags`` endpoint.
+
+    Best-effort: returns only the names it could resolve; the caller decides
+    how to handle misses. Resolved pairs are cached per-process so a run that
+    sends several shows only pays for one tag fetch.
+    """
+    need = [t for t in tag_names if t and t not in _TAG_ID_CACHE]
+    if need:
+        try:
+            url: Optional[str] = f"{BUTTONDOWN_API_BASE}/tags"
+            params: Optional[Dict[str, str]] = {"page_size": "100"}
+            while url:
+                resp = requests.get(
+                    url,
+                    headers={"Authorization": f"Token {api_key}"},
+                    params=params,
+                    timeout=15,
+                )
+                resp.raise_for_status()
+                payload = resp.json() or {}
+                for tag in (payload.get("results") or []):
+                    name = tag.get("name")
+                    tid = tag.get("id")
+                    if name and tid:
+                        _TAG_ID_CACHE[name] = tid
+                # The ``next`` URL is fully qualified and already carries
+                # the cursor — drop our params so we don't override it.
+                url = payload.get("next") or None
+                params = None
+        except Exception as exc:  # noqa: BLE001 — caller handles empty result
+            logger.error(
+                "Failed to fetch Buttondown tags for id resolution: %s", exc,
+            )
+    return {t: _TAG_ID_CACHE[t] for t in tag_names if t in _TAG_ID_CACHE}
+
+
 def send_newsletter(
     subject: str,
     body: str,
@@ -243,20 +292,40 @@ def send_newsletter(
         # or "or" are accepted (not "any"/"all").
         #
         # May 26 2026: Buttondown tightened the ``field`` enum on
-        # the leaf condition; ``field: "tag"`` now returns HTTP 422
-        # with a literal_error listing the accepted values:
-        # ``subscriber.churn_date``, ``subscriber.click_rate``,
-        # ``subscriber.last_click_date``, ``subscriber.last_open_date``,
-        # ``subscriber.open_rate``, ``subscriber.price``,
-        # ``subscriber.source``, ``subscriber.status``,
-        # ``subscriber.subscription_date``, ``subscriber.tags``,
-        # ``subscriber.upgrade_date``. Tag membership now lives at
-        # ``subscriber.tags``; the operator for "subscriber has this
-        # tag" is ``contains`` because tags is a list field.
+        # the leaf condition; ``field: "tag"`` now 422s. Tag
+        # membership lives at ``subscriber.tags`` with operator
+        # ``contains`` (tags is a list field).
+        #
+        # May 31 2026: the leaf ``value`` must be the tag's
+        # *identifier* (Buttondown TypeID, e.g. ``tag_abc123``), NOT
+        # its display name. Passing the name returns HTTP 422
+        #   {"detail":[{"value":"Tag filters must be valid tag identifiers."}]}
+        # which silently blocked EVERY show's newsletter network-wide
+        # (0 successful sends across 90 attempts). Subscribers still
+        # carry tag *names* in their ``tags`` array, so resolve
+        # name -> id via GET /v1/tags before building the filter.
+        tag_id_map = _resolve_tag_ids(tags, api_key)
+        resolved_ids = [tag_id_map[t] for t in tags if t in tag_id_map]
+        missing = [t for t in tags if t not in tag_id_map]
+        if missing:
+            logger.error(
+                "Could not resolve Buttondown tag id(s) for %s — those "
+                "subscribers will not be targeted. Verify the tag name(s) "
+                "match the Buttondown Tags page exactly.", missing,
+            )
+        if not resolved_ids:
+            # Never fall through to an unfiltered ``data`` (that would
+            # blast the email to the ENTIRE network's subscriber list).
+            logger.error(
+                "No tag filters resolved to Buttondown tag IDs (requested "
+                "%s). Refusing to send to avoid an unfiltered network-wide "
+                "blast.", tags,
+            )
+            return None
         data["filters"] = {
             "filters": [
-                {"field": "subscriber.tags", "operator": "contains", "value": t}
-                for t in tags
+                {"field": "subscriber.tags", "operator": "contains", "value": tid}
+                for tid in resolved_ids
             ],
             "groups": [],
             "predicate": "or",  # OR semantics across the listed tags

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -251,10 +251,23 @@ class TestSendNewsletter(unittest.TestCase):
         result = send_newsletter("Subj", "Body", api_key="key")
         self.assertEqual(result, "unknown")
 
+    @patch("engine.newsletter.requests.get")
     @patch("engine.newsletter.requests.post")
-    def test_zero_recipients_with_tags_returns_none(self, mock_post):
+    def test_zero_recipients_with_tags_returns_none(self, mock_post, mock_get):
         """Buttondown can accept the email and send to 0 subscribers when
         tag filters match nobody. That's a misconfiguration, not success."""
+        import engine.newsletter as _nl
+        _nl._TAG_ID_CACHE.clear()
+        # Resolve the tag name -> id so the flow reaches the POST and we
+        # actually exercise the num_recipients==0 branch (not the
+        # unresolved-tag early return).
+        get_resp = MagicMock()
+        get_resp.status_code = 200
+        get_resp.json.return_value = {
+            "results": [{"name": "ghost-tag", "id": "tag_ghost"}], "next": None,
+        }
+        mock_get.return_value = get_resp
+
         mock_resp = MagicMock()
         mock_resp.status_code = 201
         mock_resp.json.return_value = {"id": "eid", "num_recipients": 0}
@@ -464,11 +477,34 @@ def test_send_newsletter_uses_v2_filter_tree_when_tags_set(monkeypatch):
     """When tags are passed, the request body's ``filters`` must
     match Buttondown's current ``{filters, groups, predicate}``
     schema — old ``{operator, predicates}`` was rejected with
-    HTTP 422 missing-field errors on filters/groups/predicate."""
+    HTTP 422 missing-field errors on filters/groups/predicate.
+
+    May 31 2026: each leaf ``value`` must be the resolved tag
+    *identifier* (TypeID), not the display name — passing the name
+    returns HTTP 422 "Tag filters must be valid tag identifiers" and
+    blocked every show network-wide. The name->id map comes from
+    GET /v1/tags."""
     import json as _json
     from engine import newsletter
+    newsletter._TAG_ID_CACHE.clear()
 
     captured = {}
+
+    # GET /v1/tags resolves the display names to TypeIDs.
+    class _GetResp:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "results": [
+                    {"name": "Tesla Shorts Time", "id": "tag_tesla"},
+                    {"name": "Privet Russian", "id": "tag_privet"},
+                ],
+                "next": None,
+            }
 
     class _Resp:
         status_code = 200
@@ -480,6 +516,7 @@ def test_send_newsletter_uses_v2_filter_tree_when_tags_set(monkeypatch):
         captured["payload"] = _json.loads(_json.dumps(json))
         return _Resp()
 
+    monkeypatch.setattr(newsletter.requests, "get", lambda *a, **kw: _GetResp())
     monkeypatch.setattr(newsletter.requests, "post", _fake_post)
 
     out = newsletter.send_newsletter(
@@ -496,9 +533,10 @@ def test_send_newsletter_uses_v2_filter_tree_when_tags_set(monkeypatch):
     # Buttondown's predicate enum: "and" or "or" (not "any"/"all").
     assert filters["predicate"] in {"and", "or"}
     assert filters["groups"] == []
-    # Each tag becomes a leaf condition.
-    leaf_tags = {f["value"] for f in filters["filters"]}
-    assert leaf_tags == {"Tesla Shorts Time", "Privet Russian"}
+    # Each tag becomes a leaf condition whose value is the resolved
+    # tag IDENTIFIER (TypeID), NOT the display name.
+    leaf_values = {f["value"] for f in filters["filters"]}
+    assert leaf_values == {"tag_tesla", "tag_privet"}
     # No leftover keys from the old schema. May 26 2026: Buttondown
     # tightened the leaf-condition field enum — ``"tag"`` now 422s,
     # ``"subscriber.tags"`` is the accepted form, and the operator
@@ -509,6 +547,68 @@ def test_send_newsletter_uses_v2_filter_tree_when_tags_set(monkeypatch):
     # Old keys must NOT appear.
     assert "predicates" not in filters
     assert "operator" not in filters
+
+
+def test_send_newsletter_refuses_send_when_tags_unresolvable(monkeypatch):
+    """If no tag name resolves to a Buttondown tag ID, the send must be
+    refused (return None) rather than fall through to an unfiltered
+    network-wide blast to every subscriber."""
+    from engine import newsletter
+    newsletter._TAG_ID_CACHE.clear()
+
+    class _GetResp:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"results": [], "next": None}  # no tags exist
+
+    def _no_post(*a, **kw):
+        raise AssertionError("must not POST when no tag id resolves")
+
+    monkeypatch.setattr(newsletter.requests, "get", lambda *a, **kw: _GetResp())
+    monkeypatch.setattr(newsletter.requests, "post", _no_post)
+
+    out = newsletter.send_newsletter(
+        subject="s", body="b", api_key="key", tags=["Nonexistent Show"],
+    )
+    assert out is None
+
+
+def test_resolve_tag_ids_maps_names_to_ids(monkeypatch):
+    """_resolve_tag_ids paginates GET /v1/tags and maps name -> id."""
+    from engine import newsletter
+    newsletter._TAG_ID_CACHE.clear()
+
+    pages = [
+        {"results": [{"name": "A", "id": "tag_a"}], "next": "https://api.buttondown.com/v1/tags?page=2"},
+        {"results": [{"name": "B", "id": "tag_b"}], "next": None},
+    ]
+    calls = {"n": 0}
+
+    class _GetResp:
+        status_code = 200
+
+        def __init__(self, body):
+            self._body = body
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._body
+
+    def _fake_get(*a, **kw):
+        body = pages[calls["n"]]
+        calls["n"] += 1
+        return _GetResp(body)
+
+    monkeypatch.setattr(newsletter.requests, "get", _fake_get)
+    out = newsletter._resolve_tag_ids(["A", "B"], "key")
+    assert out == {"A": "tag_a", "B": "tag_b"}
+    assert calls["n"] == 2  # followed the `next` cursor
 
 
 def test_send_newsletter_omits_filters_when_no_tags(monkeypatch):


### PR DESCRIPTION
The newsletter has been silently broken network-wide. This PR fixes the **two independent bugs** behind it — both confirmed from production CI logs.

## Bug 1 — weekly workflow crashes before sending (exit 2)
`weekly-newsletter.yml` passed an empty quoted `"$ARGS"` to `run_weekly_newsletters.py`. On the Sunday cron path `ARGS=""`, so the script got one empty-string **positional** arg, which argparse rejects:
```
run_weekly_newsletters.py: error: unrecognized arguments:
Error: Process completed with exit code 2.
```
The quoting was also wrong on manual dispatch (`"--show tesla --dry-run"` passed as one token). **Fix:** use a bash array expanded with `"${ARGS[@]}"` — empty → zero args, populated → correctly split flags. Verified across all trigger scenarios on bash 5.2.

## Bug 2 — every send rejected by Buttondown (HTTP 422)
Even once the weekly runs, every show's send (daily *and* weekly, which share `send_newsletter()`) was rejected:
```
[INFO]  engine.newsletter: Buttondown API key validated successfully   ← auth is FINE
[ERROR] engine.newsletter: Newsletter send failed with tag filter error …
        Error: {"detail":[{"value":"Tag filters must be valid tag identifiers."}]}
```
The `filters` tree passed each show's **display-name** tag (`"Tesla Shorts Time"`) as the leaf `value`, but Buttondown's `subscriber.tags`/`contains` filter requires the tag's **identifier** (TypeID, e.g. `tag_…`). Subscribers still store tag *names* in their `tags` array, which is why the asymmetry went unnoticed. Committed metrics confirm the blast radius: **0 successful sends across 90 attempts**, every show.

**Fix:** new `_resolve_tag_ids()` maps display name → tag ID via the paginated `GET /v1/tags` (cached per-process); the send filter is built from resolved IDs. If no tag resolves, the send is **refused** (returns `None`) rather than falling through to an unfiltered blast to the entire network.

## Tests
- All scenarios for the weekly arg-array (cron all-shows, manual `--show`, manual `--dry-run`).
- v2-filter-tree test now mocks `GET /v1/tags` and asserts leaf values are the resolved **IDs**.
- New: unresolvable-tag → refuse-to-send guard; `_resolve_tag_ids` pagination.
- Full newsletter suite: **234 passed**. End-to-end `send_show_newsletter` trace confirmed: tag → ID → 201 → email id returned.

## ⚠️ One thing I could not verify
I can't reach the authenticated Buttondown API from the build environment, so **Bug 2's fix needs one live verification send.** The 422 message states only the *value* was invalid (field/operator `subscriber.tags`/`contains` were accepted), so name→ID is the minimal correct change — but please confirm with a real send (e.g. manual `Weekly Newsletters` dispatch, or the next daily run) before trusting it fully.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC