### PR TITLE
Newsletter: high-contrast TSLA price block + defined cards (dark mode)

### DIFF
--- a/engine/newsletter_body.py
+++ b/engine/newsletter_body.py
@@ -102,46 +102,54 @@ def render_tsla_price_block(body: str) -> str:
         price = match.group(1) or ""
         arrow = match.group(2) or ""
         delta = match.group(3) or ""
-        # Up = green, Down = red, no arrow = neutral slate.
-        # Operator caught (TST Ep465, May 6 2026) the prior #10b981
-        # / #ef4444 pair failing the newsletter contrast hard-block:
-        # both clear AA on white but fall to 2.32 / 3.44 on the
-        # cream `#fef2f2` price-block surface. Bumped to Tailwind
-        # emerald-700 / red-700 so the arrows clear AA on cream.
+        # The PRICE stays a high-contrast neutral in both modes (dark
+        # `#111827` flips to light via the universal dark override). Only
+        # the DELTA carries direction colour. Earlier the price used
+        # ``brand-text-tesla`` (→ light red in dark mode) on a red-tinted
+        # surface, which rendered as muddy red-on-red on down days
+        # (operator screenshot, Ep502, Jun 2026). Neutral card surface +
+        # neutral price + a direction-coloured delta fixes that.
+        #
+        # Delta colour: up = emerald, down = rose, flat = slate. Light-mode
+        # inline values clear WCAG AA on the `#f8fafc` card; the
+        # ``.delta-up``/``.delta-down`` classes swap to lighter variants in
+        # dark mode (class beats the universal ``span`` override) so the
+        # direction signal survives instead of washing out to grey.
         if arrow == "▲":
-            delta_color = "#047857"  # emerald-700, 5.01:1 on cream
+            delta_color = "#047857"  # emerald-700, AA on #f8fafc
+            delta_class = "delta-up"
         elif arrow == "▼":
-            delta_color = "#b91c1c"  # red-700, 5.91:1 on cream
+            delta_color = "#b91c1c"  # red-700, AA on #f8fafc
+            delta_class = "delta-down"
         else:
             delta_color = "#475569"
