### PR TITLE
Fix mobile horizontal-overflow across show pages + dashboard

### DIFF
--- a/spacex-dashboard.html
+++ b/spacex-dashboard.html
@@ -150,8 +150,8 @@
   .spx-stat .l { font-size:0.7rem; text-transform:uppercase; letter-spacing:0.08em; color:#8ea3d6; margin-top:2px; }
 
   /* cadence chart */
-  .spx-cadence { display:flex; align-items:flex-end; gap:6px; height:160px; padding-top:8px; }
-  .spx-bar-wrap { flex:1; display:flex; flex-direction:column; align-items:center; gap:4px; height:100%; justify-content:flex-end; }
+  .spx-cadence { display:flex; align-items:flex-end; gap:6px; height:160px; padding-top:8px; overflow:hidden; }
+  .spx-bar-wrap { flex:1; min-width:0; display:flex; flex-direction:column; align-items:center; gap:4px; height:100%; justify-content:flex-end; }
   .spx-bar {
     width:100%; border-radius:6px 6px 2px 2px; min-height:3px;
     background: linear-gradient(180deg, var(--spx-cyan), var(--spx-blue));
@@ -159,7 +159,8 @@
     position:relative;
   }
   .spx-bar .cnt { position:absolute; top:-18px; left:0; right:0; text-align:center; font-size:0.7rem; color:#cfe0ff; font-weight:700; }
-  .spx-bar-label { font-size:0.6rem; color:#7f93c4; white-space:nowrap; }
+  .spx-bar-label { font-size:0.58rem; color:#7f93c4; white-space:nowrap; max-width:100%; overflow:hidden; text-overflow:clip; }
+  @media (max-width: 520px){ .spx-bar-label { font-size:0.5rem; letter-spacing:-0.03em; } .spx-cadence{ gap:4px; } }
 
   .spx-since { font-size: clamp(1.4rem,3.5vw,2rem); font-weight:800; font-variant-numeric:tabular-nums; color:#fff; }
   .spx-upcoming-item { display:flex; justify-content:space-between; gap:10px; padding:0.55rem 0; border-bottom:1px solid rgba(120,160,255,0.12); font-size:0.9rem; }

--- a/styles/main.css
+++ b/styles/main.css
@@ -539,9 +539,15 @@ button { font-family: var(--font-ui); cursor: pointer; }
   display: flex;
   gap: var(--sp-2);
   max-width: 480px;
+  /* Let the button drop below the field rather than overflow when its
+     label is long (e.g. the Russian "Подписаться") on narrow phones. */
+  flex-wrap: wrap;
 }
 .nn-subscribe-row input[type="email"] {
-  flex: 1;
+  flex: 1 1 180px;
+  /* Text inputs carry a UA default min-width (~170px) that ignores
+     flex:1; min-width:0 lets the field actually shrink on small screens. */
+  min-width: 0;
   padding: var(--sp-2) var(--sp-3);
   border-radius: 8px;
   border: 1px solid var(--nn-border);
@@ -735,13 +741,29 @@ button { font-family: var(--font-ui); cursor: pointer; }
   padding: var(--sp-4);
   border-radius: 12px;
   transition: background var(--duration) var(--ease);
+  /* Allow the grid item to shrink below the min-content of its
+     (nowrap, ellipsised) text so a 1fr track can't be forced wider
+     than its share of the container. */
+  min-width: 0;
 }
+/* The inner clickable row is a flex container nested in a flex-COLUMN
+   card. align-items:stretch yields to the anchor's intrinsic (max-content)
+   width, so it sized to the full tagline and overflowed the card on
+   mobile. An explicit width:100% pins it to the card width; its own
+   flex children (fixed image + flex:1 info) then truncate within it. */
+.cross-network-card > a { width: 100%; min-width: 0; box-sizing: border-box; }
 .cross-network-card:hover { background: var(--nn-card-hover); }
 .cross-network-card img {
   width: 64px; height: 64px; border-radius: 10px; object-fit: cover;
   flex-shrink: 0;
 }
-.cross-network-card-info { min-width: 0; }
+/* flex-basis:0 so the text column fills exactly the space left by the
+   fixed image and never sizes to its (nowrap) max-content — which had
+   let the longest tagline ("SpaceX Daily — Follow SpaceX…") blow the
+   card past the viewport on every other show's "More from" grid. */
+.cross-network-card-info { flex: 1 1 0; min-width: 0; overflow: hidden; }
+.cross-network-card > a > picture,
+.cross-network-card > a > img { flex-shrink: 0; }
 .cross-network-card-name {
   font-family: var(--font-heading);
   font-size: 0.9rem; font-weight: 600;
@@ -1438,7 +1460,13 @@ button { font-family: var(--font-ui); cursor: pointer; }
 
   .nn-footer-bottom { flex-direction: column; gap: var(--sp-2); text-align: center; }
 
-  .cross-network-grid { grid-template-columns: 1fr 1fr; }
+  /* One column on mobile. The previous `1fr 1fr` forced two columns,
+     and `1fr` (= minmax(auto,1fr)) lets each track grow to the
+     min-content of the longest show name — so cards like "Models &
+     Agents for Beginners" blew the grid past the viewport, taking the
+     whole document wider than the screen and clipping the hero, buttons,
+     and resources too. A single full-width column never overflows. */
+  .cross-network-grid { grid-template-columns: minmax(0, 1fr); }
 
   .latest-scroll-card { flex: 0 0 280px; }
 }
@@ -1468,7 +1496,7 @@ button { font-family: var(--font-ui); cursor: pointer; }
     grid-template-columns: repeat(2, 1fr);
   }
 
-  .cross-network-grid { grid-template-columns: repeat(3, 1fr); }
+  .cross-network-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 
 /* Desktop: 1024px+ */
@@ -1542,6 +1570,14 @@ button:focus-visible {
   padding: var(--sp-5);
   display: flex; flex-direction: column; gap: var(--sp-2);
   text-decoration: none;
+  /* Grid item must shrink below the min-content of a long URL token. */
+  min-width: 0;
+}
+/* Long unbreakable strings (e.g. SEC EDGAR query URLs) must wrap, or
+   they floor the card's min-content and push the grid past the viewport
+   on mobile. */
+.resource-card-name, .resource-card-desc, .resource-card-url {
+  overflow-wrap: anywhere; word-break: break-word;
 }
 .resource-card:hover {
   border-color: var(--show-color, var(--nn-purple));

--- a/templates/spacex_dashboard.html.j2
+++ b/templates/spacex_dashboard.html.j2
@@ -93,8 +93,8 @@
   .spx-stat .l { font-size:0.7rem; text-transform:uppercase; letter-spacing:0.08em; color:#8ea3d6; margin-top:2px; }
 
   /* cadence chart */
-  .spx-cadence { display:flex; align-items:flex-end; gap:6px; height:160px; padding-top:8px; }
-  .spx-bar-wrap { flex:1; display:flex; flex-direction:column; align-items:center; gap:4px; height:100%; justify-content:flex-end; }
+  .spx-cadence { display:flex; align-items:flex-end; gap:6px; height:160px; padding-top:8px; overflow:hidden; }
+  .spx-bar-wrap { flex:1; min-width:0; display:flex; flex-direction:column; align-items:center; gap:4px; height:100%; justify-content:flex-end; }
   .spx-bar {
     width:100%; border-radius:6px 6px 2px 2px; min-height:3px;
     background: linear-gradient(180deg, var(--spx-cyan), var(--spx-blue));
@@ -102,7 +102,8 @@
     position:relative;
   }
   .spx-bar .cnt { position:absolute; top:-18px; left:0; right:0; text-align:center; font-size:0.7rem; color:#cfe0ff; font-weight:700; }
-  .spx-bar-label { font-size:0.6rem; color:#7f93c4; white-space:nowrap; }
+  .spx-bar-label { font-size:0.58rem; color:#7f93c4; white-space:nowrap; max-width:100%; overflow:hidden; text-overflow:clip; }
+  @media (max-width: 520px){ .spx-bar-label { font-size:0.5rem; letter-spacing:-0.03em; } .spx-cadence{ gap:4px; } }
 
   .spx-since { font-size: clamp(1.4rem,3.5vw,2rem); font-weight:800; font-variant-numeric:tabular-nums; color:#fff; }
   .spx-upcoming-item { display:flex; justify-content:space-between; gap:10px; padding:0.55rem 0; border-bottom:1px solid rgba(120,160,255,0.12); font-size:0.9rem; }


### PR DESCRIPTION
## Mobile horizontal-overflow fix (operator caught clipping on iPhone)

The attached screenshots showed text and cards clipped off the right edge on the SpaceX page. Root cause: a **single overflowing element widens the whole document**, so the hero text, buttons, and resources all appeared cut off even though they're individually fine.

Diagnosed with a headless-Chromium overflow scan (`scrollWidth` vs `innerWidth` at 320–768px) rather than guessing. Three real sources, all in `styles/main.css` (so the fixes apply to **every** page, not just SpaceX):

1. **`.cross-network-grid`** ("More from Nerra Network", on every show page) forced `1fr 1fr` on mobile. The long show names/taglines floored each track's min-content and blew the grid to ~711px in a 390px viewport. → one column (`minmax(0,1fr)`); the inner flex anchor was sizing to its tagline max-content and overflowing the card → pinned with `width:100%; min-width:0` and `flex:1 1 0` on the text column so it ellipsis-truncates. (Visible in the original IMG_5167 as the cut-off 2-column grid.)
2. **Resource cards**: long SEC EDGAR query URLs didn't wrap (IMG_5166) → `overflow-wrap:anywhere` + `min-width:0`.
3. **`.nn-subscribe-row`**: the email field's UA default min-width ignored `flex:1`, and the longer Russian "Подписаться" button overflowed at ~360px → field `min-width:0`, row `flex-wrap:wrap`.

Dashboard: the 12 cadence-bar labels overflowed the panel at ≤360px → `min-width:0` on the bar wraps + `overflow:hidden` + smaller label font under 520px.

### Verification
**0 overflow** across spacex / tesla / index / planetterrian / models-agents / finansy / privet / first-principles / dashboard at **360 / 390 / 414 / 768px** (320px has only benign overflow-hidden-clipped artifacts). Render-verified the hero, resources, FAQ, cross-network grid, and dashboard all look good at 390px. Full suite **2807 passed**.

These are CSS layout fixes; the show-page HTML is unaffected (external stylesheet) — only the dashboard's inline CSS was regenerated.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_