### PR TITLE
Fix content-quality bugs in MAB + Models & Agents (sourcing, structural validation, repetition)

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -483,6 +483,11 @@ class ShowConfig:
     description: str = ""
     sources: List[SourceConfig] = field(default_factory=list)
     x_accounts: List[XAccountConfig] = field(default_factory=list)
+    # X *sourcing* toggle, independent of X *posting* (publishing.x_enabled).
+    # None = inherit x_enabled (back-compat); True/False = explicit override.
+    # Lets a non-posting show (e.g. MAB) still read its curated X accounts
+    # for content. See engine.fetcher.x_fetch_allowed.
+    x_fetch_enabled: Optional[bool] = None
     keywords: List[str] = field(default_factory=list)
     web_search_queries: List[str] = field(default_factory=list)
     min_articles: int = 3  # Minimum articles before expanding search
@@ -672,6 +677,7 @@ def load_config(yaml_path: str | Path) -> ShowConfig:
         description=data.get("description", ""),
         sources=_build_sources(data.get("sources")),
         x_accounts=_build_x_accounts(data.get("x_accounts")),
+        x_fetch_enabled=data.get("x_fetch_enabled"),
         keywords=data.get("keywords", []),
         web_search_queries=data.get("web_search_queries", []),
         min_articles=data.get("min_articles", 3),

--- a/engine/fetcher.py
+++ b/engine/fetcher.py
@@ -337,6 +337,25 @@ def _fetch_single_feed(
             )
             articles = articles[:max_articles]
 
+        # Visibility: a feed that yields 0 usable articles is ambiguous —
+        # it could be blocked/empty (0 entries parsed) or simply filtered
+        # out (entries parsed but none matched the recency/keyword filters).
+        # The old "Fetched 0 articles" log hid the difference, so a feed
+        # silently going dark (Cloudflare block returning an empty body)
+        # looked identical to a quiet news day. Surface the parsed count.
+        if not articles:
+            n_entries = len(feed.entries)
+            if n_entries == 0:
+                logger.warning(
+                    "Feed yielded 0 entries (likely blocked/empty/stale URL): %s",
+                    source_name,
+                )
+            else:
+                logger.info(
+                    "Feed %s: parsed %d entries but 0 passed recency/keyword "
+                    "filters", source_name, n_entries,
+                )
+
         return (feed_url, articles, source_name)
 
     except requests.RequestException as exc:
