### PR TITLE
Filter recurring almanac content from Fascinating Frontiers at fetch time

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -489,6 +489,11 @@ class ShowConfig:
     # for content. See engine.fetcher.x_fetch_allowed.
     x_fetch_enabled: Optional[bool] = None
     keywords: List[str] = field(default_factory=list)
+    # Case-insensitive regex patterns; articles whose TITLE matches any are
+    # dropped at fetch time. For suppressing recurring almanac/evergreen
+    # content (moon calendars, planet-visibility roundups, "this day in
+    # history") — see engine.utils.drop_excluded_titles.
+    exclude_title_patterns: List[str] = field(default_factory=list)
     web_search_queries: List[str] = field(default_factory=list)
     min_articles: int = 3  # Minimum articles before expanding search
     min_articles_skip: int = 3  # Hard cutoff — skip episode if fewer articles
@@ -679,6 +684,7 @@ def load_config(yaml_path: str | Path) -> ShowConfig:
         x_accounts=_build_x_accounts(data.get("x_accounts")),
         x_fetch_enabled=data.get("x_fetch_enabled"),
         keywords=data.get("keywords", []),
+        exclude_title_patterns=data.get("exclude_title_patterns", []),
         web_search_queries=data.get("web_search_queries", []),
         min_articles=data.get("min_articles", 3),
         min_articles_skip=data.get("min_articles_skip", 3),

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -326,6 +326,44 @@ def extract_primary_entity(title: str, description: str = "") -> str:
     return max(filtered_runs, key=len)
 
 
