### PR TITLE
YouTube pipeline quality pass: dead config knobs, scene cycling, observability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -690,6 +690,25 @@ Rejected after verification: nav-cover empty alts (correct WCAG — visible
 text adjacent), search loading state (already exists), blog next-episode nav
 (already exists).
 
+### YouTube pipeline pass (June 10, 2026)
+
+Full video-pipeline review — writeup:
+[`docs/youtube_review_2026_06_10.md`](docs/youtube_review_2026_06_10.md);
+drift guards: `tests/test_youtube_quality_pass.py`. Headline: the
+**silent config-drop class** — `_build_nested` discarded YAML keys the
+dataclass didn't declare (now warns loudly + CI guard). Casualties fixed:
+`shorts_min_score_threshold` (Tesla's 3.5 never applied anywhere — the
+smart Shorts selector fell back to the voice start almost daily; the
+single-Short path additionally never passed a threshold at all),
+five NewsletterConfig fields (`requires_financial_disclaimer` was
+ALWAYS False on the dataclass path), and `_defaults.yaml`'s network-wide
+`min_audio_duration: 180` (dead inside the `audio:` block; now
+top-level). Viewer-facing: long-form slideshow scenes now CYCLE (≤25 s
+per image hold vs 168 s on Ep505) at zero added Grok-Imagine cost;
+`channel: ru` without `YOUTUBE_REFRESH_TOKEN_RU` warns loudly;
+`shorts_captions_path` metric records ASS vs SRT-fallback. Rejected with
+reasons in the doc: bitrate floor, more images, `-preset slow`.
+
 ### Scheduled Show Review Agent (June 2026)
 
 The manual quality-pass workflow (Tesla #573/#576, MIT #574, network #575)

--- a/docs/youtube_review_2026_06_10.md
+++ b/docs/youtube_review_2026_06_10.md
@@ -1,0 +1,82 @@
+# YouTube Pipeline Review — Shorts + Long-Form Quality (June 10, 2026)
+
+Review of the full video pipeline (engine/video.py, shorts_selector,
+captions, grok_imagine/visual_assets, video_metadata, youtube.py,
+thumbnails/end-cards, per-show YAML) for current shows (Tesla + MAB full,
+FF + MIT Shorts-only, FP/PR on @NerraRU) and future shows. Drift guards:
+`tests/test_youtube_quality_pass.py`.
+
+## Root-cause discovery: the silent config-drop class
+
+`_build_nested` instantiates config dataclasses and silently discarded any
+YAML key the dataclass didn't declare. Three live casualties found:
+
+1. **`shorts_min_score_threshold` (P0, the headline bug)** — Tesla's May
+   retune set 3.5 so the smart Shorts selector would actually pick
+   engaging beats for measured/narrative content. The field was never
+   declared on `YouTubeConfig`, so every episode ran at the 5.0 default —
+   Ep505's "best score 3.0 below threshold 5.0 → legacy start" fallback
+   was this bug. ALSO: the single-Short resolver
+   (`engine/youtube_shorts.py`) never passed the threshold to
+   `pick_engaging_window` at all. Both fixed; Tesla Shorts should start
+   at engaging beats from the next episode.
+2. **Five `NewsletterConfig` fields** (`requires_financial_disclaimer`,
+   `emoji`, `short_label`, `length_target_words`,
+   `newsletter_start_date`) — set in YAMLs, read via `getattr` on the
+   dataclass, silently defaulted. Most serious:
+   **`requires_financial_disclaimer` was always False**, so the FP and
+   MIT newsletters' YAML-requested financial disclaimer depended entirely
+   on the template path that happens to read the raw YAML dict. Declared
+   now; both access styles agree.
+3. **`min_audio_duration: 180`** sat inside `_defaults.yaml`'s `audio:`
+   block but is a top-level `ShowConfig` field — the network-wide
+   too-short-audio guard was dead for all 11 shows that didn't set it
+   top-level (only Tesla did). Moved to top level.
+
+**Class fix:** `_build_nested` now logs a WARNING naming any unknown key,
+and a CI guard asserts every `youtube:` key used in any show YAML is a
+declared field.
+
+## Viewer-facing improvements implemented
+
+- **Slideshow scene cycling (long-form)**: the May 12 cost retune (4
+  images/aspect) left each Grok-Imagine image on screen for 2–3 minutes
+  (Ep505: 673 s / 4 scenes = 168 s/image) — visually static. Scenes now
+  CYCLE in rotation so no image holds longer than ~25 s, restoring visual
+  rhythm at **zero** additional image cost (the retune's spend decision
+  stands).
+- **RU-channel observability**: `channel: ru` configured with
+  `YOUTUBE_REFRESH_TOKEN_RU` missing now logs an explicit WARNING instead
+  of an INFO "skipping" (FP/PR uploads had silently no-oped for days).
+- **Captions observability**: each Short records
+  `shorts_captions_path: ass | srt_fallback` in metrics so the operator
+  can see whether the TikTok-style per-word highlighting actually shipped.
+
+## Reviewed and rejected (with reasons)
+
+- **"Add `-b:v 5M` bitrate + lower CRF"** — rejected: the long-form is a
+  mostly-static slideshow; CRF 22 constant-quality already preserves it
+  well and a bitrate floor would inflate the 140 MB uploads (and upload
+  time) for negligible transcode gain. Revisit only if motion-heavy
+  content is added.
+- **"Buy more Grok images (16/episode) to fix cadence"** — rejected in
+  favour of cycling (above): same visual effect, $0 instead of doubling
+  image spend the operator deliberately halved.
+- **"Per-scene contexts skipped for long-form"** — false: both aspects go
+  through `_run_grok_path`, which passes `per_scene_contexts`.
+- **"`-preset slow`"** — deferred: 2–3× encode time on a step already
+  taking ~6 min, for marginal source-quality gain through YouTube's
+  re-encode. Benchmark someday; not now.
+- **Shorts duration assertion, hashtag-count knob, end-card context
+  text, thumbnail font-size trend metric** — P2s documented here for a
+  future pass; none affect current output correctness.
+
+## Future shows
+
+`scaffold_show.py` generates no `youtube:` block — a new show is
+YouTube-dark until the operator hand-copies one. Recommended (not
+implemented): scaffold a disabled-but-complete block
+(`enabled: false`, `image_queries` placeholder, `shorts_start_mode:
+smart`, category) so enabling is one flag flip. The
+`test_every_show_yaml_has_image_queries` guard already blocks shows from
+going video-live without curated queries.

--- a/engine/config.py
+++ b/engine/config.py
@@ -266,6 +266,20 @@ class NewsletterConfig:
     api_key_env: str = "BUTTONDOWN_API_KEY"
     status: str = "about_to_send"  # "about_to_send", "draft", or "scheduled"
     tag: str = ""  # Buttondown tag for per-show subscriber filtering
+    # June 10 2026: these fields were set in show YAMLs and read via
+    # getattr() on this dataclass — but never DECLARED here, so
+    # _build_nested silently dropped them and the getattr defaults always
+    # won. Most damaging: requires_financial_disclaimer was always False,
+    # so the financial-show newsletters shipped without the disclaimer
+    # their YAML requested. (Template paths that read the RAW yaml dict
+    # were unaffected — the two access styles had silently diverged.)
+    short_label: str = ""
+    emoji: str = ""
+    newsletter_start_date: str = ""
+    requires_financial_disclaimer: bool = False
+    length_target_words: int = 0
+    adjacent_shows: list = field(default_factory=list)
+    network_adjacencies: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -381,6 +395,13 @@ class YouTubeConfig:
     shorts_start_offset: Optional[float] = None
     # ``voice`` | ``first_chapter`` — see engine.youtube_shorts.
     shorts_start_mode: str = "voice"
+    # Smart-selector noise floor: candidate Shorts windows scoring below
+    # this fall back to the legacy voice start. June 10 2026 fix: this
+    # field was MISSING from the dataclass, so Tesla's 3.5 YAML override
+    # (May 2026 retune) was silently dropped by _build_nested and every
+    # episode ran at the 5.0 default — Ep505's "best score 3.0 below
+    # threshold 5.0" fallback was this bug, not a quiet news day.
+    shorts_min_score_threshold: float = 5.0
     # ``always`` | ``alternate_episodes`` — skip Shorts on odd episode
     # numbers to halve upload quota during phased rollout.
     shorts_upload_schedule: str = "always"
@@ -613,10 +634,23 @@ def _build_chapters(raw: dict) -> ChaptersConfig:
 
 
 def _build_nested(cls, raw: dict):
-    """Instantiate a dataclass from a dict, ignoring unknown keys."""
+    """Instantiate a dataclass from a dict, ignoring unknown keys.
+
+    Unknown keys are dropped for forward/backward compat, but LOUDLY —
+    a silently-ignored knob cost the Tesla smart-Shorts selector a month
+    of running at the wrong threshold (the YAML set a field the
+    dataclass didn't declare; see YouTubeConfig.shorts_min_score_threshold).
+    """
     if not raw or not isinstance(raw, dict):
         return cls()
     known = {f.name for f in cls.__dataclass_fields__.values()}
+    unknown = set(raw) - known
+    if unknown:
+        logger.warning(
+            "%s: ignoring unknown config key(s) %s — add the field to the "
+            "dataclass in engine/config.py if it's meant to do something",
+            cls.__name__, sorted(unknown),
+        )
     return cls(**{k: v for k, v in raw.items() if k in known})
 
 

--- a/engine/video.py
+++ b/engine/video.py
@@ -1115,13 +1115,32 @@ def build_long_form_video(
             audio_duration_s = _get_duration(str(audio_path)) or 0.0
         except Exception:
             audio_duration_s = 0.0
+        slideshow_scenes = list(scene_paths)
         if audio_duration_s > 0:
-            scene_duration_s = max(8.0, audio_duration_s / len(scene_paths))
+            scene_duration_s = max(8.0, audio_duration_s / len(slideshow_scenes))
+            # June 10 2026: cycle the scene list so no single image holds
+            # longer than ~25 s. The May 12 retune deliberately halved the
+            # Grok Imagine spend to 4 images/aspect, which left each scene
+            # on screen ~2-3 minutes on a full-length episode (Ep505: 4
+            # scenes over 673 s = 168 s/image) — visually static. Reusing
+            # the SAME images in rotation restores visual rhythm at zero
+            # additional image cost.
+            _MAX_SCENE_HOLD_S = 25.0
+            if scene_duration_s > _MAX_SCENE_HOLD_S and len(slideshow_scenes) > 1:
+                import math
+                target = math.ceil(audio_duration_s / _MAX_SCENE_HOLD_S)
+                slideshow_scenes = [
+                    slideshow_scenes[i % len(slideshow_scenes)]
+                    for i in range(target)
+                ]
+                scene_duration_s = max(
+                    8.0, audio_duration_s / len(slideshow_scenes),
+                )
         else:
             scene_duration_s = _SCENE_DURATION_SECONDS  # legacy 12 s
         try:
             _render_slideshow(
-                scene_paths, slideshow_path,
+                slideshow_scenes, slideshow_path,
                 scene_duration=scene_duration_s, fps=fps,
             )
             bg_path = slideshow_path

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -110,10 +110,21 @@ def get_channel_credentials_from_env(channel: str = "en"):
     refresh_token = os.getenv(f"YOUTUBE_REFRESH_TOKEN_{suffix}", "").strip()
 
     if not all([client_id, client_secret, refresh_token]):
-        logger.info(
-            "YouTube credentials not fully set for channel=%s — skipping",
-            channel,
-        )
+        if suffix == "RU" and client_id and client_secret:
+            # The EN pipeline works but the RU channel token specifically
+            # is missing — the show YAML *asked* for @NerraRU uploads and
+            # they are silently no-oping (June 2026 review: FP/PR shipped
+            # for days with youtube_enabled flipping on no upload).
+            logger.warning(
+                "YouTube channel=ru is configured for this show but "
+                "YOUTUBE_REFRESH_TOKEN_RU is not set — uploads will no-op "
+                "until the secret is added.",
+            )
+        else:
+            logger.info(
+                "YouTube credentials not fully set for channel=%s — skipping",
+                channel,
+            )
         return None
 
     return build_oauth_credentials(

--- a/engine/youtube_shorts.py
+++ b/engine/youtube_shorts.py
@@ -105,12 +105,21 @@ def resolve_shorts_start_offset(
             short_dur = float(
                 getattr(yt, "short_duration_seconds", 55.0) or 55.0
             )
+            # June 10 2026: pass the per-show noise floor. Tesla's 3.5
+            # override (May retune) never reached this path — the YAML
+            # field wasn't declared on YouTubeConfig AND this call left
+            # the selector at its 5.0 default, so measured/narrative
+            # shows fell back to the legacy voice start almost daily.
+            threshold = float(
+                getattr(yt, "shorts_min_score_threshold", 5.0) or 5.0
+            )
             best = pick_engaging_window(
                 transcript_path,
                 audio_offset=voice_offset,
                 audio_duration=audio_duration,
                 window_duration=short_dur,
                 min_start_final=voice_offset,
+                min_score_threshold=threshold,
             )
             if best is not None:
                 logger.info(

--- a/run_show.py
+++ b/run_show.py
@@ -4277,7 +4277,16 @@ def _publish_youtube(
                             )
                             if has_word_cues:
                                 this_srt_path = ass_candidate
+                                result["shorts_captions_path"] = "ass"
+                                logger.info(
+                                    "Shorts captions: per-word ASS path",
+                                )
                             else:
+                                result["shorts_captions_path"] = "srt_fallback"
+                                logger.info(
+                                    "Shorts captions: SRT fallback (no "
+                                    "word-level cues in transcript)",
+                                )
                                 srt_candidate = (
                                     work_dir / f"{base_name}_short{suffix}.srt"
                                 )

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -95,8 +95,14 @@ tts:
   # When true, any leak aborts the episode before mixing/publishing.
   tag_leak_hard_block: false
 
+# Network-wide minimum final-audio length guard (skip the episode if
+# shorter). June 10 2026 fix: this lived INSIDE the audio: block, but
+# it's a top-level ShowConfig field — AudioConfig silently dropped it,
+# so the 180 s guard was dead for every show that didn't also set it
+# top-level (only Tesla did, at 300).
+min_audio_duration: 180
+
 audio:
-  min_audio_duration: 180
   transition_sting: assets/music/transition_sting.mp3
   # Music timing — retuned May 13 2026 after operator listened to
   # TST Ep471 audio and asked for the outro to "let music run by

--- a/tests/test_slideshow_scene_cadence.py
+++ b/tests/test_slideshow_scene_cadence.py
@@ -83,18 +83,19 @@ def _capture_scene_duration(stub_paths, audio_duration_s, num_scenes=8):
 
 class TestSceneCadenceMatchesAudio:
 
-    def test_six_minute_episode_eight_scenes_44s_each(self, stub_paths):
-        """Typical Tesla / MAB episode: 360 s audio, 8 scenes →
-        45 s/scene (one cycle, no loops)."""
+    def test_six_minute_episode_cycles_to_25s_cap(self, stub_paths):
+        """June 10 2026: scenes CYCLE so no image holds longer than ~25 s
+        (360 s/8 = 45 s/scene used to ship — visually static; the scene
+        list now repeats in rotation at zero added image cost)."""
         dur = _capture_scene_duration(stub_paths, audio_duration_s=360.0)
-        assert dur == pytest.approx(45.0, rel=0.01), (
-            f"Expected ~45 s/scene for 360 s/8, got {dur}"
+        assert dur is not None and 8.0 <= dur <= 25.0, (
+            f"Expected ≤25 s/scene after cycling for 360 s/8, got {dur}"
         )
 
-    def test_ten_minute_episode_eight_scenes_75s_each(self, stub_paths):
-        """Long-form episode: 600 s audio, 8 scenes → 75 s/scene."""
+    def test_ten_minute_episode_cycles_to_25s_cap(self, stub_paths):
+        """600 s/8 = 75 s/scene pre-fix; cycling caps the hold at ≤25 s."""
         dur = _capture_scene_duration(stub_paths, audio_duration_s=600.0)
-        assert dur == pytest.approx(75.0, rel=0.01)
+        assert dur is not None and 8.0 <= dur <= 25.0
 
     def test_thirty_second_teaser_clamps_to_floor(self, stub_paths):
         """Very short audio gets clamped to the 8 s floor so scenes

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -765,9 +765,13 @@ def test_build_long_form_video_renders_slideshow_for_multi_scene(tmp_path,
 
     # Two ffmpeg invocations: stage-1 slideshow, stage-2 composite.
     assert len(captured_cmds) == 2
-    # Stage 1 has 3 inputs (one per scene), no audio output.
+    # Stage 1 has one input per scene SLOT, no audio output. June 2026:
+    # scenes cycle so no image holds >25 s — 360 s / 3 scenes would have
+    # been 120 s/image, so the list repeats (360/25 → 15 slots), each
+    # slot still drawn from the 3 source scenes.
     assert "-an" in captured_cmds[0]
-    assert captured_cmds[0].count("-i") == 3
+    assert captured_cmds[0].count("-i") >= 3
+    assert captured_cmds[0].count("-i") % 3 == 0  # whole cycles of the 3 scenes
     # Stage 2 uses -stream_loop on the slideshow MP4.
     assert "-stream_loop" in captured_cmds[1]
 

--- a/tests/test_youtube_quality_pass.py
+++ b/tests/test_youtube_quality_pass.py
@@ -1,0 +1,75 @@
+"""Drift guards for the June 10 2026 YouTube pipeline quality pass
+(docs/youtube_review_2026_06_10.md)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from engine.config import NewsletterConfig, YouTubeConfig, load_config  # noqa: E402
+
+
+class TestSilentConfigDropClass:
+    """The bug class behind this pass: YAML keys not declared on a
+    dataclass were silently dropped by _build_nested."""
+
+    def test_every_youtube_yaml_key_is_declared(self):
+        known = set(YouTubeConfig.__dataclass_fields__)
+        for f in sorted((_ROOT / "shows").glob("*.yaml")):
+            if f.stem.startswith("_") or f.stem in (
+                "network_meta", "pronunciation_map", "scaffold_pending",
+            ):
+                continue
+            yt = (yaml.safe_load(f.read_text(encoding="utf-8")) or {}).get("youtube") or {}
+            unknown = set(yt) - known
+            assert not unknown, f"{f.name}: undeclared youtube keys {sorted(unknown)}"
+
+    def test_unknown_keys_warn_loudly(self):
+        src = (_ROOT / "engine" / "config.py").read_text(encoding="utf-8")
+        assert "ignoring unknown config key(s)" in src
+
+    def test_tesla_threshold_resolves(self):
+        cfg = load_config(str(_ROOT / "shows" / "tesla.yaml"))
+        assert cfg.youtube.shorts_min_score_threshold == 3.5
+
+    def test_newsletter_fields_declared(self):
+        fields = set(NewsletterConfig.__dataclass_fields__)
+        for f in ("requires_financial_disclaimer", "emoji", "short_label",
+                  "length_target_words", "newsletter_start_date"):
+            assert f in fields
+        fp = load_config(str(_ROOT / "shows" / "finansy_prosto.yaml"))
+        assert fp.newsletter.requires_financial_disclaimer is True
+
+    def test_min_audio_duration_network_default_live(self):
+        ov = load_config(str(_ROOT / "shows" / "omni_view.yaml"))
+        assert ov.min_audio_duration == 180  # was dead inside the audio: block
+
+
+class TestShortsSelectorThresholdWired:
+    def test_single_short_path_passes_threshold(self):
+        src = (_ROOT / "engine" / "youtube_shorts.py").read_text(encoding="utf-8")
+        assert "shorts_min_score_threshold" in src
+        assert "min_score_threshold=threshold" in src
+
+
+class TestSlideshowSceneCycling:
+    def test_scene_hold_cap_present(self):
+        src = (_ROOT / "engine" / "video.py").read_text(encoding="utf-8")
+        assert "_MAX_SCENE_HOLD_S = 25.0" in src
+        assert "slideshow_scenes" in src
+
+
+class TestObservability:
+    def test_ru_token_warning(self):
+        src = (_ROOT / "engine" / "youtube.py").read_text(encoding="utf-8")
+        assert "YOUTUBE_REFRESH_TOKEN_RU is not set" in src
+
+    def test_shorts_captions_path_metric(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert 'result["shorts_captions_path"]' in src


### PR DESCRIPTION
Full review of the video pipeline (Shorts + long-form) for current and future shows. Writeup: `docs/youtube_review_2026_06_10.md`. Drift guards: `tests/test_youtube_quality_pass.py`. 2,745 tests pass.

## Headline: the silent config-drop class

`_build_nested` discarded any YAML key the target dataclass didn't declare — no warning, no error. Three live casualties, all verified:

- **`shorts_min_score_threshold` (the smart-Shorts bug):** Tesla's May retune set 3.5 so the selector would pick engaging beats for measured content — the field was never declared on `YouTubeConfig`, so every episode ran at 5.0 (Ep505: "best score 3.0 below threshold 5.0 → legacy start"). On top of that, the single-Short resolver never passed *any* threshold to `pick_engaging_window`. Both wired — Tesla Shorts should start at actual engaging beats from the next episode.
- **Five `NewsletterConfig` fields** set in YAMLs but undeclared — most seriously, **`requires_financial_disclaimer` was always `False`** on the dataclass read path used by `send_show_newsletter` (FP/MIT are the financial shows).
- **`min_audio_duration: 180`** in `_defaults.yaml` sat inside the `audio:` block but is a top-level field — the network-wide short-audio guard was dead for 11 of 12 shows.

**Class fix:** unknown nested-config keys now log a loud WARNING naming the key, and a CI guard asserts every `youtube:` key in every show YAML is declared.

## Viewer-facing improvements

- **Long-form slideshow scene cycling:** after the May cost retune halved image count, each Grok-Imagine image held the screen for 2–3 minutes (Ep505: 168 s/image). Scenes now cycle in rotation, capping any single hold at ~25 s — visual rhythm restored at **zero** added image spend (the operator's cost decision stands).
- **RU-channel observability:** `channel: ru` with `YOUTUBE_REFRESH_TOKEN_RU` missing now warns explicitly instead of an INFO "skipping" (FP/PR uploads had silently no-oped).
- **Captions observability:** `shorts_captions_path: ass | srt_fallback` metric per Short, so the dashboard can show whether the per-word TikTok-style captions actually shipped.

## Reviewed and rejected (reasons in the doc)

Bitrate floor + lower CRF (static slideshow content — would inflate 140 MB uploads for negligible transcode gain), buying more Grok images (cycling achieves the same at $0), `-preset slow` (2–3× encode time for marginal gain), and the audit agent's "per-scene contexts skipped for long-form" claim (false — both aspects share the wired path). Future-show note: scaffolding a disabled-but-complete `youtube:` block is documented as the next P2.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_