### PR TITLE
Planetterrian quality pass + network-wide missing-closing guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,18 @@ TST received a full recursive improvement architecture (analogous to MIT):
   `shows/privet_russian.yaml`; bilingual Russian language learning podcast
   for English speakers. Even days only. Uses **ElevenLabs TTS**
   (`eleven_flash_v2_5` with `language_code: ru`). X posting disabled.
+- **June 10 2026 Planetterrian pass** (review:
+  [`docs/planetterrian_review_2026_06_10.md`](docs/planetterrian_review_2026_06_10.md);
+  drift guards: `tests/test_planetterrian_quality_pass.py`): NEW
+  network-wide missing-closing guard in `engine/pipeline.py` (PT Ep081/084
+  shipped without the supplied closing block — Ep084 ended mid-teaser; the
+  pipeline now appends the resolved `closing_block` verbatim when absent,
+  before chapter parsing); ONE unified length target (1,800–2,100 words ≈
+  12–13 min, floor 1250→1600 — the prompt had demanded three conflicting
+  lengths and all 15 recent episodes ran under target, avg ~970); chapter
+  `where` anchors + "see you next" closing coverage. Watch the first week
+  for `podcast_script_too_thin` skip markers; fall back to floor 1400 if
+  PT skips more than once. A/B-listen per landmine #17.
 - **June 10 2026 Russian-shows pass** (FP + PR; review:
   [`docs/russian_shows_review_2026_06_10.md`](docs/russian_shows_review_2026_06_10.md);
   drift guards: `tests/test_russian_shows_quality_pass.py`): the spoken +

