### PR TITLE
Close the duplicate-guard race: re-check after the concurrency lock

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -359,6 +359,25 @@ jobs:
         id: pipeline
         run: |
           set +e
+          # Post-concurrency duplicate re-check (June 12 2026): the gate's
+          # duplicate guard runs at QUEUE time — FF's hours-late fallback
+          # cron passed it while a dispatched run was still mid-pipeline,
+          # waited on the per-show concurrency lock, then shipped a second
+          # episode 11 minutes after the first. This re-check runs AFTER
+          # the lock + checkout, so it always sees the first run's commit.
+          # Scheduled triggers only — manual dispatch reruns stay possible.
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            OUTPUT_DIR="digests/${{ matrix.show }}"
+            [ "${{ matrix.show }}" = "tesla" ] && OUTPUT_DIR="digests/tesla_shorts_time"
+            git fetch origin main --depth=1 -q 2>/dev/null || true
+            git checkout origin/main -- "$OUTPUT_DIR" 2>/dev/null || true
+            TODAY=$(date -u +%Y%m%d)
+            if find "$OUTPUT_DIR" -name "*_${TODAY}.md" -o -name "*${TODAY}*.md" 2>/dev/null | grep -q .; then
+              echo "::notice::Duplicate re-check: ${{ matrix.show }} already published today — skipping scheduled rerun."
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
           EXTRA_FLAGS=""
           if [ "${{ github.event.inputs.test_mode }}" = "true" ]; then
             EXTRA_FLAGS="--test"

--- a/tests/test_scheduling_punctuality.py
+++ b/tests/test_scheduling_punctuality.py
@@ -68,3 +68,11 @@ def test_gate_has_duplicate_guard():
     assert "Auto-generated: {slug} {today_str}" in _WF
     # The guard must be best-effort: API failure → run the show anyway.
     assert "proceeding without it" in _WF
+
+
+def test_run_job_has_post_concurrency_duplicate_recheck():
+    """The gate's guard runs at queue time and can be stale by the time
+    the per-show concurrency lock releases (FF double-published June 12
+    2026). The run job must re-check after the lock + fresh checkout."""
+    assert "Post-concurrency duplicate re-check" in _WF
+    assert "Duplicate re-check" in _WF


### PR DESCRIPTION
Today's catch-up dispatches surfaced a race in the same-day duplicate guard: **Fascinating Frontiers published twice** (11:31 and 11:42 UTC). Sequence: my 11:20 dispatch was mid-pipeline (no commit yet) when FF's ~4.4-hour-late fallback cron arrived → the gate's duplicate guard checked at *queue* time, saw no commit, passed → the run waited on the per-show concurrency lock → then shipped a second episode 11 minutes after the first. Gate-time checking is inherently stale against in-flight runs.

**Fix:** the run job re-checks *inside* the pipeline step — after the concurrency lock releases, against a freshly fetched main — and reuses the existing `skipped` plumbing to exit cleanly with a `::notice::`. Scheduled triggers only (manual dispatch reruns stay possible); the gate-time guard remains as the cheap first filter. Drift guard added.

Today's FF duplicate itself is left in place — both are distinct, complete episodes, so listeners simply got a bonus; removing one would be feed surgery (delete the item, R2 audio, blog post, and renumber) that I'll do on request.

119 scheduling/integration tests pass; actionlint validates the workflow in CI.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_