### PR TITLE
YouTube SEO: front-load hook in titles + add entity hashtags to long-form

### DIFF
--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -106,6 +106,35 @@ def _truncate(text: str, max_len: int) -> str:
     return text[: max_len - 3].rstrip() + "..."
 
 
+def _build_seo_title(hook: str, show_name: str, *, suffix: str = "") -> str:
+    """Build a search-optimised YouTube title that FRONT-LOADS the hook.
+
+    YouTube weights the first words of a title most heavily for search and
+    viewers scan the start, so the keyword-rich episode hook leads — not the
+    show name + "Ep N" (which wasted the most valuable real estate and isn't
+    searched). Shape: ``"<hook> | <show>[ <suffix>]"``, trimmed to fit
+    ``YOUTUBE_TITLE_MAX``. If the hook alone is too long the hook wins (keywords
+    matter most) and the show-name tail is dropped; a ``suffix`` like
+    ``#Shorts`` (the Shorts classifier hint) is preserved when possible.
+    """
+    hook = (hook or "").strip().rstrip(".")
+    show = (show_name or "").strip()
+    suffix = (suffix or "").strip()
+    if not hook:
+        base = f"{show} {suffix}".strip()
+        return _truncate(base, YOUTUBE_TITLE_MAX)
+    tail = f" | {show}" if show else ""
+    if suffix:
+        tail = f"{tail} {suffix}" if tail else f" {suffix}"
+    if len(hook) + len(tail) <= YOUTUBE_TITLE_MAX:
+        return (hook + tail).strip()
+    # Hook + show won't both fit — keep the #Shorts suffix (classifier) if it
+    # fits, otherwise the hook alone (truncated). Keywords > show name.
+    if suffix and len(hook) + 1 + len(suffix) <= YOUTUBE_TITLE_MAX:
+        return f"{hook} {suffix}"
+    return _truncate(hook, YOUTUBE_TITLE_MAX)
+
+
 # ---------------------------------------------------------------------------
 # Chapter formatting
 # ---------------------------------------------------------------------------
@@ -272,10 +301,13 @@ def build_long_form_metadata(
         getattr(config.publishing, "rss_title", "")
         or getattr(config, "name", "")
     )
-    title_seed = f"{rss_title} — Ep {episode_num}: {hook}" if hook else (
-        f"{rss_title} — Ep {episode_num} — {today_str}"
-    )
-    title = _truncate(title_seed.strip(), YOUTUBE_TITLE_MAX)
+    # SEO: front-load the keyword-rich hook (was "{show} — Ep N: {hook}",
+    # which buried the topic behind the show name + episode number).
+    if hook:
+        title = _build_seo_title(hook, rss_title)
+    else:
+        title = _truncate(f"{rss_title} — Ep {episode_num} — {today_str}".strip(),
+                          YOUTUBE_TITLE_MAX)
 
     base_url = getattr(config.publishing, "base_url",
                        "https://nerranetwork.com").rstrip("/")
@@ -333,6 +365,20 @@ def build_long_form_metadata(
         cleaned = [line.strip() for line in photo_attribution if line.strip()]
         if cleaned:
             pieces.append("Photos via Pexels:\n" + "\n".join(cleaned))
+    # SEO: entity hashtags so YouTube renders the first 3 as clickable topic
+    # links above the title (a discovery lever Shorts already had but long-form
+    # was missing). Same heuristic extractor as Shorts; static tail "#podcast".
+    try:
+        from engine.shorts_hashtags import extract_hashtags, format_hashtag_line
+        _extracted = extract_hashtags(
+            hook, show_keywords=list(getattr(config, "keywords", []) or []),
+            max_hashtags=5,
+        )
+        _hashtag_line = format_hashtag_line(_extracted, ("#podcast",))
+        if _hashtag_line:
+            pieces.append(_hashtag_line)
+    except Exception:  # noqa: BLE001 — hashtags must never block an upload
+        pass
     disclosure = (config.youtube.synthetic_disclosure or "").strip()
     if disclosure:
         pieces.append(disclosure)
@@ -392,8 +438,9 @@ def build_short_metadata(
         or getattr(config, "name", "")
     )
     headline = hook.strip() if hook else f"Ep {episode_num} highlight"
-    title_seed = f"{headline} | {rss_title} #Shorts"
-    title = _truncate(title_seed.strip(), YOUTUBE_TITLE_MAX)
+    # Same front-loaded builder as long-form; keeps the #Shorts classifier
+    # hint even when the headline is long.
+    title = _build_seo_title(headline, rss_title, suffix="#Shorts")
 
     pieces: List[str] = [headline]
     if long_form_url:

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -252,12 +252,52 @@ def test_build_long_form_metadata_truncates_title_to_100_chars():
         config,
         episode_num=1,
         today_str="2026-04-26",
-        hook="Y" * 80,
+        hook="Y" * 120,  # hook alone exceeds the 100-char cap
         digest_text="A short digest body.",
         audio_url="https://audio.nerranetwork.com/tesla/ep001.mp3",
     )
     assert len(meta["title"]) <= vm.YOUTUBE_TITLE_MAX
     assert meta["title"].endswith("...")
