### PR TITLE
Harden setup-python apt step against third-party mirror flakes

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -58,7 +58,12 @@ runs:
       if: inputs.system-packages != ''
       shell: bash
       run: |
-        sudo apt-get update -qq
+        # apt update is best-effort: third-party mirrors on the runner
+        # image (e.g. dl.google.com chrome-stable) intermittently serve
+        # Hash Sum mismatches and exit 100, which killed an entire
+        # episode run (FF, June 11 2026) even though our packages come
+        # from the Ubuntu archives and install fine from cached indexes.
+        sudo apt-get update -qq || sudo apt-get update -qq ||           echo "::warning::apt-get update failed twice — installing from cached indexes"
         sudo apt-get install -y -qq ${{ inputs.system-packages }}
 
     - name: Install dependencies


### PR DESCRIPTION
Today's Fascinating Frontiers episode run (11:58 UTC) died at `apt-get update` — a Hash Sum mismatch from **dl.google.com's chrome-stable repo** (a runner-image mirror inconsistency entirely unrelated to our stack) exited 100 and killed the whole episode, even though ffmpeg — the only package we install — comes from the Ubuntu archives and installs fine from cached indexes.

The composite's apt step is now retry-once-then-best-effort with a loud `::warning::`; the `apt-get install` itself still hard-fails if the package genuinely can't be installed. This removes a whole class of third-party-mirror flakes from the episode failure surface (the composite is used by run-show + 9 other workflows).

(FF's missing episode is being re-dispatched separately; the 16:15 audit's auto-retry would also have caught it.)

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_