### PR TITLE
Stop repetition detector from forcing futile regenerations on structural template phrases

### DIFF
--- a/engine/generator.py
+++ b/engine/generator.py
@@ -524,12 +524,28 @@ def _validate_llm_output(
             # below trip the detector at high story counts even though
             # nothing is hallucinated. Spec v2 follow-up after Ep459.
             "it matters", "matters for", "this matters",
+            # Omni View "Steel Man" format (Phase 4): every story states
+            # "the strongest case for each side ... rests on ...". With
+            # 20-40 stories these per-story framing phrases recur 30-44x and
+            # tripped 3 futile digest regenerations (regen can't change a
+            # prompt-mandated format) — Ep068 burned ~6 min on this. Treat
+            # as structural, like "this matters for". (Genuine monotony of
+            # the steel-man framing is a separate prompt concern.)
+            "strongest case", "case for", "rests on", "the strongest",
+            "they differ", "differ on", "each side",
         }
         # Podcast scripts are longer and naturally have more repeated phrases
         _rep_threshold = 5 if stage == "podcast_script" else 4
         for phrase, count in bigram_counts.most_common(5):
             # Skip common phrases
             if phrase in _COMMON_BIGRAMS:
+                continue
+            # Bold markdown in a repeated phrase is a structural label/header
+            # (e.g. "**what happened (neutral):**", "**steel-man each side:**",
+            # "**memory hook:**") — never a hallucination loop, which lives in
+            # plain prose. Skip generically so per-story bold labels at high
+            # story counts don't trigger futile regenerations.
+            if "**" in phrase:
                 continue
             # Skip phrases that are mostly stopwords or very short tokens
             tokens = phrase.split()
@@ -582,6 +598,10 @@ def _validate_llm_output(
             "hook:** sounds like", "hook:** think of",
             "**example sentence:**", "example sentence: the",
             "**example translation:**",
+            # Omni View "Steel Man" per-story framing (Phase 4) — see the
+            # bigram allowlist above. Structural, not hallucination.
+            "the strongest case", "strongest case for", "rests on the",
+            "they differ on", "case for the", "differ on the",
         }
         # Regex patterns for pedagogical trigrams that can't be enumerated
         # (mirrors _PEDAGOGICAL_PATTERNS in review_episodes.py)
@@ -596,6 +616,10 @@ def _validate_llm_output(
         ]
         for phrase, count in trigram_counts.most_common(5):
             if phrase in _COMMON_TRIGRAMS:
+                continue
+            # Bold markdown = structural label/header, never a hallucination
+            # loop (see the bigram loop). Skip generically.
+            if "**" in phrase:
                 continue
             tokens = phrase.split()
             if all(len(t) <= 3 for t in tokens):

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -306,3 +306,58 @@ class TestSpeakerLabelRepetitionSkip:
                  " ".join(f"Word{i} filler text here." for i in range(60))
         n = validate(script, stage="podcast_script", show_name="Models & Agents")
         assert n >= 1, "genuine repetition must still be detected"
