### PR TITLE
Surface X API error detail on failed posts instead of bare "403 Forbidden"

### DIFF
--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -1032,6 +1032,34 @@ def save_summary_to_github_pages(
 # X / Twitter posting
 # ---------------------------------------------------------------------------
 
+def _describe_x_error(exc: Exception) -> str:
+    """Build a detailed, single-line description of a tweepy / X API error.
+
+    tweepy's ``HTTPException`` subclasses (``Forbidden`` / ``Unauthorized`` /
+    ``TooManyRequests`` / …) carry the X API's structured error detail on
+    ``.api_messages`` / ``.api_codes`` / ``.api_errors`` and the raw response
+    body on ``.response.text``. A bare ``str(exc)`` is often just
+    ``"403 Forbidden"``, which hides *why* X refused — duplicate content, an
+    app without write permission, or a free-tier posting cap are all 403s
+    with very different fixes. Surface whatever detail is available.
+
+    Best-effort — never raises (it runs inside an error handler).
+    """
+    parts = [f"{type(exc).__name__}: {exc}"]
+    try:
+        for attr in ("api_codes", "api_messages", "api_errors"):
+            val = getattr(exc, attr, None)
+            if val:
+                parts.append(f"{attr}={val}")
+        resp = getattr(exc, "response", None)
+        body = getattr(resp, "text", None) if resp is not None else None
+        if body:
+            parts.append(f"body={str(body)[:500]}")
+    except Exception:  # noqa: BLE001 — diagnostics must never raise
+        pass
+    return " | ".join(parts)
+
+
 def post_to_x(
     text: str,
     *,
@@ -1061,7 +1089,9 @@ def post_to_x(
         return tweet_url
 
     except Exception as exc:
-        logger.error("X post failed: %s", exc)
+        # Surface the X API's structured reason (duplicate content vs.
+        # missing app write-permission vs. free-tier cap are all 403s).
+        logger.error("X post failed: %s", _describe_x_error(exc))
         return None
 
 

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -520,6 +520,47 @@ class TestPostToX:
             access_token="my_at", access_token_secret="my_ats",
         )
 
+    def test_403_logs_structured_api_detail(self, caplog):
+        """A bare '403 Forbidden' hides why X refused. The error log must
+        surface tweepy's structured api_messages / api_codes / response
+        body so the operator can tell duplicate-content from a permissions
+        or access-tier problem."""
+        import logging as _logging
+
+        # Simulate a tweepy.Forbidden-like exception carrying X API detail.
+        class _FakeResponse:
+            text = '{"detail":"oauth1 app permissions"}'
+
+        exc = Exception("403 Forbidden")
+        exc.api_codes = [453]
+        exc.api_messages = [
+            "You currently have access to a subset of X API V2 endpoints"
+        ]
+        exc.response = _FakeResponse()
+
+        mock_tweepy = MagicMock()
+        mock_client = MagicMock()
+        mock_tweepy.Client.return_value = mock_client
+        mock_client.create_tweet.side_effect = exc
+
+        with patch.dict(sys.modules, {"tweepy": mock_tweepy}):
+            with caplog.at_level(_logging.ERROR):
+                result = post_to_x(
+                    "Hello",
+                    consumer_key="ck", consumer_secret="cs",
+                    access_token="at", access_token_secret="ats",
+                )
+        assert result is None
+        logged = caplog.text
+        assert "api_codes=[453]" in logged
+        assert "subset of X API V2 endpoints" in logged
+        assert "oauth1 app permissions" in logged
+
+    def test_describe_x_error_never_raises_on_plain_exception(self):
+        from engine.publisher import _describe_x_error
+        out = _describe_x_error(ValueError("boom"))
+        assert "ValueError" in out and "boom" in out
+
 
 # ===================================================================
 # TEST: format_digest_for_x


### PR DESCRIPTION
## Context
While investigating the newsletter failures I found two unrelated issues in the same `Run Podcast Show` log (Tesla Ep494). This PR addresses the **X-posting diagnostics**; the listener-value-score item is reported separately (no code change recommended without A/B-listen evidence — see landmine #17).

## The problem
```
[ERROR] engine.publisher: X post failed: 403 Forbidden
```
`post_to_x` caught the exception and logged only `str(exc)`. A 403 from `create_tweet` is ambiguous — **duplicate content**, an **app without write permission**, or a **free-tier posting cap** are all 403s with completely different fixes — and the bare message hid which one it was.

## The fix
Add `_describe_x_error()` which pulls tweepy's structured X API detail off the `HTTPException` — `api_codes`, `api_messages`, `api_errors`, and the raw `response.text` body — and logs it from `post_to_x`'s handler. Best-effort, never raises (it runs inside the error handler). Success path and the `None`-on-failure contract are unchanged.

After this, the next failure logs something actionable, e.g.:
```
X post failed: Forbidden: 403 Forbidden | api_codes=[453] | api_messages=['You currently have access to a subset of X API V2 endpoints'] | body={...}
```
…which immediately distinguishes a free-tier cap (453) from a duplicate-content (187) or permissions error.

## Tests
- A simulated 403 carrying `api_codes` / `api_messages` / `response.text` asserts all three reach the error log.
- `_describe_x_error` degrades cleanly on a plain exception.
- Full suite: 2348 passed.

## Note — this does not fix the 403 itself
The underlying 403 is account/app-level (X developer portal access tier / app permissions / or a duplicate-teaser collision) and can't be resolved from code. This PR makes the **next** run tell you exactly which it is. Most likely candidates given the symptom: the `@teslashortstime` app is on an access tier without v2 write, lost its write permission, or the recap teaser duplicated a prior post.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_