### PR TITLE
Russian shows quality pass: Финансы Просто + Привет, Русский!

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,21 @@ TST received a full recursive improvement architecture (analogous to MIT):
   `shows/privet_russian.yaml`; bilingual Russian language learning podcast
   for English speakers. Even days only. Uses **ElevenLabs TTS**
   (`eleven_flash_v2_5` with `language_code: ru`). X posting disabled.
+- **June 10 2026 Russian-shows pass** (FP + PR; review:
+  [`docs/russian_shows_review_2026_06_10.md`](docs/russian_shows_review_2026_06_10.md);
+  drift guards: `tests/test_russian_shows_quality_pass.py`): the spoken +
+  RSS AI disclosures are now LOCALIZED (`_AI_DISCLOSURE_RU` /
+  `_AI_DISCLOSURE_RSS_RU` in `run_show.py`, gated on `_RUSSIAN_SHOWS`) —
+  closing the "English disclosure on the Olya voice" wart from two prior
+  reviews; Russian feeds title episodes "Выпуск N: …"; closing-pool
+  coverage + `where` anchors fixed (FP's "Вот и всё" variant matched no
+  pattern; PR had ONE closing ever — now 3 rotating); floors FP 900→1000,
+  PR 650→800 (PR keeps `min_podcast_word_floor: 550`); NEW
+  `engine/vocab_tracker.py` + `shows/hooks/privet_russian.py` give PR
+  vocabulary memory — spaced-repetition review callbacks + a
+  no-reteach/theme-rotation list via `{vocab_review_section}` (Animals had
+  run 3 consecutive episodes; words never reappeared). Audio-affecting
+  changes → A/B-listen per landmine #17.
 - **FPD** (First Principles Daily) runs via `run_show.py` +
   `shows/first_principles.yaml`; a **daily narrative** show
   (`narrative_mode: true`, topic-queue-driven like UC — no news fetch).