+
+
+class TestStructuralLabelAndSteelManRepetitionSkip:
+    """Omni View's 'Steel Man' format (Phase 4) emits per-story template
+    labels ('**what happened (neutral):**', '**steel-man each side:**') and
+    framing ('the strongest case for X rests on...') for every story. Across
+    20-40 stories these recur 30-44x and triggered 3 futile digest
+    regenerations (Ep068 burned ~6 min). They're structural — like the
+    already-allowlisted 'this matters for' — so the detector must not flag
+    them. Bold markdown labels are skipped generically; genuine prose loops
+    are still caught."""
+
+    def _validate(self):
+        from engine.generator import _validate_llm_output
+        return _validate_llm_output
+
+    def _steel_man_digest(self):
+        import random
+        random.seed(7)
+        words = ["alpha", "bravo", "cobalt", "delta", "ember", "flint", "gust",
+                 "hazel", "ion", "jade", "kelp", "lumen", "mica", "onyx", "pike",
+                 "quill", "rune", "sable", "tide", "umber", "vane", "wisp"]
+        uniq = lambda n: " ".join(random.choice(words) for _ in range(n))
+        parts = []
+        for i in range(20):
+            parts.append(
+                f"{i+1}. **What happened (neutral):** {uniq(12)}. "
+                f"**Steel-man each side:** The strongest case for {uniq(2)} rests "
+                f"on {uniq(8)}. The strongest case for {uniq(2)} rests on {uniq(8)}. "
+                f"They differ on {uniq(3)}."
+            )
+        return "# Omni View\n\n" + "\n\n".join(parts)
+
+    def test_steel_man_template_not_flagged(self):
+        n = self._validate()(self._steel_man_digest(), stage="digest",
+                             show_name="Omni View")
+        assert n == 0, f"steel-man template phrases must not flag (got {n})"
+
+    def test_bold_label_phrases_skipped(self):
+        # A bold label repeated many times must never count (the surrounding
+        # prose is unique per line so only the label repeats).
+        import random
+        random.seed(3)
+        words = ["alpha", "bravo", "cobalt", "delta", "ember", "flint", "gust",
+                 "hazel", "ion", "jade", "kelp", "lumen", "mica", "onyx", "pike"]
+        uniq = lambda n: " ".join(random.choice(words) for _ in range(n))
+        txt = "# X\n\n" + "\n".join(
+            f"{i}. **Memory Hook:** {uniq(9)}." for i in range(30)
+        )
+        assert self._validate()(txt, stage="digest", show_name="Test") == 0
+
+    def test_genuine_prose_loop_still_caught(self):
+        txt = ("# X\n\n" + ("the engine stalls and the engine stalls once more. " * 8)
+               + " ".join(f"separate remark {i} on a distinct subject." for i in range(40)))
+        assert self._validate()(txt, stage="digest", show_name="Test") >= 1


### PR DESCRIPTION
## Context
While reviewing today's lateness (issue #534) and the Omni View Ep068 log, I found a fixable contributor to the slow pipeline: the repetition detector burning **3 futile digest regenerations** on Omni View's own prompt format.

## The bug
Omni View's "Steel Man" format (Phase 4) makes every story emit `**What happened (neutral):**`, `**Steel-man each side:**`, and `the strongest case for X rests on…`. Across 20–40 stories those recur **30–44×**, so the detector flagged ~9–10 "suspicious" phrases and triggered retries. But regeneration can't change a prompt-mandated format — Ep068's counts went **9 → 9 → 10 → 9** across three regens, each a full LLM call (~40s + cost), pure waste that compounded the day's lateness. This is the same class as the already-allowlisted `"this matters for"` and the `Host:` speaker-label skip.

## Fix (`engine.generator._validate_llm_output`)
- **Generic bold-label skip:** any repeated bigram/trigram containing `**` is a structural markdown label/header (`**memory hook:**`, `**steel-man each side:**`) — never a hallucination loop (those are plain prose). Skip it.
- **Allowlist the steel-man framing** bigrams/trigrams (`strongest case`, `rests on`, `they differ on`, `the strongest case`, `strongest case for`, …) as per-story template, exactly like `this matters for`.

Genuine plain-prose repetition loops are **still caught** (verified). This only stops the futile *retries* — it does not touch (and is not meant to fix) the steel-man framing's audible monotony or Omni's over-long/truncated digest (see below).

## Tests
`TestStructuralLabelAndSteelManRepetitionSkip` — steel-man template + bold labels not flagged; genuine prose loop still caught. **Full suite: 2379 passed.**

## What this does NOT fix (flagged for follow-up — see my message)
- The lateness itself (GitHub scheduled-trigger delay, external).
- Omni's digest is **too long → token-truncated → "Top Stories" missing → a 232s missing-section regen** (the single biggest time sink in Ep068). That's a prompt/length fix (fewer stories) and needs an A/B listen.
- Steel-man monotony, garbled TTS names, low Listener Value — content/prompt items.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_