### PR TITLE
Tesla flagship quality pass: memory-system bug fixes, length discipline, fresher editorial, hook-led teasers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,24 @@ TST received a full recursive improvement architecture (analogous to MIT):
 - Operator tooling: `scripts/update_tesla_narrative.py` for easy updates without hand-editing JSON.
 - Goal: TST becomes the best long-term public chronicle of Tesla's major programs while
   continuously optimizing for real audience engagement.
+- **June 2026 quality pass** (drift guards: `tests/test_tesla_quality_pass.py`):
+  theme mining now reads the DIGEST only (the old code mined the narrative
+  TEMPLATE text every episode — "open questions" hit count 112 and drowned
+  real topics; `_THEME_STOPWORDS` + a one-time scrub fixed existing
+  histories). `auto_update_narrative_from_digest` auto-advances per-program
+  `last_mentioned_episode/date` on every episode (the tracker had sat 13
+  days stale on a daily show) — operator-curated `status` text still only
+  changes via `scripts/update_tesla_narrative.py`. The listener-value score
+  gained a 15%-weight length component (`target_words` kwarg). Tesla opts
+  into `llm.podcast_expand_below_target: true` — the one-shot expansion
+  retry fires on ANY below-target script, not only near the 60% skip floor
+  (9 of 10 episodes had shipped 15-35% under the 1600-word target). The X
+  teaser leads with the episode hook + links the episode blog post. The
+  prompts ban the "Taking a step back from today's headlines" opener,
+  rotate three First Principles frameworks, cap the vertical-integration
+  conclusion, enforce the Takeover/Top-12 zero-overlap check, and add
+  3-tier attribution discipline. Prompt changes alter generated output —
+  A/B-listen per landmine #17 and revert via git if quality dips.
 - **PR** (Привет, Русский!) runs via `run_show.py` +
   `shows/privet_russian.yaml`; bilingual Russian language learning podcast
   for English speakers. Even days only. Uses **ElevenLabs TTS**

--- a/digests/tesla_shorts_time/tesla_narrative_tracker.json
+++ b/digests/tesla_shorts_time/tesla_narrative_tracker.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "last_updated": "2026-05-27",
+  "last_updated": "2026-06-10T02:25:32.926954",
   "programs": {
     "optimus": {
       "display_name": "Optimus",
@@ -26,7 +26,9 @@
           "claim": "First production-intent cells expected before end of 2026",
           "status": "monitoring"
         }
-      ]
+      ],
+      "last_mentioned_episode": 505,
+      "last_mentioned_date": "2026-06-09"
     },
     "cybercab_robotaxi": {
       "display_name": "Cybercab / Robotaxi",
@@ -39,7 +41,9 @@
         "Vehicle cost target and business model (Tesla-owned fleet vs owner-operated)"
       ],
       "show_confidence": "low-medium",
-      "notable_claims": []
+      "notable_claims": [],
+      "last_mentioned_episode": 505,
+      "last_mentioned_date": "2026-06-09"
     },
     "fsd_unsupervised": {
       "display_name": "FSD Unsupervised",
@@ -52,7 +56,9 @@
         "Long-term impact of China naming/positioning change"
       ],
       "show_confidence": "medium",
-      "notable_claims": []
+      "notable_claims": [],
+      "last_mentioned_episode": 505,
+      "last_mentioned_date": "2026-06-09"
     },
     "hw5_ai5": {
       "display_name": "HW5 / AI5 + Dojo",

--- a/digests/tesla_shorts_time/tesla_theme_history.json
+++ b/digests/tesla_shorts_time/tesla_theme_history.json
@@ -1,11 +1,7 @@
 {
   "version": 1,
-  "last_updated": "2026-06-09T13:36:34.331669",
+  "last_updated": "2026-06-10T02:25:32.929686",
   "recurring_themes": {
-    "open questions": 112,
-    "questions show": 84,
-    "show following": 84,
-    "mentioned current": 70,
     "giga texas": 41,
     "volume production": 31,
     "texas dedicated": 17,
@@ -24,9 +20,13 @@
     "throughout volume": 17,
     "production still": 17,
     "still targeted": 17,
-    "optimus": 9,
+    "google https": 11,
+    "https google": 11,
+    "google articles": 11,
+    "optimus": 10,
     "announced discussed": 6,
-    "current tesla": 3,
+    "service center": 4,
+    "rivian drive": 4,
     "tesla narrative": 3,
     "narrative active": 3,
     "active programs": 3,
@@ -253,6 +253,19 @@
         "volume production",
         "texas dedicated",
         "dedicated factory"
+      ]
+    },
+    {
+      "episode": 505,
+      "top_themes": [
+        "giga texas",
+        "volume production",
+        "texas dedicated",
+        "dedicated factory",
+        "factory construction",
+        "construction underway",
+        "underway first",
+        "first visible"
       ]
     }
   ]

--- a/engine/config.py
+++ b/engine/config.py
@@ -57,6 +57,11 @@ class LLMConfig:
     # output being "broken" — set their floor lower so a thin-but-
     # legitimate episode ships instead of being skipped.
     min_podcast_word_floor: int = 600
+    # June 2026 (Tesla quality pass): when true, the one-shot expansion
+    # retry in generate_podcast_script fires whenever the script lands
+    # under the FULL min_podcast_words target instead of only near the
+    # 60%-of-target skip floor. Costs one extra LLM call on short days.
+    podcast_expand_below_target: bool = False
     podcast_chain: bool = False  # Two-stage generation: outline then expand
     # Model used when the primary refuses after educational retry. A
     # different model (or different variant of the same family) often

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -839,7 +839,9 @@ def _retry_word_count_ok(orig_words: int, retry_words: int,
     return retry_words >= threshold
 
 
-def _podcast_expansion_retry_threshold(min_words: int) -> int:
+def _podcast_expansion_retry_threshold(
+    min_words: int, *, expand_below_target: bool = False,
+) -> int:
     """Word count below which ``generate_podcast_script`` triggers a
     one-shot expansion retry.
 
@@ -853,7 +855,18 @@ def _podcast_expansion_retry_threshold(min_words: int) -> int:
     dedup pass that runs between generation and the skip check and trims a
     few percent off the count (Ep493 went 874 → 818). ``600`` is the
     network-wide absolute floor.
+
+    *expand_below_target* (June 2026, per-show opt-in via
+    ``llm.podcast_expand_below_target``): retry whenever the script is
+    under the FULL target, not just near the skip floor. Added for
+    Tesla after 9 of 10 episodes shipped 15-35% under the 1600-word
+    target (avg 1238 words) with listener-value scores pinned at
+    3.2-3.9 — the 66%-of-target threshold meant a 1100-word script
+    sailed through unexpanded. Costs one extra LLM call (~$0.03) on
+    days the first pass lands short; flagship-worthy.
     """
+    if expand_below_target:
+        return max(600, int(min_words))
     soft_floor = int(min_words * 0.6)
     return max(600, int(soft_floor * 1.1))
 
@@ -1750,7 +1763,12 @@ def generate_podcast_script(
     # soft floor). Expanding here gives the episode a real chance to clear
     # the floor instead of being thrown away.
     word_count = len(text.split())
-    _retry_threshold = _podcast_expansion_retry_threshold(min_words)
+    _retry_threshold = _podcast_expansion_retry_threshold(
+        min_words,
+        expand_below_target=bool(
+            getattr(config.llm, "podcast_expand_below_target", False)
+        ),
+    )
     if word_count < _retry_threshold:
         logger.warning(
             "Podcast script for '%s' is very short (%d words, retry threshold %d). "

--- a/engine/listener_value_scorer.py
+++ b/engine/listener_value_scorer.py
@@ -53,20 +53,37 @@ def score_script(
     script: str,
     show_slug: str = "tesla",
     memory_blocks: Dict[str, Any] | None = None,
+    target_words: int = 0,
 ) -> Dict[str, Any]:
     """
     Score a finished podcast script for listener value.
 
     Returns a dict with overall score and component scores + suggestions.
+    Pass *target_words* (the show's ``min_podcast_words``) to include a
+    length-substance component — June 2026: nine of ten Tesla episodes
+    shipped 15-35% under target while clustering at the same 3.2 score,
+    so shortness was invisible in the metric the dashboard tracks.
     """
     heuristics = _heuristic_score(script or "", memory_blocks or {})
 
-    # Simple weighted overall (can be tuned over time)
-    overall = (
-        heuristics["narrative_continuity"] * 0.35 +
-        heuristics["listener_value"] * 0.40 +
-        heuristics["engagement_potential"] * 0.25
-    )
+    if target_words and target_words > 0:
+        word_count = len((script or "").split())
+        # 10 at/above target, linear down; a 65%-of-target script scores 6.5.
+        length_score = round(min(10.0, (word_count / target_words) * 10), 1)
+        heuristics["length_substance"] = length_score
+        overall = (
+            heuristics["narrative_continuity"] * 0.30 +
+            heuristics["listener_value"] * 0.35 +
+            heuristics["engagement_potential"] * 0.20 +
+            length_score * 0.15
+        )
+    else:
+        # Legacy weighting for callers that don't pass a target.
+        overall = (
+            heuristics["narrative_continuity"] * 0.35 +
+            heuristics["listener_value"] * 0.40 +
+            heuristics["engagement_potential"] * 0.25
+        )
 
     suggestions = []
     if heuristics["narrative_continuity"] < 6:
@@ -75,12 +92,14 @@ def score_script(
         suggestions.append("Add more explicit 'why this matters to owners/fans/investors' framing drawn from tracked programs.")
     if heuristics["engagement_potential"] < 6:
         suggestions.append("Strengthen opening hook and vary sentence rhythm for better audio flow.")
+    if heuristics.get("length_substance", 10) < 8:
+        suggestions.append("Script is well under the word target — expand thin stories with takeaways/implications instead of trimming coverage.")
 
     result = {
         "overall": round(overall, 1),
         **heuristics,
         "suggestions": " | ".join(suggestions) if suggestions else "Script shows good listener value characteristics.",
-        "version": "1.0-heuristic",
+        "version": "1.1-heuristic-length",
     }
 
     return result

--- a/engine/tesla_memory.py
+++ b/engine/tesla_memory.py
@@ -197,10 +197,13 @@ def build_narrative_status_block(tracker: Dict[str, Any]) -> str:
     lines = [
         "### TESLA PROGRAM NARRATIVE MEMORY",
         "Use this to give regular listeners a sense of ongoing stories and real progress (or the lack of it).",
-        "When a story touches one of these programs, include 1-2 natural sentences answering:",
+        "When a story touches one of these programs, MAKE THE CONTINUITY AUDIBLE — open that story with a",
+        "short callback a regular listener recognizes, e.g. 'Remember, the show covered [program] on",
+        "[last covered date] — today's news moves that forward because...'. Then answer naturally:",
         "  - Where does today's development fit in the bigger arc for this program?",
         "  - Does it meaningfully move any of the key open questions?",
         "  - What should attentive listeners be watching for next?",
+        "If the show covered the same program YESTERDAY, do not re-explain it — say only what is NEW today.",
         "",
         "Tracked programs (with current status and open questions):"
     ]
@@ -210,7 +213,15 @@ def build_narrative_status_block(tracker: Dict[str, Any]) -> str:
         status = prog.get("status", "Status not yet tracked.")
         last_ep = prog.get("last_major_update_episode")
         last_date = prog.get("last_major_update_date", "")
-        when = f" (last major update mentioned: Ep{last_ep}, {last_date})" if last_ep else ""
+        when = f" (status last reviewed: Ep{last_ep}, {last_date})" if last_ep else ""
+        # Auto-tracked freshness (June 2026): when the show last actually
+        # discussed this program on air — kept current automatically by
+        # auto_update_narrative_from_digest, unlike the operator-curated
+        # status above.
+        ment_ep = prog.get("last_mentioned_episode")
+        ment_date = prog.get("last_mentioned_date", "")
+        if ment_ep and ment_ep != last_ep:
+            when += f" (last covered on air: Ep{ment_ep}, {ment_date})"
 
         lines.append(f"\n**{name}**{when}")
         lines.append(f"Current status: {status}")
@@ -308,11 +319,43 @@ def record_performance_signal(output_dir: Path, signal_type: str, value: Any) ->
     save_performance_tracker(perf, output_dir)
 
 
-# Simple theme mining stub (can be expanded significantly later)
+# Words that carry no Tesla-story signal — generic news-digest vocabulary
+# plus the narrative-template vocabulary that polluted the theme history
+# before June 2026 (the old code mined bigrams from the TEMPLATE text of
+# build_narrative_status_block on every episode, so "open questions" /
+# "questions show" / "show following" dominated the history with counts
+# in the hundreds while real topics sat in single digits).
+_THEME_STOPWORDS = {
+    "status", "last", "major", "update", "episode", "date", "open",
+    "questions", "question", "show", "following", "mentioned", "current",
+    "today", "tesla", "story", "stories", "news", "daily", "source",
+    "sources", "according", "report", "reports", "reported", "company",
+    "week", "month", "year", "time", "first", "this", "that", "with",
+    "from", "have", "been", "will", "would", "could", "should", "about",
+    "after", "before", "more", "than", "their", "they", "what", "when",
+    "where", "which", "while", "into", "over", "under", "between",
+}
+
+
 def update_theme_history_from_digest(output_dir: Path, digest_text: str, episode_num: int) -> None:
-    """Lightweight but useful theme extraction from the just-generated digest + narrative context."""
+    """Theme extraction from the just-generated digest CONTENT only.
+
+    June 2026 fix: the previous version also mined bigrams from the
+    narrative status block — i.e. from our own prompt TEMPLATE — so the
+    same template phrases were re-counted every episode and drowned out
+    real topics. Themes now come exclusively from the digest text, with
+    a stopword filter for template/news-boilerplate vocabulary. The
+    polluted entries are scrubbed from existing histories on load.
+    """
     history = load_theme_history(output_dir)
     themes = history.setdefault("recurring_themes", {})
+
+    # One-time scrub of pre-fix template-noise entries so the polluted
+    # counts don't keep outranking real topics forever.
+    for noise_key in list(themes.keys()):
+        words_in_key = noise_key.split()
+        if words_in_key and all(w in _THEME_STOPWORDS for w in words_in_key):
+            del themes[noise_key]
 
     # Core Tesla program keywords (keep in sync with narrative tracker)
     keywords = [
@@ -326,20 +369,18 @@ def update_theme_history_from_digest(output_dir: Path, digest_text: str, episode
         if kw in text_lower:
             themes[kw] = themes.get(kw, 0) + 1
 
-    # Also extract simple bigram themes from the narrative status block if present
-    # (this helps surface emerging phrases the LLM itself is using)
-    try:
-        from engine.tesla_memory import build_narrative_status_block
-        tracker = load_narrative_tracker(output_dir)
-        narrative_text = build_narrative_status_block(tracker).lower()
-        # Very lightweight bigram extraction
-        words = [w for w in re.findall(r'\b[a-z]{4,}\b', narrative_text) if w not in {"status", "last", "major", "update", "episode", "date"}]
-        for i in range(len(words)-1):
-            bigram = f"{words[i]} {words[i+1]}"
-            if len(bigram) > 8:
-                themes[bigram] = themes.get(bigram, 0) + 1
-    except Exception:
-        pass
+    # Bigram themes from the DIGEST content (never the template), so
+    # emerging story phrases ("wireless bms", "shanghai exports") get
+    # surfaced before they're promoted to tracked keywords.
+    words = [
+        w for w in re.findall(r"\b[a-z]{4,}\b", text_lower)
+        if w not in _THEME_STOPWORDS
+    ]
+    for i in range(len(words) - 1):
+        w1, w2 = words[i], words[i + 1]
+        bigram = f"{w1} {w2}"
+        if len(bigram) > 8:
+            themes[bigram] = themes.get(bigram, 0) + 1
 
     # Keep only top 30 themes to avoid bloat
     sorted_themes = dict(sorted(themes.items(), key=lambda x: x[1], reverse=True)[:30])
@@ -350,3 +391,54 @@ def update_theme_history_from_digest(output_dir: Path, digest_text: str, episode
     })
 
     save_theme_history(history, output_dir)
+
+
+# Per-program detection keywords for automatic last-mention tracking.
+# Keep in sync with DEFAULT_NARRATIVE_TRACKER program keys.
+_PROGRAM_MENTION_KEYWORDS: Dict[str, tuple] = {
+    "optimus": ("optimus",),
+    "cybercab_robotaxi": ("cybercab", "robotaxi", "robo-taxi"),
+    "fsd_unsupervised": ("fsd", "full self-driving", "unsupervised"),
+    "hw5_ai5": ("hw5", "ai5", "hardware 5"),
+    "next_gen_vehicle": ("next-gen", "next gen", "redwood", "affordable model"),
+    "4680_structural_pack": ("4680", "structural pack", "structural battery"),
+}
+
+
+def auto_update_narrative_from_digest(
+    output_dir: Path, digest_text: str, episode_num: int, date_str: str,
+) -> list:
+    """Auto-advance per-program ``last_mentioned`` freshness from a digest.
+
+    June 2026: the narrative tracker was designed for operator-driven
+    status updates (scripts/update_tesla_narrative.py) but ran for weeks
+    without one — the status block told the LLM "last major update
+    Ep475" while the show was on Ep505, so continuity framing went
+    stale. This closes the loop WITHOUT touching the operator-curated
+    ``status`` text: it only records ``last_mentioned_episode`` /
+    ``last_mentioned_date`` when the digest demonstrably discusses a
+    tracked program. Returns the list of program keys detected.
+    """
+    text_lower = (digest_text or "").lower()
+    if not text_lower.strip():
+        return []
+
+    tracker = load_narrative_tracker(output_dir)
+    programs = tracker.get("programs", {})
+    mentioned = []
+    for key, kws in _PROGRAM_MENTION_KEYWORDS.items():
+        prog = programs.get(key)
+        if prog is None:
+            continue
+        if any(kw in text_lower for kw in kws):
+            prog["last_mentioned_episode"] = episode_num
+            prog["last_mentioned_date"] = date_str
+            mentioned.append(key)
+
+    if mentioned:
+        save_narrative_tracker(tracker, output_dir)
+        logger.info(
+            "Narrative tracker: recorded mentions in Ep%s for %s",
+            episode_num, ", ".join(mentioned),
+        )
+    return mentioned

--- a/run_show.py
+++ b/run_show.py
@@ -1732,8 +1732,13 @@ def run(args: argparse.Namespace) -> None:
                 from engine import tesla_memory
                 output_dir = Path(config.episode.output_dir)
                 tesla_memory.update_theme_history_from_digest(output_dir, x_thread, episode_num)
-                # Note: narrative + performance updates are currently manual/light
-                # or driven by future YouTube data ingestion. The framework is ready.
+                # Auto-advance per-program last-mention freshness (June
+                # 2026): keeps the narrative block's continuity anchors
+                # current without touching the operator-curated status
+                # text (which stays on scripts/update_tesla_narrative.py).
+                tesla_memory.auto_update_narrative_from_digest(
+                    output_dir, x_thread, episode_num, today.isoformat(),
+                )
             except Exception as exc:
                 logger.warning("Tesla memory update failed (non-fatal): %s", exc)
 
@@ -2151,7 +2156,8 @@ def run(args: argparse.Namespace) -> None:
                 score_result = listener_value_scorer.score_script(
                     podcast_script,
                     show_slug=args.show,
-                    memory_blocks=template_vars  # passes the injected memory context
+                    memory_blocks=template_vars,  # passes the injected memory context
+                    target_words=getattr(config.llm, "min_podcast_words", 0) or 0,
                 )
                 logger.info(
                     "Listener Value Score for %s Ep%d: %.1f/10 (narrative: %.1f, value: %.1f, engagement: %.1f)",
@@ -2964,6 +2970,11 @@ def run(args: argparse.Namespace) -> None:
         access_token_secret = os.getenv(f"{prefix}ACCESS_TOKEN_SECRET", "")
 
         if all([consumer_key, consumer_secret, access_token, access_token_secret]):
+            # Surface the episode hook to the teaser builder (June 2026):
+            # the hardcoded teasers carried no episode-specific content,
+            # so every day's post read identically except the date.
+            if "hook" not in extra_context and locals().get("hook"):
+                extra_context["hook"] = hook
             teaser = _build_teaser(config, episode_num, today_str, extra_context)
             tweet_url = post_to_x(
                 teaser,
@@ -4458,10 +4469,19 @@ def _build_teaser(config, episode_num: int, today_str: str, extra_context: dict)
         price_str = ""
         if "price" in extra_context:
             price_str = f" | TSLA ${extra_context['price']}"
+        # June 2026: lead with the episode hook (the daily teasers were
+        # identical except the date — zero scroll-stopping content) and
+        # link straight to the episode's blog post (inline player +
+        # show notes) instead of the generic summaries page.
+        hook_text = (extra_context.get("hook") or "").strip()
+        if len(hook_text) > 200:
+            hook_text = hook_text[:199].rstrip() + "…"
+        hook_line = f"{hook_text}\n\n" if hook_text else ""
         teaser = (
-            f"🚀⚡ Tesla Shorts Time Daily — {today_str}{price_str}\n\n"
-            f"Episode {episode_num} is live!\n"
-            f"🎧 Listen & read: https://nerranetwork.com/tesla-summaries.html"
+            f"🚀⚡ Tesla Shorts Time Ep {episode_num}{price_str}\n\n"
+            f"{hook_line}"
+            f"🎧 Listen + show notes: "
+            f"https://nerranetwork.com/blog/tesla/ep{episode_num:03d}.html"
         )
     elif slug == "omni_view":
         teaser = (

--- a/shows/prompts/tesla_digest.txt
+++ b/shows/prompts/tesla_digest.txt
@@ -38,6 +38,8 @@ Only select articles that are SPECIFIC, FRESH (within last 48 hours), and SUBSTA
 - If 7-9 quality articles available: Use all of them; do NOT search for more
 - If fewer than 7 quality articles available: Use all available, THEN search for additional articles from reputable sources (Teslarati, The Verge, WebProNews, CleanTechnica) published within the last 48 hours to reach 10-12 total. Ensure no more than 2 articles from any single source.
 - NEVER pad with low-quality or generic content regardless of article count.
+- EDITORIAL JUDGMENT BEATS THE COUNT: a list of 10 stories that each matter to an owner, fan, or investor beats a list of 12 where two are routine service-center certifications or minor filing notices. Hitting 12 is the ceiling, not the goal — if item 11 or 12 would be filler, stop at the strong ones and give the saved depth to the biggest 2-3 stories of the day.
+- ANALYST/COMMENTARY ITEMS must earn their slot with specifics: name the analyst AND include at least one concrete anchor (price target, the metric that changed their view, which program they credit). "Some on Wall Street are looking past vehicles" is not a story; "Morgan Stanley's Adam Jonas lifted his target to $X citing robotaxi unit economics" is.
 
 **TESLA X TAKEOVER SECTION**: This section should focus on the most interesting, fresh, and engaging recent Tesla news developments, trends, or breaking stories. Use the pre-fetched news articles above to identify 5 compelling Tesla stories or trends that are generating buzz. Focus on what's NEW, INTERESTING, and DIFFERENT from the main news section. This could include:
 - Breaking developments that just emerged
@@ -47,6 +49,7 @@ Only select articles that are SPECIFIC, FRESH (within last 48 hours), and SUBSTA
 - Unique angles on Tesla stories that stand out
 
 The 5 Tesla X Takeover items must each be a DIFFERENT story from the 12 Top 12 News items — do not use the same article, same headline, or same story angle in both sections. Make each Takeover item engaging and fresh.
+ENFORCEMENT — before you finalize the output, re-read your 5 Takeover items against your Top 12 one by one. If ANY Takeover item covers the same underlying event/story as a Top 12 item (even with different wording — e.g. "Cybercab sightings spread across more states" vs "States where Cybercabs have been spotted" is the SAME story), REPLACE it with a genuinely different story from the pre-fetched pool: an owner experience, a community debate, a niche technical find, a regional development the Top 12 skipped. Five fresh Takeover items means the listener hears 17 distinct stories, not 12 stories told twice.
 
 Do not include any instruction language, meta-commentary, or formatting notes in your output — only output the actual content. Focus on fresh, interesting Tesla news that is different from the main news section.
 
@@ -158,11 +161,13 @@ INSTRUCTIONS FOR THIS SECTION (do not output these instructions):
 - MUST be a DIFFERENT topic than recent episodes:
 {recent_deep_dive_topics}
 - Output a flowing 3-paragraph editorial essay (4–6 sentences each). Do NOT output labeled bullets ("The Surprising Truth:", "The Fundamental Question:", etc.) — those are scaffolding for your thinking, not for the reader. Write as a journalist would write a measured analytical column.
-- The three paragraphs should cover, in order:
-  1. The counterintuitive opening: a specific surprising fact or data point that challenges the popular narrative, plus the question it forces.
-  2. The data: at least one concrete number, ratio, or comparison anchoring the analysis. Show how physics, economics, or engineering data actually answer the question.
-  3. The implication: how Tesla's vertical-integration, manufacturing, or engineering playbook would solve the problem, and what that means practically — for the business, the technology, or the industry.
-- Open the section with a single editorial transition sentence ("Taking a step back from today's headlines, ..." or similar). Do NOT begin a paragraph with a bold label.
+- VARY THE ANALYTICAL FRAMEWORK day to day — pick whichever of these three fits today's topic best AND differs from the framework you'd guess yesterday's essay used (recent topics are listed above; infer their shape):
+  A. Counterintuitive fact → the data that resolves it → what it means practically for the business or technology.
+  B. A hard problem stated plainly → the competing approaches to it (Tesla's and at least one rival's or the conventional one) → the genuine trade-offs, including where Tesla's approach could lose.
+  C. A historical or cross-industry parallel (aviation, smartphones, solar, shipping...) → today's Tesla data point set against it → the implication for the INDUSTRY, not only Tesla.
+- BANNED OPENER: never open with "Taking a step back from today's headlines" or any close variant — it has opened this section hundreds of times. Start mid-thought instead: lead directly with the surprising fact, the question, or the parallel. Vary the first five words every single day.
+- At most once per essay, and only when the framework calls for it, credit Tesla's vertical integration — that conclusion has been reached so often it now reads as a slogan. If the honest analysis points elsewhere (supply chain, regulation, competition, physics), say so.
+- Connect the essay to MONEY when the topic allows: what does this do to cost per unit, gross margin, capex, or the demand picture? One sentence of business-model consequence beats three sentences of engineering admiration.
 - Specific numbers > vague qualifiers. "560 miles per charge" beats "long range".
 {market_movers_section}
 
@@ -172,6 +177,14 @@ INSTRUCTIONS FOR THIS SECTION (do not output these instructions):
 (Add blank line after sign-off.)
 
 ### TONE & STYLE
+- ATTRIBUTION DISCIPLINE: distinguish the three tiers in your wording —
+  (1) official ("Tesla announced", "the filing states"), (2) credible
+  reporting ("Teslarati reports", "per Not a Tesla App"), (3) community/
+  social ("an owner on X posted", "per @tslaming — unverified"). Product
+  changes, timelines, prices, and investor-position numbers sourced from
+  community posts or aggregators MUST carry tier-3 hedging — never state
+  them as established fact. When a community claim is significant enough
+  to lead with, say explicitly what would confirm it.
 - Source pubdates: when relevant for assessing freshness, mention
   RELATIVE timing inline ("earlier today", "yesterday", "this week").
   DO NOT append absolute date+time stamps like "May 06, 2026, 9:04 AM

--- a/shows/prompts/tesla_podcast.txt
+++ b/shows/prompts/tesla_podcast.txt
@@ -70,6 +70,7 @@ Instead: mention source names naturally in conversation ("according to Teslarati
 **MANDATORY NARRATIVE CONTINUITY RULES (do not ignore):**
 - When a story touches any tracked program (Optimus, Cybercab/Robotaxi, FSD, HW5/AI5, next-gen vehicle, 4680, etc.), you **must** give listeners 1-2 natural sentences of "where we are in the bigger story."
 - Phrase it like a knowledgeable friend updating another friend: "This is the first real public data we've seen on the actuator redesign since the last major update in [recent episode context]."
+- CONSECUTIVE-DAY RULE: when the same program made news yesterday or within the last few days (check the "last covered on air" dates in the narrative memory), do NOT re-introduce it from scratch. Open with an explicit one-line callback — "Yesterday it was the Atlanta service center; today the Cybercab story moves again because..." — and then cover ONLY what is new. Re-explaining a running story from zero is the fastest way to make daily listeners feel the show doesn't remember them.
 - Use the key_open_questions from the narrative memory to surface what is still unresolved. This turns individual news items into an ongoing, compelling saga instead of isolated headlines.
 - For high-performing recent topics (from the performance signals), give them slightly more energy, specificity, or a stronger hook — but only if it fits the actual news. Never force it.
 
@@ -150,7 +151,8 @@ Pick the 2–3 most interesting items from the X Takeover section and cover them
 Cover the challenge or bearish story honestly. Acknowledge it, explain the context, then explain why Tesla is positioned to handle it. Be measured here — don't dismiss legitimate concerns, but don't catastrophize either. The tone should feel direct and constructive rather than negative. Do NOT say "Short Spot" — just transition into it naturally ("Now, one thing worth watching..." or "There is a challenge worth discussing...").
 
 [First Principles — brief analytical segment]
-If the digest includes a First Principles section, cover it in about 60–90 seconds. Explain the question, the data, and Tesla's approach. Write with slightly more weight and thoughtfulness than the straight news sections. Let the logic build with a sense of discovery. This is your analytical moment — be educational and measured. Do NOT announce it as "Tesla First Principles" — just flow into it.
+If the digest includes a First Principles section, cover it in about 60–90 seconds. Explain the question, the data, and the honest conclusion. Write with slightly more weight and thoughtfulness than the straight news sections. Let the logic build with a sense of discovery. This is your analytical moment — be educational and measured. Do NOT announce it as "Tesla First Principles" — just flow into it.
+BANNED TRANSITION: never enter this segment with "Taking a step back from today's headlines" or any close variant — it has opened this segment in hundreds of episodes and regular listeners hear the scaffolding. Enter mid-thought from whatever story naturally connects, or lead with the surprising fact itself. Vary the entry every day.
 
 [Tomorrow Teaser — one sentence before the closing]
 Patrick: Before we go — briefly tease something listeners should watch for tomorrow based on developing stories from today's news. Keep it specific and forward-looking: "Tomorrow, we'll be watching for..." or "Keep an eye on..." This builds habitual listening.

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -131,6 +131,11 @@ llm:
   # structure (was "all 12 + 2-3 × 4-6"). Tesla digest also has the
   # First Principles + Counterpoint blocks layered on top.
   min_podcast_words: 1600
+  # June 2026 quality pass: 9 of 10 recent episodes shipped 15-35%
+  # under target (avg 1238 words; listener_value pinned at 3.2-3.9 vs
+  # 4.5 on the one on-target episode). Expand-retry now fires on ANY
+  # below-target script, not just near the skip floor. ~$0.03/day.
+  podcast_expand_below_target: true
   podcast_chain: true
 
 tts:
@@ -166,8 +171,23 @@ publishing:
   # surface. The mismatched ``Daily`` suffix risked Apple's duplicate-
   # feed detector marking the show as a re-upload.
   rss_title: Tesla Shorts Time
-  rss_description: A daily podcast covering the latest Tesla news, stock prices, and industry insights.
-  rss_summary: Daily Tesla news digest and podcast covering the latest developments, stock updates, and market analysis.
+  # June 2026: value-prop description for Apple/Spotify listing pages —
+  # the previous generic one-liner ("covering the latest Tesla news")
+  # sold nothing. This is what a prospective subscriber reads before
+  # their first play.
+  rss_description: >-
+    Every Tesla story that matters, every single day — in 10 minutes.
+    The day's top developments with sources, the real-time TSLA picture,
+    what the Tesla community is buzzing about on X, one honest bearish
+    counterpoint, and a daily first-principles analysis that follows
+    the long arcs: Optimus, Cybercab and robotaxi, FSD, next-gen
+    vehicles, and 4680 cells. Seven days a week, with a Sunday recap
+    that ties the week's threads together.
+  rss_summary: >-
+    Every Tesla story that matters, every day, in 10 minutes — news with
+    sources, the TSLA picture, community buzz, one honest counterpoint,
+    and first-principles analysis tracking Optimus, Cybercab, FSD and
+    more. Daily, plus a Sunday weekly recap.
   rss_link: https://nerranetwork.com/tesla.html
   rss_author: Patrick
   rss_email: patrick@planetterrian.com

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1052,7 +1052,13 @@ class TestRunShowPipeline:
                                    today_str="February 27, 2026",
                                    extra_context={})
             assert teaser, f"_build_teaser returned empty for {show}"
-            assert "Episode 1" in teaser or "episode 1" in teaser.lower()
+            # Tesla's teaser switched to "Ep N" + hook + blog link (June
+            # 2026 quality pass); other shows still say "Episode N".
+            assert (
+                "Episode 1" in teaser
+                or "episode 1" in teaser.lower()
+                or "Ep 1" in teaser
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tesla_quality_pass.py
+++ b/tests/test_tesla_quality_pass.py
@@ -1,0 +1,230 @@
+"""Drift guards for the June 2026 Tesla show quality pass.
+
+Pins the fixes from the flagship review:
+
+* theme history mines the DIGEST, never the narrative template (the old
+  code re-counted template phrases like "open questions" every episode,
+  drowning real topics 112-to-single-digits);
+* the narrative tracker auto-advances per-program ``last_mentioned``
+  freshness from each digest (it had sat 13 days stale on a daily show)
+  without ever touching the operator-curated status text;
+* the listener-value score includes a length-substance component (nine
+  of ten episodes shipped 15-35% under the 1600-word target while all
+  clustering at the same 3.2 score);
+* the podcast expansion retry fires on ANY below-target script when
+  ``llm.podcast_expand_below_target`` is set (Tesla opts in);
+* the X teaser leads with the episode hook and links the episode blog
+  post (it previously carried zero episode-specific content);
+* the prompts ban the "Taking a step back from today's headlines"
+  boilerplate that opened every First Principles segment.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from engine import tesla_memory  # noqa: E402
+
+
+class TestThemeExtractionFromDigestOnly:
+    DIGEST = (
+        "Tesla expanded robotaxi testing today. The wireless bms patent "
+        "surfaced alongside shanghai exports data. Optimus actuators "
+        "remain the open production question."
+    )
+
+    def test_no_template_phrases_counted(self, tmp_path):
+        tesla_memory.update_theme_history_from_digest(tmp_path, self.DIGEST, 500)
+        history = json.loads(
+            (tmp_path / tesla_memory.THEME_HISTORY_FILENAME).read_text())
+        themes = history["recurring_themes"]
+        for noise in ("open questions", "questions show", "show following",
+                      "mentioned current"):
+            assert noise not in themes, (
+                f"template phrase {noise!r} leaked back into theme history"
+            )
+
+    def test_digest_bigrams_and_program_keywords_counted(self, tmp_path):
+        tesla_memory.update_theme_history_from_digest(tmp_path, self.DIGEST, 500)
+        themes = json.loads(
+            (tmp_path / tesla_memory.THEME_HISTORY_FILENAME).read_text()
+        )["recurring_themes"]
+        assert themes.get("robotaxi") == 1
+        assert themes.get("optimus") == 1
+        assert "wireless" in " ".join(themes)  # digest bigram surfaced
+
+    def test_legacy_noise_scrubbed_from_existing_history(self, tmp_path):
+        polluted = {
+            "version": 1,
+            "recurring_themes": {
+                "open questions": 112, "questions show": 84,
+                "giga texas": 41,
+            },
+            "theme_evolution": [],
+        }
+        (tmp_path / tesla_memory.THEME_HISTORY_FILENAME).write_text(
+            json.dumps(polluted))
+        tesla_memory.update_theme_history_from_digest(tmp_path, self.DIGEST, 501)
+        themes = json.loads(
+            (tmp_path / tesla_memory.THEME_HISTORY_FILENAME).read_text()
+        )["recurring_themes"]
+        assert "open questions" not in themes
+        assert "questions show" not in themes
+        assert themes.get("giga texas") == 41  # real topic preserved
+
+
+class TestNarrativeAutoFreshness:
+    def test_mentions_recorded_without_touching_status(self, tmp_path):
+        digest = "Optimus actuators hit a milestone; Cybercab spotted in Austin."
+        mentioned = tesla_memory.auto_update_narrative_from_digest(
+            tmp_path, digest, 505, "2026-06-09")
+        assert "optimus" in mentioned
+        assert "cybercab_robotaxi" in mentioned
+        tracker = tesla_memory.load_narrative_tracker(tmp_path)
+        prog = tracker["programs"]["optimus"]
+        assert prog["last_mentioned_episode"] == 505
+        assert prog["last_mentioned_date"] == "2026-06-09"
+        # Operator-curated fields untouched.
+        assert prog["status"].startswith("Early production ramp")
+        assert prog["last_major_update_episode"] is None
+
+    def test_no_mentions_writes_nothing(self, tmp_path):
+        mentioned = tesla_memory.auto_update_narrative_from_digest(
+            tmp_path, "A quiet day with generic stock commentary.", 506,
+            "2026-06-10")
+        assert mentioned == []
+        assert not (tmp_path / tesla_memory.NARRATIVE_TRACKER_FILENAME).exists()
+
+    def test_block_renders_last_covered_freshness(self, tmp_path):
+        tesla_memory.auto_update_narrative_from_digest(
+            tmp_path, "FSD unsupervised rollout expands.", 505, "2026-06-09")
+        tracker = tesla_memory.load_narrative_tracker(tmp_path)
+        block = tesla_memory.build_narrative_status_block(tracker)
+        assert "last covered on air: Ep505, 2026-06-09" in block
+        assert "MAKE THE CONTINUITY AUDIBLE" in block
+
+    def test_run_show_wires_auto_update(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "auto_update_narrative_from_digest" in src
+
+
+class TestListenerValueLengthComponent:
+    def _script(self, words):
+        return " ".join(["tesla word"] * (words // 2))
+
+    def test_short_script_scores_lower_than_full(self):
+        from engine.listener_value_scorer import score_script
+
+        short = score_script(self._script(1000), target_words=1600)
+        full = score_script(self._script(1600), target_words=1600)
+        assert short["length_substance"] < full["length_substance"]
+        assert short["overall"] < full["overall"]
+        assert full["length_substance"] == 10.0
+
+    def test_legacy_callers_unchanged(self):
+        from engine.listener_value_scorer import score_script
+
+        result = score_script(self._script(1000))
+        assert "length_substance" not in result
+
+    def test_run_show_passes_target_words(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "target_words=getattr(config.llm" in src
+
+
+class TestExpansionRetryThresholdFlag:
+    def test_default_keeps_soft_floor_band(self):
+        from engine.generator import _podcast_expansion_retry_threshold
+
+        assert _podcast_expansion_retry_threshold(1600) == int(1600 * 0.6 * 1.1)
+
+    def test_flag_raises_threshold_to_full_target(self):
+        from engine.generator import _podcast_expansion_retry_threshold
+
+        assert _podcast_expansion_retry_threshold(
+            1600, expand_below_target=True) == 1600
+
+    def test_tesla_opts_in(self):
+        from engine.config import load_config
+
+        cfg = load_config("shows/tesla.yaml")
+        assert cfg.llm.podcast_expand_below_target is True
+
+    def test_dataclass_default_off(self):
+        from engine.config import LLMConfig
+
+        assert LLMConfig().podcast_expand_below_target is False
+
+
+class TestTeslaTeaserHasHookAndBlogLink:
+    def _config(self):
+        return SimpleNamespace(
+            slug="tesla", name="Tesla Shorts Time",
+            publishing=SimpleNamespace(x_teaser_template=""),
+        )
+
+    def test_hook_leads_and_blog_linked(self):
+        import run_show
+
+        teaser = run_show._build_teaser(
+            self._config(), 505, "June 09, 2026",
+            {"price": "416.22",
+             "hook": "Multiple Cybercabs at an Atlanta service center."},
+        )
+        assert "Multiple Cybercabs at an Atlanta service center." in teaser
+        assert "blog/tesla/ep505.html" in teaser
+        assert "TSLA $416.22" in teaser
+        assert "tesla-summaries.html" not in teaser
+
+    def test_long_hook_truncated(self):
+        import run_show
+
+        teaser = run_show._build_teaser(
+            self._config(), 505, "June 09, 2026", {"hook": "x" * 300},
+        )
+        assert "…" in teaser
+        # Effective X length stays within budget (URL counts as 23).
+        import re
+        assert len(re.sub(r"https?://\S+", "x" * 23, teaser)) <= 280
+
+    def test_no_hook_still_posts(self):
+        import run_show
+
+        teaser = run_show._build_teaser(
+            self._config(), 505, "June 09, 2026", {},
+        )
+        assert "Ep 505" in teaser
+        assert "blog/tesla/ep505.html" in teaser
+
+
+class TestPromptBoilerplateBans:
+    def test_digest_prompt_bans_step_back_opener(self):
+        text = (_ROOT / "shows/prompts/tesla_digest.txt").read_text(
+            encoding="utf-8")
+        assert "BANNED OPENER" in text
+        assert "VARY THE ANALYTICAL FRAMEWORK" in text
+
+    def test_podcast_prompt_bans_step_back_transition(self):
+        text = (_ROOT / "shows/prompts/tesla_podcast.txt").read_text(
+            encoding="utf-8")
+        assert "BANNED TRANSITION" in text
+        assert "CONSECUTIVE-DAY RULE" in text
+
+    def test_digest_prompt_enforces_takeover_overlap_check(self):
+        text = (_ROOT / "shows/prompts/tesla_digest.txt").read_text(
+            encoding="utf-8")
+        assert "ENFORCEMENT" in text and "re-read your 5 Takeover items" in text
+
+    def test_digest_prompt_has_attribution_tiers(self):
+        text = (_ROOT / "shows/prompts/tesla_digest.txt").read_text(
+            encoding="utf-8")
+        assert "ATTRIBUTION DISCIPLINE" in text


### PR DESCRIPTION
# Tesla flagship quality pass — toward the best daily Tesla podcast

Full review of the Tesla pipeline, code, prompts, workflows, podcast output, blog, and website (three parallel deep-dives + competitive scan vs Tesla Daily/Rob Maurer and Ride the Lightning), followed by an implementation pass on everything safe to ship. **2,728 tests green** (+21 new drift guards in `tests/test_tesla_quality_pass.py`).

## What the review found

**Two real memory-system bugs** (the "recursive improvement" moat was running broken):
1. **Theme history mined our own prompt template, not the content.** Every episode re-counted template phrases — "open questions" reached count **112** while real topics sat in single digits. The theme context block injected into every prompt was noise. → Mining now reads the digest only, with a stopword filter + one-time scrub of polluted histories. The live history was re-seeded: top themes are now *giga texas, volume production, …*
2. **The narrative tracker sat 13 days stale on a daily show** (designed for operator-driven updates that didn't happen; the block told the LLM "last update Ep475" while shipping Ep505). → New `auto_update_narrative_from_digest` advances per-program `last_mentioned` freshness automatically every episode (curated `status` text stays operator-only via `scripts/update_tesla_narrative.py`), and the block now instructs the LLM to make continuity audible ("Remember, the show covered X on [date]…").

**Chronic underweight episodes:** 9 of the last 10 shipped 15–35% under the 1,600-word target (avg 1,238); listener-value scores pinned at 3.2–3.9 vs 4.5 on the one on-target episode. The expansion retry only fired below ~66% of target. → New `llm.podcast_expand_below_target` flag (Tesla opts in): the one-shot expansion fires on **any** below-target script (~$0.03/day extra). The listener-value score also gains a 15%-weight length component so shortness shows up in the metric.

**Formula fatigue** (editorial — prompt changes, A/B-listen per landmine #17):
- "Taking a step back from today's headlines" opened the First Principles segment in **every** episode → banned, with three rotating analytical frameworks and a cap on the every-day "vertical integration wins" conclusion + a required business-model/money consequence.
- X Takeover items duplicated Top-12 stories despite a zero-overlap rule → explicit final re-check + replace instruction (listeners should hear 17 stories, not 12 told twice).
- 12-item minimum forced filler → judgment rule (10 strong items beat 12 padded; saved depth goes to the day's biggest stories). Analyst items must carry a name + concrete anchor.
- New 3-tier attribution discipline (official / reported / community-unverified) for product changes, timelines, investor positions — the review caught unhedged community-sourced claims.
- Consecutive-day rule: running stories (Cybercab got near-identical treatment 3× in 5 days) open with a one-line callback and cover only what's new.

**Audience surfaces:**
- The daily X teaser was **identical every day except the date** and linked the generic summaries page → now leads with the episode hook + links the episode's blog post (inline player + notes).
- RSS channel description was "A daily podcast covering the latest Tesla news…" → rewritten as a real value proposition for Apple/Spotify listing pages (the first thing a prospective subscriber reads).

## What was verified-fine (no churn)
Recent RSS episode titles already use hooks (only the pre-2026 back-catalog is generic — optional backfill, skipped); blog SEO is strong (hook-led titles, full JSON-LD); the Story Tracker button exists on tesla.html; feeds are healthy; the Feb-2026 3-day-repeat dedup issue is no longer reproducible; chapters/transcripts are universal.

## Report-level items (operator decisions, not in this PR)
- **Performance tracker** still needs a real signal source — recommend wiring the now-live OP3 per-episode downloads into `strong_topics/strong_hook_styles` (follow-up), or YouTube Analytics API later.
- **Differentiation thesis vs the leaders:** Tesla Daily owns financial depth, Ride the Lightning owns community warmth; TST's lane is the **7-day serialized chronicle** (continuity + story trackers) — the consecutive-day callbacks and First Principles money-consequence rule in this PR push directly at that.
- Sunday recap quality and a possible quarterly "earnings impact" special are worth a future editorial pass.

⚠️ **Prompt changes alter generated output** — per landmine #17, listen to the first 2–3 post-merge episodes (especially the First Principles segment entries) and `git revert` the prompt commit if anything regresses.

https://claude.ai/code/session_01UCDUYhzy4gDDXEt4UE9jg6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCDUYhzy4gDDXEt4UE9jg6)_