### PR TITLE
Network review + audience-growth pass: OP3/Buttondown read-back, funnel fixes, 2.0 tags, cross-promo

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -54,6 +54,16 @@ jobs:
           requirements-file: 'requirements.txt'
           skip-checkout: 'true'
 
+      - name: Fetch audience stats (OP3 downloads + Buttondown subscribers)
+        # Clean no-ops when the secrets are unset. Must run BEFORE the
+        # dashboard build so the Audience section can consume the JSONs.
+        env:
+          OP3_API_TOKEN: ${{ secrets.OP3_API_TOKEN }}
+          BUTTONDOWN_API_KEY: ${{ secrets.BUTTONDOWN_API_KEY }}
+        run: |
+          python scripts/fetch_op3_stats.py --out api/op3_stats.json --popular-out site/data/popular_episodes.json
+          python scripts/fetch_buttondown_stats.py --out api/buttondown_stats.json
+
       - name: Generate Management Dashboard
         run: python scripts/generate_dashboard.py --out api/dashboard.json
 
@@ -77,9 +87,20 @@ jobs:
       - name: Generate MIT Performance Page + Tesla Narrative Page + Main Site
         # Ensures dedicated transparency pages (MIT performance + TST narrative tracker)
         # and other pages that depend on fresh data stay up to date.
+        # Marketing env vars must be present on EVERY html-regen step —
+        # otherwise a nightly rebuild strips analytics tags from pages the
+        # daily run-show regen (which passes them) had added.
+        env:
+          GA4_MEASUREMENT_ID: ${{ secrets.GA4_MEASUREMENT_ID }}
+          GOOGLE_ADS_ID: ${{ secrets.GOOGLE_ADS_ID }}
+          GOOGLE_ADS_SIGNUP_LABEL: ${{ secrets.GOOGLE_ADS_SIGNUP_LABEL }}
+          PLAUSIBLE_DOMAIN: ${{ secrets.PLAUSIBLE_DOMAIN }}
         run: |
           python generate_html.py --show modern_investing
           python generate_html.py --show tesla
+          # Homepage rebuild picks up the fresh popular-episodes rail +
+          # newsletter subscriber social proof from the audience-stats step.
+          python generate_html.py --network
           # Optionally regenerate full site if needed:
           # python generate_html.py --all
 
@@ -87,8 +108,12 @@ jobs:
         with:
           add-paths: |
             api/dashboard.json
+            api/op3_stats.json
+            api/buttondown_stats.json
+            site/data/popular_episodes.json
             site/data/gallery-manifest.json
             site/data/search-index.json
+            index.html
             modern-investing-performance.html
             modern-investing.html
             tesla-narrative.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -557,6 +557,56 @@ use the original Short, unchanged. Full setup + limitations:
 [`docs/social_distribution.md`](docs/social_distribution.md). Drift guards:
 `tests/test_social_distribution.py`.
 
+### Audience-growth pass (June 2026)
+
+Full network review + growth implementation —
+[`docs/network_review_2026_06.md`](docs/network_review_2026_06.md) is the
+canonical writeup (market analysis, first real audience numbers, roadmap,
+operator checklist). Shipped, all no-ops when secrets unset:
+
+- **Audience read-back.** `scripts/fetch_op3_stats.py` (needs
+  `OP3_API_TOKEN`) + `scripts/fetch_buttondown_stats.py` run in nightly
+  maintenance before the dashboard build → `api/op3_stats.json`,
+  `api/buttondown_stats.json`, public `site/data/popular_episodes.json`.
+  Surfaces: dashboard "Audience" card, homepage "Most Played This Week"
+  rail, homepage "Join N+ readers" social proof (hidden < 100 subs).
+  OP3 response shapes are pinned in `tests/test_op3_stats.py` — verified
+  live June 2026 (`monthlyDownloads`/`weeklyDownloads`; episode
+  `downloads1/3/7/30/All` keys are OMITTED when the data span is young).
+- **Adjacency-map bug fixed.** `newsletter.network_adjacencies` (and the
+  other newsletter composition keys) had been mis-indented under
+  `cost_circuit_breakers:` in `shows/_defaults.yaml` — newsletter +
+  synthesizer read an empty map, so the cross-network email module was
+  silently degraded network-wide. Drift guard pins the location. NOTE:
+  there are deliberately THREE curated cross-show mappings — web
+  (`generate_html.NETWORK_SHOWS[slug]["related_show"]`), email
+  (`newsletter.network_adjacencies`), audio/X
+  (`engine/network_promo.ENGLISH_SHOWS`). Do not consolidate casually;
+  each is tested and serves a different surface.
+- **Newsletter growth loop.** Every show now gets a deterministic
+  Buttondown slug (`<show>-ep<num>-<hook>`; was Russian-only) so the
+  view-in-browser/archive link renders pre-send on dailies AND weeklies;
+  reply/share row gained a localized "Forwarded this email? Subscribe
+  here" line (UTM `forward_subscribe`).
+- **X cross-promo reply.** Flag `publishing.x_cross_promo` (network
+  default true in `_defaults.yaml`, dataclass default false) posts a
+  second tweet threaded under the teaser: "Follow @{x_handle}" + one
+  sibling plug from the `network_promo` rotation. `x_handle` set only for
+  tesla/@teslashortstime + the PLANETTERRIAN_X_ shows/@planetterrian;
+  OV/M&A/MIT pending operator confirmation. Roughly doubles posts/day per
+  X app — flip the flag off if the free-tier cap trips.
+- **Podcasting 2.0 channel tags.** `update_rss_feed` now injects
+  `podcast:funding` (→ `/#newsletter`) + `podcast:person` (host) on every
+  rebuild via `_inject_channel_funding_person_tags` (same pattern as
+  `podcast:locked`); empty kwargs = byte-for-byte legacy behavior.
+- Sitemap: + `player.html` + `modern-investing-performance.html`,
+  − `404.html`. Nightly site-regen step now passes the marketing env vars
+  (was silently stripping analytics tags on nightly rebuilds).
+- **Known wart (operator decision pending):** Russian shows speak the
+  ENGLISH `_AI_DISCLOSURE` line at the end of every episode; a localized
+  `_AI_DISCLOSURE_RU` is a one-liner in `run_show.py` but changes shipped
+  audio → landmine #17 A/B-listen first.
+
 ## Current Refactoring Goal
 
 **Extract duplicated code from the show scripts into `engine/` modules.**

--- a/README.md
+++ b/README.md
@@ -173,9 +173,21 @@ When any GA4/Ads ID is set:
 - Newsletter form submits and Apple/Spotify clicks fire conversion events
 - All outbound subscription links carry UTM parameters for source attribution
 
+**Plausible one-step enable:** create the site at plausible.io, then set the
+repo secret `PLAUSIBLE_DOMAIN=nerranetwork.com` — the next site regeneration
+(daily run-show finalize or nightly maintenance, both pass the secret) emits
+the Plausible script on every page. Cookie-free, so no consent banner is
+required for Plausible alone.
+
 Podcast download analytics (OP3) are enabled by default for all shows in
 `shows/_defaults.yaml` — listener stats appear at https://op3.dev once
-deployed.
+deployed. The nightly maintenance job additionally pulls the numbers back
+into the repo via `scripts/fetch_op3_stats.py` (set the `OP3_API_TOKEN`
+secret, free at op3.dev/api/keys): `api/op3_stats.json` feeds the
+management dashboard's Audience card, and `site/data/popular_episodes.json`
+feeds the homepage "Most Played This Week" rail. The newsletter subscriber
+count flows the same way via `scripts/fetch_buttondown_stats.py`
+(`BUTTONDOWN_API_KEY`, already set for sends).
 
 ## Documentation
 

