### PR TITLE
Newsletter: fix dark-mode red titles, list numbering & folded bodies

### DIFF
--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -313,8 +313,12 @@ _DARK_MODE_STYLE = """\
     /* Cards (slightly lifted "panel" surfaces). */
     .card { background:#1e293b !important; background-color:#1e293b !important; }
 
-    /* Primary text on every dark-mode surface. */
-    body, p, h1, h2, h3, h4, td, span, div, li {
+    /* Primary text on every dark-mode surface. ``strong``/``b``/``em``/
+     * ``i``/``code`` are listed explicitly: we now set an inline colour
+     * on bold text (so Buttondown's theme accent can't recolour it), and
+     * that inline colour has to be flipped here for dark mode. */
+    body, p, h1, h2, h3, h4, td, span, div, li,
+    strong, b, em, i, code {
       color:#e2e8f0 !important;
     }
     /* Secondary / muted text — class-targeted so it doesn't override
@@ -800,8 +804,17 @@ def _md_inline_rich(text: str) -> str:
         esc,
     )
     # Bold (** or __) before italic so the markers don't collide.
-    esc = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", esc)
-    esc = re.sub(r"__([^_]+)__", r"<strong>\1</strong>", esc)
+    # Explicit colour (not a bare <strong>) so Buttondown's theme
+    # stylesheet can't recolour it with the account accent — that's why
+    # story titles shipped as low-contrast Tesla-red on the dark email
+    # (Ep501, Jun 2026). The dark-mode @media flips it via the strong/b
+    # selector.
+    esc = re.sub(
+        r"\*\*([^*]+)\*\*", r'<strong style="color:#0f172a;">\1</strong>', esc
+    )
+    esc = re.sub(
+        r"__([^_]+)__", r'<strong style="color:#0f172a;">\1</strong>', esc
+    )
     # Italic (single * not part of a ** pair).
     esc = re.sub(r"(?<![*\w])\*([^*\n]+)\*(?!\w)", r"<em>\1</em>", esc)
     # Inline code.
@@ -825,6 +838,103 @@ _OL_RE = re.compile(r"^\s*\d+[.)]\s+(.*)$")
 _UL_RE = re.compile(r"^\s*[-*+•]\s+(.*)$")
 _QUOTE_RE = re.compile(r"^\s*>\s?(.*)$")
 _DASHES_ONLY_RE = re.compile(r"^[\s\-—–*_]+$")
+
+
+def _collect_list(lines: List[str], start: int, ordered: bool):
+    """Collect a (possibly loose, multi-line) markdown list starting at
+    *start*. Returns ``(items, next_index)`` where each item is
+    ``(head_text, [continuation_lines])``.
+
+    The digest's news items look like::
+
+        1. **Title:** date, source
+           Body sentence. Source: [label](url)
+
+        2. **Next title:** ...
+
+    i.e. a numbered marker line, an *indented* continuation line with the
+    body + source, then a blank line before the next item. Naive
+    line-by-line parsing turned each item into its own ``<ol>`` (so every
+    item rendered as "1.") and split the body into a detached paragraph
+    (Ep501, Jun 2026). This collector keeps one list with continuous
+    numbering and folds each item's continuation into that item:
+
+      - a blank line followed by another marker → loose list, keep going
+      - a blank line followed by an indented line → continuation paragraph
+      - an indented (or hanging) non-marker line → continuation of the item
+      - a non-indented, non-marker line (or EOF) → the list ends
+    """
+    rx = _OL_RE if ordered else _UL_RE
+    items: List[tuple] = []
+    i = start
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        m = rx.match(line)
+        if m:
+            items.append((m.group(1).strip(), []))
+            i += 1
+            continue
+        if not line.strip():
+            j = i + 1
+            while j < n and not lines[j].strip():
+                j += 1
+            if j < n and rx.match(lines[j]):
+                i = j  # loose list — next item follows a blank line
+                continue
+            if j < n and lines[j].startswith((" ", "\t")) and items:
+                items[-1][1].append("")  # paragraph break within the item
+                i = j
+                continue
+            break  # list ended
+        if line.startswith((" ", "\t")) and items:
+            items[-1][1].append(line.strip())
+            i += 1
+            continue
+        break  # non-indented, non-marker line ends the list
+    return items, i
+
+
+def _render_list(items: List[tuple], ordered: bool) -> str:
+    """Render collected list items to an inline-styled <ol>/<ul>.
+
+    Each item: the marker line (bold title + any meta) on the first row,
+    then any folded continuation as a normal-weight sub-block — so a news
+    item reads as "**Title** … / body … / Source" instead of a detached
+    paragraph.
+    """
+    tag = "ol" if ordered else "ul"
+    lis: List[str] = []
+    for head, body in items:
+        if not head and not any(body):
+            continue
+        head_html = _md_inline_rich(head)
+        # Group continuation lines into paragraphs (blank = paragraph break).
+        paras: List[str] = []
+        buf: List[str] = []
+        for bl in body:
+            if bl:
+                buf.append(bl)
+            elif buf:
+                paras.append(" ".join(buf))
+                buf = []
+        if buf:
+            paras.append(" ".join(buf))
+        body_html = "".join(
+            '<div style="margin-top:4px;font-weight:400;color:#334155;">'
+            f"{_md_inline_rich(p)}</div>"
+            for p in paras if p.strip()
+        )
+        lis.append(
+            '<li style="margin:0 0 16px;padding-left:4px;font-size:16px;'
+            f'line-height:1.7;color:#1f2937;">{head_html}{body_html}</li>'
+        )
+    if not lis:
+        return ""
+    return (
+        f'<{tag} style="margin:0 0 18px;padding-left:24px;">'
+        f'{"".join(lis)}</{tag}>'
+    )
 
 
 def render_markdown_body(
@@ -948,38 +1058,20 @@ def render_markdown_body(
                 )
             continue
 
-        # 6. Ordered list.
+        # 6. Ordered list (continuous numbering + folded continuation).
         if _OL_RE.match(raw):
-            items: List[str] = []
-            while i < n and _OL_RE.match(lines[i]):
-                items.append(_OL_RE.match(lines[i]).group(1).strip())
-                i += 1
-            lis = "".join(
-                '<li style="margin:0 0 10px;font-size:16px;line-height:1.7;'
-                f'color:#1f2937;">{_md_inline_rich(it)}</li>'
-                for it in items if it
-            )
-            blocks.append(
-                '<ol style="margin:0 0 16px;padding-left:22px;">'
-                f'{lis}</ol>'
-            )
+            items, i = _collect_list(lines, i, ordered=True)
+            html = _render_list(items, ordered=True)
+            if html:
+                blocks.append(html)
             continue
 
         # 7. Unordered list.
         if _UL_RE.match(raw):
-            items = []
-            while i < n and _UL_RE.match(lines[i]):
-                items.append(_UL_RE.match(lines[i]).group(1).strip())
-                i += 1
-            lis = "".join(
-                '<li style="margin:0 0 8px;font-size:16px;line-height:1.7;'
-                f'color:#1f2937;">{_md_inline_rich(it)}</li>'
-                for it in items if it
-            )
-            blocks.append(
-                '<ul style="margin:0 0 16px;padding-left:22px;">'
-                f'{lis}</ul>'
-            )
+            items, i = _collect_list(lines, i, ordered=False)
+            html = _render_list(items, ordered=False)
+            if html:
+                blocks.append(html)
             continue
 
         # 8. Paragraph — gather consecutive plain lines until a blank

--- a/tests/test_newsletter_template.py
+++ b/tests/test_newsletter_template.py
@@ -36,7 +36,7 @@ class TestRenderMarkdownBody:
 
     def test_bold_and_italic_render(self):
         out = nt.render_markdown_body("A **bold** and *italic* word.")
-        assert "<strong>bold</strong>" in out
+        assert "<strong" in out and ">bold</strong>" in out
         assert "<em>italic</em>" in out
         assert "**" not in out
 
@@ -75,6 +75,37 @@ class TestRenderMarkdownBody:
         assert ol.count("<li") == 2 and "<ol" in ol
         ul = nt.render_markdown_body("- Alpha\n- Beta")
         assert ul.count("<li") == 2 and "<ul" in ul
+
+    def test_news_list_keeps_continuous_numbering(self):
+        """The digest's 'Top N' items are a marker line + indented body +
+        a blank line before the next item. That used to render as one
+        <ol> PER item (so every item showed '1.') and split the body off
+        as a detached paragraph (Ep501, Jun 2026). It must now be ONE
+        <ol> with the body folded into each <li>."""
+        body = (
+            "1. **First story:** June 04, 2026, Source A\n"
+            "   Body of the first story. Source: x.com\n"
+            "\n"
+            "2. **Second story:** June 04, 2026, Source B\n"
+            "   Body of the second story. Source: y.com\n"
+            "\n"
+            "3. **Third story:** June 04, 2026, Source C\n"
+            "   Body of the third story. Source: z.com\n"
+        )
+        out = nt.render_markdown_body(body)
+        assert out.count("<ol") == 1          # single continuous list
+        assert out.count("<li") == 3          # not 3 separate one-item lists
+        assert "Body of the first story." in out   # continuation folded in
+        assert "Body of the third story." in out
+        # The body folds INTO the <li>, not into a sibling <p>.
+        assert out.count("<p ") == 0
+
+    def test_bold_carries_explicit_colour(self):
+        """Bold text must carry an inline colour so Buttondown's theme
+        stylesheet can't recolour it with the account accent (that shipped
+        story titles as low-contrast Tesla-red on the dark email)."""
+        out = nt.render_markdown_body("A **bold title** here.")
+        assert '<strong style="color:#0f172a;">bold title</strong>' in out
 
     def test_standalone_html_block_passes_through(self):
         """Pre-rendered single-line HTML (markdown tables converted
@@ -202,7 +233,7 @@ def test_wrap_with_branding_weekly_renders_body_to_html_in_middle():
     assert "## This week" not in out
     assert "**bold**" not in out
     assert "<h2" in out
-    assert "<strong>bold</strong>" in out
+    assert "<strong" in out and ">bold</strong>" in out
 
 
 def test_wrap_with_branding_daily_uses_episode_pill():
@@ -793,7 +824,7 @@ def test_render_html_table_handles_inline_markdown_in_cells():
         ["Header"],
         [["**bold**"], ["[link](https://x.com)"]],
     )
