### PR TITLE
Newsletter: fix dim/unreadable section headings in iOS Mail dark mode

### DIFF
--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -295,6 +295,17 @@ _DARK_MODE_STYLE = """\
    * Spec references: §1.3 light-mode contrast swaps, §1.4 dark-mode
    * brand tokens + ``.preheader`` hide.
    */
+  /* Opt INTO native dark-mode handling. Without this, Apple Mail (iOS)
+   * runs its OWN automatic colour transform on the email and ignores the
+   * @media rules below — and its transform renders our near-black
+   * (#0f172a) section headings DIMMER than the body text, so the main
+   * headings looked washed-out/unreadable on the operator's phone while
+   * our Chromium previews (which honour @media) looked fine. Declaring
+   * color-scheme tells Apple Mail "this email ships its own dark styles,
+   * use them" so the @media block actually applies. */
+  :root { color-scheme: light dark; }
+  body { color-scheme: light dark; }
+
   body, table, td, p, h1, h2, h3, h4, span, div, a {
     -webkit-text-size-adjust:100%;
     -ms-text-size-adjust:100%;
@@ -333,6 +344,11 @@ _DARK_MODE_STYLE = """\
     strong, b, em, i, code {
       color:#e2e8f0 !important;
     }
+    /* Section headings are the BRIGHTEST text so they read as headings,
+     * not as dimmer-than-body labels (the exact regression on the
+     * operator's phone). Dedicated, simple selector + pure white, placed
+     * AFTER the universal rule so it wins for h1-h4. */
+    h1, h2, h3, h4 { color:#ffffff !important; }
     /* Secondary / muted text — class-targeted so it doesn't override
      * other usages. */
     .text-muted { color:#94a3b8 !important; }
@@ -1021,15 +1037,16 @@ def render_markdown_body(
             level = len(m.group(1))
             inner = _md_inline_rich(m.group(2))
             if level <= 2:
-                # Major section: divider above + brand underline accent.
+                # Major section: brand left-bar accent. The text is a
+                # direct child of <h2> (no inner <span>) so the dark-mode
+                # ``h1,h2,h3,h4`` white rule wins — an inner span would be
+                # caught by the universal ``span`` rule (#e2e8f0) and the
+                # heading would render dimmer than intended.
                 blocks.append(
-                    '<h2 style="margin:30px 0 12px;padding-top:18px;'
-                    'border-top:1px solid #eef0f3;font-size:19px;'
+                    '<h2 style="margin:30px 0 12px;padding:2px 0 2px 12px;'
+                    f'border-left:4px solid {brand};font-size:19px;'
                     'line-height:1.3;font-weight:700;color:#0f172a;'
-                    'letter-spacing:-0.01em;">'
-                    '<span style="display:inline-block;'
-                    f'border-bottom:3px solid {brand};padding-bottom:2px;">'
-                    f'{inner}</span></h2>'
+                    f'letter-spacing:-0.01em;">{inner}</h2>'
                 )
             elif level == 3:
                 blocks.append(

--- a/tests/test_newsletter_template.py
+++ b/tests/test_newsletter_template.py
@@ -924,6 +924,31 @@ def test_wrap_with_branding_includes_dark_mode_style_block():
     assert "#e2e8f0" in out  # dark text
 
 
+def test_dark_mode_opts_into_native_color_scheme():
+    """``color-scheme: light dark`` makes Apple Mail (iOS) use our @media
+    dark styles instead of running its own colour transform — which had
+    rendered the near-black section headings dimmer than body text
+    ('main headings very light/unreadable', operator report Jun 2026).
+    Without the opt-in the @media rules below are ignored on iOS Mail."""
+    out = nt.wrap_with_branding(
+        "tesla", "## A Section\n\nBody.", week_ending=datetime.date(2026, 4, 30),
+    )
+    assert "color-scheme: light dark" in out
+
+
+def test_dark_mode_headings_are_brightest_text():
+    """Section headings must be the BRIGHTEST text in dark mode (pure
+    white via a dedicated h1-h4 rule placed after the universal text
+    rule), so they read as headings rather than dimmer-than-body labels."""
+    out = nt.wrap_with_branding(
+        "tesla", "## A Section\n\nBody.", week_ending=datetime.date(2026, 4, 30),
+    )
+    assert "h1, h2, h3, h4 { color:#ffffff !important; }" in out
+    # The h2 text is a direct child (no inner <span> the universal span
+    # rule would dim) so the white heading rule actually wins.
+    assert "<h2" in out and "<span" not in out.split("<h2", 1)[1].split("</h2>", 1)[0]
+
+
 def test_hero_alt_text_describes_show_not_file():
     show = nt._load_show_branding("tesla")
     hero = nt._build_hero_html(show, "Pill")


### PR DESCRIPTION
## Why this kept recurring

Honest root-cause: **my local previews use Chromium, which fully honours the embedded `@media (prefers-color-scheme: dark)` `<style>` block — so headings looked fine in every test.** But **Apple Mail (iOS) runs its own automatic dark-mode colour transform and ignores that `@media` block unless the email opts in.** Its transform renders our near-black (`#0f172a`) section headings *dimmer than the body text*, so the main headings read as washed-out/unreadable on your phone while my previews looked correct. The previous newsletter fixes never reproduced this because they were either client-agnostic (Buttondown theme) or only checked in Chromium.

## Fixes

1. **`color-scheme: light dark`** (on `:root` + `body`) — tells Apple Mail "this email ships its own dark styles, use them" so the `@media` block actually applies on iOS Mail instead of being overridden by Apple's auto-transform. This is the switch that makes everything else take effect.
2. **Dedicated `h1,h2,h3,h4 { color:#ffffff !important }`** rule, placed after the universal text rule, so section headings are the **brightest** text in dark mode — they read as headings, not dimmer-than-body labels.
3. **Simplified `h2` markup**: a brand left-bar accent instead of the inner `<span>` underline. The heading text is now a direct child of `<h2>`, so the white-heading rule wins — the old inner `<span>` was caught by the universal `span` rule (`#e2e8f0`) and would have stayed dimmer.

## Verification & honest caveat

Verified light + dark in Chromium (headings now render as bright white with a brand left-bar in dark, dark with left-bar in light — no regression). **I cannot fully simulate Apple Mail's transform in this environment**, but these are the standard, documented fixes for exactly this iOS-Mail behaviour and they target its precise mechanism. Full suite green (**2412 passed**). Drift guards pin `color-scheme`, the bright-heading rule, and the no-inner-span `h2` markup.

If a future send still shows dim headings, the next lever is moving the entire dark palette to inline styles / a hybrid approach — but `color-scheme` is the correct first fix and far less invasive.

https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01D18tdM23iWwZciY4YDaHLC)_