### PR TITLE
Scheduling punctuality: exact-time Worker dispatcher, off-peak crons, duplicate guard

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -6,6 +6,18 @@ on:
     # 8 AM Eastern (~12 UTC EDT / 13 UTC EST). Pipeline takes up to 45 min,
     # so triggers must be staggered by at least that much.
     #
+    # June 2026 punctuality pass: GitHub delivers `schedule` events
+    # best-effort and 1-6 h late in practice (Tesla's 11:00 cron observed
+    # starting 13:54). Three mitigations:
+    #   1. Cron minutes shifted off the contended :00/:30 marks (:07/:37).
+    #   2. An exact-time external dispatcher (workers/scheduler — Cloudflare
+    #      Cron Triggers fire to the minute) calls workflow_dispatch per
+    #      slot once the operator deploys it; these GitHub crons then act
+    #      as the delayed fallback.
+    #   3. The gate skips a scheduled run when today's episode already
+    #      landed (see the duplicate guard below), so dispatcher + late
+    #      fallback cron can never double-publish.
+    #
     # May 2026 schedule overhaul: 7 shows went daily (OV, PT, FF, M&A, MAB,
     # MIT, TST) with Sunday's slot becoming a "weekly recap" episode that
     # synthesises the past 7 days from the content lake. MIT also runs
@@ -13,35 +25,35 @@ on:
     # lessons learned). Cron times shifted +1h from the prior schedule.
     #
     # Привет, Русский!: Even days at 6:00 UTC
-    - cron: '0 6 2-31/2 * *'
+    - cron: '7 6 2-31/2 * *'
     # Omni View: Daily at 6:30 UTC (Sunday = weekly recap)
-    - cron: '30 6 * * *'
+    - cron: '37 6 * * *'
     # Planetterrian Daily: Daily at 7:00 UTC (Sunday = weekly recap)
-    - cron: '0 7 * * *'
+    - cron: '7 7 * * *'
     # Fascinating Frontiers: Daily at 7:30 UTC (Sunday = weekly recap)
-    - cron: '30 7 * * *'
+    - cron: '37 7 * * *'
     # Environmental Intelligence: Odd weekdays at 8:00 UTC
-    - cron: '0 8 1-31/2 * 1-5'
+    - cron: '7 8 1-31/2 * 1-5'
     # Models & Agents: Daily at 8:30 UTC (Sunday = weekly recap)
-    - cron: '30 8 * * *'
+    - cron: '37 8 * * *'
     # Models & Agents for Beginners: Daily at 9:00 UTC (Sunday = weekly recap)
-    - cron: '0 9 * * *'
+    - cron: '7 9 * * *'
     # Финансы Просто: Even days at 9:30 UTC
-    - cron: '30 9 2-31/2 * *'
+    - cron: '37 9 2-31/2 * *'
     # Modern Investing Techniques: Daily at 10:00 UTC.
     # Mon-Fri = US market preview; Sat = weekend angle (international
     # markets, crypto, lessons learned, what to prepare for, long-term
     # insights); Sun = weekly recap.
-    - cron: '0 10 * * *'
+    - cron: '7 10 * * *'
     # First Principles Daily: Daily at 10:30 UTC. Narrative show —
     # topic-queue-driven, no daily news fetch. Alternates concrete
     # example / opportunity area per episode. Runs all 7 days.
-    - cron: '30 10 * * *'
+    - cron: '37 10 * * *'
     # Tesla Shorts Time: Daily at 11:00 UTC (Sunday = weekly recap)
-    - cron: '0 11 * * *'
+    - cron: '7 11 * * *'
     # Unintended Consequences: Weekdays at 11:30 UTC. Narrative show —
     # topic-queue-driven, no daily news fetch. Mon-Fri only (5x/week).
-    - cron: '30 11 * * 1-5'
+    - cron: '37 11 * * 1-5'
 
   workflow_dispatch:
     inputs:
@@ -85,6 +97,8 @@ jobs:
       - name: Determine shows to run
         id: resolve
         shell: python3 {0}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           import json, os, datetime
 