+def drop_excluded_titles(articles: list, patterns: list) -> tuple:
+    """Drop articles whose title matches any of *patterns*.
+
+    *patterns* are case-insensitive regular expressions. Returns
+    ``(kept_articles, dropped_count)``.
+
+    Purpose: suppress recurring almanac / evergreen content that feeds
+    republish across episodes and that isn't news — e.g. Fascinating
+    Frontiers kept shipping "Full Moon Calendar Lists All 2026 Dates",
+    "Venus Jupiter Mercury Shine in June Evening Skies", and
+    "Lick Observatory Ownership Transfers on June 1 1888" (caught as
+    100%-identical cross-episode repeats but shipped anyway because the
+    repeat check is non-blocking). Filtering at fetch time stops them
+    reaching the digest. Configured per-show via ``exclude_title_patterns``.
+    """
+    if not patterns or not articles:
+        return articles, 0
+    import re
+    compiled = []
+    for p in patterns:
+        try:
+            compiled.append(re.compile(p, re.IGNORECASE))
+        except re.error as exc:
+            logger.warning("Invalid exclude_title_pattern %r: %s", p, exc)
+    if not compiled:
+        return articles, 0
+    kept = []
+    dropped = 0
+    for art in articles:
+        title = art.get("title") or ""
+        if any(c.search(title) for c in compiled):
+            dropped += 1
+            logger.debug("Excluded almanac/evergreen title: %s", title[:80])
+            continue
+        kept.append(art)
+    return kept, dropped
+
+
 def deduplicate_by_entity(
     articles: list,
     max_per_entity: int = 2,

--- a/run_show.py
+++ b/run_show.py
@@ -3017,6 +3017,20 @@ def _fetch_with_expansion(
             cutoff_hours, "on" if use_keywords else "off", len(articles),
         )
 
+        # Drop recurring almanac/evergreen titles (moon calendars, planet-
+        # visibility roundups, "this day in history") that feeds republish
+        # across episodes. Per-show ``exclude_title_patterns``; no-op when
+        # unset, so every other show is unchanged.
+        _excl = list(getattr(config, "exclude_title_patterns", []) or []) if config else []
+        if _excl:
+            from engine.utils import drop_excluded_titles
+            articles, _n_excluded = drop_excluded_titles(articles, _excl)
+            if _n_excluded:
+                logger.info(
+                    "Excluded %d article(s) matching exclude_title_patterns",
+                    _n_excluded,
+                )
+
         articles = deduplicate_by_entity(articles, max_per_entity=2)
         # Reduce dedup lookback for young shows (< 10 episodes) to avoid
         # over-filtering when the content tracker has very few episodes.

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -90,6 +90,29 @@ x_accounts:
 
 min_articles_skip: 4
 
+# Drop recurring almanac / evergreen content that Space.com, Astronomy.com,
+# etc. republish daily — moon calendars, "planets visible this month"
+# roundups, "this day in history" anniversaries, supermoon/blue-moon photo
+# galleries, telescope-deal posts. These kept shipping as 100%-identical
+# cross-episode repeats (FF Ep087 had 12). Case-insensitive regex on title;
+# tune as needed. See engine.utils.drop_excluded_titles.
+exclude_title_patterns:
+  - 'full moon calendar'
+  - '(moon|lunar) calendar'
+  - 'this day in (space )?history'
+  - '\bon this day\b'
+  - 'on \w+ \d{1,2},? 1[89]\d{2}'          # "...on June 1 1888" anniversaries
+  - 'evening skies?\b'
+  - 'morning skies?\b'
+  - '(night|evening|morning) sky (this|tonight|for|in)'
+  - '\bsky this (week|month)\b'
+  - 'what to see in the (night|evening) sky'
+  - 'highest point in (the )?(evening|morning) sky'
+  - '(super|blue|harvest|wolf|pink|strawberry|blood|hunter|snow|worm|flower|buck|sturgeon|corn|beaver|cold)\s+moon\b'
+  - '(telescope|binoculars?) deals?'
+  - 'best (telescopes?|binoculars?|star projectors?)\b'
+  - 'meteor shower.*(peak|tonight|when to|how to|watch)'
+
 keywords:
   - space
   - astronomy

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -310,3 +310,92 @@ class TestStripSpeechTags:
         assert "<emphasis>" not in out and "</emphasis>" not in out
         assert "three" in out  # inner text preserved
         assert "Let's get into it." in out
+
+
+# ---------------------------------------------------------------------------
+# drop_excluded_titles — almanac / evergreen content filter
+# ---------------------------------------------------------------------------
+
+from engine.utils import drop_excluded_titles as _drop_excluded_titles
+
+
+class TestDropExcludedTitles:
+    """Suppress recurring almanac/evergreen titles (FF Ep087 shipped 12 as
+    100%-identical cross-episode repeats). Must drop the recurring content
+    while never touching real news."""
+
+    def test_no_patterns_is_noop(self):
+        arts = [{"title": "Anything goes"}]
+        kept, dropped = _drop_excluded_titles(arts, [])
+        assert dropped == 0 and kept == arts
+
+    def test_empty_articles(self):
+        assert _drop_excluded_titles([], ["x"]) == ([], 0)
+
+    def test_drops_real_ff_almanac_titles(self):
+        pats = [
+            r"full moon calendar", r"(moon|lunar) calendar",
+            r"this day in (space )?history", r"on \w+ \d{1,2},? 1[89]\d{2}",
+            r"evening skies?\b", r"highest point in (the )?(evening|morning) sky",
+            r"(super|blue|strawberry|blood)\s+moon\b",
+            r"best (telescopes?|binoculars?)\b",
+        ]
+        almanac = [
+            "Full Moon Calendar Lists All 2026 Dates and Phases",
+            "Venus Jupiter and Mercury Shine in June Evening Skies",
+            "Lick Observatory Ownership Transfers on June 1 1888",
+            "May Blue Moon Appears Smallest of 2026 in Global Photos",
+            "Mercury Reaches Highest Point in Evening Sky for 2026",
+            "The Best Telescopes for Beginners in 2026",
+        ]
+        kept, dropped = _drop_excluded_titles([{"title": t} for t in almanac], pats)
+        assert dropped == len(almanac) and kept == []
+
+    def test_keeps_real_news(self):
+        pats = [r"full moon calendar", r"evening skies?\b", r"(blue|super)\s+moon\b"]
+        news = [
+            "Giant Star Likely Destroyed in Rare Pair-Instability Supernova",
+            "China Launches Long March 12B on Unannounced Maiden Flight",
+            "Young Exoplanets Found With Longest Known Orbital Periods",
+        ]
+        arts = [{"title": t} for t in news]
+        kept, dropped = _drop_excluded_titles(arts, pats)
+        assert dropped == 0 and kept == arts
+
+    def test_case_insensitive(self):
+        kept, dropped = _drop_excluded_titles(
+            [{"title": "FULL MOON CALENDAR for the year"}], [r"full moon calendar"]
+        )
+        assert dropped == 1 and kept == []
+
+    def test_invalid_pattern_is_skipped_not_raised(self):
+        # A bad regex must not crash the fetch.
+        kept, dropped = _drop_excluded_titles(
+            [{"title": "Real news story"}], [r"(unclosed"]
+        )
+        assert dropped == 0 and len(kept) == 1
+
+
+def test_ff_yaml_exclude_patterns_filter_almanac_keep_news():
+    """End-to-end: the patterns committed in fascinating_frontiers.yaml drop
+    the recurring almanac titles and keep real news."""
+    from engine.config import load_config
+
+    cfg = load_config("shows/fascinating_frontiers.yaml")
+    assert cfg.exclude_title_patterns, "FF must declare exclude_title_patterns"
+    almanac = [
+        "Full Moon Calendar Lists All 2026 Dates and Phases",
+        "Venus Jupiter and Mercury Shine in June Evening Skies",
+        "Lick Observatory Ownership Transfers on June 1 1888",
+        "Mercury Reaches Highest Point in Evening Sky for 2026",
+    ]
+    news = [
+        "Giant Star Likely Destroyed in Rare Pair-Instability Supernova",
+        "Webb Telescope Reveals Water Vapor on Distant Exoplanet",
+    ]
+    kept, dropped = _drop_excluded_titles(
+        [{"title": t} for t in almanac + news], cfg.exclude_title_patterns
+    )
+    kept_titles = {a["title"] for a in kept}
+    assert dropped == len(almanac)
+    assert all(t in kept_titles for t in news)


### PR DESCRIPTION
## Why
FF Ep087 shipped **12 stories flagged as 100%-identical cross-episode repeats** — moon calendars (`Full Moon Calendar Lists All 2026 Dates`), planet-visibility roundups (`Venus Jupiter Mercury Shine in June Evening Skies`), and "this day in history" anniversaries (`Lick Observatory Ownership Transfers on June 1 1888`). These are evergreen content that Space.com / Astronomy.com republish daily. The cross-episode repeat check *detects* them but is non-blocking, so they ship anyway and pad the episode with stale, repetitive material.

## Fix — a per-show, fetch-time title-exclude filter
- **`engine.utils.drop_excluded_titles(articles, patterns)`** — drops articles whose title matches any case-insensitive regex; returns `(kept, dropped_count)`. Invalid regexes are warned + skipped, never raised.
- **`config.ShowConfig.exclude_title_patterns`** (default `[]`) — no-op for every other show, so they're byte-for-byte unchanged.
- Applied in **`run_show._fetch_with_expansion`** right after `fetch_rss_articles`, so excluded titles never reach dedup/the digest; logs the dropped count.
- **`fascinating_frontiers.yaml`** declares 15 conservative patterns: moon calendars, evening/morning-sky roundups, "this day in history" + dated (`18xx/19xx`) anniversaries, full-moon nicknames (blue/super/strawberry/…), telescope-deal/shopping posts, and meteor-shower how-tos.

## Verification
Tested against the **7 real almanac titles** from the Ep087 log → all dropped; and **7 real FF news titles** including the actual Ep087 lead story (`…Pair-Instability Supernova`), China launches, exoplanets, JWST → none dropped. Tests in `tests/test_utils.py`. **Full suite: 2373 passed.**

## Notes
- Conservative by design — it targets clearly-recurring almanac/shopping/anniversary phrasing, not real astronomy news. Easy to tune (just edit the YAML list).
- This is a content change (FF episodes will exclude these items), but deterministic and title-pattern-based — easy to A/B by diffing a fetch before/after. The patterns are reusable: any show can add `exclude_title_patterns` (e.g. a markets show dropping "best brokerage deals" roundups).
- Separately noted earlier and **not** in this PR: the broader cross-episode dedup also lets some *real* recent-news stories recur (a weaker fetch-time content-tracker vs. the validation check) — a follow-up if you want it.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_