### PR TITLE
Fix event-driven review dispatch: allow github-actions bot actor

### DIFF
--- a/.github/workflows/show-review.yml
+++ b/.github/workflows/show-review.yml
@@ -104,6 +104,14 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: "/review-show ${{ steps.pick.outputs.slug }}"
+          # The daily audit's dispatch_quality_reviews.py triggers this
+          # workflow via `gh workflow run` with GITHUB_TOKEN, so the
+          # initiating actor is github-actions (a bot). Without this
+          # allowlist the action refuses bot-initiated runs — which broke
+          # the event-driven review path (observed 2026-06-10 on the
+          # fascinating_frontiers dispatch). Human dispatches are
+          # unaffected.
+          allowed_bots: "github-actions"
           claude_args: |
             --model claude-opus-4-8
             --allowedTools "Bash,Read,Write,Edit,MultiEdit,Glob,Grep,WebFetch,WebSearch"

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -147,6 +147,13 @@ class TestWorkflowWiring:
         text = WORKFLOW_PATH.read_text(encoding="utf-8")
         assert "already has an open review PR" in text
 
+    def test_bot_dispatch_is_allowed(self):
+        # The daily audit dispatches this workflow as the github-actions
+        # bot; claude-code-action refuses bot-initiated runs unless the
+        # actor is allowlisted (broke the event-driven path 2026-06-10).
+        text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        assert 'allowed_bots: "github-actions"' in text
+
 
 def _load_script(name):
     spec = importlib.util.spec_from_file_location(name, ROOT / "scripts" / f"{name}.py")


### PR DESCRIPTION
## TLDR

Fixes the broken **event-driven review path**: today's Daily Audit correctly dispatched an out-of-rotation review for `fascinating_frontiers` (editorial criticals), but the run died immediately with

```
Workflow initiated by non-human actor: github-actions (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

`dispatch_quality_reviews.py` triggers `show-review.yml` via `gh workflow run` with `GITHUB_TOKEN`, so the initiating actor is the `github-actions` bot — and `claude-code-action@v1` rejects bot-initiated runs unless allowlisted.

## Fix

- `allowed_bots: "github-actions"` on the action step (scoped to exactly that bot, not `*`), with a comment explaining why.
- Drift guard `test_bot_dispatch_is_allowed` in `tests/test_review_agent.py` (28 tests passing; actionlint clean).

Manual dispatches and the Tue/Fri cron were never affected (human/schedule actors). After merge, the audit-driven dispatch will work on its next firing — or you can re-trigger the fascinating_frontiers review manually any time.

https://claude.ai/code/session_01NAenutjxenfJMjcRkA7o5d

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAenutjxenfJMjcRkA7o5d)_