### PR TITLE
Newsletter visual polish v2: one footer CTA, subtle share links, less button noise

### DIFF
--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -950,7 +950,7 @@ def _build_reply_share_html(
             '💬 <strong>Reply to this email</strong> — '
             'Patrick reads every one.'
         )
-        share_text = f"I'm reading {name} this week — give it a listen:"
+        share_text = f"I'm enjoying {name} — give it a listen:"
         share_x_label = "Share on X"
         share_li_label = "Share on LinkedIn"
         share_wa_label = "Share on WhatsApp"
@@ -970,19 +970,26 @@ def _build_reply_share_html(
         + _u.urlencode({"text": f"{share_text} {target}"})
     )
 
-    def _chip(href: str, label: str) -> str:
-        # Border uses a solid neutral slate (#cbd5e1) instead of the
-        # brand-color-with-alpha (`{brand}55`) that Outlook desktop
-        # strips down to a full-saturation brand border. Solid slate
-        # gives the chip clear definition on white in every client
-        # without competing with the brand-color text.
+    # Share intents are low-conversion in email, so they're rendered as one
+    # subtle text line (not competing pill buttons) — the reply CTA above is
+    # the high-value action and stays prominent.
+    def _share_link(href: str, label: str) -> str:
         return (
             f'<a href="{href}" '
-            f'style="display:inline-block;color:{brand};text-decoration:none;'
-            f'font-weight:600;font-size:13px;padding:6px 12px;'
-            f'margin:2px;border:1px solid #cbd5e1;border-radius:100px;'
-            f'background:#ffffff;">{label}</a>'
+            f'style="color:#64748b;text-decoration:none;font-weight:600;">'
+            f'{label}</a>'
         )
+
+    share_label = "Поделиться:" if is_russian else "Share:"
+    share_line = (
+        '<p class="text-muted" '
+        'style="font-size:12px;color:#64748b;margin:0;line-height:1.5;">'
+        f'{share_label} '
+        + _share_link(twitter, "X") + ' · '
+        + _share_link(linkedin, "LinkedIn") + ' · '
+        + _share_link(whatsapp, "WhatsApp")
+        + '</p>'
+    )
 
     return (
         '<table role="presentation" width="100%" cellpadding="0" '
@@ -993,14 +1000,10 @@ def _build_reply_share_html(
         'style="padding:8px 16px 20px;'
         "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',"
         'Roboto,Helvetica,Arial,sans-serif;color:#475569;">'
-        '<p style="font-size:13px;margin:0 0 10px;line-height:1.5;">'
+        '<p style="font-size:14px;margin:0 0 8px;line-height:1.5;">'
         f'{reply_html}'
         '</p>'
-        '<div>'
-        + _chip(twitter, share_x_label)
-        + _chip(linkedin, share_li_label)
-        + _chip(whatsapp, share_wa_label)
-        + '</div>'
+        f'{share_line}'
         '</td></tr></table>'
     )
 
@@ -1088,8 +1091,30 @@ def _build_footer_html(show: Dict[str, str]) -> str:
         )
 
     listen = _btn(show["show_page"], "▶ Listen to the podcast")
-    watch = _btn(show["youtube_playlist_url"], "📺 Watch on YouTube")
-    blog = _btn(show["blog_page"], "📝 Read the blog")
+
+    # Secondary destinations as subtle text links (not competing buttons) so
+    # the footer has ONE primary CTA. Watch/Blog were full brand buttons.
+    def _link(href: str, label: str) -> str:
+        if not href:
+            return ""
+        return (
+            f'<a href="{href}" '
+            f'style="color:#64748b;text-decoration:none;font-weight:600;">'
+            f'{label}</a>'
+        )
+
+    secondary_links = [
+        l for l in (
+            _link(show["youtube_playlist_url"], "📺 Watch on YouTube"),
+            _link(show["blog_page"], "📝 Read the blog"),
+        ) if l
+    ]
+    secondary = (
+        '<p class="text-muted" style="font-size:13px;color:#64748b;'
+        'margin:14px 0 0;line-height:1.6;">'
+        + ' &nbsp;·&nbsp; '.join(secondary_links)
+        + '</p>'
+    ) if secondary_links else ""
 
     return (
         f'<table role="presentation" width="100%" cellpadding="0" '
@@ -1100,12 +1125,8 @@ def _build_footer_html(show: Dict[str, str]) -> str:
         f'style="padding:32px 24px;'
         f"font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',"
         f'Roboto,Helvetica,Arial,sans-serif;color:#0f172a;">'
-        f'<p style="font-size:14px;color:#475569;margin:0 0 16px;">'
-        f'Catch up on more {name}:'
-        f'</p>'
-        f'<div style="line-height:1.8;">'
-        f'{listen}{watch}{blog}'
-        f'</div>'
+        f'<div>{listen}</div>'
+        f'{secondary}'
         # AI-disclosure line — bumped from #94a3b8 (3.0:1 on white) to
         # #475569 (6.4:1) so light-mode hits AA. Spec §1.3.
         # The voice provider is now "Grok TTS (xAI)" for every show

--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -931,7 +931,6 @@ def _build_reply_share_html(
     Buttondown's per-issue archive URL isn't known until after send).
     """
     name = show["name"]
-    brand = show["brand_color"]
     target = (archive_url or show["show_page"]).strip()
 
     # Russian-language localization for the reply CTA + share text.
@@ -942,18 +941,12 @@ def _build_reply_share_html(
             'Патрик читает каждое.'
         )
         share_text = f'Слушаю «{name}» — рекомендую:'
-        share_x_label = "Поделиться в X"
-        share_li_label = "Поделиться в LinkedIn"
-        share_wa_label = "Поделиться в WhatsApp"
     else:
         reply_html = (
             '💬 <strong>Reply to this email</strong> — '
             'Patrick reads every one.'
         )
         share_text = f"I'm enjoying {name} — give it a listen:"
-        share_x_label = "Share on X"
-        share_li_label = "Share on LinkedIn"
-        share_wa_label = "Share on WhatsApp"
 
     # Pre-encode the share intents (URL-encoded query strings).
     import urllib.parse as _u
@@ -1104,10 +1097,10 @@ def _build_footer_html(show: Dict[str, str]) -> str:
         )
 
     secondary_links = [
-        l for l in (
+        link for link in (
             _link(show["youtube_playlist_url"], "📺 Watch on YouTube"),
             _link(show["blog_page"], "📝 Read the blog"),
-        ) if l
+        ) if link
     ]
     secondary = (
         '<p class="text-muted" style="font-size:13px;color:#64748b;'

--- a/tests/test_newsletter_template.py
+++ b/tests/test_newsletter_template.py
@@ -601,10 +601,12 @@ def test_reply_share_renders_three_intents():
     show = nt._load_show_branding("tesla")
     out = nt._build_reply_share_html(show)
     assert "Reply to this email" in out
-    assert "Share on X" in out
-    assert "Share on LinkedIn" in out
-    assert "Share on WhatsApp" in out
-    # Twitter intent uses query params.
+    # Share intents are now a subtle "Share: X · LinkedIn · WhatsApp" text
+    # line (not competing pill buttons), but all three intents still render.
+    assert "Share:" in out
+    assert ">X</a>" in out
+    assert ">LinkedIn</a>" in out
+    assert ">WhatsApp</a>" in out
     assert "twitter.com/intent/tweet" in out
     assert "linkedin.com/sharing" in out
     assert "wa.me" in out
@@ -646,7 +648,7 @@ def test_wrap_with_branding_full_render_order_with_engagement_blocks():
     body = out.find("## Body content")
     p_s = out.find("One more thing.")
     cross = out.find("Across the Nerra Network")
-    share = out.find("Share on X")
+    share = out.find("Share:")
     foot = out.find("Listen to the podcast")
     # Documented block order (preheader → hero → stats → featured →
     # body → p_s → cross-network → reply/share → footer).
@@ -663,7 +665,7 @@ def test_wrap_with_branding_omits_engagement_blocks_by_default():
     )
     assert "10 minutes" not in out
     assert "Across the Nerra Network" not in out
-    assert "Share on X" not in out
+    assert "Share:" not in out
 
 
 def test_wrap_with_branding_show_reply_share_default_is_on():


### PR DESCRIPTION
## Context
Continuing the newsletter visual cleanup (after #544's headline/cadence/typography pass). This cuts the "too many buttons" busyness. Rendered sample sent in chat.

## Changes (template-level → all newsletters)
- **Footer:** was 3 full brand buttons (Listen / Watch / Blog). Now **one** primary `▶ Listen to the podcast` button + Watch / Blog as small secondary **text links**. One clear primary action instead of three competing ones.
- **Share row:** the 3 share **pill buttons** (Share on X / LinkedIn / WhatsApp) → one subtle `Share: X · LinkedIn · WhatsApp` text line (intents preserved). The `💬 Reply to this email` CTA stays prominent — that's the high-value, deliverability-positive action; share is low-conversion in email.
- **Copy:** `I'm reading {name} this week` → `I'm enjoying {name}` ("this week" was wrong on dailies).

## Net effect
The email now has a single obvious primary CTA (Listen), the share/secondary stuff recedes to quiet text, and there's less rounded-box visual noise. Combined with #544, the top of the email is one clean headline + one CTA, then the (now 16px) story.

## Safety
All colors kept ≥4.5:1 — the contrast validator caught and **blocked** an earlier `#94a3b8` share line (2.56:1) during testing; bumped to `#64748b` (4.67:1). Tests updated for the new share markup (the three share intents are still asserted present). **Full suite: 2395 passed.**

## Still optional (your call)
If you want it leaner still: slim/flatten the "Across the Nerra Network" card to a one-line "More from the network →", or reduce the hero. Tell me after you see the sample.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_