### PR TITLE
Workflow efficiency pass: shallow clones, Whisper cache, gallery consolidation, audit-target sync

### DIFF
--- a/.github/workflows/build-gallery-manifest.yml
+++ b/.github/workflows/build-gallery-manifest.yml
@@ -18,11 +18,13 @@ name: Build Gallery Manifest + Search Index
 # Note: nightly-maintenance.yml also runs the gallery + search builders as
 # part of its artifact refresh (for immediate post-show consistency).
 
+# June 2026 consolidation: the `workflow_run` trigger (a fresh runner after
+# EVERY Run Podcast Show completion, ~13/day) was removed — the run-show
+# finalize job now rebuilds the gallery manifest on the runner it already
+# has, and nightly-maintenance remains the daily safety rebuild. This
+# workflow stays for manual runs and builder-code changes.
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Run Podcast Show"]
-    types: [completed]
   push:
     branches: [main]
     paths:
@@ -44,9 +46,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Skip workflow_run firings where the upstream Run Podcast Show failed.
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -33,9 +33,9 @@ on:
     # old 12:15 slot ran *before* the tail and produced false "missed episode"
     # alarms + spurious auto-retries (e.g. 2026-06-02: audit at 12:15 flagged
     # MIT/Tesla/UC missed; they actually published at 14:21/14:59/15:51).
-    # Per-episode quality review still runs immediately via the workflow_run
-    # trigger below, so this later slot only delays the missed-sweep, not the
-    # quality checks. Tune later if GitHub delays worsen.
+    # (Stale-comment fix June 2026: the per-episode workflow_run trigger was
+    # removed earlier — this once-daily sweep reviews ALL of the day's
+    # committed episodes. Tune later if GitHub delays worsen.)
     - cron: '15 16 * * *'
 
   workflow_dispatch:

--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -46,7 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          # Shallow clone — nothing here reads git history, and the repo
+          # carries 2.2 GB of legacy MP3 history (landmine #1).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:

--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -214,7 +214,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          # Shallow clone (June 2026): nothing in the pipeline reads git
+          # history, and the repo carries 2.2 GB of legacy MP3 history
+          # (landmine #1) — a full clone cost minutes + GBs on every one
+          # of the ~13 daily jobs. The push step's `git pull --rebase`
+          # works fine from a depth-1 clone (it fetches what it needs).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:
@@ -222,6 +227,16 @@ jobs:
           requirements-file: 'requirements.txt'
           system-packages: 'ffmpeg'
           skip-checkout: 'true'
+
+      - name: Cache Whisper transcription model
+        # faster-whisper downloads ~150 MB from Hugging Face on every
+        # episode (unauthenticated, rate-limited, occasionally flaky —
+        # an HF hiccup degrades transcripts → captions → Shorts).
+        # The model is pinned ("base"), so a static cache key is safe.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: whisper-faster-base-v1
 
       - name: Install show-specific Python requirements
         run: |
@@ -242,27 +257,10 @@ jobs:
             tests/test_episode_validity.py tests/test_pipeline_safety.py \
             tests/test_phase2_growth.py tests/test_phase3_memory.py \
             tests/test_phase4_repositioning.py tests/test_social_distribution.py \
+            tests/test_chapters.py tests/test_tesla_quality_pass.py \
+            tests/test_four_show_quality_pass.py \
+            tests/test_russian_shows_quality_pass.py \
             -q --tb=short
