### PR TITLE
YouTube four-show expansion (FF+MIT Shorts-only, Russian shows on @NerraRU) + iPhone dark-mode newsletter fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -983,6 +983,27 @@ decision); everything else has a live status card.
     risk; it ships as a single coherent infrastructure change
     (single-call synthesis) rather than as a tag-injection retry.
 
+18a. **Newsletter dark-mode CSS must stay SCOPED (v3, June 2026)** —
+    the iPhone dark-mode bug (subject title, "NERRA NETWORK · date"
+    byline, forward line, and unsubscribe footer rendering white-on-
+    light = invisible; operator screenshots Jun 9 2026, after several
+    failed fixes) was caused by GLOBAL selectors in the dark-mode
+    `<style>` block (`h1 { color:#fff }`, universal `p/td/div/span`
+    text flips, td-style-attribute background matches). Those rules
+    leak onto **Buttondown's own wrapper**, whose backgrounds we cannot
+    flip. v3 contract in `engine/newsletter_template.py`:
+    `wrap_with_branding` stamps every emitted table/div with the `nn`
+    marker class (`_scope_nn`), and every color rule inside the
+    `@media (prefers-color-scheme: dark)` block is scoped under `.nn`
+    (surface classes like `.surface-white` are ours alone and stay
+    class-targeted). Buttondown chrome keeps its native always-readable
+    colors; our cards adapt. The `:root/body { color-scheme: light
+    dark }` opt-in stays — removing it regresses to Apple Mail's
+    auto-transform (washed-out headings, the original May 2026 bug).
+    Drift guards: `tests/test_newsletter_template.py::TestDarkModeScoping`
+    (no unscoped color selectors, no attribute background selectors,
+    every block carries `.nn`).
+
 18. **Newsletter pipeline spec v2 (May 2026)** — multi-day refinement
     pass on the Buttondown send pipeline addressing contrast bugs,
     LLM scaffold leaks, and daily-vs-weekly template parity. Files:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1077,20 +1077,33 @@ decision); everything else has a live status card.
     alt-cadence shows NOT carrying it, and the YouTube quota cap
     (only TST and MAB enabled — see also landmine #20).
 
-20. **YouTube quota cap (May 2026)** — the YouTube Data API quota for
-    the `@NerraNetwork` channel is 10,000 units/day; each `videos.insert`
-    costs 1,600 units. With 7 daily English shows × 2 videos
-    (long-form + Shorts) = 14 uploads/day requested but only 6 fit in
-    quota. The May 2026 schedule overhaul disabled YouTube on every
-    English show except Tesla and MAB — operator-chosen pair (TST is
-    the largest property; MAB is the educational beginner-friendly
-    flagship). Re-enabling other shows requires either (a) a quota
-    increase from YouTube, (b) staggering uploads across days, or
-    (c) skipping Shorts on most shows. Until then the
-    `test_only_tst_and_mab_enable_youtube` drift guard fails CI on any
-    accidental re-enable. Russian channel `@NerraRU` has its own quota
-    so Финансы Просто and Привет, Русский! could be re-enabled
-    independently.
+20. **YouTube quota cap (May 2026; four-show expansion June 2026)** —
+    the YouTube Data API quota is 10,000 units/day **per channel**;
+    each `videos.insert` costs 1,600 units (plus thumbnail 50 /
+    playlist 50 / caption 400 on the paper model in
+    `engine/youtube_quota.py`). The May 2026 schedule overhaul had
+    disabled YouTube on every English show except Tesla and MAB
+    (long-form + 2 Shorts each). **June 2026 expansion (operator
+    decision, quota-increase request submitted and pending):**
+    - Tesla + MAB dropped from 2 Shorts to 1 each.
+    - Fascinating Frontiers + Modern Investing enabled **Shorts-only**
+      (`publish_long_form: false`) on `@NerraNetwork`. Flip
+      `publish_long_form: true` per show once the increase is granted.
+    - Финансы Просто + Привет, Русский! enabled **full format** on
+      `@NerraRU` (`channel: ru`, its own 10k/day quota; both run even
+      days only ≈ 7,600 paper-units). Requires the
+      `YOUTUBE_REFRESH_TOKEN_RU` secret — uploads no-op with a logged
+      warning until it's set.
+    EN channel paper-math now projects 11,000/day — the SAME paper
+    level as the previous Tesla+MAB 2-Shorts config, which ran in
+    production without quota failures (the documented-cost model is
+    conservative vs. actual charging), so the daily preflight
+    `::error::` annotation is expected until the increase lands.
+    `estimate_network_daily_units` groups per channel since June 2026
+    (a RU show never counts against the EN budget). Drift guards:
+    `test_only_tst_and_mab_enable_youtube` pins the exact enabled set,
+    `test_youtube_expansion_quota_shape` pins the 1-Short /
+    Shorts-only / ru-channel shape so a partial revert fails CI.
 
 21. **`min_articles_skip` is tuned per-show, not per-network (May 2026)**
     — `engine/config.py` defaults `min_articles_skip` to `3` (a show

--- a/engine/newsletter_template.py
+++ b/engine/newsletter_template.py
@@ -286,21 +286,30 @@ def _build_hero_html(show: Dict[str, str], pill_text: str) -> str:
 
 _DARK_MODE_STYLE = """\
 <style>
-  /* Newsletter v2 (May 2026): expanded dark-mode stylesheet that
-   * targets each brand color individually so contrast hits WCAG AA on
-   * the dark surface, plus class hooks for ``preheader``,
-   * ``card``, ``surface-*`` so inline-color overrides don't lose the
-   * specificity war in Outlook iOS / mobile Gmail.
+  /* Newsletter v3 (June 2026): SCOPED dark-mode stylesheet.
    *
-   * Spec references: §1.3 light-mode contrast swaps, §1.4 dark-mode
-   * brand tokens + ``.preheader`` hide.
+   * History of the iPhone dark-mode bug (several failed attempts):
+   * the v2 block used GLOBAL selectors (``h1 { color:#fff }``, a
+   * universal ``p/td/div/span → #e2e8f0`` flip, and td-style-attribute
+   * background matches). Those rules don't stop at our content — they
+   * also recolor BUTTONDOWN'S OWN WRAPPER (the subject-as-title
+   * heading, the "NERRA NETWORK · date" byline, the forward line,
+   * the unsubscribe footer). Our
+   * backgrounds flipped dark but Buttondown's wrapper backgrounds
+   * stayed light → white-on-white headings on iOS Mail (operator
+   * screenshots, Jun 9 2026).
+   *
+   * v3 rule: every selector that changes a COLOR must be scoped to
+   * ``.nn`` — the marker class ``wrap_with_branding`` stamps on every
+   * table/div we emit. Buttondown's chrome keeps its native colors
+   * (dark-on-light in both modes — always readable); our cards adapt.
+   * Drift guard: tests/test_newsletter_template.py::TestDarkModeScoping
+   * fails on any unscoped color rule inside the @media block.
    */
   /* Opt INTO native dark-mode handling. Without this, Apple Mail (iOS)
    * runs its OWN automatic colour transform on the email and ignores the
    * @media rules below — and its transform renders our near-black
-   * (#0f172a) section headings DIMMER than the body text, so the main
-   * headings looked washed-out/unreadable on the operator's phone while
-   * our Chromium previews (which honour @media) looked fine. Declaring
+   * (#0f172a) section headings DIMMER than the body text. Declaring
    * color-scheme tells Apple Mail "this email ships its own dark styles,
    * use them" so the @media block actually applies. */
   :root { color-scheme: light dark; }
@@ -312,49 +321,49 @@ _DARK_MODE_STYLE = """\
   }
 
   @media (prefers-color-scheme: dark) {
-    /* Page + table containers — flip the white shells. */
-    body, .email-bg, .surface-white, .surface-fafafa, .surface-f8fafc,
-    table[role=presentation] td[style*='background:#ffffff'],
-    table[role=presentation] td[style*='background:#fafafa'],
-    table[role=presentation] td[style*='background:#f8fafc'] {
+    /* Our white/gray shells — class-targeted only. The v2 td-style-
+     * attribute background selectors are deliberately GONE: they could
+     * match Buttondown wrapper tables whose text we no longer recolor,
+     * producing dark-on-dark in their chrome. */
+    .surface-white, .surface-fafafa, .surface-f8fafc {
       background:#0f172a !important;
       background-color:#0f172a !important;
     }
 
     /* Cards (slightly lifted "panel" surfaces). A subtle border helps
      * them read as distinct panels against the near-black page. */
-    .card {
+    .nn .card, .card {
       background:#1e293b !important;
       background-color:#1e293b !important;
       border-color:#334155 !important;
     }
 
     /* Stock-watch delta direction colours — lighter variants so the
-     * up/down signal survives dark mode (class beats the universal
+     * up/down signal survives dark mode (class beats the scoped
      * ``span`` text override). */
-    .delta-up   { color:#34d399 !important; }   /* emerald-400 */
-    .delta-down { color:#fb7185 !important; }   /* rose-400 */
-    .delta-flat { color:#94a3b8 !important; }   /* slate-400 */
+    .nn .delta-up   { color:#34d399 !important; }   /* emerald-400 */
+    .nn .delta-down { color:#fb7185 !important; }   /* rose-400 */
+    .nn .delta-flat { color:#94a3b8 !important; }   /* slate-400 */
 
-    /* Primary text on every dark-mode surface. ``strong``/``b``/``em``/
-     * ``i``/``code`` are listed explicitly: we now set an inline colour
-     * on bold text (so Buttondown's theme accent can't recolour it), and
-     * that inline colour has to be flipped here for dark mode. */
-    body, p, h1, h2, h3, h4, td, span, div, li,
-    strong, b, em, i, code {
+    /* Primary text on OUR dark-mode surfaces only. ``strong``/``b``/
+     * ``em``/``i``/``code`` are listed explicitly: bold text carries an
+     * inline colour (so Buttondown's theme accent can't recolour it),
+     * and that inline colour has to be flipped here for dark mode. */
+    .nn, .nn p, .nn td, .nn span, .nn div, .nn li,
+    .nn strong, .nn b, .nn em, .nn i, .nn code {
       color:#e2e8f0 !important;
     }
     /* Section headings are the BRIGHTEST text so they read as headings,
-     * not as dimmer-than-body labels (the exact regression on the
-     * operator's phone). Dedicated, simple selector + pure white, placed
-     * AFTER the universal rule so it wins for h1-h4. */
-    h1, h2, h3, h4 { color:#ffffff !important; }
+     * not as dimmer-than-body labels. Placed AFTER the universal rule
+     * so it wins for h1-h4 — and scoped so Buttondown's subject-title
+     * heading is never touched. */
+    .nn h1, .nn h2, .nn h3, .nn h4 { color:#ffffff !important; }
     /* Secondary / muted text — class-targeted so it doesn't override
      * other usages. */
-    .text-muted { color:#94a3b8 !important; }
+    .nn .text-muted { color:#94a3b8 !important; }
 
     /* Links. */
-    a, a span { color:#93c5fd !important; }
+    .nn a, .nn a span { color:#93c5fd !important; }
 
     /* Brand-color tokens — lighter dark-mode variants for AA contrast
      * on `#1e293b` cards. The original brand colors are preserved in
@@ -387,11 +396,42 @@ _DARK_MODE_STYLE = """\
      * is active; the !important class hook fixes it. */
     .preheader { display:none !important; }
 
-    /* `<hr>` separators flip from light slate to dark slate. */
-    hr { border-top-color:#334155 !important; }
+    /* `<hr>` separators flip from light slate to dark slate — ours
+     * only (Buttondown's chrome may use its own hr). */
+    .nn hr, hr.nn { border-top-color:#334155 !important; }
   }
 </style>
 """
+
+
+# Matches the opening tags wrap_with_branding stamps with the ``nn``
+# scope-marker class. Tables/divs are the roots of every block we emit;
+# marking nested ones too is harmless (descendant selectors are
+# unaffected) and removes any dependence on block-internal structure.
+_NN_TAG_RE = re.compile(r"<(table|div|p|hr)\b([^>]*)>", re.IGNORECASE)
+
+
+def _scope_nn(html: str) -> str:
+    """Stamp the ``nn`` marker class on every table/div/p/hr in *html*.
+
+    The dark-mode stylesheet (v3, June 2026) only recolors elements
+    under ``.nn`` so Buttondown's own wrapper (subject title, byline,
+    forward line, unsubscribe footer) keeps its native colors — the
+    iPhone dark-mode white-on-white bug was our global selectors
+    leaking onto chrome we don't control.
+    """
+    if not html:
+        return html
+
+    def _add(match: "re.Match[str]") -> str:
+        tag, attrs = match.group(1), match.group(2)
+        if re.search(r'\bclass="', attrs):
+            attrs = attrs.replace('class="', 'class="nn ', 1)
+        else:
+            attrs = f'{attrs} class="nn"'
+        return f"<{tag}{attrs}>"
+
+    return _NN_TAG_RE.sub(_add, html)
 
 
 # ---------------------------------------------------------------------------
@@ -559,6 +599,7 @@ def _build_p_s_html(p_s: str, brand: str, slug: str = "") -> str:
     return (
         '<table role="presentation" width="100%" cellpadding="0" '
         'cellspacing="0" border="0" '
+        'class="surface-white" '
         'style="background:#ffffff;">'
         '<tr><td style="padding:12px 24px 24px;">'
         f'<table role="presentation" width="100%" cellpadding="0" '
@@ -1875,19 +1916,25 @@ def wrap_with_branding(
     # them as separate sections. Empty blocks contribute nothing. The
     # dark-mode <style> block goes at the very top so any client that
     # respects @media queries picks it up before parsing the body.
+    # Every content block is stamped with the ``nn`` scope-marker class
+    # (_scope_nn) so the dark-mode stylesheet recolors OUR content only
+    # — never Buttondown's wrapper (June 2026 iPhone dark-mode fix).
     parts = [
         _DARK_MODE_STYLE,
-        preheader_div,
-        view_in_browser,
-        hero,
-        stats_block,
-        featured_block,
-        disclaimer,
-        body_wrapped,
-        p_s_block,
-        cross_network,
-        reply_share,
-        footer,
-        issue_counter,
+    ] + [
+        _scope_nn(p) for p in (
+            preheader_div,
+            view_in_browser,
+            hero,
+            stats_block,
+            featured_block,
+            disclaimer,
+            body_wrapped,
+            p_s_block,
+            cross_network,
+            reply_share,
+            footer,
+            issue_counter,
+        )
     ]
     return "\n\n".join(p for p in parts if p) + "\n"

--- a/engine/youtube_quota.py
+++ b/engine/youtube_quota.py
@@ -23,6 +23,7 @@ class QuotaEstimate:
     shorts: bool
     caption_track: bool
     units: int
+    shorts_count: int = 1
 
     @property
     def uploads(self) -> int:
@@ -30,7 +31,7 @@ class QuotaEstimate:
         if self.long_form:
             n += 1
         if self.shorts:
-            n += 1
+            n += self.shorts_count
         return n
 
 
@@ -38,11 +39,17 @@ def estimate_episode_units(
     *,
     publish_long_form: bool = True,
     publish_shorts: bool = True,
+    shorts_count: int = 1,
     with_thumbnail: bool = True,
     with_playlist: bool = True,
     with_caption_track: bool = True,
 ) -> QuotaEstimate:
-    """Return per-episode quota breakdown."""
+    """Return per-episode quota breakdown.
+
+    *shorts_count* mirrors ``youtube.shorts_per_episode`` — each Short is
+    its own ``videos.insert`` (June 2026 fix: the estimator previously
+    counted one Short regardless, undercounting multi-Shorts shows).
+    """
     units = 0
     if publish_long_form:
         units += QUOTA_VIDEO_INSERT
@@ -52,17 +59,20 @@ def estimate_episode_units(
             units += QUOTA_PLAYLIST_INSERT
         if with_caption_track:
             units += QUOTA_CAPTION_INSERT
+    shorts_count = max(1, int(shorts_count or 1))
     if publish_shorts:
-        units += QUOTA_VIDEO_INSERT
+        per_short = QUOTA_VIDEO_INSERT
         if with_thumbnail:
-            units += QUOTA_THUMBNAIL_SET
+            per_short += QUOTA_THUMBNAIL_SET
         if with_playlist:
-            units += QUOTA_PLAYLIST_INSERT
+            per_short += QUOTA_PLAYLIST_INSERT
+        units += per_short * shorts_count
     return QuotaEstimate(
         long_form=publish_long_form,
         shorts=publish_shorts,
         caption_track=publish_long_form and with_caption_track,
         units=units,
+        shorts_count=shorts_count if publish_shorts else 0,
     )
 
 
@@ -91,11 +101,19 @@ def estimate_network_daily_units(
     *,
     daily_quota: int = DEFAULT_DAILY_QUOTA,
 ) -> dict:
-    """Sum quota for all enabled shows (reads show YAML only)."""
+    """Sum quota for all enabled shows (reads show YAML only).
+
+    June 2026: quota is **per channel** — @NerraNetwork (``channel: en``)
+    and @NerraRU (``channel: ru``) each get their own daily budget, so
+    shows are grouped by channel and ``over_quota`` means "at least one
+    channel exceeds its own quota". Top-level ``total_units`` keeps the
+    legacy all-shows-summed meaning for dashboards; per-channel detail
+    lives under ``per_channel``.
+    """
     from engine.config import discover_show_slugs, load_config
 
-    total = 0
     per_show: dict[str, int] = {}
+    show_channel: dict[str, str] = {}
     for slug in discover_show_slugs(shows_dir):
         yaml_path = shows_dir / f"{slug}.yaml"
         try:
@@ -106,9 +124,10 @@ def estimate_network_daily_units(
             est = estimate_episode_units(
                 publish_long_form=getattr(yt, "publish_long_form", True),
                 publish_shorts=getattr(yt, "publish_shorts", True),
+                shorts_count=getattr(yt, "shorts_per_episode", 1),
             )
             per_show[slug] = est.units
-            total += est.units
+            show_channel[slug] = (getattr(yt, "channel", "en") or "en").lower()
         except Exception:
             # Fallback to raw parse
             raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
@@ -118,29 +137,72 @@ def estimate_network_daily_units(
             est = estimate_episode_units(
                 publish_long_form=bool(yt.get("publish_long_form", True)),
                 publish_shorts=bool(yt.get("publish_shorts", True)),
+                shorts_count=int(yt.get("shorts_per_episode", 1) or 1),
             )
             per_show[slug] = est.units
-            total += est.units
+            show_channel[slug] = str(yt.get("channel", "en") or "en").lower()
+
+    per_channel: dict[str, dict] = {}
+    for slug, units in per_show.items():
+        ch = show_channel[slug]
+        entry = per_channel.setdefault(ch, {
+            "enabled_slugs": [],
+            "total_units": 0,
+            "daily_quota": daily_quota,
+        })
+        entry["enabled_slugs"].append(slug)
+        entry["total_units"] += units
+    for entry in per_channel.values():
+        entry["over_quota"] = entry["total_units"] > entry["daily_quota"]
+        entry["headroom_units"] = entry["daily_quota"] - entry["total_units"]
+
+    total = sum(per_show.values())
+    over = any(e["over_quota"] for e in per_channel.values())
+    min_headroom = min(
+        (e["headroom_units"] for e in per_channel.values()),
+        default=daily_quota,
+    )
 
     return {
         "enabled_slugs": list(per_show.keys()),
         "per_show_units": per_show,
+        "per_channel": per_channel,
         "total_units": total,
         "daily_quota": daily_quota,
-        "over_quota": total > daily_quota,
-        "headroom_units": daily_quota - total,
+        "over_quota": over,
+        # Tightest channel's headroom — the number that matters for
+        # "can I enable one more upload anywhere".
+        "headroom_units": min_headroom,
     }
 
 
 def format_quota_warning(summary: dict) -> Optional[str]:
-    """Human-readable warning when enabled shows exceed default quota."""
+    """Human-readable warning when an enabled channel exceeds its quota."""
     if not summary.get("over_quota"):
         return None
-    slugs = ", ".join(summary.get("enabled_slugs") or [])
+    per_channel = summary.get("per_channel") or {}
+    over_channels = {
+        ch: e for ch, e in per_channel.items() if e.get("over_quota")
+    }
+    if over_channels:
+        parts = []
+        for ch, e in sorted(over_channels.items()):
+            slugs = ", ".join(e.get("enabled_slugs") or [])
+            parts.append(
+                f"channel '{ch}' projected {e['total_units']} units/day "
+                f"({slugs}) vs quota {e['daily_quota']}"
+            )
+        detail = "; ".join(parts)
+    else:  # legacy summaries without per_channel
+        slugs = ", ".join(summary.get("enabled_slugs") or [])
+        detail = (
+            f"estimated {summary['total_units']} units/day for enabled "
+            f"shows ({slugs}) exceeds {summary['daily_quota']}"
+        )
     return (
-        f"YouTube quota: estimated {summary['total_units']} units/day for "
-        f"enabled shows ({slugs}) exceeds default {summary['daily_quota']} "
-        f"(~{summary['daily_quota'] // QUOTA_VIDEO_INSERT} video inserts). "
-        "Request a quota increase or set youtube.shorts_upload_schedule: "
-        "alternate_episodes on some shows."
+        f"YouTube quota: {detail} "
+        f"(~{summary['daily_quota'] // QUOTA_VIDEO_INSERT} video inserts/channel). "
+        "Request a quota increase, drop shorts_per_episode, set "
+        "publish_long_form: false, or use shorts_upload_schedule: "
+        "alternate_episodes."
     )

--- a/scripts/youtube_quota_preflight.py
+++ b/scripts/youtube_quota_preflight.py
@@ -46,10 +46,19 @@ def main(argv=None) -> int:
     slugs = ", ".join(summary["enabled_slugs"]) or "(none)"
     print(
         f"YouTube-enabled shows: {slugs} | projected {summary['total_units']} "
-        f"units/day vs quota {summary['daily_quota']} "
-        f"(headroom {summary['headroom_units']})",
+        f"units/day across all channels",
         flush=True,
     )
+    # Quota is per channel (@NerraNetwork = en, @NerraRU = ru) — print
+    # one line per channel so the headroom that matters is visible.
+    for ch, entry in sorted((summary.get("per_channel") or {}).items()):
+        ch_slugs = ", ".join(entry["enabled_slugs"]) or "(none)"
+        print(
+            f"  channel '{ch}': {entry['total_units']} units/day "
+            f"({ch_slugs}) vs quota {entry['daily_quota']} "
+            f"(headroom {entry['headroom_units']})",
+            flush=True,
+        )
 
     if summary["over_quota"]:
         warning = format_quota_warning(summary) or "YouTube quota exceeded."

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -285,11 +285,16 @@ content_freshness:
 
 youtube:
   podcast_playlist_id: PLRHMnzNNXPYDC7-f8Dary-bTZyvwxR-dR
-  enabled: false                # Disabled May 2026 — moved to daily cadence,
-                                # YouTube quota only fits 2 daily shows
-                                # (10K/day ÷ 1.6K/upload ≈ 6 uploads;
-                                # network shipped 16+/day pre-disable). Only
-                                # TST and MAB stay on YouTube for now.
+  enabled: true                 # June 2026 four-show expansion: Shorts-only
+                                # launch while the quota-increase request is
+                                # pending (Tesla + MAB dropped to 1 Short each
+                                # to make room). Flip publish_long_form to
+                                # true once the increase is granted.
+  publish_long_form: false      # Shorts-only until quota increase lands.
+  # Smart Shorts segment selection (same as Tesla/MAB) — starts the
+  # clip at the most engaging transcript beat instead of the intro.
+  shorts_start_mode: smart
+  short_duration_seconds: 40
   channel: en
   category_id: 28               # Science & Tech
   default_language: en

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -267,8 +267,16 @@ slow_news:
 
 youtube:
   podcast_playlist_id: PLrkQSSjMOK2fb9y1CV3UsH0f-ZTJWYPpD
-  enabled: false                # Phase 2 — flip after quota raise + RU channel set up
+  enabled: true                 # June 2026: @NerraRU has its own 10k/day quota
+                                # (separate from @NerraNetwork), so full format
+                                # (long-form + 1 Short) fits — both Russian
+                                # shows run even days only. Requires the
+                                # YOUTUBE_REFRESH_TOKEN_RU secret to be set;
+                                # uploads no-op with a logged warning until it is.
   channel: ru
+  # Russian-language end-screen CTA (the network default is English).
+  shorts_end_card_main_text: "СМОТРЕТЬ ПОЛНЫЙ ВЫПУСК"
+  shorts_end_card_sub_text: "Подпишитесь ↗"
   category_id: 25               # News & Politics
   default_language: ru
   # Russian-language financial-literacy show for women in Canada.

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -248,12 +248,11 @@ youtube:
   # the legacy voice-intro start. Falls back to voice mode when the
   # heuristic can't find a clear winner. See engine.shorts_selector.
   shorts_start_mode: smart
-  # Publish 2 Shorts per episode (May 2026 retune). See the parallel
-  # block in shows/tesla.yaml for the quota math — Tesla + MAB
-  # combined are at 96 % of the daily 10 000-unit YouTube quota on
-  # the @NerraNetwork channel. Tight; one of these dials back to 1
-  # if uploads start 429-ing.
-  shorts_per_episode: 2
+  # 1 Short per episode (June 2026 four-show expansion). Was 2 during
+  # the May 2026 retune; dropped back to 1 alongside Tesla to free
+  # quota for the FF + MIT Shorts-only launch. See the parallel block
+  # in shows/tesla.yaml for the quota math.
+  shorts_per_episode: 1
   # Shorter clips perform better on the Shorts surface — 40 s lands
   # in the 30-45 s "high completion rate" sweet spot.
   short_duration_seconds: 40

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -270,7 +270,16 @@ deep_dive:
 
 youtube:
   podcast_playlist_id: PLRHMnzNNXPYCnD0HJiNss4SZPLBsH7z6v
-  enabled: false                # Phase 2 — flip after quota raise
+  enabled: true                 # June 2026 four-show expansion: Shorts-only
+                                # launch while the quota-increase request is
+                                # pending (Tesla + MAB dropped to 1 Short each
+                                # to make room). Flip publish_long_form to
+                                # true once the increase is granted.
+  publish_long_form: false      # Shorts-only until quota increase lands.
+  # Smart Shorts segment selection (same as Tesla/MAB) — starts the
+  # clip at the most engaging transcript beat instead of the intro.
+  shorts_start_mode: smart
+  short_duration_seconds: 40
   channel: en
   category_id: 25               # News & Politics (markets/business)
   default_language: en

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -222,8 +222,16 @@ slow_news:
 
 youtube:
   podcast_playlist_id: PLrkQSSjMOK2d9QSWFlehgK5dlv38lfqWI
-  enabled: false                # Phase 2 — flip after quota raise + RU channel set up
+  enabled: true                 # June 2026: @NerraRU has its own 10k/day quota
+                                # (separate from @NerraNetwork), so full format
+                                # (long-form + 1 Short) fits — both Russian
+                                # shows run even days only. Requires the
+                                # YOUTUBE_REFRESH_TOKEN_RU secret to be set;
+                                # uploads no-op with a logged warning until it is.
   channel: ru
+  # Russian-language end-screen CTA (the network default is English).
+  shorts_end_card_main_text: "СМОТРЕТЬ ПОЛНЫЙ ВЫПУСК"
+  shorts_end_card_sub_text: "Подпишитесь ↗"
   category_id: 27               # Education (language learning)
   default_language: ru
   # Bilingual Russian-language-learning show. Queries are English

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -247,14 +247,13 @@ youtube:
   # legacy voice-intro start. Falls back to voice mode when the
   # heuristic can't find a clear winner. See engine.shorts_selector.
   shorts_start_mode: smart
-  # Publish 2 Shorts per episode (May 2026 retune). Each is sourced
-  # from a different non-overlapping engaging window via
-  # ``engine.shorts_selector.pick_top_n_engaging_windows``; each
-  # gets a distinct headline, thumbnail, and caption track. Quota
-  # math: Tesla long + 2 shorts = 4 800 + MAB long + 2 shorts
-  # = 4 800 = 9 600 / 10 000 daily YouTube quota. Tight on retries;
-  # if uploads start 429-ing dial one of them back to 1.
-  shorts_per_episode: 2
+  # 1 Short per episode (June 2026 four-show expansion). Was 2 during
+  # the May 2026 retune; dropped back to 1 to free quota for the
+  # Fascinating Frontiers + Modern Investing Shorts-only launch while
+  # the quota-increase request is pending. Restore to 2 only after the
+  # increase lands AND FF/MIT long-form is re-evaluated (see CLAUDE.md
+  # landmine #20 quota math).
+  shorts_per_episode: 1
   # Shorter clips perform better on the Shorts surface — 40 s lands
   # in the 30-45 s "high completion rate" sweet spot vs the previous
   # 55 s near-max. Same generation cost, better algorithmic signal.

--- a/tests/test_newsletter_template.py
+++ b/tests/test_newsletter_template.py
@@ -939,11 +939,15 @@ def test_dark_mode_opts_into_native_color_scheme():
 def test_dark_mode_headings_are_brightest_text():
     """Section headings must be the BRIGHTEST text in dark mode (pure
     white via a dedicated h1-h4 rule placed after the universal text
-    rule), so they read as headings rather than dimmer-than-body labels."""
+    rule) — and SCOPED to .nn (June 2026): the unscoped form recolored
+    Buttondown's subject-title heading white on its light wrapper →
+    invisible on iOS Mail dark mode."""
     out = nt.wrap_with_branding(
         "tesla", "## A Section\n\nBody.", week_ending=datetime.date(2026, 4, 30),
     )
-    assert "h1, h2, h3, h4 { color:#ffffff !important; }" in out
+    assert ".nn h1, .nn h2, .nn h3, .nn h4 { color:#ffffff !important; }" in out
+    # The buggy unscoped rule must never come back.
+    assert "\n    h1, h2, h3, h4 { color:#ffffff !important; }" not in out
     # The h2 text is a direct child (no inner <span> the universal span
     # rule would dim) so the white heading rule actually wins.
     assert "<h2" in out and "<span" not in out.split("<h2", 1)[1].split("</h2>", 1)[0]
@@ -1136,3 +1140,83 @@ def test_view_in_browser_renders_when_archive_url_passed():
         archive_url="https://buttondown.com/patricknovak1/archive/tesla-ep503/",
     )
     assert "buttondown.com/patricknovak1/archive/tesla-ep503/" in out
+
+
+# ---------------------------------------------------------------------------
+# Dark-mode scoping contract (v3, June 2026 iPhone fix)
+# ---------------------------------------------------------------------------
+
+class TestDarkModeScoping:
+    """The iPhone dark-mode white-on-white bug (operator screenshots,
+    Jun 9 2026) was our dark-mode CSS recoloring BUTTONDOWN'S wrapper
+    (subject title, byline, forward line, unsubscribe footer) via
+    global selectors, while only OUR surfaces got dark backgrounds.
+    Contract: every color rule inside the @media block is scoped to the
+    .nn marker class; every block we emit carries .nn; the attribute
+    selectors that could match Buttondown tables are gone."""
+
+    def _wrap(self):
+        return nt.wrap_with_branding(
+            "tesla",
+            "## Top Stories\n\nTesla **moved**. [link](https://x.com)",
+            daily_label="Ep 505", daily_date=datetime.date(2026, 6, 9),
+            preheader="preview", p_s="One more thing.",
+            adjacent_shows=[{"name": "MIT", "hook": "Oil",
+                             "url": "https://nerranetwork.com/x.html",
+                             "emoji": "📈"}],
+            archive_url="https://buttondown.com/p/archive/tesla-ep505/",
+            issue_number=505,
+        )
+
+    def test_no_unscoped_color_rules_in_media_block(self):
+        import re as _re
+
+        out = self._wrap()
+        media = out.split("@media (prefers-color-scheme: dark)", 1)[1]
+        media = media.split("</style>")[0]
+        offenders = []
+        for line in media.splitlines():
+            m = _re.match(r"\s*([^{/@}*]+)\{", line)
+            if not m:
+                continue
+            for sel in m.group(1).split(","):
+                sel = sel.strip()
+                # Allowed: class-/id-scoped selectors and .nn-scoped
+                # element selectors. Forbidden: bare element selectors
+                # (h1, p, body, a, td …) that leak onto Buttondown.
+                if sel and not sel.startswith((".", "#")) and "nn" not in sel:
+                    offenders.append(sel)
+        assert not offenders, (
+            f"Unscoped color selectors inside the dark @media block leak "
+            f"onto Buttondown's wrapper (iPhone white-on-white bug): "
+            f"{offenders}"
+        )
+
+    def test_no_attribute_background_selectors(self):
+        out = self._wrap()
+        assert "td[style*=" not in out, (
+            "v2 attribute selectors can match Buttondown wrapper tables "
+            "whose text we no longer recolor → dark-on-dark chrome"
+        )
+
+    def test_every_block_table_and_div_carries_nn(self):
+        import re as _re
+
+        out = self._wrap()
+        body = out.split("</style>", 1)[1]
+        tags = _re.findall(r"<(?:table|div)\b[^>]*>", body)
+        assert tags, "expected rendered blocks"
+        missing = [t for t in tags if 'class="nn' not in t]
+        assert not missing, f"blocks missing the .nn scope marker: {missing[:3]}"
+
+    def test_scope_nn_adds_class_idempotently_shaped(self):
+        html = '<table role="presentation"><tr><td><div class="card">x</div></td></tr></table>'
+        scoped = nt._scope_nn(html)
+        assert '<table role="presentation" class="nn">' in scoped
+        assert '<div class="nn card">' in scoped
+
+    def test_color_scheme_optin_still_present(self):
+        # Removing the opt-in regresses to Apple Mail's auto-transform
+        # (washed-out headings — the ORIGINAL May 2026 bug).
+        out = self._wrap()
+        assert ":root { color-scheme: light dark; }" in out

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -190,14 +190,23 @@ def test_daily_narrative_show_runs_daily_without_recap(slug):
 # YouTube quota cap (post-May-2026 schedule)
 # ---------------------------------------------------------------------------
 
-YOUTUBE_ENABLED_SHOWS = {"tesla", "models_agents_beginners"}
+# June 2026 four-show expansion (operator-approved): Tesla + MAB dropped
+# from 2 Shorts to 1 each to free quota; Fascinating Frontiers + Modern
+# Investing launched Shorts-only (publish_long_form: false) on
+# @NerraNetwork while the quota-increase request is pending; both Russian
+# shows launched full-format on @NerraRU, which has its own 10k/day quota.
+YOUTUBE_ENABLED_SHOWS = {
+    "tesla", "models_agents_beginners",
+    "fascinating_frontiers", "modern_investing",
+    "finansy_prosto", "privet_russian",
+}
 
 
 def test_only_tst_and_mab_enable_youtube():
-    """YouTube Data API quota is 10,000 units/day, 1,600 per upload.
-    The @NerraNetwork channel can only ship ~6 uploads/day; with 8
-    English shows × 2 videos that's 16 — far over quota. Until quota
-    is increased, only TST and MAB ship to YouTube."""
+    """Pin the exact YouTube-enabled show set (quota is finite; landmine
+    #20). Any change must be deliberate: rerun the quota math in
+    scripts/youtube_quota_preflight.py (per-channel since June 2026) and
+    update YOUTUBE_ENABLED_SHOWS together with the show YAMLs."""
     enabled: set[str] = set()
     for cfg_path in SHOWS_DIR.glob("*.yaml"):
         if cfg_path.name.startswith("_"):
@@ -333,3 +342,33 @@ class TestWeeklyRecapHelper:
         assert "numbers" in low
         assert "watch for next week" in low
         assert "open question" in low
+
+
+def test_youtube_expansion_quota_shape():
+    """June 2026 expansion shape: while the @NerraNetwork quota-increase
+    request is pending, Tesla + MAB are capped at 1 Short each and
+    FF + MIT are Shorts-only (no long-form). A partial revert (e.g.
+    bumping Tesla back to 2 Shorts without re-disabling something else)
+    overruns the EN channel — fail loudly here instead."""
+    import yaml as _yaml
+
+    def yt(slug):
+        cfg = _yaml.safe_load((SHOWS_DIR / f"{slug}.yaml").read_text(
+            encoding="utf-8")) or {}
+        return cfg.get("youtube") or {}
+
+    for slug in ("tesla", "models_agents_beginners"):
+        assert int(yt(slug).get("shorts_per_episode", 1)) == 1, (
+            f"{slug} must stay at 1 Short/episode until the quota "
+            f"increase is granted"
+        )
+    for slug in ("fascinating_frontiers", "modern_investing"):
+        assert yt(slug).get("publish_long_form") is False, (
+            f"{slug} launched Shorts-only; long-form flips on only after "
+            f"the quota increase"
+        )
+    for slug in ("finansy_prosto", "privet_russian"):
+        assert yt(slug).get("channel") == "ru", (
+            f"{slug} must upload to @NerraRU (its own quota), never the "
+            f"EN channel"
+        )

--- a/tests/test_youtube_quota.py
+++ b/tests/test_youtube_quota.py
@@ -41,3 +41,58 @@ def test_network_estimate_two_enabled_shows(tmp_path):
     summary = estimate_network_daily_units(shows)
     assert summary["enabled_slugs"] == ["tesla"]
     assert summary["total_units"] > 0
+
+
+def test_estimate_counts_multiple_shorts():
+    one = estimate_episode_units(publish_long_form=True, publish_shorts=True,
+                                 shorts_count=1)
+    two = estimate_episode_units(publish_long_form=True, publish_shorts=True,
+                                 shorts_count=2)
+    assert two.units > one.units
+    assert two.uploads == 3  # long + 2 shorts
+    # The delta is exactly one more Short's worth of calls.
+    assert two.units - one.units == one.units - estimate_episode_units(
+        publish_long_form=True, publish_shorts=False).units
+
+
+def test_network_estimate_splits_channels(tmp_path):
+    shows = tmp_path / "shows"
+    shows.mkdir()
+    (shows / "en_show.yaml").write_text(
+        "name: X\nslug: en_show\nyoutube:\n  enabled: true\n  channel: en\n",
+        encoding="utf-8",
+    )
+    (shows / "ru_show.yaml").write_text(
+        "name: Y\nslug: ru_show\nyoutube:\n  enabled: true\n  channel: ru\n",
+        encoding="utf-8",
+    )
+    summary = estimate_network_daily_units(shows)
+    per_channel = summary["per_channel"]
+    assert set(per_channel) == {"en", "ru"}
+    assert per_channel["en"]["enabled_slugs"] == ["en_show"]
+    assert per_channel["ru"]["enabled_slugs"] == ["ru_show"]
+    # A RU show must never count against the EN channel's budget.
+    assert per_channel["en"]["total_units"] < summary["total_units"]
+
+
+def test_over_quota_is_per_channel(tmp_path):
+    shows = tmp_path / "shows"
+    shows.mkdir()
+    # Three full-format EN shows (~2100+1700 each) bust a 6000 budget;
+    # one RU show alone does not.
+    for i in range(3):
+        (shows / f"en{i}.yaml").write_text(
+            f"name: E{i}\nslug: en{i}\nyoutube:\n  enabled: true\n  channel: en\n",
+            encoding="utf-8",
+        )
+    (shows / "ru0.yaml").write_text(
+        "name: R\nslug: ru0\nyoutube:\n  enabled: true\n  channel: ru\n",
+        encoding="utf-8",
+    )
+    summary = estimate_network_daily_units(shows, daily_quota=6000)
+    assert summary["per_channel"]["en"]["over_quota"] is True
+    assert summary["per_channel"]["ru"]["over_quota"] is False
+    assert summary["over_quota"] is True
+    msg = format_quota_warning(summary)
+    assert "channel 'en'" in msg
+    assert "channel 'ru'" not in msg


### PR DESCRIPTION
# YouTube four-show expansion + iPhone dark-mode newsletter fix

Two operator-requested changes (June 10).

## 1. YouTube expansion (quota-increase request pending)

| Show | Change |
|---|---|
| Tesla Shorts Time | 2 Shorts → **1 Short** + long-form (frees EN quota) |
| Models & Agents for Beginners | 2 Shorts → **1 Short** + long-form |
| Fascinating Frontiers | **Enabled, Shorts-only** (`publish_long_form: false`, smart start, 40s) |
| Modern Investing | **Enabled, Shorts-only** (same shape) |
| Финансы Просто | **Enabled, full format** on @NerraRU (`channel: ru`, RU end-card text) |
| Привет, Русский! | **Enabled, full format** on @NerraRU |

- **Flip `publish_long_form: true` on FF/MIT the day the quota increase is granted** — one line each.
- @NerraRU has its own 10k/day quota (both RU shows run even days ≈ 7,600 paper-units). RU uploads **no-op with a logged warning until the `YOUTUBE_REFRESH_TOKEN_RU` secret is set** (workflow already passes it).
- Quota estimator fixed to match reality: now counts `shorts_per_episode` (previously assumed 1 Short — undercounted Tesla/MAB) and **groups per channel** (a RU show no longer counts against the EN budget). Preflight prints per-channel lines.
- EN channel paper-math projects 11,000/day — the same paper level as the previous proven-working Tesla+MAB 2-Shorts config, so the daily preflight `::error::` annotation is **expected** until the increase lands (non-blocking).
- Drift guards updated: the enabled-set pin now covers all six shows, and a new `test_youtube_expansion_quota_shape` fails CI on any partial revert (e.g. Tesla back to 2 Shorts without freeing quota elsewhere).

## 2. iPhone dark-mode newsletter fix (the one several attempts missed)

Root cause from the operator's Jun 9 screenshots: the dark-mode `<style>` block used **global selectors** (`h1 {color:#fff}`, universal `p/td/div/span` flips, td-attribute background matches). Those leak onto **Buttondown's own wrapper** — subject-as-title heading, "NERRA NETWORK · date" byline, forward line, unsubscribe footer — whose light backgrounds we can't flip. White text on light chrome = invisible.

Fix (v3 contract): `wrap_with_branding` stamps every emitted block with an `nn` marker class, and **every color rule in the dark `@media` block is scoped under `.nn`**. Buttondown's chrome keeps its native always-readable colors in both modes; our dark navy cards adapt exactly as before. The `color-scheme` opt-in stays (removing it regresses to Apple Mail's auto-transform — the original washed-out-headings bug from May).

Drift guards: `TestDarkModeScoping` — no unscoped color selectors inside the media block, no attribute background selectors, every block carries `.nn`, opt-in present — so this class of regression can't ship again.

## Tests
Full suite green: **2,707 passed, 3 skipped** (CI-equivalent ruff + actionlint + pytest run locally).

## Operator actions
- Set `YOUTUBE_REFRESH_TOKEN_RU` (mint via the OAuth bootstrap script against @NerraRU) to light up Russian uploads.
- When the quota increase is granted: flip `publish_long_form: true` in `shows/fascinating_frontiers.yaml` + `shows/modern_investing.yaml` (and optionally restore `shorts_per_episode: 2` on Tesla/MAB), updating `test_youtube_expansion_quota_shape` in the same commit.

https://claude.ai/code/session_01UCDUYhzy4gDDXEt4UE9jg6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCDUYhzy4gDDXEt4UE9jg6)_