### PR TITLE
Fix SpaceX hero clipping on mobile (clip-without-scroll root cause)

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1398,7 +1398,12 @@ button { font-family: var(--font-ui); cursor: pointer; }
   }
 
   .show-hero-inner {
-    grid-template-columns: 1fr;
+    /* minmax(0,1fr) — NOT 1fr — so the single column can't grow to a
+       child's min-content (the SPCX stock pill / launch teaser are wide
+       nowrap rows). With plain 1fr the column resolved to ~469px on a
+       390px screen and `.show-hero{overflow:hidden}` clipped the hero
+       text instead of scrolling. */
+    grid-template-columns: minmax(0, 1fr);
     text-align: center;
     gap: var(--sp-6);
   }
@@ -1914,7 +1919,11 @@ body.menu-open {
   display: inline-flex;
   align-items: center;
   gap: var(--sp-3);
-  max-width: 400px;
+  /* Wrap + cap at the container so the "Updated …" line drops below the
+     quote instead of forcing the hero column wider than the phone. */
+  flex-wrap: wrap;
+  max-width: 100%;
+  min-width: 0;
   margin: 2rem auto 0;
   padding: 12px 20px;
   background: rgba(255,255,255,0.04);


### PR DESCRIPTION
## The actual root cause of the SpaceX hero clipping

The previous mobile pass (#609) fixed document-level horizontal *scroll*, but the operator's new screenshots showed the hero text **still clipped on iPhone with no scrollbar** — a different failure mode my `scrollWidth` checks couldn't detect.

**Root cause:** `.show-hero` has `overflow:hidden`, and `.show-hero-inner` used `grid-template-columns: 1fr` on mobile. `1fr` = `minmax(auto,1fr)`, so the single column grew to the **min-content of its widest child** — the SPCX stock pill (a 400px nowrap `SPCX $160.95 +25.95 (+19.22%) Updated…` row) and the launch teaser. The column resolved to **~469px on a 390px screen**; `overflow:hidden` then *clipped* the hero (title, tagline, about-text, buttons, pill, teaser all cut at the screen edge) instead of scrolling. Because it clipped rather than scrolled, `scrollWidth == innerWidth` and my earlier checks reported "0 overflow."

**Fix** (`styles/main.css`):
- `.show-hero-inner` mobile → `minmax(0, 1fr)` so the column can never exceed the container; children wrap/truncate within it.
- `.stock-widget` → `flex-wrap:wrap; max-width:100%; min-width:0` so the "Updated…" line drops below the quote instead of forcing width.

**Verified** the hero fits with correct padding at **360/375/390/393/414px** (info right edge = viewport − 24px on every width). Render-verified: hero text wraps fully, buttons form a clean 2-column grid, the SPCX pill wraps the timestamp below the quote, the launch teaser truncates the mission and shows the countdown. Also benefits Tesla's hero pill. Tests green.

This time I measured per-element geometry (not just document scroll), which is how I caught the clip-without-scroll case the first pass missed.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_