@@ -482,6 +501,31 @@ def fetch_rss_articles(
 # ---------------------------------------------------------------------------
 # X / Twitter account fetcher (via xAI Grok x_search)
 # ---------------------------------------------------------------------------
+
+def x_fetch_allowed(
+    x_accounts: list,
+    x_enabled: bool,
+    x_fetch_enabled: Optional[bool] = None,
+) -> bool:
+    """Whether to fetch X posts as a *content source* for this show.
+
+    Decouples X *sourcing* from X *posting*. A show with curated
+    ``x_accounts`` can read them for content even when it never posts to X
+    (``x_enabled: false``) — set ``x_fetch_enabled: true`` in its YAML.
+
+    Resolution:
+      - no ``x_accounts`` → never fetch.
+      - ``x_fetch_enabled`` explicitly set (True/False) → honour it.
+      - otherwise default to ``x_enabled`` (preserves the pre-existing
+        behaviour where X fetch piggy-backed on the X-posting flag, so
+        every other show is byte-for-byte unchanged).
+    """
+    if not x_accounts:
+        return False
+    if x_fetch_enabled is not None:
+        return bool(x_fetch_enabled)
+    return bool(x_enabled)
+
 
 def fetch_x_posts(
     x_accounts: list,

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -535,6 +535,15 @@ def _validate_llm_output(
             tokens = phrase.split()
             if all(len(t) <= 3 for t in tokens):
                 continue
+            # Skip speaker-attribution bigrams (e.g. "host: the", "patrick:
+            # this", "olya: now"): the first token is a dialogue label ending
+            # in a colon, so the repeat is the script format, not a
+            # hallucination. The enumerated allowlist only covered the bold
+            # "**host:**" / named "patrick:" forms — a plain "Host:" label
+            # (Models & Agents) slipped through and triggered wasteful
+            # repetition retries that can't fix a format artifact.
+            if tokens and tokens[0].endswith(":"):
+                continue
             # Skip date-shape fragments — purely structural, not hallucination.
             if _is_date_fragment(phrase):
                 continue
@@ -590,6 +599,11 @@ def _validate_llm_output(
                 continue
             tokens = phrase.split()
             if all(len(t) <= 3 for t in tokens):
+                continue
+            # Speaker-attribution trigrams (e.g. "host: the first") are a
+            # dialogue-format artifact, not hallucination — see the bigram
+            # loop above.
+            if tokens and tokens[0].endswith(":"):
                 continue
             if any(p.match(phrase) for p in _PEDAGOGICAL_TRIGRAM_PATTERNS):
                 continue

--- a/engine/newsletter_sanitizer.py
+++ b/engine/newsletter_sanitizer.py
@@ -163,6 +163,12 @@ _RAW_RULES: List[Tuple[str, str, str]] = [
     (r"(?im)^\s*Source:\s*General concept\s*\n?", "", "Source: General concept"),
     (r"\(full URL from pre-fetched:\s*[^)]*\)", "", "(full URL from pre-fetched: …)"),
     (r"\(full URL from pre[ -]?fetched\s*[^)]*\)", "", "(full URL from pre-fetched: variant)"),
+    # MAB "Cool Stuff" title template used to end ``: Source Name`` — the
+    # model echoed the literal placeholder (committed in MAB Ep056 + the
+    # Ep057 retry). The prompt no longer carries it; this scrubs any that
+    # already leaked or slip through (``Title:** Source Name`` / ``Title: Source Name``).
+    (r"(?i)\s*:\*{0,2}\s*Source Name\b", "", "': Source Name' placeholder"),
+    (r"(?im)^\s*\*{0,2}Source Name\*{0,2}\s*$", "", "bare 'Source Name' line"),
     # NOTE: box-drawing horizontal rules (━━━ / ─── / ═══) are NOT
     # scrubbed here — they're converted to proper ``<hr>`` separators
     # by ``engine.newsletter_body.replace_box_rules_with_hr`` in the

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -485,8 +485,20 @@ def enforce_x_char_limit(text: str, max_chars: int = 280) -> str:
 # HTTP constants
 # ---------------------------------------------------------------------------
 
+# Use a real browser User-Agent. The previous bot UA
+# ("PodcastBot/1.0 …") was silently blocked or served empty/challenge
+# pages by Cloudflare-fronted publishers (TechCrunch, MIT Tech Review,
+# Wired, The Verge, Ars Technica, Reddit), which returned HTTP 200 with
+# zero entries — counted as "0 articles, 0 failed" and invisible in the
+# logs. A browser UA + Accept header restores those feeds. (May 2026
+# MAB sourcing audit — the show had silently collapsed onto Reddit +
+# The Decoder because the high-signal AI feeds were all returning 0.)
 DEFAULT_HEADERS = {
-    "User-Agent": "PodcastBot/1.0 (+https://github.com/Planetterrian/nerranetwork)"
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/rss+xml, application/atom+xml, application/xml, text/xml, text/html;q=0.9, */*;q=0.8",
 }
 HTTP_TIMEOUT_SECONDS = 10
 

--- a/engine/validation.py
+++ b/engine/validation.py
@@ -125,6 +125,11 @@ class SectionRule:
     pattern: str = ""
     min_items: int = 0
     max_items: int = 0  # 0 = no max
+    # Minimum prose length (chars) for PROSE sections that have no list
+    # items (e.g. MAB's "The Big Story" is 8-12 sentences, not bullets).
+    # Counting ``**bold**`` items there always returns 0 and falsely trips
+    # the structural-retry. 0 = disabled (item-count validation only).
+    min_chars: int = 0
     # If True, section is optional (don't flag if missing)
     optional: bool = False
 
@@ -224,6 +229,16 @@ def check_item_counts(
             issues.append(
                 f"Section '{section.name}': {count} items (maximum {section.max_items})"
             )
+        # Prose sections (no list items) are validated by length instead.
+        # ``0 chars`` on a mandatory prose section reads as structural and
+        # triggers the regenerate; a full section passes silently.
+        if section.min_chars:
+            prose = _extract_section_text(digest_text, section.pattern)
+            n_chars = len(prose)
+            if n_chars < section.min_chars:
+                issues.append(
+                    f"Section '{section.name}': {n_chars} chars (minimum {section.min_chars})"
+                )
     return issues
 
 
@@ -574,7 +589,12 @@ def mab_validation_config() -> ValidationConfig:
                     r"(.*?)"
                     r"(?=━━|### Cool Stuff|## Cool Stuff|### Cool Tools|## Cool Tools|$)"
                 ),
-                min_items=1,
+                # Prose section (8-12 sentences), NOT a bullet list — validate
+                # by length, not ``**bold**`` item count. The old min_items=1
+                # always saw 0 items and regenerated the digest on essentially
+                # every episode (wasteful + the retry introduced repetition).
+                min_items=0,
+                min_chars=250,
             ),
         ],
         forbidden_patterns=[

--- a/engine/validation.py
+++ b/engine/validation.py
@@ -558,7 +558,12 @@ def ma_validation_config() -> ValidationConfig:
                     r"(.*?)"
                     r"(?=━━|### Model Updates|## Model Updates|$)"
                 ),
-                min_items=1,
+                # Prose lead story (4-6 sentences), NOT a bullet list. The old
+                # min_items=1 counted 0 ``**bold**`` items on a perfectly good
+                # prose section and forced a regenerate that shrank the digest
+                # (Ep066: 12.9k → 9.0k chars). Validate by length instead.
+                min_items=0,
+                min_chars=250,
             ),
             SectionRule(
                 name="Model Updates",

--- a/run_show.py
+++ b/run_show.py
@@ -627,15 +627,20 @@ def run(args: argparse.Namespace) -> None:
             )
 
         def _run_x_fetch():
-            # Skip the X API call if X posting is disabled for this show —
-            # before May 12 2026 the fetch ran whenever ``x_accounts`` was
-            # configured, regardless of ``x_enabled``, so shows with X
-            # posting off still paid for X API calls and ingested X posts
-            # that were never used. Operator-caught during the May 12 2026
-            # pipeline audit.
-            if not config.x_accounts or not config.publishing.x_enabled:
+            # X *sourcing* is decoupled from X *posting* (May 2026 MAB audit).
+            # The May 12 2026 change gated X fetch on ``x_enabled`` to stop
+            # non-posting shows paying for unused X calls — but that also
+            # silently dropped curated X accounts as a CONTENT source for
+            # shows like MAB. A show now opts back in with
+            # ``x_fetch_enabled: true`` in its YAML; unset still defaults to
+            # ``x_enabled`` so every other show is unchanged.
+            from engine.fetcher import x_fetch_allowed, fetch_x_posts
+            if not x_fetch_allowed(
+                config.x_accounts,
+                config.publishing.x_enabled,
+                getattr(config, "x_fetch_enabled", None),
+            ):
                 return []
-            from engine.fetcher import fetch_x_posts
             return fetch_x_posts(config.x_accounts, keywords=config.keywords)
 
         articles = []
@@ -3104,8 +3109,12 @@ def _empty_mandatory_section_issues(item_count_issues: list) -> list:
     podcast then dropped the whole main-news body). A soft shortfall like
     ``has only 8 items (minimum 10)`` is usually a formatting mismatch on a
     long digest and is deliberately NOT treated as structural.
+
+    ``0 chars`` covers prose sections validated by length rather than item
+    count (e.g. MAB's "The Big Story"), so a genuinely empty prose section
+    still triggers a regenerate while a full one does not.
     """
-    return [i for i in item_count_issues if re.search(r":\s*0\s+items", i)]
+    return [i for i in item_count_issues if re.search(r":\s*0\s+(?:items|chars)", i)]
 
 
 def _resolve_weekly_recap(

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -30,8 +30,10 @@ sources:
     label: GitHub Blog
   - url: https://devblogs.microsoft.com/semantic-kernel/feed/
     label: Microsoft Semantic Kernel
-  - url: https://blog.langchain.dev/rss/
-    label: LangChain Blog
+  # Removed: blog.langchain.dev/rss/ — serves malformed XML ("not
+  # well-formed (invalid token)"), 0 entries + 1 failed feed every run.
+  # No working replacement (blog.langchain.com/rss also malformed,
+  # changelog 404). LangChain coverage still flows via Google News + Reddit.
   - url: https://www.latent.space/feed
     label: Latent Space
 

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -3,10 +3,17 @@ slug: models_agents_beginners
 weekly_recap_on_sunday: true   # May 2026: daily cadence; Sunday slot recaps the past 7 days from the content lake.
 description: "An AI podcast for beginners and teens — learn about models, agents, and the AI revolution in plain language. We explain the jargon, encourage experimentation, and help you understand the most exciting technology of our generation."
 
+# Read the curated X accounts below for CONTENT even though this show does
+# not POST to X (publishing.x_enabled: false). Without this, the May 12 2026
+# fetch-gating left MAB sourcing only from RSS — see engine.fetcher.x_fetch_allowed.
+x_fetch_enabled: true
+
 sources:
   # Major AI Labs & Research
-  - url: https://openai.com/blog/rss.xml
-    label: OpenAI Blog
+  # OpenAI moved their feed: /blog/rss.xml now 307-redirects and yields
+  # 0 entries. The live feed is /news/rss.xml (verified 200 + fresh).
+  - url: https://openai.com/news/rss.xml
+    label: OpenAI News
   # Removed: ai.meta.com/blog/rss/ (404), anthropic.com/rss.xml (404),
   # mistral.ai/feed.xml (404) — lab blogs removed or moved
 
@@ -31,7 +38,9 @@ sources:
     label: One Useful Thing (Ethan Mollick)
   - url: https://www.engadget.com/rss.xml
     label: Engadget
-  - url: https://www.livescience.com/feeds/all
+  # Live Science moved their feed: /feeds/all now 301/404s. Live URL is
+  # /home/feed/site.xml (verified 200 + fresh).
+  - url: https://www.livescience.com/home/feed/site.xml
     label: Live Science
   - url: https://theconversation.com/us/articles.atom
     label: The Conversation

--- a/shows/prompts/mab_digest.txt
+++ b/shows/prompts/mab_digest.txt
@@ -128,7 +128,7 @@ Source: [EXACT URL — if referencing a specific article, or "General concept" i
 ━━━━━━━━━━━━━━━━━━━━
 ### Cool Stuff & Try This
 2-3 items about AI tools, models, or updates that beginners can understand AND ideally try. For each:
-**[Catchy title that a teen would click on]: Source Name**
+**[Catchy title that a teen would click on]**
 5-6 sentences: What it does (explain like they've NEVER heard of the underlying technology). Why it's cool or exciting. Who should try it. How to access it (website name, app name — be specific). Include a concrete, detailed thing the reader can TRY right now — "Go to [website name] and try [this specific thing]" or "Ask [chatbot] to [do this specific thing]". Frame experiments as fun challenges or creative projects, not homework.
 REQUIREMENTS: Every experiment must be doable by a teen with a phone or laptop. NO coding. NO developer tools. NO terminal commands. NO GitHub repos. Just web browsers and free apps.
 ACCESSIBILITY: Prioritize tools that work without account creation. If a tool requires age verification or account signup, note "you may need a parent's help to sign up" naturally in the text. Avoid tools that require credit cards, personal location data, or significant personal information.

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -263,3 +263,46 @@ class TestCallGrok:
         monkeypatch.delenv("XAI_API_KEY", raising=False)
         with pytest.raises(RuntimeError):
             _call_grok("hello")
+
+
+class TestSpeakerLabelRepetitionSkip:
+    """Plain ``Host:`` speaker labels are a dialogue-format artifact, not a
+    hallucination. They must NOT inflate the suspicious-repetition count (which
+    would trigger wasteful retries that shorten the episode — Models & Agents
+    Ep066 flagged 'host: the' x18 and lost ~200 words to anti-repetition regens).
+    Genuine topic repetition must still be caught.
+    """
+
+    def _validate(self):
+        from engine.generator import _validate_llm_output
+        return _validate_llm_output
+
+    def test_host_label_bigrams_not_flagged(self):
+        validate = self._validate()
+        # 18 host lines that all start "Host: The" (the artifact that tripped
+        # the detector) but whose remaining content is genuinely distinct, so
+        # ONLY the speaker-label bigram/trigram repeats.
+        topics = [
+            "quantum annealing surprised everyone", "robots folded laundry quickly",
+            "compilers optimized themselves overnight", "satellites mapped deep oceans",
+            "drones delivered medicine remotely", "sensors detected faint tremors",
+            "batteries charged within seconds", "telescopes captured distant galaxies",
+            "algorithms sorted petabytes instantly", "vaccines reached rural clinics",
+            "turbines harvested gentle breezes", "microscopes revealed hidden proteins",
+            "printers fabricated tiny gears", "rovers climbed steep craters",
+            "antennas captured weak signals", "reactors fused light isotopes",
+            "cameras tracked migrating whales", "engines burned cleaner fuels",
+        ]
+        lines = [f"Host: The {t}." for t in topics]
+        script = " ".join(lines)
+        n = validate(script, stage="podcast_script", show_name="Models & Agents")
+        assert n == 0, f"speaker-label phrases should not be flagged (got {n})"
+
+    def test_genuine_repetition_still_flagged(self):
+        validate = self._validate()
+        # Real topic loop: "mixture of experts" repeated far above threshold,
+        # NOT behind a speaker label.
+        script = ("We discuss the mixture of experts approach. " * 8) + \
+                 " ".join(f"Word{i} filler text here." for i in range(60))
+        n = validate(script, stage="podcast_script", show_name="Models & Agents")
+        assert n >= 1, "genuine repetition must still be detected"

--- a/tests/test_newsletter_sanitizer.py
+++ b/tests/test_newsletter_sanitizer.py
@@ -299,3 +299,33 @@ class TestPatternCoverage:
         once = scrub_scaffold(text)
         twice = scrub_scaffold(once)
         assert once == twice
+
+
+# ---------------------------------------------------------------------------
+# 'Source Name' placeholder leak (MAB Cool-Stuff title template)
+# ---------------------------------------------------------------------------
+
+class TestSourceNamePlaceholderScrub:
+    """MAB's digest prompt used to template ``Title: Source Name``; the model
+    echoed the literal placeholder (committed MAB Ep056 + Ep057 retry). The
+    prompt is fixed, but the sanitizer scrubs any that slip through before a
+    subscriber sees it."""
+
+    def test_strips_trailing_colon_source_name(self):
+        out = scrub_scaffold("Redesign your room with Claude:** Source Name")
+        assert "Source Name" not in out
+        assert "Redesign your room with Claude" in out
+
+    def test_strips_plain_colon_source_name(self):
+        out = scrub_scaffold("A fun new tool: Source Name")
+        assert "Source Name" not in out
+        assert "A fun new tool" in out
+
+    def test_strips_bare_source_name_line(self):
+        out = scrub_scaffold("**Source Name**")
+        assert "Source Name" not in out
+
+    def test_real_prose_unaffected(self):
+        # Defensive: ordinary sentences must survive untouched.
+        s = "The model remembers the whole book at once."
+        assert scrub_scaffold(s) == s

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -15,7 +15,57 @@ from engine.validation import (
     ff_validation_config,
     pt_validation_config,
     ov_validation_config,
+    mab_validation_config,
 )
+import re as _re
+
+
+class TestMabBigStoryProse:
+    """MAB's 'The Big Story' is an 8-12 sentence PROSE section, not a bullet
+    list. The old ``min_items=1`` counted ``**bold**`` items, found 0 on a
+    perfectly good prose section, and forced a wasteful (quality-degrading)
+    digest regenerate on essentially every episode. It's now validated by
+    ``min_chars`` instead.
+    """
+
+    _FULL = (
+        "# MAB\n\n### The Big Story\n"
+        "A new open AI model just launched with a million-token memory. Imagine "
+        "reading an entire book and remembering every page at once. Until now, "
+        "models forgot the start of long chats. This matters for students across "
+        "a whole textbook. You can try a free version today on the model's site.\n\n"
+        "━━━━\n### Cool Stuff & Try This\n"
+        "**A fun image tool**\nIt turns sketches into art.\n"
+    )
+    _EMPTY = "# MAB\n\n### The Big Story\n\n### Cool Stuff & Try This\n**Tool**\nBody.\n"
+
+    def _struct(self, issues):
+        # Mirror run_show._empty_mandatory_section_issues.
+        return [i for i in issues if _re.search(r":\s*0\s+(?:items|chars)", i)]
+
+    def test_full_prose_big_story_not_flagged(self):
+        _, issues, _ = validate_digest(self._FULL, mab_validation_config())
+        assert not [i for i in issues if "The Big Story" in i]
+        assert self._struct(issues) == []  # no structural regenerate
+
+    def test_empty_big_story_flags_zero_chars_and_triggers_regenerate(self):
+        _, issues, _ = validate_digest(self._EMPTY, mab_validation_config())
+        bs = [i for i in issues if "The Big Story" in i]
+        assert any(_re.search(r":\s*0\s+chars", i) for i in bs)
+        assert self._struct(issues)  # structural regenerate fires
+
+    def test_min_chars_field_on_section_rule(self):
+        rule = SectionRule(name="x", pattern=r"### x(.*)$", min_chars=100)
+        assert rule.min_chars == 100 and rule.min_items == 0
+
+
+def test_mab_digest_prompt_has_no_source_name_placeholder():
+    """The 'Cool Stuff' title template used to end ': Source Name', which the
+    model echoed verbatim into digests/blog/newsletter. It must not return."""
+    from pathlib import Path
+
+    text = Path("shows/prompts/mab_digest.txt").read_text(encoding="utf-8")
+    assert "Source Name" not in text
 from engine.content_tracker import TST_SECTION_PATTERNS, FF_SECTION_PATTERNS
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -16,8 +16,34 @@ from engine.validation import (
     pt_validation_config,
     ov_validation_config,
     mab_validation_config,
+    ma_validation_config,
 )
 import re as _re
+
+
+class TestMaTopStoryProse:
+    """Models & Agents' 'Top Story' is a 4-6 sentence PROSE lead, not a list.
+    The old min_items=1 forced a regenerate that shrank the digest (Ep066:
+    12.9k -> 9.0k chars). Now validated by length."""
+
+    _FULL = (
+        "# M&A\n\n### Top Story\n"
+        "OpenAI's model cracked an 80-year math problem by leaning on structured "
+        "reasoning rather than brute force. It beat prior methods on the benchmark "
+        "by a wide margin. Builders can try the approach through the API today. "
+        "Watch for follow-up releases as other labs respond over the coming weeks.\n\n"
+        "━━━━\n### Model Updates\n**A new model**\nDetails here.\n"
+    )
+    _EMPTY = "# M&A\n\n### Top Story\n\n### Model Updates\n**X**\nY.\n"
+
+    def test_full_prose_top_story_not_flagged(self):
+        _, issues, _ = validate_digest(self._FULL, ma_validation_config())
+        assert not [i for i in issues if "Top Story" in i]
+
+    def test_empty_top_story_flags_zero_chars(self):
+        _, issues, _ = validate_digest(self._EMPTY, ma_validation_config())
+        ts = [i for i in issues if "Top Story" in i]
+        assert any(_re.search(r":\s*0\s+chars", i) for i in ts)
 
 
 class TestMabBigStoryProse:

--- a/tests/test_x_fetch_gating.py
+++ b/tests/test_x_fetch_gating.py
@@ -1,93 +1,72 @@
-"""Verify X-post fetching is gated by ``publishing.x_enabled``.
+"""Verify X-post *fetching* is gated correctly, decoupled from X *posting*.
 
-Before May 12 2026 the ``_run_x_fetch()`` closure in run_show.py
-gated only on ``config.x_accounts`` — so any show that had
-accounts configured ran the X API call on every cron tick, even
-when X posting was disabled for that show. Six shows fit this
-shape (Env Intel, MAB, M&A pre-PR, FP, PR, MIT pre-PR) and were
-silently spending X API quota for content that was never used.
+History:
+  - Before May 12 2026 ``_run_x_fetch()`` gated only on ``x_accounts`` —
+    so shows with accounts configured ran the X API call every tick even
+    with posting off, spending quota on unused content.
+  - May 12 2026: gated on ``publishing.x_enabled`` too.
+  - May 2026 (MAB sourcing audit): that coupling ALSO killed X as a
+    *content source* for non-posting shows (MAB had collapsed onto
+    RSS-only). The gate now lives in ``engine.fetcher.x_fetch_allowed``
+    and a show opts X sourcing back in with ``x_fetch_enabled: true`` —
+    independent of whether it posts. Unset still inherits ``x_enabled``,
+    so every other show is unchanged.
 
-The gate is now ``not x_accounts or not publishing.x_enabled`` so
-both flags must agree before the API call goes out. These tests
-pin the new contract.
+These tests pin the real ``x_fetch_allowed`` helper (no test-only copy).
 """
 
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
-
-
-def _make_config(*, x_accounts, x_enabled):
-    """Build a minimal config namespace matching what run_show uses."""
-    return SimpleNamespace(
-        x_accounts=x_accounts,
-        keywords=["test", "keywords"],
-        publishing=SimpleNamespace(x_enabled=x_enabled),
-    )
-
-
-def _fetch_under_gate(config):
-    """Replica of the gate logic in run_show.py:_run_x_fetch().
-
-    Kept here as a test-only copy because the production function is
-    a closure inside run() — not importable. The gate predicate is
-    one line; pinning it here guards against silent regression."""
-    if not config.x_accounts or not config.publishing.x_enabled:
-        return []
-    from engine.fetcher import fetch_x_posts
-    return fetch_x_posts(config.x_accounts, keywords=config.keywords)
+from engine.fetcher import x_fetch_allowed
 
 
 def test_skip_when_no_accounts():
-    """Empty x_accounts → no fetch, no API call."""
-    cfg = _make_config(x_accounts=[], x_enabled=True)
-    with patch("engine.fetcher.fetch_x_posts") as mock_fetch:
-        result = _fetch_under_gate(cfg)
-    assert result == []
-    mock_fetch.assert_not_called()
+    """Empty x_accounts → never fetch, regardless of flags."""
+    assert x_fetch_allowed([], True, True) is False
+    assert x_fetch_allowed([], True, None) is False
 
 
-def test_skip_when_x_posting_disabled():
-    """x_accounts configured but x_enabled=False → no fetch.
-
-    This is the May 12 2026 fix. The previous code only checked
-    accounts; this assertion would have failed before the fix."""
-    cfg = _make_config(x_accounts=["@example"], x_enabled=False)
-    with patch("engine.fetcher.fetch_x_posts") as mock_fetch:
-        result = _fetch_under_gate(cfg)
-    assert result == []
-    mock_fetch.assert_not_called()
+def test_default_inherits_x_enabled():
+    """x_fetch_enabled unset (None) → behaves exactly like the old gate:
+    fetch iff x_enabled. Pins back-compat for every non-opted-in show."""
+    assert x_fetch_allowed(["@a"], True, None) is True
+    assert x_fetch_allowed(["@a"], False, None) is False
 
 
-def test_fetch_when_both_configured():
-    """Accounts + posting both on → fetch runs."""
-    cfg = _make_config(x_accounts=["@example"], x_enabled=True)
-    with patch("engine.fetcher.fetch_x_posts", return_value=[{"id": 1}]) as mock_fetch:
-        result = _fetch_under_gate(cfg)
-    assert result == [{"id": 1}]
-    mock_fetch.assert_called_once_with(["@example"], keywords=["test", "keywords"])
+def test_explicit_override_enables_fetch_without_posting():
+    """The MAB fix: posting off (x_enabled False) but x_fetch_enabled True
+    → fetch the curated accounts for content anyway."""
+    assert x_fetch_allowed(["@a"], False, True) is True
 
 
-def test_skip_when_both_disabled():
-    """Neither flag set → no fetch (degenerate case but worth pinning)."""
-    cfg = _make_config(x_accounts=[], x_enabled=False)
-    with patch("engine.fetcher.fetch_x_posts") as mock_fetch:
-        result = _fetch_under_gate(cfg)
-    assert result == []
-    mock_fetch.assert_not_called()
+def test_explicit_override_can_disable_fetch_while_posting():
+    """x_fetch_enabled False wins even if the show posts (x_enabled True)."""
+    assert x_fetch_allowed(["@a"], True, False) is False
 
 
-def test_yaml_state_shows_with_x_disabled_have_dormant_accounts():
-    """The four shows that keep X posting off (Env Intel, MAB, FP,
-    PR) all still have ``x_accounts`` configured in their YAML —
-    they just won't fetch any more. Pinning so a future YAML edit
-    that removes ``x_accounts`` to "fix" this isn't needed (and
-    so re-enabling X on these shows later is a single-flag flip)."""
+def test_mab_resolves_to_fetch_enabled_from_yaml():
+    """MAB posts to nobody (x_enabled False) but opts into X sourcing
+    (x_fetch_enabled True), so the gate now ALLOWS the fetch — reversing
+    the dormant-accounts behaviour for this show specifically."""
     from engine.config import load_config
 
-    for slug in ("env_intel", "models_agents_beginners", "finansy_prosto", "privet_russian"):
+    cfg = load_config("shows/models_agents_beginners.yaml")
+    assert cfg.publishing.x_enabled is False
+    assert cfg.x_fetch_enabled is True
+    assert cfg.x_accounts, "MAB must keep its curated X accounts"
+    assert x_fetch_allowed(
+        cfg.x_accounts, cfg.publishing.x_enabled, cfg.x_fetch_enabled
+    ) is True
+
+
+def test_other_non_posting_shows_stay_dormant():
+    """Shows that did NOT opt in (no x_fetch_enabled) still don't fetch
+    while posting is off — unchanged behaviour."""
+    from engine.config import load_config
+
+    for slug in ("env_intel", "finansy_prosto", "privet_russian"):
         cfg = load_config(f"shows/{slug}.yaml")
-        # X disabled — gate should block fetch.
-        assert cfg.publishing.x_enabled is False, (
-            f"{slug}: expected x_enabled False (gate blocks fetch); "
-            f"if you re-enable, update this test."
-        )
+        assert cfg.publishing.x_enabled is False
+        # Not opted in → inherits x_enabled=False → no fetch.
+        assert x_fetch_allowed(
+            cfg.x_accounts, cfg.publishing.x_enabled,
+            getattr(cfg, "x_fetch_enabled", None),
+        ) is False


### PR DESCRIPTION
Reviews of two sister shows surfaced overlapping bugs. Both shows were producing thin/degraded episodes — MAB from **eroded sourcing**, M&A from **false-positive guardrails that shrink the episode**.

## MAB — sourcing eroded onto Reddit + The Decoder
Ep057: `21 RSS + 0 X + 0 web_search`, premium feeds returning 0, single-story digest.
- **Browser User-Agent** (`engine/utils.py:DEFAULT_HEADERS`) — the bot UA was served empty/challenge pages by Cloudflare-fronted publishers (TechCrunch, MIT, Wired, Verge, Ars, Reddit): HTTP 200 / 0 entries, invisible as "0 articles, 0 failed". **Network-wide fix.**
- **Decouple X sourcing from posting** — new `engine.fetcher.x_fetch_allowed` + `config.x_fetch_enabled` (`None` = inherit `x_enabled`, back-compat). MAB sets `x_fetch_enabled: true` → its 6 curated accounts are read again without posting.
- **Dead feed URLs replaced** (verified live): OpenAI `/blog/rss.xml`→`/news/rss.xml`; Live Science `/feeds/all`→`/home/feed/site.xml`.
- **Feed visibility** — log `0 entries (blocked/empty/stale)` vs `parsed N, 0 passed filters`.

## M&A — not light on sources, but self-shrinking
Ep066: 140 raw → 88 + 5 X, yet two guardrails fired regenerations that cut the digest **12.9k → 9.0k chars** and the script **1490 → 1290 words**:
- **Same false-positive structural validation** — `ma_validation_config`'s prose `"Top Story"` was `min_items=1`; the `**bold**` item-counter returned 0 → forced regenerate. Fixed with the `min_chars` mechanism (also applied to MAB's `"The Big Story"`).
- **Repetition detector false-hits on plain `Host:` labels** — allowlist covered `**host:**`/`patrick:`/`olya:` but not a plain `Host:` (M&A's format), so `host: the` ×18 inflated the count → wasteful retries + an anti-repetition regen that *shortened* the script. Now skips any bigram/trigram whose first token is a speaker label ending in `:` (generic). Genuine repetition (`mixture of experts`) still caught.
- Dropped the malformed `blog.langchain.dev/rss` feed.

## Shared quality bugs
- **`Source Name` placeholder leak** (MAB prompt template echoed verbatim into digests/blog/newsletter) — removed from the prompt + sanitizer scrub.
- **Prose-section structural validation** (`SectionRule.min_chars`) — fixes the every-run wasteful regenerate for both prose-lead shows.

## Verification
Live-tested all replacement feeds + the UA unblock; exercised `x_fetch_allowed`, prose-vs-empty validation for both configs, the speaker-label repetition skip (Host: not flagged, genuine repetition still flagged), and the sanitizer scrub. **Full suite: 2362 passed, 6 skipped.**

## Notes
- The DEFAULT_HEADERS + repetition-detector changes are network-wide and make output strictly better (more sources, fewer spurious shortening regens) — but they do change generated MAB/M&A content, so an A/B listen on the next episodes is worth it (landmine #17). These are deterministic infra/guardrail fixes, not prompt-voice changes.
- Deferred (you didn't pick it for MAB): skip-threshold / slow-news tuning.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC