### PR TITLE
Marketing readiness: beacon conversions + Consent Mode v2 cookieless flags

### DIFF
--- a/assets/js/consent.js
+++ b/assets/js/consent.js
@@ -63,6 +63,13 @@
         'analytics_storage': 'denied',
         'wait_for_update': 500,
     });
+    // Consent Mode v2 cookieless measurement (June 2026 marketing-
+    // readiness review): with denied defaults, these two flags let
+    // Google Ads attribute conversions via URL passthrough + send
+    // redacted cookieless pings instead of losing every non-consenting
+    // visitor's conversion entirely.
+    gtag('set', 'url_passthrough', true);
+    gtag('set', 'ads_data_redaction', true);
     if (stored && stored.state === 'accepted') {
         applyConsent('accepted');
     }

--- a/assets/js/tracking.js
+++ b/assets/js/tracking.js
@@ -40,14 +40,23 @@
                 form.querySelectorAll('input[name="tag"]:checked').forEach(function (cb) {
                     tags.push(cb.value);
                 });
+                // transport_type beacon: the form navigates to
+                // Buttondown immediately after submit, and non-beacon
+                // gtag hits fired during unload are frequently lost —
+                // fatal for an Ads campaign optimizing on this
+                // conversion (June 2026 marketing-readiness review).
                 track('newsletter_signup', {
                     tags: tags.join(','),
                     tag_count: tags.length,
                     location: window.location.pathname,
+                    transport_type: 'beacon',
                 });
                 // Fire Google Ads conversion if configured
                 if (window._GOOGLE_ADS_SIGNUP_TARGET) {
-                    track('conversion', { send_to: window._GOOGLE_ADS_SIGNUP_TARGET });
+                    track('conversion', {
+                        send_to: window._GOOGLE_ADS_SIGNUP_TARGET,
+                        transport_type: 'beacon',
+                    });
                 }
             });
         });
@@ -67,7 +76,9 @@
             else if (lower.indexOf('open.spotify.com') !== -1) directory = 'spotify';
             else if (lower.endsWith('.rss') || lower.indexOf('/podcast.rss') !== -1) directory = 'rss';
             if (!directory) return;
+            // Outbound click — beacon survives the navigation.
             track('subscribe_click', {
+                transport_type: 'beacon',
                 directory: directory,
                 show: link.getAttribute('data-show') || 'unknown',
                 location: window.location.pathname,


### PR DESCRIPTION
Pre-campaign review of the GA4 / Google Ads stack. Verdict: **the foundation is genuinely campaign-ready** — GA4 live with Consent Mode v2, conversion wiring in place, full UTM coverage — but two measurement-quality gaps would have quietly poisoned a conversion-optimized campaign, fixed here:

1. **Lossy conversions:** the newsletter-signup GA4 event + Ads conversion fire on form *submit*, while the page immediately navigates to Buttondown — non-beacon gtag hits during unload are frequently dropped. `newsletter_signup`, the Ads `conversion`, and outbound `subscribe_click` now use `transport_type: 'beacon'`.
2. **No cookieless recovery:** consent defaults are all-denied (correct) but lacked `url_passthrough` + `ads_data_redaction`, so every non-consenting visitor's conversion was lost entirely instead of recovered as modeled/cookieless. Both flags set.

The `AW-` Ads tag stays dormant by design until the operator creates the Ads account and sets the `GOOGLE_ADS_ID` + `GOOGLE_ADS_SIGNUP_LABEL` secrets — the template gating and conversion target auto-wire already exist.

2,770 tests pass. Static JS assets — live immediately on merge, no regen needed.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_