### PR TITLE
Newsletter visual polish v3: lighten the cross-network module

### DIFF
--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -891,19 +891,23 @@ def _build_cross_network_html(
         )
     if not rows:
         return ""
+    # Light treatment: white background + a thin top rule instead of a solid
+    # slate "card", so this reads as a quiet "more from the network" list near
+    # the foot of the email rather than another competing panel.
     return (
         '<table role="presentation" width="100%" cellpadding="0" '
         'cellspacing="0" border="0" '
-        'class="surface-f8fafc" '
-        'style="background:#f8fafc;">'
+        'class="surface-white" '
+        'style="background:#ffffff;">'
         '<tr><td '
-        'style="padding:24px;'
+        'style="padding:8px 24px 4px;border-top:1px solid #e2e8f0;'
         "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',"
         'Roboto,Helvetica,Arial,sans-serif;">'
         '<div class="text-muted" '
         'style="font-size:11px;font-weight:700;color:#475569;'
-        'letter-spacing:0.08em;text-transform:uppercase;margin-bottom:8px;">'
-        '🌐 Across the Nerra Network'
+        'letter-spacing:0.08em;text-transform:uppercase;'
+        'margin:16px 0 4px;">'
+        '🌐 More from the Nerra Network'
         '</div>'
         '<table role="presentation" width="100%" cellpadding="0" '
         'cellspacing="0" border="0">'

--- a/tests/test_newsletter_template.py
+++ b/tests/test_newsletter_template.py
@@ -551,7 +551,7 @@ def test_cross_network_renders_adjacent_shows():
         },
     ]
     out = nt._build_cross_network_html(siblings, "#E31937")
-    assert "Across the Nerra Network" in out
+    assert "More from the Nerra Network" in out
     assert "MIT" in out
     assert "Oil hit" in out
     assert "M&amp;A" not in out  # name passes through; only hook is escaped
@@ -647,7 +647,7 @@ def test_wrap_with_branding_full_render_order_with_engagement_blocks():
     featured = out.find("10 minutes")
     body = out.find("## Body content")
     p_s = out.find("One more thing.")
-    cross = out.find("Across the Nerra Network")
+    cross = out.find("More from the Nerra Network")
     share = out.find("Share:")
     foot = out.find("Listen to the podcast")
     # Documented block order (preheader → hero → stats → featured →
@@ -664,7 +664,7 @@ def test_wrap_with_branding_omits_engagement_blocks_by_default():
         show_reply_share=False,
     )
     assert "10 minutes" not in out
-    assert "Across the Nerra Network" not in out
+    assert "More from the Nerra Network" not in out
     assert "Share:" not in out
 
 


### PR DESCRIPTION
## Context
Final pass of the newsletter visual cleanup (after #544 + #545). Rendered sample sent in chat.

## Change
The "Across the Nerra Network" cross-promo was a solid slate (`#f8fafc`) **card** — another competing panel stacked near the footer. It's now a quiet **"More from the Nerra Network"** list: white background + a thin top rule to separate it from the body, same clickable show rows. It recedes as a footer-adjacent "more to read" list instead of a heavy box. (Header reworded "Across the…" → "More from the…", a softer invitation; tests updated for the new string.)

## The full arc (this + #544 + #545)
- **#544:** headline shown once (was 2–3×), cadence-correct eyebrow ("Today's episode"), 16px/1.7 body.
- **#545:** one primary footer CTA (Listen), share pill-buttons → subtle text line, "💬 Reply" stays prominent.
- **#546 (this):** the last competing card lightened.

Net top-to-bottom: clean cover/gradient hero → one "Today's episode" Listen card → readable 16px story → quiet network list → Reply + subtle share → footer with a single Listen button.

## Safety
ruff clean, **full suite 2395 passed**, all colors ≥4.5:1 (contrast validator green).

This is the end of the planned visual arc — if the sample looks right, this completes it. Any specific further tweak (hero size, spacing, colors), just say.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_