### PR TITLE
Widen fetch-time URL dedup to 7 days so re-fetched stories drop before generation

### DIFF
--- a/engine/content_tracker.py
+++ b/engine/content_tracker.py
@@ -742,32 +742,44 @@ class ContentTracker:
         articles: List[Dict],
         similarity_threshold: float = 0.65,
         days: Optional[int] = None,
+        url_days: Optional[int] = None,
     ) -> List[Dict]:
         """Filter out articles that are too similar to recently covered stories.
 
         Uses two complementary checks:
-        1. **URL match** — catches the same story syndicated across sources
-           (different domains but identical path slug).
-        2. **Title similarity** — catches rephrased versions of the same story.
+        1. **URL match** — exact normalized-URL match means the *same article*
+           was re-fetched (publishers keep stories in their RSS feed for days,
+           so the same URL re-surfaces). This has zero false-positive risk, so
+           it uses a WIDER window (``url_days``, default 7 — matching the
+           validation-time cross-episode check ``get_recent_headlines(days=7)``).
+           Previously this used the same narrow 3-day window as title
+           similarity, so a story lingering in a feed for 4-7 days re-shipped
+           and was only caught (non-blocking) at validation. (FF Ep087.)
+        2. **Title similarity** — fuzzy, so it stays on the narrower ``days``
+           window to avoid dropping legitimately-distinct follow-up stories.
 
         More aggressive than the in-episode dedup (0.85 threshold) because
         cross-episode repetition is more noticeable to listeners.
         """
         day_window = days or 3
+        url_window = url_days or max(day_window, 7)
         recent_headlines = self.get_recent_headlines(days=day_window)
-        recent_urls = self.get_recent_urls(days=day_window)
+        recent_urls = self.get_recent_urls(days=url_window)
 
         if (not recent_headlines and not recent_urls) or not articles:
             return articles
 
         recent_norm = [norm_headline_for_similarity(h) for h in recent_headlines if h]
         filtered = []
+        url_dropped = 0
+        title_dropped = 0
         for article in articles:
             # URL-based check (exact path match ignoring query params)
             article_url = (article.get("url") or "").strip()
             if article_url and recent_urls:
                 norm_url = _normalize_url_for_dedup(article_url)
                 if norm_url and norm_url in recent_urls:
+                    url_dropped += 1
                     logger.debug(
                         "Filtering article by URL match: %s...", article_url[:80]
                     )
@@ -784,6 +796,7 @@ class ContentTracker:
                     continue
                 if calculate_similarity(norm_title, r) >= similarity_threshold:
                     is_repeat = True
+                    title_dropped += 1
                     logger.debug(
                         "Filtering recently-covered article: %s...", title[:60]
                     )
@@ -791,10 +804,12 @@ class ContentTracker:
             if not is_repeat:
                 filtered.append(article)
 
-        dropped = len(articles) - len(filtered)
+        dropped = url_dropped + title_dropped
         if dropped:
             logger.info(
-                "Filtered %d articles similar to recently covered stories", dropped
+                "Filtered %d articles similar to recently covered stories "
+                "(%d by URL ≤%dd, %d by title ≤%dd)",
+                dropped, url_dropped, url_window, title_dropped, day_window,
             )
         return filtered
 

--- a/tests/test_content_tracker.py
+++ b/tests/test_content_tracker.py
@@ -301,6 +301,60 @@ class TestFilterRecentArticles:
         filtered = tracker.filter_recent_articles(articles, similarity_threshold=0.65)
         assert len(filtered) == 2
 