--- a/docs/russian_shows_review_2026_06_10.md
+++ b/docs/russian_shows_review_2026_06_10.md
@@ -1,0 +1,86 @@
+# Russian Shows Quality Review — Финансы Просто + Привет, Русский! (June 10, 2026)
+
+Same review-then-fix process as the Tesla (#576) and four-show (#577) passes,
+applied to the two Russian shows. Drift guards:
+`tests/test_russian_shows_quality_pass.py`. As with #577, all audited episodes
+(FP Ep45–49, PR Ep32–36, June 2–8) predate the June 9 evening merges, so
+"expand-retry not firing" / "tips shortfall" findings are pre-fix artifacts.
+
+## Fixed in this pass
+
+### 1. English AI disclosure spoken on the Russian voice (the known wart)
+Every FP/PR episode ended with *"This episode used AI voice synthesis of my
+voice…"* in English on the Olya voice — flagged as an operator item in two
+prior network reviews. `run_show.py` now defines `_AI_DISCLOSURE_RU` +
+`_AI_DISCLOSURE_RSS_RU` and gates all three injection points (spoken script,
+per-episode RSS description, channel description) on `_RUSSIAN_SHOWS`.
+**Changes shipped audio — A/B-listen per landmine #17.**
+
+### 2. Mixed-language episode titles
+"Финансы Просто - Episode 49" / "Ep 48: Сегодня разберёмся…" — the Russian
+feeds now title episodes "Выпуск 49: …" (hook path and no-hook fallback).
+
+### 3. Closing chapters + rotation (the Tesla bug class)
+- FP's second closing variant ("Вот и всё на сегодня!") matched no pattern →
+  the closing got an auto-segment fragment title (verified Ep48). Pattern now
+  covers it; Приветствие/Завершение carry `where: start/end` anchors.
+- PR had **one** closing — identical sign-off on every episode ever. Pool now
+  rotates 3 variants, each pinned to match the Closing pattern.
+- Both shows' under-matching mid-section patterns broadened to phrases the
+  natural scripts actually speak (FP: "сегодня разберёмся", "первый совет",
+  "как это устроено"; PR: "let's build more", "little grammar", "story
+  behind") — recent episodes were losing 3–4 of their 6–8 chapters to the
+  fallback segmenter.
+
+### 4. Word floors raised to make the expand-retry meaningful
+- FP: 900 → **1000** (prompt targets 1,300–1,700; floor deliberately NOT at
+  the prompt's low end — the 60% skip line stays at 600, under the worst
+  recent raw output of 645 words, so an episode still ships even if the
+  retry fails entirely).
+- PR: 650 → **800** (prompt targets 900–1,200; the explicit
+  `min_podcast_word_floor: 550` ship floor is kept).
+
+### 5. Привет, Русский! vocabulary memory (new: `engine/vocab_tracker.py`)
+The show's biggest pedagogical gap: vocabulary was taught in complete
+isolation — words never reappeared, and themes repeated back-to-back
+(Animals ran Ep33/34/35) because nothing remembered what had been taught.
+New lightweight memory, the show's equivalent of the narrative-memory
+engines:
+- `post_generate` (new `shows/hooks/privet_russian.py`) mines the episode's
+  taught Cyrillic vocabulary (frequency ranking after a Russian
+  function-word filter — verified to recover космос/звезда/ракета and
+  яблоко/хлеб/молоко from real episodes) into
+  `digests/privet_russian/vocab_taught.json`, idempotent per episode.
+- `pre_fetch` composes `{vocab_review_section}`: 2–3 words due for a spoken
+  spaced-repetition callback (taught ≥2 episodes ago, oldest first) plus a
+  recently-taught DO-NOT-RETEACH list that also forces theme rotation.
+- Placeholder added to both PR prompts; `run_show.py` setdefaults the key on
+  both the digest and podcast paths so a hook failure can never KeyError.
+  Empty history composes to an empty string — a true no-op until data
+  accrues.
+
+### 6. Stale TTS claim in the PR prompt
+"This script is synthesized by AI text-to-speech **in English**" — false
+since the May 2026 Olya-voice migration (and the scripts already write
+Cyrillic). Now: "synthesized by a bilingual AI voice (Russian + English);
+write Russian words in Cyrillic with pronunciation guidance nearby" —
+matches what recent episodes already do.
+
+## Checked and rejected
+
+- **"RSS feed missing"** (PR) — the agent looked in `digests/privet_russian/`;
+  `privet_russian_podcast.rss` lives at the repo root like every feed.
+- **FP tips shortfall / both shows' under-target word counts** — all audited
+  episodes predate #575's "3–4 tips" requirement and the expand-retry flag;
+  the digest-carrying retry from #576 applies network-wide. Verify the next
+  even-day episodes (June 10/12).
+- **FP "Главная тема" missing because writers don't speak labels** — partially
+  true; addressed by pattern broadening rather than forcing the host to
+  announce section headers (which the prompts deliberately avoid).
+
+## Operator items
+- A/B-listen the next FP/PR episodes: localized disclosure, PR closing
+  rotation, PR vocab-review callbacks, and the raised length targets all
+  change shipped audio (landmine #17).
+- The vocab tracker starts empty — review callbacks begin once two episodes
+  have been recorded (≈June 14).

--- a/engine/intros.py
+++ b/engine/intros.py
@@ -433,12 +433,27 @@ _SHOW_PERSONALITIES: dict[str, dict[str, Any]] = {
             "I'm Olya, and we've got some great Russian words to learn today. Poyekhali — let's go!",
             "I'm Olya. Today's lesson is going to be a fun one. Poyekhali!",
         ],
+        # June 10 2026: rotation added — every episode had ended with the
+        # identical single closing (the daily-show tic the network bans
+        # everywhere else). Each variant must match the YAML Closing
+        # chapter pattern (molodets|well done|poka|see you) — guarded in
+        # tests/test_russian_shows_quality_pass.py.
         "closings": [
             (
                 "Molodets! That means, well done! Remember, every expert started as a "
                 "beginner. Practice saying today's words out loud, even just once, and "
                 "you'll be amazed how fast you learn. See you next time! Poka! "
                 "That's Russian for, bye!"
+            ),
+            (
+                "And that's our lesson for today — molodets for sticking with it! "
+                "Try using today's words in one real sentence before the next episode. "
+                "Little steps, big progress. Poka, friends — that's, bye!"
+            ),
+            (
+                "You did great today — say today's words out loud one more time and "
+                "they're yours. Share the show with a friend who wants to learn "
+                "Russian, and I'll see you next time. Poka!"
             ),
         ],
     },

--- a/engine/vocab_tracker.py
+++ b/engine/vocab_tracker.py
@@ -1,0 +1,164 @@
+"""Vocabulary memory for Привет, Русский! (spaced repetition + theme rotation).
+
+June 10 2026 Russian-shows review: the language-learning show taught each
+episode's vocabulary in complete isolation — words never reappeared, and
+the "rotating everyday domains" promise broke down (Animals ran three
+consecutive episodes) because nothing remembered what had been taught.
+
+This module is the show's equivalent of the narrative-memory engines:
+
+* ``record_episode_vocab`` mines the Cyrillic vocabulary actually taught
+  in a digest/lesson plan and persists it (word → first/last episode).
+* ``build_review_section`` composes the ``{vocab_review_section}`` prompt
+  block: 3-4 previously-taught words due for a quick spoken review
+  callback (oldest-seen first — crude spaced repetition), plus the last
+  few episodes' vocabulary as a DO-NOT-RETEACH list so themes rotate.
+
+Storage: ``digests/privet_russian/vocab_taught.json``. Empty/missing
+state composes to an empty string, so the placeholder is a true no-op
+until at least one episode has been recorded.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+VOCAB_FILENAME = "vocab_taught.json"
+
+# Russian function words / glue vocabulary that appear in every lesson's
+# example sentences but are never the *taught* word. Mining counts
+# frequency, so without this filter "это"/"очень" would outrank the
+# actual lesson vocabulary.
+_RU_STOPWORDS = {
+    "это", "как", "что", "для", "его", "она", "оно", "они", "оны", "вас",
+    "нас", "мне", "вам", "там", "тут", "уже", "ещё", "еще", "или", "если",
+    "когда", "очень", "просто", "сегодня", "завтра", "вчера", "теперь",
+    "потом", "можно", "нужно", "надо", "есть", "был", "была", "было",
+    "были", "будет", "тоже", "только", "даже", "перед", "после", "между",
+    "через", "слово", "слова", "русский", "русском", "по-русски", "пример",
+    "предложение", "значит", "давайте", "пока", "привет", "спасибо",
+    "пожалуйста", "хорошо", "день", "выпуск", "урок", "тема",
+}
+
+# A taught word becomes "due for review" this many episodes after it was
+# last heard. Two episodes ≈ 4 calendar days on the even-day cadence —
+# inside the forgetting window without crowding new material.
+_REVIEW_GAP_EPISODES = 2
+_REVIEW_WORDS_PER_EPISODE = 4
+_RECENT_EPISODES_NO_RETEACH = 3
+_WORDS_PER_EPISODE_CAP = 12
+
+
+def _path(output_dir: Path) -> Path:
+    return Path(output_dir) / VOCAB_FILENAME
+
+
+def load_vocab(output_dir: Path) -> Dict[str, Any]:
+    p = _path(output_dir)
+    if not p.exists():
+        return {"version": 1, "last_updated": "", "words": {}, "episodes": {}}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to load %s (%s) — starting fresh", p.name, exc)
+        return {"version": 1, "last_updated": "", "words": {}, "episodes": {}}
+
+
+def save_vocab(data: Dict[str, Any], output_dir: Path) -> None:
+    data["last_updated"] = datetime.now().isoformat()
+    p = _path(output_dir)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    tmp.replace(p)
+
+
+def mine_vocabulary(text: str, cap: int = _WORDS_PER_EPISODE_CAP) -> List[str]:
+    """Extract the episode's taught Cyrillic vocabulary from lesson text.
+
+    Heuristic: in a vocabulary-first lesson the taught words are the
+    most-repeated Cyrillic tokens (each is said, repeated slowly, and
+    used in an example sentence), so frequency ranking after a
+    function-word filter recovers them well — verified against Ep32-36
+    (космос/звезда/ракета…, яблоко/хлеб/молоко…).
+    """
+    words = re.findall(r"\b[а-яё]{3,}\b", (text or "").lower())
+    counts = Counter(w for w in words if w not in _RU_STOPWORDS)
+    return [w for w, c in counts.most_common(cap) if c >= 2]
+
+
+def record_episode_vocab(output_dir: Path, episode_num: int, text: str) -> List[str]:
+    """Mine + persist the episode's vocabulary. Idempotent per episode.
+
+    Returns the recorded word list.
+    """
+    data = load_vocab(output_dir)
+    episodes = data.setdefault("episodes", {})
+    key = str(episode_num)
+    if key in episodes:
+        logger.info("Vocab tracker already has Ep%s — skipping", episode_num)
+        return episodes[key]
+
+    taught = mine_vocabulary(text)
+    if not taught:
+        logger.info("No vocabulary mined from Ep%s — nothing recorded", episode_num)
+        return []
+
+    episodes[key] = taught
+    words = data.setdefault("words", {})
+    for w in taught:
+        entry = words.setdefault(w, {"first_taught": episode_num, "last_heard": episode_num})
+        entry["last_heard"] = episode_num
+    save_vocab(data, output_dir)
+    logger.info("Vocab tracker: recorded %d words for Ep%s (%s…)",
+                len(taught), episode_num, ", ".join(taught[:5]))
+    return taught
+
+
+def build_review_section(output_dir: Path, current_episode: int) -> str:
+    """Compose the ``{vocab_review_section}`` prompt block ('' when empty)."""
+    data = load_vocab(output_dir)
+    words = data.get("words", {})
+    episodes = data.get("episodes", {})
+    if not words:
+        return ""
+
+    due = sorted(
+        (
+            (w, e) for w, e in words.items()
+            if current_episode - int(e.get("last_heard", 0)) >= _REVIEW_GAP_EPISODES
+        ),
+        key=lambda item: int(item[1].get("last_heard", 0)),
+    )
+    review_words = [w for w, _ in due[:_REVIEW_WORDS_PER_EPISODE]]
+
+    recent_eps = sorted((int(k) for k in episodes), reverse=True)
+    recent_words: List[str] = []
+    for ep in recent_eps[:_RECENT_EPISODES_NO_RETEACH]:
+        recent_words.extend(episodes[str(ep)])
+
+    lines = ["### VOCABULARY MEMORY (from previous episodes — use, do not read this section aloud)"]
+    if review_words:
+        lines.append(
+            "REVIEW CALLBACKS (spaced repetition): naturally weave SHORT review "
+            "moments for 2-3 of these previously taught words into today's lesson "
+            "— e.g. 'Remember " + review_words[0] + " from a few lessons ago?' "
+            "Then say the word slowly once and give its English meaning again. "
+            "Due for review: " + ", ".join(review_words) + "."
+        )
+    if recent_words:
+        lines.append(
+            "RECENTLY TAUGHT (do NOT re-teach these as new words, and pick a "
+            "DIFFERENT theme than they suggest): " + ", ".join(recent_words[:20]) + "."
+        )
+    if len(lines) == 1:
+        return ""
+    return "\n".join(lines)

--- a/run_show.py
+++ b/run_show.py
@@ -67,6 +67,23 @@ _AI_DISCLOSURE_RSS = (
     "voice synthesis for audio production."
 )
 
+# Russian shows (Финансы Просто / Привет, Русский!) used to speak the
+# ENGLISH disclosure line at the end of every episode on the Russian
+# Olya voice — flagged as a known wart in two network reviews. The
+# localized lines below close it (June 10 2026 Russian-shows pass;
+# changes shipped audio → A/B-listen per landmine #17).
+_RUSSIAN_SHOWS = ("finansy_prosto", "privet_russian")
+
+_AI_DISCLOSURE_RU = (
+    "Этот выпуск озвучен с помощью ИИ-синтеза голоса — "
+    "подбор тем и анализ остаются за человеком."
+)
+
+_AI_DISCLOSURE_RSS_RU = (
+    "Дисклеймер об ИИ: подкаст курирует Патрик, а озвучка создаётся "
+    "с помощью ИИ-синтеза голоса."
+)
+
 # ---------------------------------------------------------------------------
 # Bootstrap
 # ---------------------------------------------------------------------------
@@ -1147,6 +1164,10 @@ def run(args: argparse.Namespace) -> None:
         # pre_fetch hook. Default it to empty so a hook-load failure (or a show
         # without memory) can never KeyError in prompt substitution.
         template_vars.setdefault("narrative_memory_section", "")
+        # Привет, Русский! vocabulary memory (June 2026): the prompts
+        # reference {vocab_review_section}, supplied by the show's hook.
+        # Same defaulting contract as above.
+        template_vars.setdefault("vocab_review_section", "")
 
         # 7. Generate digest
         #
@@ -1886,6 +1907,10 @@ def run(args: argparse.Namespace) -> None:
             }
             # Merge extra context for podcast prompt (e.g. tone_hint, intro_line)
             pod_vars.update(extra_context)
+            # Привет, Русский! vocabulary memory — same hook-failure-safe
+            # defaulting as the digest stage (str.format_map raises
+            # KeyError on missing placeholders).
+            pod_vars.setdefault("vocab_review_section", "")
 
             # Provide default intro_line/closing_block if hook didn't supply them.
             # Uses engine.intros for day-varying, show-specific intros so
@@ -2204,8 +2229,13 @@ def run(args: argparse.Namespace) -> None:
                 from engine.russian_text import russify_english_dates
                 podcast_script = russify_english_dates(podcast_script)
 
-            # Append AI disclosure at the end of the episode
-            podcast_script = podcast_script.rstrip() + "\n\n" + _AI_DISCLOSURE
+            # Append AI disclosure at the end of the episode (localized for
+            # the Russian shows — an English sentence on the Russian voice
+            # was the worst audio moment of every FP/PR episode).
+            _disclosure = (
+                _AI_DISCLOSURE_RU if args.show in _RUSSIAN_SHOWS else _AI_DISCLOSURE
+            )
+            podcast_script = podcast_script.rstrip() + "\n\n" + _disclosure
 
             # Parse chapter markers from the cleaned script (before TTS)
             from engine.chapters import parse_chapters
@@ -2699,9 +2729,14 @@ def run(args: argparse.Namespace) -> None:
         from engine.audio import format_duration
 
         if hook:
-            episode_title = f"Ep {episode_num}: {hook}"
+            # Russian shows get a Russian episode-number prefix — the
+            # listing is read by Russian speakers ("Episode 49" looked
+            # foreign in an otherwise-Russian feed).
+            _ep_prefix = "Выпуск" if args.show in _RUSSIAN_SHOWS else "Ep"
+            episode_title = f"{_ep_prefix} {episode_num}: {hook}"
         else:
-            episode_title = f"{config.name} - Episode {episode_num} - {today_str}"
+            _ep_word = "Выпуск" if args.show in _RUSSIAN_SHOWS else "Episode"
+            episode_title = f"{config.name} - {_ep_word} {episode_num} - {today_str}"
         # Use a short summary for the RSS description (first ~500 chars at sentence boundary)
         # to avoid overwhelming podcast app UIs with the full digest.
         _desc_limit = 500
@@ -2710,7 +2745,11 @@ def run(args: argparse.Namespace) -> None:
             episode_desc = x_thread[:_cut + 1] + " ..." if _cut > 100 else x_thread[:_desc_limit] + "..."
         else:
             episode_desc = x_thread
-        episode_desc = episode_desc.rstrip() + "\n\n" + _AI_DISCLOSURE_RSS
+        _rss_disclosure = (
+            _AI_DISCLOSURE_RSS_RU if args.show in _RUSSIAN_SHOWS
+            else _AI_DISCLOSURE_RSS
+        )
+        episode_desc = episode_desc.rstrip() + "\n\n" + _rss_disclosure
         # If the episode landed on YouTube, surface the watch link in
         # the RSS description so listeners on every podcast app can
         # click through to the video version.
@@ -2776,7 +2815,8 @@ def run(args: argparse.Namespace) -> None:
         channel_desc_with_disclosure = (
             config.publishing.rss_description.rstrip()
             + "\n\n"
-            + _AI_DISCLOSURE_RSS
+            + (_AI_DISCLOSURE_RSS_RU if args.show in _RUSSIAN_SHOWS
+               else _AI_DISCLOSURE_RSS)
         )
 
         logger.info("Updating RSS feed: %s", config.publishing.rss_file)

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -170,7 +170,12 @@ llm:
   podcast_temperature: 0.75
   max_tokens: 5000
   podcast_max_tokens: 6000
-  min_podcast_words: 900
+  # June 10 2026 review: 900 -> 1200. The prompt targets 1,300-1,700
+  # слов but the floor sat at 900, so short episodes never tripped the
+  # expand-retry. 1000 (not the prompt's 1300 low end) keeps the 60%
+  # skip floor at 600 — below the worst recent raw output (645 words,
+  # Ep45) so an episode still ships even if the expand-retry fails.
+  min_podcast_words: 1000
   # June 2026 network quality pass: chronic below-target episodes —
   # the expand-retry now fires on ANY below-target script.
   podcast_expand_below_target: true
@@ -235,18 +240,23 @@ episode:
 chapters:
   enabled: true
   section_markers:
+    # June 10 2026: positional `where` anchors (the Tesla chapter-bug
+    # class) + the second closing-pool variant ("Вот и всё на сегодня!")
+    # previously matched no pattern.
     - pattern: "Финансы Просто|добро пожаловать"
       title: "Приветствие"
-    - pattern: "главная тема|главная новость|самое важное"
+      where: start
+    - pattern: "главная тема|главная новость|самое важное|сегодня разберёмся|сегодня мы разберём|тема сегодня"
       title: "Главная тема"
-    - pattern: "как это работает|разбираемся|давайте разберёмся|объясни как подруге"
+    - pattern: "как это работает|как это устроено|разбираемся|давайте разберёмся|почему это работает|объясни как подруге"
       title: "Как это работает"
-    - pattern: "попробуйте сами|практический совет|на практике"
+    - pattern: "попробуйте сами|практическ\\w+ совет|первый совет|несколько советов|на практике"
       title: "Практические советы"
     - pattern: "коротко и ясно|быстрые новости"
       title: "Коротко и ясно"
-    - pattern: "на сегодня всё|до завтра"
+    - pattern: "на сегодня всё|вот и всё|до завтра"
       title: "Завершение"
+      where: end
 
 newsletter:
   enabled: true

--- a/shows/hooks/privet_russian.py
+++ b/shows/hooks/privet_russian.py
@@ -1,0 +1,38 @@
+"""Привет, Русский! hooks — vocabulary memory (June 10 2026 review).
+
+Closes the show's biggest pedagogical gap: vocabulary was taught in
+complete isolation (words never reappeared across episodes) and themes
+repeated back-to-back (Animals ran Ep33/34/35) because nothing
+remembered what had been taught. See ``engine/vocab_tracker.py``.
+
+``pre_fetch`` always returns the ``vocab_review_section`` key (empty
+string when there's no history) so prompt substitution can never
+KeyError; ``post_generate`` mines and records the episode's vocabulary.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from engine import vocab_tracker
+
+logger = logging.getLogger(__name__)
+
+
+def pre_fetch(config, *, episode_num: int | None = None, today_str: str | None = None) -> dict:
+    section = ""
+    try:
+        output_dir = Path(config.episode.output_dir)
+        section = vocab_tracker.build_review_section(output_dir, int(episode_num or 0))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Vocab review section failed (non-fatal): %s", exc)
+    return {"vocab_review_section": section}
+
+
+def post_generate(config, *, digest_text: str = "", episode_num: int = 0) -> None:
+    try:
+        output_dir = Path(config.episode.output_dir)
+        vocab_tracker.record_episode_vocab(output_dir, int(episode_num), digest_text)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Vocab recording failed (non-fatal): %s", exc)

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -114,7 +114,10 @@ llm:
   podcast_temperature: 0.75
   max_tokens: 4000
   podcast_max_tokens: 5000
-  min_podcast_words: 650
+  # June 10 2026 review: 650 -> 800. The prompt targets 900-1,200 words
+  # but the floor sat at 650, so short episodes never tripped the
+  # expand-retry. The floor now sits just under the prompt's low end.
+  min_podcast_words: 800
   min_podcast_word_floor: 550   # Specialist language-learning show with slower bilingual pacing; allow slightly thinner days rather than aborting good episodes.
 
 tts:
@@ -183,15 +186,18 @@ episode:
 chapters:
   enabled: true
   section_markers:
+    # June 10 2026: positional `where` anchors (the Tesla chapter-bug
+    # class — "Privyet"/"poka" recur naturally inside lesson content).
     - pattern: "Privyet|welcome to Privyet"
       title: "Привет! Welcome"
+      where: start
     - pattern: "word of the day|first word"
       title: "Word of the Day"
-    - pattern: "vocabulary builder|let's learn more|more words"
+    - pattern: "vocabulary builder|let's learn more|let's build more|more words|more new words"
       title: "Vocabulary Builder"
-    - pattern: "grammar bite|grammar time|how Russian works"
+    - pattern: "grammar bite|grammar time|how Russian works|little grammar|quick grammar|grammar moment"
       title: "Grammar Bite"
-    - pattern: "word origins|where.*come from|etymology|history of"
+    - pattern: "word origins|where.*comes? from|etymology|history of|cool about one of today's words|story behind"
       title: "Word Origins Deep Dive"
     - pattern: "culture corner|fun fact|did you know"
       title: "Culture Corner"
@@ -199,6 +205,7 @@ chapters:
       title: "Practice Time"
     - pattern: "molodets|well done|poka|see you"
       title: "Closing"
+      where: end
 
 newsletter:
   enabled: true

--- a/shows/prompts/privet_russian_digest.txt
+++ b/shows/prompts/privet_russian_digest.txt
@@ -95,3 +95,5 @@ If pre-fetched articles do not provide a strong vocabulary hook, default to a us
 Your episode plan must contain enough rich, detailed content across all required sections (especially a substantial Word of the Day + 8-12 vocabulary items + Grammar + Word Origins + Cultural Corner + Practice Challenge) to allow the downstream podcast script writer to produce a full, natural 650-900 word bilingual script. Do not produce thin or placeholder content. Every section must have concrete examples, sentences, and teaching value.
 
 Select a theme and create the episode plan exactly as formatted above. Make every section meaty enough to support a complete, engaging 6-8 minute lesson.
+
+{vocab_review_section}

--- a/shows/prompts/privet_russian_podcast.txt
+++ b/shows/prompts/privet_russian_podcast.txt
@@ -53,7 +53,7 @@ Olya introduces herself ONCE in the welcome segment ("I'm Olya"). After that, NE
 - Pet names for the audience (e.g. "buddy", "pal", "bro", "friend", "folks", "gang") — use "you" or "listeners"
 
 === TTS QUALITY: WRITE FOR SPOKEN DELIVERY ===
-This script is synthesized by AI text-to-speech in English. Russian words should be written with transliteration guidance nearby so the TTS handles them as naturally as possible:
+This script is synthesized by a bilingual AI voice (Russian + English). Write Russian words in Cyrillic, with pronunciation/transliteration guidance nearby so learners can follow along:
 - Keep sentences between 8 and 25 words
 - Use natural breathing pauses with periods and commas
 - Spell out ALL numbers as words ("five" not "5", "twelve percent" not "12%")
@@ -131,6 +131,8 @@ CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with anoth
 - Russian-language financial literacy for newcomers → "Финансы Просто covers personal finance for women in Canada."
 - World news / current events → "Omni View has today's balanced briefing."
 If today's topic doesn't naturally overlap with any of these, omit the cross-promo entirely. NEVER force a connection. The point is to help listeners discover sister shows they'd genuinely enjoy, not to fill slots.
+
+{vocab_review_section}
 
 Here is today's episode plan. Use ONLY this content:
 

--- a/tests/test_phase3_calibration.py
+++ b/tests/test_phase3_calibration.py
@@ -75,8 +75,8 @@ class TestRecalibratedMinPodcastWords:
         "modern_investing":        1800,  # June 10 2026 review: single 2,000-2,200-word target
         "omni_view":               900,
         "unintended_consequences": 1300,
-        "finansy_prosto":          900,
-        "privet_russian":          650,
+        "finansy_prosto":          1000,  # June 10 2026 Russian-shows pass
+        "privet_russian":          800,  # June 10 2026 Russian-shows pass
     }
 
     @pytest.mark.parametrize("slug,expected", list(EXPECTED.items()))

--- a/tests/test_russian_shows_quality_pass.py
+++ b/tests/test_russian_shows_quality_pass.py
@@ -1,0 +1,147 @@
+"""Drift guards for the June 10 2026 Russian-shows quality pass
+(Финансы Просто + Привет, Русский!) — same review process as the Tesla
+flagship pass, per docs/russian_shows_review_2026_06_10.md.
+
+Pins:
+* the spoken + RSS AI disclosures are LOCALIZED for the Russian shows
+  (an English sentence on the Russian Olya voice ended every episode —
+  the known wart from two prior network reviews);
+* Russian episode titles use "Выпуск" instead of "Ep"/"Episode";
+* every closing-pool variant matches its show's Closing chapter pattern
+  (FP's second variant matched nothing) with where: start|end anchors;
+* raised word floors sit safely above the absolute ship floors;
+* the Привет, Русский! vocabulary memory (engine/vocab_tracker.py):
+  mining, idempotency, spaced-repetition review block, no-reteach list,
+  and the prompt placeholder wiring.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from engine import vocab_tracker  # noqa: E402
+from engine.intros import _SHOW_PERSONALITIES  # noqa: E402
+
+_YAMLS = {
+    "finansy_prosto": "shows/finansy_prosto.yaml",
+    "privet_russian": "shows/privet_russian.yaml",
+}
+_CLOSING_TITLES = {"finansy_prosto": "Завершение", "privet_russian": "Closing"}
+_INTRO_TITLES = {"finansy_prosto": "Приветствие", "privet_russian": "Привет! Welcome"}
+
+
+def _markers(slug):
+    cfg = yaml.safe_load((_ROOT / _YAMLS[slug]).read_text(encoding="utf-8"))
+    return cfg["chapters"]["section_markers"]
+
+
+class TestLocalizedDisclosures:
+    def test_run_show_defines_and_gates_russian_disclosures(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "_AI_DISCLOSURE_RU" in src
+        assert "_AI_DISCLOSURE_RSS_RU" in src
+        assert '_RUSSIAN_SHOWS = ("finansy_prosto", "privet_russian")' in src
+        # The spoken pick is gated, not unconditional English.
+        assert "_AI_DISCLOSURE_RU if args.show in _RUSSIAN_SHOWS else _AI_DISCLOSURE" in src
+
+    def test_russian_disclosure_is_actually_russian(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        m = re.search(r'_AI_DISCLOSURE_RU = \(\s*"([^"]+)"', src)
+        assert m and re.search(r"[а-яё]", m.group(1).lower())
+
+    def test_russian_episode_titles(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert 'if args.show in _RUSSIAN_SHOWS else "Ep"' in src
+        assert "Выпуск" in src
+
+
+class TestClosingsAndAnchors:
+    @pytest.mark.parametrize("slug", sorted(_YAMLS))
+    def test_every_closing_variant_matched(self, slug):
+        closing = next(m for m in _markers(slug)
+                       if m["title"] == _CLOSING_TITLES[slug])
+        regex = re.compile(closing["pattern"], re.IGNORECASE)
+        for variant in _SHOW_PERSONALITIES[slug]["closings"]:
+            assert regex.search(variant), (
+                f"{slug}: closing variant unmatched by Closing pattern: "
+                f"{variant[:80]!r}"
+            )
+
+    @pytest.mark.parametrize("slug", sorted(_YAMLS))
+    def test_positional_anchors(self, slug):
+        by_title = {m["title"]: m for m in _markers(slug)}
+        assert by_title[_CLOSING_TITLES[slug]].get("where") == "end"
+        assert by_title[_INTRO_TITLES[slug]].get("where") == "start"
+
+    def test_pr_closing_pool_rotates(self):
+        assert len(_SHOW_PERSONALITIES["privet_russian"]["closings"]) >= 3
+
+
+class TestRaisedFloors:
+    def test_floors_above_absolute_ship_floor(self):
+        fp = yaml.safe_load((_ROOT / _YAMLS["finansy_prosto"]).read_text(encoding="utf-8"))
+        pr = yaml.safe_load((_ROOT / _YAMLS["privet_russian"]).read_text(encoding="utf-8"))
+        assert fp["llm"]["min_podcast_words"] == 1000
+        assert pr["llm"]["min_podcast_words"] == 800
+        # PR keeps its explicit absolute floor so thin-but-good lessons ship.
+        assert pr["llm"]["min_podcast_word_floor"] == 550
+
+
+class TestVocabTracker:
+    LESSON = (
+        "Our word of the day is яблоко. Яблоко. The example is Я люблю яблоко. "
+        "Яблоко means apple. Next: хлеб. Хлеб. Хлеб is bread — я ем хлеб. "
+        "And молоко. Молоко. Я пью молоко. Молоко means milk."
+    )
+
+    def test_mine_recovers_taught_words(self):
+        words = vocab_tracker.mine_vocabulary(self.LESSON)
+        assert "яблоко" in words
+        assert "хлеб" in words
+        assert "молоко" in words
+        # Function words filtered.
+        assert "люблю" not in vocab_tracker._RU_STOPWORDS or True
+        assert "это" not in words
+
+    def test_record_idempotent(self, tmp_path):
+        vocab_tracker.record_episode_vocab(tmp_path, 36, self.LESSON)
+        vocab_tracker.record_episode_vocab(tmp_path, 36, self.LESSON)
+        data = json.loads((tmp_path / vocab_tracker.VOCAB_FILENAME).read_text())
+        assert list(data["episodes"]) == ["36"]
+
+    def test_review_section_spaced_repetition(self, tmp_path):
+        vocab_tracker.record_episode_vocab(tmp_path, 32, "космос космос звезда звезда ракета ракета")
+        vocab_tracker.record_episode_vocab(tmp_path, 36, self.LESSON)
+        section = vocab_tracker.build_review_section(tmp_path, 38)
+        # Ep32 words are due (gap >= 2); Ep36 words are recent no-reteach.
+        assert "космос" in section
+        assert "REVIEW CALLBACKS" in section
+        assert "RECENTLY TAUGHT" in section
+        assert "яблоко" in section
+
+    def test_empty_state_is_noop(self, tmp_path):
+        assert vocab_tracker.build_review_section(tmp_path, 5) == ""
+
+    def test_prompts_carry_placeholder(self):
+        for f in ("shows/prompts/privet_russian_podcast.txt",
+                  "shows/prompts/privet_russian_digest.txt"):
+            assert "{vocab_review_section}" in (_ROOT / f).read_text(encoding="utf-8")
+
+    def test_run_show_defaults_placeholder(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert src.count('setdefault("vocab_review_section", "")') >= 2
+
+    def test_hook_always_returns_key(self):
+        from shows.hooks import privet_russian as hook
+        out = hook.pre_fetch(object(), episode_num=1, today_str="x")
+        assert out == {"vocab_review_section": ""}


### PR DESCRIPTION
Same review-then-fix process as #576/#577, applied to the two Russian shows. Writeup: `docs/russian_shows_review_2026_06_10.md`. Drift guards: `tests/test_russian_shows_quality_pass.py` (16 tests). 2,672 tests pass.

**Headline fix — localized AI disclosures:** every FP/PR episode ended with the *English* disclosure line on the Russian Olya voice (the known wart from two prior network reviews). All three injection points (spoken script, per-episode RSS description, channel description) now use Russian equivalents, gated on `_RUSSIAN_SHOWS`. Russian feeds also title episodes "Выпуск N: …" instead of "Ep N:".

**Chapters (the Tesla bug class):** FP's second closing variant matched no pattern (its closing got fragment titles); PR had **one** closing variant ever — now 3 rotating, each pinned to the Closing pattern; `where: start|end` anchors added; under-matching mid-section patterns broadened to phrases the natural scripts actually speak (recent episodes lost 3–4 of their 6–8 chapters to the fallback segmenter).

**Floors:** FP 900→1000 (the 60% skip line stays under the worst recent raw output, so a failed retry still ships), PR 650→800 (explicit 550 ship floor kept).

**New — Привет, Русский! vocabulary memory** (`engine/vocab_tracker.py` + `shows/hooks/privet_russian.py`): taught words never reappeared and themes repeated back-to-back (Animals ran 3 consecutive episodes). Each episode's Cyrillic vocabulary is now mined and persisted; `{vocab_review_section}` injects 2–3 spaced-repetition review callbacks plus a recently-taught no-reteach list that forces theme rotation. KeyError-safe defaulting on both pipeline stages; empty history is a true no-op.

Also corrected the PR prompt's stale "synthesized in English" TTS claim (bilingual Olya voice since May 2026).

**Checked and rejected:** "RSS feed missing" (it's at repo root); tips/word-count shortfalls in audited episodes (all predate the June 9 merges).

**A/B-listen per landmine #17:** disclosure, PR closings, vocab callbacks, and length targets all change shipped audio. Vocab review callbacks begin once two post-merge episodes have been recorded (≈June 14).

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_