### PR TITLE
Don't let repetition retry shorten a publishable script below the skip floor

### DIFF
--- a/engine/generator.py
+++ b/engine/generator.py
@@ -793,11 +793,12 @@ def _strip_metadata_from_script(script: str) -> str:
 
 
 def _retry_word_count_ok(orig_words: int, retry_words: int,
-                         show_floor: int) -> bool:
+                         show_floor: int,
+                         publication_floor: int = 0) -> bool:
     """Decide whether a podcast-script retry's word count is healthy
     enough to swap in. Both repetition-retry paths use this gate.
 
-    Two failure modes the gate protects against:
+    Three failure modes the gate protects against:
 
       1. ``Omni View Ep059 (2026-05-23)`` — anti-repetition retry
          replaced an 883-word original with a 555-word "cleaner"
@@ -808,13 +809,33 @@ def _retry_word_count_ok(orig_words: int, retry_words: int,
       2. Drastic shrinkage even above the floor. A retry that's
          lost 20%+ of word count almost certainly lost real
          content along with the repetition.
+      3. ``Tesla Ep500 (2026-06-04)`` — the repetition retry took an
+         already-publishable 1128-word script down to 1003 words.
+         That cleared the hard-floor gate (1003 > 650), so the swap
+         happened, but the dedup pass then trimmed it to 954 — under
+         Tesla's 960-word *publication* soft floor — and the flagship
+         episode was skipped. Cleaning up repetition is never worth
+         turning a shippable episode into a skipped one, so when
+         ``publication_floor`` is supplied and the ORIGINAL already
+         clears it (with a ~10% dedup margin), the retry must clear it
+         too.
 
-    Returns True when ``retry_words`` clears BOTH:
-      * 80 % of the original word count, AND
+    Returns True when ``retry_words`` clears ALL of:
+      * 80 % of the original word count,
       * the per-show ``min_podcast_word_floor`` + 50-word margin
-        (so the downstream hard-floor check has headroom).
+        (so the downstream hard-floor check has headroom), AND
+      * (when ``publication_floor`` is given and the original was
+        already publishable) the publication soft floor + ~10% margin
+        for the dedup pass that runs before the runner's skip check.
     """
     threshold = max(int(orig_words * 0.8), show_floor + 50)
+    if publication_floor:
+        # ~10% margin mirrors ``_podcast_expansion_retry_threshold`` —
+        # the dedup pass between here and run_show's skip check trims a
+        # few percent off the word count.
+        pub_margin = int(publication_floor * 1.1)
+        if orig_words >= pub_margin:
+            threshold = max(threshold, pub_margin)
     return retry_words >= threshold
 
 
@@ -1813,12 +1834,17 @@ def generate_podcast_script(
                 show_floor = (
                     getattr(config.llm, "min_podcast_word_floor", 600) or 600
                 )
-                if not _retry_word_count_ok(orig_words, retry_words, show_floor):
+                # Mirror run_show.py's publication soft floor (int(target*0.6))
+                # so the retry can't shorten a publishable script below it.
+                pub_floor = int(min_words * 0.6)
+                if not _retry_word_count_ok(orig_words, retry_words, show_floor,
+                                            publication_floor=pub_floor):
                     logger.warning(
                         "Repetition retry for '%s' has fewer repetitions but "
-                        "would drop word count too far (%d → %d, show floor=%d) "
-                        "— keeping original",
+                        "would drop word count too far (%d → %d, show floor=%d, "
+                        "publication floor=%d) — keeping original",
                         config.name, orig_words, retry_words, show_floor,
+                        pub_floor,
                     )
                 else:
                     logger.info(
@@ -1886,12 +1912,16 @@ def generate_podcast_script(
                 show_floor = (
                     getattr(config.llm, "min_podcast_word_floor", 600) or 600
                 )
-                # See ``_retry_word_count_ok`` for the OV Ep059
-                # incident this guard protects against (anti-rep
-                # retry replaced 883-word original with 555-word
-                # retry that then tripped the 600-word hard floor).
+                pub_floor = int(min_words * 0.6)
+                # See ``_retry_word_count_ok`` for the OV Ep059 +
+                # Tesla Ep500 incidents this guard protects against
+                # (anti-rep retry replaced 883-word original with
+                # 555-word retry that tripped the 600-word hard floor;
+                # publication_floor stops a retry shortening a
+                # publishable script below run_show's skip threshold).
                 if not critical_rr and _retry_word_count_ok(
                     orig_words, retry_words, show_floor,
+                    publication_floor=pub_floor,
                 ):
                     logger.info(
                         "Anti-repetition retry cleared critical loops for '%s' "

--- a/tests/test_generator_postprocess.py
+++ b/tests/test_generator_postprocess.py
@@ -217,6 +217,50 @@ class TestRetryWordCountOk:
             orig_words=500, retry_words=400, show_floor=600,
         ) is False
 
+    def test_ep500_publication_floor_rejects_shortening_below_soft_floor(self):
+        """Tesla Ep500 (2026-06-04): the repetition retry took an
+        already-publishable 1128-word script down to 1003 words. With
+        only the hard-floor gate (max(902, 650)=902), 1003 passed and
+        the swap happened — then dedup trimmed it to 954, under Tesla's
+        960-word publication soft floor, and the flagship was skipped.
+
+        With ``publication_floor=960`` supplied, the gate now also
+        requires the retry to clear 960*1.1 = 1056 (because the 1128
+        original already cleared that margin), so 1003 is REJECTED and
+        the publishable original is kept."""
+        from engine.generator import _retry_word_count_ok
+        assert _retry_word_count_ok(
+            orig_words=1128, retry_words=1003, show_floor=600,
+            publication_floor=960,
+        ) is False
+        # A retry that stays above the dedup margin (1056) is still fine.
+        assert _retry_word_count_ok(
+            orig_words=1128, retry_words=1080, show_floor=600,
+            publication_floor=960,
+        ) is True
+
+    def test_publication_floor_skipped_when_original_already_thin(self):
+        """If the original is itself below the publication soft floor
+        (the episode is heading for a skip regardless), the publication
+        guard must NOT block a cleaner retry — only the hard-floor and
+        80%-of-original constraints apply. orig=900 < 1056 margin, so
+        the publication clause is inert; retry=820 clears 80% (720) and
+        floor+50 (650) → ACCEPT."""
+        from engine.generator import _retry_word_count_ok
+        assert _retry_word_count_ok(
+            orig_words=900, retry_words=820, show_floor=600,
+            publication_floor=960,
+        ) is True
+
+    def test_publication_floor_default_is_inert(self):
+        """Omitting ``publication_floor`` (default 0) preserves the
+        original two-constraint behaviour byte-for-byte — no caller that
+        skips the new arg sees a behaviour change."""
+        from engine.generator import _retry_word_count_ok
+        assert _retry_word_count_ok(
+            orig_words=1128, retry_words=1003, show_floor=600,
+        ) is True
+
 
 # ---------------------------------------------------------------------------
 # _podcast_expansion_retry_threshold — no dead band vs run_show's soft floor


### PR DESCRIPTION
## Problem

Tesla **Ep500** (2026-06-04) — the flagship episode — was **skipped** despite good sourcing (79 raw → 69 articles, digest generated fine at 13,194 chars, validation passed).

Tracing the run log:

1. Podcast script came in short (790 words, target 1600).
2. The expansion retry lifted it to **1128 words** — comfortably above the floor.
3. The repetition retry then swapped in a de-repeated version: `Repetition retry improved script for 'Tesla Shorts Time' (4 → 0 suspicious phrases, 1128 → 1003 words)`.
4. The dedup pass trimmed 1003 → **954 words**.
5. `Podcast script too thin for publication (954 words, soft floor 960) — skipping episode`.

**Root cause:** `_retry_word_count_ok` only protected the 600-word *hard* floor (`threshold = max(int(1128*0.8), 600+50) = max(902, 650) = 902`), so the 1003-word retry passed and the swap happened. It had no awareness of run_show's **publication soft floor** (`int(target*0.6)` = 960 for Tesla), so it happily traded a publishable script for an unpublishable one just to clean up repetition.

## Fix

Add an optional `publication_floor` argument to `_retry_word_count_ok`. When the **original** script already clears the soft floor (with a ~10% dedup margin, mirroring `_podcast_expansion_retry_threshold`), the de-repeated retry must clear it too. Otherwise the gate keeps the mildly-repetitive but **shippable** original rather than trade it for a skipped episode.

- Both repetition-retry paths (low-temp retry + anti-repetition retry) pass `int(min_words * 0.6)`, exactly matching run_show.py's `_SOFT_FLOOR`.
- Default `publication_floor=0` keeps every existing caller byte-for-byte — no behaviour change unless the floor is supplied.
- For Ep500: margin = `int(960*1.1) = 1056`; original 1128 ≥ 1056 so the clause engages; retry 1003 < 1056 → **rejected**, the 1128-word original is kept and the episode ships.

## Tests

Added 4 drift guards in `tests/test_generator_postprocess.py`:
- Ep500 case rejects the 1128→1003 shortening; a 1128→1080 retry still passes.
- When the original is itself already thin (below the margin), the publication clause stays inert (only hard-floor + 80% rules apply).
- Omitting `publication_floor` preserves the original two-constraint behaviour.

`ruff check engine/generator.py` clean; `pytest tests/test_generator_postprocess.py tests/test_generator.py tests/test_deep_dive.py` → 82 passed.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_