### PR TITLE
Newsletter: render body markdown to HTML (fix wall-of-raw-markdown on mobile)

### DIFF
--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -732,6 +732,282 @@ def convert_md_tables_to_html(body_md: str, *, brand: str = "#6B47FF") -> str:
     return "\n".join(out_lines)
 
 
+# ---------------------------------------------------------------------------
+# Full markdown body → inline-styled HTML
+# ---------------------------------------------------------------------------
+#
+# WHY THIS EXISTS (operator-caught, Tesla Ep500 newsletter, Jun 2026):
+# Buttondown renders the email ``body`` field as CommonMark. BUT CommonMark
+# does NOT parse markdown *inside* an HTML block element. The body is wrapped
+# in a ``surface-white`` <table> (so the dark-mode <style> can flip its
+# background), and the moment the markdown lives inside that <table>,
+# Buttondown stops converting it — every ``**bold**``, ``## heading``,
+# ``> quote`` and numbered list ships as literal text. On a phone that reads
+# as an unbroken wall of ``**`` / ``###`` / ``>`` characters.
+#
+# Fix: render the body to HTML ourselves *before* it goes in the table. That
+# both repairs the rendering and lets us give the body a real typographic
+# hierarchy — scannable sections with breathing room instead of a slab.
+
+# AA-on-white link colour (4.6:1), matches ``_render_md_inline_to_html``.
+_BODY_LINK_STYLE = "color:#2563eb;text-decoration:underline;"
+
+_INLINE_ANCHOR_RE = re.compile(r"<a\b[^>]*>.*?</a>", re.IGNORECASE | re.DOTALL)
+
+
+def _md_inline_rich(text: str) -> str:
+    """Render inline markdown (links, bold, italic, code) to HTML.
+
+    Escapes ``& < >`` first, so this only runs on plain-markdown text
+    (paragraphs / headings / list items / blockquotes) — never on the
+    pre-rendered standalone HTML lines, which the block parser passes
+    through untouched.
+
+    Exception: a couple of upstream transforms inject inline ``<a>``
+    anchors *mid-line* (``render_source_links_as_html`` turns
+    ``Source: [label](url)`` into an HTML anchor before we run). Those
+    are protected behind placeholders so we don't escape their angle
+    brackets into visible ``&lt;a&gt;`` text. Style them to match our
+    own links if they lack an inline colour.
+
+    Bold/italic carry NO inline colour so they inherit their parent's
+    colour, which the dark-mode universal selector flips correctly
+    (``<strong>``/``<em>`` aren't in that selector list).
+    """
+    # 1. Pull existing inline anchors out so escaping can't mangle them.
+    anchors: List[str] = []
+
+    def _stash(m: "re.Match[str]") -> str:
+        a = m.group(0)
+        # Give pipeline-injected anchors (target=_blank, no style) the
+        # same AA-on-white link colour our markdown links use.
+        if "style=" not in a.lower():
+            a = a.replace("<a ", f'<a style="{_BODY_LINK_STYLE}" ', 1)
+        anchors.append(a)
+        return f"\x00A{len(anchors) - 1}\x00"
+
+    text = _INLINE_ANCHOR_RE.sub(_stash, text)
+
+    esc = (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+    # Links: [label](http(s)://url)
+    esc = re.sub(
+        r"\[([^\]]+)\]\((https?://[^)\s]+)\)",
+        rf'<a href="\2" style="{_BODY_LINK_STYLE}">\1</a>',
+        esc,
+    )
+    # Bold (** or __) before italic so the markers don't collide.
+    esc = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", esc)
+    esc = re.sub(r"__([^_]+)__", r"<strong>\1</strong>", esc)
+    # Italic (single * not part of a ** pair).
+    esc = re.sub(r"(?<![*\w])\*([^*\n]+)\*(?!\w)", r"<em>\1</em>", esc)
+    # Inline code.
+    esc = re.sub(
+        r"`([^`]+)`",
+        r'<code style="background:#f1f5f9;padding:1px 5px;border-radius:4px;'
+        r'font-size:0.92em;">\1</code>',
+        esc,
+    )
+    # Drop any stray unmatched bold markers (malformed pairs from the LLM).
+    esc = esc.replace("**", "")
+    # 2. Restore the protected inline anchors.
+    for idx, anchor in enumerate(anchors):
+        esc = esc.replace(f"\x00A{idx}\x00", anchor)
+    return esc
+
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*\S)\s*$")
+_HR_RE = re.compile(r"^\s*(?:[-*_]\s*){3,}$")
+_OL_RE = re.compile(r"^\s*\d+[.)]\s+(.*)$")
+_UL_RE = re.compile(r"^\s*[-*+•]\s+(.*)$")
+_QUOTE_RE = re.compile(r"^\s*>\s?(.*)$")
+_DASHES_ONLY_RE = re.compile(r"^[\s\-—–*_]+$")
+
+
+def render_markdown_body(
+    body_md: str, *, brand: str = "#6B47FF", slug: str = ""
+) -> str:
+    """Render a cleaned digest markdown body to inline-styled HTML.
+
+    Produces a clean, scannable hierarchy:
+
+      - ``#`` / ``##``  → section headings with a hairline divider above
+        and a short brand-coloured underline accent (scan anchors)
+      - ``###`` +       → bold sub-headings
+      - ``> quote``     → a brand-accented highlight card (the episode hook)
+      - ``1.`` / ``-``  → real lists with generous item spacing
+      - paragraphs      → 16px / 1.7 line-height prose
+      - ``---``         → a subtle rule
+
+    Pre-rendered single-line HTML blocks (markdown tables converted
+    upstream, the TSLA stock-watch block, Russian vocab cards, styled
+    ``<hr>``s) are detected by a leading ``<`` and passed through verbatim.
+
+    All blocks are joined with single newlines and contain no blank lines,
+    so the whole thing stays one CommonMark "raw HTML block" once wrapped
+    in the body table — Buttondown passes it through instead of re-parsing.
+    Light-mode colours are WCAG AA on white / ``#f8fafc``; dark mode is
+    handled by ``_DARK_MODE_STYLE`` (universal text flip + ``.card`` bg).
+    """
+    if not body_md or not body_md.strip():
+        return ""
+
+    lines = body_md.split("\n")
+    blocks: List[str] = []
+    i = 0
+    n = len(lines)
+
+    def _para(text_lines: List[str]) -> str:
+        joined = " ".join(s.strip() for s in text_lines if s.strip())
+        if not joined:
+            return ""
+        return (
+            '<p style="margin:0 0 14px;font-size:16px;line-height:1.7;'
+            f'color:#1f2937;">{_md_inline_rich(joined)}</p>'
+        )
+
+    while i < n:
+        raw = lines[i]
+        stripped = raw.strip()
+
+        # 1. Blank line — skip (block separator).
+        if not stripped:
+            i += 1
+            continue
+
+        # 2. Pre-rendered HTML block (single line) — pass through.
+        if stripped.startswith("<"):
+            blocks.append(stripped)
+            i += 1
+            continue
+
+        # 3. Horizontal rule.
+        if _HR_RE.match(stripped):
+            blocks.append(
+                '<hr style="border:none;border-top:1px solid #e5e7eb;'
+                'margin:24px 0;" />'
+            )
+            i += 1
+            continue
+
+        # 4. Heading.
+        m = _HEADING_RE.match(stripped)
+        if m:
+            level = len(m.group(1))
+            inner = _md_inline_rich(m.group(2))
+            if level <= 2:
+                # Major section: divider above + brand underline accent.
+                blocks.append(
+                    '<h2 style="margin:30px 0 12px;padding-top:18px;'
+                    'border-top:1px solid #eef0f3;font-size:19px;'
+                    'line-height:1.3;font-weight:700;color:#0f172a;'
+                    'letter-spacing:-0.01em;">'
+                    '<span style="display:inline-block;'
+                    f'border-bottom:3px solid {brand};padding-bottom:2px;">'
+                    f'{inner}</span></h2>'
+                )
+            elif level == 3:
+                blocks.append(
+                    '<h3 style="margin:24px 0 8px;font-size:16px;'
+                    'line-height:1.35;font-weight:700;color:#0f172a;">'
+                    f'{inner}</h3>'
+                )
+            else:
+                blocks.append(
+                    '<h4 style="margin:20px 0 6px;font-size:13px;'
+                    'line-height:1.4;font-weight:700;color:#475569;'
+                    'text-transform:uppercase;letter-spacing:0.05em;">'
+                    f'{inner}</h4>'
+                )
+            i += 1
+            continue
+
+        # 5. Blockquote (collect consecutive ``>`` lines).
+        if _QUOTE_RE.match(raw):
+            quote_lines: List[str] = []
+            while i < n and _QUOTE_RE.match(lines[i]):
+                content = _QUOTE_RE.match(lines[i]).group(1).strip()
+                # Drop separator-only quote lines (e.g. a stray ``--``).
+                if content and not _DASHES_ONLY_RE.match(content):
+                    quote_lines.append(content)
+                i += 1
+            if quote_lines:
+                inner = _md_inline_rich(" ".join(quote_lines))
+                blocks.append(
+                    '<table role="presentation" width="100%" cellpadding="0" '
+                    'cellspacing="0" border="0" class="card" '
+                    'style="background:#f8fafc;border-radius:10px;'
+                    'margin:6px 0 18px;">'
+                    '<tr><td style="padding:14px 18px;'
+                    f'border-left:4px solid {brand};font-size:16px;'
+                    'line-height:1.6;color:#0f172a;font-weight:600;">'
+                    f'{inner}</td></tr></table>'
+                )
+            continue
+
+        # 6. Ordered list.
+        if _OL_RE.match(raw):
+            items: List[str] = []
+            while i < n and _OL_RE.match(lines[i]):
+                items.append(_OL_RE.match(lines[i]).group(1).strip())
+                i += 1
+            lis = "".join(
+                '<li style="margin:0 0 10px;font-size:16px;line-height:1.7;'
+                f'color:#1f2937;">{_md_inline_rich(it)}</li>'
+                for it in items if it
+            )
+            blocks.append(
+                '<ol style="margin:0 0 16px;padding-left:22px;">'
+                f'{lis}</ol>'
+            )
+            continue
+
+        # 7. Unordered list.
+        if _UL_RE.match(raw):
+            items = []
+            while i < n and _UL_RE.match(lines[i]):
+                items.append(_UL_RE.match(lines[i]).group(1).strip())
+                i += 1
+            lis = "".join(
+                '<li style="margin:0 0 8px;font-size:16px;line-height:1.7;'
+                f'color:#1f2937;">{_md_inline_rich(it)}</li>'
+                for it in items if it
+            )
+            blocks.append(
+                '<ul style="margin:0 0 16px;padding-left:22px;">'
+                f'{lis}</ul>'
+            )
+            continue
+
+        # 8. Paragraph — gather consecutive plain lines until a blank
+        #    line or a line that starts a different block.
+        para_lines = [raw]
+        i += 1
+        while i < n:
+            nxt = lines[i]
+            nxt_s = nxt.strip()
+            if (
+                not nxt_s
+                or nxt_s.startswith("<")
+                or _HEADING_RE.match(nxt_s)
+                or _HR_RE.match(nxt_s)
+                or _QUOTE_RE.match(nxt)
+                or _OL_RE.match(nxt)
+                or _UL_RE.match(nxt)
+            ):
+                break
+            para_lines.append(nxt)
+            i += 1
+        para = _para(para_lines)
+        if para:
+            blocks.append(para)
+
+    return "\n".join(b for b in blocks if b)
+
+
 def episode_blog_url(slug: str, episode_num: int) -> str:
     """Canonical per-episode permalink on nerranetwork.com.
 
@@ -1385,10 +1661,18 @@ def wrap_with_branding(
             body_clean, featured_with_slug["hook"]
         )
     # Pre-render any markdown tables in the body to inline HTML so they
-    # survive Outlook / Yahoo / ProtonMail. Non-table markdown is left
-    # alone for Buttondown's renderer to handle.
+    # survive Outlook / Yahoo / ProtonMail.
     body_clean = convert_md_tables_to_html(
         body_clean, brand=show["brand_color"]
+    )
+    # Render the REST of the body markdown to HTML ourselves. We can't
+    # rely on Buttondown's markdown→HTML here because the body gets
+    # wrapped in a <table> below and CommonMark doesn't parse markdown
+    # inside an HTML block — which shipped the body as a wall of raw
+    # ``**``/``###``/``>`` characters on mobile (Tesla Ep500, Jun 2026).
+    # Doing it here also gives the body a real, scannable hierarchy.
+    body_clean = render_markdown_body(
+        body_clean, brand=show["brand_color"], slug=slug
     )
 
     # Two trust-and-tracking blocks added in spec v2: a "view in
@@ -1408,13 +1692,12 @@ def wrap_with_branding(
             show, issue_number, send_date, slug=slug,
         )
 
-    # Wrap the body markdown in a ``surface-white`` table so the
-    # dark-mode ``<style>`` override flips its background. Without
-    # this wrapper Buttondown's markdown→HTML conversion produces
-    # bare ``<p>`` tags that the email client renders against its
-    # own page background, which on iOS Mail dark mode results in
-    # near-black body text (Buttondown default `#0f172a`-ish) against
-    # a darkening surface — barely readable. Spec v2 follow-up.
+    # Wrap the (now fully-rendered HTML) body in a ``surface-white``
+    # table so the dark-mode ``<style>`` override flips its background.
+    # The inner content is HTML with no blank lines, so Buttondown
+    # treats the whole table as one CommonMark raw-HTML block and passes
+    # it through verbatim instead of trying (and failing) to re-parse
+    # markdown inside it. Spec v2 follow-up + Ep500 render fix.
     body_wrapped = ""
     if body_clean.strip():
         body_wrapped = (

--- a/tests/test_newsletter_template.py
+++ b/tests/test_newsletter_template.py
@@ -16,6 +16,87 @@ from engine import newsletter_template as nt
 # Per-show branding lookup
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# render_markdown_body — the Ep500 "wall of raw markdown" fix
+# ---------------------------------------------------------------------------
+
+class TestRenderMarkdownBody:
+    """The body is wrapped in a <table> for the dark-mode bg flip, and
+    CommonMark doesn't parse markdown inside an HTML block — so Buttondown
+    shipped the body as literal ``**``/``###``/``>`` text on mobile
+    (Tesla Ep500 newsletter, Jun 2026). ``render_markdown_body`` renders
+    the body to HTML ourselves so it never leaks raw markdown again."""
+
+    def test_headings_become_html_no_hash_leak(self):
+        out = nt.render_markdown_body("## Big Section\n\n### Sub")
+        assert "## Big Section" not in out
+        assert "### Sub" not in out
+        assert "<h2" in out and "Big Section" in out
+        assert "<h3" in out and "Sub" in out
+
+    def test_bold_and_italic_render(self):
+        out = nt.render_markdown_body("A **bold** and *italic* word.")
+        assert "<strong>bold</strong>" in out
+        assert "<em>italic</em>" in out
+        assert "**" not in out
+
+    def test_markdown_links_render_to_anchors(self):
+        out = nt.render_markdown_body(
+            "See [the source](https://example.com/x) now."
+        )
+        assert '<a href="https://example.com/x"' in out
+        assert "[the source]" not in out
+
+    def test_preserves_pipeline_injected_inline_anchors(self):
+        """``render_source_links_as_html`` injects inline ``<a target=_blank>``
+        anchors mid-line *before* we run. They must pass through, not get
+        escaped into visible ``&lt;a&gt;`` text (the screenshot bug)."""
+        line = (
+            '1. **Story:** body text. Source: '
+            '<a href="https://news.google.com" target="_blank" '
+            'rel="noopener">Google News</a>'
+        )
+        out = nt.render_markdown_body(line)
+        assert "&lt;a" not in out
+        assert 'href="https://news.google.com"' in out
+        assert 'target="_blank"' in out
+        assert "Google News</a>" in out
+        # Rendered as an ordered-list item, not raw "1.".
+        assert "<ol" in out and "<li" in out
+
+    def test_blockquote_becomes_accent_card(self):
+        out = nt.render_markdown_body("> **The hook line.**")
+        assert "border-left:4px solid" in out
+        assert "The hook line." in out
+        assert "&gt;" not in out and "> **" not in out
+
+    def test_lists_render_with_items(self):
+        ol = nt.render_markdown_body("1. First\n2. Second")
+        assert ol.count("<li") == 2 and "<ol" in ol
+        ul = nt.render_markdown_body("- Alpha\n- Beta")
+        assert ul.count("<li") == 2 and "<ul" in ul
+
+    def test_standalone_html_block_passes_through(self):
+        """Pre-rendered single-line HTML (markdown tables converted
+        upstream, TSLA block, vocab cards, styled <hr>) must pass through
+        untouched, not get escaped."""
+        html_line = '<table role="presentation"><tr><td>x</td></tr></table>'
+        out = nt.render_markdown_body(html_line)
+        assert out.strip() == html_line
+        assert "&lt;table" not in out
+
+    def test_no_blank_lines_in_output(self):
+        """Output must contain no blank lines so the surrounding <table>
+        stays one CommonMark raw-HTML block (otherwise Buttondown would
+        re-parse the tail as markdown)."""
+        out = nt.render_markdown_body("# H\n\npara one\n\n## H2\n\npara two")
+        assert "\n\n" not in out
+
+    def test_empty_body_is_empty(self):
+        assert nt.render_markdown_body("") == ""
+        assert nt.render_markdown_body("   \n  ") == ""
+
+
 def test_load_show_branding_uses_network_shows_for_known_slug():
     show = nt._load_show_branding("tesla")
     # Pulled straight from generate_html.NETWORK_SHOWS["tesla"].
@@ -106,19 +187,22 @@ def test_footer_html_omits_youtube_when_playlist_missing():
 # Top-level wrap_with_branding
 # ---------------------------------------------------------------------------
 
-def test_wrap_with_branding_weekly_keeps_markdown_in_middle():
+def test_wrap_with_branding_weekly_renders_body_to_html_in_middle():
     body_md = "## This week\n\nA paragraph with **bold** text."
     out = nt.wrap_with_branding(
         "tesla", body_md,
         week_ending=datetime.date(2026, 4, 30),
     )
-    # Hero appears before the markdown.
+    # Hero appears before the rendered body, body before the footer.
     hero_idx = out.find("Tesla Shorts Time")
-    body_idx = out.find("## This week")
+    body_idx = out.find("This week")
     footer_idx = out.find("Listen to the podcast")
     assert 0 <= hero_idx < body_idx < footer_idx
-    # The original markdown is preserved verbatim (no transformation).
-    assert body_md in out
+    # The body is rendered to HTML — no raw markdown leaks (the Ep500 bug).
+    assert "## This week" not in out
+    assert "**bold**" not in out
+    assert "<h2" in out
+    assert "<strong>bold</strong>" in out
 
 
 def test_wrap_with_branding_daily_uses_episode_pill():
@@ -386,11 +470,12 @@ def test_wrap_with_branding_renders_all_blocks_in_order():
     pre = out.find("Inbox preview teaser")
     hero = out.find("Tesla Shorts Time")
     stats = out.find("TSLA close")
-    body = out.find("## Body content")
+    body = out.find("Body content")  # rendered into an <h2>, no raw "##"
     p_s = out.find("One more thing.")
     foot = out.find("Listen to the podcast")
     # All present and in the documented order.
     assert 0 <= pre < hero < stats < body < p_s < foot
+    assert "## Body content" not in out  # body is rendered to HTML
 
 
 def test_wrap_with_branding_renders_disclaimer_when_flagged():
@@ -418,8 +503,11 @@ def test_wrap_with_branding_strips_redundant_title():
     out = nt.wrap_with_branding(
         "tesla", body, week_ending=datetime.date(2026, 4, 30),
     )
-    # The repeated "Weekly" line is gone; the section heading remains.
-    assert "## Big picture" in out
+    # The repeated "Weekly" line is gone; the section heading remains
+    # (now rendered to an <h2>, not raw markdown).
+    assert "## Big picture" not in out
+    assert "Big picture" in out
+    assert "<h2" in out
     # Hero still shows the show name (this lives in the gradient block
     # not the markdown body).
     assert "Tesla Shorts Time" in out
@@ -645,7 +733,7 @@ def test_wrap_with_branding_full_render_order_with_engagement_blocks():
     hero = out.find("Tesla Shorts Time")
     stats = out.find("TSLA close")
     featured = out.find("10 minutes")
-    body = out.find("## Body content")
+    body = out.find("Body content")  # rendered into an <h2>, no raw "##"
     p_s = out.find("One more thing.")
     cross = out.find("More from the Nerra Network")
     share = out.find("Share:")
@@ -653,6 +741,7 @@ def test_wrap_with_branding_full_render_order_with_engagement_blocks():
     # Documented block order (preheader → hero → stats → featured →
     # body → p_s → cross-network → reply/share → footer).
     assert 0 <= pre < hero < stats < featured < body < p_s < cross < share < foot
+    assert "## Body content" not in out  # body rendered to HTML
 
 
 def test_wrap_with_branding_omits_engagement_blocks_by_default():


### PR DESCRIPTION
## Problem

The operator's phone screenshots of the latest Tesla newsletter showed the email body as an unreadable **wall of raw markdown** — literal `**bold**`, `### Top 12 News Items`, `## Tesla X Takeover`, `> hook`, and numbered lists all rendered as plain text characters. Some labels were also too light. This affects **every** newsletter (all shows share `wrap_with_branding`).

## Root cause

The body is wrapped in a `surface-white` `<table>` so the dark-mode `<style>` block can flip its background. But CommonMark (which Buttondown uses to render the email body) **does not parse markdown inside an HTML block element**. Once the body lived inside that table, Buttondown silently stopped converting it and dumped the raw markdown. The table wrapper (added earlier to fix dark-mode background) had quietly disabled all body markdown rendering.

## Fix

Render the body markdown to inline-styled HTML **ourselves** (`render_markdown_body`) before the table wrap. This repairs the rendering *and* gives the body a real, scannable hierarchy:

- `#`/`##` → section headings with a hairline divider above + short brand-colour underline accent (scan anchors)
- `###` → bold sub-headings
- `> quote` → the episode hook as a brand-accented highlight card
- `1.`/`-` → real `<ol>`/`<ul>` with generous item spacing
- paragraphs → 16px / 1.7 prose
- `---` → a subtle rule

All light-mode colours are WCAG AA on white/`#f8fafc`; dark mode is handled by the existing universal text-flip + `.card` background flip (no `_DARK_MODE_STYLE` change needed).

Pipeline-injected inline `<a target="_blank">` source anchors (from `render_source_links_as_html`) are protected from escaping via a placeholder swap, so `Source: Google News` stays a clickable link instead of leaking `<a ...>` as visible text.

Blocks are joined with single newlines (no blank lines) so the wrapped table stays one CommonMark raw-HTML block — Buttondown passes it through verbatim.

## Verification

Rendered the actual Tesla Ep500 email at phone width in **both light and dark mode** with headless Chromium (screenshots shared with the operator):
- No raw markdown leaks, no escaped-anchor leaks
- Light-mode contrast tripwire: **0 failures**
- Verified MIT (markdown table + disclaimer) and Привет (vocab cards) render cleanly too

Full suite green (2398 passed). New drift guards in `TestRenderMarkdownBody` pin the no-raw-markdown / anchor-preservation / single-HTML-block contract; 4 existing wrap tests updated from asserting the old (broken) "markdown preserved verbatim" behaviour to the new HTML-rendered behaviour.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_