--- a/api/op3_stats.json
+++ b/api/op3_stats.json
@@ -1,0 +1,973 @@
+{
+  "fetched_at": "2026-06-10T00:19:48.004524+00:00",
+  "shows": {
+    "env_intel": {
+      "show_uuid": "6dfc963562e34d93ab940dfbde7d233a",
+      "feed_url": "https://nerranetwork.com/env_intel_podcast.rss",
+      "asof": "2026-06-08",
+      "downloads_7d": 11,
+      "downloads_30d": 24,
+      "weekly_avg": 11,
+      "weekly_downloads": [
+        0,
+        0,
+        13,
+        11
+      ],
+      "episodes": [
+        {
+          "title": "Ep 42: Alberta oilsands carbon capture target cut 77% to 16 Mt/year, with Manitoba pipeline and BC spill settlement also advancing.",
+          "item_guid": "env-intel-ep042-20260605-113848946051",
+          "pubdate": "2026-06-05T08:00:00.000Z",
+          "downloads_3d": 2,
+          "downloads_7d": 2,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 41: DFO endorses relocation of Marineland belugas to Spain and US facilities under federal marine mammal oversight.",
+          "item_guid": "env-intel-ep041-20260603-125231435887",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 2,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "Ep 36: Alberta commits $5 million to lobbyists securing BC Indigenous support for pipelines, directly affecting project timelines under IAA and provincial environmental assessments.",
+          "item_guid": "env-intel-ep036-20260527-092225542535",
+          "pubdate": "2026-05-27T08:00:00.000Z",
+          "downloads_3d": 1,
+          "downloads_7d": 1,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "Ep 35: US EPA proposes delays for certain PFAS regulations, a move Canadian practitioners should monitor for CCME and provincial threshold alignment.",
+          "item_guid": "env-intel-ep035-20260519-092318552051",
+          "pubdate": "2026-05-19T08:00:00.000Z",
+          "downloads_3d": 1,
+          "downloads_7d": 1,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "Ep 40: Alberta oil pipeline route options through northern BC trigger West Moberly First Nations opposition over territory impacts.",
+          "item_guid": "env-intel-ep040-20260603-102533898214",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "Ep 39: Ottawa faces mounting pressure to quantify emissions outcomes from policy shifts while federal vehicle regulations advance.",
+          "item_guid": "env-intel-ep039-20260601-135005331597",
+          "pubdate": "2026-06-01T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "Ep 38: Federal environment minister claims substantial climate progress while facing Bloc Qu\u00e9b\u00e9cois accusations of historic policy reversal.",
+          "item_guid": "env-intel-ep038-20260529-113607096394",
+          "pubdate": "2026-05-29T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 1,
+          "downloads_all_time": 1
+        },
+        {
+          "title": "Ep 34: Federal electricity strategy advances electrification targets but leaves implementation timelines and provincial coordination gaps unresolved.",
+          "item_guid": "env-intel-ep034-20260515-091715639638",
+          "pubdate": "2026-05-15T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 1,
+          "downloads_all_time": 1
+        }
+      ]
+    },
+    "fascinating_frontiers": {
+      "show_uuid": "f7317f31e079492caf6e393b40969503",
+      "feed_url": "https://nerranetwork.com/fascinating_frontiers_podcast.rss",
+      "asof": "2026-06-08",
+      "downloads_7d": 24,
+      "downloads_30d": 150,
+      "weekly_avg": 35,
+      "weekly_downloads": [
+        16,
+        28,
+        72,
+        24
+      ],
+      "episodes": [
+        {
+          "title": "Ep 89: Blue Origin plans to fly its New Glenn rocket again before year\u2019s end after a launch-pad incident damaged the gantry but spared key tanks.",
+          "item_guid": "fascinating-frontiers-ep089-20260603-102710525953",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 3,
+          "downloads_7d": 3,
+          "downloads_30d": 4,
+          "downloads_all_time": 4
+        },
+        {
+          "title": "Ep 90: A meteorite has delivered the first direct evidence that a Mars-sized world once orbited the young sun before shattering in a collision.",
+          "item_guid": "fascinating-frontiers-ep090-20260603-122716692740",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 2,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 95: NASA will name the crew for Artemis III, the mission that will test docking with commercial landers ahead of crewed lunar landings.",
+          "item_guid": "fascinating-frontiers-ep095-20260608-122335348330",
+          "pubdate": "2026-06-08T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 4,
+          "downloads_all_time": 4
+        },
+        {
+          "title": "Ep 94: Looking back at 7 episodes from 2026-06-01 to 2026-06-07 \u2014 the stories that mattered, what we learned, and what to watch next.",
+          "item_guid": "fascinating-frontiers-ep094-20260607-101906510415",
+          "pubdate": "2026-06-07T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 93: Astronomers have finally detected winds streaming from the Milky Way\u2019s central black hole after a fifty-year search.",
+          "item_guid": "fascinating-frontiers-ep093-20260606-094221898596",
+          "pubdate": "2026-06-06T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "Ep 92: An interstellar comet is venting methane at levels never seen in solar-system comets, hinting at a wildly different formation history.",
+          "item_guid": "fascinating-frontiers-ep092-20260605-110456981702",
+          "pubdate": "2026-06-05T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 91: A meteorite from the Sahara holds the first direct traces of a lost moon-size world that formed just after the solar system began.",
+          "item_guid": "fascinating-frontiers-ep091-20260604-105446704396",
+          "pubdate": "2026-06-04T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 88: Seven scorching hot Jupiters are showing the strongest signs yet of magnetic fields through their bizarre wind patterns.",
+          "item_guid": "fascinating-frontiers-ep088-20260602-115756451464",
+          "pubdate": "2026-06-02T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        }
+      ]
+    },
+    "finansy_prosto": {
+      "show_uuid": "18a2d900922847a1922d9d9729915cac",
+      "feed_url": "https://nerranetwork.com/finansy_prosto_podcast.rss",
+      "asof": "2026-06-08",
+      "downloads_7d": 7,
+      "downloads_30d": 64,
+      "weekly_avg": 13,
+      "weekly_downloads": [
+        5,
+        12,
+        26,
+        7
+      ],
+      "episodes": [
+        {
+          "title": "\u0424\u0438\u043d\u0430\u043d\u0441\u044b \u041f\u0440\u043e\u0441\u0442\u043e - Episode 42 - May 24, 2026",
+          "item_guid": "fp-ep042-20260524-101644755375",
+          "pubdate": "2026-05-24T08:00:00.000Z",
+          "downloads_3d": 2,
+          "downloads_7d": 2,
+          "downloads_30d": 4,
+          "downloads_all_time": 4
+        },
+        {
+          "title": "\u0424\u0438\u043d\u0430\u043d\u0441\u044b \u041f\u0440\u043e\u0441\u0442\u043e - Episode 44 - May 30, 2026",
+          "item_guid": "fp-ep044-20260530-110625382326",
+          "pubdate": "2026-05-30T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 1,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "\u0424\u0438\u043d\u0430\u043d\u0441\u044b \u041f\u0440\u043e\u0441\u0442\u043e - Episode 49 - June 08, 2026",
+          "item_guid": "fp-ep049-20260608-135902601627",
+          "pubdate": "2026-06-08T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 1,
+          "downloads_all_time": 1
+        },
+        {
+          "title": "Ep 48: \u0421\u0435\u0433\u043e\u0434\u043d\u044f \u0440\u0430\u0437\u0431\u0435\u0440\u0451\u043c\u0441\u044f, \u043a\u0430\u043a \u043a\u0430\u043d\u0430\u0434\u0441\u043a\u0438\u0435 \u0438\u043c\u043c\u0438\u0433\u0440\u0430\u043d\u0442\u043a\u0438 \u043c\u043e\u0433\u0443\u0442 \u0437\u0430\u0449\u0438\u0442\u0438\u0442\u044c \u0441\u0432\u043e\u0438 \u0441\u0431\u0435\u0440\u0435\u0436\u0435\u043d\u0438\u044f, \u0434\u0430\u0436\u0435 \u0435\u0441\u043b\u0438 \u0431\u0430\u043d\u043a\u043e\u0432\u0441\u043a\u0438\u0435 \u0441\u0438\u0441\u0442\u0435\u043c\u044b \u043f\u043e\u0434\u0432\u043e\u0434\u044f\u0442.",
+          "item_guid": "fp-ep048-20260606-111258155494",
+          "pubdate": "2026-06-06T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "\u0424\u0438\u043d\u0430\u043d\u0441\u044b \u041f\u0440\u043e\u0441\u0442\u043e - Episode 47 - June 04, 2026",
+          "item_guid": "fp-ep047-20260604-123622021689",
+          "pubdate": "2026-06-04T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "\u0424\u0438\u043d\u0430\u043d\u0441\u044b \u041f\u0440\u043e\u0441\u0442\u043e - Episode 46 - June 03, 2026",
+          "item_guid": "fp-ep046-20260603-102521140059",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 1,
+          "downloads_all_time": 1
+        },
+        {
+          "title": "Ep 45: \u0421\u0435\u0433\u043e\u0434\u043d\u044f \u0440\u0430\u0437\u0431\u0435\u0440\u0451\u043c\u0441\u044f, \u043a\u0430\u043a \u043a\u0430\u043d\u0430\u0434\u0441\u043a\u0438\u0435 \u0431\u0440\u043e\u043a\u0435\u0440\u044b \u043f\u043e\u043c\u043e\u0433\u0430\u044e\u0442 \u0436\u0435\u043d\u0449\u0438\u043d\u0430\u043c \u0438\u043d\u0432\u0435\u0441\u0442\u0438\u0440\u043e\u0432\u0430\u0442\u044c \u0431\u0435\u0437 \u043b\u0438\u0448\u043d\u0438\u0445 \u043a\u043e\u043c\u0438\u0441\u0441\u0438\u0439 \u0438 \u043f\u043e\u0447\u0435\u043c\u0443 \u044d\u0442\u043e \u0432\u0430\u0436\u043d\u043e \u0434\u043b\u044f \u0444\u0438\u043d\u0430\u043d\u0441\u043e\u0432\u043e\u0439 \u043d\u0435\u0437\u0430\u0432\u0438\u0441\u0438\u043c\u043e\u0441\u0442\u0438.",
+          "item_guid": "fp-ep045-20260602-130328912784",
+          "pubdate": "2026-06-02T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 1,
+          "downloads_all_time": 1
+        },
+        {
+          "title": "\u0424\u0438\u043d\u0430\u043d\u0441\u044b \u041f\u0440\u043e\u0441\u0442\u043e - Episode 43 - May 28, 2026",
+          "item_guid": "fp-ep043-20260528-133245315321",
+          "pubdate": "2026-05-28T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 1,
+          "downloads_all_time": 1
+        }
+      ]
+    },
+    "models_agents": {
+      "show_uuid": "b4f448c5a0dc49099eb88748afeeb2d8",
+      "feed_url": "https://nerranetwork.com/models_agents_podcast.rss",
+      "asof": "2026-06-08",
+      "downloads_7d": 99,
+      "downloads_30d": 422,
+      "weekly_avg": 100,
+      "weekly_downloads": [
+        90,
+        79,
+        131,
+        99
+      ],
+      "episodes": [
+        {
+          "title": "Ep 69: Microsoft is shipping hardware built from the silicon up to run AI agents instead of conventional apps.",
+          "item_guid": "models-agents-ep069-20260603-130138779141",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 13,
+          "downloads_7d": 13,
+          "downloads_30d": 15,
+          "downloads_all_time": 15
+        },
+        {
+          "title": "Ep 72: Microsoft just gained the freedom to build its own frontier models after a contract change with OpenAI, and the first MAI family is already shipping.",
+          "item_guid": "models-agents-ep072-20260606-103718529788",
+          "pubdate": "2026-06-06T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 10,
+          "downloads_30d": 11,
+          "downloads_all_time": 11
+        },
+        {
+          "title": "Ep 73: Looking back at 7 episodes from 2026-06-01 to 2026-06-07 \u2014 the stories that mattered, what we learned, and what to watch next.",
+          "item_guid": "models-agents-ep073-20260607-104730525665",
+          "pubdate": "2026-06-07T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 9,
+          "downloads_30d": 11,
+          "downloads_all_time": 11
+        },
+        {
+          "title": "Ep 70: Gemma 4 12B puts capable local agents on laptops with only 16GB VRAM under an Apache 2.0 license.",
+          "item_guid": "models-agents-ep070-20260604-113735932658",
+          "pubdate": "2026-06-04T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 9,
+          "downloads_30d": 11,
+          "downloads_all_time": 11
+        },
+        {
+          "title": "Ep 68: NVIDIA's Cosmos 3 pairs an autoregressive reasoner with a diffusion generator so builders can now train agents that jointly reason about physics, generate worlds, and output actions.",
+          "item_guid": "models-agents-ep068-20260603-102658759027",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 9,
+          "downloads_7d": 9,
+          "downloads_30d": 10,
+          "downloads_all_time": 10
+        },
+        {
+          "title": "Ep 67: Enterprise teams can now run governed AI agents inside existing procurement systems instead of leaking data to personal ChatGPT accounts.",
+          "item_guid": "models-agents-ep067-20260602-123347835723",
+          "pubdate": "2026-06-02T08:00:00.000Z",
+          "downloads_3d": 9,
+          "downloads_7d": 9,
+          "downloads_30d": 10,
+          "downloads_all_time": 10
+        },
+        {
+          "title": "Ep 71: Microsoft just dropped seven new MAI models purpose-built for reasoning, coding, image, voice, and transcription, all integrated into the Microsoft stack.",
+          "item_guid": "models-agents-ep071-20260605-115000508126",
+          "pubdate": "2026-06-05T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 8,
+          "downloads_30d": 13,
+          "downloads_all_time": 13
+        },
+        {
+          "title": "Ep 74: Enterprise agents just gained a built-in factuality check that keeps re-querying until multi-hop questions have enough evidence.",
+          "item_guid": "models-agents-ep074-20260608-125518058542",
+          "pubdate": "2026-06-08T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 6,
+          "downloads_all_time": 6
+        }
+      ]
+    },
+    "models_agents_beginners": {
+      "show_uuid": "a21c6266fc7846e28b6a8d917169e4a7",
+      "feed_url": "https://nerranetwork.com/models_agents_beginners_podcast.rss",
+      "asof": "2026-06-08",
+      "downloads_7d": 52,
+      "downloads_30d": 235,
+      "weekly_avg": 57,
+      "weekly_downloads": [
+        35,
+        52,
+        87,
+        52
+      ],
+      "episodes": [
+        {
+          "title": "Ep 60: Teens are using AI to outsmart expensive World Cup ticket scalpers and build their own tools.",
+          "item_guid": "mab-ep060-20260603-133040341487",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 9,
+          "downloads_7d": 9,
+          "downloads_30d": 11,
+          "downloads_all_time": 11
+        },
+        {
+          "title": "Ep 59: A snake game just got self-aware thanks to Claude Code \u2014 and you can play it right now.",
+          "item_guid": "mab-ep059-20260603-103049318045",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 8,
+          "downloads_7d": 8,
+          "downloads_30d": 9,
+          "downloads_all_time": 9
+        },
+        {
+          "title": "Ep 58: Hackers took over big Instagram accounts just by chatting with Meta\u2019s AI support bot.",
+          "item_guid": "mab-ep058-20260602-125030828551",
+          "pubdate": "2026-06-02T08:00:00.000Z",
+          "downloads_3d": 6,
+          "downloads_7d": 6,
+          "downloads_30d": 8,
+          "downloads_all_time": 8
+        },
+        {
+          "title": "Ep 61: Google just released an AI that runs on ordinary laptops and understands pictures, text, and sound all at once.",
+          "item_guid": "mab-ep061-20260604-115813659264",
+          "pubdate": "2026-06-04T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 4,
+          "downloads_30d": 5,
+          "downloads_all_time": 5
+        },
+        {
+          "title": "Ep 64: Looking back at 7 episodes from 2026-06-01 to 2026-06-07 \u2014 the stories that mattered, what we learned, and what to watch next.",
+          "item_guid": "mab-ep064-20260607-111626235653",
+          "pubdate": "2026-06-07T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 3,
+          "downloads_30d": 5,
+          "downloads_all_time": 5
+        },
+        {
+          "title": "Ep 62: ChatGPT just learned to remember way more about you without you asking.",
+          "item_guid": "mab-ep062-20260605-121048736062",
+          "pubdate": "2026-06-05T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 2,
+          "downloads_30d": 5,
+          "downloads_all_time": 5
+        },
+        {
+          "title": "Ep 65: ChatGPT just gave free users way more power to create images without paying.",
+          "item_guid": "mab-ep065-20260608-131413414731",
+          "pubdate": "2026-06-08T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 63: A brand-new open-source AI can listen to you all day and decide on its own when to jump into the conversation.",
+          "item_guid": "mab-ep063-20260606-110549538615",
+          "pubdate": "2026-06-06T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 5,
+          "downloads_all_time": 5
+        }
+      ]
+    },
+    "modern_investing": {
+      "show_uuid": "59be70b36fde40ac8a3463c660b228ee",
+      "feed_url": "https://nerranetwork.com/modern_investing_podcast.rss",
+      "asof": "2026-06-08",
+      "downloads_7d": 27,
+      "downloads_30d": 148,
+      "weekly_avg": 36,
+      "weekly_downloads": [
+        21,
+        20,
+        74,
+        27
+      ],
+      "episodes": [
+        {
+          "title": "Ep 65: Canadian investors holding energy names face renewed pressure as oil climbs toward $100 amid fresh tariff and supply disruption risks.",
+          "item_guid": "modern-investing-ep065-20260603-145728784716",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 4,
+          "downloads_7d": 4,
+          "downloads_30d": 5,
+          "downloads_all_time": 5
+        },
+        {
+          "title": "Ep 63: Canadian investors holding healthcare platforms now have a concrete acquisition catalyst to evaluate after Hims & Hers closed its Eucalyptus deal, accelerating generic semaglutide access and whole-body care offerings north of the border.",
+          "item_guid": "modern-investing-ep063-20260602-142140034461",
+          "pubdate": "2026-06-02T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 3,
+          "downloads_30d": 5,
+          "downloads_all_time": 5
+        },
+        {
+          "title": "Ep 67: Stronger-than-expected U.S. hiring data raises the odds that rate-cut hopes fade, so Canadian investors holding rate-sensitive dividend payers in TFSAs should review duration exposure this week.",
+          "item_guid": "modern-investing-ep067-20260605-125115067695",
+          "pubdate": "2026-06-05T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 2,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 64: American buyers are flooding Canadian real estate searches, creating a potential tailwind for TFSA holders eyeing cross-border property exposure.",
+          "item_guid": "modern-investing-ep064-20260603-102807084204",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 1,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "Ep 70: AI-exposed TFSA holdings could rebound faster than broad indexes as chip and software names recover Monday's premarket losses.",
+          "item_guid": "modern-investing-ep070-20260608-142420355055",
+          "pubdate": "2026-06-08T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "Ep 69: Looking back at 7 episodes from 2026-06-01 to 2026-06-07 \u2014 the stories that mattered, what we learned, and what to watch next.",
+          "item_guid": "modern-investing-ep069-20260607-120241791706",
+          "pubdate": "2026-06-07T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 68: Canadian investors holding U.S. index exposure just saw the S&P 500 post its worst day of 2026, so re-checking stop levels and sector weights before Monday\u2019s open is the immediate priority.",
+          "item_guid": "modern-investing-ep068-20260606-114848402348",
+          "pubdate": "2026-06-06T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 66: Rising U.S. jobless claims to 225K signal potential Fed easing that could lift Canadian dividend payers in your RRSP this quarter.",
+          "item_guid": "modern-investing-ep066-20260604-125901995479",
+          "pubdate": "2026-06-04T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        }
+      ]
+    },
+    "omni_view": {
+      "show_uuid": "13f20a21a932418d8db9dbfe11351e15",
+      "feed_url": "https://nerranetwork.com/omni_view_podcast.rss",
+      "asof": "2026-06-08",
+      "downloads_7d": 28,
+      "downloads_30d": 126,
+      "weekly_avg": 30,
+      "weekly_downloads": [
+        13,
+        16,
+        63,
+        28
+      ],
+      "episodes": [
+        {
+          "title": "Ep 72: Britain's defence investment plan, long delayed, now faces a 2030 Russia threat timeline as Starmer prepares to meet Trump at NATO.",
+          "item_guid": "omni-view-ep072-20260605-104201547446",
+          "pubdate": "2026-06-05T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 3,
+          "downloads_30d": 6,
+          "downloads_all_time": 6
+        },
+        {
+          "title": "Ep 69: New US tariffs on 60 economies over forced-labor practices could raise prices for British shoppers and slow already-fragile global growth.",
+          "item_guid": "omni-view-ep069-20260603-102815584364",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 3,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 73: Ukraine\u2019s drone strikes on St Petersburg escalate the Russia conflict, threatening civilian safety and energy supplies far beyond the battlefield.",
+          "item_guid": "omni-view-ep073-20260606-091729864249",
+          "pubdate": "2026-06-06T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 2,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 68: Escalating Russian drone and missile barrages on Ukrainian cities are testing the limits of civilian protection and Western support as casualty counts rise.",
+          "item_guid": "omni-view-ep068-20260602-112212214316",
+          "pubdate": "2026-06-02T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 2,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 75: Renewed strikes between Israel and Iran risk breaking the recent ceasefire and pushing global oil prices higher for drivers and businesses everywhere.",
+          "item_guid": "omni-view-ep075-20260608-113846367967",
+          "pubdate": "2026-06-08T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 74: Looking back at 7 episodes from 2026-06-01 to 2026-06-07 \u2014 the stories that mattered, what we learned, and what to watch next.",
+          "item_guid": "omni-view-ep074-20260607-095551142969",
+          "pubdate": "2026-06-07T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 71: A new Israel-Lebanon ceasefire takes hold even as Israel continues operations in southern Lebanon, testing whether the agreement can hold amid broader regional talks.",
+          "item_guid": "omni-view-ep071-20260604-103647423525",
+          "pubdate": "2026-06-04T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "Ep 70: Six states are suing the Trump administration over a nearly $1 billion payout to cancel a major offshore wind lease, testing the reach of federal energy decisions.",
+          "item_guid": "omni-view-ep070-20260603-113838097663",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        }
+      ]
+    },
+    "planetterrian": {
+      "show_uuid": "f76f3f90954847c1a3e4738d1053a67b",
+      "feed_url": "https://nerranetwork.com/planetterrian_podcast.rss",
+      "asof": "2026-06-08",
+      "downloads_7d": 58,
+      "downloads_30d": 173,
+      "weekly_avg": 41,
+      "weekly_downloads": [
+        14,
+        19,
+        74,
+        58
+      ],
+      "episodes": [
+        {
+          "title": "Ep 80: Brains from people aged 80\u2013100 reveal how microglia shift from protective to destructive states in Alzheimer's.",
+          "item_guid": "planetterrian-daily-ep080-20260605-104829121549",
+          "pubdate": "2026-06-05T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 3,
+          "downloads_30d": 4,
+          "downloads_all_time": 4
+        },
+        {
+          "title": "Ep 76: Smartphone cameras can now measure resting heart rate passively across skin tones using facial video alone.",
+          "item_guid": "planetterrian-daily-ep076-20260602-111921628206",
+          "pubdate": "2026-06-02T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 3,
+          "downloads_30d": 4,
+          "downloads_all_time": 4
+        },
+        {
+          "title": "Ep 77: Engineered hookworms can now produce and deliver therapeutics inside a living host.",
+          "item_guid": "planetterrian-daily-ep077-20260603-102624506982",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 2,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 78: Childhood flu vaccine analysis shows 9 to 14 fewer influenza cases per 100 children aged 2 to 5.",
+          "item_guid": "planetterrian-daily-ep078-20260603-115854206353",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 1,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "Ep 83: Acetylcholine surges in the brain when expected rewards fail, prompting mice to switch strategies in a virtual maze.",
+          "item_guid": "planetterrian-daily-ep083-20260608-115800074608",
+          "pubdate": "2026-06-08T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 5,
+          "downloads_all_time": 5
+        },
+        {
+          "title": "Ep 82: Looking back at 7 episodes from 2026-06-01 to 2026-06-07 \u2014 the stories that mattered, what we learned, and what to watch next.",
+          "item_guid": "planetterrian-daily-ep082-20260607-100404325095",
+          "pubdate": "2026-06-07T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 81: Strength training shows a clear upper limit of benefit at 120 minutes weekly for lowering mortality risk.",
+          "item_guid": "planetterrian-daily-ep081-20260606-092516064115",
+          "pubdate": "2026-06-06T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 5,
+          "downloads_all_time": 5
+        },
+        {
+          "title": "Ep 79: Physical fitness correlates with brain health in young adults, with effects varying by sex.",
+          "item_guid": "planetterrian-daily-ep079-20260604-104308611452",
+          "pubdate": "2026-06-04T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        }
+      ]
+    },
+    "privet_russian": {
+      "show_uuid": "088b65032dfe4947a41b3ccde3f3d2c1",
+      "feed_url": "https://nerranetwork.com/privet_russian_podcast.rss",
+      "asof": "2026-06-08",
+      "downloads_7d": 4,
+      "downloads_30d": 77,
+      "weekly_avg": 19,
+      "weekly_downloads": [
+        6,
+        38,
+        28,
+        4
+      ],
+      "episodes": [
+        {
+          "title": "\u041f\u0440\u0438\u0432\u0435\u0442, \u0420\u0443\u0441\u0441\u043a\u0438\u0439! - Episode 26 - May 18, 2026",
+          "item_guid": "pr-ep026-20260518-074015568168",
+          "pubdate": "2026-05-18T08:00:00.000Z",
+          "downloads_3d": 4,
+          "downloads_7d": 4,
+          "downloads_30d": 7,
+          "downloads_all_time": 7
+        },
+        {
+          "title": "\u041f\u0440\u0438\u0432\u0435\u0442, \u0420\u0443\u0441\u0441\u043a\u0438\u0439! - Episode 30 - May 24, 2026",
+          "item_guid": "pr-ep030-20260524-071943750557",
+          "pubdate": "2026-05-24T08:00:00.000Z",
+          "downloads_3d": 1,
+          "downloads_7d": 2,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "\u041f\u0440\u0438\u0432\u0435\u0442, \u0420\u0443\u0441\u0441\u043a\u0438\u0439! - Episode 27 - May 20, 2026",
+          "item_guid": "pr-ep027-20260520-073501752976",
+          "pubdate": "2026-05-20T08:00:00.000Z",
+          "downloads_3d": 1,
+          "downloads_7d": 2,
+          "downloads_30d": 4,
+          "downloads_all_time": 4
+        },
+        {
+          "title": "\u041f\u0440\u0438\u0432\u0435\u0442, \u0420\u0443\u0441\u0441\u043a\u0438\u0439! - Episode 31 - May 30, 2026",
+          "item_guid": "pr-ep031-20260530-082822656067",
+          "pubdate": "2026-05-30T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 1,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "\u041f\u0440\u0438\u0432\u0435\u0442, \u0420\u0443\u0441\u0441\u043a\u0438\u0439! - Episode 29 - May 22, 2026",
+          "item_guid": "pr-ep029-20260522-072848254453",
+          "pubdate": "2026-05-22T08:00:00.000Z",
+          "downloads_3d": 1,
+          "downloads_7d": 1,
+          "downloads_30d": 2,
+          "downloads_all_time": 2
+        },
+        {
+          "title": "\u041f\u0440\u0438\u0432\u0435\u0442, \u0420\u0443\u0441\u0441\u043a\u0438\u0439! - Episode 28 - May 21, 2026",
+          "item_guid": "pr-ep028-20260521-144339359467",
+          "pubdate": "2026-05-21T08:00:00.000Z",
+          "downloads_3d": 1,
+          "downloads_7d": 1,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 33: Today we discover fun Russian words for animals while learning how Russians talk about their favorite pets and wild creatures.",
+          "item_guid": "pr-ep033-20260603-102439297062",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 1,
+          "downloads_all_time": 1
+        },
+        {
+          "title": "Ep 32: Blast off with us today as we learn Russian words that will take you straight to the stars and planets!",
+          "item_guid": "pr-ep032-20260602-101910086816",
+          "pubdate": "2026-06-02T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 1,
+          "downloads_all_time": 1
+        }
+      ]
+    },
+    "tesla": {
+      "show_uuid": "ccbf3c42eb3f4352a341594196e83e87",
+      "feed_url": "https://nerranetwork.com/podcast.rss",
+      "asof": "2026-06-08",
+      "downloads_7d": 149,
+      "downloads_30d": 616,
+      "weekly_avg": 150,
+      "weekly_downloads": [
+        96,
+        112,
+        241,
+        149
+      ],
+      "episodes": [
+        {
+          "title": "Ep 501: Tesla ending free Supercharging for new Model 3s on June 15 removes a key ownership perk just as buyers weigh total costs against rivals.",
+          "item_guid": "tesla-shorts-time-ep501-20260605-140505714241",
+          "pubdate": "2026-06-05T08:00:00.000Z",
+          "downloads_3d": 12,
+          "downloads_7d": 12,
+          "downloads_30d": 13,
+          "downloads_all_time": 13
+        },
+        {
+          "title": "Ep 497: China's 39% jump in Tesla wholesale volume signals resilient demand amid intensifying EV rivalry.",
+          "item_guid": "tesla-shorts-time-ep497-20260602-145929468982",
+          "pubdate": "2026-06-02T08:00:00.000Z",
+          "downloads_3d": 11,
+          "downloads_7d": 11,
+          "downloads_30d": 12,
+          "downloads_all_time": 12
+        },
+        {
+          "title": "Ep 500: Tokyo's new EV incentives could nearly halve Tesla prices in the capital region.",
+          "item_guid": "tesla-shorts-time-ep500-20260604-143149928930",
+          "pubdate": "2026-06-04T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 10,
+          "downloads_30d": 11,
+          "downloads_all_time": 11
+        },
+        {
+          "title": "Ep 502: Tesla's import of a Chinese-built Premium AWD Model 3 into Canada for under $50,000 tests whether cross-border sourcing can offset domestic production constraints.",
+          "item_guid": "tesla-shorts-time-ep502-20260606-122349115505",
+          "pubdate": "2026-06-06T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 9,
+          "downloads_30d": 11,
+          "downloads_all_time": 11
+        },
+        {
+          "title": "Ep 498: Halifax gets its first Supercharger site under construction, extending the network into Atlantic Canada for the first time.",
+          "item_guid": "tesla-shorts-time-ep498-20260603-104327550155",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 9,
+          "downloads_30d": 10,
+          "downloads_all_time": 10
+        },
+        {
+          "title": "Ep 499: Tesla's new interior accent lights now turn red to warn of blind-spot vehicles, giving drivers a direct visual cue without glancing at mirrors.",
+          "item_guid": "tesla-shorts-time-ep499-20260603-155122998306",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 8,
+          "downloads_7d": 8,
+          "downloads_30d": 9,
+          "downloads_all_time": 9
+        },
+        {
+          "title": "Ep 503: Looking back at 8 episodes from 2026-06-01 to 2026-06-07 \u2014 the stories that mattered, what we learned, and what to watch next.",
+          "item_guid": "tesla-shorts-time-ep503-20260607-123431367964",
+          "pubdate": "2026-06-07T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 5,
+          "downloads_30d": 8,
+          "downloads_all_time": 8
+        },
+        {
+          "title": "Ep 504: China's 22% Tesla sales rebound in May signals demand recovery after a two-month slump.",
+          "item_guid": "tesla-shorts-time-ep504-20260608-150014742445",
+          "pubdate": "2026-06-08T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 7,
+          "downloads_all_time": 7
+        }
+      ]
+    },
+    "unintended_consequences": {
+      "show_uuid": "3471a7f661d048429a2f06d06f994032",
+      "feed_url": "https://nerranetwork.com/unintended_consequences_podcast.rss",
+      "asof": "2026-06-08",
+      "downloads_7d": 23,
+      "downloads_30d": 31,
+      "weekly_avg": 15,
+      "weekly_downloads": [
+        0,
+        2,
+        6,
+        23
+      ],
+      "episodes": [
+        {
+          "title": "Ep 21: California's three-strikes law promised to lock up dangerous repeat offenders \u2014 and instead gave life sentences for stealing pizza and videotapes.",
+          "item_guid": "unintended-consequences-ep021-20260603-102432919896",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 4,
+          "downloads_30d": 5,
+          "downloads_all_time": 5
+        },
+        {
+          "title": "Ep 23: Cash for Clunkers paid Americans to destroy nearly 700,000 old cars in 2009 to revive the economy, but it left low-income buyers facing higher used-car prices for years.",
+          "item_guid": "unintended-consequences-ep023-20260604-142115926733",
+          "pubdate": "2026-06-04T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 2,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 22: Nixon declared the War on Drugs in 1971 to protect families by treating addiction as crime; five decades later the U.S. prison population had grown sixfold while drug-use rates stayed roughly unchanged.",
+          "item_guid": "unintended-consequences-ep022-20260603-161311319712",
+          "pubdate": "2026-06-03T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 2,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 20: Algorithms built to personalize the internet for every user instead narrowed each person\u2019s view to what they had already clicked.",
+          "item_guid": "unintended-consequences-ep020-20260602-155105253195",
+          "pubdate": "2026-06-02T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 2,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 19: Wikipedia invited the entire world to write its own encyclopedia, yet the result is an archive that still underrepresents half of humanity.",
+          "item_guid": "unintended-consequences-ep019-20260601-170851489350",
+          "pubdate": "2026-06-01T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 2,
+          "downloads_30d": 4,
+          "downloads_all_time": 4
+        },
+        {
+          "title": "Ep 18: Ring sold doorbells to keep families safe, but its Neighbors app built a private surveillance grid shared with thousands of police departments.",
+          "item_guid": "unintended-consequences-ep018-20260528-145626093834",
+          "pubdate": "2026-05-28T08:00:00.000Z",
+          "downloads_3d": 1,
+          "downloads_7d": 1,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        },
+        {
+          "title": "Ep 25: Rent control was meant to shield tenants from unaffordable rents, yet it repeatedly reduced the supply of rental housing and raised prices for everyone else.",
+          "item_guid": "unintended-consequences-ep025-20260608-150531280443",
+          "pubdate": "2026-06-08T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 1,
+          "downloads_all_time": 1
+        },
+        {
+          "title": "Ep 24: China's one-child policy aimed to ease population pressure but instead produced a 30-million-person gender imbalance and a shrinking workforce that will shape the country for decades.",
+          "item_guid": "unintended-consequences-ep024-20260605-141518960212",
+          "pubdate": "2026-06-05T08:00:00.000Z",
+          "downloads_3d": 0,
+          "downloads_7d": 0,
+          "downloads_30d": 3,
+          "downloads_all_time": 3
+        }
+      ]
+    }
+  }
+}

--- a/docs/env_var_inventory.md
+++ b/docs/env_var_inventory.md
@@ -27,6 +27,13 @@ Passed as step `env:` to the pipeline step (not in `.env` file):
 
 HTML generation / finalize also use: `GA4_MEASUREMENT_ID`, `GOOGLE_ADS_*`, `PLAUSIBLE_DOMAIN`, `GSC_VERIFICATION`.
 
+Nightly audience stats (June 2026; both optional — scripts no-op when unset):
+
+| Secret | Purpose |
+|--------|---------|
+| `OP3_API_TOKEN` | `scripts/fetch_op3_stats.py` — per-show/episode download counts → dashboard Audience card + homepage "Most Played" rail (free token at op3.dev/api/keys) |
+| `BUTTONDOWN_API_KEY` | also reused by `scripts/fetch_buttondown_stats.py` for the subscriber count → homepage social proof |
+
 ---
 
 ## Required for a full episode (typical English show)

--- a/docs/network_review_2026_06.md
+++ b/docs/network_review_2026_06.md
@@ -1,0 +1,322 @@
+# Nerra Network — Full Network Review & Growth Plan (June 2026)
+
+A full review of the codebase, website, workflows, pipelines, and the market
+the network operates in, with a prioritized plan to increase audience value
+and position the network for growth. Produced June 10, 2026 alongside an
+implementation pass (see "What shipped with this review" below).
+
+---
+
+## 1. Executive summary
+
+The network is **production-mature and remarkably cheap to run** — twelve
+shows, ~10 episodes/day, 100% pipeline success over the trailing week,
+broadcast-quality audio, ~$0.07–0.21 marginal cost per episode (~$60/month
+variable + $150/month Buttondown). Engineering risk is well-managed
+(23 documented landmines, drift-guard tests, recovery PRs, multi-source
+fallbacks).
+
+The strategic gap is on the **audience side, not the production side**:
+
+1. **The network was audience-blind.** OP3 analytics prefixes have been on
+   every RSS enclosure since launch, but the data was never read back. No
+   subscriber counts, no web analytics, no download numbers anywhere in the
+   repo or dashboards. The Feb 2026 monetization roadmap stalled at exactly
+   this step. *Fixed in this pass* — see §6.
+2. **The funnel leaked at every stage** — no cross-show discovery loop in
+   email (a YAML indentation bug silently emptied the adjacency map), no
+   social proof, no view-in-browser/forward path on newsletters, no
+   "popular episodes" surface, X teasers with no follow CTA. *Largely fixed
+   in this pass.*
+3. **Distribution is capped below its potential.** YouTube — the #1 podcast
+   discovery surface in 2026 — carries only 2 of 12 shows (API quota).
+   IG/TikTok auto-posting is code-complete but waiting on operator app
+   registrations. Gallery lead-capture is built but not yet live.
+
+### First real audience numbers (OP3, 30 days to 2026-06-08)
+
+| Show | 30-day downloads | Weekly avg |
+|---|---|---|
+| Tesla Shorts Time | 616 | 150 |
+| Models & Agents | 422 | 100 |
+| Models & Agents for Beginners | 235 | 57 |
+| Planetterrian Daily | 173 | 41 |
+| Fascinating Frontiers | 150 | 35 |
+| Modern Investing Techniques | 148 | 36 |
+| Omni View | 126 | 30 |
+| Привет, Русский! | 77 | 19 |
+| Финансы Просто | 64 | 13 |
+| Unintended Consequences | 31 | 15 |
+| Environmental Intelligence | 24 | 11 |
+| **Network total** | **~2,066** | **~507** |
+
+Reading: a real but early-stage audience. Tesla + the two AI shows carry
+~62% of listening. The narrative shows (UC, FPD) launched with distribution
+off and predictably have near-zero reach. At ~$210/month all-in cost, the
+network costs ~$0.10 per download — the economics work at tiny scale, which
+is the structural advantage to press.
+
+---
+
+## 2. Market context (June 2026)
+
+- **The AI-podcast flood is the defining market dynamic.** Roughly 35% of
+  all new podcast feeds are now AI-generated; one network alone ships 3,000
+  episodes/week at <$1/episode. Platforms are responding: Spotify added
+  Verified badges and bans voice impersonation; **Apple requires AI
+  disclosure in both audio and metadata** when AI generates a material
+  portion of audio. Sources: [Eastern Herald](https://easternherald.com/2026/05/04/ai-podcasts-boom-35-percent-machine-generated/),
+  [Digital Music News "podslop"](https://www.digitalmusicnews.com/2026/05/04/podslop-ai-podcast-problem/),
+  [Variety on Spotify's policy](https://variety.com/2026/digital/news/spotify-bans-ai-generated-podcasts-impersonate-verified-badges-1236752944/),
+  [RSS.com AI disclosure guide](https://rss.com/blog/ai-disclosure-in-podcasting-what-it-is-why-it-matters-and-how-to-do-it/).
+  **Nerra is already compliant and ahead of the curve**: spoken disclosure
+  on every episode, RSS channel+item disclosure, ai-disclosure.html, the
+  AI-transparency badge site-wide, and YouTube's syntheticMedia flag. In a
+  podslop market, *documented* transparency + longitudinal depth (story
+  trackers, narrative memory) is the moat — generic AI news recaps are now
+  a commodity.
+- **YouTube is the #1 discovery surface**: 1B+ monthly podcast viewers;
+  for video-first shows 30–55% of first exposures come from algorithm or
+  search; Gen Z discovers via YouTube/TikTok/IG. Sources:
+  [The Podcast Host industry stats](https://www.thepodcasthost.com/listening/podcast-industry-stats/),
+  [eMarketer](https://www.emarketer.com/content/faq-on-podcasting--video-s-rise--ctv-growth--what-means-advertisers-2026),
+  [PodRewind video stats](https://podrewind.com/blog/video-podcast-statistics-2026).
+  The 10k units/day quota (landmine #20) limiting video to Tesla+MAB is the
+  single biggest distribution constraint.
+- **Monetization economics for niche shows** favor engaged audiences over
+  scale: direct sponsors $25–40 CPM, memberships $5–10/mo at 2–10%
+  conversion, programmatic only $3–15 CPM. Sources:
+  [biztoolkit ad rates](https://www.biztoolkit.co/post/podcast-advertising-rates-2026-what-sponsors-actually-pay),
+  [RSS.com programmatic](https://rss.com/blog/why-small-podcasts-win-with-programmatic-advertising/).
+  At current scale (~500 downloads/week) monetization is premature;
+  measurement-first was the right call.
+- **Podcasting 2.0 tags have real platform support** (transcript, chapters,
+  person, funding). Nerra already shipped transcript+chapters universally;
+  funding+person were at zero across all feeds (fixed in this pass).
+  Source: [Podcasting 2.0 namespace](https://podcasting2.org/docs/podcast-namespace/1.0).
+
+---
+
+## 3. System review (codebase, workflows, pipelines)
+
+**Strengths worth protecting** (don't churn these):
+
+- Unified runner + YAML config with deep-merge defaults; scaffolded
+  new-show creation; per-episode cost tracking with historical pricing.
+- Multi-layer quality gates: 14 smoke suites on every run, post-run audit
+  with auto-retry, output validation, recovery PRs on push failure.
+- Broadcast audio chain (48kHz WAV, sidechain ducking, −16 LUFS) at 36×
+  lower TTS cost than the ElevenLabs era.
+- Narrative memory / story trackers (Tesla bespoke + generalized engine on
+  M&A, FF, PT) — the clearest differentiation vs. commodity AI podcasts.
+- Disciplined A/B-listen policy for audio changes (landmine #17) — every
+  theory-driven audio "improvement" has regressed; the policy is the guard.
+
+**Top risks** (all previously documented; status confirmed live):
+
+| Risk | Status | Action |
+|---|---|---|
+| Repo size (#1): 2.2GB+ MP3s in git | Live, ~18–24mo runway | R2 migration for MP3s — already planned in `docs/audio_storage_plan.md`; schedule it |
+| YouTube quota (#20): 9,600/10,000 units used by 2 shows | Live | See roadmap §7 — quota increase request + rotation options |
+| Grok TTS single-vendor (#17) | Live | Quarterly rollback drill to ElevenLabs (kept configured) |
+| Git push transients (#23) | Mitigated (recovery PRs) | None |
+| TSLA price chain (#22) | Mitigated (3-source fallback) | None |
+
+**Bug found during this review (fixed):** the cross-network adjacency map
+in `shows/_defaults.yaml` was indented under `cost_circuit_breakers:` while
+`engine/newsletter.py` and `engine/synthesizer.py` read it under
+`newsletter:` — every daily and weekly email's "Across the Nerra Network"
+module was silently degraded. Also added the missing
+`unintended_consequences` entry, plus drift guards pinning the location.
+
+---
+
+## 4. Audience funnel review (website + distribution)
+
+State at the start of this review, stage by stage:
+
+- **Awareness:** RSS directories ✓, X on 7 shows (single teaser, no follow
+  CTA, no cross-promo), YouTube on 2 shows (well-optimized Shorts), no
+  IG/TikTok (built, disabled), newsletter (no viral loop).
+- **Sampling:** homepage Latest Episodes rail with inline players ✓ (the
+  earlier internal review that called it missing was wrong), no
+  popularity/social-proof signal anywhere.
+- **Conversion:** subscribe buttons ✓, newsletter form ✓ (11-checkbox
+  cognitive load, no social proof), gallery email-gate built but secrets
+  unset.
+- **Retention/deepening:** cross-show recs on web ✓, in email ✗ (the
+  adjacency bug), story-tracker pages ✓ but under-promoted, no
+  view-in-browser/archive path on emails.
+- **Measurement:** none surfaced anywhere (OP3 wired but never read,
+  Buttondown count never fetched, GA4/Plausible scaffolded but unset).
+
+Most of the ✗s above are addressed in §6. Remaining structural gaps are in
+the roadmap (§7).
+
+---
+
+## 5. Portfolio & editorial review
+
+- **Growth engines (by data, not just intuition now):** Tesla Shorts Time
+  (616/mo, YouTube, narrative memory, real-time stock hook), Models &
+  Agents (422/mo, AI tailwind, expert positioning), MAB (235/mo, only
+  beginner-AI show, YouTube + Education category), Modern Investing
+  (148/mo, Canadian niche, investment tracker, monetization-ready
+  audience).
+- **Solid niches:** Planetterrian, Fascinating Frontiers (narrative memory
+  live; YouTube-ready if quota allows).
+- **Watch list:** Omni View — the "Steel Man" repositioning (May 2026) is
+  the right differentiation but remains unvalidated against output; its
+  126/mo is mid-pack despite a broad niche. Env Intel — 24/mo on a B2B
+  micro-niche; viable only as a premium/B2B play later. Russian shows —
+  small but real (141/mo combined) and structurally underserved niches.
+- **New narrative shows (UC, First Principles):** distribution is off/min —
+  their evergreen format is exactly what differentiates against podslop,
+  but nobody can find them. Cheapest growth lever in the portfolio:
+  turn their channels on (UC newsletter+X are now in the cross-promo
+  rotation; FPD newsletter/X remain off pending operator call).
+- **Format risk:** 7 of 12 shows share the "news + narration" architecture;
+  differentiation is topic-only and switching costs are low. The narrative
+  memory / story-tracker surfaces are the answer — extend them (MIT's
+  investment tracker is already a variant) and promote them.
+
+---
+
+## 6. What shipped with this review (June 10, 2026)
+
+All additive, all clean no-ops when secrets/config are unset, each with
+drift-guard tests. Full suite green (2,696 tests).
+
+1. **Adjacency-map bug fix** — newsletter cross-network module restored
+   network-wide; `unintended_consequences` added to the rotation; blog
+   cross-show recs now deterministically lead with the curated sibling.
+2. **OP3 read-back** (`scripts/fetch_op3_stats.py`) — nightly fetch of
+   per-show/per-episode downloads → `api/op3_stats.json` (operator
+   dashboard "Audience" card) + public `site/data/popular_episodes.json`
+   → new homepage **"Most Played This Week"** rail with inline players.
+   Initial snapshot committed (the numbers in §1).
+3. **Buttondown subscriber count** (`scripts/fetch_buttondown_stats.py`)
+   → dashboard + homepage **"Join N+ readers"** social proof (hidden
+   below 100 subscribers, rounded down to nearest 10).
+4. **Plausible readiness** — nightly site-regen now passes the marketing
+   env vars (it previously would have stripped analytics tags nightly);
+   enabling analytics is now literally one secret (`PLAUSIBLE_DOMAIN`).
+5. **Sitemap hygiene** — player.html + MIT performance page added,
+   404.html removed.
+6. **Podcasting 2.0 channel tags** — `podcast:funding` (points at the
+   newsletter signup; the network's support ask is "subscribe", not
+   money) + `podcast:person` (host credit) injected into every feed on
+   its next rebuild.
+7. **Newsletter growth loop** — deterministic Buttondown slugs for every
+   show (was Russian-only) unlock the never-used view-in-browser/archive
+   link on every daily + weekly; new localized "Forwarded this email?
+   Subscribe here" line with UTM attribution (forwarding is the only
+   viral loop email has; Buttondown has no native referral program).
+8. **X cross-promo reply** — flag-gated second tweet threaded under each
+   daily teaser: "Follow @handle" + one sibling-show plug from the
+   deterministic daily rotation, UTM-tagged. Kill switch:
+   `publishing.x_cross_promo: false` in `_defaults.yaml`.
+
+---
+
+## 7. Prioritized roadmap (next 1–6 months)
+
+**Near-term, operator-action (see checklist §8):** light up the
+measurement (OP3 token, Plausible), confirm X handles, watch the new
+funnel surfaces for 2–4 weeks to establish baselines.
+
+**P1 — YouTube expansion (biggest lever, operator decision).**
+Options, not mutually exclusive: (a) request a quota increase from
+YouTube (audit-based, free; the channel is a legitimate publisher);
+(b) drop Tesla/MAB from 2 Shorts to 1 (saves 3,200 units — enough for
+two more shows' Shorts-only presence; Shorts are the discovery lever,
+long-form converts); (c) day-of-week rotation for the freed slots
+(e.g. FF/PT/M&A/MIT each get 1–2 video days/week). Any change requires
+updating the `test_only_tst_and_mab_enable_youtube` drift guard
+deliberately. The Russian channel (@NerraRU) has its own untouched
+quota — FP/PR video is free headroom if those audiences justify it.
+
+**P2 — IG Reels / TikTok enablement.** Code-complete
+(`docs/social_distribution.md`); blocked only on Meta/TikTok developer-app
+approvals. Start with Tesla. This + P1 is the entire "where Gen Z
+discovers podcasts" story.
+
+**P3 — Turn on the narrative shows' distribution.** UC and First
+Principles are the most podslop-proof content in the portfolio. FPD:
+enable newsletter + add to X rotation after a quality pass on the first
+~30 episodes. Consider a `@nerranetwork` umbrella X account if per-show
+accounts don't scale.
+
+**P4 — Promote the moat.** Story-tracker pages (tesla-narrative et al.)
+are linked from show pages but invisible elsewhere: add them to the
+newsletter footer rotation and X cross-promo variants; consider a
+"narrative tracker" Shorts format (what changed this month in 60s).
+
+**P5 — Validate Omni View's "Steel Man" claim** — sample 10 episodes
+against the May 2026 prompt spec; if balance isn't measurably visible,
+either fix sourcing (the Feb audit showed ~40% single-source stories)
+or reposition again. A differentiator that isn't real is a liability.
+
+**P6 — Monetization (only after P1–P3 move the numbers).** Thresholds
+to act: ~2,000 downloads/week network → Podcorn/affiliate experiments on
+MIT (brokers) and M&A (AI tooling); ~5,000/week → direct sponsor
+outreach on Tesla/M&A; memberships only with demonstrated superfans
+(newsletter reply rate, repeat downloads). The `podcast:funding` tag
+currently pointing at the newsletter can be repointed to a support page
+in one line when the time comes.
+
+**P7 — Repo size (engineering).** Execute the already-planned R2
+migration for committed MP3s before the 10GB wall (~18–24 months out);
+it also removes the biggest contributor to push transients (#23).
+
+---
+
+## 8. Operator checklist (things code cannot do)
+
+- [ ] Create an OP3 API token (free, op3.dev/api/keys) → repo secret
+      `OP3_API_TOKEN`. Until then the committed snapshot ages.
+- [ ] Create a Plausible site → repo secret `PLAUSIBLE_DOMAIN`
+      (`nerranetwork.com`). One secret = site-wide analytics.
+- [ ] Confirm the live @handle for each X app (`X_*` vs
+      `PLANETTERRIAN_X_*`) and fill `publishing.x_handle` for
+      omni_view / models_agents / modern_investing (CLAUDE.md's table
+      lists @omniviewnews for OV, which contradicts its `X_` prefix).
+      Also confirm the X apps' write-tier headroom — the cross-promo
+      reply roughly doubles daily posts per app (kill switch in
+      `_defaults.yaml` if it trips the free-tier cap).
+- [ ] Verify the Buttondown `/v1/subscribers` response on the live
+      account (the stats script logs the keys it saw if `count` is
+      missing).
+- [ ] Gallery Phase 3 go-live: set the four Worker secrets
+      (`JWT_SECRET`, `BUTTONDOWN_API_KEY`, `RESEND_API_KEY`,
+      `RESEND_FROM_EMAIL`), test the magic-link flow, then link the
+      gallery from the newsletter (lead capture).
+- [ ] YouTube quota: file the increase request; decide on the
+      1-Short/rotation options (P1).
+- [ ] Register Meta + TikTok developer apps for social distribution (P2).
+- [ ] Spotify "Verified" badge: request via Spotify for Creators for the
+      flagship shows (trust signal in the podslop era).
+- [ ] Decide on a Russian-localized spoken AI disclosure for Финансы
+      Просто / Привет, Русский! — currently the English disclosure
+      sentence plays on the Russian Olya voice at the end of every
+      episode. One-line fix (`_AI_DISCLOSURE_RU` keyed on
+      `config.language` in `run_show.py`) but it changes shipped audio →
+      A/B listen first per landmine #17.
+- [ ] OP3 caveat: data accrues only from the prefix go-live; no backfill
+      exists, so treat early per-episode numbers as directional.
+
+---
+
+## 9. What was deliberately NOT done
+
+- No prompt/editorial changes and no audio-path changes (landmine #17
+  A/B-listen policy). The Russian disclosure fix is specced but parked.
+- No YouTube quota reallocation (drift-guard-pinned operator decision).
+- No monetization surfaces beyond the `podcast:funding` tag (audience
+  growth first — the operator's stated priority).
+- No show pruning or repositioning (operator chose "grow all 12").
+- No consolidation of the three curated cross-show mappings
+  (`NETWORK_SHOWS.related_show` for web, `newsletter.network_adjacencies`
+  for email, `network_promo.ENGLISH_SHOWS` for audio/X) — three tested
+  surfaces, zero audience gain from churning them; documented here
+  instead.

--- a/engine/config.py
+++ b/engine/config.py
@@ -221,6 +221,12 @@ class PublishingConfig:
     x_env_prefix: str = "X_"
     x_teaser_template: str = ""
     x_hashtags: str = ""
+    # Cross-promo reply tweet under the daily teaser (June 2026 growth
+    # pass). x_handle is the @handle the show posts as (used for the
+    # "Follow @…" line; leave empty to omit the line). x_cross_promo
+    # gates the whole reply — false is a byte-for-byte no-op.
+    x_handle: str = ""
+    x_cross_promo: bool = False
     host_name: str = "Patrick"
 
 

--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -18,6 +18,12 @@ logger = logging.getLogger(__name__)
 
 BUTTONDOWN_API_BASE = "https://api.buttondown.com/v1"
 
+# Buttondown account username — used to build public archive URLs
+# (https://buttondown.com/<username>/archive/<slug>/). Matches the
+# subscribe-form embed on the homepage; override via env if the
+# account ever moves.
+BUTTONDOWN_USERNAME = os.getenv("BUTTONDOWN_USERNAME", "patricknovak1")
+
 
 def convert_digest_to_email_html(markdown_text: str) -> str:
     """Convert a markdown digest to clean, mobile-friendly email HTML.
@@ -502,6 +508,18 @@ def send_show_newsletter(
         getattr(newsletter, "requires_financial_disclaimer", False)
     )
 
+    # Buttondown slug — explicit transliterated form for Russian
+    # shows so the archive URL doesn't end up as
+    # `archive/u041f-u0440-...`. Computed BEFORE the wrap so the
+    # view-in-browser link can point at the issue's archive page
+    # (wrap_with_branding always accepted archive_url; it was never
+    # passed — June 2026 growth pass).
+    bd_slug = _buttondown_slug_for(slug, episode_num, hook)
+    archive_url = (
+        f"https://buttondown.com/{BUTTONDOWN_USERNAME}/archive/{bd_slug}/"
+        if bd_slug else ""
+    )
+
     branded_body = wrap_with_branding(
         slug,
         body_clean,
@@ -516,6 +534,7 @@ def send_show_newsletter(
         # episodes have shipped (Tesla Ep 458 read "Issue #1" on
         # the May 2 daily — bug). Pass the episode number explicitly.
         issue_number=episode_num,
+        archive_url=archive_url,
     )
 
     # Pre-send contrast tripwire (§7.3). Light-mode-only check — the
@@ -536,11 +555,6 @@ def send_show_newsletter(
     except ContrastError as exc:
         logger.error("Newsletter contrast issues (blocking send): %s", exc)
         return None
-
-    # Buttondown slug — explicit transliterated form for Russian
-    # shows so the archive URL doesn't end up as
-    # `archive/u041f-u0440-...`.
-    bd_slug = _buttondown_slug_for(slug, episode_num, hook)
 
     email_id = send_newsletter(
         subject=subject,
@@ -623,11 +637,12 @@ def _buttondown_slug_for(
     """Return an ASCII slug suitable for Buttondown's archive URL.
 
     Russian-language shows must transliterate hook + show name so the
-    archive URL doesn't end up percent-escaped. English shows can let
-    Buttondown auto-derive (return None).
+    archive URL doesn't end up percent-escaped. English shows get the
+    same deterministic ``<show>-ep<num>-<hook>`` shape (June 2026
+    growth pass) so the view-in-browser link can be built BEFORE the
+    send — previously they returned None (Buttondown auto-derived the
+    slug, unpredictable pre-send, so no archive link was ever passed).
     """
-    if slug not in ("finansy_prosto", "privet_russian"):
-        return None
     base_map = {
         "finansy_prosto": "finansy-prosto",
         "privet_russian": "privet-russian",

--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -1388,6 +1388,37 @@ def _build_reply_share_html(
         + '</p>'
     )
 
+    # Forwarded-copy conversion line (June 2026 growth pass): email
+    # forwarding is the network's only viral loop, so a forwarded copy
+    # must carry its own subscribe path. UTM-tagged so analytics can
+    # attribute signups to forwards; the query string goes BEFORE the
+    # #newsletter fragment.
+    subscribe_url = (
+        "https://nerranetwork.com/"
+        "?utm_source=newsletter&utm_medium=email&utm_campaign=forward_subscribe"
+        "#newsletter"
+    )
+    if is_russian:
+        forward_html = (
+            f'Вам переслали это письмо? '
+            f'<a href="{subscribe_url}" '
+            f'style="color:#475569;font-weight:600;">Подпишитесь здесь</a>'
+            f' — это бесплатно.'
+        )
+    else:
+        forward_html = (
+            f'Forwarded this email? '
+            f'<a href="{subscribe_url}" '
+            f'style="color:#475569;font-weight:600;">Subscribe here</a>'
+            f" — it's free."
+        )
+    forward_line = (
+        '<p class="text-muted" '
+        'style="font-size:12px;color:#64748b;margin:6px 0 0;line-height:1.5;">'
+        f'{forward_html}'
+        '</p>'
+    )
+
     return (
         '<table role="presentation" width="100%" cellpadding="0" '
         'cellspacing="0" border="0" '
@@ -1401,6 +1432,7 @@ def _build_reply_share_html(
         f'{reply_html}'
         '</p>'
         f'{share_line}'
+        f'{forward_line}'
         '</td></tr></table>'
     )
 

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -285,6 +285,11 @@ def update_rss_feed(
     format_duration_func=None,
     chapters_url: Optional[str] = None,
     transcript_url: Optional[str] = None,
+    funding_url: str = "",
+    funding_label: str = "Support the show — free newsletter",
+    person_name: str = "",
+    person_url: str = "",
+    person_img: str = "",
 ) -> Path:
     """Create or update an RSS feed with a new episode.
 
@@ -578,6 +583,19 @@ def update_rss_feed(
             channel_email or "patrick@planetterrian.com",
         )
 
+        # Add channel-level <podcast:funding> + <podcast:person>
+        # (Podcasting 2.0 discovery/support surface; June 2026 growth
+        # pass). No-ops when the args are empty so legacy callers are
+        # byte-for-byte unaffected.
+        _inject_channel_funding_person_tags(
+            Path(tmp_path),
+            funding_url=funding_url,
+            funding_label=funding_label,
+            person_name=person_name,
+            person_url=person_url,
+            person_img=person_img,
+        )
+
         os.replace(tmp_path, str(rss_path))
     except Exception:
         # Clean up temp file on failure
@@ -596,6 +614,8 @@ def update_rss_feed(
         chapters_url=chapters_url,
         transcript_url=transcript_url,
         expect_locked=True,
+        expect_funding=bool(funding_url),
+        expect_person=bool(person_name),
     )
 
     logger.info("RSS feed updated: %s", rss_path)
@@ -609,6 +629,8 @@ def _validate_injected_tags(
     chapters_url: str,
     transcript_url: str,
     expect_locked: bool,
+    expect_funding: bool = False,
+    expect_person: bool = False,
 ) -> None:
     """Parse the final RSS and log ERROR if expected Podcasting 2.0 tags are missing."""
     PODCAST_NS = "https://podcastindex.org/namespace/1.0"
@@ -624,6 +646,17 @@ def _validate_injected_tags(
             logger.error(
                 "RSS validation: <podcast:locked> missing after injection "
                 "(%s). Feed imports are not protected.", rss_path,
+            )
+
+        if expect_funding and channel.find(f"{{{PODCAST_NS}}}funding") is None:
+            logger.error(
+                "RSS validation: <podcast:funding> missing after injection "
+                "(%s).", rss_path,
+            )
+        if expect_person and channel.find(f"{{{PODCAST_NS}}}person") is None:
+            logger.error(
+                "RSS validation: <podcast:person> missing after injection "
+                "(%s).", rss_path,
             )
 
         if chapters_url or transcript_url:
@@ -699,6 +732,75 @@ def _inject_podcast_locked_tag(rss_path: Path, owner_email: str) -> None:
 
     except Exception as exc:
         logger.error("Failed to inject <podcast:locked> tag: %s", exc)
+
+
+def _inject_channel_funding_person_tags(
+    rss_path: Path,
+    *,
+    funding_url: str = "",
+    funding_label: str = "Support the show — free newsletter",
+    person_name: str = "",
+    person_url: str = "",
+    person_img: str = "",
+) -> None:
+    """Add channel-level ``<podcast:funding>`` + ``<podcast:person>`` tags.
+
+    Podcasting 2.0 surfaces these in supporting apps (Podcast Addict,
+    Fountain, Podverse, …): funding renders as a support/subscribe button,
+    person feeds host-based discovery and credits. Like the other
+    ``podcast:`` tags, feedgen can't emit them, so this post-processes the
+    XML on every rebuild (the feed is fully rewritten each episode).
+
+    Idempotent — skips tags that already exist. Empty args are a no-op so
+    legacy callers are byte-for-byte unaffected.
+    """
+    if not funding_url and not person_name:
+        return
+
+    PODCAST_NS = "https://podcastindex.org/namespace/1.0"
+
+    try:
+        ET.register_namespace("podcast", PODCAST_NS)
+        ET.register_namespace("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd")
+        ET.register_namespace("atom", "http://www.w3.org/2005/Atom")
+
+        tree = ET.parse(str(rss_path))
+        root = tree.getroot()
+
+        for attr in list(root.attrib):
+            if attr == "xmlns:podcast" or (
+                attr.startswith("xmlns:") and root.attrib[attr] == PODCAST_NS
+            ):
+                del root.attrib[attr]
+
+        channel = root.find("channel")
+        if channel is None:
+            return
+
+        changed = False
+
+        if funding_url and channel.find(f"{{{PODCAST_NS}}}funding") is None:
+            funding_el = ET.SubElement(channel, f"{{{PODCAST_NS}}}funding")
+            funding_el.set("url", funding_url)
+            funding_el.text = funding_label or "Support the show"
+            changed = True
+
+        if person_name and channel.find(f"{{{PODCAST_NS}}}person") is None:
+            person_el = ET.SubElement(channel, f"{{{PODCAST_NS}}}person")
+            person_el.set("role", "host")
+            if person_url:
+                person_el.set("href", person_url)
+            if person_img:
+                person_el.set("img", person_img)
+            person_el.text = person_name
+            changed = True
+
+        if changed:
+            tree.write(str(rss_path), xml_declaration=True, encoding="UTF-8")
+            logger.info("Injected <podcast:funding>/<podcast:person> tags")
+
+    except Exception as exc:
+        logger.error("Failed to inject funding/person tags: %s", exc)
 
 
 def _inject_chapters_tag(rss_path: Path, guid: str, chapters_url: str) -> None:

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -1169,11 +1169,14 @@ def post_to_x(
     consumer_secret: str,
     access_token: str,
     access_token_secret: str,
+    in_reply_to_tweet_id: Optional[str] = None,
 ) -> Optional[str]:
     """Post a tweet and return the tweet URL, or ``None`` on failure.
 
     Credentials are accepted as explicit parameters so the caller (or
-    config system) decides which env vars to read.
+    config system) decides which env vars to read. Pass
+    *in_reply_to_tweet_id* to post the tweet as a reply (used by the
+    cross-promo follow-up under the daily teaser, June 2026).
     """
     try:
         import tweepy
@@ -1184,7 +1187,12 @@ def post_to_x(
             access_token=access_token,
             access_token_secret=access_token_secret,
         )
-        response = client.create_tweet(text=text)
+        if in_reply_to_tweet_id:
+            response = client.create_tweet(
+                text=text, in_reply_to_tweet_id=in_reply_to_tweet_id,
+            )
+        else:
+            response = client.create_tweet(text=text)
         tweet_id = response.data["id"]
         tweet_url = f"https://x.com/i/status/{tweet_id}"
         logger.info("Tweet posted: %s", tweet_url)

--- a/generate_html.py
+++ b/generate_html.py
@@ -123,7 +123,15 @@ def _read_show_image_provider(slug: str) -> str:
 _GA4_DEFAULT = "G-6PWJCVQQ7B"  # Nerra Network GA4 property (533581233)
 
 MARKETING_CONFIG = {
-    "ga4_measurement_id": os.environ.get("GA4_MEASUREMENT_ID", _GA4_DEFAULT).strip(),
+    # NOTE: `or _GA4_DEFAULT`, not a .get() default — CI passes
+    # `GA4_MEASUREMENT_ID: ${{ secrets.GA4_MEASUREMENT_ID }}`, and an UNSET
+    # secret arrives as an empty-but-present env var, which defeats a
+    # .get() default. That stripped gtag from every CI-regenerated page
+    # (homepage/blog indexes had no GA on main while nightly-regenerated
+    # tesla.html, built without the env var, kept it) — caught June 2026.
+    "ga4_measurement_id": (
+        os.environ.get("GA4_MEASUREMENT_ID") or _GA4_DEFAULT
+    ).strip(),
     "google_ads_id": os.environ.get("GOOGLE_ADS_ID", "").strip(),
     "google_ads_signup_label": os.environ.get("GOOGLE_ADS_SIGNUP_LABEL", "").strip(),
     "plausible_domain": os.environ.get("PLAUSIBLE_DOMAIN", "").strip(),

--- a/generate_html.py
+++ b/generate_html.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import argparse
+import json
 import os
 import sys
 from pathlib import Path
@@ -31,6 +32,10 @@ ROOT = Path(__file__).resolve().parent
 TEMPLATES_DIR = ROOT / "templates"
 SHOWS_DIR = ROOT / "shows"
 GITHUB_RAW = "https://nerranetwork.com"
+
+# Newsletter social proof is hidden until the subscriber count clears this
+# floor — "Join 23 readers" is anti-proof, "Join 250 readers" converts.
+MIN_SOCIAL_PROOF_SUBSCRIBERS = 100
 
 # Channel handles for the YouTube CTA on show pages. The handle is
 # determined per-show by youtube.channel in the YAML (en → @NerraNetwork,
@@ -2125,6 +2130,36 @@ def generate_network_page(*, dry_run=False):
     except Exception as e:
         print(f"Warning: could not collect latest episodes from RSS: {e}")
 
+    # "Most played this week" rail — fed by the nightly OP3 stats fetch
+    # (scripts/fetch_op3_stats.py). Renders nothing when the file is
+    # missing/empty (OP3_API_TOKEN not configured yet).
+    popular_episodes = []
+    try:
+        _popular_path = ROOT / "site" / "data" / "popular_episodes.json"
+        if _popular_path.exists():
+            popular_episodes = json.loads(
+                _popular_path.read_text(encoding="utf-8")) or []
+            popular_episodes = [
+                ep for ep in popular_episodes if ep.get("audio_url")
+            ][:6]
+    except Exception as e:
+        print(f"Warning: could not load popular episodes: {e}")
+
+    # Newsletter social proof — fed by the nightly Buttondown stats fetch
+    # (scripts/fetch_buttondown_stats.py). Hidden below the threshold so a
+    # small number never reads as anti-proof; rounded down to the nearest
+    # 10 so it doesn't read as fake-precise.
+    newsletter_subscriber_count = None
+    try:
+        _bd_path = ROOT / "api" / "buttondown_stats.json"
+        if _bd_path.exists():
+            _count = (json.loads(_bd_path.read_text(encoding="utf-8"))
+                      or {}).get("subscriber_count")
+            if isinstance(_count, int) and _count >= MIN_SOCIAL_PROOF_SUBSCRIBERS:
+                newsletter_subscriber_count = (_count // 10) * 10
+    except Exception as e:
+        print(f"Warning: could not load newsletter stats: {e}")
+
     context = {
         "path_prefix": "",
         "page_title": "Nerra Network | 11 Daily Shows",
@@ -2137,6 +2172,8 @@ def generate_network_page(*, dry_run=False):
         "all_shows": _build_all_shows_list(),
         "latest_blog_posts": latest_blog_posts,
         "latest_episodes": latest_episodes,
+        "popular_episodes": popular_episodes,
+        "newsletter_subscriber_count": newsletter_subscriber_count,
         "emit_bilingual_hreflang": True,
         "total_episodes": _count_total_episodes(),
     }

--- a/generate_html.py
+++ b/generate_html.py
@@ -2177,6 +2177,35 @@ _SHOW_DIRS = {
 }
 
 
+def _pick_cross_show_related(slug, cross_show_posts, *, want=3):
+    """Pick up to *want* cross-show posts for a blog post's rec section.
+
+    The show's curated sibling (``NETWORK_SHOWS[slug]["related_show"]``)
+    always takes the first slot when it has a recent post, so the
+    on-brand recommendation is deterministic; remaining slots are
+    sampled from the latest cross-show pool.
+    """
+    if not cross_show_posts:
+        return []
+    import random
+    related = []
+    candidates = [p for p in cross_show_posts if p.get("show_slug") != slug]
+    curated_slug = (NETWORK_SHOWS.get(slug) or {}).get("related_show")
+    curated = next(
+        (p for p in candidates if p.get("show_slug") == curated_slug),
+        None,
+    )
+    if curated is not None:
+        related.append(curated)
+        candidates = [p for p in candidates if p is not curated]
+    remaining = want - len(related)
+    if len(candidates) <= remaining:
+        related.extend(candidates[:remaining])
+    else:
+        related.extend(random.sample(candidates[:12], remaining))
+    return related
+
+
 def generate_blog_posts(slug, *, dry_run=False, cross_show_posts=None):
     """Generate blog post HTML pages for all episodes of a show.
 
@@ -2240,11 +2269,7 @@ def generate_blog_posts(slug, *, dry_run=False, cross_show_posts=None):
         md_text = meta["_md_path"].read_text(encoding="utf-8")
 
         # Pick up to 3 recent posts from other shows for cross-show recs
-        _related = []
-        if cross_show_posts:
-            import random
-            _candidates = [p for p in cross_show_posts if p.get("show_slug") != slug]
-            _related = _candidates[:3] if len(_candidates) <= 3 else random.sample(_candidates[:12], 3)
+        _related = _pick_cross_show_related(slug, cross_show_posts)
 
         html = generate_blog_post_html(
             md_text, meta, cfg, env,

--- a/generate_html.py
+++ b/generate_html.py
@@ -2546,12 +2546,13 @@ def generate_sitemap(*, dry_run=False):
         if (ROOT / legal).exists():
             urls.append((f"{base}/{legal}", "0.4", _file_lastmod(ROOT / legal)))
 
-    # Special pages
+    # Special pages. 404.html is deliberately NOT listed — error pages
+    # don't belong in sitemaps (Search Console flags them).
     for extra in ["modern-investing-resources.html", "start-here.html",
                   "about.html", "how-to-listen.html", "faq.html",
                   "press.html", "contact.html", "editorial.html",
-                  "gallery.html",
-                  "404.html"]:
+                  "gallery.html", "player.html",
+                  "modern-investing-performance.html"]:
         if (ROOT / extra).exists():
             urls.append((f"{base}/{extra}", "0.5", _file_lastmod(ROOT / extra)))
 

--- a/index.html
+++ b/index.html
@@ -44,6 +44,20 @@
 
     
     
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
     
     
     <script defer src="assets/js/tracking.js"></script>
@@ -859,6 +873,70 @@
         </div>
         
     </section>
+
+    
+    <!-- Most Played This Week (OP3 download data, refreshed nightly) -->
+    <section id="popular" class="nn-section">
+        <div class="container">
+            <div class="nn-section-header">
+                <div class="section-label">Listener Favorites</div>
+                <h2>Most Played This Week</h2>
+                <p>The episodes our listeners played most over the last seven days.</p>
+            </div>
+        </div>
+        <div class="latest-scroll-row">
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#7C3AED;">#1 · Models & Agents</div>
+                <div class="episode-card-title">Ep 69: Microsoft is shipping hardware built from the silicon up to run AI agents instead of conventional apps.</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep069_20260603.mp3" aria-label="Models & Agents episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#E31937;">#2 · Tesla Shorts Time</div>
+                <div class="episode-card-title">Ep 501: Tesla ending free Supercharging for new Model 3s on June 15 removes a key ownership perk just as buyers weigh total costs against rivals.</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep501_20260605.mp3" aria-label="Tesla Shorts Time episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#E31937;">#3 · Tesla Shorts Time</div>
+                <div class="episode-card-title">Ep 497: China's 39% jump in Tesla wholesale volume signals resilient demand amid intensifying EV rivalry.</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep497_20260602.mp3" aria-label="Tesla Shorts Time episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#7C3AED;">#4 · Models & Agents</div>
+                <div class="episode-card-title">Ep 72: Microsoft just gained the freedom to build its own frontier models after a contract change with OpenAI, and the first MAI family is already shipping.</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep072_20260606.mp3" aria-label="Models & Agents episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#E31937;">#5 · Tesla Shorts Time</div>
+                <div class="episode-card-title">Ep 500: Tokyo's new EV incentives could nearly halve Tesla prices in the capital region.</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep500_20260604.mp3" aria-label="Tesla Shorts Time episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:#7C3AED;">#6 · Models & Agents</div>
+                <div class="episode-card-title">Ep 73: Looking back at 7 episodes from 2026-06-01 to 2026-06-07 — the stories that mattered, what we learned, and what to watch next.</div>
+                
+                <audio controls preload="none" src="https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep073_20260607.mp3" aria-label="Models & Agents episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                
+            </div>
+            
+        </div>
+    </section>
+    
 
     <!-- Latest from the Blog -->
     
@@ -1776,6 +1854,7 @@
                 <div class="section-label">Weekly digest</div>
                 <h2>Get the best of the network in your inbox</h2>
                 <p>One email per week. Top episodes from every show you follow. Unsubscribe anytime.</p>
+                
             </div>
             <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow"
                   class="nn-subscribe-form" style="max-width:none;"

--- a/management.html
+++ b/management.html
@@ -195,6 +195,11 @@
   </section>
 
   <section class="mgmt-section">
+    <h2>Audience <span id="audience-status-pill" style="font-size:12px;font-weight:normal;color:#94a3b8;margin-left:8px;"></span></h2>
+    <div id="audience-section"></div>
+  </section>
+
+  <section class="mgmt-section">
     <h2>30-day cost per show</h2>
     <div id="cost-sparklines"></div>
   </section>
@@ -412,6 +417,57 @@
       "</svg>"
     );
   };
+
+  // -------- Audience (OP3 downloads + newsletter subscribers) --------
+  const audRoot = $("#audience-section");
+  const audience = data.audience || {};
+  const op3 = audience.op3 || {};
+  const bd = audience.newsletter || {};
+  const audPill = $("#audience-status-pill");
+  if (!op3.configured && !bd.configured) {
+    audPill.textContent = "(not configured — set OP3_API_TOKEN / BUTTONDOWN_API_KEY secrets)";
+  } else {
+    const bits = [];
+    if (op3.configured && !op3.error) {
+      bits.push((op3.network_downloads_30d || 0).toLocaleString() + " downloads · 30d");
+      bits.push((op3.network_downloads_7d || 0).toLocaleString() + " · 7d");
+    } else if (op3.error) {
+      bits.push("OP3 error");
+    }
+    if (bd.configured && bd.subscriber_count != null) {
+      bits.push(bd.subscriber_count.toLocaleString() + " newsletter subscribers");
+    }
+    if (op3.fetched_at) bits.push("fetched " + ageText(op3.fetched_at));
+    audPill.textContent = "· " + bits.join(" · ");
+
+    const perShow = op3.per_show || {};
+    Object.keys(perShow)
+      .sort((a, b) => (perShow[b].downloads_30d || 0) - (perShow[a].downloads_30d || 0))
+      .forEach((slug) => {
+        const v = perShow[slug] || {};
+        const row = h("div", { class: "sparkline-row" });
+        row.appendChild(h("div", { class: "label", text: slug }));
+        const bar = h("div", { style: "flex:1;height:8px;background:#1e293b;border-radius:4px;overflow:hidden;" });
+        const maxDl = Math.max.apply(null,
+          Object.values(perShow).map((p) => p.downloads_30d || 0)) || 1;
+        bar.appendChild(h("div", {
+          style: "height:100%;background:#6B47FF;width:" +
+            (100 * (v.downloads_30d || 0) / maxDl).toFixed(0) + "%;",
+        }));
+        row.appendChild(bar);
+        row.appendChild(h("div", { class: "value",
+          text: (v.downloads_30d || 0).toLocaleString() + " · 30d  (" +
+                (v.downloads_7d || 0).toLocaleString() + " · 7d)" }));
+        audRoot.appendChild(row);
+      });
+
+    (op3.top_episodes_7d || []).forEach((ep, i) => {
+      const row = h("div", { style: "font-size:12px;color:#94a3b8;padding:2px 0;" });
+      row.textContent = "#" + (i + 1) + " [" + ep.show_slug + "] " +
+        ep.title.slice(0, 90) + " — " + ep.downloads_7d + " · 7d";
+      audRoot.appendChild(row);
+    });
+  }
 
   const costSparks = $("#cost-sparklines");
   const costPerShow = (data.cost_rollup && data.cost_rollup.per_show) || {};

--- a/run_show.py
+++ b/run_show.py
@@ -2800,6 +2800,14 @@ def run(args: argparse.Namespace) -> None:
             audio_url=feed_audio_url,  # Use R2/OP3-prefixed URL if available
             chapters_url=chapters_url,
             transcript_url=transcript_url,
+            # Podcasting 2.0 channel tags (June 2026 growth pass): funding
+            # points at the newsletter signup (the network's support ask is
+            # "subscribe", not money), person credits the host for
+            # host-based discovery in 2.0 apps.
+            funding_url=f"{config.publishing.base_url}/#newsletter",
+            funding_label="Free newsletter — best of the network weekly",
+            person_name=config.publishing.host_name or "Patrick",
+            person_url=f"{config.publishing.base_url}/about.html",
         )
 
         metrics.record("rss_update_duration_s", round(time.monotonic() - _t_rss, 2))

--- a/run_show.py
+++ b/run_show.py
@@ -2975,6 +2975,28 @@ def run(args: argparse.Namespace) -> None:
             if tweet_url:
                 record_x_post(tracker)
                 logger.info("Posted to X: %s", tweet_url)
+
+                # Cross-promo follow-up reply (June 2026 growth pass):
+                # "Follow @handle" + one sibling-show plug, threaded under
+                # the teaser so the teaser itself stays clean. Flag-gated
+                # (publishing.x_cross_promo); failure never blocks.
+                if getattr(config.publishing, "x_cross_promo", False):
+                    try:
+                        reply_text = _build_cross_promo_reply(config, today)
+                        if reply_text:
+                            reply_url = post_to_x(
+                                reply_text,
+                                consumer_key=consumer_key,
+                                consumer_secret=consumer_secret,
+                                access_token=access_token,
+                                access_token_secret=access_token_secret,
+                                in_reply_to_tweet_id=tweet_url.rsplit("/", 1)[-1],
+                            )
+                            if reply_url:
+                                record_x_post(tracker)
+                                logger.info("Posted cross-promo reply: %s", reply_url)
+                    except Exception as exc:
+                        logger.warning("Cross-promo reply failed (non-fatal): %s", exc)
         else:
             logger.warning("X credentials missing (prefix=%s). Skipping X post.", prefix)
 
@@ -4462,6 +4484,62 @@ def _build_teaser(config, episode_num: int, today_str: str, extra_context: dict)
     else:
         teaser = f"{config.name} Episode {episode_num} — {today_str}"
     return _append_youtube_line(teaser, extra_context)
+
+
+def _build_cross_promo_reply(config, today) -> str:
+    """Build the cross-promo reply posted under the daily teaser tweet.
+
+    Shape: optional "Follow @handle" line (omitted when the show's YAML
+    doesn't set ``publishing.x_handle``) + one sibling-show plug picked
+    by :func:`engine.network_promo.pick_featured_show` (deterministic
+    daily rotation, English shows only — same rotation the spoken outro
+    promo uses) + a UTM-tagged link to the sibling's show page.
+
+    Returns "" when there's nothing worth posting (no handle AND no
+    eligible sibling). X counts any URL as 23 chars, so the 280 budget
+    is enforced on that basis by trimming the tagline first.
+    """
+    from engine.network_promo import ENGLISH_SHOWS, pick_featured_show
+
+    handle = (getattr(config.publishing, "x_handle", "") or "").strip()
+    follow_line = f"Follow {handle} for daily episodes." if handle else ""
+
+    promo_line = ""
+    url = ""
+    featured = pick_featured_show(config.slug, today)
+    if featured:
+        try:
+            from generate_html import NETWORK_SHOWS
+            show_page = (NETWORK_SHOWS.get(featured) or {}).get("show_page", "")
+        except Exception:
+            show_page = ""
+        name = ENGLISH_SHOWS[featured]["spoken_name"]
+        tagline = ENGLISH_SHOWS[featured]["tagline"]
+        if show_page:
+            url = (
+                f"https://nerranetwork.com/{show_page}"
+                "?utm_source=x&utm_medium=social&utm_campaign=cross_promo"
+            )
+        # Budget: 280 minus follow line, minus the t.co URL (23) + spacing.
+        X_URL_LEN = 23
+        fixed = len(follow_line) + (2 if follow_line else 0)  # + blank line
+        fixed += len(f"More from the Nerra Network: {name} — ")
+        fixed += (1 + X_URL_LEN) if url else 0  # newline + t.co URL
+        room = 280 - fixed
+        if len(tagline) > room:
+            tagline = tagline[: max(room - 1, 0)].rstrip() + "…" if room > 10 else ""
+        promo_line = f"More from the Nerra Network: {name}"
+        if tagline:
+            promo_line += f" — {tagline}"
+
+    if not follow_line and not promo_line:
+        return ""
+
+    parts = [p for p in (follow_line, promo_line) if p]
+    text = "\n\n".join(parts)
+    if url:
+        text += f"\n{url}"
+    return text
 
 
 

--- a/scripts/fetch_buttondown_stats.py
+++ b/scripts/fetch_buttondown_stats.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Fetch the Buttondown newsletter subscriber count.
+
+Writes ``api/buttondown_stats.json`` for the operator dashboard and the
+homepage "Join N readers" social proof. Clean no-op when
+``BUTTONDOWN_API_KEY`` is unset (logs one line, exits 0, leaves any
+previously committed output untouched) — same convention as every other
+optional integration in this repo.
+
+Buttondown API: ``GET /v1/subscribers?page_size=1`` returns a paginated
+envelope whose ``count`` field is the total number of subscribers. If the
+field is ever missing we skip rather than guess (no page-walking — a
+wrong number shown publicly is worse than none).
+
+Usage::
+
+    python scripts/fetch_buttondown_stats.py                 # write api/buttondown_stats.json
+    python scripts/fetch_buttondown_stats.py --dry-run       # print, write nothing
+    python scripts/fetch_buttondown_stats.py --out /tmp/b.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_ROOT = _SCRIPT_DIR.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+import requests
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+log = logging.getLogger("buttondown_stats")
+
+BUTTONDOWN_API_BASE = "https://api.buttondown.com/v1"
+HTTP_TIMEOUT = 15
+
+
+def fetch_subscriber_count(api_key: str) -> Optional[int]:
+    """Return the total subscriber count, or None on any failure."""
+    try:
+        resp = requests.get(
+            f"{BUTTONDOWN_API_BASE}/subscribers",
+            headers={"Authorization": f"Token {api_key}"},
+            params={"page_size": "1", "type": "regular"},
+            timeout=HTTP_TIMEOUT,
+        )
+        if resp.status_code != 200:
+            log.warning("buttondown: HTTP %s from /subscribers", resp.status_code)
+            return None
+        data = resp.json() or {}
+        count = data.get("count")
+        if isinstance(count, int) and count >= 0:
+            return count
+        log.warning("buttondown: no usable 'count' field in response "
+                    "(keys: %s)", sorted(data.keys()))
+        return None
+    except Exception as exc:  # noqa: BLE001 — never break the nightly job
+        log.warning("buttondown: fetch failed: %s", exc)
+        return None
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default="api/buttondown_stats.json")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print JSON to stdout, write nothing")
+    args = parser.parse_args(argv)
+
+    api_key = (os.getenv("BUTTONDOWN_API_KEY") or "").strip()
+    if not api_key:
+        log.info("buttondown: BUTTONDOWN_API_KEY unset — skipping (clean no-op)")
+        return 0
+
+    count = fetch_subscriber_count(api_key)
+    if count is None:
+        log.warning("buttondown: leaving existing stats untouched")
+        return 0
+
+    stats = {
+        "fetched_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "subscriber_count": count,
+    }
+
+    if args.dry_run:
+        print(json.dumps(stats, indent=2))
+        return 0
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(stats, indent=2) + "\n", encoding="utf-8")
+    log.info("buttondown: wrote %s (%d subscribers)", out_path, count)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fetch_buttondown_stats.py
+++ b/scripts/fetch_buttondown_stats.py
@@ -35,7 +35,7 @@ _ROOT = _SCRIPT_DIR.parent
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-import requests
+import requests  # noqa: E402  (after sys.path fix)
 
 logging.basicConfig(level=logging.INFO, stream=sys.stdout,
                     format="%(levelname)s %(message)s")

--- a/scripts/fetch_op3_stats.py
+++ b/scripts/fetch_op3_stats.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Fetch OP3 (op3.dev) download statistics for every show.
+
+The network has wrapped every RSS enclosure URL with the OP3 analytics
+prefix since launch (``engine/publisher.py:apply_op3_prefix``) but never
+read the resulting data back. This script closes that loop:
+
+* ``api/op3_stats.json`` — full per-show + per-episode download counts
+  for the operator dashboard (``scripts/generate_dashboard.py`` reads it).
+* ``site/data/popular_episodes.json`` — public, display-fields-only feed
+  of the network's most-downloaded recent episodes, rendered as the
+  "Most played" rail on the homepage. (``/api/`` is robots-disallowed,
+  ``site/data/`` is the public spot, next to ``search-index.json``.)
+
+Clean no-op when ``OP3_API_TOKEN`` is unset: logs one line, exits 0, and
+leaves any previously committed output untouched — same convention as
+every other optional integration in this repo.
+
+OP3 API (https://op3.dev/api/docs): base ``https://op3.dev/api/1``,
+``Authorization: Bearer <token>``. Shows are resolved from the feed URL
+via ``GET /shows/<urlsafe-base64-of-feed-url>``; counts come from
+``/queries/show-download-counts`` and ``/queries/episode-download-counts``
+(``format=json-o``). OP3 only has data from the date the prefix went
+live; there is no backfill for earlier listens.
+
+Usage::
+
+    python scripts/fetch_op3_stats.py                  # write both files
+    python scripts/fetch_op3_stats.py --dry-run        # print, write nothing
+    python scripts/fetch_op3_stats.py --out /tmp/o.json --popular-out /tmp/p.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as _dt
+import json
+import logging
+import os
+import sys
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Make `engine` / `generate_html` importable when run from anywhere.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_ROOT = _SCRIPT_DIR.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+import requests
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+log = logging.getLogger("op3_stats")
+
+OP3_API_BASE = "https://op3.dev/api/1"
+SITE_BASE_URL = "https://nerranetwork.com"
+HTTP_TIMEOUT = 15
+# Public popular-episodes feed size (homepage rail shows fewer).
+POPULAR_LIMIT = 12
+# Only display fields may reach the public file — never tokens/uuids.
+_PUBLIC_EPISODE_FIELDS = (
+    "title", "show_slug", "show_name", "brand_color", "show_page",
+    "audio_url", "downloads_7d", "rank",
+)
+
+_NON_SHOW_YAMLS = {
+    "_defaults", "_blocked_sources", "pronunciation_map",
+    "network_meta", "scaffold_pending",
+}
+
+
+def _list_show_yaml_paths(shows_dir: Path) -> List[Path]:
+    return sorted(
+        p for p in shows_dir.glob("*.yaml")
+        if p.stem not in _NON_SHOW_YAMLS
+        and not p.stem.endswith("_template")
+        and not p.stem.startswith("_")
+    )
+
+
+class _RateLimited(requests.exceptions.RequestException):
+    """HTTP 429 from OP3 — retried with backoff like a transient error."""
+
+
+@retry(
+    stop=stop_after_attempt(4),
+    wait=wait_exponential(multiplier=2, min=5, max=40),
+    retry=retry_if_exception_type((
+        requests.exceptions.ConnectionError,
+        requests.exceptions.Timeout,
+        _RateLimited,
+    )),
+    reraise=True,
+)
+def _get(url: str, token: str, params: Optional[Dict[str, str]] = None) -> Any:
+    resp = requests.get(
+        url,
+        headers={"Authorization": f"Bearer {token}"},
+        params=params or {},
+        timeout=HTTP_TIMEOUT,
+    )
+    if resp.status_code == 429:
+        raise _RateLimited(f"429 Too Many Requests: {url}")
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _feed_url_for(rss_file: str) -> str:
+    return f"{SITE_BASE_URL}/{rss_file}"
+
+
+def _show_uuid_for_feed(feed_url: str, token: str) -> Optional[str]:
+    """Resolve the OP3 showUuid from the feed URL (urlsafe base64)."""
+    encoded = base64.urlsafe_b64encode(feed_url.encode("utf-8")).decode("ascii")
+    data = _get(f"{OP3_API_BASE}/shows/{encoded}", token)
+    uuid = (data or {}).get("showUuid")
+    return uuid or None
+
+
+def _fetch_show_stats(slug: str, feed_url: str, token: str,
+                      cached_uuid: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Fetch per-show + per-episode download counts. Best-effort per show."""
+    try:
+        uuid = cached_uuid or _show_uuid_for_feed(feed_url, token)
+        if not uuid:
+            log.warning("op3: no showUuid for %s (%s) — prefix may be too new",
+                        slug, feed_url)
+            return None
+
+        show_counts = _get(
+            f"{OP3_API_BASE}/queries/show-download-counts",
+            token, {"showUuid": uuid, "format": "json-o"},
+        )
+        episode_counts = _get(
+            f"{OP3_API_BASE}/queries/episode-download-counts",
+            token, {"showUuid": uuid, "format": "json-o"},
+        )
+
+        # show-download-counts → {"asof": "YYYY-MM-DD",
+        #   "showDownloadCounts": {uuid: {"monthlyDownloads": N,
+        #   "weeklyDownloads": [w-3, w-2, w-1, w0], "weeklyAvgDownloads": N,
+        #   "numWeeks": N, "days": "0101…"}}} (verified live 2026-06).
+        per_show = ((show_counts or {}).get("showDownloadCounts") or {}).get(uuid) or {}
+        weekly = per_show.get("weeklyDownloads") or []
+        # episode-download-counts → {"showUuid":…, "episodes": [{"itemGuid",
+        #   "title", "pubdate", "downloads1", "downloads3", "downloads7",
+        #   "downloads30", "downloadsAll"}]}; window keys are OMITTED when
+        # OP3's data span doesn't cover them yet (verified live 2026-06).
+        raw_eps = (episode_counts or {}).get("episodes") or []
+
+        episodes = []
+        for ep in raw_eps:
+            downloads_all = ep.get("downloadsAll") or 0
+            episodes.append({
+                "title": ep.get("title") or "",
+                "item_guid": ep.get("itemGuid") or "",
+                "pubdate": ep.get("pubdate") or "",
+                "downloads_3d": ep.get("downloads3") or 0,
+                # Fall back through wider windows so young feeds (data span
+                # < 7 days) still rank sensibly on the popular rail.
+                "downloads_7d": ep.get("downloads7") or ep.get("downloads3")
+                or ep.get("downloads1") or 0,
+                "downloads_30d": ep.get("downloads30") or downloads_all,
+                "downloads_all_time": downloads_all,
+            })
+        episodes.sort(key=lambda e: e["downloads_7d"], reverse=True)
+
+        return {
+            "show_uuid": uuid,
+            "feed_url": feed_url,
+            "asof": (show_counts or {}).get("asof") or "",
+            "downloads_7d": (weekly[-1] if weekly else 0),
+            "downloads_30d": per_show.get("monthlyDownloads") or 0,
+            "weekly_avg": per_show.get("weeklyAvgDownloads") or 0,
+            "weekly_downloads": weekly,
+            "episodes": episodes,
+        }
+    except Exception as exc:  # noqa: BLE001 — one show must not kill the run
+        log.warning("op3: %s fetch failed: %s", slug, exc)
+        return None
+
+
+def _episode_audio_urls(rss_path: Path) -> Dict[str, str]:
+    """Map episode title AND guid → enclosure URL from a committed feed."""
+    mapping: Dict[str, str] = {}
+    try:
+        root = ET.parse(rss_path).getroot()
+        for item in root.iter("item"):
+            title = (item.findtext("title") or "").strip()
+            guid = (item.findtext("guid") or "").strip()
+            enclosure = item.find("enclosure")
+            url = enclosure.get("url") if enclosure is not None else ""
+            if url:
+                if title:
+                    mapping[title] = url
+                if guid:
+                    mapping[guid] = url
+    except Exception as exc:  # noqa: BLE001
+        log.warning("op3: could not parse %s: %s", rss_path, exc)
+    return mapping
+
+
+def build_popular_episodes(stats: Dict[str, Any], root: Path) -> List[Dict[str, Any]]:
+    """Derive the public top-N list. Display fields only — no uuids/tokens."""
+    from generate_html import NETWORK_SHOWS  # canonical show registry
+
+    candidates: List[Dict[str, Any]] = []
+    for slug, show_stats in (stats.get("shows") or {}).items():
+        meta = NETWORK_SHOWS.get(slug) or {}
+        rss_file = meta.get("rss_file") or ""
+        audio_urls = _episode_audio_urls(root / rss_file) if rss_file else {}
+        for ep in (show_stats.get("episodes") or []):
+            if not ep.get("downloads_7d"):
+                continue
+            audio = audio_urls.get(ep.get("title", "")) or audio_urls.get(
+                ep.get("item_guid", ""))
+            candidates.append({
+                "title": ep.get("title") or "",
+                "show_slug": slug,
+                "show_name": meta.get("name") or slug,
+                "brand_color": meta.get("brand_color") or "#00D4FF",
+                "show_page": meta.get("show_page") or "",
+                "audio_url": audio or "",
+                "downloads_7d": ep.get("downloads_7d") or 0,
+            })
+
+    candidates.sort(key=lambda e: e["downloads_7d"], reverse=True)
+    top = candidates[:POPULAR_LIMIT]
+    for rank, ep in enumerate(top, start=1):
+        ep["rank"] = rank
+    # Defense-in-depth: strip anything outside the public whitelist.
+    return [
+        {k: v for k, v in ep.items() if k in _PUBLIC_EPISODE_FIELDS}
+        for ep in top
+    ]
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default="api/op3_stats.json")
+    parser.add_argument("--popular-out", default="site/data/popular_episodes.json")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print JSON to stdout, write nothing")
+    args = parser.parse_args(argv)
+
+    token = (os.getenv("OP3_API_TOKEN") or "").strip()
+    if not token:
+        log.info("op3: OP3_API_TOKEN unset — skipping (clean no-op)")
+        return 0
+
+    root = _ROOT
+    out_path = Path(args.out)
+    popular_path = Path(args.popular_out)
+
+    # Reuse previously resolved showUuids so reruns skip the lookup.
+    previous: Dict[str, Any] = {}
+    if out_path.exists():
+        try:
+            previous = json.loads(out_path.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            previous = {}
+    prev_shows = previous.get("shows") or {}
+
+    import yaml
+    shows: Dict[str, Any] = {}
+    for yaml_path in _list_show_yaml_paths(root / "shows"):
+        slug = yaml_path.stem
+        try:
+            data = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+        except Exception as exc:  # noqa: BLE001
+            log.warning("op3: cannot parse %s: %s", yaml_path, exc)
+            continue
+        rss_file = ((data.get("publishing") or {}).get("rss_file") or "").strip()
+        if not rss_file:
+            continue
+        cached_uuid = (prev_shows.get(slug) or {}).get("show_uuid")
+        if shows:
+            time.sleep(2)  # politeness — OP3 rate-limits bursts (429)
+        result = _fetch_show_stats(
+            slug, _feed_url_for(rss_file), token, cached_uuid,
+        )
+        if result is not None:
+            shows[slug] = result
+
+    stats = {
+        "fetched_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "shows": shows,
+    }
+    popular = build_popular_episodes(stats, root)
+
+    if args.dry_run:
+        print(json.dumps(stats, indent=2)[:2000])
+        print(json.dumps(popular, indent=2)[:2000])
+        return 0
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(stats, indent=2) + "\n", encoding="utf-8")
+    log.info("op3: wrote %s (%d shows)", out_path, len(shows))
+
+    popular_path.parent.mkdir(parents=True, exist_ok=True)
+    popular_path.write_text(json.dumps(popular, indent=2) + "\n", encoding="utf-8")
+    log.info("op3: wrote %s (%d episodes)", popular_path, len(popular))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fetch_op3_stats.py
+++ b/scripts/fetch_op3_stats.py
@@ -50,8 +50,8 @@ _ROOT = _SCRIPT_DIR.parent
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-import requests
-from tenacity import (
+import requests  # noqa: E402  (after sys.path fix)
+from tenacity import (  # noqa: E402  (after sys.path fix)
     retry,
     retry_if_exception_type,
     stop_after_attempt,

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1522,11 +1522,80 @@ def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optiona
         "pipeline_health": metrics,
         "rss_audit": rss,
         "mit_performance": aggregate_mit_performance(root),
+        "audience": build_audience_section(root),
         "content_lake": {
             "stats": _get_content_lake_stats_safe(),
             "compaction_note": "Run scripts/compact_lake.py or engine.content_lake.compact_lake() to prune old full text.",
         },
     }
+
+
+def build_audience_section(root: Path) -> Dict[str, Any]:
+    """Summarise OP3 download + Buttondown subscriber stats (June 2026).
+
+    Reads ``api/op3_stats.json`` and ``api/buttondown_stats.json`` written
+    by the nightly audience-stats step. Both files are optional — when
+    absent (secrets not configured yet) the section reports
+    ``configured: false`` so the dashboard card can render a setup hint
+    instead of zeros.
+    """
+    section: Dict[str, Any] = {
+        "op3": {"configured": False},
+        "newsletter": {"configured": False},
+    }
+
+    op3_path = root / "api" / "op3_stats.json"
+    if op3_path.exists():
+        try:
+            data = json.loads(op3_path.read_text(encoding="utf-8"))
+            shows = data.get("shows") or {}
+            per_show = {
+                slug: {
+                    "downloads_7d": s.get("downloads_7d") or 0,
+                    "downloads_30d": s.get("downloads_30d") or 0,
+                    "weekly_avg": s.get("weekly_avg") or 0,
+                }
+                for slug, s in shows.items()
+            }
+            top_episodes = sorted(
+                (
+                    {
+                        "show_slug": slug,
+                        "title": ep.get("title") or "",
+                        "downloads_7d": ep.get("downloads_7d") or 0,
+                    }
+                    for slug, s in shows.items()
+                    for ep in (s.get("episodes") or [])
+                ),
+                key=lambda e: e["downloads_7d"],
+                reverse=True,
+            )[:5]
+            section["op3"] = {
+                "configured": True,
+                "fetched_at": data.get("fetched_at"),
+                "network_downloads_30d": sum(
+                    v["downloads_30d"] for v in per_show.values()),
+                "network_downloads_7d": sum(
+                    v["downloads_7d"] for v in per_show.values()),
+                "per_show": per_show,
+                "top_episodes_7d": top_episodes,
+            }
+        except Exception as exc:  # noqa: BLE001 — never break the dashboard
+            section["op3"] = {"configured": True, "error": str(exc)}
+
+    bd_path = root / "api" / "buttondown_stats.json"
+    if bd_path.exists():
+        try:
+            data = json.loads(bd_path.read_text(encoding="utf-8"))
+            section["newsletter"] = {
+                "configured": True,
+                "fetched_at": data.get("fetched_at"),
+                "subscriber_count": data.get("subscriber_count"),
+            }
+        except Exception as exc:  # noqa: BLE001
+            section["newsletter"] = {"configured": True, "error": str(exc)}
+
+    return section
 
 
 def _get_content_lake_stats_safe() -> dict:

--- a/scripts/run_weekly_newsletters.py
+++ b/scripts/run_weekly_newsletters.py
@@ -133,6 +133,18 @@ def main():
             # disclaimer callout, body, P.S. block, and footer.
             # Buttondown passes inline HTML through its markdown
             # renderer untouched.
+            # Deterministic Buttondown slug so the view-in-browser link
+            # can point at the issue's archive page before the send
+            # (June 2026 growth pass).
+            from engine.newsletter import BUTTONDOWN_USERNAME
+            bd_slug = (
+                f"{show_slug.replace('_', '-')}-weekly-issue-{issue_number:03d}"
+            )
+            archive_url = (
+                f"https://buttondown.com/{BUTTONDOWN_USERNAME}"
+                f"/archive/{bd_slug}/"
+            )
+
             branded_body = wrap_with_branding(
                 show_slug, newsletter_md,
                 week_ending=week_ending,
@@ -142,6 +154,7 @@ def main():
                 p_s=envelope.get("p_s", ""),
                 adjacent_shows=envelope.get("cross_network") or [],
                 requires_financial_disclaimer=requires_disclaimer,
+                archive_url=archive_url,
             )
 
             email_id = send_newsletter(
@@ -150,6 +163,7 @@ def main():
                 api_key=api_key,
                 status=getattr(newsletter_cfg, "status", "draft"),
                 tags=tags_list,
+                slug=bd_slug,
             )
             results[show_slug] = f"sent ({email_id})" if email_id else "send failed"
         except Exception as e:

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -146,6 +146,12 @@ publishing:
   rss_email: patrick@planetterrian.com
   base_url: https://nerranetwork.com
   host_name: Patrick
+  # Cross-promo reply tweet under the daily teaser (June 2026 growth
+  # pass): "Follow @handle" + one sibling-show plug, posted as a reply
+  # so the teaser stays clean. Per-show x_handle lives in the show
+  # YAMLs; shows without a handle still post the sibling plug. Flip to
+  # false here for a network-wide kill switch.
+  x_cross_promo: true
 
 analytics:
   # OP3 (https://op3.dev) is a free, open podcast analytics service.

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -166,18 +166,6 @@ newsletter:
   # model knows where to land. Per-show overrides are encouraged;
   # 1300 is a sensible network default for a news-driven weekly.
   length_target_words: 1300
-
-# ---- Item 4 cost circuit breaker defaults (May 2026 review) ----
-# All 0 = disabled (current network posture). Per-show YAMLs can opt in.
-# The runner reads recent metrics_ep*.json + credit_usage for the 7-day sums.
-# Per-episode hard stops (max_*_per_episode) are enforced before the expensive
-# calls (TTS synthesis, Grok Imagine image gen) when >0.
-cost_circuit_breakers:
-  # max_weekly_cost_usd: 0.0          # existing USD aggregate from dashboard
-  # max_weekly_tts_chars: 0
-  # max_weekly_grok_images: 0
-  # max_tts_chars_per_episode: 0
-  # max_grok_images_per_episode: 0
   # Compose flag for the styled "Heads up: educational only..."
   # callout. Flip to true on shows that discuss money / trades.
   requires_financial_disclaimer: false
@@ -213,7 +201,26 @@ cost_circuit_breakers:
     env_intel: [planetterrian, omni_view]
     finansy_prosto: [modern_investing, privet_russian]
     privet_russian: [finansy_prosto]
+    unintended_consequences: [planetterrian, omni_view]
     first_principles: [tesla, models_agents]
+
+# ---- Item 4 cost circuit breaker defaults (May 2026 review) ----
+# All 0 = disabled (current network posture). Per-show YAMLs can opt in.
+# The runner reads recent metrics_ep*.json + credit_usage for the 7-day sums.
+# Per-episode hard stops (max_*_per_episode) are enforced before the expensive
+# calls (TTS synthesis, Grok Imagine image gen) when >0.
+cost_circuit_breakers:
+  # max_weekly_cost_usd: 0.0          # existing USD aggregate from dashboard
+  # max_weekly_tts_chars: 0
+  # max_weekly_grok_images: 0
+  # max_tts_chars_per_episode: 0
+  # max_grok_images_per_episode: 0
+  # NOTE: the newsletter-related keys (requires_financial_disclaimer,
+  # short_label, emoji, newsletter_start_date, adjacent_shows,
+  # network_adjacencies) used to live here by indentation accident —
+  # engine/newsletter.py and engine/synthesizer.py read them under
+  # ``newsletter:``, where they now live. Drift guard:
+  # tests/test_newsletter.py::test_defaults_yaml_network_adjacencies_under_newsletter
 
 chapters:
   enabled: true

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -234,6 +234,7 @@ publishing:
   summaries_podcast_name: space
   x_enabled: true
   x_env_prefix: "PLANETTERRIAN_X_"
+  x_handle: "@planetterrian"
 
 episode:
   prefix: Fascinating_Frontiers

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -247,6 +247,7 @@ publishing:
   summaries_podcast_name: planet
   x_enabled: true
   x_env_prefix: "PLANETTERRIAN_X_"
+  x_handle: "@planetterrian"
 
 episode:
   prefix: Planetterrian_Daily

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -181,6 +181,7 @@ publishing:
   summaries_podcast_name: tesla
   x_enabled: true
   x_env_prefix: "X_"
+  x_handle: "@teslashortstime"
 
 episode:
   prefix: Tesla_Shorts_Time_Pod

--- a/shows/unintended_consequences.yaml
+++ b/shows/unintended_consequences.yaml
@@ -81,6 +81,7 @@ publishing:
   # posting goes out via the planetterrian creds. Weekday cadence.
   x_enabled: true
   x_env_prefix: "PLANETTERRIAN_X_"
+  x_handle: "@planetterrian"
 
 episode:
   prefix: Unintended_Consequences

--- a/site/data/popular_episodes.json
+++ b/site/data/popular_episodes.json
@@ -1,0 +1,122 @@
+[
+  {
+    "title": "Ep 69: Microsoft is shipping hardware built from the silicon up to run AI agents instead of conventional apps.",
+    "show_slug": "models_agents",
+    "show_name": "Models & Agents",
+    "brand_color": "#7C3AED",
+    "show_page": "models-agents.html",
+    "audio_url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep069_20260603.mp3",
+    "downloads_7d": 13,
+    "rank": 1
+  },
+  {
+    "title": "Ep 501: Tesla ending free Supercharging for new Model 3s on June 15 removes a key ownership perk just as buyers weigh total costs against rivals.",
+    "show_slug": "tesla",
+    "show_name": "Tesla Shorts Time",
+    "brand_color": "#E31937",
+    "show_page": "tesla.html",
+    "audio_url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep501_20260605.mp3",
+    "downloads_7d": 12,
+    "rank": 2
+  },
+  {
+    "title": "Ep 497: China's 39% jump in Tesla wholesale volume signals resilient demand amid intensifying EV rivalry.",
+    "show_slug": "tesla",
+    "show_name": "Tesla Shorts Time",
+    "brand_color": "#E31937",
+    "show_page": "tesla.html",
+    "audio_url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep497_20260602.mp3",
+    "downloads_7d": 11,
+    "rank": 3
+  },
+  {
+    "title": "Ep 72: Microsoft just gained the freedom to build its own frontier models after a contract change with OpenAI, and the first MAI family is already shipping.",
+    "show_slug": "models_agents",
+    "show_name": "Models & Agents",
+    "brand_color": "#7C3AED",
+    "show_page": "models-agents.html",
+    "audio_url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep072_20260606.mp3",
+    "downloads_7d": 10,
+    "rank": 4
+  },
+  {
+    "title": "Ep 500: Tokyo's new EV incentives could nearly halve Tesla prices in the capital region.",
+    "show_slug": "tesla",
+    "show_name": "Tesla Shorts Time",
+    "brand_color": "#E31937",
+    "show_page": "tesla.html",
+    "audio_url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep500_20260604.mp3",
+    "downloads_7d": 10,
+    "rank": 5
+  },
+  {
+    "title": "Ep 73: Looking back at 7 episodes from 2026-06-01 to 2026-06-07 \u2014 the stories that mattered, what we learned, and what to watch next.",
+    "show_slug": "models_agents",
+    "show_name": "Models & Agents",
+    "brand_color": "#7C3AED",
+    "show_page": "models-agents.html",
+    "audio_url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep073_20260607.mp3",
+    "downloads_7d": 9,
+    "rank": 6
+  },
+  {
+    "title": "Ep 70: Gemma 4 12B puts capable local agents on laptops with only 16GB VRAM under an Apache 2.0 license.",
+    "show_slug": "models_agents",
+    "show_name": "Models & Agents",
+    "brand_color": "#7C3AED",
+    "show_page": "models-agents.html",
+    "audio_url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep070_20260604.mp3",
+    "downloads_7d": 9,
+    "rank": 7
+  },
+  {
+    "title": "Ep 68: NVIDIA's Cosmos 3 pairs an autoregressive reasoner with a diffusion generator so builders can now train agents that jointly reason about physics, generate worlds, and output actions.",
+    "show_slug": "models_agents",
+    "show_name": "Models & Agents",
+    "brand_color": "#7C3AED",
+    "show_page": "models-agents.html",
+    "audio_url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep068_20260603.mp3",
+    "downloads_7d": 9,
+    "rank": 8
+  },
+  {
+    "title": "Ep 67: Enterprise teams can now run governed AI agents inside existing procurement systems instead of leaking data to personal ChatGPT accounts.",
+    "show_slug": "models_agents",
+    "show_name": "Models & Agents",
+    "brand_color": "#7C3AED",
+    "show_page": "models-agents.html",
+    "audio_url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep067_20260602.mp3",
+    "downloads_7d": 9,
+    "rank": 9
+  },
+  {
+    "title": "Ep 60: Teens are using AI to outsmart expensive World Cup ticket scalpers and build their own tools.",
+    "show_slug": "models_agents_beginners",
+    "show_name": "Models & Agents for Beginners",
+    "brand_color": "#C2410C",
+    "show_page": "models-agents-beginners.html",
+    "audio_url": "https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep060_20260603.mp3",
+    "downloads_7d": 9,
+    "rank": 10
+  },
+  {
+    "title": "Ep 502: Tesla's import of a Chinese-built Premium AWD Model 3 into Canada for under $50,000 tests whether cross-border sourcing can offset domestic production constraints.",
+    "show_slug": "tesla",
+    "show_name": "Tesla Shorts Time",
+    "brand_color": "#E31937",
+    "show_page": "tesla.html",
+    "audio_url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep502_20260606.mp3",
+    "downloads_7d": 9,
+    "rank": 11
+  },
+  {
+    "title": "Ep 498: Halifax gets its first Supercharger site under construction, extending the network into Atlantic Canada for the first time.",
+    "show_slug": "tesla",
+    "show_name": "Tesla Shorts Time",
+    "brand_color": "#E31937",
+    "show_page": "tesla.html",
+    "audio_url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep498_20260603.mp3",
+    "downloads_7d": 9,
+    "rank": 12
+  }
+]

--- a/templates/network_page.html.j2
+++ b/templates/network_page.html.j2
@@ -234,6 +234,30 @@
         {% endif %}
     </section>
 
+    {% if popular_episodes %}
+    <!-- Most Played This Week (OP3 download data, refreshed nightly) -->
+    <section id="popular" class="nn-section">
+        <div class="container">
+            <div class="nn-section-header">
+                <div class="section-label">Listener Favorites</div>
+                <h2>Most Played This Week</h2>
+                <p>The episodes our listeners played most over the last seven days.</p>
+            </div>
+        </div>
+        <div class="latest-scroll-row">
+            {% for ep in popular_episodes %}
+            <div class="latest-scroll-card glass-card">
+                <div class="episode-card-show" style="background:{{ ep.brand_color }};">#{{ ep.rank }} · {{ ep.show_name }}</div>
+                <div class="episode-card-title">{{ ep.title }}</div>
+                {% if ep.audio_url %}
+                <audio controls preload="none" src="{{ ep.audio_url }}" aria-label="{{ ep.show_name }} episode audio" style="width:100%;height:36px;border-radius:8px;margin-top:var(--sp-2);"></audio>
+                {% endif %}
+            </div>
+            {% endfor %}
+        </div>
+    </section>
+    {% endif %}
+
     <!-- Latest from the Blog -->
     {% if latest_blog_posts %}
     <section class="nn-section">
@@ -440,6 +464,9 @@
                 <div class="section-label">Weekly digest</div>
                 <h2>Get the best of the network in your inbox</h2>
                 <p>One email per week. Top episodes from every show you follow. Unsubscribe anytime.</p>
+                {% if newsletter_subscriber_count %}
+                <p style="font-family:var(--font-ui);font-size:0.85rem;color:var(--nn-text-muted);margin-top:var(--sp-2);">Join {{ "{:,}".format(newsletter_subscriber_count) }}+ readers already subscribed.</p>
+                {% endif %}
             </div>
             <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow"
                   class="nn-subscribe-form" style="max-width:none;"

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -281,3 +281,44 @@ class TestCitationHoverCards:
         assert "news.google.com/rss/articles/CBMiabc123?oc=5" in out
         # The literal "Source/Post:" prefix stays before the pill.
         assert "Source/Post:" in out
+
+
+class TestCrossShowRelatedCuratedFirst:
+    """The curated sibling (NETWORK_SHOWS[slug]['related_show']) must take
+    the first cross-show rec slot when it has a recent post (June 2026
+    growth pass)."""
+
+    def _posts(self, *slugs):
+        return [
+            {"show_slug": s, "title": f"{s} post", "url": f"/blog/{s}/ep1.html"}
+            for s in slugs
+        ]
+
+    def test_curated_sibling_takes_first_slot(self):
+        from generate_html import NETWORK_SHOWS, _pick_cross_show_related
+
+        curated = NETWORK_SHOWS["tesla"]["related_show"]
+        pool = self._posts(
+            "planetterrian", "models_agents", curated, "env_intel",
+        )
+        picked = _pick_cross_show_related("tesla", pool)
+        assert picked, "expected non-empty recommendations"
+        assert picked[0]["show_slug"] == curated
+        assert len(picked) == 3
+
+    def test_own_show_excluded_and_empty_pool_ok(self):
+        from generate_html import _pick_cross_show_related
+
+        assert _pick_cross_show_related("tesla", []) == []
+        picked = _pick_cross_show_related("tesla", self._posts("tesla"))
+        assert picked == []
+
+    def test_every_curated_sibling_is_a_known_show(self):
+        from generate_html import NETWORK_SHOWS
+
+        for slug, meta in NETWORK_SHOWS.items():
+            related = meta.get("related_show")
+            if related:
+                assert related in NETWORK_SHOWS, (
+                    f"NETWORK_SHOWS[{slug}].related_show={related!r} unknown"
+                )

--- a/tests/test_buttondown_stats.py
+++ b/tests/test_buttondown_stats.py
@@ -1,0 +1,80 @@
+"""Drift guards for scripts/fetch_buttondown_stats.py (June 2026 growth pass)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.fetch_buttondown_stats import (  # noqa: E402
+    fetch_subscriber_count,
+    main,
+)
+
+
+class TestNoOpWithoutKey:
+    def test_exit_zero_and_file_untouched(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("BUTTONDOWN_API_KEY", raising=False)
+        out = tmp_path / "buttondown_stats.json"
+        out.write_text('{"sentinel": true}', encoding="utf-8")
+
+        rc = main(["--out", str(out)])
+
+        assert rc == 0
+        assert json.loads(out.read_text()) == {"sentinel": True}
+
+    def test_fetch_failure_leaves_file_untouched(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("BUTTONDOWN_API_KEY", "key")
+        out = tmp_path / "buttondown_stats.json"
+        out.write_text('{"subscriber_count": 42}', encoding="utf-8")
+
+        with patch("scripts.fetch_buttondown_stats.fetch_subscriber_count",
+                   return_value=None):
+            rc = main(["--out", str(out)])
+
+        assert rc == 0
+        assert json.loads(out.read_text()) == {"subscriber_count": 42}
+
+
+class TestCountParsing:
+    def _resp(self, status=200, body=None):
+        resp = MagicMock()
+        resp.status_code = status
+        resp.json.return_value = body if body is not None else {}
+        return resp
+
+    def test_reads_count_field(self):
+        with patch("scripts.fetch_buttondown_stats.requests.get",
+                   return_value=self._resp(body={"count": 257, "results": []})):
+            assert fetch_subscriber_count("key") == 257
+
+    def test_missing_count_returns_none(self):
+        with patch("scripts.fetch_buttondown_stats.requests.get",
+                   return_value=self._resp(body={"results": []})):
+            assert fetch_subscriber_count("key") is None
+
+    def test_http_error_returns_none(self):
+        with patch("scripts.fetch_buttondown_stats.requests.get",
+                   return_value=self._resp(status=401)):
+            assert fetch_subscriber_count("key") is None
+
+    def test_network_error_returns_none(self):
+        with patch("scripts.fetch_buttondown_stats.requests.get",
+                   side_effect=ConnectionError("boom")):
+            assert fetch_subscriber_count("key") is None
+
+    def test_writes_stats_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("BUTTONDOWN_API_KEY", "key")
+        out = tmp_path / "b.json"
+        with patch("scripts.fetch_buttondown_stats.fetch_subscriber_count",
+                   return_value=257):
+            rc = main(["--out", str(out)])
+        assert rc == 0
+        data = json.loads(out.read_text())
+        assert data["subscriber_count"] == 257
+        assert "fetched_at" in data

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -296,3 +296,66 @@ def test_item_4_output_dirs_no_violations_on_real_shows(tmp_path, monkeypatch):
         f"item_4_output_dirs still FAIL: {result.get('details')} "
         f"violations={result.get('evidence', {}).get('violations')}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Audience section (June 2026 growth pass) — OP3 + Buttondown read-back
+# ---------------------------------------------------------------------------
+
+
+def test_audience_section_graceful_when_stats_missing(tmp_path):
+    """A repo without api/op3_stats.json / api/buttondown_stats.json must
+    still build a dashboard, with the audience section reporting
+    configured: false (the management card renders a setup hint)."""
+    section = gd.build_audience_section(tmp_path)
+    assert section["op3"] == {"configured": False}
+    assert section["newsletter"] == {"configured": False}
+
+
+def test_audience_section_summarises_stats(tmp_path):
+    import json as _json
+
+    api_dir = tmp_path / "api"
+    api_dir.mkdir()
+    (api_dir / "op3_stats.json").write_text(_json.dumps({
+        "fetched_at": "2026-06-10T00:00:00+00:00",
+        "shows": {
+            "tesla": {
+                "downloads_7d": 149, "downloads_30d": 616, "weekly_avg": 150,
+                "episodes": [
+                    {"title": "Big ep", "downloads_7d": 12},
+                    {"title": "Small ep", "downloads_7d": 1},
+                ],
+            },
+            "env_intel": {
+                "downloads_7d": 11, "downloads_30d": 24, "weekly_avg": 11,
+                "episodes": [],
+            },
+        },
+    }), encoding="utf-8")
+    (api_dir / "buttondown_stats.json").write_text(_json.dumps({
+        "fetched_at": "2026-06-10T00:00:00+00:00",
+        "subscriber_count": 257,
+    }), encoding="utf-8")
+
+    section = gd.build_audience_section(tmp_path)
+
+    assert section["op3"]["configured"] is True
+    assert section["op3"]["network_downloads_30d"] == 640
+    assert section["op3"]["network_downloads_7d"] == 160
+    assert section["op3"]["per_show"]["tesla"]["downloads_30d"] == 616
+    assert section["op3"]["top_episodes_7d"][0]["title"] == "Big ep"
+    assert section["newsletter"]["subscriber_count"] == 257
+
+
+def test_audience_section_in_dashboard_payload():
+    data = gd.build_dashboard(ROOT, offline=True)
+    assert "audience" in data, (
+        "build_dashboard must always emit the audience section"
+    )
+
+
+def test_management_html_renders_audience_card():
+    html = (ROOT / "management.html").read_text(encoding="utf-8")
+    assert 'id="audience-section"' in html
+    assert "data.audience" in html

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -729,3 +729,68 @@ def test_contrast_failure_blocks_send_and_logs_error(monkeypatch, caplog):
         and rec.levelno >= logging.ERROR
         for rec in caplog.records
     ), "Expected a logger.error for the blocking contrast failure"
+
+
+# ---------------------------------------------------------------------------
+# Drift guard: the cross-network adjacency map must live under ``newsletter:``
+# in shows/_defaults.yaml. It was originally shipped mis-indented under
+# ``cost_circuit_breakers:`` (June 2026 review), which made
+# engine.newsletter._adjacent_shows_for and
+# engine.synthesizer._load_network_adjacencies silently read an empty map —
+# degrading the cross-network module on every daily + weekly send.
+# ---------------------------------------------------------------------------
+
+_NON_SHOW_YAML_STEMS = {
+    "_defaults", "_blocked_sources", "pronunciation_map",
+    "network_meta", "scaffold_pending",
+}
+
+
+def _all_show_slugs():
+    from pathlib import Path
+    return sorted(
+        p.stem for p in Path("shows").glob("*.yaml")
+        if p.stem not in _NON_SHOW_YAML_STEMS
+        and not p.stem.endswith("_template")
+        and not p.stem.startswith("_")
+    )
+
+
+def test_defaults_yaml_network_adjacencies_under_newsletter():
+    import yaml
+    from pathlib import Path
+
+    data = yaml.safe_load(
+        Path("shows/_defaults.yaml").read_text(encoding="utf-8")
+    ) or {}
+    nl = data.get("newsletter") or {}
+    adj = nl.get("network_adjacencies")
+    assert isinstance(adj, dict) and adj, (
+        "newsletter.network_adjacencies missing/empty in shows/_defaults.yaml "
+        "— the cross-network email module reads it from exactly this path"
+    )
+    slugs = set(_all_show_slugs())
+    assert slugs <= set(adj.keys()), (
+        f"network_adjacencies missing shows: {sorted(slugs - set(adj.keys()))}"
+    )
+    # Every referenced sibling must itself be a real show slug.
+    for slug, sisters in adj.items():
+        for sister in sisters:
+            assert sister in slugs, (
+                f"network_adjacencies[{slug}] references unknown show {sister!r}"
+            )
+    # And the newsletter-composition keys moved in the same fix must be
+    # readable from the same block.
+    for key in ("requires_financial_disclaimer", "short_label", "emoji",
+                "newsletter_start_date", "adjacent_shows"):
+        assert key in nl, f"newsletter.{key} missing from shows/_defaults.yaml"
+
+
+def test_synthesizer_reads_nonempty_adjacencies():
+    from engine.synthesizer import _load_network_adjacencies
+
+    adj = _load_network_adjacencies()
+    assert adj.get("tesla"), (
+        "engine.synthesizer._load_network_adjacencies returned an empty map "
+        "for tesla — adjacency block likely mis-indented again"
+    )

--- a/tests/test_newsletter_sender.py
+++ b/tests/test_newsletter_sender.py
@@ -16,9 +16,14 @@ import pytest
 
 class TestButtondownSlug:
 
-    def test_english_show_returns_none(self):
+    def test_english_show_gets_deterministic_slug(self):
+        # June 2026 growth pass: English shows used to return None
+        # (Buttondown auto-derived → archive URL unknown pre-send, so
+        # the view-in-browser link was never built). Now every show
+        # gets the same deterministic <show>-ep<num>-<hook> shape.
         from engine.newsletter import _buttondown_slug_for
-        assert _buttondown_slug_for("tesla", 42, "Cybertruck production begins") is None
+        slug = _buttondown_slug_for("tesla", 42, "Cybertruck production begins")
+        assert slug == "tesla-ep042-cybertruck-production-begins"
 
     def test_russian_show_transliterates(self):
         from engine.newsletter import _buttondown_slug_for
@@ -144,3 +149,59 @@ class TestDailySubjectBuilder:
             "tesla", "", send_date=send_date, is_daily=True,
         )
         assert "May 2 update" in subject
+
+
+class TestArchiveUrlPassedToWrap:
+    """June 2026 growth pass: send_show_newsletter must compute the
+    Buttondown slug BEFORE wrapping so the view-in-browser link points
+    at the issue's archive page, and pass the same slug to the send."""
+
+    def test_wrap_receives_archive_url_and_send_receives_slug(self, monkeypatch):
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from engine import newsletter
+
+        monkeypatch.setenv("TEST_BUTTONDOWN_KEY", "key")
+        captured = {}
+
+        def fake_wrap(slug, body, **kwargs):
+            captured["archive_url"] = kwargs.get("archive_url")
+            return body
+
+        def fake_send(**kwargs):
+            captured["slug"] = kwargs.get("slug")
+            return "email-id"
+
+        config = SimpleNamespace(
+            newsletter=SimpleNamespace(
+                enabled=True,
+                api_key_env="TEST_BUTTONDOWN_KEY",
+                tag="Tesla",
+                status="about_to_send",
+                requires_financial_disclaimer=False,
+            ),
+            name="Tesla Shorts Time",
+            slug="tesla",
+        )
+
+        with patch("engine.newsletter_template.wrap_with_branding",
+                   side_effect=fake_wrap), \
+             patch("engine.newsletter.send_newsletter",
+                   side_effect=fake_send), \
+             patch("engine.newsletter.validate_api_key", return_value=True), \
+             patch("engine.newsletter._can_send_now", return_value=True), \
+             patch("engine.newsletter._record_send"), \
+             patch("engine.newsletter._adjacent_shows_for", return_value=None):
+            result = newsletter.send_show_newsletter(
+                "## Digest body\n\nStory.", config, 503, "2026-06-10",
+                hook="Cybercab production begins",
+            )
+
+        assert result == "email-id"
+        expected_slug = "tesla-ep503-cybercab-production-begins"
+        assert captured["slug"] == expected_slug
+        assert captured["archive_url"] == (
+            f"https://buttondown.com/{newsletter.BUTTONDOWN_USERNAME}"
+            f"/archive/{expected_slug}/"
+        )

--- a/tests/test_newsletter_template.py
+++ b/tests/test_newsletter_template.py
@@ -1104,3 +1104,35 @@ class TestDailyReadabilityCleanup:
     def test_body_uses_readable_type(self):
         html = self._render()
         assert "font-size:16px;line-height:1.7" in html
+
+
+# ---------------------------------------------------------------------------
+# Forward-to-a-friend conversion line (June 2026 growth pass)
+# ---------------------------------------------------------------------------
+
+def test_reply_share_includes_forward_subscribe_line():
+    show = nt._load_show_branding("tesla")
+    out = nt._build_reply_share_html(show, slug="tesla")
+    assert "Forwarded this email?" in out
+    assert "Subscribe here" in out
+    # UTM attribution, with the query string BEFORE the #newsletter fragment.
+    assert "utm_campaign=forward_subscribe" in out
+    assert "forward_subscribe#newsletter" in out
+
+
+def test_reply_share_forward_line_localized_for_russian():
+    show = nt._load_show_branding("privet_russian")
+    out = nt._build_reply_share_html(show, slug="privet_russian")
+    assert "Вам переслали это письмо?" in out
+    assert "Подпишитесь здесь" in out
+    assert "utm_campaign=forward_subscribe" in out
+
+
+def test_view_in_browser_renders_when_archive_url_passed():
+    out = nt.wrap_with_branding(
+        "tesla", "## Body",
+        daily_label="Ep 503",
+        daily_date=datetime.date(2026, 6, 10),
+        archive_url="https://buttondown.com/patricknovak1/archive/tesla-ep503/",
+    )
+    assert "buttondown.com/patricknovak1/archive/tesla-ep503/" in out

--- a/tests/test_op3_stats.py
+++ b/tests/test_op3_stats.py
@@ -1,0 +1,199 @@
+"""Drift guards for scripts/fetch_op3_stats.py (June 2026 growth pass).
+
+The OP3 integration is the network's first read-back of real audience
+data. Contract pinned here:
+
+* clean no-op when ``OP3_API_TOKEN`` is unset (exit 0, files untouched);
+* correct parsing of the live OP3 response shapes (verified against the
+  real API 2026-06: show-download-counts ``monthlyDownloads`` /
+  ``weeklyDownloads`` and episode-download-counts ``downloads1/3/7/30/All``
+  with window keys omitted on young feeds);
+* the public ``site/data/popular_episodes.json`` carries display fields
+  only — never tokens or show UUIDs.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.fetch_op3_stats import (  # noqa: E402
+    _PUBLIC_EPISODE_FIELDS,
+    _fetch_show_stats,
+    build_popular_episodes,
+    main,
+)
+
+
+class TestNoOpWithoutToken:
+    def test_exit_zero_and_files_untouched(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("OP3_API_TOKEN", raising=False)
+        out = tmp_path / "op3_stats.json"
+        popular = tmp_path / "popular.json"
+        out.write_text('{"sentinel": true}', encoding="utf-8")
+
+        rc = main(["--out", str(out), "--popular-out", str(popular)])
+
+        assert rc == 0
+        assert json.loads(out.read_text()) == {"sentinel": True}, (
+            "existing stats file must be left untouched when token unset"
+        )
+        assert not popular.exists()
+
+    def test_blank_token_is_unset(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OP3_API_TOKEN", "   ")
+        rc = main(["--out", str(tmp_path / "o.json"),
+                   "--popular-out", str(tmp_path / "p.json")])
+        assert rc == 0
+        assert not (tmp_path / "o.json").exists()
+
+
+# Canned responses mirroring the live API shapes (captured 2026-06).
+_SHOW_COUNTS = {
+    "asof": "2026-06-08",
+    "showDownloadCounts": {
+        "abc123": {
+            "days": "000000000000000000000111111101",
+            "monthlyDownloads": 24,
+            "weeklyDownloads": [0, 0, 13, 11],
+            "weeklyAvgDownloads": 11,
+            "numWeeks": 1,
+        }
+    },
+}
+_EPISODE_COUNTS = {
+    "showUuid": "abc123",
+    "episodes": [
+        {  # young episode: downloads7/30 omitted by the API
+            "itemGuid": "guid-young",
+            "title": "Young episode",
+            "pubdate": "2026-06-05T08:00:00.000Z",
+            "downloads1": 2,
+            "downloads3": 2,
+            "downloadsAll": 3,
+        },
+        {  # mature episode: all windows present
+            "itemGuid": "guid-mature",
+            "title": "Mature episode",
+            "pubdate": "2026-05-20T08:00:00.000Z",
+            "downloads3": 1,
+            "downloads7": 9,
+            "downloads30": 20,
+            "downloadsAll": 40,
+        },
+    ],
+}
+
+
+def _fake_get(url, token, params=None):
+    if "/shows/" in url:
+        return {"showUuid": "abc123"}
+    if "show-download-counts" in url:
+        return _SHOW_COUNTS
+    if "episode-download-counts" in url:
+        return _EPISODE_COUNTS
+    raise AssertionError(f"unexpected url {url}")
+
+
+class TestResponseParsing:
+    def test_show_and_episode_fields(self):
+        with patch("scripts.fetch_op3_stats._get", side_effect=_fake_get):
+            stats = _fetch_show_stats(
+                "env_intel", "https://nerranetwork.com/env_intel_podcast.rss",
+                "tok", None,
+            )
+        assert stats is not None
+        assert stats["downloads_30d"] == 24
+        assert stats["downloads_7d"] == 11  # last weeklyDownloads bucket
+        assert stats["weekly_avg"] == 11
+        assert stats["show_uuid"] == "abc123"
+
+        by_guid = {e["item_guid"]: e for e in stats["episodes"]}
+        mature = by_guid["guid-mature"]
+        assert mature["downloads_7d"] == 9
+        assert mature["downloads_30d"] == 20
+        assert mature["downloads_all_time"] == 40
+        # Young feed: 7d falls back to the 3d window so it still ranks.
+        young = by_guid["guid-young"]
+        assert young["downloads_7d"] == 2
+        assert young["downloads_30d"] == 3  # falls back to all-time
+
+    def test_episodes_sorted_by_7d(self):
+        with patch("scripts.fetch_op3_stats._get", side_effect=_fake_get):
+            stats = _fetch_show_stats("x", "https://e/feed.rss", "tok", None)
+        sevens = [e["downloads_7d"] for e in stats["episodes"]]
+        assert sevens == sorted(sevens, reverse=True)
+
+    def test_cached_uuid_skips_lookup(self):
+        calls = []
+
+        def tracking_get(url, token, params=None):
+            calls.append(url)
+            return _fake_get(url, token, params)
+
+        with patch("scripts.fetch_op3_stats._get", side_effect=tracking_get):
+            _fetch_show_stats("x", "https://e/feed.rss", "tok", "abc123")
+        assert not any("/shows/" in u for u in calls)
+
+    def test_one_show_failure_returns_none(self):
+        with patch("scripts.fetch_op3_stats._get",
+                   side_effect=RuntimeError("boom")):
+            assert _fetch_show_stats("x", "https://e/f.rss", "tok", None) is None
+
+
+class TestPopularEpisodes:
+    def _stats(self, n=20):
+        return {
+            "shows": {
+                "tesla": {
+                    "show_uuid": "secret-uuid",
+                    "episodes": [
+                        {"title": f"Ep {i}", "item_guid": f"g{i}",
+                         "downloads_7d": i, "downloads_30d": i,
+                         "downloads_all_time": i}
+                        for i in range(1, n + 1)
+                    ],
+                }
+            }
+        }
+
+    def test_caps_at_twelve_sorted_with_ranks(self, tmp_path):
+        popular = build_popular_episodes(self._stats(), tmp_path)
+        assert len(popular) == 12
+        assert [e["rank"] for e in popular] == list(range(1, 13))
+        downloads = [e["downloads_7d"] for e in popular]
+        assert downloads == sorted(downloads, reverse=True)
+
+    def test_public_fields_whitelisted_no_uuid_leak(self, tmp_path):
+        popular = build_popular_episodes(self._stats(), tmp_path)
+        for ep in popular:
+            assert set(ep.keys()) <= set(_PUBLIC_EPISODE_FIELDS)
+        blob = json.dumps(popular)
+        assert "secret-uuid" not in blob
+        assert "item_guid" not in blob
+
+    def test_zero_download_episodes_excluded(self, tmp_path):
+        stats = {"shows": {"tesla": {"episodes": [
+            {"title": "Quiet", "item_guid": "g", "downloads_7d": 0},
+        ]}}}
+        assert build_popular_episodes(stats, tmp_path) == []
+
+
+def test_nightly_maintenance_runs_op3_fetch():
+    """The nightly workflow must invoke the fetch script before the
+    dashboard build, with the token passed from secrets."""
+    wf = (_ROOT / ".github" / "workflows" / "nightly-maintenance.yml").read_text(
+        encoding="utf-8")
+    assert "scripts/fetch_op3_stats.py" in wf
+    assert "OP3_API_TOKEN" in wf
+    assert wf.index("fetch_op3_stats.py") < wf.index("generate_dashboard.py"), (
+        "OP3 stats must be fetched before the dashboard build consumes them"
+    )

--- a/tests/test_phase2_growth.py
+++ b/tests/test_phase2_growth.py
@@ -199,3 +199,36 @@ class TestAiBadge:
         src = (PROJECT_ROOT / "templates" / "blog_post.html.j2").read_text(encoding="utf-8")
         assert 'import ai_badge' in src
         assert "ai_badge(" in src
+
+
+class TestHomepageAudienceSurfaces:
+    """June 2026 growth pass: the homepage's 'Most Played This Week' rail
+    (OP3 data) and the newsletter social-proof line must stay wired."""
+
+    TEMPLATE = PROJECT_ROOT / "templates" / "network_page.html.j2"
+
+    def test_template_references_popular_episodes(self):
+        src = self.TEMPLATE.read_text(encoding="utf-8")
+        assert "popular_episodes" in src
+        assert "Most Played This Week" in src
+
+    def test_template_references_subscriber_social_proof(self):
+        src = self.TEMPLATE.read_text(encoding="utf-8")
+        assert "newsletter_subscriber_count" in src
+
+    def test_generate_network_page_supplies_both_context_keys(self):
+        import inspect
+
+        import generate_html
+
+        src = inspect.getsource(generate_html.generate_network_page)
+        assert '"popular_episodes"' in src
+        assert '"newsletter_subscriber_count"' in src
+
+    def test_social_proof_threshold_constant(self):
+        import generate_html
+
+        assert generate_html.MIN_SOCIAL_PROOF_SUBSCRIBERS >= 100, (
+            "social proof below ~100 subscribers reads as anti-proof; "
+            "keep the floor"
+        )

--- a/tests/test_phase5_seo_trust.py
+++ b/tests/test_phase5_seo_trust.py
@@ -119,3 +119,25 @@ class TestSitemapPerFileLastmod:
         # the function exists at module scope.
         from generate_html import generate_sitemap
         assert callable(generate_sitemap)
+
+
+class TestSitemapSpecialPages:
+    """June 2026 growth pass: player.html + the MIT performance page are
+    indexable destinations and must be in the sitemap; 404.html is an
+    error page and must NOT be (Search Console flags it)."""
+
+    def _extras_source(self):
+        import inspect
+
+        from generate_html import generate_sitemap
+
+        return inspect.getsource(generate_sitemap)
+
+    def test_player_and_mit_performance_listed(self):
+        src = self._extras_source()
+        assert '"player.html"' in src
+        assert '"modern-investing-performance.html"' in src
+
+    def test_404_not_listed(self):
+        src = self._extras_source()
+        assert '"404.html"' not in src

--- a/tests/test_phase5_seo_trust.py
+++ b/tests/test_phase5_seo_trust.py
@@ -141,3 +141,36 @@ class TestSitemapSpecialPages:
     def test_404_not_listed(self):
         src = self._extras_source()
         assert '"404.html"' not in src
+
+
+class TestGa4EmptyEnvFallback:
+    """June 2026: CI passes GA4_MEASUREMENT_ID from a secret; an UNSET
+    secret arrives as an empty-but-present env var, which must NOT
+    defeat the committed in-repo GA4 default (it silently stripped
+    gtag from every CI-regenerated page)."""
+
+    def test_empty_env_falls_back_to_default(self, monkeypatch):
+        import importlib
+
+        monkeypatch.setenv("GA4_MEASUREMENT_ID", "")
+        import generate_html
+        importlib.reload(generate_html)
+        try:
+            assert generate_html.MARKETING_CONFIG["ga4_measurement_id"] == \
+                generate_html._GA4_DEFAULT
+        finally:
+            monkeypatch.delenv("GA4_MEASUREMENT_ID", raising=False)
+            importlib.reload(generate_html)
+
+    def test_set_env_overrides_default(self, monkeypatch):
+        import importlib
+
+        monkeypatch.setenv("GA4_MEASUREMENT_ID", "G-OVERRIDE123")
+        import generate_html
+        importlib.reload(generate_html)
+        try:
+            assert generate_html.MARKETING_CONFIG["ga4_measurement_id"] == \
+                "G-OVERRIDE123"
+        finally:
+            monkeypatch.delenv("GA4_MEASUREMENT_ID", raising=False)
+            importlib.reload(generate_html)

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1238,3 +1238,72 @@ class TestBuildShowNotesFooter:
         assert f'<a href="{self.BASE}">' in rendered
         # No leftover markdown link brackets.
         assert "](" not in rendered
+
+
+# ===================================================================
+# TEST: channel-level <podcast:funding> + <podcast:person> (June 2026)
+# ===================================================================
+
+class TestFundingPersonTags:
+    """update_rss_feed must inject channel-level podcast:funding +
+    podcast:person when the kwargs are set, survive rebuilds
+    idempotently, and stay absent when the kwargs are empty (legacy
+    callers byte-for-byte unaffected)."""
+
+    PODCAST_NS = "https://podcastindex.org/namespace/1.0"
+
+    _KW = dict(
+        funding_url="https://nerranetwork.com/#newsletter",
+        funding_label="Free newsletter",
+        person_name="Patrick",
+        person_url="https://nerranetwork.com/about.html",
+    )
+
+    def _channel(self, rss_path):
+        import xml.etree.ElementTree as ET
+        return ET.parse(str(rss_path)).getroot().find("channel")
+
+    def test_tags_injected(self, tmp_path):
+        rss = _make_rss(tmp_path, **self._KW)
+        channel = self._channel(rss)
+        funding = channel.find(f"{{{self.PODCAST_NS}}}funding")
+        person = channel.find(f"{{{self.PODCAST_NS}}}person")
+        assert funding is not None
+        assert funding.get("url") == "https://nerranetwork.com/#newsletter"
+        assert funding.text == "Free newsletter"
+        assert person is not None
+        assert person.get("role") == "host"
+        assert person.get("href") == "https://nerranetwork.com/about.html"
+        assert person.text == "Patrick"
+
+    def test_idempotent_across_rebuilds(self, tmp_path):
+        _make_rss(tmp_path, **self._KW)
+        # Second episode rebuilds the whole feed from the existing file.
+        mp3 = _make_mp3(tmp_path, "ep002.mp3")
+        rss = update_rss_feed(
+            tmp_path / "podcast.rss", 2, "Ep 2", "Desc",
+            datetime.date(2026, 1, 2), "ep002.mp3", 300.0, mp3,
+            format_duration_func=_fmt_dur,
+            **self._KW,
+        )
+        channel = self._channel(rss)
+        assert len(channel.findall(f"{{{self.PODCAST_NS}}}funding")) == 1
+        assert len(channel.findall(f"{{{self.PODCAST_NS}}}person")) == 1
+
+    def test_absent_when_args_empty(self, tmp_path):
+        rss = _make_rss(tmp_path)
+        channel = self._channel(rss)
+        assert channel.find(f"{{{self.PODCAST_NS}}}funding") is None
+        assert channel.find(f"{{{self.PODCAST_NS}}}person") is None
+
+    def test_feed_stays_well_formed(self, tmp_path):
+        import xml.etree.ElementTree as ET
+        rss = _make_rss(tmp_path, **self._KW)
+        ET.parse(str(rss))  # raises on malformed XML
+
+    def test_run_show_passes_funding_and_person(self):
+        """The production call site must pass the new kwargs."""
+        src = (Path(__file__).resolve().parent.parent / "run_show.py").read_text(
+            encoding="utf-8")
+        assert "funding_url=" in src
+        assert "person_name=" in src

--- a/tests/test_x_cross_promo.py
+++ b/tests/test_x_cross_promo.py
@@ -1,0 +1,153 @@
+"""Drift guards for the X cross-promo reply tweet (June 2026 growth pass).
+
+The daily teaser gains a flag-gated follow-up reply ("Follow @handle" +
+one sibling-show plug from the network_promo rotation). Pinned here:
+
+* every X-enabled show × many dates stays within X's 280-char budget
+  (URLs counted as t.co's 23 chars);
+* Russian shows produce an empty reply (rotation is English-only and
+  they have no handle);
+* ``publishing.x_cross_promo: false`` keeps the pipeline teaser-only;
+* ``post_to_x`` passes ``in_reply_to_tweet_id`` through to tweepy.
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+import run_show  # noqa: E402
+from engine.config import load_config  # noqa: E402
+
+_X_ENABLED = [
+    "tesla", "omni_view", "fascinating_frontiers", "planetterrian",
+    "models_agents", "modern_investing", "unintended_consequences",
+]
+_RUSSIAN = ["finansy_prosto", "privet_russian"]
+
+
+def _effective_x_len(text: str) -> int:
+    """X counts every URL as 23 chars (t.co)."""
+    return len(re.sub(r"https?://\S+", "x" * 23, text))
+
+
+class TestReplyText:
+    @pytest.mark.parametrize("slug", _X_ENABLED)
+    @pytest.mark.parametrize("day", range(1, 15))
+    def test_within_280_chars_across_dates(self, slug, day):
+        cfg = load_config(f"shows/{slug}.yaml")
+        text = run_show._build_cross_promo_reply(
+            cfg, datetime.date(2026, 6, day))
+        assert _effective_x_len(text) <= 280, (
+            f"{slug} {day}: reply too long ({_effective_x_len(text)})"
+        )
+
+    @pytest.mark.parametrize("slug", _X_ENABLED)
+    def test_plug_links_a_sibling_with_utm(self, slug):
+        cfg = load_config(f"shows/{slug}.yaml")
+        text = run_show._build_cross_promo_reply(
+            cfg, datetime.date(2026, 6, 10))
+        assert "More from the Nerra Network:" in text
+        assert "utm_campaign=cross_promo" in text
+        assert cfg.name not in text.split("More from the Nerra Network:")[1], (
+            "the plug must feature a SIBLING show, not the show itself"
+        )
+
+    def test_follow_line_present_when_handle_set(self):
+        cfg = load_config("shows/tesla.yaml")
+        text = run_show._build_cross_promo_reply(
+            cfg, datetime.date(2026, 6, 10))
+        assert text.startswith("Follow @teslashortstime")
+
+    def test_follow_line_omitted_when_no_handle(self):
+        cfg = load_config("shows/omni_view.yaml")
+        text = run_show._build_cross_promo_reply(
+            cfg, datetime.date(2026, 6, 10))
+        assert "Follow @" not in text
+        assert text.startswith("More from the Nerra Network:")
+
+    @pytest.mark.parametrize("slug", _RUSSIAN)
+    def test_russian_shows_produce_empty_reply(self, slug):
+        cfg = load_config(f"shows/{slug}.yaml")
+        assert run_show._build_cross_promo_reply(
+            cfg, datetime.date(2026, 6, 10)) == ""
+
+    def test_rotation_varies_across_days(self):
+        cfg = load_config("shows/tesla.yaml")
+        texts = {
+            run_show._build_cross_promo_reply(cfg, datetime.date(2026, 6, d))
+            for d in range(1, 9)
+        }
+        assert len(texts) >= 4, "daily rotation should vary the featured show"
+
+
+class TestConfigGating:
+    def test_network_default_enables_cross_promo(self):
+        cfg = load_config("shows/tesla.yaml")
+        assert cfg.publishing.x_cross_promo is True
+
+    def test_dataclass_default_is_off(self):
+        """Callers that bypass YAML (legacy scripts) must stay teaser-only."""
+        from engine.config import PublishingConfig
+        assert PublishingConfig().x_cross_promo is False
+        assert PublishingConfig().x_handle == ""
+
+    def test_pipeline_gates_on_flag(self):
+        """The call site must check publishing.x_cross_promo before posting."""
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        wiring = src.split("_build_cross_promo_reply(config, today)")[0]
+        assert 'x_cross_promo' in wiring.rsplit("def ", 1)[-1] or \
+            'getattr(config.publishing, "x_cross_promo"' in wiring, (
+                "cross-promo reply must be gated on publishing.x_cross_promo"
+            )
+
+
+class TestPostToXReplySupport:
+    def test_in_reply_to_passed_to_tweepy(self):
+        from engine.publisher import post_to_x
+
+        fake_client = MagicMock()
+        fake_client.create_tweet.return_value = MagicMock(
+            data={"id": "12345"})
+        fake_tweepy = MagicMock()
+        fake_tweepy.Client.return_value = fake_client
+
+        with patch.dict(sys.modules, {"tweepy": fake_tweepy}):
+            url = post_to_x(
+                "reply text",
+                consumer_key="k", consumer_secret="s",
+                access_token="t", access_token_secret="ts",
+                in_reply_to_tweet_id="999",
+            )
+
+        assert url == "https://x.com/i/status/12345"
+        fake_client.create_tweet.assert_called_once_with(
+            text="reply text", in_reply_to_tweet_id="999",
+        )
+
+    def test_no_reply_id_keeps_legacy_call_shape(self):
+        from engine.publisher import post_to_x
+
+        fake_client = MagicMock()
+        fake_client.create_tweet.return_value = MagicMock(
+            data={"id": "12345"})
+        fake_tweepy = MagicMock()
+        fake_tweepy.Client.return_value = fake_client
+
+        with patch.dict(sys.modules, {"tweepy": fake_tweepy}):
+            post_to_x(
+                "teaser",
+                consumer_key="k", consumer_secret="s",
+                access_token="t", access_token_secret="ts",
+            )
+
+        fake_client.create_tweet.assert_called_once_with(text="teaser")


### PR DESCRIPTION
# Network review + audience-growth implementation (June 2026)

Full review of the codebase, website, workflows, pipelines, and the market the network operates in — plus an implementation pass on the highest-leverage growth gaps. The canonical writeup is **`docs/network_review_2026_06.md`** (market analysis with sources, first real audience numbers, prioritized roadmap, operator checklist).

## Headline findings

- The network is production-mature and cheap (~$0.07–0.21/episode) but was **audience-blind**: OP3 prefixes on every enclosure since launch, data never read back; no subscriber counts; web analytics partially dark (see GA4 bug below).
- **First real audience numbers** (OP3, 30d): ~2,066 downloads network-wide — Tesla 616, Models & Agents 422, MAB 235 … Env Intel 24. Tesla + the AI shows carry ~62% of listening.
- **Production bug #1 (fixed)**: the cross-network adjacency map in `shows/_defaults.yaml` was mis-indented under `cost_circuit_breakers:` while `engine/newsletter.py` + `engine/synthesizer.py` read it under `newsletter:` — the newsletter cross-promotion module was silently degraded network-wide (and `unintended_consequences` was missing from the map).
- **Production bug #2 (fixed)**: **GA4 was silently stripped from every CI-regenerated page.** `generate_html.py` commits the GA4 property (`G-6PWJCVQQ7B`) as an in-repo default, but CI passes `GA4_MEASUREMENT_ID` from a GitHub secret — an unset secret arrives as an empty-but-present env var, defeating the `.get()` default. On `main` today: `tesla.html` (nightly regen, no env vars) carries gtag; `index.html`/`models-agents.html`/blog indexes (run-show finalize, empty env) have none. Empty env now falls back to the committed default; a real secret still overrides. *Note: GA4 measures the website only — podcast downloads are fetched by apps directly from the enclosure URL where no JS runs, which is why OP3 (already enabled in `_defaults.yaml`) is the download-measurement layer. They're complementary.*
- Market: ~35% of new podcast feeds are AI-generated; Apple now requires AI disclosure in audio + metadata (Nerra already compliant); YouTube is the #1 discovery surface while quota caps Nerra to 2/12 shows — the biggest constraint, P1 in the roadmap.

## What shipped (all additive; clean no-ops when secrets unset; drift guards on everything)

1. **Adjacency-map fix** + blog cross-show recs now lead with the curated sibling.
2. **OP3 read-back** — `scripts/fetch_op3_stats.py` (response shapes verified against the live API) → dashboard **Audience** card + public `site/data/popular_episodes.json` → new homepage **"Most Played This Week"** rail. Initial snapshot committed.
3. **Buttondown subscriber count** — `scripts/fetch_buttondown_stats.py` → dashboard + homepage **"Join N+ readers"** social proof (hidden < 100 subs).
4. **GA4 empty-env fallback fix** (bug #2 above) + Plausible readiness — nightly site-regen now passes marketing env vars; enabling Plausible is one secret.
5. **Sitemap hygiene** — +`player.html`, +MIT performance page, −`404.html`.
6. **Podcasting 2.0 channel tags** — `podcast:funding` (→ newsletter signup) + `podcast:person` (host) injected on every feed rebuild (was 0 across all 12 feeds).
7. **Newsletter growth loop** — deterministic Buttondown slugs for every show unlock the never-used view-in-browser/archive link on dailies + weeklies; localized "Forwarded this email? Subscribe here" line with UTM attribution.
8. **X cross-promo reply** — flag-gated second tweet under each daily teaser: "Follow @handle" + one sibling-show plug from the deterministic daily rotation (kill switch: `publishing.x_cross_promo: false`).

## Tests

Full suite green: **2,698 passed, 3 skipped** (+~118 new drift guards: `test_op3_stats.py`, `test_buttondown_stats.py`, `test_x_cross_promo.py`, plus extensions to dashboard/publisher/newsletter/blog/phase2/phase5 suites).

## Operator actions needed to light everything up (checklist in the report, §8)

`OP3_API_TOKEN` secret · `PLAUSIBLE_DOMAIN` secret (optional, alongside GA4) · confirm X handles for OV/M&A/MIT + API write-tier headroom · gallery Worker secrets · YouTube quota increase request · Meta/TikTok dev apps · decide on the Russian-localized spoken AI disclosure (currently English on the Olya voice — A/B listen per landmine #17).

https://claude.ai/code/session_01UCDUYhzy4gDDXEt4UE9jg6