### PR TITLE
Make daily-audit + nightly-maintenance run once per day (drop per-show triggers)

### DIFF
--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -26,8 +26,17 @@ name: Daily Audit & Automated Remediation
 
 on:
   schedule:
-    # Safety net + primary daily audit slot (after last show ~11:30 UTC)
-    - cron: '15 12 * * *'
+    # Missed-episode sweep + issue creation. Runs LATE enough that the day's
+    # slate has actually finished. The scheduled crons end at 11:30 UTC, but
+    # GitHub Actions routinely delivers scheduled events hours late (observed
+    # 3-6h in May-Jun 2026), so shows can finish as late as ~16:00 UTC. The
+    # old 12:15 slot ran *before* the tail and produced false "missed episode"
+    # alarms + spurious auto-retries (e.g. 2026-06-02: audit at 12:15 flagged
+    # MIT/Tesla/UC missed; they actually published at 14:21/14:59/15:51).
+    # Per-episode quality review still runs immediately via the workflow_run
+    # trigger below, so this later slot only delays the missed-sweep, not the
+    # quality checks. Tune later if GitHub delays worsen.
+    - cron: '15 16 * * *'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -54,9 +54,10 @@ on:
         default: "true"
         type: string
 
-  workflow_run:
-    workflows: ["Run Podcast Show"]
-    types: [completed]
+# Runs ONCE per day (the 16:15 cron) + on manual dispatch. Previously it also
+# triggered on every "Run Podcast Show" completion (workflow_run), so it ran
+# ~10x/day; that per-episode trigger was removed — the once-daily sweep already
+# reviews ALL of the day's committed episodes via discover_episodes().
 
 permissions:
   contents: read
@@ -70,8 +71,6 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Skip only if the triggering run-show job itself failed
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -20,12 +20,17 @@ name: Nightly Maintenance
 
 on:
   schedule:
-    # ~30-45 min after the last show (Unintended Consequences at 11:30 UTC)
-    - cron: '45 12 * * *'
+    # Runs ONCE per day, after the day's slate has finished. The crons end at
+    # 11:30 UTC but GitHub delivers scheduled events 3-6h late (observed
+    # May-Jun 2026), so shows finish as late as ~16:00. Run at 16:45 so the
+    # regenerated dashboard / gallery / search index / narrative pages reflect
+    # the whole day. Previously this also triggered on every "Run Podcast Show"
+    # completion (workflow_run) — that ran it ~10x/day and churned the repo
+    # with redundant maintenance commits; the per-show trigger was removed.
+    # (Each show already refreshes the shared site pages in its own finalize
+    # step, so intraday freshness is unaffected.)
+    - cron: '45 16 * * *'
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Run Podcast Show"]
-    types: [completed]
 
 permissions:
   contents: write
@@ -37,7 +42,6 @@ concurrency:
 jobs:
   generate-artifacts:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## What you asked for
Make the **daily audit** and **nightly maintenance** each run **once per day** (not after every show).

## The problem
Both workflows triggered on `workflow_run: ["Run Podcast Show"] completed`, so they ran after **every** show — ~10–11×/day. Today (2026-06-02) there were ~11 "Nightly maintenance" commits, churning the repo with redundant dashboard/maintenance commits, and the audit's missed-sweep ran repeatedly.

On top of that, the audit's cron (12:15 UTC) ran *before* the GitHub-delayed slate finished, producing false "missed episode" alarms (today it flagged MIT/Tesla/UC missed; they published at 14:21/14:59/15:51 — one episode each, no real miss, **no duplicate**).

## The fix
Removed the `workflow_run` (per-show) trigger from **both** workflows. They now run **once per day** on their cron + manual dispatch:
- **daily-audit → 16:15 UTC.** The once-daily sweep already reviews *all* of the day's committed episodes via `discover_episodes()`, so per-episode review isn't lost — just consolidated into one accurate run after the slate finishes.
- **nightly-maintenance → 16:45 UTC** (moved from 12:45). Runs after the (delayed) slate so the regenerated dashboard / gallery / search index / narrative pages reflect the whole day. Each show already refreshes the shared site pages in its own finalize step, so intraday freshness is unaffected.

Also dropped the now-dead `if: github.event_name != 'workflow_run' || …` job guards in both.

## Safety
- Workflow-only change; YAML validated; the two related tests (`test_daily_audit_notify_policy`, `test_show_scaffold`) pass.
- Trade-off (intended): the audit/maintenance reports/pages update once daily after the slate rather than continuously. Both still support manual `workflow_dispatch` for an on-demand run.
- Root-cause of lateness (GitHub scheduled-trigger delay) remains external; this just stops the repeated runs + false alarms.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC