### PR TITLE
Look-and-feel pass: four screenshot-verified visual fixes

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -657,7 +657,11 @@ button { font-family: var(--font-ui); cursor: pointer; }
 .show-hero-tagline {
   font-family: var(--font-ui);
   font-size: 1.15rem; font-weight: 500;
+  /* Raw brand colors (Tesla red, deep blues) land near 3:1 on the dark
+     background — visibly murky (June 2026 look-and-feel pass). Tint
+     55/45 toward white: keeps the hue, clears AA contrast. */
   color: var(--show-color, var(--nn-purple));
+  color: color-mix(in srgb, var(--show-color, var(--nn-purple)) 55%, #fff);
   margin-bottom: var(--sp-4);
 }
 .show-hero-desc {
@@ -1332,7 +1336,12 @@ button { font-family: var(--font-ui); cursor: pointer; }
   .nn-global-search {
     max-width: 140px !important;
     margin-right: 0.25rem !important;
+    min-width: 90px !important;
   }
+  /* The full wordmark + search field + hamburger don't fit at phone
+     widths — the search box overlapped "Network" (June 2026 look-and-
+     feel pass). Keep the icon + "Nerra"; drop the second word. */
+  .nn-nav-logo .nn-wordmark-rest { display: none; }
   .nn-global-search input {
     font-size: 0.8rem !important;
     padding: 5px 6px !important;
@@ -1986,6 +1995,11 @@ body.menu-open {
 #nn-consent-banner .nn-consent-accept:hover { background: #6841ff; }
 @media (max-width: 480px) {
   #nn-consent-banner { flex-direction: column; align-items: stretch; }
+  /* In the column layout the text's flex-basis (320px, tuned for the
+     ROW layout's width) becomes HEIGHT — the banner ballooned to ~60%
+     of a phone viewport with a giant void (June 2026 look-and-feel
+     pass). Let it hug its content instead. */
+  #nn-consent-banner .nn-consent-text { flex: 0 0 auto; }
   #nn-consent-banner .nn-consent-actions { justify-content: stretch; }
   #nn-consent-banner .nn-consent-btn { flex: 1; }
 }

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -179,7 +179,7 @@
         <div class="nn-nav-inner">
             <a href="{{ path_prefix }}index.html" class="nn-nav-logo">
                 <img src="{{ path_prefix }}assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
-                <span class="gradient-text">Nerra</span> Network
+                <span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span>
             </a>
 
             {# Global search (Item 2, May 2026 review) — powered by server-built
@@ -281,7 +281,7 @@
         <div class="container">
             <div class="nn-footer-grid">
                 <div>
-                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
+                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span></div>
                     <p class="nn-footer-desc">{{ t.footer_brand_desc }}</p>
                 </div>
                 <div class="nn-footer-col">

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -937,7 +937,7 @@
                 const priceEl = document.getElementById('stock-price');
                 const changeEl = document.getElementById('stock-change');
                 const updatedEl = document.getElementById('stock-updated');
-                if (priceEl) priceEl.textContent = 'TSLA';
+                if (priceEl) priceEl.textContent = '\u2014';  // ticker label already says TSLA
                 if (changeEl) changeEl.textContent = msg || 'Market data unavailable';
                 if (updatedEl) updatedEl.textContent = '';
             }


### PR DESCRIPTION
Look-and-feel pass done with **real headless-Chromium renders** (desktop 1440px + mobile 390px) rather than code inspection — four visual defects found and each fix verified by re-render:

1. **Mobile consent banner ballooned to ~60% of the viewport** with a giant void between text and buttons. Root cause: the ≤480px media query flips the banner to `flex-direction: column`, but `.nn-consent-text` kept its row-tuned `flex-basis: 320px` — which becomes *height* in a column. Now hugs content (~120px card). This is the first thing every mobile visitor sees, so it's the highest-impact fix here.
2. **Mobile nav collision**: wordmark + search field + hamburger don't fit at phone widths — the search box rendered on top of "Network". The wordmark's second word now hides ≤480px (icon + "Nerra" remain) and the search can shrink to 90px.
3. **Show-page tagline contrast**: raw brand colors on the dark background sat near 3:1 (Tesla's "Shorting Tesla? Time's Up." was visibly murky). Tinted 55/45 toward white via `color-mix` with the plain-var fallback for older browsers — computed render now ~7.5:1, brand hue preserved.
4. **Stock widget error state read "TSLA TSLA Market data unavailable"** — the JS error path wrote the symbol next to the static ticker label. Now an em dash.

Source-only: `styles/main.css` is live the moment this merges; the two template changes propagate via the nightly regen. Before/after screenshots shared in chat.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_