-
-      - name: Create .env
-        run: |
-          cat > .env <<'ENVEOF'
-          GROK_API_KEY=${{ secrets.GROK_API_KEY }}
-          ELEVENLABS_API_KEY=${{ secrets.ELEVENLABS_API_KEY }}
-          X_CONSUMER_KEY=${{ secrets.X_CONSUMER_KEY }}
-          X_CONSUMER_SECRET=${{ secrets.X_CONSUMER_SECRET }}
-          X_ACCESS_TOKEN=${{ secrets.X_ACCESS_TOKEN }}
-          X_ACCESS_TOKEN_SECRET=${{ secrets.X_ACCESS_TOKEN_SECRET }}
-          X_BEARER_TOKEN=${{ secrets.X_BEARER_TOKEN }}
-          PLANETTERRIAN_X_CONSUMER_KEY=${{ secrets.PLANETTERRIAN_X_CONSUMER_KEY }}
-          PLANETTERRIAN_X_CONSUMER_SECRET=${{ secrets.PLANETTERRIAN_X_CONSUMER_SECRET }}
-          PLANETTERRIAN_X_ACCESS_TOKEN=${{ secrets.PLANETTERRIAN_X_ACCESS_TOKEN }}
-          PLANETTERRIAN_X_ACCESS_TOKEN_SECRET=${{ secrets.PLANETTERRIAN_X_ACCESS_TOKEN_SECRET }}
-          PLANETTERRIAN_X_BEARER_TOKEN=${{ secrets.PLANETTERRIAN_X_BEARER_TOKEN }}
-          BUTTONDOWN_API_KEY=${{ secrets.BUTTONDOWN_API_KEY }}
-          ENVEOF
-          # Strip leading whitespace from heredoc lines (YAML indentation artifact)
-          sed -i 's/^[[:space:]]*//' .env
 
       - name: Validate config before run
         run: |
@@ -325,6 +323,23 @@ jobs:
           exit $EXIT_CODE
         timeout-minutes: 45
         env:
