### PR TITLE
Network-wide: stop prose lead sections from forcing wasteful digest regenerations

### DIFF
--- a/engine/validation.py
+++ b/engine/validation.py
@@ -201,6 +201,17 @@ def check_section_overlap(
     return overlaps
 
 
+# A section with this many characters of prose is "not empty" even if it
+# contains zero ``**bold**`` list items. Many shows lead with a PROSE feature
+# (FF "Cosmic Spotlight", PT "Planetterrian Spotlight", EI "Lead Story", MI
+# "Strategy Spotlight", FP/PR leads, MAB "The Big Story", M&A "Top Story").
+# Those have no bold items, so the item-counter returns 0 and — when the
+# section is mandatory (min_items>=1) — run_show treats "0 items" as a
+# structural defect and forces a wasteful digest regenerate (often degrading
+# quality). Below this floor the section is genuinely empty and still flags.
+_PROSE_CONTENT_FLOOR = 200
+
+
 def check_item_counts(
     digest_text: str,
     sections: List[SectionRule],
@@ -221,24 +232,27 @@ def check_item_counts(
             continue
 
         count = len(items)
+        prose_chars = len(_extract_section_text(digest_text, section.pattern))
         if section.min_items and count < section.min_items:
-            issues.append(
-                f"Section '{section.name}': {count} items (minimum {section.min_items})"
-            )
+            # Prose-aware structural guard (network-wide): a mandatory section
+            # with 0 bold items but real prose content is a prose lead, NOT a
+            # structural defect. Suppress the "0 items" signal that would
+            # otherwise trigger a regenerate; a genuinely empty section
+            # (< floor) still flags and regenerates.
+            if not (count == 0 and prose_chars >= _PROSE_CONTENT_FLOOR):
+                issues.append(
+                    f"Section '{section.name}': {count} items (minimum {section.min_items})"
+                )
         if section.max_items and count > section.max_items:
             issues.append(
                 f"Section '{section.name}': {count} items (maximum {section.max_items})"
             )
-        # Prose sections (no list items) are validated by length instead.
-        # ``0 chars`` on a mandatory prose section reads as structural and
-        # triggers the regenerate; a full section passes silently.
-        if section.min_chars:
-            prose = _extract_section_text(digest_text, section.pattern)
-            n_chars = len(prose)
-            if n_chars < section.min_chars:
-                issues.append(
-                    f"Section '{section.name}': {n_chars} chars (minimum {section.min_chars})"
-                )
+        # Optional explicit prose-length floor (stricter than the structural
+        # guard above). ``0 chars`` reads as structural and regenerates.
+        if section.min_chars and prose_chars < section.min_chars:
+            issues.append(
+                f"Section '{section.name}': {prose_chars} chars (minimum {section.min_chars})"
+            )
     return issues
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -17,8 +17,66 @@ from engine.validation import (
     ov_validation_config,
     mab_validation_config,
     ma_validation_config,
+    ei_validation_config,
+    mi_validation_config,
 )
 import re as _re
+
+
+def _structural(issues):
+    """Mirror run_show._empty_mandatory_section_issues."""
+    return [i for i in issues if _re.search(r":\s*0\s+(?:items|chars)", i)]
+
+
+class TestProseSectionStructuralGuardNetworkWide:
+    """Many shows lead with a PROSE feature (FF 'Cosmic Spotlight', PT
+    'Planetterrian Spotlight', EI 'Lead Story', MI 'Strategy Spotlight')
+    set to min_items>=1. Those have no **bold** items, so the item-counter
+    returns 0 and run_show used to force a wasteful digest regenerate on
+    every episode (FF Ep087 confirmed). The prose-aware guard suppresses the
+    '0 items' signal when real prose is present; a genuinely empty section
+    still triggers the regenerate.
+    """
+
+    _PROSE = ("This is a substantial prose lead with real content. " * 8)
+
+    def _digest(self, header, body):
+        return f"# Show\n\n{header}\n{body}\n"
+
+    def test_ff_prose_cosmic_spotlight_not_structural(self):
+        d = (
+            "# FF\n\n### Top 15 Space Stories\n"
+            + "".join(f"{i}. **Story {i} headline goes here**\n   Body text.\n"
+                     for i in range(1, 9))
+            + "\n━━━━\n### Cosmic Spotlight\n" + self._PROSE + "\n"
+        )
+        _, issues, _ = validate_digest(d, ff_validation_config())
+        assert not [i for i in _structural(issues) if "Cosmic Spotlight" in i]
+
+    def test_ff_empty_cosmic_spotlight_still_structural(self):
+        d = ("# FF\n\n### Top 15 Space Stories\n1. **A headline here today**\n   B.\n"
+             "\n━━━━\n### Cosmic Spotlight\n\n")
+        _, issues, _ = validate_digest(d, ff_validation_config())
+        assert [i for i in _structural(issues) if "Cosmic Spotlight" in i]
+
+    def test_pt_ei_mi_prose_leads_not_structural(self):
+        for cfg, header, name in [
+            (pt_validation_config(), "### Planetterrian Spotlight", "Planetterrian Spotlight"),
+            (ei_validation_config(), "### Lead Story", "Lead Story"),
+            (mi_validation_config(), "### Strategy Spotlight", "Strategy Spotlight"),
+        ]:
+            _, issues, _ = validate_digest(self._digest(header, self._PROSE), cfg)
+            assert not [i for i in _structural(issues) if name in i], name
+
+    def test_list_section_thin_count_still_warns(self):
+        # A list section below target (but non-zero) still gets the soft
+        # item-count warning — the guard only suppresses the 0-items case.
+        cfg = ValidationConfig(sections=[
+            SectionRule(name="Stories", pattern=r"(?:### Stories)(.*?)(?=$)", min_items=5),
+        ])
+        d = "# X\n\n### Stories\n1. **First headline here**\n2. **Second headline here**\n"
+        issues = check_item_counts(d, cfg.sections)
+        assert any("Stories" in i and "2 items" in i for i in issues)
 
 
 class TestMaTopStoryProse:


### PR DESCRIPTION
## Why
Reviewing Fascinating Frontiers (Ep087) showed the prose-section structural bug fixed per-show for MAB/M&A in #523 is actually **network-wide**: FF's `Cosmic Spotlight`, PT's `Planetterrian Spotlight`, EI's `Lead Story`, MI's `Strategy Spotlight`, and the FP/PR leads are all **prose features** set to `min_items>=1`. They have no `**bold**` items → item-counter returns 0 → run_show reads "0 items" as structural → forces a full digest regenerate **every episode** (FF Ep087: 57s regen, retry didn't even improve). The regens waste credits and frequently shrink/degrade the digest.

## Fix
Instead of hand-classifying every section, add a general **prose-aware guard** in `validation.check_item_counts`: a mandatory section with 0 bold items but **≥200 chars of prose** is a prose lead, not structurally empty, so the "0 items" signal is suppressed. A genuinely empty section (< floor) still flags and regenerates. Soft item-count warnings for partially-filled **list** sections are unchanged.

Fixes FF / PT / EI / MI / FP / PR at once. (MAB/M&A already got explicit `min_chars` in #523; that still works alongside the guard.)

## Tests
Prose leads across FF/PT/EI/MI don't trigger a structural regen; an empty FF `Cosmic Spotlight` still does; thin list sections still warn. **Full suite: 2366 passed.**

## Operator notes from the same FF run (no code here — surfacing for you)
- **The #523 browser-UA fix revives FF's "dead" feeds.** I tested ESA (×3), `science.org` (was a hard 403!), Nature Astronomy, Quanta, and Spaceflight Now with the new UA — **all return full feeds now**. They were UA-blocked, not dead, so FF's sourcing should jump once #523 is live. No feed pruning needed.
- **X posting is failing on billing, not code.** `X post failed: 402 Payment Required — account [1988738079830487040] does not have any credits` — the `@planetterrian` X API account (FF/PT) is **out of credits**. Top it up in the X developer portal; nothing to change in the repo. (My #510 logging is what surfaced this.)
- **FF recycles almanac content.** Ep087 had 12 "identical to recent story" repeats (full-moon calendars, planet-visibility, "this day in history"). Those are flagged "BLOCKING" but run_show treats all validation as non-blocking, so they ship anyway. Worth a follow-up (filter recurring almanac items, or make those repeats actually drop) — not in this PR.
- **Listener Value is systemically low on dailies** (FF 0.3, M&A 1.7, MAB 1.5) on the "why this matters / concrete numbers" dimension. A prompt/content change (A/B-listen per landmine #17) — flagging, not touching here.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_