-    assert "<strong>bold</strong>" in out
+    assert "<strong" in out and ">bold</strong>" in out
     assert '<a href="https://x.com"' in out
 
 


### PR DESCRIPTION
## Context

Follow-up to #555, driven by the operator's phone screenshots of the **Ep501 dark-mode** email. The markdown now renders to HTML, but three readability bugs remained in dark mode.

## Bugs fixed

**1. Story titles shipped as low-contrast Tesla-red on the dark background.**
Bare `<strong>` carries no colour, so **Buttondown's theme stylesheet recoloured it with the account accent** (red). Section headings were unaffected because they already carry an explicit inline colour — that was the tell. Fix: render bold with an explicit inline colour (`#0f172a`) so the theme can't win, and add `strong/b/em/i/code` to the dark-mode `@media` text-flip so it lightens correctly.

**2. Every "Top 12" item rendered as "1.".**
Each item is a marker line + an *indented continuation line* + a blank line before the next item. The naive line parser made each item its own one-item `<ol>` (each restarting at 1). Fix: `_collect_list()` walks loose lists (blank line between items) and folds indented continuation lines into the item → **one continuous `<ol>` numbered 1…N**.

**3. Each item's body split off as a detached paragraph.**
The folded continuation now renders as a normal-weight sub-block inside the `<li>`, so a news item reads as **Title / body / Source** as intended.

## Verification

Rendered the **real Ep500 digest** through the full newsletter pipeline (scrub → transforms → wrap) in both light and dark mode with headless Chromium:
- Continuous numbering (1, 2, 3 …), bodies folded under each item
- Story titles readable in **both** modes (light `#0f172a` / dark flipped to `#e2e8f0`), no more red
- Source links clickable
- Light-mode contrast tripwire: **0 failures**

Network-wide (all shows share `wrap_with_branding`). Full suite green (**2409 passed**). New drift guards: continuous-numbering, folded-body, explicit-bold-colour.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_