+
+
+def test_long_form_title_front_loads_hook_for_seo():
+    """The keyword-rich hook must lead the title (it's what viewers scan and
+    YouTube weights most), not the show name + 'Ep N'."""
+    config = _make_config(rss_title="Tesla Shorts Time")
+    meta = vm.build_long_form_metadata(
+        config, episode_num=7, today_str="2026-04-26",
+        hook="Cybercab gets a wireless battery system",
+        digest_text="body", audio_url="https://x/ep.mp3",
+    )
+    title = meta["title"]
+    assert title.startswith("Cybercab gets a wireless battery system")
+    assert "| Tesla Shorts Time" in title
+    assert "Ep 7" not in title  # episode number no longer clutters the title
+
+
+def test_long_form_description_has_entity_hashtags():
+    """Long-form descriptions now carry entity hashtags (Shorts already did),
+    so YouTube renders the first 3 as clickable topic links above the title."""
+    config = _make_config()
+    meta = vm.build_long_form_metadata(
+        config, episode_num=7, today_str="2026-04-26",
+        hook="Tesla Cybercab unveiled with new battery",
+        digest_text="body", audio_url="https://x/ep.mp3",
+    )
+    hashtag_lines = [l for l in meta["description"].splitlines() if l.strip().startswith("#")]
+    assert hashtag_lines, "long-form description should contain a hashtag line"
+    assert "#podcast" in hashtag_lines[0]
+    # At least one entity hashtag derived from the hook.
+    assert any("#Tesla" in l or "#Cybercab" in l for l in hashtag_lines)
+
+
+def test_short_title_keeps_shorts_suffix_when_hook_is_long():
+    """When the headline is long, the #Shorts classifier hint must survive
+    even if the show name is dropped."""
+    config = _make_config(rss_title="Tesla Shorts Time")
+    title = vm._build_seo_title("Z" * 88, "Tesla Shorts Time", suffix="#Shorts")
+    assert len(title) <= vm.YOUTUBE_TITLE_MAX
+    assert title.endswith("#Shorts")
 
 
 def test_build_long_form_metadata_includes_disclosure_and_utm():


### PR DESCRIPTION
## Context
You've been getting "pay me to fix your YouTube SEO" DMs — those are spam; nobody can do anything you can't do yourself through metadata + content. This PR makes two concrete, deterministic SEO improvements to the existing video-metadata builders (no audio/prompt changes, so nothing to A/B-listen).

## Changes
**1. Front-loaded titles (biggest lever).** Long-form titles were `"{show} — Ep {N}: {hook}"`, burying the keyword-rich topic behind the show name + episode number — the part viewers ignore and search weights least. New shared `_build_seo_title()` leads with the **hook**, then `| {show}`:
- before: `Tesla Shorts Time — Ep 497: Cybercab gets a wireless battery system`
- after: `Cybercab gets a wireless battery system | Tesla Shorts Time`

Shorts already front-loaded; they now use the same helper (which also keeps the `#Shorts` classifier hint when a headline is long). Episode number stays in the description, out of the title.

**2. Entity hashtags on long-form descriptions.** Shorts carried entity hashtags (YouTube renders the **first 3 as clickable topic links above the title** — a top discovery lever); long-form didn't. Long-form now reuses the same heuristic extractor with a `#podcast` tail, e.g. `#TeslaCybercab #Tsla #Model3 #ModelY #ModelS #podcast`. Best-effort — never blocks an upload.

## Tests
Front-loaded title, episode number absent from title, long-form hashtag line present, Shorts `#Shorts` suffix survives a long headline, and the >100-char truncation path. **Full suite: 2383 passed.**

## The rest of the SEO/growth review (no code — playbook in my message)
The pipeline already does the hard technical SEO well (chapters, uploaded captions/transcripts = searchable, playlists, UTM links, end-card, thumbnails). The remaining levers are operator/content ones I'll lay out — none require paying anyone.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_