### PR TITLE
Clone cost: correct landmine #1 to measured reality + guard HEAD against episode media

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -823,8 +823,23 @@ decision); everything else has a live status card.
 
 ### Active Issues
 
-1. **2.2 GB of MP3s in git** — repo will hit GitHub's 10 GB limit within ~6
-   months at current growth. Cloudflare R2 migration recommended.
+1. **2.2 GB of MP3s in git HISTORY (HEAD is clean)** — measured June 10
+   2026: zero episode MP3s are tracked at HEAD (guards in `.gitignore` +
+   the commit step's `git reset -- '*.mp3'`; only the 43 MB of
+   `assets/music` themes + two voice-reference WAVs remain, which the
+   pipeline needs). All enclosure URLs serve from R2. CI clones are
+   shallow since the June 2026 workflow pass (~115 MB packed vs ~2.5 GB
+   full), so the day-to-day clone cost is FIXED and growth is now
+   text-only (~50 MB/month → years of headroom under GitHub's 10 GB
+   limit). The history weight itself can only be removed by a
+   `git filter-repo` rewrite + force-push of main — DESTRUCTIVE:
+   requires a paused-cron window (12 daily workflows push to main and
+   could race the force-push and resurrect old history), invalidates
+   every existing clone, and dangles the commit SHAs referenced across
+   docs/. Playbook in
+   [`docs/workflow_review_2026_06_10.md`](docs/workflow_review_2026_06_10.md);
+   operator-scheduled, not urgent. For full local clones meanwhile:
+   `git clone --filter=blob:none` skips historical blobs.
 2. **Git LFS breaks RSS** — `raw.githubusercontent.com` returns pointer files
    for LFS-tracked content. Do NOT use LFS for MP3s.
 3. **Historical TST/OV flat files in `digests/`** — ~220 legacy output files

--- a/docs/workflow_review_2026_06_10.md
+++ b/docs/workflow_review_2026_06_10.md
@@ -84,8 +84,24 @@ the operator's run-log review. Drift guards: `tests/test_workflow_efficiency.py`
 
 ## Future candidates (not done; revisit when they hurt)
 
-- **R2-migrate the legacy in-git MP3 history** (landmine #1) — would shrink
-  even shallow clones and is the real fix behind item 1.
+- **History rewrite to drop the 2.2 GB of legacy MP3 blobs** (landmine #1).
+  Follow-up measurement (June 10 2026): HEAD is already clean — zero episode
+  MP3s tracked, all enclosures serve from R2, and a shallow CI clone is
+  ~115 MB packed — so the rewrite buys GitHub-storage headroom and faster
+  *full* clones only, not faster CI. Playbook when scheduled:
+  1. Pick a quiet window and disable the 12 run-show crons + nightly/audit
+     (a concurrent matrix-job push during the force-push can resurrect the
+     old history).
+  2. Fresh mirror clone; `git filter-repo --path-glob 'digests/**/*.mp3'
+     --path-glob 'digests/*.mp3' --invert-paths` (NEVER touch
+     `assets/music/` — the pipeline mixes those at runtime).
+  3. Force-push; re-enable crons; everyone re-clones (or
+     `git fetch && git reset --hard origin/main` on clean clones).
+  4. Accept that commit SHAs referenced in docs/ and old PRs dangle;
+     GitHub Support can run a server-side gc to reclaim space sooner.
+  Not urgent: with MP3s out of HEAD, growth is text-only
+  (~50 MB/month), leaving years of headroom under the 10 GB limit.
+  Interim for humans: `git clone --filter=blob:none`.
 - **safe-commit-push recovery escape hatch** for nightly + the 8 other
   callers (landmine #23 notes only run-show has the recovery-PR path; the
   other callers' outputs are regenerable, so risk is low).

--- a/tests/test_workflow_efficiency.py
+++ b/tests/test_workflow_efficiency.py
@@ -84,3 +84,23 @@ class TestBackfillSkipsMetaYamls:
         src = (_ROOT / "scripts" / "backfill_content_lake.py").read_text(encoding="utf-8")
         assert "_NON_SHOW_YAMLS" in src
         assert 'startswith("_")' in src
+
+
+class TestNoEpisodeMediaAtHead:
+    """The clone-cost fix holds only while HEAD stays free of episode
+    media (landmine #1: 2.2 GB of MP3s live in history; a shallow clone
+    still downloads every blob at HEAD)."""
+
+    def test_no_episode_mp3s_tracked(self):
+        import subprocess
+        out = subprocess.run(
+            ["git", "ls-files", "digests/*.mp3", "digests/**/*.mp3",
+             "digests/**/*.mp4", "digests/**/*.wav"],
+            capture_output=True, text=True, cwd=_ROOT,
+        ).stdout.strip()
+        assert out == "", f"episode media tracked at HEAD: {out[:200]}"
+
+    def test_gitignore_guards_present(self):
+        gi = (_ROOT / ".gitignore").read_text(encoding="utf-8")
+        assert "digests/**/*.mp3" in gi
+        assert "!assets/music/*.mp3" in gi


### PR DESCRIPTION
Follow-up to #582, answering "can you fix the clone cost now?" with measurements instead of the stale landmine text.

## Finding: the clone cost is already fixed

- **HEAD is clean**: zero episode MP3s are tracked — only the 43 MB of `assets/music` themes and two 1.4 MB voice-reference WAVs the pipeline actually needs. `.gitignore` guards + the commit step's `*.mp3` reset keep it that way.
- **All enclosure URLs serve from R2** (`audio.nerranetwork.com`, OP3-wrapped) — nothing references in-git audio.
- **A shallow CI clone is ~115 MB packed** (measured) vs ~2.5 GB full — the `fetch-depth: 1` change in #582 captured the whole win, because a depth-1 clone only downloads blobs at HEAD and HEAD has no episode media.
- The 2.2 GB exists **only in history**, and growth is now text-only (~50 MB/month) — years of headroom under GitHub's 10 GB limit, not the "~6 months" the landmine claimed.

## What this PR changes

1. **Landmine #1 rewritten** to the measured reality (it still recommended an "R2 migration" that effectively already happened, on a deadline that no longer exists).
2. **History-rewrite playbook documented** in `docs/workflow_review_2026_06_10.md` for whenever the operator wants the last ~2.2 GB gone from GitHub's storage: it requires `git filter-repo` + force-push of main inside a **paused-cron window** (a concurrent matrix-job push can resurrect the old history), invalidates every clone, and dangles commit SHAs referenced in docs — deliberately not executed now, with the day's episode crons starting minutes from this PR. Interim tip for humans: `git clone --filter=blob:none`.
3. **Drift guards**: `TestNoEpisodeMediaAtHead` fails CI if episode MP3/MP4/WAV files ever re-enter HEAD or the `.gitignore` guards are removed — the condition that keeps shallow clones small.

2,693 tests pass.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_