### PR TITLE
Fix Omni View: validation regex never matched header (every-episode regen) + over-long digest

### DIFF
--- a/engine/validation.py
+++ b/engine/validation.py
@@ -519,9 +519,16 @@ def ov_validation_config() -> ValidationConfig:
             SectionRule(
                 name="Top Stories",
                 pattern=(
-                    r"(?:### Top \d+|### Today's Top)"
+                    # Omni View's digest leads with "## Top stories (5)"
+                    # (level-2 header, lowercase, count suffix). The old
+                    # `### Top \d+` pattern never matched it, so "Top Stories
+                    # missing" fired a full digest regenerate on EVERY episode
+                    # (Ep068 burned ~232s on it). Match the real header (and
+                    # keep the legacy forms as fallbacks).
+                    r"(?:#{2,3}\s*Top stories|#{2,3}\s*Today's Top|### Top \d+)"
                     r"(.*?)"
-                    r"(?=━━|### (?:Deep Dive|Closing)|$)"
+                    r"(?=━━|#{2,3}\s*Top world|#{2,3}\s*Top business|"
+                    r"### (?:Deep Dive|Closing)|$)"
                 ),
                 min_items=5,
             ),

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -151,7 +151,12 @@ llm:
   podcast_prompt_file: shows/prompts/omni_view_podcast.txt
   digest_temperature: 0.5
   podcast_temperature: 0.7
-  max_tokens: 4000
+  # Steel-man format is verbose (~1.6k chars/story). 4000 truncated the
+  # 22-story digest mid-way (losing the later sections + tripping retries);
+  # the story count is now 12 (5+2+2+1+1+1) and this gives headroom to
+  # finish all sections without truncation. Digest still lands well under
+  # the 30k-char "too long" guard.
+  max_tokens: 10000
   podcast_max_tokens: 8000
   min_podcast_words: 900
 

--- a/shows/prompts/omni_view_digest.txt
+++ b/shows/prompts/omni_view_digest.txt
@@ -23,11 +23,11 @@ Write a single website-friendly markdown briefing with this exact structure and 
 **HOOK:** [One sentence (under 120 characters) that captures today's most important or widely discussed story. **Lead with the stake — what it means for ordinary people, regional stability, or the global outlook — then the fact.** Compare: WEAK ("UK local elections deliver heavy losses for Labour while Reform UK and pro-independence parties advance.") vs STRONG ("Britain's two-party stability just fractured: Labour bled councils to Reform UK and the SNP in a result not seen since the 1980s."). WEAK ("Pakistan launches airstrikes on Afghanistan.") vs STRONG ("Pakistan and Afghanistan are now openly at war on the border, with both sides reporting heavy casualties."). Specific and engaging, not hype. No URLs, no dates, no emoji.]
 
 ## Top stories (5)
-## Top world stories (5)
-## Top business stories (3)
-## Top technology stories (3)
-## Top popular media stories (3)
-## Top gossip stories (3)
+## Top world stories (2)
+## Top business stories (2)
+## Top technology stories (1)
+## Top popular media stories (1)
+## Top gossip stories (1)
 
 Rules:
 - Do NOT repeat the same story across sections.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -499,7 +499,9 @@ class TestLoadConfigRealFiles:
         assert "election" in cfg.keywords
         assert cfg.llm.model == "grok-4.3"
         assert cfg.llm.digest_temperature == 0.5
-        assert cfg.llm.max_tokens == 4000
+        # Raised 4000 -> 10000 so the steel-man digest (now 12 stories)
+        # completes without truncation. See shows/omni_view.yaml.
+        assert cfg.llm.max_tokens == 10000
         assert cfg.tts.stability == 0.5
         assert cfg.tts.style == 0.0
         # OV got its own dedicated theme in May 2026 (replaced LubechangeOilers.mp3).

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -392,3 +392,27 @@ class TestPrebuiltConfigs:
     def test_ov_config(self):
         config = ov_validation_config()
         assert len(config.sections) > 0
+
+
+def test_ov_top_stories_matches_real_header():
+    """Omni View's digest header is '## Top stories (5)' (level-2, lowercase,
+    count suffix). The old `### Top \\d+` pattern never matched it, so 'Top
+    Stories missing' fired a full digest regenerate on EVERY episode (Ep068
+    ~232s). Pin the corrected pattern against the real header shape."""
+    digest = (
+        "# Omni View\n\n**HOOK:** Something happened.\n\n"
+        "## Top stories (5)\n"
+        "### 1) A neutral headline about the lead story today\n"
+        "**What happened (neutral):** Plain-language summary of the event.\n"
+        "**Steel-man each side:** The strongest case for one side rests on X. "
+        "The strongest case for the other rests on Y.\n\n"
+        "### 2) A second neutral headline covering another major story\n"
+        "**What happened (neutral):** Another summary here.\n"
+        "**Steel-man each side:** Both sides framed fairly here.\n\n"
+        "### 3) Third headline\n**What happened (neutral):** x.\n**Steel-man each side:** y.\n\n"
+        "### 4) Fourth headline\n**What happened (neutral):** x.\n**Steel-man each side:** y.\n\n"
+        "### 5) Fifth headline\n**What happened (neutral):** x.\n**Steel-man each side:** y.\n\n"
+        "## Top world stories (2)\n### 6) World headline\n**What happened (neutral):** z.\n"
+    )
+    passed, issues, _ = validate_digest(digest, ov_validation_config())
+    assert not any("Top Stories" in i for i in issues), issues


### PR DESCRIPTION
## Context
Follow-up to the lateness review — Omni View Ep068 took ~8 min and truncated. Two distinct problems:

## 1. Validation regex never matched the header — a chronic every-episode regen (the big one)
Omni's digest leads with `## Top stories (5)` (level-2 header, lowercase, count suffix), but `ov_validation_config`'s "Top Stories" pattern looked for `### Top \d+`. **They never match** — verified against committed Ep067 and Ep068 — so "Top Stories missing" fired a full **~232s digest regenerate on *every* Omni episode**. This was the single biggest time sink in Ep068 and pure waste.

**Fix:** match the real header (`#{2,3}\s*Top stories`, legacy `### Top \d+` / `### Today's Top` kept as fallbacks) with a proper section-end lookahead. Validation now passes cleanly on the real digest.

## 2. Over-long / truncated digest (you approved capping to ~10–12)
The Steel Man format (~1.6k chars/story) was applied to **22 stories** (5+5+3+3+3+3) → 31k chars, truncating at `max_tokens` (4000 → 6000 retry still truncated) and cutting off the later sections.

**Fix:** reduce to **12 stories** (5+2+2+1+1+1 — "Top stories" stays at the prompt-mandated 5) and raise digest `max_tokens` 4000 → 10000 so all sections complete. The digest now lands ~17k chars (under the 30k "too long" guard), and since the podcast only used ~1.2k words anyway, nothing of value is lost — but the steel-man monotony drops (fewer stories, same depth).

## Tests
- `test_ov_top_stories_matches_real_header` pins the corrected pattern against the real `## Top stories` shape.
- Omni `max_tokens` assertion updated 4000 → 10000.
- **Full suite: 2380 passed.**

## Note
Fix #1 is a pure bug fix (no content change). Fix #2 (the story-count cap) **does** change Omni's generated content — fewer stories per episode — so it's worth an A/B listen, per your earlier guidance. Easy one-line revert of the counts if you don't like it. Combined with #536 (repetition retries) this should bring Omni's per-episode time down dramatically (from ~8 min toward the network's ~2 min norm).

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_