+          # June 2026: secrets are passed directly as env vars instead of
+          # being written to a .env file via a heredoc + sed strip — same
+          # effect (load_dotenv never overrides existing env), no secrets
+          # on disk, no indentation-sensitive shell hack.
+          GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+          X_CONSUMER_KEY: ${{ secrets.X_CONSUMER_KEY }}
+          X_CONSUMER_SECRET: ${{ secrets.X_CONSUMER_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          X_BEARER_TOKEN: ${{ secrets.X_BEARER_TOKEN }}
+          PLANETTERRIAN_X_CONSUMER_KEY: ${{ secrets.PLANETTERRIAN_X_CONSUMER_KEY }}
+          PLANETTERRIAN_X_CONSUMER_SECRET: ${{ secrets.PLANETTERRIAN_X_CONSUMER_SECRET }}
+          PLANETTERRIAN_X_ACCESS_TOKEN: ${{ secrets.PLANETTERRIAN_X_ACCESS_TOKEN }}
+          PLANETTERRIAN_X_ACCESS_TOKEN_SECRET: ${{ secrets.PLANETTERRIAN_X_ACCESS_TOKEN_SECRET }}
+          PLANETTERRIAN_X_BEARER_TOKEN: ${{ secrets.PLANETTERRIAN_X_BEARER_TOKEN }}
+          BUTTONDOWN_API_KEY: ${{ secrets.BUTTONDOWN_API_KEY }}
           R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -569,7 +584,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: main
-          fetch-depth: 0
+          # Shallow — finalize only regenerates pages from working-tree
+          # state and pushes one commit.
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:
@@ -586,6 +603,13 @@ jobs:
           GOOGLE_ADS_ID: ${{ secrets.GOOGLE_ADS_ID }}
           GOOGLE_ADS_SIGNUP_LABEL: ${{ secrets.GOOGLE_ADS_SIGNUP_LABEL }}
           PLAUSIBLE_DOMAIN: ${{ secrets.PLAUSIBLE_DOMAIN }}
+          # R2 read creds for the gallery-manifest rebuild (clean no-op
+          # when unset — the builder writes an empty manifest).
+          R2_GALLERY_BUCKET: ${{ secrets.R2_GALLERY_BUCKET }}
+          R2_GALLERY_PUBLIC_BASE_URL: ${{ secrets.R2_GALLERY_PUBLIC_BASE_URL }}
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
           # Network homepage (latest episodes + blog posts from all shows)
           # Network-wide blog index (aggregates all shows' posts)
@@ -596,6 +620,12 @@ jobs:
           # Rebuild the global search index so new episodes are immediately searchable.
           # This (combined with the backfill in nightly) makes search reliable and up-to-date.
           python scripts/build_search_index.py --out site/data/search-index.json
+
+          # Gallery manifest (June 2026): previously a standalone workflow
+          # spun up a fresh runner after EVERY Run Podcast Show completion
+          # (~13/day) just to run this one script. Building it here reuses
+          # this runner; the nightly job remains the safety rebuild.
+          python scripts/build_gallery_manifest.py --out site/data/gallery-manifest.json
 
       - name: Commit and push shared pages
         run: |
@@ -609,6 +639,7 @@ jobs:
           git add api/*.json || true
           git add blog*.rss || true
           git add site/data/search-index.json || true
+          git add site/data/gallery-manifest.json || true
 
           if git diff --cached --quiet; then
             echo "Shared pages are already up to date."

--- a/docs/workflow_review_2026_06_10.md
+++ b/docs/workflow_review_2026_06_10.md
@@ -1,0 +1,93 @@
+# CI/CD Workflow Review — Efficiency, Reliability, Manageability (June 10, 2026)
+
+Review of all 11 GitHub Actions workflows + 4 composite actions, prompted by
+the operator's run-log review. Drift guards: `tests/test_workflow_efficiency.py`.
+
+## The estate (for orientation)
+
+| Workflow | Trigger | Role |
+|---|---|---|
+| run-show.yml | 12 staggered crons (06:00–11:30 UTC) | The pipeline: one matrix job per show + a finalize job for shared pages |
+| daily-audit.yml | 16:15 UTC | Quality review of the day's episodes, missed-episode sweep + auto-retry, GitHub issue |
+| nightly-maintenance.yml | 16:45 UTC | Audience stats, performance trackers, dashboard, content lake, gallery/search, heavy pages |
+| build-gallery-manifest.yml | dispatch + builder-code pushes | Manual/dev rebuilds (see consolidation below) |
+| weekly-newsletter.yml | Sun 14:00 | Weekly synthesis newsletters |
+| feed-audit (Sun), source-discovery (monthly), monthly-report, data-retention, buttondown-tag-subscriber, test.yml | various | Periodic upkeep |
+
+## Implemented
+
+### Efficiency
+1. **Shallow clones** (`fetch-depth: 0` → `1` in run-show's run + finalize jobs
+   and nightly-maintenance). The repo carries 2.2 GB of legacy MP3 history
+   (landmine #1); ~13 jobs/day were each cloning the full history for
+   pipelines that never read git history. `git pull --rebase` works fine from
+   a depth-1 clone. This is the single largest per-run time/bandwidth saving.
+2. **Whisper model cache** (`actions/cache` on `~/.cache/huggingface`).
+   faster-whisper re-downloaded ~150 MB from Hugging Face unauthenticated on
+   every episode (the run log shows the rate-limit warning) — an HF hiccup
+   degrades transcripts → captions → Shorts. The model is pinned, so a static
+   key is safe.
+3. **Gallery-manifest consolidation**: `build-gallery-manifest.yml`'s
+   `workflow_run` trigger spun up a fresh runner (checkout + pip install)
+   after EVERY Run Podcast Show completion (~13/day) to run one script.
+   The run-show **finalize** job now rebuilds the manifest on the runner it
+   already has (R2 read creds added to its env); nightly remains the safety
+   rebuild; the standalone workflow keeps dispatch + builder-code-push
+   triggers for development.
+
+### Reliability
+4. **Smoke suite extended** with the June 2026 drift guards
+   (`test_chapters`, `test_tesla_quality_pass`, `test_four_show_quality_pass`,
+   `test_russian_shows_quality_pass`) — the guards that pin the
+   listener-facing fixes now gate every episode, not just PR CI.
+5. **@TeslaAIBot removed from Tesla's X accounts** — the pasted Ep505 log
+   shows its fetched "posts" were emoji spam and a slur one-liner, polluting
+   the digest prompt (and previously the public content tracker). Also saves
+   one Grok x_search call per episode.
+6. **Secrets as env vars, not a .env file**: the `Create .env` heredoc + `sed`
+   indentation strip was replaced by an `env:` block on the pipeline step —
+   same semantics (`load_dotenv` never overrides existing env), no secrets
+   written to disk, no shell hack.
+
+### Manageability
+7. **Audit targets follow the YAMLs**: `review_episodes.py`'s hardcoded
+   `min_tts_words` registry desynced from `llm.min_podcast_words` every time
+   a quality pass retargeted a show (the June 9 audit flagged Tesla against
+   2200 while the enforced floor was 1600). The reviewer now reads the YAML
+   floor and falls back to the registry only if the config can't load.
+8. **Content-lake backfill noise**: the script loaded `_defaults.yaml`,
+   `_blocked_sources.yaml`, `network_meta.yaml`, etc. as "shows" (the log's
+   `Loaded config for ''` lines). Meta YAMLs are now skipped.
+9. **Stale comment fix** in daily-audit.yml (claimed a workflow_run trigger
+   that had already been removed).
+
+## Reviewed and deliberately NOT changed
+
+- **The 12 staggered crons**: superficially consolidatable into fewer matrix
+  triggers, but the stagger is load-bearing — it spreads publish times across
+  the morning, keeps per-show concurrency groups simple, and (most
+  importantly) limits concurrent `git push origin main` races between matrix
+  jobs, which are the source of the `commit_refs` transients (landmine #23).
+  Clustering shows into one matrix would *increase* push contention.
+- **daily-audit vs nightly-maintenance** stay separate: 30 minutes apart but
+  different concerns (paging gate vs heavy idempotent builds), different
+  permissions (issues:write vs contents:write), and the audit's auto-retry
+  must not share a failure domain with the artifact builds.
+- **Per-show requirements files** (`requirements_fascinating_frontiers.txt`,
+  `requirements_planetterrian.txt`) look redundant but isolate two shows'
+  extra deps from the other ten jobs/day.
+- **The finalize job running per workflow-run** (~13/day): it's the shared-
+  pages race-avoidance mechanism and now also carries the gallery rebuild —
+  each instance is cheap and the alternative (a single deferred build) would
+  delay episode pages for hours.
+- **pip caching** — already handled by the `setup-python` composite.
+
+## Future candidates (not done; revisit when they hurt)
+
+- **R2-migrate the legacy in-git MP3 history** (landmine #1) — would shrink
+  even shallow clones and is the real fix behind item 1.
+- **safe-commit-push recovery escape hatch** for nightly + the 8 other
+  callers (landmine #23 notes only run-show has the recovery-PR path; the
+  other callers' outputs are regenerable, so risk is low).
+- **HF_TOKEN secret** for authenticated Hugging Face pulls — moot while the
+  cache holds, useful if more Whisper models are ever used.

--- a/review_episodes.py
+++ b/review_episodes.py
@@ -432,6 +432,22 @@ def check_digest_length(ep: EpisodeReview, info: dict) -> None:
         ))
 
 
+def _config_min_words(show_slug: str) -> int:
+    """The show YAML's enforced word floor (llm.min_podcast_words), or 0.
+
+    June 2026: the registry's hardcoded ``min_tts_words`` desynced from
+    the YAMLs every time a quality pass retargeted a show — the audit
+    was flagging against stale numbers. The YAML is the single source
+    of truth for length; the registry value is only a fallback.
+    """
+    try:
+        from engine.config import load_config
+        cfg = load_config(PROJECT_ROOT / "shows" / f"{show_slug}.yaml")
+        return int(getattr(cfg.llm, "min_podcast_words", 0) or 0)
+    except Exception:
+        return 0
+
+
 def check_tts_script(ep: EpisodeReview, info: dict) -> None:
     """Check podcast script quality."""
     if not ep.tts_text:
@@ -439,7 +455,7 @@ def check_tts_script(ep: EpisodeReview, info: dict) -> None:
         return
 
     words = len(ep.tts_text.split())
-    min_words = info["min_tts_words"]
+    min_words = _config_min_words(ep.show_slug) or info["min_tts_words"]
 
     if words < min_words * 0.5:
         ep.issues.append(Issue(

--- a/scripts/backfill_content_lake.py
+++ b/scripts/backfill_content_lake.py
@@ -121,7 +121,13 @@ def main(argv=None):
 
     total_imported = 0
 
+    # Meta/config YAMLs that are not shows — loading them logs a noisy
+    # "Loaded config for ''" line and scans the digests root pointlessly.
+    _NON_SHOW_YAMLS = {"network_meta", "pronunciation_map", "scaffold_pending"}
+
     for config_path in sorted(SHOWS_DIR.glob("*.yaml")):
+        if config_path.stem.startswith("_") or config_path.stem in _NON_SHOW_YAMLS:
+            continue
         try:
             from engine.config import load_config
             cfg = load_config(str(config_path))

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -61,9 +61,10 @@ x_accounts:
   - handle: tslaming
     label: TSLAming
     max_posts: 3
-  - handle: TeslaAIBot
-    label: Tesla AI Bot
-    max_posts: 3
+  # TeslaAIBot removed June 2026 — its fetched posts were emoji spam and
+  # slur-bearing one-liners ("Laughing Emojis", "NY is full of liberal
+  # retards") that polluted the digest prompt and the content tracker
+  # (see Ep505 run log + the content-tracker junk filter in #576).
   - handle: Teslarati
     label: Teslarati
     max_posts: 3

--- a/tests/test_workflow_efficiency.py
+++ b/tests/test_workflow_efficiency.py
@@ -1,0 +1,86 @@
+"""Drift guards for the June 10 2026 workflow efficiency pass
+(docs/workflow_review_2026_06_10.md)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_WF = _ROOT / ".github" / "workflows"
+
+
+def _read(name: str) -> str:
+    return (_WF / name).read_text(encoding="utf-8")
+
+
+class TestRunShowWorkflow:
+    def test_shallow_checkouts(self):
+        """The repo carries 2.2 GB of legacy MP3 history (landmine #1);
+        fetch-depth 0 cost minutes + GBs on every one of ~13 daily jobs."""
+        wf = _read("run-show.yml")
+        assert "fetch-depth: 0" not in wf
+        assert wf.count("fetch-depth: 1") >= 2  # run + finalize
+
+    def test_whisper_model_cached(self):
+        wf = _read("run-show.yml")
+        assert "~/.cache/huggingface" in wf
+        assert "whisper-faster-base" in wf
+
+    def test_secrets_as_env_not_dotenv_file(self):
+        """Secrets go to the pipeline step's env block — no .env heredoc
+        on disk, no indentation-sensitive sed hack."""
+        wf = _read("run-show.yml")
+        assert "ENVEOF" not in wf
+        assert "Create .env" not in wf
+        assert "GROK_API_KEY: ${{ secrets.GROK_API_KEY }}" in wf
+        assert "BUTTONDOWN_API_KEY: ${{ secrets.BUTTONDOWN_API_KEY }}" in wf
+
+    def test_smoke_tests_include_quality_pass_guards(self):
+        wf = _read("run-show.yml")
+        for t in ("test_chapters.py", "test_tesla_quality_pass.py",
+                  "test_four_show_quality_pass.py",
+                  "test_russian_shows_quality_pass.py"):
+            assert t in wf, f"smoke suite must include {t}"
+
+    def test_finalize_builds_gallery_manifest(self):
+        wf = _read("run-show.yml")
+        assert "build_gallery_manifest.py" in wf
+        assert "R2_GALLERY_BUCKET" in wf
+
+
+class TestGalleryWorkflowConsolidated:
+    def test_no_per_show_workflow_run_trigger(self):
+        """A fresh runner per Run Podcast Show completion (~13/day) was
+        replaced by the finalize-job rebuild + nightly safety rebuild."""
+        wf = _read("build-gallery-manifest.yml")
+        assert "workflow_run:" not in wf
+        assert "workflow_dispatch:" in wf
+
+
+class TestNightlyShallow:
+    def test_nightly_shallow_checkout(self):
+        wf = _read("nightly-maintenance.yml")
+        assert "fetch-depth: 1" in wf
+        assert "fetch-depth: 0" not in wf
+
+
+class TestAuditTargetsFollowYaml:
+    def test_review_uses_config_floor(self):
+        src = (_ROOT / "review_episodes.py").read_text(encoding="utf-8")
+        assert "_config_min_words" in src
+        assert '_config_min_words(ep.show_slug) or info["min_tts_words"]' in src
+
+
+class TestTeslaXAccounts:
+    def test_teslaaibot_removed(self):
+        import yaml
+        cfg = yaml.safe_load((_ROOT / "shows" / "tesla.yaml").read_text(encoding="utf-8"))
+        handles = [a["handle"] for a in cfg["x_accounts"]]
+        assert "TeslaAIBot" not in handles
+
+
+class TestBackfillSkipsMetaYamls:
+    def test_meta_yaml_skip(self):
+        src = (_ROOT / "scripts" / "backfill_content_lake.py").read_text(encoding="utf-8")
+        assert "_NON_SHOW_YAMLS" in src
+        assert 'startswith("_")' in src


### PR DESCRIPTION
Review of all 11 GitHub Actions workflows + 4 composite actions, prompted by the operator's run-log review. Writeup: `docs/workflow_review_2026_06_10.md`. Drift guards: `tests/test_workflow_efficiency.py`. 2,691 tests pass (CI's actionlint also validates the workflow YAML).

## Efficiency
- **Shallow clones** (`fetch-depth: 0` → `1` on run-show's run + finalize jobs and nightly-maintenance): ~13 jobs/day were full-cloning a repo carrying 2.2 GB of legacy MP3 history (landmine #1) for pipelines that never read git history. `git pull --rebase` works fine from depth 1. Largest single per-run saving.
- **Whisper model cached** (`~/.cache/huggingface` via actions/cache): faster-whisper re-downloaded ~150 MB from Hugging Face unauthenticated on *every episode* (the rate-limit warning is in the pasted log) — and an HF hiccup degrades transcripts → captions → Shorts.
- **Gallery-manifest consolidation**: the standalone workflow's `workflow_run` trigger spun up a fresh runner (checkout + pip install) after every Run Podcast Show completion (~13/day) to run one script. The run-show **finalize** job now rebuilds the manifest on the runner it already has (R2 read creds added); nightly remains the safety rebuild; the standalone workflow keeps dispatch + builder-code-push triggers.

## Reliability
- **Smoke suite extended** with the June quality-pass drift guards (chapters + Tesla/four-show/Russian passes) so the listener-facing fixes gate every episode, not just PR CI.
- **@TeslaAIBot dropped from Tesla's X accounts** — its fetched posts in the Ep505 log were emoji spam and a slur one-liner polluting the digest prompt; also saves a Grok x_search call per episode.
- **Secrets as `env:` instead of a `.env` heredoc + `sed` strip** — same semantics, no secrets written to disk, no indentation-sensitive shell hack.

## Manageability
- **Audit targets follow the YAMLs**: `review_episodes.py` had a hardcoded word-target registry that desynced on every quality pass (June 9's audit flagged Tesla against 2200+ while the enforced floor was 1600). It now reads `llm.min_podcast_words` from the show YAML, registry as fallback.
- **Content-lake backfill** no longer loads `_defaults.yaml`/`network_meta.yaml`/etc. as "shows" (the `Loaded config for ''` log noise).
- Stale daily-audit comment fixed (referenced an already-removed trigger).

## Reviewed and deliberately NOT changed (rationale in the doc)
The 12 staggered crons (the stagger limits concurrent `git push` races — the `commit_refs` transients of landmine #23; clustering would make them worse), the daily-audit/nightly separation (paging gate vs heavy builds, different permissions), per-show requirements files, the per-run finalize job, pip caching (already in the composite).

## Future candidates
R2-migrating the legacy in-git MP3 history (the real fix behind shallow clones), the recovery-PR escape hatch for `safe-commit-push`'s other callers, HF_TOKEN.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_