--- a/docs/planetterrian_review_2026_06_10.md
+++ b/docs/planetterrian_review_2026_06_10.md
@@ -1,0 +1,48 @@
+# Planetterrian Quality Review (June 10, 2026)
+
+Same review-then-fix process as the Tesla (#576), four-show (#577), and
+Russian (#579) passes. Drift guards: `tests/test_planetterrian_quality_pass.py`.
+PT already inherited the engine-level fixes from #577 (show_memory echo
+filter/idempotency/word-boundary detection, theme-history scrub, nightly OP3
+performance loop) — this pass covers what remained.
+
+**Date framing:** all audited episodes (Ep70–84, May 26–June 9) predate both
+the #575 prompt bans (the "fits the tracked program" tic verified gone only
+because Ep082 predates the ban — re-check post-pass episodes) and the #576
+digest-carrying expand-retry. The "15 of 15 episodes under target" and the
+banned-phrase findings are pre-fix states.
+
+## Fixed
+
+1. **Missing-closing guard (network-wide, `engine/pipeline.py`).** Ep081
+   ended "See you next time." with no closing block; Ep084 ended mid-teaser
+   with no sign-off, no CTA, and no Closing chapter. The prompts say "use
+   this exact closing (do not rewrite it)" but the LLM occasionally omits
+   it. The pipeline now appends the resolved `closing_block` verbatim when
+   its opening signature is absent from the script's tail — before chapter
+   parsing, so the Closing chapter always parses. Benefits every show.
+2. **Contradictory length targets** — prompt said "10–13 minute", "12–15
+   minute", and "at least 2400 words" while the YAML enforced 1250 (all 15
+   recent episodes under it, avg ~970). One target now: **1,800–2,100 words
+   ≈ 12–13 min, floor 1600** (mirrors the FF twin). The 60% skip line lands
+   at 960 — the digest-carrying retry must lift a weak ~800-word draft past
+   it; an episode that can't reach 960 even with the digest in hand is
+   better skipped than shipped (the network's documented thin-day policy).
+   **A/B-listen per landmine #17.**
+3. **Chapter anchors + closing coverage** — `where: start/end` anchors;
+   Closing pattern gains "see you next" (the Ep081 failure mode).
+
+## Checked / no action
+
+- Intros closing pool (2 variants) both matched the Closing pattern already.
+- Theme-history identical lists Ep73–83 are pre-scrub snapshots; the #577
+  scrub + echo filter govern from Ep85 on.
+- RSS hook-first titles, narrative page freshness (rebuilt today), memory
+  wiring, X teaser — all verified healthy.
+
+## Operator items
+
+- A/B-listen the next 2–3 episodes (length target change).
+- Watch the first post-pass week for soft-floor skips (`.skip_*.json`
+  markers with reason `podcast_script_too_thin`) — if PT skips more than
+  once, drop `min_podcast_words` to 1400 rather than reverting the prompt.

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -328,6 +328,28 @@ def run_generation_phase(
         template_vars_for_script, config, tracker=tracker
     )
 
+    # Missing-closing guard (June 10 2026, Planetterrian review): PT
+    # Ep081/Ep084 shipped without the supplied closing block — Ep084
+    # ended mid-teaser with no sign-off, no CTA, and no Closing chapter.
+    # The prompts say "use this exact closing (do not rewrite it)" but
+    # the LLM occasionally omits it. If the resolved closing's opening
+    # signature isn't in the script's tail, append the block verbatim so
+    # every episode ends properly (and the Closing chapter always parses).
+    _closing = str(pod_vars.get("closing_block", "")).strip()
+    if _closing and podcast_script:
+        import re as _re_close
+        _sig = " ".join(
+            _re_close.sub(r"^\s*\w+:\s*", "", _closing).split()[:5]
+        ).lower()
+        _tail = podcast_script[-max(len(podcast_script) // 4, 600):].lower()
+        if _sig and _sig not in _tail:
+            logger.warning(
+                "Podcast script is missing the supplied closing block — "
+                "appending it verbatim (script ended: %r)",
+                podcast_script.rstrip()[-80:],
+            )
+            podcast_script = podcast_script.rstrip() + "\n\n" + _closing
+
     # Chapter parsing (if enabled for the show)
     episode_chapters: list = []
     if (getattr(config, "chapters", None)

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -203,7 +203,13 @@ llm:
   podcast_max_tokens: 10000
   # May 2026 substance-boost: target bumped 950 → 1250 to match the new
   # "12-14 stories × 5-7 sentences" podcast structure (was "9-11 × 4-6").
-  min_podcast_words: 1250
+  # June 10 2026 review: 1250 -> 1600. The prompt simultaneously said
+  # "10-13 minute", "12-15 minute", and "at least 2400 words" while
+  # this floor enforced 1250 (15 of 15 recent episodes under it, avg
+  # ~970). One target now: 1,800-2,100 words ~ 12-13 min. The 60% skip
+  # line lands at 960 — the digest-carrying expand-retry must lift a
+  # weak ~800-word draft past it, mirroring the FF twin's tuning.
+  min_podcast_words: 1600
   # June 2026 network quality pass: 8 of 8 recent episodes below target.
   # Expand-retry now fires on ANY below-target script.
   podcast_expand_below_target: true
@@ -261,16 +267,22 @@ episode:
 chapters:
   enabled: true
   section_markers:
+    # June 10 2026: positional `where` anchors (the Tesla chapter-bug
+    # class) + "see you next" closing coverage (Ep081 ended "See you
+    # next time." which matched no pattern -> no Closing chapter).
     - pattern: "Welcome.*Planet|Planet-terry-an.*episode"
       title: "Introduction"
+      where: start
     - pattern: "Planetterrian Spotlight|Planet-terry-an Spotlight|Spotlight"
       title: "Planetterrian Spotlight"
     - pattern: "science deep dive|deep dive|under the microscope"
       title: "Science Deep Dive"
     - pattern: "Before we go|Next time|before we wrap"
       title: "Tomorrow Teaser"
-    - pattern: "That's Planet|that.?s.*for today|until next time"
+      where: end
+    - pattern: "That's Planet|that.?s.*for today|until next time|see you next"
       title: "Closing"
+      where: end
 
 newsletter:
   enabled: true

--- a/shows/prompts/planetterrian_podcast.txt
+++ b/shows/prompts/planetterrian_podcast.txt
@@ -16,7 +16,7 @@ PRONUNCIATION GUIDE:
 - DO expand an acronym ONLY on first use, using the full name followed by the acronym: "the National Aeronautics and Space Administration, or NASA"
 [END PRODUCTION NOTES]
 
-You are writing a 10–13 minute solo podcast script for "Planetterrian Daily" Episode {episode_num}.
+You are writing a 12–13 minute (1,800–2,100 words) solo podcast script for "Planetterrian Daily" Episode {episode_num}. This is the ONE length target for this script — there is no other.
 
 HOST: Patrick in Vancouver — Canadian, scientist, newscaster. Knowledgeable about science, health, and longevity research.
 
@@ -25,7 +25,7 @@ STRUCTURAL REQUIREMENTS (these determine episode length):
 - Each story: **5-7 sentences focused on facts** — opening finding, 3-4 sentences with concrete source details (study size, methodology, journal, mechanisms, researcher quotes, specific numbers), 1 transition. Reserve commentary/implications for AT MOST ONE sentence per story, and only when it adds something the facts don't.
 - That is 60-98 sentences of story content alone
 - Add intro (2-3 sentences), hook (1 sentence), Spotlight (5-7 sentences), tomorrow teaser (2 sentences), closing
-- Total: 75-110+ sentences, producing a 12-15 minute episode
+- Total: 75-110+ sentences, producing a 12-13 minute episode
 - This is a science NEWS show, not an analysis show. Lead with the actual research findings — sample sizes, mechanisms, p-values, specific molecules — not with "this could lead to" sentences.
 
 RULES:
@@ -132,7 +132,7 @@ WHAT TO SKIP (do NOT read aloud):
 - "Quick scan" lines — skip entirely
 
 LENGTH TARGET:
-Your script must be at least 2400 words (60+ sentences). If you find yourself finishing early, COVER MORE STORIES from the digest — or add more concrete research details (methodology, sample size, journal, specific molecules, quotes) to stories you've already covered. Do NOT pad existing stories with "this could lead to" sentences, "the implications touch everything from" sentences, or rephrased findings. If the digest is genuinely short, let the episode be shorter rather than fill space with editorial padding.
+Your script must be at least 1,800 words (60+ sentences, aim for 1,800–2,100). If you find yourself finishing early, COVER MORE STORIES from the digest — or add more concrete research details (methodology, sample size, journal, specific molecules, quotes) to stories you've already covered. Do NOT pad existing stories with "this could lead to" sentences, "the implications touch everything from" sentences, or rephrased findings. If the digest is genuinely short, let the episode be shorter rather than fill space with editorial padding.
 
 CROSS-PROMO (use sparingly — ONLY when the topic genuinely overlaps with another Nerra Network show, and ONLY in the closing or final lesson segment, single sentence max):
 - Space / astronomy / cosmology → "Fascinating Frontiers covers the latest from space and astronomy."

--- a/tests/test_phase3_calibration.py
+++ b/tests/test_phase3_calibration.py
@@ -71,7 +71,7 @@ class TestRecalibratedMinPodcastWords:
     EXPECTED = {
         "tesla":                   2000,  # June 10 2026 review: single 2,200-2,400-word target
         "fascinating_frontiers":   1700,  # June 10 2026 review: single 1,900-2,200-word target
-        "planetterrian":           1250,
+        "planetterrian":           1600,  # June 10 2026 PT pass: single 1,800-2,100-word target
         "modern_investing":        1800,  # June 10 2026 review: single 2,000-2,200-word target
         "omni_view":               900,
         "unintended_consequences": 1300,

--- a/tests/test_planetterrian_quality_pass.py
+++ b/tests/test_planetterrian_quality_pass.py
@@ -1,0 +1,108 @@
+"""Drift guards for the June 10 2026 Planetterrian quality pass
+(docs/planetterrian_review_2026_06_10.md) — same process as the Tesla
+flagship pass.
+
+Pins:
+* the network-wide missing-closing guard in engine/pipeline.py (PT
+  Ep081/Ep084 shipped without the supplied closing block — Ep084 ended
+  mid-teaser with no sign-off and no Closing chapter);
+* PT chapter markers carry positional anchors and the Closing pattern
+  covers "see you next" + every intros-pool closing variant;
+* the unified single length target (1,800-2,100 words; floor 1600).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from engine.intros import _SHOW_PERSONALITIES  # noqa: E402
+
+
+def _markers():
+    cfg = yaml.safe_load((_ROOT / "shows/planetterrian.yaml").read_text(encoding="utf-8"))
+    return cfg["chapters"]["section_markers"]
+
+
+class TestChapters:
+    def test_every_closing_variant_matched(self):
+        closing = next(m for m in _markers() if m["title"] == "Closing")
+        regex = re.compile(closing["pattern"], re.IGNORECASE)
+        for variant in _SHOW_PERSONALITIES["planetterrian"]["closings"]:
+            assert regex.search(variant), variant[:80]
+        # The Ep081 failure mode: a model-written "See you next time."
+        assert regex.search("See you next time.")
+
+    def test_positional_anchors(self):
+        by_title = {m["title"]: m for m in _markers()}
+        assert by_title["Introduction"].get("where") == "start"
+        assert by_title["Closing"].get("where") == "end"
+        assert by_title["Tomorrow Teaser"].get("where") == "end"
+
+
+class TestUnifiedLength:
+    def test_floor_and_single_target(self):
+        cfg = yaml.safe_load((_ROOT / "shows/planetterrian.yaml").read_text(encoding="utf-8"))
+        assert cfg["llm"]["min_podcast_words"] == 1600
+        prompt = (_ROOT / "shows/prompts/planetterrian_podcast.txt").read_text(encoding="utf-8")
+        assert "1,800–2,100 words" in prompt
+        assert "at least 2400 words" not in prompt
+        assert "12-15 minute" not in prompt
+
+
+class TestMissingClosingGuard:
+    """The pipeline appends the supplied closing block verbatim when the
+    LLM omitted it, BEFORE chapter parsing (so Closing always parses)."""
+
+    def _run(self, script: str, closing: str, monkeypatch):
+        from engine import pipeline as pl
+        captured = {}
+
+        def fake_generate(template_vars, config, tracker=None):
+            return script
+
+        def fake_parse(podcast_script, markers, show_name=""):
+            captured["script"] = podcast_script
+            return []
+
+        monkeypatch.setattr("engine.generator.generate_podcast_script", fake_generate)
+        monkeypatch.setattr("engine.generator.generate_digest",
+                            lambda *a, **k: "digest")
+        monkeypatch.setattr("engine.chapters.parse_chapters", fake_parse)
+        from types import SimpleNamespace
+        config = SimpleNamespace(
+            name="Planetterrian Daily", slug="planetterrian",
+            llm=SimpleNamespace(min_podcast_words=1600),
+            chapters=SimpleNamespace(enabled=True, section_markers=[{"pattern": "x", "title": "y"}]),
+            publishing=SimpleNamespace(host_name="Patrick"),
+        )
+        result = pl.run_generation_phase(
+            config, episode_num=85, today_str="June 10, 2026",
+            hook="hook", x_thread="# Digest\ncontent",
+            extra_context={"closing_block": closing},
+            template_vars={"digest": "d", "episode_num": 85},
+            args=None, tracker=None,
+        )
+        return captured.get("script", result[1])
+
+    def test_appends_when_missing(self, monkeypatch):
+        closing = ("That's Planetterrian Daily for today. I'm Patrick in "
+                   "Vancouver. Thanks for listening.")
+        script = "Patrick: Story one.\n\nPatrick: Next time, watch for the koala genome results."
+        out = self._run(script, closing, monkeypatch)
+        assert "That's Planetterrian Daily for today" in out
+
+    def test_no_double_append_when_present(self, monkeypatch):
+        closing = ("That's Planetterrian Daily for today. I'm Patrick in "
+                   "Vancouver. Thanks for listening.")
+        script = ("Patrick: Story one.\n\nPatrick: That's Planetterrian Daily "
+                  "for today. I'm Patrick in Vancouver. Thanks for listening.")
+        out = self._run(script, closing, monkeypatch)
+        assert out.count("That's Planetterrian Daily for today") == 1


### PR DESCRIPTION
Same review-then-fix process as #576/#577/#579, applied to Planetterrian Daily. Writeup: `docs/planetterrian_review_2026_06_10.md`. PT already inherited the engine fixes from #577 (memory hardening, theme scrub, OP3 performance loop) — this covers what remained. 2,677 tests pass.

**New, network-wide: missing-closing guard** (`engine/pipeline.py`). PT Ep081 ended "See you next time." with no closing block, and Ep084 ended *mid-teaser* with no sign-off, CTA, or Closing chapter — the LLM occasionally omits the "use this exact closing" block. The pipeline now appends the resolved `closing_block` verbatim when its opening signature is absent from the script's tail, before chapter parsing (so the Closing chapter always parses). Integration-tested against the real `run_generation_phase`.

**Length unified:** the prompt simultaneously demanded "10–13 minute", "12–15 minute", and "≥2400 words" while the YAML enforced 1250 — and all 15 recent episodes ran under even that (avg ~970). One target now: 1,800–2,100 words ≈ 12–13 min, floor 1600 (mirrors the FF twin). The 60% skip line lands at 960; the digest-carrying expand-retry from #576 must lift weak drafts past it. **Operator watch:** if PT writes more than one `podcast_script_too_thin` skip marker this week, drop the floor to 1400 rather than reverting the prompt. A/B-listen per landmine #17.

**Chapters:** `where: start|end` anchors + "see you next" in the Closing pattern (the Ep081 failure mode).

**Date framing:** all audited episodes predate the June 9/10 merges; the "banned tic" and under-target findings were pre-fix states, documented as such.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_