+            delta_class = "delta-flat"
         delta_html = ""
         if arrow or delta:
             delta_html = (
-                f' <span style="color:{delta_color};font-size:14px;'
-                f'font-weight:600;">{arrow} {delta}</span>'.strip()
-            )
-        # Dark-mode rules in `_DARK_MODE_STYLE` flip ``.surface-tsla``
-        # to a dark slate background. Without the class hook the cream
-        # `#fef2f2` survives into dark mode and the dark-text override
-        # turns the whole block into light-on-light = invisible. Spec
-        # v2 follow-up after the May 2 Tesla daily render bug.
+                f' <span class="{delta_class}" style="color:{delta_color};'
+                f'font-size:14px;font-weight:600;">{arrow} {delta}</span>'
+            ).rstrip()
+        # Neutral ``card`` surface (flips to dark slate in dark mode) +
+        # a brand-red left accent. No same-hue text-on-tint contrast trap.
         return (
             '<table role="presentation" cellpadding="0" cellspacing="0" '
             'border="0" '
             'class="surface-white" '
             'style="background:#ffffff;margin:0 0 16px;">'
             '<tr><td '
-            'class="surface-tsla" '
-            'style="padding:10px 14px;border-left:4px solid #E31937;'
-            'background:#fef2f2;border-radius:0 6px 6px 0;'
+            'class="card" '
+            'style="padding:12px 16px;border-left:4px solid #E31937;'
+            'background:#f8fafc;border-radius:0 8px 8px 0;'
+            'border:1px solid #eef0f3;border-left:4px solid #E31937;'
             "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',"
             'Roboto,Helvetica,Arial,sans-serif;">'
             '<div class="text-muted" '
             'style="font-size:11px;font-weight:700;color:#475569;'
             'text-transform:uppercase;letter-spacing:0.06em;'
             'margin-bottom:2px;">TSLA today</div>'
-            '<div class="brand-text-tesla" '
-            'style="font-size:18px;font-weight:700;color:#0f172a;'
+            '<div '
+            'style="font-size:20px;font-weight:700;color:#111827;'
             'line-height:1.2;">'
             f'{price}{delta_html}'
             '</div>'

--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -310,8 +310,20 @@ _DARK_MODE_STYLE = """\
       background-color:#0f172a !important;
     }
 
-    /* Cards (slightly lifted "panel" surfaces). */
-    .card { background:#1e293b !important; background-color:#1e293b !important; }
+    /* Cards (slightly lifted "panel" surfaces). A subtle border helps
+     * them read as distinct panels against the near-black page. */
+    .card {
+      background:#1e293b !important;
+      background-color:#1e293b !important;
+      border-color:#334155 !important;
+    }
+
+    /* Stock-watch delta direction colours — lighter variants so the
+     * up/down signal survives dark mode (class beats the universal
+     * ``span`` text override). */
+    .delta-up   { color:#34d399 !important; }   /* emerald-400 */
+    .delta-down { color:#fb7185 !important; }   /* rose-400 */
+    .delta-flat { color:#94a3b8 !important; }   /* slate-400 */
 
     /* Primary text on every dark-mode surface. ``strong``/``b``/``em``/
      * ``i``/``code`` are listed explicitly: we now set an inline colour
@@ -1051,9 +1063,11 @@ def render_markdown_body(
                     'cellspacing="0" border="0" class="card" '
                     'style="background:#f8fafc;border-radius:10px;'
                     'margin:6px 0 18px;">'
-                    '<tr><td style="padding:14px 18px;'
+                    '<tr><td class="card" style="padding:14px 18px;'
+                    'border:1px solid #eef0f3;'
                     f'border-left:4px solid {brand};font-size:16px;'
-                    'line-height:1.6;color:#0f172a;font-weight:600;">'
+                    'line-height:1.6;color:#0f172a;font-weight:600;'
+                    'border-radius:10px;">'
                     f'{inner}</td></tr></table>'
                 )
             continue
@@ -1184,7 +1198,8 @@ def _build_featured_episode_html(
         'font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\','
         'Roboto,Helvetica,Arial,sans-serif;">'
         f'<div class="card" '
-        f'style="background:#f8fafc;border-left:3px solid {brand};'
+        f'style="background:#f8fafc;border:1px solid #eef0f3;'
+        f'border-left:3px solid {brand};'
         f'border-radius:8px;padding:18px 18px 16px;">'
         '<div style="font-size:11px;font-weight:700;'
         f'color:{eyebrow_color};letter-spacing:0.08em;'

--- a/tests/test_newsletter_body.py
+++ b/tests/test_newsletter_body.py
@@ -93,6 +93,21 @@ class TestTeslaPriceBlock:
         text = "Some prose, no TSLA price line here."
         assert render_tsla_price_block(text) == text
 
+    def test_price_is_neutral_high_contrast_not_brand_red(self):
+        """The PRICE must stay a high-contrast neutral (dark `#111827`,
+        flipped to light in dark mode) — NOT brand red on the tinted
+        surface, which rendered as muddy red-on-red on down days
+        (operator screenshot, Ep502, Jun 2026). Only the delta carries
+        direction colour, via the ``delta-up``/``delta-down`` classes that
+        survive the dark-mode text override."""
+        up = render_tsla_price_block("**TSLA today:** $390.82 ▲ $9.44 (2.5%)")
+        assert "color:#111827" in up           # neutral price
+        assert "brand-text-tesla" not in up     # not the muddy red class
+        assert 'class="delta-up"' in up         # direction survives dark mode
+        down = render_tsla_price_block("**TSLA today:** $372.80 ▼ $5.20 (-1.4%)")
+        assert "color:#111827" in down
+        assert 'class="delta-down"' in down
+
 
 # ---------------------------------------------------------------------------
 # Hook → blockquote
@@ -673,12 +688,14 @@ class TestCanonicalScrubIntegration:
 
 class TestTeslaArrowAaGuard:
     """Both arrow colors must clear WCAG AA (4.5:1) on the price
-    block's cream `#fef2f2` background so the newsletter contrast
+    block's neutral `#f8fafc` card background so the newsletter contrast
     hard-block doesn't fire on any future TST send. Pin the arrow
     colors AND the AA result so a future palette tweak can't drop
-    below the threshold without CI flagging it."""
+    below the threshold without CI flagging it. (Surface moved from the
+    old red-tinted cream to a neutral card in Jun 2026 — the muddy
+    red-price-on-red-tint down-day render, Ep502.)"""
 
-    CREAM_BG = "#fef2f2"
+    CREAM_BG = "#f8fafc"
 
     def _ratio(self, fg, bg):
         from engine.contrast_validator import contrast_ratio


### PR DESCRIPTION
## Context

From the operator's **Ep502 dark-mode** screenshots — a down day (−6.6%). The body now renders cleanly (per #555/#557), but two issues remained.

## Fixes

**1. TSLA price block was muddy red-on-red.**
The price carried the `brand-text-tesla` class (→ light red in dark mode) sitting on a red-tinted surface, so on a down day the price + delta were low-contrast red-on-dark-red. Redesigned:
- Neutral card surface (no same-hue text-on-tint trap)
- The **price** is now a high-contrast neutral (`#111827` light, flipped to light in dark mode)
- Only the **delta** carries direction colour, via new `delta-up`/`delta-down`/`delta-flat` classes that beat the dark-mode universal text override — so the green/red up/down signal is preserved instead of washing out to grey

**2. Cards barely separated from the near-black page in dark mode.**
The featured-episode, hook, and TSLA cards (`#1e293b` on `#0f172a`) were nearly indistinguishable. Added a subtle 1px border (flipped to `#334155` in dark via the `.card` rule) so they read as distinct panels.

## Verification

Rendered the **real Ep502 digest** through the full pipeline in both light and dark mode:
- Price is now clearly legible (white `$391.00` in dark / dark in light) with a readable directional delta (`▼ $27.45 (6.6%)` in rose/red)
- Featured / hook / TSLA cards are well-defined panels
- Light-mode contrast tripwire: **0 failures**

Network-wide. Full suite green (**2410 passed**). Drift guard pins the neutral-price + direction-class design; the existing arrow-AA guard updated to the new neutral surface.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_