### PR TITLE
Show-count consistency: 12 shows everywhere, computed where possible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,7 +346,7 @@ Use `python scripts/scaffold_show.py` to generate YAML, prompts, output dirs, an
 - `GROK_API_KEY` — primary xAI key (all shows)
 - `ELEVENLABS_API_KEY` — ElevenLabs TTS (all shows)
 - `X_*` / `PLANETTERRIAN_X_*` — two separate X accounts
-- Voice IDs: **All 11 shows are on Grok TTS** as of the May 2026 full-network migration. The 8 English shows (including Tesla Shorts Time) share the operator's custom-trained voice `kdif6sqjcyiq`. Russian shows (FP/PR) use the custom Olya voice `0b875ae2`. ElevenLabs is no longer used in production but the API key + legacy settings stay in `_defaults.yaml` for emergency rollback. See landmine #17.
+- Voice IDs: **All 12 shows are on Grok TTS** as of the May 2026 full-network migration. The 10 English shows (including Tesla Shorts Time) share the operator's custom-trained voice `kdif6sqjcyiq`. Russian shows (FP/PR) use the custom Olya voice `0b875ae2`. ElevenLabs is no longer used in production but the API key + legacy settings stay in `_defaults.yaml` for emergency rollback. See landmine #17.
 - See `docs/env_var_inventory.md` for the complete inventory
 
 ### RSS Feeds

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nerra Network — Daily Podcast Network
 
-Automated daily podcast generation system running **11 shows** via a unified
+Automated daily podcast generation system running **12 shows** via a unified
 `run_show.py` runner + per-show YAML configs. Each show fetches news via RSS
 and xAI/Grok web search (or topic queues for narrative shows), generates a
 digest and podcast script via xAI/Grok, synthesizes audio via Grok TTS (full
@@ -53,7 +53,7 @@ All shows are available on **Apple Podcasts**, **Spotify**, and via **RSS**.
 ## Architecture
 
 ```
-run_show.py                     # Unified entry point for all 11 shows
+run_show.py                     # Unified entry point for all 12 shows
 ├── engine/                     # ~50 shared modules (see engine/ + CLAUDE.md)
 │   ├── config.py               # YAML deep-merge + ShowConfig dataclasses
 │   ├── fetcher.py              # RSS + web_search + x_search

--- a/editorial.html
+++ b/editorial.html
@@ -503,7 +503,7 @@
     <section class="editorial-hero">
         <h1>How we make every episode</h1>
         <p class="lede">
-            Nerra Network produces eleven podcasts using AI voice
+            Nerra Network produces 12 podcasts using AI voice
             synthesis. We're transparent about how that works — and
             equally transparent about where the human judgment
             (story selection, source curation, editorial standards)
@@ -652,7 +652,7 @@
             <div class="nn-footer-grid">
                 <div>
                     <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
-                    <p class="nn-footer-desc">Eleven shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                    <p class="nn-footer-desc">12 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
                 </div>
                 <div class="nn-footer-col">
                     <h4>Shows</h4>

--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -94,7 +94,7 @@ def convert_digest_to_email_html(markdown_text: str) -> str:
         '<a href="https://nerranetwork.com#subscribe" style="color: #6B47FF;">Subscribe to more shows</a>'
         '</p>'
         '<p style="margin: 8px 0; font-size: 0.8em; color: #a0aec0;">'
-        'Nerra Network &mdash; 11 daily podcasts, ad-free, from Vancouver, Canada.'
+        'Nerra Network &mdash; 12 daily podcasts, ad-free, from Vancouver, Canada.'
         '</p>'
     )
 

--- a/fascinating-frontiers-narrative.html
+++ b/fascinating-frontiers-narrative.html
@@ -664,7 +664,7 @@
             <div class="nn-footer-grid">
                 <div>
                     <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
-                    <p class="nn-footer-desc">Eleven shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                    <p class="nn-footer-desc">12 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
                 </div>
                 <div class="nn-footer-col">
                     <h4>Shows</h4>

--- a/generate_html.py
+++ b/generate_html.py
@@ -2172,8 +2172,8 @@ def generate_network_page(*, dry_run=False):
 
     context = {
         "path_prefix": "",
-        "page_title": "Nerra Network | 11 Daily Shows",
-        "meta_description": "Nerra Network — Eleven daily podcasts keeping you informed. Tesla, world news, space, science, environment, AI, modern investing, narrative case studies, Russian finance, and language learning. Independent, daily, free.",
+        "page_title": f"Nerra Network | {len(NETWORK_SHOWS)} Daily Shows",
+        "meta_description": f"Nerra Network — {len(NETWORK_SHOWS)} daily podcasts keeping you informed. Tesla, world news, space, science, environment, AI, modern investing, first-principles thinking, narrative case studies, Russian finance, and language learning. Independent, daily, free.",
         "meta_keywords": "podcast network, daily podcasts, Nerra Network, Tesla, space, science, AI, environment, history, unintended consequences",
         "theme_color": "#6B47FF",
         "og_image": f"{GITHUB_RAW}/assets/og-preview.png",
@@ -2756,7 +2756,7 @@ def generate_about_page(*, dry_run=False):
         "path_prefix": "",
         "page_title": "About — Nerra Network",
         "page_description": "Meet the independent podcast network producing 11 ad-free daily shows on AI, Tesla, investing, space, science, and environmental policy. Based in Vancouver, Canada.",
-        "meta_description": "About Nerra Network — an independent, ad-free podcast network producing 11 daily shows in Vancouver, Canada. Founded by Patrick Novak.",
+        "meta_description": f"About Nerra Network — an independent, ad-free podcast network producing {len(NETWORK_SHOWS)} daily shows in Vancouver, Canada. Founded by Patrick Novak.",
         "meta_keywords": "about Nerra Network, Patrick Novak, independent podcast network, Vancouver podcasts, ad-free podcasts",
         "theme_color": "#6B47FF",
         "og_image": "",
@@ -2964,7 +2964,7 @@ def generate_player_page(*, dry_run=False):
     context = {
         "path_prefix": "",
         "page_title": "Player | Nerra Network",
-        "meta_description": "Listen to all Nerra Network shows in one player. Build your queue, reorder episodes, and discover new content across 11 daily podcasts.",
+        "meta_description": f"Listen to all Nerra Network shows in one player. Build your queue, reorder episodes, and discover new content across {len(NETWORK_SHOWS)} daily podcasts.",
         "meta_keywords": "podcast player, Nerra Network, queue, playlist",
         "theme_color": "#6B47FF",
         "og_image": None,

--- a/generate_network_rss.py
+++ b/generate_network_rss.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate a combined Nerra Network RSS feed from all 11 show feeds."""
+"""Generate a combined Nerra Network RSS feed from all 12 show feeds."""
 
 import xml.etree.ElementTree as ET
 from email.utils import parsedate_to_datetime, format_datetime
@@ -25,7 +25,7 @@ OUTPUT = "network.rss"
 
 NETWORK_TITLE = "Nerra Network"
 NETWORK_DESCRIPTION = (
-    "Eleven podcasts in two languages keeping you informed about exciting changes in the world. "
+    "Twelve podcasts in two languages keeping you informed about exciting changes in the world. "
     "Unbiased, multi-perspective coverage of Tesla, world news, space, science, AI, "
     "the environment, modern investing, financial literacy, Russian language learning, "
     "and the unintended consequences of well-meant ideas."

--- a/models-agents-narrative.html
+++ b/models-agents-narrative.html
@@ -659,7 +659,7 @@
             <div class="nn-footer-grid">
                 <div>
                     <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
-                    <p class="nn-footer-desc">Eleven shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                    <p class="nn-footer-desc">12 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
                 </div>
                 <div class="nn-footer-col">
                     <h4>Shows</h4>

--- a/planetterrian-narrative.html
+++ b/planetterrian-narrative.html
@@ -664,7 +664,7 @@
             <div class="nn-footer-grid">
                 <div>
                     <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
-                    <p class="nn-footer-desc">Eleven shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                    <p class="nn-footer-desc">12 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
                 </div>
                 <div class="nn-footer-col">
                     <h4>Shows</h4>

--- a/scripts/buttondown_tag_subscriber.py
+++ b/scripts/buttondown_tag_subscriber.py
@@ -16,7 +16,7 @@ each show's ``newsletter.tag`` in ``shows/<slug>.yaml``.
 
 Usage::
 
-    # Tag the user across all 11 shows
+    # Tag the user across all 12 shows
     python scripts/buttondown_tag_subscriber.py user@example.com --all
 
     # Tag for specific shows

--- a/scripts/generate_api.py
+++ b/scripts/generate_api.py
@@ -4,7 +4,7 @@ Nerra Network API Generator
 Generates static JSON API files for the Nerra Network mobile app.
 
 This script produces:
-- api/shows.json: Metadata for all 11 shows
+- api/shows.json: Metadata for all 12 shows
 - api/episodes.json: Aggregated feed of recent episodes (last 100)
 - api/articles.json: All blog articles for news reader (last 100)
 - api/shows/{show_id}.json: Detailed show info with full episode list

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -389,7 +389,7 @@ def item_8_feature_flags(shows: List[Dict[str, Any]]) -> Dict[str, Any]:
 def item_11_tts_provider(shows: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Network-wide TTS provider invariant.
 
-    All 11 shows migrated to Grok TTS in the May 2026 full-network
+    All 12 shows run Grok TTS since the May 2026 full-network
     flip (CLAUDE.md landmine #17). ElevenLabs is the rollback path,
     not the live provider — accidental drift back to it would be a
     cost regression (Grok is ~36× cheaper per character) and a voice-
@@ -1153,7 +1153,7 @@ def aggregate_costs(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]:
     # - Surface for future live YT quota remaining (engine.youtube_quota already exists).
     episodes_7 = max(network_7.get("episodes", 0), 1)
     avg_per_episode = round(network_7["total"] / episodes_7, 4)
-    # Conservative: network ships ~60-70 episodes/week across 11 shows
+    # Conservative: network ships ~70-80 episodes/week across 12 shows
     projected_weekly = round(avg_per_episode * 65, 2)
 
     return {
@@ -1168,7 +1168,7 @@ def aggregate_costs(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]:
         "youtube_quota": {
             "enabled_shows_count": 2,  # TST + MAB only (per landmine #20 quota cap)
             "daily_insert_cost_units": 1600,  # long + short typical (see engine/youtube_quota.py)
-            "note": "Hard cap ~10k units/day per channel. Preflight + youtube_quota.py have the estimators. Only 2 shows currently enabled.",
+            "note": "Hard cap ~10k units/day per channel. Preflight + youtube_quota.py have the estimators. 6 shows enabled across 2 channels (EN: Tesla+MAB full, FF+MIT Shorts-only; RU: FP+PR) — see landmine #20.",
         },
     }
 

--- a/scripts/ping_directories.py
+++ b/scripts/ping_directories.py
@@ -2,7 +2,7 @@
 """Ping all podcast directories for all Nerra Network shows.
 
 Usage:
-    python scripts/ping_directories.py              # ping all 9 shows
+    python scripts/ping_directories.py              # ping every show feed
     python scripts/ping_directories.py tesla        # ping only Tesla Shorts Time
 """
 import sys

--- a/templates/about.html.j2
+++ b/templates/about.html.j2
@@ -207,7 +207,7 @@
             <div class="about-hero-inner">
                 <h1>About Nerra Network</h1>
                 <p class="lede">
-                    Eleven ad-free podcasts. One mission — help curious people stay informed
+                    {{ all_shows|length }} ad-free podcasts. One mission — help curious people stay informed
                     without drowning in noise, anxiety, or algorithmic outrage.
                 </p>
             </div>

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -149,7 +149,7 @@
         'footer_listen': 'Слушать' if _is_ru else 'Listen',
         'footer_connect': 'Контакты' if _is_ru else 'Connect',
         'footer_about': 'О сети' if _is_ru else 'About',
-        'footer_brand_desc': 'Одиннадцать подкастов. Без рекламы. Независимая сеть из Ванкувера, Канада.' if _is_ru else 'Eleven shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.',
+        'footer_brand_desc': ('Подкастов: ' ~ (all_shows|length) ~ '. Без рекламы. Независимая сеть из Ванкувера, Канада.') if _is_ru else ((all_shows|length) ~ ' shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.'),
         'footer_network_player': 'Плеер сети' if _is_ru else 'Network Player',
         'footer_network_rss': 'RSS сети' if _is_ru else 'Network RSS',
         'footer_about_network': 'О Nerra Network' if _is_ru else 'About Nerra Network',
@@ -337,7 +337,7 @@
                     <h4>{{ t.subscribe_h4 }}</h4>
                     <p>{{ t.subscribe_subtitle }}</p>
                     <div class="nn-subscribe-tags">
-                        {#- All 11 shows. Tag values must match each show's
+                        {#- Every show (count tracked dynamically). Tag values must match each show's
                             YAML ``newsletter.tag`` exactly so the same
                             tag is used by both the daily-send pipeline
                             AND footer signups (operator caught a 7-of-11

--- a/templates/editorial.html.j2
+++ b/templates/editorial.html.j2
@@ -103,7 +103,7 @@
     <section class="editorial-hero">
         <h1>How we make every episode</h1>
         <p class="lede">
-            Nerra Network produces eleven podcasts using AI voice
+            Nerra Network produces {{ all_shows|length }} podcasts using AI voice
             synthesis. We're transparent about how that works — and
             equally transparent about where the human judgment
             (story selection, source curation, editorial standards)

--- a/templates/how_to_listen.html.j2
+++ b/templates/how_to_listen.html.j2
@@ -228,7 +228,7 @@
             </div>
 
             <section class="htl-shows-section">
-                <h2>All 11 shows</h2>
+                <h2>All {{ all_shows|length }} shows</h2>
                 <p>Tap a platform link to open the show in the corresponding app.</p>
                 <table class="htl-table">
                     <thead>

--- a/templates/player_page.html.j2
+++ b/templates/player_page.html.j2
@@ -393,7 +393,7 @@
 <div class="nn-player-header">
   <div>
     <h1><span class="gradient-text">Network</span> Player</h1>
-    <p>All 11 shows. One queue. Your order.</p>
+    <p>All {{ all_shows|length }} shows. One queue. Your order.</p>
   </div>
   <button class="nn-player-refresh" id="refresh-btn" aria-label="Check for new episodes" title="Check for new episodes">
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M3 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/></svg>

--- a/templates/start_here.html.j2
+++ b/templates/start_here.html.j2
@@ -118,7 +118,7 @@
 {% block content %}
     <header class="start-hero">
         <h1>Not sure where to <span class="gradient-text">start</span>?</h1>
-        <p>We have 11 shows covering different topics. Pick what interests you most, or explore them all — every show is ad-free, and most run daily (a few publish on weekdays or alternating days).</p>
+        <p>We have {{ all_shows|length }} shows covering different topics. Pick what interests you most, or explore them all — every show is ad-free, and most run daily (a few publish on weekdays or alternating days).</p>
     </header>
 
     <div class="start-categories">

--- a/tests/test_show_count_consistency.py
+++ b/tests/test_show_count_consistency.py
@@ -1,0 +1,75 @@
+"""Drift guards for show-count consistency (June 11 2026 sweep).
+
+The network grew 10 → 11 → 12 shows and public surfaces fossilized at
+"Eleven shows" / "11 daily podcasts" in seven templates, the homepage
+metas, the newsletter footer, the network RSS description, and README.
+Living surfaces now either compute the count from ``all_shows`` /
+``NETWORK_SHOWS`` (templates + generate_html metas) or hardcode the
+current count and are pinned here, so adding show #13 fails CI with a
+list of every spot to update. Dated historical docs (docs/reviews/*,
+CLAUDE.md pass narratives) are deliberately NOT covered — they describe
+the network as it was.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+def _show_count() -> int:
+    import generate_html
+    return len(generate_html.NETWORK_SHOWS)
+
+
+def test_network_has_twelve_shows():
+    """When this fails you've added/removed a show — update the
+    hardcoded-count surfaces listed in the other tests, then bump this."""
+    assert _show_count() == 12
+
+
+def test_no_stale_count_phrases_in_templates():
+    stale = re.compile(
+        r"\b(?:eleven|ten|nine)\s+(?:ad-free\s+|daily\s+)?(?:shows|podcasts)\b"
+        r"|\b(?:9|10|11)\s+(?:daily\s+)?(?:shows|podcasts)\b"
+        r"|Одиннадцать подкаст",
+        re.IGNORECASE,
+    )
+    offenders = []
+    for f in (_ROOT / "templates").glob("*.j2"):
+        for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            if stale.search(line):
+                offenders.append(f"{f.name}:{i}: {line.strip()[:80]}")
+    assert not offenders, "stale show counts in templates:\n" + "\n".join(offenders)
+
+
+def test_templates_use_dynamic_count():
+    for name in ("about.html.j2", "editorial.html.j2", "how_to_listen.html.j2",
+                 "start_here.html.j2", "player_page.html.j2", "base.html.j2"):
+        src = (_ROOT / "templates" / name).read_text(encoding="utf-8")
+        assert "all_shows|length" in src, f"{name} no longer computes the show count"
+
+
+def test_hardcoded_count_surfaces_match():
+    n = str(_show_count())
+    surfaces = {
+        "engine/newsletter.py": f"{n} daily podcasts, ad-free",
+        "generate_network_rss.py": "Twelve podcasts in two languages",
+        "README.md": f"running **{n} shows**",
+        "CLAUDE.md": f"running {n} shows via a unified",
+    }
+    for rel, needle in surfaces.items():
+        src = (_ROOT / rel).read_text(encoding="utf-8")
+        assert needle in src, f"{rel}: expected {needle!r} (show count changed?)"
+
+
+def test_generate_html_metas_are_computed():
+    src = (_ROOT / "generate_html.py").read_text(encoding="utf-8")
+    assert src.count("{len(NETWORK_SHOWS)}") >= 4
+    assert "11 Daily Shows" not in src
+    assert "Eleven daily podcasts" not in src


### PR DESCRIPTION
Thorough sweep of the website + full codebase for show-count claims. The network is 12 shows, but public surfaces had fossilized at "Eleven shows" / "11 daily podcasts" (and one "all 9 shows") across seven templates, the homepage/about/player metas, the newsletter footer, the network RSS description, README, and the dashboard.

**The fix is structural, not just find-replace:**
- **Templates compute the count** — the footer brand line (English + Russian), about, editorial, how-to-listen, start-here, and player pages all render `{{ all_shows|length }}`, so show #13 updates them automatically. Verified by live render ("12 shows. Zero fluff" from real data).
- **generate_html metas compute `len(NETWORK_SHOWS)`** (homepage title/description, about, player); the homepage description also gains the missing "first-principles thinking" topic.
- **Hardcoded surfaces updated and pinned**: newsletter footer, network RSS ("Twelve podcasts in two languages"), README, script docstrings, dashboard comments — including the dashboard's stale "Only 2 shows currently enabled" YouTube note (now: 6 across 2 channels per landmine #20) — and CLAUDE.md's current-state voice claim (12 shows on Grok TTS, 10 English on the custom voice; was 11/8).

**Deliberately untouched:** dated historical records (`docs/reviews/*`, CLAUDE.md pass narratives like "the other ten shows", landmine #11's May snapshot) — they describe the network as it was — and the "7 shows" Sunday-recap references, which remain accurate (exactly 7 YAMLs carry the recap flag).

**Drift guard:** `tests/test_show_count_consistency.py` — adding show #13 fails CI with the list of every hardcoded surface to update, plus a stale-phrase blacklist over all templates.

2,770 tests pass. Site changes are source-only; the nightly regen propagates them.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_