@@ -117,18 +131,18 @@ jobs:
               # so some crons fire more often than intended.  The day_filter
               # applies the intended restriction.
               CRON_MAP = {
-                  "0 6 2-31/2 * *":   ("privet_russian",          "even"),
-                  "30 6 * * *":       ("omni_view",                None),
-                  "0 7 * * *":        ("planetterrian",            None),
-                  "30 7 * * *":       ("fascinating_frontiers",    None),
-                  "0 8 1-31/2 * 1-5": ("env_intel",               "odd_weekday"),
-                  "30 8 * * *":       ("models_agents",            None),
-                  "0 9 * * *":        ("models_agents_beginners",  None),
-                  "30 9 2-31/2 * *":  ("finansy_prosto",          "even"),
-                  "0 10 * * *":       ("modern_investing",         None),
-                  "30 10 * * *":      ("first_principles",         None),
-                  "0 11 * * *":       ("tesla",                    None),
-                  "30 11 * * 1-5":    ("unintended_consequences", "weekday"),
+                  "7 6 2-31/2 * *":   ("privet_russian",          "even"),
+                  "37 6 * * *":       ("omni_view",                None),
+                  "7 7 * * *":        ("planetterrian",            None),
+                  "37 7 * * *":       ("fascinating_frontiers",    None),
+                  "7 8 1-31/2 * 1-5": ("env_intel",               "odd_weekday"),
+                  "37 8 * * *":       ("models_agents",            None),
+                  "7 9 * * *":        ("models_agents_beginners",  None),
+                  "37 9 2-31/2 * *":  ("finansy_prosto",          "even"),
+                  "7 10 * * *":       ("modern_investing",         None),
+                  "37 10 * * *":      ("first_principles",         None),
+                  "7 11 * * *":       ("tesla",                    None),
+                  "37 11 * * 1-5":    ("unintended_consequences", "weekday"),
               }
 
               shows = []
@@ -166,6 +180,43 @@ jobs:
                   msg = f"WARNING: Unknown cron expression '{event_schedule}' — no show matched"
                   print(msg)
                   print(f"::warning::{msg}")
+
+              # Same-day duplicate guard (June 2026): with the external
+              # exact-time dispatcher (workers/scheduler) publishing on
+              # time and GitHub's delayed cron arriving hours later, the
+              # late cron must NOT produce a second episode. Each show
+              # job commits "Auto-generated: <show> <YYYY-MM-DD>"; if
+              # that commit already exists today, drop the show from
+              # this scheduled run. Applies to `schedule` events only —
+              # manual workflow_dispatch reruns stay possible.
+              if shows:
+                  import urllib.request
+                  token = os.environ.get("GITHUB_TOKEN", "")
+                  since = now_utc.strftime("%Y-%m-%dT00:00:00Z")
+                  today_str = now_utc.strftime("%Y-%m-%d")
+                  try:
+                      req = urllib.request.Request(
+                          f"https://api.github.com/repos/${{ github.repository }}/commits?since={since}&per_page=100",
+                          headers={"Authorization": f"Bearer {token}",
+                                   "Accept": "application/vnd.github+json"},
+                      )
+                      with urllib.request.urlopen(req, timeout=15) as resp:
+                          commits = json.load(resp)
+                      messages = [c.get("commit", {}).get("message", "") for c in commits]
+                      remaining = []
+                      for slug in shows:
+                          marker = f"Auto-generated: {slug} {today_str}"
+                          if any(m.startswith(marker) for m in messages):
+                              known_noop = True
+                              print(f"Duplicate guard: {slug} already published today "
+                                    f"(found '{marker}' commit) — skipping scheduled rerun.")
+                          else:
+                              remaining.append(slug)
+                      shows = remaining
+                  except Exception as exc:
+                      # Guard is best-effort: on API failure, run the show
+                      # (a duplicate is annoying; a missing episode is worse).
+                      print(f"Duplicate guard check failed ({exc}) — proceeding without it.")
 
           matrix = json.dumps(shows)
           print(f"Shows to run: {matrix}")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -883,6 +883,19 @@ decision); everything else has a live status card.
     yet have the recovery escape hatch (lower risk callers). Drift guard:
     the recovery script + the warning annotation in the Actions log.
 
+24. **Schedule punctuality: exact-time dispatcher + duplicate guard (June
+    2026)** — GitHub delivers cron `schedule` events 1-6 h late (Tesla's
+    11:00 slot observed starting 13:54). Fix: run-show crons moved to
+    off-peak :07/:37; `workers/scheduler/` (Cloudflare Cron Trigger,
+    fires to the minute) dispatches each show via `workflow_dispatch` at
+    its intended slot once the operator deploys it (fine-grained PAT →
+    `wrangler secret put GITHUB_DISPATCH_TOKEN`, `wrangler deploy` — see
+    its README); the gate's same-day duplicate guard (checks today's
+    "Auto-generated: <show> <date>" commit) lets the delayed GitHub cron
+    coexist as fallback without double-publishing. The Worker's SLOTS
+    table must stay in sync with the gate's CRON_MAP —
+    `tests/test_scheduling_punctuality.py` fails CI on drift.
+
 ### Resolved Issues (Feb 2026)
 
 4. **TST/OV output dirs fixed** — `shows/tesla.yaml` and `shows/omni_view.yaml`

--- a/docs/workflow_review_2026_06_10.md
+++ b/docs/workflow_review_2026_06_10.md
@@ -107,3 +107,32 @@ the operator's run-log review. Drift guards: `tests/test_workflow_efficiency.py`
   other callers' outputs are regenerable, so risk is low).
 - **HF_TOKEN secret** for authenticated Hugging Face pulls — moot while the
   cache holds, useful if more Whisper models are ever used.
+
+## Addendum — scheduling punctuality (June 10, 2026)
+
+Shows were publishing hours later than planned: GitHub delivers `schedule`
+events best-effort, observed **1–6 h late** (Tesla's `0 11 * * *` cron
+started at 13:54 on June 9; daily-audit had already been moved to 16:15 to
+cope). Three-layer fix, drift guards in
+`tests/test_scheduling_punctuality.py`:
+
+1. **Off-peak cron minutes** — all twelve crons moved from :00/:30 (the
+   most contended slots in GitHub's scheduler) to :07/:37. Helps the
+   fallback path; does not fix systemic delay by itself.
+2. **Exact-time dispatcher** — `workers/scheduler/` (Cloudflare Worker;
+   Cron Triggers fire to the minute) dispatches each show via
+   `workflow_dispatch` at its intended slot. One trigger
+   (`7,37 6-11 * * *`) maps firing time → show, mirroring the gate's
+   CRON_MAP (CI fails on drift). **Operator setup required once**: create
+   a fine-grained PAT (Actions: write on this repo), `wrangler secret put
+   GITHUB_DISPATCH_TOKEN`, `wrangler deploy` — see
+   `workers/scheduler/README.md`. Until deployed, behaviour is unchanged.
+3. **Same-day duplicate guard** — the gate drops a *scheduled* show when
+   today's `Auto-generated: <show> <date>` commit already exists (the
+   Worker published on time; the delayed GitHub cron arrives later and
+   must no-op). Best-effort: if the API check fails, the show runs — a
+   duplicate is annoying, a missing episode is worse. Manual
+   `workflow_dispatch` reruns are never blocked.
+
+GitHub crons stay enabled as the fallback: if the Worker is down,
+episodes ship late exactly as today — never not at all.