+    def _ep(self, days_ago, headlines, urls):
+        d = (datetime.date.today() - datetime.timedelta(days=days_ago)).isoformat()
+        return {"date": d, "headlines": headlines, "urls": urls,
+                "quote_author": None, "sections": {}}
+
+    def test_url_match_drops_refetched_article_up_to_7_days(self, tmp_path):
+        """A publisher keeps a story in its feed for days; the SAME URL
+        re-surfacing 5 days later must be dropped even with the 3-day title
+        window, because URL-exact match has zero false-positive risk and uses
+        a 7-day window (matching the validation check). FF Ep087 lingering
+        almanac/news stories were missed here before."""
+        tracker = ContentTracker("test_show", tmp_path)
+        tracker.load()
+        tracker.data["episodes"].append(
+            self._ep(5, ["Pair-Instability Supernova Erases Massive Star"],
+                     ["https://space.com/pair-instability-supernova-2026"])
+        )
+        articles = [
+            # Same URL, rewritten title, 5 days old -> dropped by URL match.
+            {"title": "A completely rephrased headline about the star",
+             "url": "https://space.com/pair-instability-supernova-2026"},
+            {"title": "Brand new distinct discovery", "url": "https://space.com/fresh"},
+        ]
+        filtered = tracker.filter_recent_articles(articles, days=3)
+        urls = {a["url"] for a in filtered}
+        assert "https://space.com/pair-instability-supernova-2026" not in urls
+        assert "https://space.com/fresh" in urls
+
+    def test_title_similarity_stays_on_narrow_window(self, tmp_path):
+        """A title-similar (not URL-identical) story from 5 days ago is NOT
+        dropped under a 3-day title window — the fuzzy match must stay narrow
+        so legitimately-distinct follow-ups aren't over-filtered."""
+        tracker = ContentTracker("test_show", tmp_path)
+        tracker.load()
+        tracker.data["episodes"].append(
+            self._ep(5, ["Pair-Instability Supernova Erases Massive Star"],
+                     ["https://space.com/old-url"])
+        )
+        articles = [{"title": "Pair-Instability Supernova Erases Massive Star",
+                     "url": "https://space.com/today-different-url"}]
+        filtered = tracker.filter_recent_articles(articles, days=3)
+        assert len(filtered) == 1  # title match at 5d is beyond the 3d title window
+
+    def test_url_match_beyond_window_kept(self, tmp_path):
+        """A same-URL article older than the 7-day URL window is kept."""
+        tracker = ContentTracker("test_show", tmp_path)
+        tracker.load()
+        tracker.data["episodes"].append(
+            self._ep(9, ["Old Story"], ["https://space.com/nine-days-old"])
+        )
+        articles = [{"title": "Old Story resurfaces", "url": "https://space.com/nine-days-old"}]
+        filtered = tracker.filter_recent_articles(articles, days=3)
+        assert len(filtered) == 1
+
 
 class TestGetSummaryForPrompt:
     def test_empty_tracker_returns_empty(self, tmp_path):


### PR DESCRIPTION
## Why
Follow-up to the FF reviews: the **fetch-time** cross-episode dedup was weaker than the **validation-time** check, so real recurring stories slipped through to the digest.

- Fetch-time (`ContentTracker.filter_recent_articles`) used a **3-day** window for *both* URL and title matching.
- Validation (`get_recent_headlines(days=7)`) looks back **7 days**.

Publishers keep stories in their RSS feed for up to a week (Space.com, etc.), so a story lingering 4–7 days re-surfaced, **slipped past fetch dedup**, got regenerated into the digest, and was only caught at validation — which is non-blocking, so it was stripped post-hoc (wasting LLM tokens and thinning the digest). FF Ep087 is the smoking gun: fetch filtered **1**, validation flagged **12** as 100%-identical to recent stories.

## Fix
In `filter_recent_articles`, dedup **URLs over a wider window** (`url_days`, default `max(days, 7)`) while keeping the **fuzzy title-similarity on the narrow `days` window**.

A URL-exact match means the *same article* was re-fetched — **zero false-positive risk** — so widening it is safe and precise. It does **not** drop legitimately-distinct follow-up stories (those are only matched by the narrow title window, unchanged). Self-contained: the default closes the gap for **every show** with no `run_show` change. The summary log now splits URL-drops vs title-drops with their windows for visibility:
```
Filtered N articles … (X by URL ≤7d, Y by title ≤3d)
```

## Verification / tests
- A same-URL re-fetch at **5 days** now drops (was kept).
- A *title-similar* (not URL-identical) story at 5 days **still survives** the 3-day title window — no over-filtering of distinct follow-ups.
- A same-URL story at **9 days** is kept (beyond the 7-day window).
- **Full suite: 2376 passed.**

## Scope note
This catches the **same-article re-fetch** case (the main driver of real-news recurrence) precisely. It does *not* widen fuzzy title matching (deliberately — that risks dropping distinct same-topic stories). Combined with #524 (no spurious structural regen) and #525 (almanac filter), FF's repeat problem should be substantially resolved. Belt-and-suspenders: the validation-time exact-duplicate stripping still runs as the final net.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_