### PR TITLE
Visual pass II: summaries page, blog-index titles, narrative polish

### DIFF
--- a/editorial.html
+++ b/editorial.html
@@ -187,7 +187,7 @@
         <div class="nn-nav-inner">
             <a href="index.html" class="nn-nav-logo">
                 <img src="assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
-                <span class="gradient-text">Nerra</span> Network
+                <span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span>
             </a>
 
             
@@ -651,7 +651,7 @@
         <div class="container">
             <div class="nn-footer-grid">
                 <div>
-                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
+                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span></div>
                     <p class="nn-footer-desc">12 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
                 </div>
                 <div class="nn-footer-col">

--- a/engine/blog.py
+++ b/engine/blog.py
@@ -166,6 +166,20 @@ def extract_blog_metadata(
     if not title and hook:
         title = hook[:80] + ("..." if len(hook) > 80 else "")
 
+    # June 2026 look-and-feel pass: when the extracted title is just the
+    # show name (digests lead with "# <Show Name>"), prefer the unique
+    # episode hook — previously normalized only on the post page, so
+    # every blog-INDEX card and feed item for a show carried an
+    # identical title. Lazy import avoids a module cycle.
+    if title and hook:
+        try:
+            from generate_html import NETWORK_SHOWS
+            _show_name = (NETWORK_SHOWS.get(show_slug) or {}).get("name", "")
+        except Exception:
+            _show_name = ""
+        if _show_name and (title == _show_name or title.startswith(_show_name)):
+            title = hook[:100].rstrip(" .,;:—-") + ("…" if len(hook) > 100 else "")
+
     # Fallback: derive hook from first substantive content paragraph
     if not hook:
         for line in lines:
@@ -222,6 +236,11 @@ def extract_blog_metadata(
     reading_time_min = max(1, round(word_count / 220))
 
     return {
+        # June 2026 look-and-feel pass: prefer the unique episode hook as
+        # the title HERE (not only in generate_blog_post_html) so blog
+        # INDEX cards and feeds stop titling every card with the show
+        # name. The post-page normalization remains as idempotent
+        # defense (a hook-derived title never equals the show name).
         "title": title,
         "date": date_str,
         "date_iso": parsed_date.strftime("%Y-%m-%d") if parsed_date else "",

--- a/fascinating-frontiers-narrative.html
+++ b/fascinating-frontiers-narrative.html
@@ -91,7 +91,7 @@
         <div class="nn-nav-inner">
             <a href="index.html" class="nn-nav-logo">
                 <img src="assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
-                <span class="gradient-text">Nerra</span> Network
+                <span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span>
             </a>
 
             
@@ -663,7 +663,7 @@
         <div class="container">
             <div class="nn-footer-grid">
                 <div>
-                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
+                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span></div>
                     <p class="nn-footer-desc">12 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
                 </div>
                 <div class="nn-footer-col">

--- a/models-agents-narrative.html
+++ b/models-agents-narrative.html
@@ -91,7 +91,7 @@
         <div class="nn-nav-inner">
             <a href="index.html" class="nn-nav-logo">
                 <img src="assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
-                <span class="gradient-text">Nerra</span> Network
+                <span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span>
             </a>
 
             
@@ -658,7 +658,7 @@
         <div class="container">
             <div class="nn-footer-grid">
                 <div>
-                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
+                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span></div>
                     <p class="nn-footer-desc">12 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
                 </div>
                 <div class="nn-footer-col">

--- a/planetterrian-narrative.html
+++ b/planetterrian-narrative.html
@@ -91,7 +91,7 @@
         <div class="nn-nav-inner">
             <a href="index.html" class="nn-nav-logo">
                 <img src="assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
-                <span class="gradient-text">Nerra</span> Network
+                <span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span>
             </a>
 
             
@@ -663,7 +663,7 @@
         <div class="container">
             <div class="nn-footer-grid">
                 <div>
-                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> Network</div>
+                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span></div>
                     <p class="nn-footer-desc">12 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
                 </div>
                 <div class="nn-footer-col">

--- a/styles/main.css
+++ b/styles/main.css
@@ -123,6 +123,7 @@ button { font-family: var(--font-ui); cursor: pointer; }
   display: flex; align-items: center; gap: var(--sp-8);
   list-style: none;
 }
+.nn-nav-links li { white-space: nowrap; }
 .nn-nav-links a {
   font-family: var(--font-ui);
   font-size: 0.9rem; font-weight: 500;

--- a/templates/narrative_page.html.j2
+++ b/templates/narrative_page.html.j2
@@ -82,7 +82,7 @@
               <strong>Notable claims surfaced on the show:</strong>
               {% for claim in prog.notable_claims %}
                 <div style="margin-top:4px; padding-left:8px; border-left:2px solid var(--nn-border);">
-                  Ep {{ claim.episode }} ({{ claim.date }}): "{{ claim.claim }}" — <em>Status: {{ claim.status }}</em>
+                  Ep {{ claim.episode }} ({{ claim.date }}): "{{ claim.claim }}" — <em>Status: {{ claim.status | replace('_', ' ') }}</em>
                 </div>
               {% endfor %}
             </div>

--- a/templates/summaries_page.html.j2
+++ b/templates/summaries_page.html.j2
@@ -8,7 +8,10 @@
 <li><a href="{{ path_prefix }}how-to-listen.html">{{ t.nav_listen }}</a></li>
 <li><a href="{{ path_prefix }}about.html">{{ t.nav_about }}</a></li>
 <li><a href="{{ path_prefix }}player.html">{{ t.nav_player }}</a></li>
-<li><a href="{{ path_prefix }}{{ show_page }}">{{ show_name }}</a></li>
+{# Show-name link removed from the DESKTOP nav (June 2026 look-and-feel
+   pass): the 9th flat item overflowed the bar at 1440px — links wrapped
+   to 2-3 lines and the search box collided with the wordmark. The page
+   header names the show; the mobile menu keeps the link. #}
 <li><a href="{{ path_prefix }}blog/{{ show_slug }}/index.html">Blog</a></li>
 <li><a href="{{ path_prefix }}{{ summaries_page }}">Summaries</a></li>
 <li><a href="{{ path_prefix }}{{ rss_file }}">RSS</a></li>
@@ -429,6 +432,8 @@
 
                 if (!trimmed) { flush(); out += '<p></p>'; continue; }
 
+                if (/^-{3,}$/.test(trimmed) || /^\u2014{3,}$/.test(trimmed) || /^\u2501{3,}$/.test(trimmed)) { flush(); out += '<hr style="border:none;border-top:1px solid var(--nn-border);margin:1rem 0;">'; continue; }
+                if (trimmed.startsWith('&gt; ')) { flush(); const hookText = trimmed.slice(5).replace(/\*\*([^*]+)\*\*/g, '$1'); out += `<p style="border-left:3px solid var(--show-color, var(--nn-purple));padding-left:0.75rem;font-weight:600;">${linkify(hookText)}</p>`; continue; }
                 if (trimmed.startsWith('### ')) { flush(); out += `<h3>${linkify(trimmed.slice(4))}</h3>`; continue; }
                 if (trimmed.startsWith('## '))  { flush(); out += `<h2>${linkify(trimmed.slice(3))}</h2>`; continue; }
                 if (trimmed.startsWith('# '))   { flush(); out += `<h1>${linkify(trimmed.slice(2))}</h1>`; continue; }

--- a/templates/tesla_narrative_page.html.j2
+++ b/templates/tesla_narrative_page.html.j2
@@ -87,7 +87,7 @@
               <strong>Notable claims surfaced on the show:</strong>
               {% for claim in prog.notable_claims %}
                 <div style="margin-top:4px; padding-left:8px; border-left:2px solid var(--nn-border);">
-                  Ep {{ claim.episode }} ({{ claim.date }}): "{{ claim.claim }}" — <em>Status: {{ claim.status }}</em>
+                  Ep {{ claim.episode }} ({{ claim.date }}): "{{ claim.claim }}" — <em>Status: {{ claim.status | replace('_', ' ') }}</em>
                 </div>
               {% endfor %}
             </div>


### PR DESCRIPTION
Second render-verified visual pass, covering the surfaces the first pass (#600) didn't reach: blog indexes, summaries pages, gallery, narrative trackers, about/FAQ, Russian pages, and 404. Three fixes, each confirmed by headless-Chromium re-render (before/after screenshots shared in chat):

1. **Summaries pages had a broken header at desktop** — their per-show nav override carries a 9th flat item (the full show name), overflowing the bar at 1440px: links wrapped to 2–3 lines and the search box collided with the wordmark. The item is dropped on desktop (the page header names the show; the mobile menu keeps the link), and nav links can no longer wrap mid-link. The episode renderer also displayed raw markdown — `> **hook**` and `---` as literal text — now a brand-bordered hook callout and proper `<hr>`s.

2. **Every blog-index card carried the show name as its title** ("Tesla Shorts Time" × every card) because the hook-preference normalization only ran on the post page. Moved into `extract_blog_metadata` so index cards and feeds get unique episode headlines; the post-page pass remains as idempotent defense. Verified: Tesla's index now shows four distinct hooks.

3. **Narrative tracker claim statuses rendered as raw snake_case** (`partially_on_track`) — humanized on both the Tesla and generic narrative templates.

Clean on render: blog index layout, narrative page, about, FAQ, 404, Russian show page, gallery structure (images blocked locally — R2). Source-only: CSS live on merge, the rest propagates via regen.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_