### PR TITLE
SpaceX: live SPCX price pill, resources hub + Launch Dashboard

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -75,6 +75,13 @@ jobs:
         # api/op3_stats.json is missing or has no entry for a show.
         run: python scripts/update_performance_trackers.py
 
+      - name: Refresh SpaceX launch dashboard data
+        # Next/previous launch, 12-month cadence, and stats for
+        # spacex-dashboard.html (The Space Devs Launch Library 2). Keeps
+        # last-good cache on failure; refreshes even on days SpaceX's own
+        # run is skipped.
+        run: python scripts/fetch_spacex_launches.py --out api/spacex_launches.json || true
+
       - name: Generate Management Dashboard
         run: python scripts/generate_dashboard.py --out api/dashboard.json
 
@@ -111,6 +118,7 @@ jobs:
           python generate_html.py --show tesla
           # Homepage rebuild picks up the fresh popular-episodes rail +
           # newsletter subscriber social proof from the audience-stats step.
+          # --network also regenerates spacex-dashboard.html (data-light).
           python generate_html.py --network
           # Optionally regenerate full site if needed:
           # python generate_html.py --all
@@ -126,6 +134,7 @@ jobs:
             digests/fascinating_frontiers/fascinating_frontiers_performance_tracker.json
             digests/planetterrian/planetterrian_performance_tracker.json
             digests/spacex/spacex_performance_tracker.json
+            api/spacex_launches.json
             site/data/popular_episodes.json
             site/data/gallery-manifest.json
             site/data/search-index.json
@@ -134,7 +143,8 @@ jobs:
             modern-investing.html
             tesla-narrative.html
             tesla.html
-          commit-message: "Nightly maintenance: update dashboard + gallery + search index + MIT + Tesla narrative pages"
+            spacex-dashboard.html
+          commit-message: "Nightly maintenance: update dashboard + gallery + search index + MIT + Tesla narrative + SpaceX launch pages"
 
       - name: Notify on failure (webhook)
         if: failure() && env.NOTIFICATION_WEBHOOK_URL != ''

--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -543,6 +543,9 @@ jobs:
           # consumed by ``spacex.html`` JS so the SPCX pill has a
           # reliable same-origin source between runs.
           git add api/spcx.json || true
+          # SpaceX launch-dashboard data (next/previous launch, cadence,
+          # stats) for spacex-dashboard.html. Same reliability contract.
+          git add api/spacex_launches.json || true
           # Topic queues — narrative-mode shows mark topics as produced
           # after each successful run. Without committing this, every
           # narrative-show run re-picks the same first-unproduced topic

--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -538,6 +538,11 @@ jobs:
           # website shows "Market data unavailable" between runs
           # (operator caught this May 15 2026, TST Ep473).
           git add api/tsla.json || true
+          # SpaceX cached SPCX price — same contract as api/tsla.json
+          # above. Written by ``shows/hooks/spacex.py`` every SpaceX run,
+          # consumed by ``spacex.html`` JS so the SPCX pill has a
+          # reliable same-origin source between runs.
+          git add api/spcx.json || true
           # Topic queues — narrative-mode shows mark topics as produced
           # after each successful run. Without committing this, every
           # narrative-show run re-picks the same first-unproduced topic

--- a/api/spacex_launches.json
+++ b/api/spacex_launches.json
@@ -1,0 +1,197 @@
+{
+  "next": {
+    "id": "bad5ea8c-8b17-4cb3-a063-d427fb092275",
+    "name": "Falcon 9 Block 5 | Starlink Group 17-54",
+    "net": "2026-06-15T14:00:00Z",
+    "window_start": "2026-06-15T14:00:00Z",
+    "window_end": "2026-06-15T18:00:00Z",
+    "status": "Go",
+    "status_name": "Go for Launch",
+    "rocket": "Falcon 9",
+    "pad": "Space Launch Complex 4E",
+    "location": "Vandenberg SFB, CA, USA",
+    "mission": "Starlink Group 17-54",
+    "mission_type": "Communications",
+    "mission_description": "A batch of 24 satellites for the Starlink mega-constellation - SpaceX's project for space-based Internet communication system.",
+    "orbit": "Low Earth Orbit",
+    "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/falcon2520925_image_20221009234147.png",
+    "webcast": null,
+    "info_url": null
+  },
+  "previous": {
+    "id": "229267d8-74ca-4d0b-8711-b2efe621fc6b",
+    "name": "Falcon 9 Block 5 | Starlink Group 10-54",
+    "net": "2026-06-12T12:37:00Z",
+    "window_start": "2026-06-12T12:27:00Z",
+    "window_end": "2026-06-12T16:27:00Z",
+    "status": "Success",
+    "status_name": "Launch Successful",
+    "rocket": "Falcon 9",
+    "pad": "Space Launch Complex 40",
+    "location": "Cape Canaveral SFS, FL, USA",
+    "mission": "Starlink Group 10-54",
+    "mission_type": "Communications",
+    "mission_description": "A batch of 29 satellites for the Starlink mega-constellation - SpaceX's project for space-based Internet communication system.",
+    "orbit": "Low Earth Orbit",
+    "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/falcon2520925_image_20221009234147.png",
+    "webcast": null,
+    "info_url": null
+  },
+  "upcoming": [
+    {
+      "id": "229267d8-74ca-4d0b-8711-b2efe621fc6b",
+      "name": "Falcon 9 Block 5 | Starlink Group 10-54",
+      "net": "2026-06-12T12:37:00Z",
+      "window_start": "2026-06-12T12:27:00Z",
+      "window_end": "2026-06-12T16:27:00Z",
+      "status": "Success",
+      "status_name": "Launch Successful",
+      "rocket": "Falcon 9",
+      "pad": "Space Launch Complex 40",
+      "location": "Cape Canaveral SFS, FL, USA",
+      "mission": "Starlink Group 10-54",
+      "mission_type": "Communications",
+      "mission_description": "A batch of 29 satellites for the Starlink mega-constellation - SpaceX's project for space-based Internet communication system.",
+      "orbit": "Low Earth Orbit",
+      "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/falcon2520925_image_20221009234147.png",
+      "webcast": null,
+      "info_url": null
+    },
+    {
+      "id": "bad5ea8c-8b17-4cb3-a063-d427fb092275",
+      "name": "Falcon 9 Block 5 | Starlink Group 17-54",
+      "net": "2026-06-15T14:00:00Z",
+      "window_start": "2026-06-15T14:00:00Z",
+      "window_end": "2026-06-15T18:00:00Z",
+      "status": "Go",
+      "status_name": "Go for Launch",
+      "rocket": "Falcon 9",
+      "pad": "Space Launch Complex 4E",
+      "location": "Vandenberg SFB, CA, USA",
+      "mission": "Starlink Group 17-54",
+      "mission_type": "Communications",
+      "mission_description": "A batch of 24 satellites for the Starlink mega-constellation - SpaceX's project for space-based Internet communication system.",
+      "orbit": "Low Earth Orbit",
+      "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/falcon2520925_image_20221009234147.png",
+      "webcast": null,
+      "info_url": null
+    },
+    {
+      "id": "c3f48f48-0e0a-4bca-917e-de494cfca35b",
+      "name": "Falcon 9 Block 5 | BlueBird Block 2 #3-5",
+      "net": "2026-06-17T06:39:00Z",
+      "window_start": "2026-06-17T06:39:00Z",
+      "window_end": "2026-06-17T08:15:00Z",
+      "status": "Go",
+      "status_name": "Go for Launch",
+      "rocket": "Falcon 9",
+      "pad": "Space Launch Complex 40",
+      "location": "Cape Canaveral SFS, FL, USA",
+      "mission": "BlueBird Block 2 #3-5",
+      "mission_type": "Communications",
+      "mission_description": "AST SpaceMobile\u2019s Block 2 BlueBird satellites are designed to deliver up to 10 times the bandwidth capacity of the BlueBird Block 1 satellites, required to achieve 24/7 continuous cellular broadband service coverage in the United States, with beams designed to support a capacity of up to 40 MHz, enabling peak data transmission speeds up to 120 Mbps, supporting voice, full data and video applications. The Block 2 BlueBirds, featuring as large as 2400 square foot communications arrays, will be the largest satellites ever commercially deployed in Low Earth orbit once launched.\r\n\r\nThis launch will feature 3 satellites.",
+      "orbit": "Low Earth Orbit",
+      "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/f9_on_slc-40_2_image_20240919072420.jpg",
+      "webcast": null,
+      "info_url": null
+    },
+    {
+      "id": "5d4099bf-a0be-4f54-b236-b6ab3aed4146",
+      "name": "Falcon 9 Block 5 | NROL-179",
+      "net": "2026-06-18T08:54:00Z",
+      "window_start": "2026-06-18T08:54:00Z",
+      "window_end": "2026-06-18T09:29:00Z",
+      "status": "Go",
+      "status_name": "Go for Launch",
+      "rocket": "Falcon 9",
+      "pad": "Space Launch Complex 4E",
+      "location": "Vandenberg SFB, CA, USA",
+      "mission": "NROL-179",
+      "mission_type": "Government/Top Secret",
+      "mission_description": "Fourteenth batch of satellites for a reconnaissance satellite constellation built by SpaceX and Northrop Grumman for the National Reconnaissance Office to provide imaging and other reconnaissance capabilities.",
+      "orbit": "Unknown",
+      "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/falcon_9_on_slc_image_20241024165956.jpg",
+      "webcast": null,
+      "info_url": null
+    },
+    {
+      "id": "be8b4b0d-1989-48a5-a96d-e8e4d59ed8b3",
+      "name": "Falcon 9 Block 5 | Globalstar 2-R Mission 1 (x 9)",
+      "net": "2026-06-20T06:39:00Z",
+      "window_start": "2026-06-20T06:39:00Z",
+      "window_end": "2026-06-20T07:51:00Z",
+      "status": "TBC",
+      "status_name": "To Be Confirmed",
+      "rocket": "Falcon 9",
+      "pad": "Space Launch Complex 40",
+      "location": "Cape Canaveral SFS, FL, USA",
+      "mission": "Globalstar 2-R Mission 1 (x 9)",
+      "mission_type": "Communications",
+      "mission_description": "The Globalstar global mobile communications network offers global, digital real time voice, data and fax services via its Low Earth Orbit satellite constellation. The constellation operates in a 1410 km orbit inclined at 52 degrees.\r\n\r\nIn early 2022, Globalstar contracted with MDA for the construction of 17 new 2nd generation refresh satellites to replenish the existing constellation. Rocket Lab is sub-contracted to build the satellites' buses and the launch dispensers.",
+      "orbit": "Low Earth Orbit",
+      "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/falcon_9_image_20230807133459.jpeg",
+      "webcast": null,
+      "info_url": null
+    }
+  ],
+  "cadence_monthly": [
+    {
+      "month": "2025-07",
+      "count": 13
+    },
+    {
+      "month": "2025-08",
+      "count": 15
+    },
+    {
+      "month": "2025-09",
+      "count": 16
+    },
+    {
+      "month": "2025-10",
+      "count": 16
+    },
+    {
+      "month": "2025-11",
+      "count": 13
+    },
+    {
+      "month": "2025-12",
+      "count": 13
+    },
+    {
+      "month": "2026-01",
+      "count": 13
+    },
+    {
+      "month": "2026-02",
+      "count": 12
+    },
+    {
+      "month": "2026-03",
+      "count": 15
+    },
+    {
+      "month": "2026-04",
+      "count": 12
+    },
+    {
+      "month": "2026-05",
+      "count": 12
+    },
+    {
+      "month": "2026-06",
+      "count": 6
+    }
+  ],
+  "stats": {
+    "launches_ytd": 70,
+    "launches_last_30d": 14,
+    "launches_last_365d": 166,
+    "starlink_launches_ytd": 56,
+    "avg_days_between_last_365d": 2.2
+  },
+  "total_launches": 689,
+  "source": "thespacedevs_ll2",
+  "updated_at": "2026-06-13T03:05:08.697428+00:00"
+}

--- a/api/spcx.json
+++ b/api/spcx.json
@@ -1,0 +1,8 @@
+{
+  "symbol": "SPCX",
+  "price": 160.95,
+  "prev_close": 135.0,
+  "change_str": "+19.2%",
+  "source": "yfinance_history",
+  "updated_at": "2026-06-13T02:48:28.041642+00:00"
+}

--- a/generate_html.py
+++ b/generate_html.py
@@ -1293,6 +1293,20 @@ NETWORK_SHOWS = {
 }
 
 
+# Complete English nav/footer translation map for standalone pages that
+# extend base.html.j2 (dashboard, etc.). Mirrors the inline dicts the
+# narrative pages use, with the mobile-nav keys filled in so no label
+# renders empty.
+_NAV_T = {
+    "nav_shows": "Shows", "nav_blog": "Blog", "all_blog_posts": "All Blog Posts",
+    "show_blog_suffix": "Blog", "nav_start_here": "Start Here",
+    "nav_listen": "How to Listen", "nav_how_to_listen": "How to Listen",
+    "nav_about": "About", "nav_player": "Player", "nav_home": "Home",
+    "toggle_menu": "Toggle menu", "mobile_all_shows": "All Shows",
+    "mobile_blogs": "Blogs", "footer_network_status": "Network Status",
+}
+
+
 # Shows that render a live stock-price pill in the hero. Each show's
 # pipeline hook writes the same-origin JSON; the page JS reads it first
 # and falls back to Yahoo Finance via CORS proxies. yahoo_symbol is the
@@ -1854,6 +1868,49 @@ def generate_narrative_page(slug, *, dry_run=False):
         return out_path
     out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
     print(f"Wrote narrative page: {out_path}")
+    return out_path
+
+
+def generate_spacex_dashboard(*, dry_run=False):
+    """Render the SpaceX Launch Dashboard (spacex-dashboard.html).
+
+    A standalone themed page with a live next-launch countdown, time
+    since last launch, launch-cadence chart, SPCX price, and the upcoming
+    manifest. All data is read client-side from same-origin caches
+    (``api/spacex_launches.json`` + ``api/spcx.json``) with a live
+    Launch Library 2 fallback, so the page itself carries no data and
+    regenerates cheaply on every site build.
+    """
+    cfg = NETWORK_SHOWS.get("spacex")
+    if cfg is None:
+        return None
+    env = _get_jinja_env()
+    template = env.get_template("spacex_dashboard.html.j2")
+    context = {
+        "path_prefix": "",
+        "page_lang": "en",
+        "show_name": "SpaceX Daily",
+        "page_title": "SpaceX Launch Dashboard | Nerra Network",
+        "meta_description": (
+            "Live SpaceX launch dashboard — countdown to the next launch, time "
+            "since the last one, launch cadence, the upcoming manifest, and the "
+            "SPCX market picture. The companion to the SpaceX Daily podcast."
+        ),
+        "theme_color": cfg.get("brand_color", "#1A5CFF"),
+        "brand_color": cfg.get("brand_color", "#1A5CFF"),
+        "canonical_url": f"{GITHUB_RAW}/spacex-dashboard.html",
+        "og_image": f"{GITHUB_RAW}/{_url_encode_image(cfg['podcast_image'])}",
+        "rss_url": f"{cfg['rss_file']}",
+        "t": _NAV_T,
+        "all_shows": _build_all_shows_list(),
+    }
+    html = template.render(**context)
+    out_path = ROOT / "spacex-dashboard.html"
+    if dry_run:
+        print(f"[dry-run] Would write {out_path} ({len(html):,} bytes)")
+        return out_path
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
+    print(f"Wrote {out_path} ({len(html):,} bytes)")
     return out_path
 
 
@@ -2663,7 +2720,8 @@ def generate_sitemap(*, dry_run=False):
                   "about.html", "how-to-listen.html", "faq.html",
                   "press.html", "contact.html", "editorial.html",
                   "gallery.html", "player.html",
-                  "modern-investing-performance.html"]:
+                  "modern-investing-performance.html",
+                  "spacex-dashboard.html"]:
         if (ROOT / extra).exists():
             urls.append((f"{base}/{extra}", "0.5", _file_lastmod(ROOT / extra)))
 
@@ -3161,6 +3219,9 @@ def main():
         # Tesla Narrative page
         if args.show == "tesla":
             generate_tesla_narrative_page(dry_run=args.dry_run)
+        # SpaceX Launch Dashboard
+        if args.show == "spacex":
+            generate_spacex_dashboard(dry_run=args.dry_run)
         # Phase 3 narrative page for other memory-enabled shows (no-op otherwise)
         generate_narrative_page(args.show, dry_run=args.dry_run)
         if args.blogs:
@@ -3180,6 +3241,7 @@ def main():
         generate_start_here_page(dry_run=args.dry_run)
         generate_about_page(dry_run=args.dry_run)
         generate_gallery_page(dry_run=args.dry_run)
+        generate_spacex_dashboard(dry_run=args.dry_run)
         generate_how_to_listen_page(dry_run=args.dry_run)
         generate_press_page(dry_run=args.dry_run)
         generate_contact_page(dry_run=args.dry_run)
@@ -3208,6 +3270,9 @@ def main():
         generate_all_summaries(dry_run=args.dry_run)
     if args.network:
         generate_network_page(dry_run=args.dry_run)
+        # The SpaceX dashboard is data-light (reads same-origin caches at
+        # runtime) so it's cheap to regenerate on every network rebuild.
+        generate_spacex_dashboard(dry_run=args.dry_run)
         # --network --blogs: regenerate network blog index only (not all posts)
         if args.blogs:
             generate_network_blog_index(dry_run=args.dry_run)

--- a/generate_html.py
+++ b/generate_html.py
@@ -1293,6 +1293,90 @@ NETWORK_SHOWS = {
 }
 
 
+# Shows that render a live stock-price pill in the hero. Each show's
+# pipeline hook writes the same-origin JSON; the page JS reads it first
+# and falls back to Yahoo Finance via CORS proxies. yahoo_symbol is the
+# fallback ticker queried at query{1,2}.finance.yahoo.com.
+_STOCK_WIDGETS: dict = {
+    "tesla": {"ticker": "TSLA", "json_path": "/api/tsla.json", "yahoo_symbol": "TSLA"},
+    "spacex": {"ticker": "SPCX", "json_path": "/api/spcx.json", "yahoo_symbol": "SPCX"},
+}
+
+
+# Curated "best source of <topic> information" resource blocks for
+# scaffolded shows (the hardcoded NETWORK_SHOWS entries carry their own;
+# this layers rich resources onto shows defined in network_meta.yaml
+# without bloating that auto-generated file). Merged in below.
+_SCAFFOLD_SHOW_RESOURCES: dict = {
+    "spacex": {
+        "resource_categories": [
+            {
+                "title": "SpaceX — Official",
+                "resources": [
+                    {"name": "SpaceX.com", "url": "https://www.spacex.com", "desc": "The company's official site — vehicles, missions, and capabilities"},
+                    {"name": "SpaceX Launches", "url": "https://www.spacex.com/launches/", "desc": "Upcoming and past launches with mission details and webcasts"},
+                    {"name": "Starship", "url": "https://www.spacex.com/vehicles/starship/", "desc": "The fully reusable launch system built for the Moon and Mars"},
+                    {"name": "Starlink", "url": "https://www.starlink.com", "desc": "SpaceX's satellite-internet constellation — the company's cash engine"},
+                    {"name": "SpaceX on X", "url": "https://x.com/SpaceX", "desc": "Official launch announcements, webcasts, and mission updates"},
+                    {"name": "SpaceX on YouTube", "url": "https://www.youtube.com/@SpaceX", "desc": "Live launch webcasts and mission replays in full"},
+                ],
+            },
+            {
+                "title": "SPCX — Stock, Filings & the IPO",
+                "resources": [
+                    {"name": "SpaceX S-1 / Prospectus (SEC EDGAR)", "url": "https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&company=space+exploration+technologies&type=S-1&dateb=&owner=include&count=40", "desc": "The registration statement behind the June 2026 IPO — the numbers, straight from the source"},
+                    {"name": "SEC EDGAR — all SpaceX filings", "url": "https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&company=space+exploration+technologies&type=&dateb=&owner=include&count=40", "desc": "Every public filing as it lands — 10-Ks, 10-Qs, 8-Ks, insider forms"},
+                    {"name": "SPCX on Yahoo Finance", "url": "https://finance.yahoo.com/quote/SPCX", "desc": "Real-time quote, charts, financials, and analyst coverage"},
+                    {"name": "SPCX on TradingView", "url": "https://www.tradingview.com/symbols/NASDAQ-SPCX/", "desc": "Advanced charting, technicals, and community trade ideas"},
+                    {"name": "SPCX on Nasdaq", "url": "https://www.nasdaq.com/market-activity/stocks/spcx", "desc": "Exchange-of-record quote page, volume, and corporate data"},
+                ],
+            },
+            {
+                "title": "Spaceflight News & Analysis",
+                "resources": [
+                    {"name": "NASASpaceflight", "url": "https://www.nasaspaceflight.com", "desc": "The deepest independent launch reporting and Starbase coverage"},
+                    {"name": "SpaceNews", "url": "https://spacenews.com", "desc": "Industry, policy, and business of the space sector"},
+                    {"name": "Ars Technica — Space", "url": "https://arstechnica.com/space/", "desc": "Eric Berger's authoritative, skeptical spaceflight analysis"},
+                    {"name": "Spaceflight Now", "url": "https://spaceflightnow.com", "desc": "Launch schedules and live mission coverage"},
+                    {"name": "Eric Berger on X", "url": "https://x.com/SciGuySpace", "desc": "Breaking SpaceX news and reporting from Ars Technica's senior space editor"},
+                    {"name": "Michael Sheetz on X", "url": "https://x.com/thesheetztweetz", "desc": "CNBC's space-business reporter — the SPCX investor angle"},
+                ],
+            },
+            {
+                "title": "Launch Tracking & Data",
+                "resources": [
+                    {"name": "Next Spaceflight", "url": "https://nextspaceflight.com", "desc": "Every upcoming launch with countdowns, rockets, and pads"},
+                    {"name": "Flight Club", "url": "https://flightclub.io", "desc": "Live trajectory simulations and telemetry for orbital launches"},
+                    {"name": "Jonathan's Space Report", "url": "https://planet4589.org/space/jsr/jsr.html", "desc": "Jonathan McDowell's authoritative catalogue of launches and satellites"},
+                    {"name": "r/SpaceX", "url": "https://www.reddit.com/r/spacex/", "desc": "The largest SpaceX community — launch threads and technical discussion"},
+                    {"name": "r/SpaceXLounge", "url": "https://www.reddit.com/r/SpaceXLounge/", "desc": "Looser SpaceX discussion, speculation, and community analysis"},
+                ],
+            },
+            {
+                "title": "Musk & the xAI Ecosystem",
+                "resources": [
+                    {"name": "Elon Musk on X", "url": "https://x.com/elonmusk", "desc": "First-hand program updates and milestones, straight from the CEO"},
+                    {"name": "xAI", "url": "https://x.ai", "desc": "Musk's AI company — the AI-compute thread that runs through the SpaceX story"},
+                    {"name": "Grok", "url": "https://grok.com", "desc": "xAI's assistant — the AI that powers this show's research and voice"},
+                ],
+            },
+        ],
+        "tools": [
+            {"name": "SPCX on TradingView", "url": "https://www.tradingview.com/symbols/NASDAQ-SPCX/", "desc": "Chart SPCX with technicals and alerts", "badge": "Free tier"},
+            {"name": "SEC EDGAR Full-Text Search", "url": "https://efts.sec.gov/LATEST/search-index?q=%22space+exploration+technologies%22", "desc": "Search every word of every SpaceX filing", "badge": "Free"},
+            {"name": "Next Spaceflight", "url": "https://nextspaceflight.com", "desc": "Never miss a launch — schedules and countdowns", "badge": "Free"},
+        ],
+        "faq": [
+            {"q": "What is SpaceX Daily?", "a": "A daily podcast and blog that tracks SpaceX now that it's a public company (Nasdaq: SPCX). Every weekday: the day's developments with sources, what the spaceflight community is talking about, one honest counterpoint, the engineering and economics behind the headlines, and the SPCX market picture. Hosted by Patrick in Vancouver."},
+            {"q": "What is SPCX?", "a": "SPCX is SpaceX's stock ticker on the Nasdaq. SpaceX held the largest IPO in history in June 2026, pricing at $135 per share and raising about $75 billion at a valuation near $1.8 trillion. A dual-class share structure leaves Elon Musk with a controlling majority of the voting power. Nothing on this show is financial advice."},
+            {"q": "Where do the numbers come from?", "a": "Official sources wherever possible — SpaceX announcements, the SEC S-1/prospectus and later filings, and credible reporting from NASASpaceflight, SpaceNews, Ars Technica, and CNBC. Community and social posts are clearly flagged as unverified. The live SPCX price on this page is refreshed every run from market data."},
+            {"q": "How long are episodes?", "a": "About 12 to 14 minutes — enough to walk through the day's launches, programs, and market picture, short enough for a commute."},
+            {"q": "Is this just Elon Musk fan content?", "a": "No. The show is genuinely balanced: every episode carries an honest counterpoint, and the premiere named the real risks — stretched valuation, Musk's concentrated voting control, and a launch business that still loses money while Starlink carries the profit. Enthusiasm grounded in numbers is the brand."},
+        ],
+    },
+}
+
+
 def _merge_scaffolded_network_registry() -> None:
     """Overlay shows/network_meta.yaml (from scaffold_show.py) onto registries."""
     meta_path = SHOWS_DIR / "network_meta.yaml"
@@ -1310,6 +1394,13 @@ def _merge_scaffolded_network_registry() -> None:
             continue
         meta = dict(meta)
         picker = meta.pop("picker_tags", None)
+        # Layer curated resource blocks (resource_categories/tools/faq)
+        # onto the scaffolded base metadata — keeps the rich, hand-written
+        # link sets in Python instead of the auto-generated YAML.
+        if slug in _SCAFFOLD_SHOW_RESOURCES:
+            for key, value in _SCAFFOLD_SHOW_RESOURCES[slug].items():
+                if not meta.get(key):
+                    meta[key] = value
         if slug not in NETWORK_SHOWS:
             NETWORK_SHOWS[slug] = meta
         if picker and slug not in _SHOW_PICKER_TAGS:
@@ -1943,12 +2034,19 @@ def generate_show_page(slug, *, dry_run=False):
     else:
         narrative_page_url = ""
 
+    # Live stock-price pill (Tesla + SpaceX). Each show's pipeline hook
+    # writes a same-origin api/<ticker>.json the page JS reads first, with
+    # a Yahoo-Finance CORS-proxy fallback. SPCX joined when SpaceX IPO'd
+    # June 2026.
+    stock_widget = _STOCK_WIDGETS.get(slug)
+
     context = {
         **cfg,
         "narrative_page_url": narrative_page_url,
         "path_prefix": prefix,
         "show_name": cfg["name"],
         "show_slug": cfg["slug"],
+        "stock_widget": stock_widget,
         "show_description": cfg.get("about_text", cfg["description"]),
         "page_title": page_title,
         "meta_description": meta_description,  # override the static one from **cfg

--- a/scripts/fetch_spacex_launches.py
+++ b/scripts/fetch_spacex_launches.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Fetch SpaceX launch data for the public launch dashboard.
+
+Pulls upcoming + previous launches for SpaceX (Launch Library 2, agency
+id 121) and writes a compact, dashboard-ready JSON to ``api/spacex_launches.json``.
+The dashboard page (``spacex-dashboard.html``) reads this same-origin file
+first, so per-visitor traffic never hits the upstream API's rate limit.
+
+Robust by design (mirrors the SPCX price cache, landmine #22):
+- A failed/empty fetch NEVER overwrites a previous-good cache.
+- All upstream access is best-effort; the dashboard degrades to a
+  friendly "data unavailable" state when the file is missing.
+
+Free, no API key. CORS-enabled upstream, so the dashboard can also fall
+back to calling the API directly client-side if the cache is stale.
+
+Usage:
+    python scripts/fetch_spacex_launches.py [--out api/spacex_launches.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("fetch_spacex_launches")
+
+_ROOT = Path(__file__).resolve().parent.parent
+_API_BASE = "https://ll.thespacedevs.com/2.3.0/launches"
+_SPACEX_LSP_ID = 121
+_UA = {"User-Agent": "NerraNetwork/1.0 (+https://nerranetwork.com)"}
+_TIMEOUT = 25
+
+
+def _get(url: str) -> Optional[Dict[str, Any]]:
+    try:
+        req = urllib.request.Request(url, headers=_UA)
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+            return json.load(resp)
+    except Exception as exc:  # network/HTTP/JSON — all non-fatal
+        logger.warning("Launch API fetch failed (%s): %s", url, exc)
+        return None
+
+
+def _slim_launch(r: Dict[str, Any]) -> Dict[str, Any]:
+    """Reduce a Launch Library record to the fields the dashboard needs."""
+    pad = r.get("pad") or {}
+    loc = pad.get("location") or {}
+    rocket = (r.get("rocket") or {}).get("configuration") or {}
+    mission = r.get("mission") or {}
+    status = r.get("status") or {}
+    image = r.get("image")
+    image_url = image.get("image_url") if isinstance(image, dict) else image
+    webcasts = [
+        v.get("url") for v in (r.get("vidURLs") or [])
+        if isinstance(v, dict) and v.get("url")
+    ]
+    return {
+        "id": r.get("id"),
+        "name": r.get("name"),
+        "net": r.get("net"),  # ISO 8601 UTC "no earlier than" time
+        "window_start": r.get("window_start"),
+        "window_end": r.get("window_end"),
+        "status": status.get("abbrev"),
+        "status_name": status.get("name"),
+        "rocket": rocket.get("name"),
+        "pad": pad.get("name"),
+        "location": loc.get("name"),
+        "mission": mission.get("name"),
+        "mission_type": mission.get("type"),
+        "mission_description": mission.get("description"),
+        "orbit": (mission.get("orbit") or {}).get("name") if isinstance(mission.get("orbit"), dict) else None,
+        "image": image_url,
+        "webcast": webcasts[0] if webcasts else None,
+        "info_url": (r.get("infoURLs") or [{}])[0].get("url") if r.get("infoURLs") else None,
+    }
+
+
+def _is_spacex(r: Dict[str, Any]) -> bool:
+    return (r.get("launch_service_provider") or {}).get("id") == _SPACEX_LSP_ID
+
+
+def _monthly_cadence(previous: List[Dict[str, Any]], months: int = 12) -> List[Dict[str, Any]]:
+    """Count SpaceX launches per calendar month for the last *months*."""
+    today = _dt.datetime.now(_dt.timezone.utc).date().replace(day=1)
+    buckets: Dict[str, int] = {}
+    labels: List[str] = []
+    y, m = today.year, today.month
+    for _ in range(months):
+        key = f"{y:04d}-{m:02d}"
+        buckets[key] = 0
+        labels.append(key)
+        m -= 1
+        if m == 0:
+            m = 12
+            y -= 1
+    labels.reverse()
+    for r in previous:
+        net = r.get("net")
+        if not net:
+            continue
+        key = net[:7]  # YYYY-MM
+        if key in buckets:
+            buckets[key] += 1
+    return [{"month": k, "count": buckets[k]} for k in labels]
+
+
+def _stats(previous: List[Dict[str, Any]], now: _dt.datetime) -> Dict[str, Any]:
+    def _parse(net: Optional[str]) -> Optional[_dt.datetime]:
+        if not net:
+            return None
+        try:
+            return _dt.datetime.fromisoformat(net.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+
+    dates = [d for d in (_parse(r.get("net")) for r in previous) if d]
+    ytd = sum(1 for d in dates if d.year == now.year)
+    last_30 = sum(1 for d in dates if (now - d).days <= 30)
+    last_365 = sum(1 for d in dates if (now - d).days <= 365)
+    starlink_ytd = sum(
+        1 for r in previous
+        if (_parse(r.get("net")) or now).year == now.year
+        and "starlink" in (r.get("name") or "").lower()
+    )
+    return {
+        "launches_ytd": ytd,
+        "launches_last_30d": last_30,
+        "launches_last_365d": last_365,
+        "starlink_launches_ytd": starlink_ytd,
+        "avg_days_between_last_365d": round(365 / last_365, 2) if last_365 else None,
+    }
+
+
+def _fetch_previous_paginated(now: _dt.datetime, max_pages: int = 4) -> tuple[List[Dict[str, Any]], Optional[int]]:
+    """Walk the previous-launches feed until ~13 months of history is
+    covered (SpaceX flies ~12-15/month, so a true 12-month cadence chart
+    + accurate 365-day stats need well over 100 records). Capped at
+    *max_pages* (100/page) to bound API calls."""
+    cutoff = now - _dt.timedelta(days=400)
+    collected: List[Dict[str, Any]] = []
+    total: Optional[int] = None
+    url = (
+        f"{_API_BASE}/previous/?lsp__id={_SPACEX_LSP_ID}"
+        f"&limit=100&ordering=-net&mode=detailed"
+    )
+    for _ in range(max_pages):
+        page = _get(url)
+        if not page:
+            break
+        if total is None:
+            total = page.get("count")
+        results = [r for r in page.get("results", []) if _is_spacex(r)]
+        collected.extend(results)
+        # Stop once we've walked past the 13-month cutoff.
+        oldest = results[-1].get("net") if results else None
+        if oldest:
+            try:
+                if _dt.datetime.fromisoformat(oldest.replace("Z", "+00:00")) < cutoff:
+                    break
+            except ValueError:
+                pass
+        url = page.get("next")
+        if not url:
+            break
+    return collected, total
+
+
+def build_payload() -> Optional[Dict[str, Any]]:
+    now = _dt.datetime.now(_dt.timezone.utc)
+
+    up = _get(
+        f"{_API_BASE}/upcoming/?lsp__id={_SPACEX_LSP_ID}"
+        f"&limit=6&ordering=net&mode=detailed"
+    )
+    prev_results, prev_total = _fetch_previous_paginated(now)
+    if not up and not prev_results:
+        return None
+
+    up_results = [r for r in (up or {}).get("results", []) if _is_spacex(r)]
+
+    # "Next" = soonest upcoming whose net is in the future. LL2 sometimes
+    # leaves a just-flown launch in the upcoming feed for a beat; skip any
+    # whose net is already in the past.
+    next_launch = None
+    for r in up_results:
+        net = r.get("net")
+        try:
+            net_dt = _dt.datetime.fromisoformat((net or "").replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if net_dt > now:
+            next_launch = _slim_launch(r)
+            break
+
+    previous_launch = _slim_launch(prev_results[0]) if prev_results else None
+    upcoming_list = [_slim_launch(r) for r in up_results][:5]
+
+    slim_prev = [_slim_launch(r) for r in prev_results]
+    return {
+        "next": next_launch,
+        "previous": previous_launch,
+        "upcoming": upcoming_list,
+        "cadence_monthly": _monthly_cadence(slim_prev),
+        "stats": _stats(slim_prev, now),
+        "total_launches": prev_total,
+        "source": "thespacedevs_ll2",
+        "updated_at": now.isoformat(),
+    }
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="api/spacex_launches.json")
+    args = ap.parse_args()
+
+    out_path = _ROOT / args.out
+    payload = build_payload()
+
+    if not payload or (not payload.get("next") and not payload.get("previous")):
+        # Keep last-good cache; never overwrite with an empty result.
+        if out_path.exists():
+            logger.warning("Launch fetch empty — keeping existing %s", out_path)
+            return 0
+        logger.error("Launch fetch empty and no existing cache to keep.")
+        return 0  # non-fatal: dashboard shows a friendly empty state
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    nxt = payload.get("next") or {}
+    logger.info(
+        "Wrote %s — next: %s (%s), ytd: %s launches",
+        out_path, nxt.get("name"), nxt.get("net"),
+        payload.get("stats", {}).get("launches_ytd"),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shows/hooks/spacex.py
+++ b/shows/hooks/spacex.py
@@ -56,6 +56,20 @@ def pre_fetch(config, *, episode_num=None, today_str=None) -> dict:
     context["closing_block"] = _pick_closing(price, change_str, source)
 
     context["ipo_debut_section"] = _ipo_debut_section(episode_num)
+
+    # Refresh the public launch-dashboard data (best-effort, non-fatal).
+    # Writes api/spacex_launches.json for spacex-dashboard.html; a failure
+    # keeps the last-good cache and never blocks the episode.
+    try:
+        import subprocess
+        subprocess.run(
+            [__import__("sys").executable,
+             str(_ROOT / "scripts" / "fetch_spacex_launches.py")],
+            timeout=120, cwd=str(_ROOT), check=False,
+        )
+    except Exception as exc:
+        logger.warning("Launch-dashboard data refresh failed (non-fatal): %s", exc)
+
     return context
 
 

--- a/spacex-dashboard.html
+++ b/spacex-dashboard.html
@@ -1,0 +1,961 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Live SpaceX launch dashboard — countdown to the next launch, time since the last one, launch cadence, the upcoming manifest, and the SPCX market picture. The companion to the SpaceX Daily podcast.">
+    
+    
+    <title>SpaceX Launch Dashboard | Nerra Network</title>
+    <meta name="theme-color" content="#1A5CFF">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="SpaceX Launch Dashboard | Nerra Network">
+    <meta property="og:description" content="Live SpaceX launch dashboard — countdown to the next launch, time since the last one, launch cadence, the upcoming manifest, and the SPCX market picture. The companion to the SpaceX Daily podcast.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://nerranetwork.com/assets/covers/spacex.jpg">
+    <meta property="og:url" content="https://nerranetwork.com/spacex-dashboard.html">
+    <meta property="og:site_name" content="Nerra Network">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="SpaceX Launch Dashboard | Nerra Network">
+    <meta name="twitter:description" content="Live SpaceX launch dashboard — countdown to the next launch, time since the last one, launch cadence, the upcoming manifest, and the SPCX market picture. The companion to the SpaceX Daily podcast.">
+    <meta name="twitter:image" content="https://nerranetwork.com/assets/covers/spacex.jpg">
+
+    <link rel="canonical" href="https://nerranetwork.com/spacex-dashboard.html">
+    
+    <link rel="alternate" type="application/rss+xml" title="SpaceX Daily RSS" href="spacex_podcast.rss">
+    
+    
+    
+
+    <!-- Google Fonts: DM Sans + Source Serif 4 -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&display=swap" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%236B47FF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/></svg>">
+
+    
+    
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
+    
+    
+    <script defer src="assets/js/tracking.js"></script>
+
+    <!-- Shared CSS -->
+    <link rel="stylesheet" href="styles/main.css">
+
+    
+<style>
+  /* ---- SpaceX Launch Dashboard (scoped under .spx-dash) ---- */
+  .spx-dash {
+    --spx-blue: #1A5CFF;
+    --spx-cyan: #00D4FF;
+    --spx-ink: #0a1020;
+    position: relative;
+    color: #eaf0ff;
+  }
+  .spx-hero-wrap {
+    position: relative;
+    overflow: hidden;
+    background:
+      radial-gradient(1200px 600px at 50% -10%, rgba(26,92,255,0.28), transparent 60%),
+      linear-gradient(180deg, #05080f 0%, #0a1124 60%, #0a0f1e 100%);
+    border-bottom: 1px solid rgba(120,160,255,0.15);
+  }
+  .spx-stars {
+    position: absolute; inset: 0; z-index: 0; pointer-events: none;
+  }
+  .spx-container {
+    position: relative; z-index: 1;
+    max-width: 1120px; margin: 0 auto;
+    padding: calc(var(--nav-height) + 2.5rem) 1.25rem 2rem;
+  }
+  .spx-kicker {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 0.78rem; letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--spx-cyan); font-weight: 700; margin-bottom: 0.6rem;
+  }
+  .spx-kicker .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--spx-cyan);
+    box-shadow: 0 0 10px var(--spx-cyan); animation: spx-pulse 1.8s infinite; }
+  @keyframes spx-pulse { 0%,100%{opacity:1} 50%{opacity:.35} }
+  .spx-h1 { font-size: clamp(1.8rem, 4vw, 2.8rem); line-height: 1.05; margin: 0 0 0.4rem; font-weight: 800; letter-spacing: -0.02em; }
+  .spx-sub { color: #aebbe0; font-size: 1.02rem; max-width: 62ch; margin: 0 0 1.6rem; }
+
+  .spx-countdown {
+    display: flex; gap: 0.6rem; flex-wrap: wrap; margin: 0.4rem 0 1.2rem;
+  }
+  .spx-cd-unit {
+    min-width: 78px; text-align: center;
+    background: rgba(13,22,46,0.7); border: 1px solid rgba(120,160,255,0.22);
+    border-radius: 14px; padding: 0.7rem 0.5rem;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.05), 0 8px 30px rgba(0,0,0,0.35);
+    backdrop-filter: blur(6px);
+  }
+  .spx-cd-num { font-size: clamp(1.6rem, 4.5vw, 2.6rem); font-weight: 800; font-variant-numeric: tabular-nums;
+    background: linear-gradient(180deg, #fff, #9fc0ff); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+  .spx-cd-label { font-size: 0.66rem; letter-spacing: 0.12em; text-transform: uppercase; color: #8ea3d6; margin-top: 2px; }
+
+  .spx-status {
+    display:inline-flex; align-items:center; gap:7px; font-weight:700; font-size:0.82rem;
+    padding: 4px 12px; border-radius: 999px; border:1px solid transparent;
+  }
+  .spx-status.go   { color:#7efbb0; background:rgba(40,200,120,0.12); border-color:rgba(40,200,120,0.35); }
+  .spx-status.tbd  { color:#ffd27a; background:rgba(255,180,40,0.12); border-color:rgba(255,180,40,0.32); }
+  .spx-status.hold { color:#ff9a9a; background:rgba(255,80,80,0.12); border-color:rgba(255,80,80,0.32); }
+
+  .spx-launchcard {
+    background: rgba(11,18,38,0.66); border: 1px solid rgba(120,160,255,0.2);
+    border-radius: 18px; padding: 1.1rem 1.2rem; backdrop-filter: blur(8px);
+  }
+  .spx-launchcard h3 { margin: 0.2rem 0 0.5rem; font-size: 1.25rem; }
+  .spx-meta { display:grid; grid-template-columns: repeat(auto-fit, minmax(150px,1fr)); gap: 0.6rem 1rem; margin-top: 0.6rem; }
+  .spx-meta .k { font-size:0.68rem; text-transform:uppercase; letter-spacing:0.1em; color:#8ea3d6; }
+  .spx-meta .v { font-size:0.95rem; color:#eaf0ff; font-weight:600; }
+  .spx-btn {
+    display:inline-flex; align-items:center; gap:8px; margin-top: 0.9rem;
+    background: linear-gradient(135deg, var(--spx-blue), #3f7bff); color:#fff; font-weight:700;
+    padding: 0.6rem 1.1rem; border-radius: 12px; text-decoration:none; font-size:0.92rem;
+    box-shadow: 0 8px 24px rgba(26,92,255,0.4);
+  }
+  .spx-btn.ghost { background: transparent; border:1px solid rgba(120,160,255,0.4); box-shadow:none; }
+
+  .spx-grid { max-width:1120px; margin: 1.5rem auto; padding: 0 1.25rem; display:grid; gap:1.1rem; grid-template-columns: 1fr 1fr; }
+  @media (max-width: 760px){ .spx-grid{ grid-template-columns:1fr; } }
+  .spx-panel {
+    background: var(--nn-surface, #0f1830); border:1px solid rgba(120,160,255,0.16);
+    border-radius:16px; padding:1.1rem 1.2rem;
+  }
+  .spx-panel h2 { font-size:1.05rem; margin:0 0 0.9rem; letter-spacing:-0.01em; }
+
+  .spx-stats { display:grid; grid-template-columns: repeat(auto-fit,minmax(120px,1fr)); gap:0.8rem; }
+  .spx-stat { text-align:center; padding:0.6rem; border-radius:12px; background:rgba(26,92,255,0.08); border:1px solid rgba(120,160,255,0.14); }
+  .spx-stat .n { font-size:1.7rem; font-weight:800; color:#fff; font-variant-numeric:tabular-nums; }
+  .spx-stat .l { font-size:0.7rem; text-transform:uppercase; letter-spacing:0.08em; color:#8ea3d6; margin-top:2px; }
+
+  /* cadence chart */
+  .spx-cadence { display:flex; align-items:flex-end; gap:6px; height:160px; padding-top:8px; }
+  .spx-bar-wrap { flex:1; display:flex; flex-direction:column; align-items:center; gap:4px; height:100%; justify-content:flex-end; }
+  .spx-bar {
+    width:100%; border-radius:6px 6px 2px 2px; min-height:3px;
+    background: linear-gradient(180deg, var(--spx-cyan), var(--spx-blue));
+    transition: height .6s cubic-bezier(.2,.7,.2,1);
+    position:relative;
+  }
+  .spx-bar .cnt { position:absolute; top:-18px; left:0; right:0; text-align:center; font-size:0.7rem; color:#cfe0ff; font-weight:700; }
+  .spx-bar-label { font-size:0.6rem; color:#7f93c4; white-space:nowrap; }
+
+  .spx-since { font-size: clamp(1.4rem,3.5vw,2rem); font-weight:800; font-variant-numeric:tabular-nums; color:#fff; }
+  .spx-upcoming-item { display:flex; justify-content:space-between; gap:10px; padding:0.55rem 0; border-bottom:1px solid rgba(120,160,255,0.12); font-size:0.9rem; }
+  .spx-upcoming-item:last-child{ border-bottom:none; }
+  .spx-upcoming-item .when { color:#8ea3d6; white-space:nowrap; font-variant-numeric:tabular-nums; }
+
+  .spx-spcx { display:flex; align-items:baseline; gap:12px; }
+  .spx-spcx .px { font-size:2rem; font-weight:800; color:#fff; }
+  .spx-spcx .ch.up { color:#5ef0a0; } .spx-spcx .ch.down{ color:#ff8a8a; }
+  .spx-muted { color:#8ea3d6; font-size:0.82rem; }
+  .spx-foot-note { max-width:1120px; margin:0 auto 2rem; padding:0 1.25rem; color:#7f93c4; font-size:0.78rem; }
+  .spx-disclaimer { color:#7f93c4; font-size:0.74rem; margin-top:0.4rem; }
+</style>
+
+
+    
+    <style>
+        @media (max-width: 768px) {
+            .nn-footer-grid { grid-template-columns: 1fr; }
+            .nn-footer-col h4 {
+                cursor: pointer;
+                position: relative;
+                padding-right: 1.5rem;
+            }
+            .nn-footer-col h4::after {
+                content: '+';
+                position: absolute;
+                right: 0;
+                font-size: 1.2rem;
+                color: var(--nn-text-muted);
+            }
+            .nn-footer-col.expanded h4::after { content: '\2212'; }
+            .nn-footer-col > a,
+            .nn-footer-col > ul { display: none; }
+            .nn-footer-col.expanded > a,
+            .nn-footer-col.expanded > ul { display: block; }
+        }
+    </style>
+</head>
+<body><a href="#main-content" class="skip-link">Skip to content</a>
+    <!-- Navigation -->
+    <nav class="nn-nav" aria-label="Main navigation">
+        <div class="nn-nav-inner">
+            <a href="index.html" class="nn-nav-logo">
+                <img src="assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
+                <span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span>
+            </a>
+
+            
+            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.5rem;max-width:180px;flex:1 1 auto;min-width:120px;">
+                <input type="search" id="nn-global-search-input"
+                       placeholder="Search…"
+                       style="width:100%;padding:6px 8px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.85rem;"
+                       aria-label="Search all episodes across the network">
+                <div id="nn-global-search-results"
+                     style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:340px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
+            </div>
+
+            <ul class="nn-nav-links">
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Shows
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu" role="menu">
+                        
+                        <a href="models-agents.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents
+                        </a>
+                        
+                        <a href="planetterrian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily
+                        </a>
+                        
+                        <a href="omni-view.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View
+                        </a>
+                        
+                        <a href="models-agents-beginners.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners
+                        </a>
+                        
+                        <a href="fascinating-frontiers.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers
+                        </a>
+                        
+                        <a href="modern-investing.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques
+                        </a>
+                        
+                        <a href="tesla.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time
+                        </a>
+                        
+                        <a href="env-intel.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence
+                        </a>
+                        
+                        <a href="ru/finansy-prosto.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто
+                        </a>
+                        
+                        <a href="ru/privet-russian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский!
+                        </a>
+                        
+                        <a href="unintended-consequences.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences
+                        </a>
+                        
+                        <a href="first-principles.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            First Principles Daily
+                        </a>
+                        
+                        <a href="spacex.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily
+                        </a>
+                        
+                    </div>
+                </li>
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Blog
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu">
+                        <a href="blog/index.html" style="font-weight:600;border-bottom:1px solid var(--nn-border);padding-bottom:8px;margin-bottom:4px">
+                            All Blog Posts
+                        </a>
+                        
+                        <a href="blog/models_agents/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents Blog
+                        </a>
+                        
+                        <a href="blog/planetterrian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily Blog
+                        </a>
+                        
+                        <a href="blog/omni_view/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View Blog
+                        </a>
+                        
+                        <a href="blog/models_agents_beginners/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners Blog
+                        </a>
+                        
+                        <a href="blog/fascinating_frontiers/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers Blog
+                        </a>
+                        
+                        <a href="blog/modern_investing/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques Blog
+                        </a>
+                        
+                        <a href="blog/tesla/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time Blog
+                        </a>
+                        
+                        <a href="blog/env_intel/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence Blog
+                        </a>
+                        
+                        <a href="blog/finansy_prosto/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто Blog
+                        </a>
+                        
+                        <a href="blog/privet_russian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский! Blog
+                        </a>
+                        
+                        <a href="blog/unintended_consequences/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences Blog
+                        </a>
+                        
+                        <a href="blog/first_principles/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            First Principles Daily Blog
+                        </a>
+                        
+                        <a href="blog/spacex/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily Blog
+                        </a>
+                        
+                    </div>
+                </li>
+                
+                <li><a href="start-here.html">Start Here</a></li>
+                <li><a href="how-to-listen.html">Listen</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="player.html">Player</a></li>
+                <li><a href="index.html">Home</a></li>
+                
+            </ul>
+
+            <button class="nn-hamburger" aria-label="Toggle menu" aria-expanded="false" onclick="var m=document.getElementById('mobileMenu');m.classList.toggle('open');this.setAttribute('aria-expanded',m.classList.contains('open'));document.body.classList.toggle('menu-open')">&#9776;</button>
+        </div>
+    </nav>
+
+    <!-- Mobile Menu -->
+    <div id="mobileMenu" class="nn-mobile-menu">
+        
+        <a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Start Here</a>
+        <a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">How to Listen</a>
+        <a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">About</a>
+        <a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Player</a>
+        <a href="index.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Home</a>
+        
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">All Shows</div>
+            
+            <a href="models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents
+            </a>
+            
+            <a href="planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily
+            </a>
+            
+            <a href="omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View
+            </a>
+            
+            <a href="models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners
+            </a>
+            
+            <a href="fascinating-frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers
+            </a>
+            
+            <a href="modern-investing.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques
+            </a>
+            
+            <a href="tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time
+            </a>
+            
+            <a href="env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence
+            </a>
+            
+            <a href="ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто
+            </a>
+            
+            <a href="ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский!
+            </a>
+            
+            <a href="unintended-consequences.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences
+            </a>
+            
+            <a href="first-principles.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                First Principles Daily
+            </a>
+            
+            <a href="spacex.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily
+            </a>
+            
+        </div>
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">Blogs</div>
+            <a href="blog/index.html" class="nn-mobile-show-link" style="font-weight:600" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                All Blog Posts
+            </a>
+            
+            <a href="blog/models_agents/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents Blog
+            </a>
+            
+            <a href="blog/planetterrian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily Blog
+            </a>
+            
+            <a href="blog/omni_view/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View Blog
+            </a>
+            
+            <a href="blog/models_agents_beginners/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners Blog
+            </a>
+            
+            <a href="blog/fascinating_frontiers/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers Blog
+            </a>
+            
+            <a href="blog/modern_investing/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques Blog
+            </a>
+            
+            <a href="blog/tesla/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time Blog
+            </a>
+            
+            <a href="blog/env_intel/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence Blog
+            </a>
+            
+            <a href="blog/finansy_prosto/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто Blog
+            </a>
+            
+            <a href="blog/privet_russian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский! Blog
+            </a>
+            
+            <a href="blog/unintended_consequences/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences Blog
+            </a>
+            
+            <a href="blog/first_principles/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                First Principles Daily Blog
+            </a>
+            
+            <a href="blog/spacex/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily Blog
+            </a>
+            
+        </div>
+    </div>
+
+    <main id="main-content">
+    
+<div class="spx-dash">
+  <div class="spx-hero-wrap">
+    <canvas class="spx-stars" id="spxStars"></canvas>
+    <div class="spx-container">
+      <div class="spx-kicker"><span class="dot"></span> SpaceX Launch Dashboard · Live</div>
+      <h1 class="spx-h1">Next SpaceX Launch</h1>
+      <p class="spx-sub">A live countdown to the next launch, time since the last one, cadence, and the SPCX market picture — the companion dashboard to <a href="spacex.html" style="color:var(--spx-cyan);">SpaceX Daily</a>.</p>
+
+      <div id="spxNext">
+        <div class="spx-countdown" id="spxCountdown">
+          <div class="spx-cd-unit"><div class="spx-cd-num" id="cd-d">--</div><div class="spx-cd-label">Days</div></div>
+          <div class="spx-cd-unit"><div class="spx-cd-num" id="cd-h">--</div><div class="spx-cd-label">Hours</div></div>
+          <div class="spx-cd-unit"><div class="spx-cd-num" id="cd-m">--</div><div class="spx-cd-label">Min</div></div>
+          <div class="spx-cd-unit"><div class="spx-cd-num" id="cd-s">--</div><div class="spx-cd-label">Sec</div></div>
+        </div>
+        <div class="spx-launchcard">
+          <span class="spx-status tbd" id="spxStatus">Loading…</span>
+          <h3 id="spxMission">Fetching the latest launch manifest…</h3>
+          <div class="spx-meta">
+            <div><div class="k">Vehicle</div><div class="v" id="spxRocket">—</div></div>
+            <div><div class="k">Launch Pad</div><div class="v" id="spxPad">—</div></div>
+            <div><div class="k">Location</div><div class="v" id="spxLoc">—</div></div>
+            <div><div class="k">Target (your time)</div><div class="v" id="spxLocal">—</div></div>
+          </div>
+          <p class="spx-muted" id="spxDesc" style="margin:0.7rem 0 0;"></p>
+          <a class="spx-btn" id="spxWebcast" href="#" target="_blank" rel="noopener" style="display:none;">▶ Watch the webcast</a>
+          <a class="spx-btn ghost" id="spxMore" href="#" target="_blank" rel="noopener" style="display:none;">Mission details</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="spx-grid">
+    <div class="spx-panel">
+      <h2>Time since last launch</h2>
+      <div class="spx-since" id="spxSince">—</div>
+      <p class="spx-muted" id="spxLast" style="margin:0.4rem 0 0;">—</p>
+    </div>
+    <div class="spx-panel">
+      <h2>SPCX</h2>
+      <div class="spx-spcx"><span class="px" id="spxPx">—</span><span class="ch" id="spxChg"></span></div>
+      <p class="spx-muted" id="spxPxNote" style="margin:0.4rem 0 0;">Nasdaq: SPCX</p>
+      <p class="spx-disclaimer">Not financial advice.</p>
+    </div>
+  </div>
+
+  <div class="spx-grid" style="grid-template-columns:1fr;">
+    <div class="spx-panel">
+      <h2>Launch cadence — last 12 months</h2>
+      <div class="spx-cadence" id="spxCadence"></div>
+      <div class="spx-stats" style="margin-top:1.2rem;">
+        <div class="spx-stat"><div class="n" id="stYtd">—</div><div class="l">Launches YTD</div></div>
+        <div class="spx-stat"><div class="n" id="st30">—</div><div class="l">Last 30 days</div></div>
+        <div class="spx-stat"><div class="n" id="stAvg">—</div><div class="l">Avg days apart</div></div>
+        <div class="spx-stat"><div class="n" id="stStar">—</div><div class="l">Starlink YTD</div></div>
+        <div class="spx-stat"><div class="n" id="stTotal">—</div><div class="l">Total launches</div></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="spx-grid" style="grid-template-columns:1fr;">
+    <div class="spx-panel">
+      <h2>Upcoming manifest</h2>
+      <div id="spxUpcoming"><p class="spx-muted">Loading…</p></div>
+    </div>
+  </div>
+
+  <p class="spx-foot-note">
+    Launch data from <a href="https://thespacedevs.com/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">The Space Devs</a> Launch Library 2 (updated each pipeline run). Times are “no earlier than” and slip often — always confirm against the official <a href="https://www.spacex.com/launches/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">SpaceX launch schedule</a> and webcast. Full source links live on the <a href="spacex.html#resources" style="color:var(--spx-cyan);">SpaceX Daily resources</a> page.
+  </p>
+</div>
+
+    </main>
+
+    <!-- Footer -->
+    <footer class="nn-footer">
+        <div class="container">
+            <div class="nn-footer-grid">
+                <div>
+                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span></div>
+                    <p class="nn-footer-desc">13 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Shows</h4>
+                    
+                    <a href="models-agents.html">Models & Agents</a>
+                    
+                    <a href="planetterrian.html">Planetterrian Daily</a>
+                    
+                    <a href="omni-view.html">Omni View</a>
+                    
+                    <a href="models-agents-beginners.html">Models & Agents for Beginners</a>
+                    
+                    <a href="fascinating-frontiers.html">Fascinating Frontiers</a>
+                    
+                    <a href="modern-investing.html">Modern Investing Techniques</a>
+                    
+                    <a href="tesla.html">Tesla Shorts Time</a>
+                    
+                    <a href="env-intel.html">Environmental Intelligence</a>
+                    
+                    <a href="ru/finansy-prosto.html">Финансы Просто</a>
+                    
+                    <a href="ru/privet-russian.html">Привет, Русский!</a>
+                    
+                    <a href="unintended-consequences.html">Unintended Consequences</a>
+                    
+                    <a href="first-principles.html">First Principles Daily</a>
+                    
+                    <a href="spacex.html">SpaceX Daily</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Blog</h4>
+                    <a href="blog/index.html">All Blog Posts</a>
+                    
+                    <a href="blog/models_agents/index.html">Models & Agents</a>
+                    
+                    <a href="blog/planetterrian/index.html">Planetterrian Daily</a>
+                    
+                    <a href="blog/omni_view/index.html">Omni View</a>
+                    
+                    <a href="blog/models_agents_beginners/index.html">Models & Agents for Beginners</a>
+                    
+                    <a href="blog/fascinating_frontiers/index.html">Fascinating Frontiers</a>
+                    
+                    <a href="blog/modern_investing/index.html">Modern Investing Techniques</a>
+                    
+                    <a href="blog/tesla/index.html">Tesla Shorts Time</a>
+                    
+                    <a href="blog/env_intel/index.html">Environmental Intelligence</a>
+                    
+                    <a href="blog/finansy_prosto/index.html">Финансы Просто</a>
+                    
+                    <a href="blog/privet_russian/index.html">Привет, Русский!</a>
+                    
+                    <a href="blog/unintended_consequences/index.html">Unintended Consequences</a>
+                    
+                    <a href="blog/first_principles/index.html">First Principles Daily</a>
+                    
+                    <a href="blog/spacex/index.html">SpaceX Daily</a>
+                    
+                    <a href="blog.rss">Blog RSS (All Shows)</a>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Listen</h4>
+                    <a href="how-to-listen.html" style="font-weight:600">How to Listen</a>
+                    <a href="player.html" style="font-weight:600">Network Player</a>
+                    <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939?utm_source=nerranetwork&utm_medium=footer&utm_campaign=tesla" target="_blank" rel="noopener" data-show="tesla">Apple Podcasts</a>
+                    <a href="network.rss">Network RSS</a>
+                    
+                    <a href="models_agents_podcast.rss">Models & Agents RSS</a>
+                    
+                    <a href="planetterrian_podcast.rss">Planetterrian Daily RSS</a>
+                    
+                    <a href="omni_view_podcast.rss">Omni View RSS</a>
+                    
+                    <a href="models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
+                    
+                    <a href="fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
+                    
+                    <a href="modern_investing_podcast.rss">Modern Investing Techniques RSS</a>
+                    
+                    <a href="podcast.rss">Tesla Shorts Time RSS</a>
+                    
+                    <a href="env_intel_podcast.rss">Environmental Intelligence RSS</a>
+                    
+                    <a href="finansy_prosto_podcast.rss">Финансы Просто RSS</a>
+                    
+                    <a href="privet_russian_podcast.rss">Привет, Русский! RSS</a>
+                    
+                    <a href="unintended_consequences_podcast.rss">Unintended Consequences RSS</a>
+                    
+                    <a href="first_principles_podcast.rss">First Principles Daily RSS</a>
+                    
+                    <a href="spacex_podcast.rss">SpaceX Daily RSS</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Connect</h4>
+                    <a href="https://x.com/teslashortstime" target="_blank" rel="noopener">@teslashortstime</a>
+                    <a href="https://x.com/omniviewnews" target="_blank" rel="noopener">@omniviewnews</a>
+                    <a href="https://x.com/planetterrian" target="_blank" rel="noopener">@planetterrian</a>
+                </div>
+            </div>
+            <div class="nn-footer-col">
+                <h4>About</h4>
+                <a href="about.html">About Nerra Network</a>
+                <a href="start-here.html">Start Here</a>
+                <a href="how-to-listen.html">How to Listen</a>
+                <a href="faq.html">FAQ</a>
+                <a href="contact.html">Contact</a>
+                <a href="press.html">Press Kit</a>
+                <a href="privacy-policy.html">Privacy Policy</a>
+                <a href="terms-of-service.html">Terms of Service</a>
+                <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="editorial.html">Editorial Process</a>
+                <a href="gallery.html">Image Gallery</a>
+                <a href="management.html">Network Status</a>
+            </div>
+            <!-- Newsletter Subscribe -->
+            <div class="nn-footer-subscribe">
+                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                    <h4>Get Show Updates</h4>
+                    <p>Pick the shows you want in your inbox:</p>
+                    <div class="nn-subscribe-tags"><label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                        <label><input type="checkbox" name="tag" value="Omni View"> Omni View</label>
+                        <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
+                        <label><input type="checkbox" name="tag" value="Planetterrian Daily"> Planetterrian Daily</label>
+                        <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents"> Models &amp; Agents</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models &amp; Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
+                        <label><input type="checkbox" name="tag" value="Unintended Consequences"> Unintended Consequences</label><label><input type="checkbox" name="tag" value="Finansy Prosto"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Privet Russian"> Привет, Русский!</label>
+                    </div>
+                    <div class="nn-subscribe-row">
+                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="hidden" value="1" name="embed">
+                        <button type="submit">Subscribe</button>
+                    </div>
+                </form>
+            </div>
+            <div class="nn-footer-bottom">
+                <span>© 2026 Nerra Network. All shows independently produced.</span>
+                <a href="index.html">nerranetwork.com</a>
+            </div>
+            <div class="nn-footer-legal">
+                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
+                <div>
+                    <a href="privacy-policy.html">Privacy</a> &middot;
+                    <a href="terms-of-service.html">Terms</a> &middot;
+                    <a href="ai-disclosure.html">AI Disclosure</a>
+                    <span style="opacity:0.5;">&middot;</span>
+                    <span style="font-size:0.7rem;opacity:0.6;">Automation: reliable nightly + post-publish pipeline</span>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    // Toggle aria-expanded on dropdown hover/focus
+    document.querySelectorAll('.nn-nav-dropdown').forEach(function(dd) {
+        var btn = dd.querySelector('.nn-nav-dropdown-btn');
+        if (!btn) return;
+        dd.addEventListener('mouseenter', function() { btn.setAttribute('aria-expanded', 'true'); });
+        dd.addEventListener('mouseleave', function() { btn.setAttribute('aria-expanded', 'false'); });
+        btn.addEventListener('focus', function() { btn.setAttribute('aria-expanded', 'true'); });
+        btn.addEventListener('blur', function() {
+            setTimeout(function() {
+                if (!dd.contains(document.activeElement)) btn.setAttribute('aria-expanded', 'false');
+            }, 100);
+        });
+    });
+    // Mobile footer accordions
+    if (window.innerWidth <= 768) {
+        document.querySelectorAll('.nn-footer-col h4').forEach(function(h4) {
+            h4.addEventListener('click', function() {
+                h4.parentElement.classList.toggle('expanded');
+            });
+        });
+    }
+    </script>
+    
+<script>
+(function(){
+  // ---- Starfield ----
+  const cv = document.getElementById('spxStars');
+  if (cv) {
+    const ctx = cv.getContext('2d');
+    let stars = [];
+    function resize(){
+      cv.width = cv.offsetWidth; cv.height = cv.offsetHeight;
+      stars = Array.from({length: Math.min(180, Math.floor(cv.width/8))}, () => ({
+        x: Math.random()*cv.width, y: Math.random()*cv.height,
+        r: Math.random()*1.4+0.2, a: Math.random()*0.6+0.2, tw: Math.random()*0.02+0.005
+      }));
+    }
+    function draw(){
+      if(!ctx) return;
+      ctx.clearRect(0,0,cv.width,cv.height);
+      for(const s of stars){
+        s.a += s.tw; const al = 0.3+Math.abs(Math.sin(s.a))*0.7;
+        ctx.beginPath(); ctx.arc(s.x,s.y,s.r,0,7); ctx.fillStyle='rgba(180,205,255,'+al+')'; ctx.fill();
+      }
+      requestAnimationFrame(draw);
+    }
+    resize(); draw(); window.addEventListener('resize', resize);
+  }
+
+  const pad = n => String(n).padStart(2,'0');
+  function fmtLocal(iso){
+    try { return new Date(iso).toLocaleString([], {weekday:'short', month:'short', day:'numeric', hour:'2-digit', minute:'2-digit'}); }
+    catch(_) { return iso || '—'; }
+  }
+  function statusClass(abbr){
+    const a = (abbr||'').toUpperCase();
+    if(a==='GO') return 'go';
+    if(a.includes('HOLD')||a.includes('FAIL')||a==='TBC') return 'hold';
+    return 'tbd';
+  }
+
+  let nextNet = null, lastNet = null;
+
+  function tick(){
+    const now = Date.now();
+    if(nextNet){
+      let diff = Math.max(0, nextNet - now);
+      const d = Math.floor(diff/86400000); diff -= d*86400000;
+      const h = Math.floor(diff/3600000); diff -= h*3600000;
+      const m = Math.floor(diff/60000); diff -= m*60000;
+      const s = Math.floor(diff/1000);
+      const set=(id,v)=>{const e=document.getElementById(id); if(e) e.textContent=v;};
+      set('cd-d', d); set('cd-h', pad(h)); set('cd-m', pad(m)); set('cd-s', pad(s));
+    }
+    if(lastNet){
+      let diff = Math.max(0, now - lastNet);
+      const d = Math.floor(diff/86400000); diff -= d*86400000;
+      const h = Math.floor(diff/3600000); diff -= h*3600000;
+      const m = Math.floor(diff/60000);
+      const el = document.getElementById('spxSince');
+      if(el) el.textContent = (d>0? d+'d ':'') + pad(h)+'h '+pad(m)+'m ago';
+    }
+  }
+
+  function renderCadence(months){
+    const wrap = document.getElementById('spxCadence');
+    if(!wrap || !months || !months.length) return;
+    const max = Math.max(1, ...months.map(x=>x.count));
+    wrap.innerHTML = months.map(x=>{
+      const h = Math.round((x.count/max)*130)+3;
+      const lab = x.month.slice(2).replace('-','/'); // YY/MM
+      return '<div class="spx-bar-wrap"><div class="spx-bar" style="height:0" data-h="'+h+'"><span class="cnt">'+x.count+'</span></div><div class="spx-bar-label">'+lab+'</div></div>';
+    }).join('');
+    requestAnimationFrame(()=>{ wrap.querySelectorAll('.spx-bar').forEach(b=>{ b.style.height=b.dataset.h+'px'; }); });
+  }
+
+  function renderNext(n){
+    if(!n){ document.getElementById('spxMission').textContent='No upcoming launch on the manifest right now.'; return; }
+    nextNet = n.net ? new Date(n.net).getTime() : null;
+    const set=(id,v)=>{const e=document.getElementById(id); if(e) e.textContent=v||'—';};
+    const st = document.getElementById('spxStatus');
+    st.textContent = n.status_name || n.status || 'Scheduled';
+    st.className = 'spx-status '+statusClass(n.status);
+    set('spxMission', n.name || n.mission || 'Upcoming SpaceX launch');
+    set('spxRocket', n.rocket);
+    set('spxPad', n.pad);
+    set('spxLoc', n.location);
+    set('spxLocal', n.net ? fmtLocal(n.net) : 'TBD');
+    document.getElementById('spxDesc').textContent = n.mission_description || '';
+    if(n.webcast){ const w=document.getElementById('spxWebcast'); w.href=n.webcast; w.style.display='inline-flex'; }
+    const more = n.info_url || 'https://www.spacex.com/launches/';
+    const mEl=document.getElementById('spxMore'); mEl.href=more; mEl.style.display='inline-flex';
+  }
+
+  function renderPrev(p){
+    if(!p) return;
+    lastNet = p.net ? new Date(p.net).getTime() : null;
+    const el=document.getElementById('spxLast');
+    if(el) el.textContent = (p.name||'Last launch') + (p.net ? ' · '+fmtLocal(p.net) : '');
+  }
+
+  function renderStats(s, total){
+    const set=(id,v)=>{const e=document.getElementById(id); if(e) e.textContent=(v==null?'—':v);};
+    if(s){ set('stYtd',s.launches_ytd); set('st30',s.launches_last_30d); set('stAvg',s.avg_days_between_last_365d); set('stStar',s.starlink_launches_ytd); }
+    set('stTotal', total!=null ? total.toLocaleString() : '—');
+  }
+
+  function renderUpcoming(list){
+    const wrap=document.getElementById('spxUpcoming');
+    if(!wrap) return;
+    if(!list || !list.length){ wrap.innerHTML='<p class="spx-muted">No upcoming launches listed.</p>'; return; }
+    wrap.innerHTML = list.map(x=>'<div class="spx-upcoming-item"><span>'+(x.name||'Launch')+'</span><span class="when">'+(x.net?fmtLocal(x.net):'TBD')+'</span></div>').join('');
+  }
+
+  function applyLaunches(data){
+    if(!data) return;
+    renderNext(data.next);
+    renderPrev(data.previous);
+    renderStats(data.stats, data.total_launches);
+    renderCadence(data.cadence_monthly);
+    renderUpcoming(data.upcoming);
+  }
+
+  // SPCX price (same source as the show page pill)
+  function applyPrice(d){
+    if(!d || !(d.price>0)) return;
+    const px=document.getElementById('spxPx'); px.textContent='$'+Number(d.price).toFixed(2);
+    if(d.prev_close>0){
+      const ch=(d.price-d.prev_close), pct=(ch/d.prev_close*100);
+      const up=ch>=0; const el=document.getElementById('spxChg');
+      el.textContent=(up?'+':'')+ch.toFixed(2)+' ('+(up?'+':'')+pct.toFixed(2)+'%)';
+      el.className='ch '+(up?'up':'down');
+    }
+  }
+
+  // PRIMARY: same-origin cache written by the pipeline. Fallback: live API.
+  fetch('/api/spacex_launches.json',{cache:'no-cache'})
+    .then(r=>r.ok?r.json():Promise.reject())
+    .then(applyLaunches)
+    .catch(()=>{
+      // Client-side fallback straight to Launch Library 2 (CORS-enabled).
+      fetch('https://ll.thespacedevs.com/2.3.0/launches/upcoming/?lsp__id=121&limit=1&ordering=net&mode=detailed')
+        .then(r=>r.json()).then(d=>{ const r=(d.results||[])[0]; if(r) renderNext({
+          name:r.name, net:r.net, status:(r.status||{}).abbrev, status_name:(r.status||{}).name,
+          rocket:((r.rocket||{}).configuration||{}).name, pad:(r.pad||{}).name,
+          location:((r.pad||{}).location||{}).name, webcast:((r.vidURLs||[])[0]||{}).url
+        }); }).catch(()=>{ document.getElementById('spxMission').textContent='Launch data is temporarily unavailable — check spacex.com/launches.'; });
+    });
+
+  fetch('/api/spcx.json',{cache:'no-cache'}).then(r=>r.ok?r.json():Promise.reject()).then(applyPrice).catch(()=>{});
+
+  tick(); setInterval(tick, 1000);
+})();
+</script>
+
+
+    <!-- Centralized, improved global search -->
+    <script src="assets/js/search.js" defer></script>
+</body>
+</html>

--- a/spacex.html
+++ b/spacex.html
@@ -507,6 +507,9 @@
                     <a href="spacex-narrative.html" class="nn-btn">Story Tracker</a>
                     
                     
+                    <a href="spacex-dashboard.html" class="nn-btn">🚀 Launch Dashboard</a>
+                    
+                    
                     
                     <a href="spacex_podcast.rss" class="nn-btn" data-show="spacex">RSS Feed</a>
                     

--- a/spacex.html
+++ b/spacex.html
@@ -523,6 +523,13 @@
 </a>
                 </div>
                 
+                <div class="stock-widget" id="stock-widget">
+                    <span class="ticker">SPCX</span>
+                    <span class="price" id="stock-price">--</span>
+                    <span class="change" id="stock-change">--</span>
+                    <div id="stock-updated" style="font-size:0.7rem;opacity:0.6;margin-top:2px;"></div>
+                </div>
+                
             </div>
         </div>
     </section>
@@ -615,14 +622,271 @@
 
     <!-- Resources (categorized) -->
     
+    <section id="resources" class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Resources &amp; Further Reading</h2>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">SpaceX — Official</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.spacex.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SpaceX.com</div>
+                        <div class="resource-card-desc">The company's official site — vehicles, missions, and capabilities</div>
+                        <div class="resource-card-url">www.spacex.com</div>
+                    </a>
+                    
+                    <a href="https://www.spacex.com/launches/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SpaceX Launches</div>
+                        <div class="resource-card-desc">Upcoming and past launches with mission details and webcasts</div>
+                        <div class="resource-card-url">www.spacex.com/launches/</div>
+                    </a>
+                    
+                    <a href="https://www.spacex.com/vehicles/starship/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Starship</div>
+                        <div class="resource-card-desc">The fully reusable launch system built for the Moon and Mars</div>
+                        <div class="resource-card-url">www.spacex.com/vehicles/starship/</div>
+                    </a>
+                    
+                    <a href="https://www.starlink.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Starlink</div>
+                        <div class="resource-card-desc">SpaceX's satellite-internet constellation — the company's cash engine</div>
+                        <div class="resource-card-url">www.starlink.com</div>
+                    </a>
+                    
+                    <a href="https://x.com/SpaceX" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SpaceX on X</div>
+                        <div class="resource-card-desc">Official launch announcements, webcasts, and mission updates</div>
+                        <div class="resource-card-url">x.com/SpaceX</div>
+                    </a>
+                    
+                    <a href="https://www.youtube.com/@SpaceX" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SpaceX on YouTube</div>
+                        <div class="resource-card-desc">Live launch webcasts and mission replays in full</div>
+                        <div class="resource-card-url">www.youtube.com/@SpaceX</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">SPCX — Stock, Filings & the IPO</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&company=space+exploration+technologies&type=S-1&dateb=&owner=include&count=40" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SpaceX S-1 / Prospectus (SEC EDGAR)</div>
+                        <div class="resource-card-desc">The registration statement behind the June 2026 IPO — the numbers, straight from the source</div>
+                        <div class="resource-card-url">www.sec.gov/cgi-bin/browse-edgar?action=getcompany&company=space+exploration+technologies&type=S-1&dateb=&owner=include&count=40</div>
+                    </a>
+                    
+                    <a href="https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&company=space+exploration+technologies&type=&dateb=&owner=include&count=40" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SEC EDGAR — all SpaceX filings</div>
+                        <div class="resource-card-desc">Every public filing as it lands — 10-Ks, 10-Qs, 8-Ks, insider forms</div>
+                        <div class="resource-card-url">www.sec.gov/cgi-bin/browse-edgar?action=getcompany&company=space+exploration+technologies&type=&dateb=&owner=include&count=40</div>
+                    </a>
+                    
+                    <a href="https://finance.yahoo.com/quote/SPCX" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SPCX on Yahoo Finance</div>
+                        <div class="resource-card-desc">Real-time quote, charts, financials, and analyst coverage</div>
+                        <div class="resource-card-url">finance.yahoo.com/quote/SPCX</div>
+                    </a>
+                    
+                    <a href="https://www.tradingview.com/symbols/NASDAQ-SPCX/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SPCX on TradingView</div>
+                        <div class="resource-card-desc">Advanced charting, technicals, and community trade ideas</div>
+                        <div class="resource-card-url">www.tradingview.com/symbols/NASDAQ-SPCX/</div>
+                    </a>
+                    
+                    <a href="https://www.nasdaq.com/market-activity/stocks/spcx" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SPCX on Nasdaq</div>
+                        <div class="resource-card-desc">Exchange-of-record quote page, volume, and corporate data</div>
+                        <div class="resource-card-url">www.nasdaq.com/market-activity/stocks/spcx</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Spaceflight News & Analysis</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://www.nasaspaceflight.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">NASASpaceflight</div>
+                        <div class="resource-card-desc">The deepest independent launch reporting and Starbase coverage</div>
+                        <div class="resource-card-url">www.nasaspaceflight.com</div>
+                    </a>
+                    
+                    <a href="https://spacenews.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">SpaceNews</div>
+                        <div class="resource-card-desc">Industry, policy, and business of the space sector</div>
+                        <div class="resource-card-url">spacenews.com</div>
+                    </a>
+                    
+                    <a href="https://arstechnica.com/space/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Ars Technica — Space</div>
+                        <div class="resource-card-desc">Eric Berger's authoritative, skeptical spaceflight analysis</div>
+                        <div class="resource-card-url">arstechnica.com/space/</div>
+                    </a>
+                    
+                    <a href="https://spaceflightnow.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Spaceflight Now</div>
+                        <div class="resource-card-desc">Launch schedules and live mission coverage</div>
+                        <div class="resource-card-url">spaceflightnow.com</div>
+                    </a>
+                    
+                    <a href="https://x.com/SciGuySpace" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Eric Berger on X</div>
+                        <div class="resource-card-desc">Breaking SpaceX news and reporting from Ars Technica's senior space editor</div>
+                        <div class="resource-card-url">x.com/SciGuySpace</div>
+                    </a>
+                    
+                    <a href="https://x.com/thesheetztweetz" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Michael Sheetz on X</div>
+                        <div class="resource-card-desc">CNBC's space-business reporter — the SPCX investor angle</div>
+                        <div class="resource-card-url">x.com/thesheetztweetz</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Launch Tracking & Data</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://nextspaceflight.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Next Spaceflight</div>
+                        <div class="resource-card-desc">Every upcoming launch with countdowns, rockets, and pads</div>
+                        <div class="resource-card-url">nextspaceflight.com</div>
+                    </a>
+                    
+                    <a href="https://flightclub.io" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Flight Club</div>
+                        <div class="resource-card-desc">Live trajectory simulations and telemetry for orbital launches</div>
+                        <div class="resource-card-url">flightclub.io</div>
+                    </a>
+                    
+                    <a href="https://planet4589.org/space/jsr/jsr.html" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Jonathan's Space Report</div>
+                        <div class="resource-card-desc">Jonathan McDowell's authoritative catalogue of launches and satellites</div>
+                        <div class="resource-card-url">planet4589.org/space/jsr/jsr.html</div>
+                    </a>
+                    
+                    <a href="https://www.reddit.com/r/spacex/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">r/SpaceX</div>
+                        <div class="resource-card-desc">The largest SpaceX community — launch threads and technical discussion</div>
+                        <div class="resource-card-url">www.reddit.com/r/spacex/</div>
+                    </a>
+                    
+                    <a href="https://www.reddit.com/r/SpaceXLounge/" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">r/SpaceXLounge</div>
+                        <div class="resource-card-desc">Looser SpaceX discussion, speculation, and community analysis</div>
+                        <div class="resource-card-url">www.reddit.com/r/SpaceXLounge/</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+            <div class="resource-category">
+                <h3 class="resource-category-title">Musk & the xAI Ecosystem</h3>
+                <div class="resources-grid">
+                    
+                    <a href="https://x.com/elonmusk" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Elon Musk on X</div>
+                        <div class="resource-card-desc">First-hand program updates and milestones, straight from the CEO</div>
+                        <div class="resource-card-url">x.com/elonmusk</div>
+                    </a>
+                    
+                    <a href="https://x.ai" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">xAI</div>
+                        <div class="resource-card-desc">Musk's AI company — the AI-compute thread that runs through the SpaceX story</div>
+                        <div class="resource-card-url">x.ai</div>
+                    </a>
+                    
+                    <a href="https://grok.com" class="resource-card glass-card" target="_blank" rel="noopener">
+                        <div class="resource-card-name">Grok</div>
+                        <div class="resource-card-desc">xAI's assistant — the AI that powers this show's research and voice</div>
+                        <div class="resource-card-url">grok.com</div>
+                    </a>
+                    
+                </div>
+            </div>
+            
+        </div>
+    </section>
+    
 
     <!-- Recommended Tools -->
+    
+    <section class="nn-section" style="padding-top:0;">
+        <div class="container">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Recommended Tools</h2>
+            </div>
+            <div class="tools-grid">
+                
+                <a href="https://www.tradingview.com/symbols/NASDAQ-SPCX/" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free tier</span>
+                    <div class="tool-card-name">SPCX on TradingView</div>
+                    <div class="tool-card-desc">Chart SPCX with technicals and alerts</div>
+                </a>
+                
+                <a href="https://efts.sec.gov/LATEST/search-index?q=%22space+exploration+technologies%22" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">SEC EDGAR Full-Text Search</div>
+                    <div class="tool-card-desc">Search every word of every SpaceX filing</div>
+                </a>
+                
+                <a href="https://nextspaceflight.com" class="tool-card glass-card" target="_blank" rel="noopener">
+                    <span class="tool-badge">Free</span>
+                    <div class="tool-card-name">Next Spaceflight</div>
+                    <div class="tool-card-desc">Never miss a launch — schedules and countdowns</div>
+                </a>
+                
+            </div>
+        </div>
+    </section>
     
 
     <!-- Referral -->
     
 
     <!-- Key Concepts / FAQ -->
+    
+    <section id="faq" class="nn-section" style="padding-top:0;">
+        <div class="container" style="max-width:800px;">
+            <div class="nn-section-header" style="text-align:left;">
+                <h2>Key Concepts</h2>
+            </div>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is SpaceX Daily?</summary>
+                <div class="faq-answer">A daily podcast and blog that tracks SpaceX now that it's a public company (Nasdaq: SPCX). Every weekday: the day's developments with sources, what the spaceflight community is talking about, one honest counterpoint, the engineering and economics behind the headlines, and the SPCX market picture. Hosted by Patrick in Vancouver.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">What is SPCX?</summary>
+                <div class="faq-answer">SPCX is SpaceX's stock ticker on the Nasdaq. SpaceX held the largest IPO in history in June 2026, pricing at $135 per share and raising about $75 billion at a valuation near $1.8 trillion. A dual-class share structure leaves Elon Musk with a controlling majority of the voting power. Nothing on this show is financial advice.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">Where do the numbers come from?</summary>
+                <div class="faq-answer">Official sources wherever possible — SpaceX announcements, the SEC S-1/prospectus and later filings, and credible reporting from NASASpaceflight, SpaceNews, Ars Technica, and CNBC. Community and social posts are clearly flagged as unverified. The live SPCX price on this page is refreshed every run from market data.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">How long are episodes?</summary>
+                <div class="faq-answer">About 12 to 14 minutes — enough to walk through the day's launches, programs, and market picture, short enough for a commute.</div>
+            </details>
+            
+            <details class="faq-item glass-card">
+                <summary class="faq-question">Is this just Elon Musk fan content?</summary>
+                <div class="faq-answer">No. The show is genuinely balanced: every episode carries an honest counterpoint, and the premiere named the real risks — stretched valuation, Musk's concentrated voting control, and a launch business that still loses money while Starlink carries the profit. Enthusiasm grounded in numbers is the brand.</div>
+            </details>
+            
+        </div>
+    </section>
     
 
     
@@ -1203,6 +1467,133 @@
             document.getElementById('episodes-grid').innerHTML = '<p style="color:var(--nn-text-muted);grid-column:1/-1;text-align:center;padding:2rem 0;">Episodes will appear here once available.</p>';
         }
 
+        
+        // --- Stock widget (Tesla + SpaceX) ---
+        const STOCK_TICKER = "SPCX";
+        const STOCK_JSON = "/api/spcx.json";
+        const STOCK_YAHOO = "SPCX";
+        async function loadStock() {
+            // Tracks whether the same-origin snapshot already populated a
+            // valid price. If so, a later Yahoo-fallback failure must NOT
+            // overwrite it with "Market data unavailable" (the off-hours
+            // bug: proxies fail on weekends, but the pipeline snapshot is
+            // good). Yahoo only ever UPGRADES a shown price during the day.
+            let havePrimary = false;
+            function displayPrice(price, prev, marketState = null) {
+                const p = parseFloat(price), pc = parseFloat(prev);
+                // Validate: price should be in a reasonable range
+                if (isNaN(p) || isNaN(pc) || p <= 0 || pc <= 0 || p > 99999 || pc > 99999) {
+                    if (!havePrimary) showStockError('Invalid price data');
+                    return;
+                }
+                const ch = (p - pc).toFixed(2);
+                const pct = ((p - pc) / pc * 100).toFixed(2);
+                const isUp = parseFloat(ch) >= 0;
+                document.getElementById('stock-price').textContent = '$' + p.toFixed(2);
+                const changeEl = document.getElementById('stock-change');
+                let label = '';
+                if (marketState) {
+                    const ms = String(marketState).toUpperCase();
+                    if (ms === 'PRE') label = 'Pre-Market';
+                    else if (ms.includes('POST')) label = 'After Hours';
+                    else if (ms === 'REGULAR') label = '';
+                }
+                changeEl.textContent = (isUp ? '+' : '') + ch + ' (' + (isUp ? '+' : '') + pct + '%)' + (label ? ` · ${label}` : '');
+                changeEl.className = 'change ' + (isUp ? 'up' : 'down');
+            }
+            function showStockError(msg) {
+                const priceEl = document.getElementById('stock-price');
+                const changeEl = document.getElementById('stock-change');
+                const updatedEl = document.getElementById('stock-updated');
+                if (priceEl) priceEl.textContent = '\u2014';  // ticker label already says TSLA
+                if (changeEl) changeEl.textContent = msg || 'Market data unavailable';
+                if (updatedEl) updatedEl.textContent = '';
+            }
+
+            // PRIMARY source: same-origin JSON written by the show's
+            // pipeline hook every run.  No CORS proxy, no Yahoo-Finance
+            // flakiness.  Operator caught (May 14 2026) the previous
+            // Yahoo-only path showing "Market data unavailable" because
+            // every CORS proxy was failing — yet the pipeline knew the
+            // live price the whole time.  Tolerates both the Tesla schema
+            // (market_state/fetched_at) and the SpaceX schema
+            // (change_str/updated_at) — only price + prev_close are required.
+            try {
+                const resp = await fetch(STOCK_JSON, {
+                    cache: 'no-cache',
+                    signal: AbortSignal.timeout(4000),
+                });
+                if (resp.ok) {
+                    const cached = await resp.json();
+                    const price = parseFloat(cached.price);
+                    const prev = parseFloat(cached.prev_close);
+                    if (price > 0 && prev > 0) {
+                        displayPrice(price, prev, cached.market_state || null);
+                        havePrimary = true;
+                        const updatedEl = document.getElementById('stock-updated');
+                        const ts = cached.fetched_at || cached.updated_at;
+                        if (updatedEl && ts) {
+                            try {
+                                const d = new Date(ts);
+                                updatedEl.textContent = `Updated ${d.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})} (snapshot)`;
+                            } catch (_) {}
+                        }
+                        // Do NOT return — fall through to Yahoo attempts.
+                        // This lets a live trading-hours quote from Yahoo upgrade
+                        // the displayed price + timestamp for visitors during the day.
+                    }
+                }
+            } catch { /* fall through to Yahoo */ }
+
+            // FALLBACK: Yahoo Finance v8 chart API via CORS proxies.
+            const yahooUrl = 'https://query2.finance.yahoo.com/v8/finance/chart/' + STOCK_YAHOO + '?interval=1d&range=5d';
+            // Yahoo Finance v6 quote API — alternative endpoint
+            const yahooQuoteUrl = 'https://query1.finance.yahoo.com/v6/finance/quote?symbols=' + STOCK_YAHOO;
+            const proxies = [
+                url => 'https://api.allorigins.win/raw?url=' + encodeURIComponent(url),
+                url => 'https://corsproxy.io/?' + encodeURIComponent(url),
+                url => url
+            ];
+
+            // Try chart API first (most reliable for price + previous close)
+            for (const makeUrl of proxies) {
+                try {
+                    const resp = await fetch(makeUrl(yahooUrl), { signal: AbortSignal.timeout(8000) });
+                    if (!resp.ok) continue;
+                    const data = await resp.json();
+                    const result = data?.chart?.result?.[0];
+                    if (!result?.meta) continue;
+                    const meta = result.meta;
+                    const price = meta.regularMarketPrice;
+                    const prev = meta.chartPreviousClose || meta.previousClose;
+                    if (price && prev) {
+                        displayPrice(price, prev, meta.marketState || null);
+                        return;
+                    }
+                } catch { /* try next proxy */ }
+            }
+
+            // Fallback: try quote API
+            for (const makeUrl of proxies) {
+                try {
+                    const resp = await fetch(makeUrl(yahooQuoteUrl), { signal: AbortSignal.timeout(8000) });
+                    if (!resp.ok) continue;
+                    const data = await resp.json();
+                    const quote = data?.quoteResponse?.result?.[0];
+                    if (quote?.regularMarketPrice && quote?.regularMarketPreviousClose) {
+                        displayPrice(quote.regularMarketPrice, quote.regularMarketPreviousClose, quote.marketState);
+                        return;
+                    }
+                } catch { /* try next proxy */ }
+            }
+
+            // All Yahoo fallbacks failed. Only show the error if the
+            // same-origin snapshot didn't already populate a good price.
+            if (!havePrimary) showStockError('Market data unavailable');
+        }
+        loadStock();
+        // Refresh stock price every 5 minutes during page session
+        setInterval(loadStock, 300000);
         
 
         loadEpisodes();

--- a/spacex.html
+++ b/spacex.html
@@ -533,6 +533,17 @@
                     <div id="stock-updated" style="font-size:0.7rem;opacity:0.6;margin-top:2px;"></div>
                 </div>
                 
+                
+                <a href="spacex-dashboard.html" id="launch-teaser" style="display:none;margin-top:var(--sp-3);align-items:center;gap:12px;padding:10px 16px;border:1px solid rgba(120,160,255,0.3);border-radius:14px;background:linear-gradient(135deg,rgba(26,92,255,0.14),rgba(0,212,255,0.06));text-decoration:none;color:inherit;max-width:520px;">
+                    <span aria-hidden="true" style="font-size:1.4rem;line-height:1;">🚀</span>
+                    <span style="flex:1;min-width:0;">
+                        <span style="display:block;font-size:0.66rem;letter-spacing:0.12em;text-transform:uppercase;color:#7fb0ff;font-weight:700;">Next SpaceX launch</span>
+                        <span id="lt-mission" style="display:block;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">Loading…</span>
+                    </span>
+                    <span id="lt-countdown" style="font-variant-numeric:tabular-nums;font-weight:800;font-size:1.05rem;color:#fff;white-space:nowrap;">—</span>
+                    <span aria-hidden="true" style="color:#7fb0ff;font-weight:700;">→</span>
+                </a>
+                
             </div>
         </div>
     </section>
@@ -1597,6 +1608,42 @@
         loadStock();
         // Refresh stock price every 5 minutes during page session
         setInterval(loadStock, 300000);
+        
+
+        
+        // --- Next-launch teaser strip (links to the full dashboard) ---
+        (function(){
+            const teaser = document.getElementById('launch-teaser');
+            if (!teaser) return;
+            let netMs = null;
+            function pad(n){ return String(n).padStart(2,'0'); }
+            function tick(){
+                if (netMs == null) return;
+                let diff = Math.max(0, netMs - Date.now());
+                const d = Math.floor(diff/86400000); diff -= d*86400000;
+                const h = Math.floor(diff/3600000); diff -= h*3600000;
+                const m = Math.floor(diff/60000); diff -= m*60000;
+                const s = Math.floor(diff/1000);
+                const el = document.getElementById('lt-countdown');
+                if (el) el.textContent = (d>0 ? d+'d ' : '') + pad(h)+':'+pad(m)+':'+pad(s);
+            }
+            function render(n){
+                if (!n || !n.name) return;
+                netMs = n.net ? new Date(n.net).getTime() : null;
+                const mEl = document.getElementById('lt-mission');
+                if (mEl) mEl.textContent = n.name;
+                teaser.style.display = 'flex';
+                tick(); setInterval(tick, 1000);
+            }
+            fetch('/api/spacex_launches.json', {cache:'no-cache'})
+                .then(r => r.ok ? r.json() : Promise.reject())
+                .then(d => render(d.next))
+                .catch(() => {
+                    fetch('https://ll.thespacedevs.com/2.3.0/launches/upcoming/?lsp__id=121&limit=1&ordering=net&mode=list')
+                        .then(r=>r.json()).then(d=>{ const r=(d.results||[])[0]; if(r) render({name:r.name, net:r.net}); })
+                        .catch(()=>{});
+                });
+        })();
         
 
         loadEpisodes();

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -138,9 +138,9 @@
                 <div style="margin-top:var(--sp-3);">
                     {{ ai_badge(path_prefix=path_prefix, is_ru=_is_ru) }}
                 </div>
-                {% if show_slug == 'tesla' %}
+                {% if stock_widget %}
                 <div class="stock-widget" id="stock-widget">
-                    <span class="ticker">TSLA</span>
+                    <span class="ticker">{{ stock_widget.ticker }}</span>
                     <span class="price" id="stock-price">--</span>
                     <span class="change" id="stock-change">--</span>
                     <div id="stock-updated" style="font-size:0.7rem;opacity:0.6;margin-top:2px;"></div>
@@ -908,14 +908,23 @@
             document.getElementById('episodes-grid').innerHTML = '<p style="color:var(--nn-text-muted);grid-column:1/-1;text-align:center;padding:2rem 0;">Episodes will appear here once available.</p>';
         }
 
-        {% if show_slug == 'tesla' %}
-        // --- Stock widget (Tesla only) ---
+        {% if stock_widget %}
+        // --- Stock widget (Tesla + SpaceX) ---
+        const STOCK_TICKER = {{ stock_widget.ticker | tojson }};
+        const STOCK_JSON = {{ stock_widget.json_path | tojson }};
+        const STOCK_YAHOO = {{ stock_widget.yahoo_symbol | tojson }};
         async function loadStock() {
+            // Tracks whether the same-origin snapshot already populated a
+            // valid price. If so, a later Yahoo-fallback failure must NOT
+            // overwrite it with "Market data unavailable" (the off-hours
+            // bug: proxies fail on weekends, but the pipeline snapshot is
+            // good). Yahoo only ever UPGRADES a shown price during the day.
+            let havePrimary = false;
             function displayPrice(price, prev, marketState = null) {
                 const p = parseFloat(price), pc = parseFloat(prev);
-                // Validate: TSLA price should be in a reasonable range
+                // Validate: price should be in a reasonable range
                 if (isNaN(p) || isNaN(pc) || p <= 0 || pc <= 0 || p > 99999 || pc > 99999) {
-                    showStockError('Invalid price data');
+                    if (!havePrimary) showStockError('Invalid price data');
                     return;
                 }
                 const ch = (p - pc).toFixed(2);
@@ -942,15 +951,16 @@
                 if (updatedEl) updatedEl.textContent = '';
             }
 
-            // PRIMARY source: same-origin api/tsla.json written by the
-            // Tesla pipeline (shows/hooks/tesla.py) every run via Grok's
-            // x_search.  No CORS proxy, no Yahoo-Finance flakiness.
-            // Operator caught (May 14 2026) the previous Yahoo-only path
-            // showing "Market data unavailable" on the website because
+            // PRIMARY source: same-origin JSON written by the show's
+            // pipeline hook every run.  No CORS proxy, no Yahoo-Finance
+            // flakiness.  Operator caught (May 14 2026) the previous
+            // Yahoo-only path showing "Market data unavailable" because
             // every CORS proxy was failing — yet the pipeline knew the
-            // live price the whole time.
+            // live price the whole time.  Tolerates both the Tesla schema
+            // (market_state/fetched_at) and the SpaceX schema
+            // (change_str/updated_at) — only price + prev_close are required.
             try {
-                const resp = await fetch('/api/tsla.json', {
+                const resp = await fetch(STOCK_JSON, {
                     cache: 'no-cache',
                     signal: AbortSignal.timeout(4000),
                 });
@@ -960,10 +970,12 @@
                     const prev = parseFloat(cached.prev_close);
                     if (price > 0 && prev > 0) {
                         displayPrice(price, prev, cached.market_state || null);
+                        havePrimary = true;
                         const updatedEl = document.getElementById('stock-updated');
-                        if (updatedEl && cached.fetched_at) {
+                        const ts = cached.fetched_at || cached.updated_at;
+                        if (updatedEl && ts) {
                             try {
-                                const d = new Date(cached.fetched_at);
+                                const d = new Date(ts);
                                 updatedEl.textContent = `Updated ${d.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})} (snapshot)`;
                             } catch (_) {}
                         }
@@ -975,9 +987,9 @@
             } catch { /* fall through to Yahoo */ }
 
             // FALLBACK: Yahoo Finance v8 chart API via CORS proxies.
-            const yahooUrl = 'https://query2.finance.yahoo.com/v8/finance/chart/TSLA?interval=1d&range=5d';
+            const yahooUrl = 'https://query2.finance.yahoo.com/v8/finance/chart/' + STOCK_YAHOO + '?interval=1d&range=5d';
             // Yahoo Finance v6 quote API — alternative endpoint
-            const yahooQuoteUrl = 'https://query1.finance.yahoo.com/v6/finance/quote?symbols=TSLA';
+            const yahooQuoteUrl = 'https://query1.finance.yahoo.com/v6/finance/quote?symbols=' + STOCK_YAHOO;
             const proxies = [
                 url => 'https://api.allorigins.win/raw?url=' + encodeURIComponent(url),
                 url => 'https://corsproxy.io/?' + encodeURIComponent(url),
@@ -996,7 +1008,7 @@
                     const price = meta.regularMarketPrice;
                     const prev = meta.chartPreviousClose || meta.previousClose;
                     if (price && prev) {
-                        displayPrice(price, prev, marketState);
+                        displayPrice(price, prev, meta.marketState || null);
                         return;
                     }
                 } catch { /* try next proxy */ }
@@ -1016,7 +1028,9 @@
                 } catch { /* try next proxy */ }
             }
 
-            showStockError('Market data unavailable');
+            // All Yahoo fallbacks failed. Only show the error if the
+            // same-origin snapshot didn't already populate a good price.
+            if (!havePrimary) showStockError('Market data unavailable');
         }
         loadStock();
         // Refresh stock price every 5 minutes during page session

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -115,6 +115,9 @@
                     {% if narrative_page_url %}
                     <a href="{{ path_prefix }}{{ narrative_page_url }}" class="nn-btn">{% if _is_ru %}Хронология{% else %}Story Tracker{% endif %}</a>
                     {% endif %}
+                    {% if show_slug == 'spacex' %}
+                    <a href="{{ path_prefix }}spacex-dashboard.html" class="nn-btn">🚀 Launch Dashboard</a>
+                    {% endif %}
                     {% if apple_podcasts_url %}
                     <a href="{{ apple_podcasts_url | with_utm(campaign=show_slug) }}" class="nn-btn" target="_blank" rel="noopener" data-show="{{ show_slug }}">Apple Podcasts</a>
                     {% endif %}

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -149,6 +149,17 @@
                     <div id="stock-updated" style="font-size:0.7rem;opacity:0.6;margin-top:2px;"></div>
                 </div>
                 {% endif %}
+                {% if show_slug == 'spacex' %}
+                <a href="{{ path_prefix }}spacex-dashboard.html" id="launch-teaser" style="display:none;margin-top:var(--sp-3);align-items:center;gap:12px;padding:10px 16px;border:1px solid rgba(120,160,255,0.3);border-radius:14px;background:linear-gradient(135deg,rgba(26,92,255,0.14),rgba(0,212,255,0.06));text-decoration:none;color:inherit;max-width:520px;">
+                    <span aria-hidden="true" style="font-size:1.4rem;line-height:1;">🚀</span>
+                    <span style="flex:1;min-width:0;">
+                        <span style="display:block;font-size:0.66rem;letter-spacing:0.12em;text-transform:uppercase;color:#7fb0ff;font-weight:700;">Next SpaceX launch</span>
+                        <span id="lt-mission" style="display:block;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">Loading…</span>
+                    </span>
+                    <span id="lt-countdown" style="font-variant-numeric:tabular-nums;font-weight:800;font-size:1.05rem;color:#fff;white-space:nowrap;">—</span>
+                    <span aria-hidden="true" style="color:#7fb0ff;font-weight:700;">→</span>
+                </a>
+                {% endif %}
             </div>
         </div>
     </section>
@@ -1038,6 +1049,42 @@
         loadStock();
         // Refresh stock price every 5 minutes during page session
         setInterval(loadStock, 300000);
+        {% endif %}
+
+        {% if show_slug == 'spacex' %}
+        // --- Next-launch teaser strip (links to the full dashboard) ---
+        (function(){
+            const teaser = document.getElementById('launch-teaser');
+            if (!teaser) return;
+            let netMs = null;
+            function pad(n){ return String(n).padStart(2,'0'); }
+            function tick(){
+                if (netMs == null) return;
+                let diff = Math.max(0, netMs - Date.now());
+                const d = Math.floor(diff/86400000); diff -= d*86400000;
+                const h = Math.floor(diff/3600000); diff -= h*3600000;
+                const m = Math.floor(diff/60000); diff -= m*60000;
+                const s = Math.floor(diff/1000);
+                const el = document.getElementById('lt-countdown');
+                if (el) el.textContent = (d>0 ? d+'d ' : '') + pad(h)+':'+pad(m)+':'+pad(s);
+            }
+            function render(n){
+                if (!n || !n.name) return;
+                netMs = n.net ? new Date(n.net).getTime() : null;
+                const mEl = document.getElementById('lt-mission');
+                if (mEl) mEl.textContent = n.name;
+                teaser.style.display = 'flex';
+                tick(); setInterval(tick, 1000);
+            }
+            fetch('/api/spacex_launches.json', {cache:'no-cache'})
+                .then(r => r.ok ? r.json() : Promise.reject())
+                .then(d => render(d.next))
+                .catch(() => {
+                    fetch('https://ll.thespacedevs.com/2.3.0/launches/upcoming/?lsp__id=121&limit=1&ordering=net&mode=list')
+                        .then(r=>r.json()).then(d=>{ const r=(d.results||[])[0]; if(r) render({name:r.name, net:r.net}); })
+                        .catch(()=>{});
+                });
+        })();
         {% endif %}
 
         loadEpisodes();

--- a/templates/spacex_dashboard.html.j2
+++ b/templates/spacex_dashboard.html.j2
@@ -1,0 +1,347 @@
+{% extends "base.html.j2" %}
+
+{% block title %}SpaceX Launch Dashboard — Next Launch Countdown, Cadence & SPCX | Nerra Network{% endblock %}
+
+{% block og_type %}website{% endblock %}
+
+{% block head_extra %}
+<style>
+  /* ---- SpaceX Launch Dashboard (scoped under .spx-dash) ---- */
+  .spx-dash {
+    --spx-blue: #1A5CFF;
+    --spx-cyan: #00D4FF;
+    --spx-ink: #0a1020;
+    position: relative;
+    color: #eaf0ff;
+  }
+  .spx-hero-wrap {
+    position: relative;
+    overflow: hidden;
+    background:
+      radial-gradient(1200px 600px at 50% -10%, rgba(26,92,255,0.28), transparent 60%),
+      linear-gradient(180deg, #05080f 0%, #0a1124 60%, #0a0f1e 100%);
+    border-bottom: 1px solid rgba(120,160,255,0.15);
+  }
+  .spx-stars {
+    position: absolute; inset: 0; z-index: 0; pointer-events: none;
+  }
+  .spx-container {
+    position: relative; z-index: 1;
+    max-width: 1120px; margin: 0 auto;
+    padding: calc(var(--nav-height) + 2.5rem) 1.25rem 2rem;
+  }
+  .spx-kicker {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 0.78rem; letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--spx-cyan); font-weight: 700; margin-bottom: 0.6rem;
+  }
+  .spx-kicker .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--spx-cyan);
+    box-shadow: 0 0 10px var(--spx-cyan); animation: spx-pulse 1.8s infinite; }
+  @keyframes spx-pulse { 0%,100%{opacity:1} 50%{opacity:.35} }
+  .spx-h1 { font-size: clamp(1.8rem, 4vw, 2.8rem); line-height: 1.05; margin: 0 0 0.4rem; font-weight: 800; letter-spacing: -0.02em; }
+  .spx-sub { color: #aebbe0; font-size: 1.02rem; max-width: 62ch; margin: 0 0 1.6rem; }
+
+  .spx-countdown {
+    display: flex; gap: 0.6rem; flex-wrap: wrap; margin: 0.4rem 0 1.2rem;
+  }
+  .spx-cd-unit {
+    min-width: 78px; text-align: center;
+    background: rgba(13,22,46,0.7); border: 1px solid rgba(120,160,255,0.22);
+    border-radius: 14px; padding: 0.7rem 0.5rem;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.05), 0 8px 30px rgba(0,0,0,0.35);
+    backdrop-filter: blur(6px);
+  }
+  .spx-cd-num { font-size: clamp(1.6rem, 4.5vw, 2.6rem); font-weight: 800; font-variant-numeric: tabular-nums;
+    background: linear-gradient(180deg, #fff, #9fc0ff); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+  .spx-cd-label { font-size: 0.66rem; letter-spacing: 0.12em; text-transform: uppercase; color: #8ea3d6; margin-top: 2px; }
+
+  .spx-status {
+    display:inline-flex; align-items:center; gap:7px; font-weight:700; font-size:0.82rem;
+    padding: 4px 12px; border-radius: 999px; border:1px solid transparent;
+  }
+  .spx-status.go   { color:#7efbb0; background:rgba(40,200,120,0.12); border-color:rgba(40,200,120,0.35); }
+  .spx-status.tbd  { color:#ffd27a; background:rgba(255,180,40,0.12); border-color:rgba(255,180,40,0.32); }
+  .spx-status.hold { color:#ff9a9a; background:rgba(255,80,80,0.12); border-color:rgba(255,80,80,0.32); }
+
+  .spx-launchcard {
+    background: rgba(11,18,38,0.66); border: 1px solid rgba(120,160,255,0.2);
+    border-radius: 18px; padding: 1.1rem 1.2rem; backdrop-filter: blur(8px);
+  }
+  .spx-launchcard h3 { margin: 0.2rem 0 0.5rem; font-size: 1.25rem; }
+  .spx-meta { display:grid; grid-template-columns: repeat(auto-fit, minmax(150px,1fr)); gap: 0.6rem 1rem; margin-top: 0.6rem; }
+  .spx-meta .k { font-size:0.68rem; text-transform:uppercase; letter-spacing:0.1em; color:#8ea3d6; }
+  .spx-meta .v { font-size:0.95rem; color:#eaf0ff; font-weight:600; }
+  .spx-btn {
+    display:inline-flex; align-items:center; gap:8px; margin-top: 0.9rem;
+    background: linear-gradient(135deg, var(--spx-blue), #3f7bff); color:#fff; font-weight:700;
+    padding: 0.6rem 1.1rem; border-radius: 12px; text-decoration:none; font-size:0.92rem;
+    box-shadow: 0 8px 24px rgba(26,92,255,0.4);
+  }
+  .spx-btn.ghost { background: transparent; border:1px solid rgba(120,160,255,0.4); box-shadow:none; }
+
+  .spx-grid { max-width:1120px; margin: 1.5rem auto; padding: 0 1.25rem; display:grid; gap:1.1rem; grid-template-columns: 1fr 1fr; }
+  @media (max-width: 760px){ .spx-grid{ grid-template-columns:1fr; } }
+  .spx-panel {
+    background: var(--nn-surface, #0f1830); border:1px solid rgba(120,160,255,0.16);
+    border-radius:16px; padding:1.1rem 1.2rem;
+  }
+  .spx-panel h2 { font-size:1.05rem; margin:0 0 0.9rem; letter-spacing:-0.01em; }
+
+  .spx-stats { display:grid; grid-template-columns: repeat(auto-fit,minmax(120px,1fr)); gap:0.8rem; }
+  .spx-stat { text-align:center; padding:0.6rem; border-radius:12px; background:rgba(26,92,255,0.08); border:1px solid rgba(120,160,255,0.14); }
+  .spx-stat .n { font-size:1.7rem; font-weight:800; color:#fff; font-variant-numeric:tabular-nums; }
+  .spx-stat .l { font-size:0.7rem; text-transform:uppercase; letter-spacing:0.08em; color:#8ea3d6; margin-top:2px; }
+
+  /* cadence chart */
+  .spx-cadence { display:flex; align-items:flex-end; gap:6px; height:160px; padding-top:8px; }
+  .spx-bar-wrap { flex:1; display:flex; flex-direction:column; align-items:center; gap:4px; height:100%; justify-content:flex-end; }
+  .spx-bar {
+    width:100%; border-radius:6px 6px 2px 2px; min-height:3px;
+    background: linear-gradient(180deg, var(--spx-cyan), var(--spx-blue));
+    transition: height .6s cubic-bezier(.2,.7,.2,1);
+    position:relative;
+  }
+  .spx-bar .cnt { position:absolute; top:-18px; left:0; right:0; text-align:center; font-size:0.7rem; color:#cfe0ff; font-weight:700; }
+  .spx-bar-label { font-size:0.6rem; color:#7f93c4; white-space:nowrap; }
+
+  .spx-since { font-size: clamp(1.4rem,3.5vw,2rem); font-weight:800; font-variant-numeric:tabular-nums; color:#fff; }
+  .spx-upcoming-item { display:flex; justify-content:space-between; gap:10px; padding:0.55rem 0; border-bottom:1px solid rgba(120,160,255,0.12); font-size:0.9rem; }
+  .spx-upcoming-item:last-child{ border-bottom:none; }
+  .spx-upcoming-item .when { color:#8ea3d6; white-space:nowrap; font-variant-numeric:tabular-nums; }
+
+  .spx-spcx { display:flex; align-items:baseline; gap:12px; }
+  .spx-spcx .px { font-size:2rem; font-weight:800; color:#fff; }
+  .spx-spcx .ch.up { color:#5ef0a0; } .spx-spcx .ch.down{ color:#ff8a8a; }
+  .spx-muted { color:#8ea3d6; font-size:0.82rem; }
+  .spx-foot-note { max-width:1120px; margin:0 auto 2rem; padding:0 1.25rem; color:#7f93c4; font-size:0.78rem; }
+  .spx-disclaimer { color:#7f93c4; font-size:0.74rem; margin-top:0.4rem; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="spx-dash">
+  <div class="spx-hero-wrap">
+    <canvas class="spx-stars" id="spxStars"></canvas>
+    <div class="spx-container">
+      <div class="spx-kicker"><span class="dot"></span> SpaceX Launch Dashboard · Live</div>
+      <h1 class="spx-h1">Next SpaceX Launch</h1>
+      <p class="spx-sub">A live countdown to the next launch, time since the last one, cadence, and the SPCX market picture — the companion dashboard to <a href="{{ path_prefix }}spacex.html" style="color:var(--spx-cyan);">SpaceX Daily</a>.</p>
+
+      <div id="spxNext">
+        <div class="spx-countdown" id="spxCountdown">
+          <div class="spx-cd-unit"><div class="spx-cd-num" id="cd-d">--</div><div class="spx-cd-label">Days</div></div>
+          <div class="spx-cd-unit"><div class="spx-cd-num" id="cd-h">--</div><div class="spx-cd-label">Hours</div></div>
+          <div class="spx-cd-unit"><div class="spx-cd-num" id="cd-m">--</div><div class="spx-cd-label">Min</div></div>
+          <div class="spx-cd-unit"><div class="spx-cd-num" id="cd-s">--</div><div class="spx-cd-label">Sec</div></div>
+        </div>
+        <div class="spx-launchcard">
+          <span class="spx-status tbd" id="spxStatus">Loading…</span>
+          <h3 id="spxMission">Fetching the latest launch manifest…</h3>
+          <div class="spx-meta">
+            <div><div class="k">Vehicle</div><div class="v" id="spxRocket">—</div></div>
+            <div><div class="k">Launch Pad</div><div class="v" id="spxPad">—</div></div>
+            <div><div class="k">Location</div><div class="v" id="spxLoc">—</div></div>
+            <div><div class="k">Target (your time)</div><div class="v" id="spxLocal">—</div></div>
+          </div>
+          <p class="spx-muted" id="spxDesc" style="margin:0.7rem 0 0;"></p>
+          <a class="spx-btn" id="spxWebcast" href="#" target="_blank" rel="noopener" style="display:none;">▶ Watch the webcast</a>
+          <a class="spx-btn ghost" id="spxMore" href="#" target="_blank" rel="noopener" style="display:none;">Mission details</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="spx-grid">
+    <div class="spx-panel">
+      <h2>Time since last launch</h2>
+      <div class="spx-since" id="spxSince">—</div>
+      <p class="spx-muted" id="spxLast" style="margin:0.4rem 0 0;">—</p>
+    </div>
+    <div class="spx-panel">
+      <h2>SPCX</h2>
+      <div class="spx-spcx"><span class="px" id="spxPx">—</span><span class="ch" id="spxChg"></span></div>
+      <p class="spx-muted" id="spxPxNote" style="margin:0.4rem 0 0;">Nasdaq: SPCX</p>
+      <p class="spx-disclaimer">Not financial advice.</p>
+    </div>
+  </div>
+
+  <div class="spx-grid" style="grid-template-columns:1fr;">
+    <div class="spx-panel">
+      <h2>Launch cadence — last 12 months</h2>
+      <div class="spx-cadence" id="spxCadence"></div>
+      <div class="spx-stats" style="margin-top:1.2rem;">
+        <div class="spx-stat"><div class="n" id="stYtd">—</div><div class="l">Launches YTD</div></div>
+        <div class="spx-stat"><div class="n" id="st30">—</div><div class="l">Last 30 days</div></div>
+        <div class="spx-stat"><div class="n" id="stAvg">—</div><div class="l">Avg days apart</div></div>
+        <div class="spx-stat"><div class="n" id="stStar">—</div><div class="l">Starlink YTD</div></div>
+        <div class="spx-stat"><div class="n" id="stTotal">—</div><div class="l">Total launches</div></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="spx-grid" style="grid-template-columns:1fr;">
+    <div class="spx-panel">
+      <h2>Upcoming manifest</h2>
+      <div id="spxUpcoming"><p class="spx-muted">Loading…</p></div>
+    </div>
+  </div>
+
+  <p class="spx-foot-note">
+    Launch data from <a href="https://thespacedevs.com/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">The Space Devs</a> Launch Library 2 (updated each pipeline run). Times are “no earlier than” and slip often — always confirm against the official <a href="https://www.spacex.com/launches/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">SpaceX launch schedule</a> and webcast. Full source links live on the <a href="{{ path_prefix }}spacex.html#resources" style="color:var(--spx-cyan);">SpaceX Daily resources</a> page.
+  </p>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function(){
+  // ---- Starfield ----
+  const cv = document.getElementById('spxStars');
+  if (cv) {
+    const ctx = cv.getContext('2d');
+    let stars = [];
+    function resize(){
+      cv.width = cv.offsetWidth; cv.height = cv.offsetHeight;
+      stars = Array.from({length: Math.min(180, Math.floor(cv.width/8))}, () => ({
+        x: Math.random()*cv.width, y: Math.random()*cv.height,
+        r: Math.random()*1.4+0.2, a: Math.random()*0.6+0.2, tw: Math.random()*0.02+0.005
+      }));
+    }
+    function draw(){
+      if(!ctx) return;
+      ctx.clearRect(0,0,cv.width,cv.height);
+      for(const s of stars){
+        s.a += s.tw; const al = 0.3+Math.abs(Math.sin(s.a))*0.7;
+        ctx.beginPath(); ctx.arc(s.x,s.y,s.r,0,7); ctx.fillStyle='rgba(180,205,255,'+al+')'; ctx.fill();
+      }
+      requestAnimationFrame(draw);
+    }
+    resize(); draw(); window.addEventListener('resize', resize);
+  }
+
+  const pad = n => String(n).padStart(2,'0');
+  function fmtLocal(iso){
+    try { return new Date(iso).toLocaleString([], {weekday:'short', month:'short', day:'numeric', hour:'2-digit', minute:'2-digit'}); }
+    catch(_) { return iso || '—'; }
+  }
+  function statusClass(abbr){
+    const a = (abbr||'').toUpperCase();
+    if(a==='GO') return 'go';
+    if(a.includes('HOLD')||a.includes('FAIL')||a==='TBC') return 'hold';
+    return 'tbd';
+  }
+
+  let nextNet = null, lastNet = null;
+
+  function tick(){
+    const now = Date.now();
+    if(nextNet){
+      let diff = Math.max(0, nextNet - now);
+      const d = Math.floor(diff/86400000); diff -= d*86400000;
+      const h = Math.floor(diff/3600000); diff -= h*3600000;
+      const m = Math.floor(diff/60000); diff -= m*60000;
+      const s = Math.floor(diff/1000);
+      const set=(id,v)=>{const e=document.getElementById(id); if(e) e.textContent=v;};
+      set('cd-d', d); set('cd-h', pad(h)); set('cd-m', pad(m)); set('cd-s', pad(s));
+    }
+    if(lastNet){
+      let diff = Math.max(0, now - lastNet);
+      const d = Math.floor(diff/86400000); diff -= d*86400000;
+      const h = Math.floor(diff/3600000); diff -= h*3600000;
+      const m = Math.floor(diff/60000);
+      const el = document.getElementById('spxSince');
+      if(el) el.textContent = (d>0? d+'d ':'') + pad(h)+'h '+pad(m)+'m ago';
+    }
+  }
+
+  function renderCadence(months){
+    const wrap = document.getElementById('spxCadence');
+    if(!wrap || !months || !months.length) return;
+    const max = Math.max(1, ...months.map(x=>x.count));
+    wrap.innerHTML = months.map(x=>{
+      const h = Math.round((x.count/max)*130)+3;
+      const lab = x.month.slice(2).replace('-','/'); // YY/MM
+      return '<div class="spx-bar-wrap"><div class="spx-bar" style="height:0" data-h="'+h+'"><span class="cnt">'+x.count+'</span></div><div class="spx-bar-label">'+lab+'</div></div>';
+    }).join('');
+    requestAnimationFrame(()=>{ wrap.querySelectorAll('.spx-bar').forEach(b=>{ b.style.height=b.dataset.h+'px'; }); });
+  }
+
+  function renderNext(n){
+    if(!n){ document.getElementById('spxMission').textContent='No upcoming launch on the manifest right now.'; return; }
+    nextNet = n.net ? new Date(n.net).getTime() : null;
+    const set=(id,v)=>{const e=document.getElementById(id); if(e) e.textContent=v||'—';};
+    const st = document.getElementById('spxStatus');
+    st.textContent = n.status_name || n.status || 'Scheduled';
+    st.className = 'spx-status '+statusClass(n.status);
+    set('spxMission', n.name || n.mission || 'Upcoming SpaceX launch');
+    set('spxRocket', n.rocket);
+    set('spxPad', n.pad);
+    set('spxLoc', n.location);
+    set('spxLocal', n.net ? fmtLocal(n.net) : 'TBD');
+    document.getElementById('spxDesc').textContent = n.mission_description || '';
+    if(n.webcast){ const w=document.getElementById('spxWebcast'); w.href=n.webcast; w.style.display='inline-flex'; }
+    const more = n.info_url || 'https://www.spacex.com/launches/';
+    const mEl=document.getElementById('spxMore'); mEl.href=more; mEl.style.display='inline-flex';
+  }
+
+  function renderPrev(p){
+    if(!p) return;
+    lastNet = p.net ? new Date(p.net).getTime() : null;
+    const el=document.getElementById('spxLast');
+    if(el) el.textContent = (p.name||'Last launch') + (p.net ? ' · '+fmtLocal(p.net) : '');
+  }
+
+  function renderStats(s, total){
+    const set=(id,v)=>{const e=document.getElementById(id); if(e) e.textContent=(v==null?'—':v);};
+    if(s){ set('stYtd',s.launches_ytd); set('st30',s.launches_last_30d); set('stAvg',s.avg_days_between_last_365d); set('stStar',s.starlink_launches_ytd); }
+    set('stTotal', total!=null ? total.toLocaleString() : '—');
+  }
+
+  function renderUpcoming(list){
+    const wrap=document.getElementById('spxUpcoming');
+    if(!wrap) return;
+    if(!list || !list.length){ wrap.innerHTML='<p class="spx-muted">No upcoming launches listed.</p>'; return; }
+    wrap.innerHTML = list.map(x=>'<div class="spx-upcoming-item"><span>'+(x.name||'Launch')+'</span><span class="when">'+(x.net?fmtLocal(x.net):'TBD')+'</span></div>').join('');
+  }
+
+  function applyLaunches(data){
+    if(!data) return;
+    renderNext(data.next);
+    renderPrev(data.previous);
+    renderStats(data.stats, data.total_launches);
+    renderCadence(data.cadence_monthly);
+    renderUpcoming(data.upcoming);
+  }
+
+  // SPCX price (same source as the show page pill)
+  function applyPrice(d){
+    if(!d || !(d.price>0)) return;
+    const px=document.getElementById('spxPx'); px.textContent='$'+Number(d.price).toFixed(2);
+    if(d.prev_close>0){
+      const ch=(d.price-d.prev_close), pct=(ch/d.prev_close*100);
+      const up=ch>=0; const el=document.getElementById('spxChg');
+      el.textContent=(up?'+':'')+ch.toFixed(2)+' ('+(up?'+':'')+pct.toFixed(2)+'%)';
+      el.className='ch '+(up?'up':'down');
+    }
+  }
+
+  // PRIMARY: same-origin cache written by the pipeline. Fallback: live API.
+  fetch('/api/spacex_launches.json',{cache:'no-cache'})
+    .then(r=>r.ok?r.json():Promise.reject())
+    .then(applyLaunches)
+    .catch(()=>{
+      // Client-side fallback straight to Launch Library 2 (CORS-enabled).
+      fetch('https://ll.thespacedevs.com/2.3.0/launches/upcoming/?lsp__id=121&limit=1&ordering=net&mode=detailed')
+        .then(r=>r.json()).then(d=>{ const r=(d.results||[])[0]; if(r) renderNext({
+          name:r.name, net:r.net, status:(r.status||{}).abbrev, status_name:(r.status||{}).name,
+          rocket:((r.rocket||{}).configuration||{}).name, pad:(r.pad||{}).name,
+          location:((r.pad||{}).location||{}).name, webcast:((r.vidURLs||[])[0]||{}).url
+        }); }).catch(()=>{ document.getElementById('spxMission').textContent='Launch data is temporarily unavailable — check spacex.com/launches.'; });
+    });
+
+  fetch('/api/spcx.json',{cache:'no-cache'}).then(r=>r.ok?r.json():Promise.reject()).then(applyPrice).catch(()=>{});
+
+  tick(); setInterval(tick, 1000);
+})();
+</script>
+{% endblock %}

--- a/tesla-narrative.html
+++ b/tesla-narrative.html
@@ -172,6 +172,11 @@
                             First Principles Daily
                         </a>
                         
+                        <a href="spacex.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily
+                        </a>
+                        
                     </div>
                 </li>
                 <li class="nn-nav-dropdown">
@@ -242,6 +247,11 @@
                         <a href="blog/first_principles/index.html">
                             <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
                             First Principles Daily Blog
+                        </a>
+                        
+                        <a href="blog/spacex/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily Blog
                         </a>
                         
                     </div>
@@ -331,6 +341,11 @@
                 First Principles Daily
             </a>
             
+            <a href="spacex.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily
+            </a>
+            
         </div>
         <div class="nn-mobile-shows">
             <div class="nn-mobile-shows-title">Blogs</div>
@@ -396,6 +411,11 @@
             <a href="blog/first_principles/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
                 <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
                 First Principles Daily Blog
+            </a>
+            
+            <a href="blog/spacex/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily Blog
             </a>
             
         </div>
@@ -700,7 +720,7 @@
             <div class="nn-footer-grid">
                 <div>
                     <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span></div>
-                    <p class="nn-footer-desc">12 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                    <p class="nn-footer-desc">13 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
                 </div>
                 <div class="nn-footer-col">
                     <h4>Shows</h4>
@@ -728,6 +748,8 @@
                     <a href="unintended-consequences.html">Unintended Consequences</a>
                     
                     <a href="first-principles.html">First Principles Daily</a>
+                    
+                    <a href="spacex.html">SpaceX Daily</a>
                     
                 </div>
                 <div class="nn-footer-col">
@@ -757,6 +779,8 @@
                     <a href="blog/unintended_consequences/index.html">Unintended Consequences</a>
                     
                     <a href="blog/first_principles/index.html">First Principles Daily</a>
+                    
+                    <a href="blog/spacex/index.html">SpaceX Daily</a>
                     
                     <a href="blog.rss">Blog RSS (All Shows)</a>
                 </div>
@@ -790,6 +814,8 @@
                     <a href="unintended_consequences_podcast.rss">Unintended Consequences RSS</a>
                     
                     <a href="first_principles_podcast.rss">First Principles Daily RSS</a>
+                    
+                    <a href="spacex_podcast.rss">SpaceX Daily RSS</a>
                     
                 </div>
                 <div class="nn-footer-col">

--- a/tesla-summaries.html
+++ b/tesla-summaries.html
@@ -181,6 +181,11 @@
                             First Principles Daily
                         </a>
                         
+                        <a href="spacex.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily
+                        </a>
+                        
                     </div>
                 </li>
                 <li class="nn-nav-dropdown">
@@ -251,6 +256,11 @@
                         <a href="blog/first_principles/index.html">
                             <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
                             First Principles Daily Blog
+                        </a>
+                        
+                        <a href="blog/spacex/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily Blog
                         </a>
                         
                     </div>
@@ -350,6 +360,11 @@
                 First Principles Daily
             </a>
             
+            <a href="spacex.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily
+            </a>
+            
         </div>
         <div class="nn-mobile-shows">
             <div class="nn-mobile-shows-title">Blogs</div>
@@ -415,6 +430,11 @@
             <a href="blog/first_principles/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
                 <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
                 First Principles Daily Blog
+            </a>
+            
+            <a href="blog/spacex/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily Blog
             </a>
             
         </div>
@@ -683,6 +703,20 @@
                 </a>
                 
                 
+                
+                <a href="spacex-summaries.html" class="cross-network-card">
+                    
+                    <picture>
+                        <source type="image/webp" srcset="assets/covers/spacex-400.webp">
+                        <img src="assets/covers/spacex.jpg" alt="SpaceX Daily cover art" width="1400" height="1400" loading="lazy">
+                    </picture>
+                    <div class="cross-network-card-info">
+                        <div class="cross-network-card-name">SpaceX Daily</div>
+                        <div class="cross-network-card-tagline">Follow SpaceX as a public company — launches, Starlink, Starship, and the SPCX market picture, every day.</div>
+                    </div>
+                </a>
+                
+                
             </div>
         </div>
     </section>
@@ -695,7 +729,7 @@
             <div class="nn-footer-grid">
                 <div>
                     <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span></div>
-                    <p class="nn-footer-desc">12 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                    <p class="nn-footer-desc">13 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
                 </div>
                 <div class="nn-footer-col">
                     <h4>Shows</h4>
@@ -723,6 +757,8 @@
                     <a href="unintended-consequences.html">Unintended Consequences</a>
                     
                     <a href="first-principles.html">First Principles Daily</a>
+                    
+                    <a href="spacex.html">SpaceX Daily</a>
                     
                 </div>
                 <div class="nn-footer-col">
@@ -752,6 +788,8 @@
                     <a href="blog/unintended_consequences/index.html">Unintended Consequences</a>
                     
                     <a href="blog/first_principles/index.html">First Principles Daily</a>
+                    
+                    <a href="blog/spacex/index.html">SpaceX Daily</a>
                     
                     <a href="blog.rss">Blog RSS (All Shows)</a>
                 </div>
@@ -785,6 +823,8 @@
                     <a href="unintended_consequences_podcast.rss">Unintended Consequences RSS</a>
                     
                     <a href="first_principles_podcast.rss">First Principles Daily RSS</a>
+                    
+                    <a href="spacex_podcast.rss">SpaceX Daily RSS</a>
                     
                 </div>
                 <div class="nn-footer-col">

--- a/tesla.html
+++ b/tesla.html
@@ -218,6 +218,11 @@
                             First Principles Daily
                         </a>
                         
+                        <a href="spacex.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily
+                        </a>
+                        
                     </div>
                 </li>
                 <li class="nn-nav-dropdown">
@@ -288,6 +293,11 @@
                         <a href="blog/first_principles/index.html">
                             <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
                             First Principles Daily Blog
+                        </a>
+                        
+                        <a href="blog/spacex/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily Blog
                         </a>
                         
                     </div>
@@ -386,6 +396,11 @@
                 First Principles Daily
             </a>
             
+            <a href="spacex.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily
+            </a>
+            
         </div>
         <div class="nn-mobile-shows">
             <div class="nn-mobile-shows-title">Blogs</div>
@@ -451,6 +466,11 @@
             <a href="blog/first_principles/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
                 <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
                 First Principles Daily Blog
+            </a>
+            
+            <a href="blog/spacex/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily Blog
             </a>
             
         </div>
@@ -1171,7 +1191,7 @@
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
-                <p>10 shows keeping you informed.</p>
+                <p>11 shows keeping you informed.</p>
             </div>
             <div class="cross-network-grid">
                 
@@ -1321,6 +1341,22 @@
                 </div>
                 
                 
+                
+                <div class="cross-network-card" style="display:flex;flex-direction:column;">
+                    <a href="spacex.html" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
+                        <picture>
+                            <source type="image/webp" srcset="assets/covers/spacex-400.webp">
+                            <img src="assets/covers/spacex.jpg" alt="SpaceX Daily cover art" width="1400" height="1400" loading="lazy">
+                        </picture>
+                        <div class="cross-network-card-info">
+                            <div class="cross-network-card-name">SpaceX Daily</div>
+                            <div class="cross-network-card-tagline">Follow SpaceX as a public company — launches, Starlink, Starship, and the SPCX market picture, every day.</div>
+                        </div>
+                    </a>
+                    <a href="blog/spacex/index.html" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
+                </div>
+                
+                
             </div>
         </div>
     </section>
@@ -1333,7 +1369,7 @@
             <div class="nn-footer-grid">
                 <div>
                     <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span></div>
-                    <p class="nn-footer-desc">12 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                    <p class="nn-footer-desc">13 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
                 </div>
                 <div class="nn-footer-col">
                     <h4>Shows</h4>
@@ -1361,6 +1397,8 @@
                     <a href="unintended-consequences.html">Unintended Consequences</a>
                     
                     <a href="first-principles.html">First Principles Daily</a>
+                    
+                    <a href="spacex.html">SpaceX Daily</a>
                     
                 </div>
                 <div class="nn-footer-col">
@@ -1390,6 +1428,8 @@
                     <a href="blog/unintended_consequences/index.html">Unintended Consequences</a>
                     
                     <a href="blog/first_principles/index.html">First Principles Daily</a>
+                    
+                    <a href="blog/spacex/index.html">SpaceX Daily</a>
                     
                     <a href="blog.rss">Blog RSS (All Shows)</a>
                 </div>
@@ -1423,6 +1463,8 @@
                     <a href="unintended_consequences_podcast.rss">Unintended Consequences RSS</a>
                     
                     <a href="first_principles_podcast.rss">First Principles Daily RSS</a>
+                    
+                    <a href="spacex_podcast.rss">SpaceX Daily RSS</a>
                     
                 </div>
                 <div class="nn-footer-col">
@@ -1655,13 +1697,22 @@
         }
 
         
-        // --- Stock widget (Tesla only) ---
+        // --- Stock widget (Tesla + SpaceX) ---
+        const STOCK_TICKER = "TSLA";
+        const STOCK_JSON = "/api/tsla.json";
+        const STOCK_YAHOO = "TSLA";
         async function loadStock() {
+            // Tracks whether the same-origin snapshot already populated a
+            // valid price. If so, a later Yahoo-fallback failure must NOT
+            // overwrite it with "Market data unavailable" (the off-hours
+            // bug: proxies fail on weekends, but the pipeline snapshot is
+            // good). Yahoo only ever UPGRADES a shown price during the day.
+            let havePrimary = false;
             function displayPrice(price, prev, marketState = null) {
                 const p = parseFloat(price), pc = parseFloat(prev);
-                // Validate: TSLA price should be in a reasonable range
+                // Validate: price should be in a reasonable range
                 if (isNaN(p) || isNaN(pc) || p <= 0 || pc <= 0 || p > 99999 || pc > 99999) {
-                    showStockError('Invalid price data');
+                    if (!havePrimary) showStockError('Invalid price data');
                     return;
                 }
                 const ch = (p - pc).toFixed(2);
@@ -1688,15 +1739,16 @@
                 if (updatedEl) updatedEl.textContent = '';
             }
 
-            // PRIMARY source: same-origin api/tsla.json written by the
-            // Tesla pipeline (shows/hooks/tesla.py) every run via Grok's
-            // x_search.  No CORS proxy, no Yahoo-Finance flakiness.
-            // Operator caught (May 14 2026) the previous Yahoo-only path
-            // showing "Market data unavailable" on the website because
+            // PRIMARY source: same-origin JSON written by the show's
+            // pipeline hook every run.  No CORS proxy, no Yahoo-Finance
+            // flakiness.  Operator caught (May 14 2026) the previous
+            // Yahoo-only path showing "Market data unavailable" because
             // every CORS proxy was failing — yet the pipeline knew the
-            // live price the whole time.
+            // live price the whole time.  Tolerates both the Tesla schema
+            // (market_state/fetched_at) and the SpaceX schema
+            // (change_str/updated_at) — only price + prev_close are required.
             try {
-                const resp = await fetch('/api/tsla.json', {
+                const resp = await fetch(STOCK_JSON, {
                     cache: 'no-cache',
                     signal: AbortSignal.timeout(4000),
                 });
@@ -1706,10 +1758,12 @@
                     const prev = parseFloat(cached.prev_close);
                     if (price > 0 && prev > 0) {
                         displayPrice(price, prev, cached.market_state || null);
+                        havePrimary = true;
                         const updatedEl = document.getElementById('stock-updated');
-                        if (updatedEl && cached.fetched_at) {
+                        const ts = cached.fetched_at || cached.updated_at;
+                        if (updatedEl && ts) {
                             try {
-                                const d = new Date(cached.fetched_at);
+                                const d = new Date(ts);
                                 updatedEl.textContent = `Updated ${d.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})} (snapshot)`;
                             } catch (_) {}
                         }
@@ -1721,9 +1775,9 @@
             } catch { /* fall through to Yahoo */ }
 
             // FALLBACK: Yahoo Finance v8 chart API via CORS proxies.
-            const yahooUrl = 'https://query2.finance.yahoo.com/v8/finance/chart/TSLA?interval=1d&range=5d';
+            const yahooUrl = 'https://query2.finance.yahoo.com/v8/finance/chart/' + STOCK_YAHOO + '?interval=1d&range=5d';
             // Yahoo Finance v6 quote API — alternative endpoint
-            const yahooQuoteUrl = 'https://query1.finance.yahoo.com/v6/finance/quote?symbols=TSLA';
+            const yahooQuoteUrl = 'https://query1.finance.yahoo.com/v6/finance/quote?symbols=' + STOCK_YAHOO;
             const proxies = [
                 url => 'https://api.allorigins.win/raw?url=' + encodeURIComponent(url),
                 url => 'https://corsproxy.io/?' + encodeURIComponent(url),
@@ -1742,7 +1796,7 @@
                     const price = meta.regularMarketPrice;
                     const prev = meta.chartPreviousClose || meta.previousClose;
                     if (price && prev) {
-                        displayPrice(price, prev, marketState);
+                        displayPrice(price, prev, meta.marketState || null);
                         return;
                     }
                 } catch { /* try next proxy */ }
@@ -1762,7 +1816,9 @@
                 } catch { /* try next proxy */ }
             }
 
-            showStockError('Market data unavailable');
+            // All Yahoo fallbacks failed. Only show the error if the
+            // same-origin snapshot didn't already populate a good price.
+            if (!havePrimary) showStockError('Market data unavailable');
         }
         loadStock();
         // Refresh stock price every 5 minutes during page session

--- a/tests/test_spacex_show.py
+++ b/tests/test_spacex_show.py
@@ -278,3 +278,49 @@ class TestEp001RegressionChapters:
         text = (_ROOT / "shows/prompts/spacex_podcast.txt").read_text(encoding="utf-8")
         assert 'REQUIRED: open the segment with the words "One thing worth watching"' in text
         assert '"from an engineering standpoint" or "the engineering angle"' in text
+
+
+class TestLaunchDashboard:
+    """SpaceX Launch Dashboard data + page."""
+
+    def test_fetcher_pure_helpers(self):
+        import importlib.util, datetime as dt
+        spec = importlib.util.spec_from_file_location(
+            "fetch_spacex_launches", _ROOT / "scripts" / "fetch_spacex_launches.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        # _slim_launch reduces a raw record
+        raw = {
+            "id": "x", "name": "Falcon 9 | Starlink", "net": "2026-06-15T14:00:00Z",
+            "status": {"abbrev": "Go", "name": "Go for Launch"},
+            "rocket": {"configuration": {"name": "Falcon 9"}},
+            "pad": {"name": "SLC-40", "location": {"name": "Cape Canaveral"}},
+            "mission": {"name": "Starlink", "description": "d"},
+            "launch_service_provider": {"id": 121, "name": "SpaceX"},
+        }
+        slim = mod._slim_launch(raw)
+        assert slim["rocket"] == "Falcon 9" and slim["pad"] == "SLC-40"
+        assert mod._is_spacex(raw) is True
+        assert mod._is_spacex({"launch_service_provider": {"id": 1}}) is False
+        # cadence: 12 month buckets, counts by YYYY-MM
+        now = dt.datetime(2026, 6, 13, tzinfo=dt.timezone.utc)
+        prev = [{"net": "2026-06-01T00:00:00Z"}, {"net": "2026-06-10T00:00:00Z"},
+                {"net": "2026-05-02T00:00:00Z"}]
+        cad = mod._monthly_cadence(prev)
+        assert len(cad) == 12
+        assert cad[-1] == {"month": "2026-06", "count": 2}
+        # stats
+        st = mod._stats(prev, now)
+        assert st["launches_ytd"] == 3
+        assert st["launches_last_30d"] >= 2
+
+    def test_dashboard_page_renders(self):
+        import generate_html as g
+        g.generate_spacex_dashboard(dry_run=True)  # smoke
+
+    def test_dashboard_in_sitemap_and_show_page_links_it(self):
+        import generate_html as g
+        # show page hero links the dashboard
+        html = (_ROOT / "spacex.html").read_text(encoding="utf-8") if (_ROOT / "spacex.html").exists() else ""
+        if html:
+            assert "spacex-dashboard.html" in html


### PR DESCRIPTION
Three additive SpaceX features to make the show the best source of SpaceX info.

## 1. Live SPCX price pill (show page hero)
Generalized the Tesla-only stock widget to a data-driven `_STOCK_WIDGETS` registry. SPCX reads `api/spcx.json` (git-added in `run-show.yml`). **Fixed a latent bug affecting Tesla too**: a failing Yahoo fallback was overwriting the good same-origin snapshot with "Market data unavailable" off-hours — now tracked via `havePrimary`. Render-verified `$160.95 +19.22%`.

## 2. Resources hub (best-source links)
5 curated categories on the show page: SpaceX Official (site/launches/Starship/Starlink/X/YouTube), SPCX Stock & Filings (**S-1 prospectus + SEC EDGAR**, Yahoo, TradingView, Nasdaq), Spaceflight News (NASASpaceflight/SpaceNews/Ars/Berger/Sheetz), Launch Tracking (Next Spaceflight/Flight Club/JSR/r-SpaceX), **Musk & xAI ecosystem** (Musk on X, xAI, Grok). + 3 tools + 5 FAQ.

## 3. SpaceX Launch Dashboard (`spacex-dashboard.html`) — NEW
A beautiful SpaceX-themed dashboard:
- **Live countdown** to the next launch + mission card (vehicle, pad, location, target time in viewer TZ, Go/TBD/Hold badge, webcast link)
- **Time since last launch** (ticking) + last mission
- **Launch cadence**: animated 12-month bar chart (cyan→blue) + stats — launches YTD (70), last 30 days (14), **avg days between (2.2)**, Starlink YTD (56), total (689)
- Upcoming manifest (next 5) + SPCX price card + starfield hero
- Data: `scripts/fetch_spacex_launches.py` → The Space Devs Launch Library 2 (free, no key), paginates ~13 months for accurate cadence/stats, writes `api/spacex_launches.json` with the landmine #22 reliability contract (keeps last-good on failure). Page reads the same-origin cache first with a live LL2 fallback + friendly empty state.
- Refreshed in the spacex hook pre_fetch + nightly maintenance; rendered on `--all`/`--network`/`--show spacex`; in sitemap; linked from the show-page hero ("🚀 Launch Dashboard").

All three **render-verified via headless Chromium** (screenshots shared with operator). Drift guards added. Full suite **2807 passed**.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5