--- a/tests/test_scheduling_punctuality.py
+++ b/tests/test_scheduling_punctuality.py
@@ -1,0 +1,70 @@
+"""Drift guards for the June 2026 scheduling-punctuality pass.
+
+GitHub delivers `schedule` events 1-6 h late (Tesla's 11:00 cron observed
+starting 13:54). The fix is three-layered: off-peak cron minutes
+(:07/:37), an exact-time Cloudflare Worker dispatcher
+(workers/scheduler), and a same-day duplicate guard in the gate so the
+two drivers never double-publish. These tests pin all three AND that the
+Worker's SLOTS table stays in sync with the workflow's CRON_MAP.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_WF = (_ROOT / ".github" / "workflows" / "run-show.yml").read_text(encoding="utf-8")
+_TS = (_ROOT / "workers" / "scheduler" / "src" / "index.ts").read_text(encoding="utf-8")
+
+
+def _cron_map() -> dict:
+    """Parse CRON_MAP entries: "M H ..." -> (show, day_filter|None)."""
+    entries = {}
+    for m in re.finditer(
+        r'"(\d+) (\d+) [^"]*":\s*\("(\w+)",\s*(?:"(\w+)"|None)\)', _WF,
+    ):
+        minute, hour, show, day_filter = m.groups()
+        entries[show] = (int(hour), int(minute), day_filter)
+    return entries
+
+
+def _worker_slots() -> dict:
+    entries = {}
+    for m in re.finditer(
+        r'\[(\d+),\s*(\d+),\s*"(\w+)",\s*(?:"(\w+)"|null)\]', _TS,
+    ):
+        hour, minute, show, day_filter = m.groups()
+        entries[show] = (int(hour), int(minute), day_filter)
+    return entries
+
+
+def test_cron_minutes_off_peak():
+    """Top-of-hour and half-hour marks are the most contended schedule
+    slots; every show cron must sit at :07/:37."""
+    crons = re.findall(r"- cron: '(\d+) ", _WF)
+    assert crons, "no crons parsed"
+    assert set(crons) <= {"7", "37"}, f"on-peak cron minutes present: {crons}"
+
+
+def test_worker_slots_match_cron_map():
+    cron_map = _cron_map()
+    slots = _worker_slots()
+    assert len(cron_map) == 12, f"CRON_MAP parse drift: {sorted(cron_map)}"
+    assert slots == cron_map, (
+        "workers/scheduler SLOTS desynced from run-show.yml CRON_MAP:\n"
+        f"  worker-only/changed: { {k: v for k, v in slots.items() if cron_map.get(k) != v} }\n"
+        f"  cron-map-only/changed: { {k: v for k, v in cron_map.items() if slots.get(k) != v} }"
+    )
+
+
+def test_worker_trigger_covers_all_slots():
+    toml = (_ROOT / "workers" / "scheduler" / "wrangler.toml").read_text(encoding="utf-8")
+    assert '"7,37 6-11 * * *"' in toml
+
+
+def test_gate_has_duplicate_guard():
+    assert "Duplicate guard" in _WF
+    assert "Auto-generated: {slug} {today_str}" in _WF
+    # The guard must be best-effort: API failure → run the show anyway.
+    assert "proceeding without it" in _WF

--- a/tests/test_unintended_consequences.py
+++ b/tests/test_unintended_consequences.py
@@ -348,11 +348,12 @@ class TestUCPodcastPromptRules:
 def test_cron_entry_exists_for_unintended_consequences():
     workflow = (REPO_ROOT / ".github" / "workflows" / "run-show.yml"
                 ).read_text(encoding="utf-8")
-    assert "30 11 * * 1-5" in workflow, (
-        "Cron line for Unintended Consequences (11:30 UTC weekdays) "
+    # June 2026 punctuality pass: crons moved off-peak to :37.
+    assert "37 11 * * 1-5" in workflow, (
+        "Cron line for Unintended Consequences (11:37 UTC weekdays) "
         "missing from run-show.yml"
     )
-    assert '"30 11 * * 1-5":' in workflow, (
+    assert '"37 11 * * 1-5":' in workflow, (
         "CRON_MAP entry for Unintended Consequences missing — show "
         "would fire but never run"
     )

--- a/workers/scheduler/README.md
+++ b/workers/scheduler/README.md
@@ -1,0 +1,31 @@
+# nerra-scheduler — exact-time show dispatcher
+
+GitHub Actions delivers `schedule` events best-effort (observed 1–6 h late,
+May–June 2026; Tesla's 11:00 UTC cron started at 13:54 on June 9). Cloudflare
+Cron Triggers fire to the minute. This Worker dispatches each show's
+`Run Podcast Show` run via `workflow_dispatch` at its intended slot.
+
+The GitHub crons in `run-show.yml` stay enabled as the delayed fallback;
+the gate's same-day duplicate guard (it checks for today's
+`Auto-generated: <show> <date>` commit) ensures the two drivers never
+double-publish. If this Worker is down, episodes still ship — just late,
+exactly as today.
+
+## One-time setup (operator)
+
+1. Create a **fine-grained PAT**: repo `Planetterrian/nerranetwork`,
+   permission **Actions: Read and write** only. 1-year expiry; calendar
+   reminder to rotate.
+2. `cd workers/scheduler`
+3. `wrangler secret put GITHUB_DISPATCH_TOKEN` (paste the PAT)
+4. `wrangler deploy`
+5. Verify next slot in the Cloudflare dashboard (Workers → nerra-scheduler
+   → Logs) and confirm the corresponding workflow run starts within ~1 min
+   of :07/:37.
+
+## Keeping it in sync
+
+`SLOTS` in `src/index.ts` mirrors `CRON_MAP` in
+`.github/workflows/run-show.yml`. `tests/test_scheduling_punctuality.py`
+parses both and fails CI on drift. When changing the schedule, update both
++ redeploy the Worker.

--- a/workers/scheduler/src/index.ts
+++ b/workers/scheduler/src/index.ts
@@ -1,0 +1,89 @@
+/**
+ * Exact-time dispatcher for the Run Podcast Show workflow.
+ *
+ * Mirrors the CRON_MAP in .github/workflows/run-show.yml — keep the two
+ * in sync (drift guard: tests/test_scheduling_punctuality.py parses both).
+ * dayFilter semantics match the gate: "even"/"odd" = UTC day of month
+ * parity, "weekday" = Mon-Fri, "odd_weekday" = both.
+ */
+
+interface Env {
+  GITHUB_DISPATCH_TOKEN: string;
+}
+
+const REPO = "Planetterrian/nerranetwork";
+const WORKFLOW = "run-show.yml";
+
+// [utcHour, utcMinute, show, dayFilter]
+const SLOTS: Array<[number, number, string, string | null]> = [
+  [6, 7,  "privet_russian",          "even"],
+  [6, 37, "omni_view",                null],
+  [7, 7,  "planetterrian",            null],
+  [7, 37, "fascinating_frontiers",    null],
+  [8, 7,  "env_intel",               "odd_weekday"],
+  [8, 37, "models_agents",            null],
+  [9, 7,  "models_agents_beginners",  null],
+  [9, 37, "finansy_prosto",          "even"],
+  [10, 7, "modern_investing",         null],
+  [10, 37, "first_principles",        null],
+  [11, 7, "tesla",                    null],
+  [11, 37, "unintended_consequences", "weekday"],
+];
+
+function dayFilterPasses(filter: string | null, now: Date): boolean {
+  const day = now.getUTCDate();
+  const weekday = now.getUTCDay(); // 0=Sun .. 6=Sat
+  const isWeekday = weekday >= 1 && weekday <= 5;
+  switch (filter) {
+    case "even":
+      return day % 2 === 0;
+    case "odd":
+      return day % 2 === 1;
+    case "weekday":
+      return isWeekday;
+    case "odd_weekday":
+      return day % 2 === 1 && isWeekday;
+    default:
+      return true;
+  }
+}
+
+async function dispatch(env: Env, show: string): Promise<void> {
+  const res = await fetch(
+    `https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW}/dispatches`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.GITHUB_DISPATCH_TOKEN}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "nerra-scheduler",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ ref: "main", inputs: { show } }),
+    },
+  );
+  if (res.status !== 204) {
+    const body = await res.text();
+    throw new Error(`workflow_dispatch for ${show} failed: ${res.status} ${body}`);
+  }
+  console.log(`Dispatched ${show}`);
+}
+
+export default {
+  async scheduled(controller: ScheduledController, env: Env): Promise<void> {
+    const now = new Date(controller.scheduledTime);
+    const slot = SLOTS.find(
+      ([h, m]) => h === now.getUTCHours() && m === now.getUTCMinutes(),
+    );
+    if (!slot) {
+      console.log(`No slot for ${now.toISOString()} — nothing to dispatch.`);
+      return;
+    }
+    const [, , show, filter] = slot;
+    if (!dayFilterPasses(filter, now)) {
+      console.log(`${show}: day filter '${filter}' not satisfied today — no-op.`);
+      return;
+    }
+    await dispatch(env, show);
+  },
+};

--- a/workers/scheduler/wrangler.toml
+++ b/workers/scheduler/wrangler.toml
@@ -1,0 +1,22 @@
+# Exact-time show dispatcher (June 2026 punctuality pass).
+#
+# GitHub Actions delivers `schedule` events best-effort — observed 1-6 h
+# late (Tesla's 11:00 UTC cron started at 13:54 on June 9 2026). Cloudflare
+# Cron Triggers fire to the minute, so this Worker dispatches each show's
+# run via the GitHub workflow_dispatch API at its intended time; the
+# GitHub crons in run-show.yml remain as delayed fallbacks, and the
+# gate's same-day duplicate guard prevents double-publishing.
+#
+# Deploy (one-time):
+#   cd workers/scheduler
+#   wrangler secret put GITHUB_DISPATCH_TOKEN   # fine-grained PAT, see README
+#   wrangler deploy
+name = "nerra-scheduler"
+main = "src/index.ts"
+compatibility_date = "2026-05-01"
+
+[triggers]
+# One trigger covering every slot (:07/:37 from 06:00-11:59 UTC); the
+# Worker maps the firing time to the show, mirroring run-show.yml's
+# CRON_MAP (drift guard: tests/test_scheduling_punctuality.py).
+crons = ["7,37 6-11 * * *"]


### PR DESCRIPTION
Answers "shows are creating later than planned — can we fix that?" The root cause isn't the config: GitHub delivers cron `schedule` events best-effort, observed **1–6 hours late** (Tesla's `0 11 * * *` started at 13:54 on June 9; daily-audit had already been pushed to 16:15 to cope). Three-layer fix, documented in the `docs/workflow_review_2026_06_10.md` addendum, drift guards in `tests/test_scheduling_punctuality.py`:

1. **Off-peak cron minutes** — all twelve run-show crons moved from :00/:30 (GitHub's most contended scheduler slots) to :07/:37, in both the schedule block and the gate's CRON_MAP (the existing cron-consistency tests pin the pairing; the UC-specific pin updated).

2. **Exact-time dispatcher — `workers/scheduler/`** (new Cloudflare Worker; Cron Triggers fire to the minute). One trigger (`7,37 6-11 * * *`) maps the firing time to the show — including the even/odd/weekday day filters — and calls `workflow_dispatch`. A CI guard parses the Worker's SLOTS table against the gate's CRON_MAP and fails on drift. **One-time operator setup** (until then, behaviour is unchanged): fine-grained PAT with *Actions: write* on this repo → `wrangler secret put GITHUB_DISPATCH_TOKEN` → `wrangler deploy` (see the Worker README).

3. **Same-day duplicate guard in the gate** — once the Worker publishes on time, GitHub's delayed fallback cron arrives hours later; the gate now drops a *scheduled* show when today's `Auto-generated: <show> <date>` commit already exists. Best-effort by design (API failure → the show runs anyway: a duplicate is annoying, a missing episode is worse), and manual `workflow_dispatch` reruns are never blocked.

Failure model after deploy: Worker healthy → episodes publish within ~1 minute of their slot. Worker down → GitHub crons ship them late, exactly as today — never not at all.

2,702 tests pass.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_