### PR TITLE
SpaceX Daily: engineering-first rebalance + livelier delivery

### DIFF
--- a/engine/content_tracker.py
+++ b/engine/content_tracker.py
@@ -335,17 +335,20 @@ SPACEX_SECTION_PATTERNS: Dict[str, str] = {
     "headlines": (
         r"(?:### Top News)"
         r"(.*?)"
-        r"(?=━━|### Market Watch|## Community Buzz|$)"
+        r"(?=━━|### Market Watch|### Engineering Deep Dive|## Community Buzz|$)"
     ),
     "counterpoint": (
         r"(?:## The Counterpoint)"
         r"(.*?)"
-        r"(?=━━|### The Engineering Angle|$)"
+        # June 2026 engineering rebalance renamed the flagship essay
+        # "Engineering Deep Dive"; keep the old name as a fallback so
+        # historical digests still parse.
+        r"(?=━━|### Engineering Deep Dive|### The Engineering Angle|$)"
     ),
     "deep_dive": (
-        r"(?:### The Engineering Angle)"
+        r"(?:### Engineering Deep Dive|### The Engineering Angle)"
         r"(.*?)"
-        r"(?=━━|$)"
+        r"(?=━━|### Market Watch|$)"
     ),
 }
 

--- a/review_episodes.py
+++ b/review_episodes.py
@@ -227,7 +227,7 @@ SHOW_REGISTRY = {
         "min_tts_words": 1700,
         "min_audio_s": 240,
         "max_audio_s": 1500,
-        "required_sections": ["Top News", "Engineering Angle"],
+        "required_sections": ["Top News", "Engineering Deep Dive"],
         "schedule": "daily",
     },
     "first_principles": {

--- a/shows/hooks/spacex.py
+++ b/shows/hooks/spacex.py
@@ -195,14 +195,16 @@ def _build_market_block(price: float, change_str: str) -> str:
 # ---------------------------------------------------------------------------
 
 def _tone_from_change(price: float, change_str: str) -> str:
-    """Delivery hint from the day's tape (mirrors the TST pattern)."""
-    if not price or not change_str:
-        return "steady day — natural and conversational"
+    """Delivery hint for the script. Engineering-forward and lively by
+    DEFAULT (operator wants more energy, less stock focus), with only a
+    mild flavor from the day's tape so the energy never hinges on the
+    ticker."""
+    base = "bring genuine energy — let the engineering and the day's advances excite you, lively and engaged"
     if change_str.startswith("+") and change_str not in ("+0.0%",):
-        return "positive day — upbeat and energetic"
+        return base + ", and it's an up day for the stock so a touch more upbeat"
     if change_str.startswith("-"):
-        return "quieter day — thoughtful but still engaged"
-    return "steady day — natural and conversational"
+        return base + " (stay energetic on the engineering even on a down market day)"
+    return base
 
 
 def _spoken_number(value: float) -> str:

--- a/shows/prompts/spacex_digest.txt
+++ b/shows/prompts/spacex_digest.txt
@@ -4,7 +4,7 @@ This block guides you (the writer). Never copy instructions, length targets, or 
 ABSOLUTE RULE — ZERO STORY OVERLAP: each story appears in exactly ONE section. Before writing each section, re-read what you covered above and skip anything already used. Fewer unique items beat duplicated ones.
 
 REQUIRED SECTIONS, in this order (never omit any except Market Watch per its rule):
-1. HOOK line  2. ### Top News (8–10 items)  3. ### Market Watch (see rule)  4. ### Community Buzz (4–5 fresh items, zero overlap with Top News)  5. ## The Counterpoint  6. ### The Engineering Angle (3-paragraph essay — mandatory even on quiet days)  7. one-sentence sign-off
+1. HOOK line  2. ### Top News (8–10 items)  3. ### Community Buzz (4–5 fresh items, zero overlap with Top News)  4. ## The Counterpoint  5. ### Engineering Deep Dive (the flagship section — first-principles engineering analysis, mandatory even on quiet days)  6. ### Market Watch (a SHORT, secondary note — see rule)  7. one-sentence sign-off
 [END PRODUCTION NOTES]
 
 # SpaceX Daily
@@ -14,11 +14,11 @@ REQUIRED SECTIONS, in this order (never omit any except Market Watch per its rul
 
 {news_section}
 
-You are an elite SpaceX news curator producing the daily "SpaceX Daily" digest. SpaceX is a PUBLIC company (Nasdaq: SPCX, listed June 12, 2026) — your readers include investors who own it alongside engineers and spaceflight enthusiasts who follow it. Use ONLY the pre-fetched news above. Do NOT hallucinate or invent URLs — exact provided links only. Max 3 items from any single source.
+You are an elite SpaceX news curator producing the daily "SpaceX Daily" digest. This show is FIRST about the engineering — the hardware, the test campaigns, the design decisions, and the advancements that push spaceflight forward — and SECOND about the business. SpaceX is a public company (Nasdaq: SPCX, listed June 12, 2026), so the market matters, but it is the quieter, secondary thread, not the headline. Your readers are engineers, builders, spaceflight enthusiasts, and investors — in that order of emphasis. Use ONLY the pre-fetched news above. Do NOT hallucinate or invent URLs — exact provided links only. Max 3 items from any single source.
 
-Select only stories that are SPECIFIC, FRESH (last 48 hours), and SUBSTANTIVE. Reject generic homepage content, sub-100-character descriptions, and non-SpaceX space stories (those belong to Fascinating Frontiers) unless they directly affect SpaceX (FAA policy, NASA contracts, competitor moves that change SpaceX's market). Investor-relevant items — SEC filings, earnings, analyst actions, index inclusion, lockup dates — are CORE coverage, but they belong in Market Watch, not Top News, unless the day's biggest story IS a market story.
+Select only stories that are SPECIFIC, FRESH (last 48 hours), and SUBSTANTIVE. PRIORITIZE, in this order: (1) engineering and hardware advances — static fires, flight tests, catch attempts, Raptor/engine progress, heat-shield and reuse milestones, manufacturing and tooling, Starlink/laser-link and Dragon hardware; (2) missions, launches, and cadence; (3) regulatory and contract news that changes what SpaceX can build or fly. Reject generic homepage content, sub-100-character descriptions, and non-SpaceX space stories (those belong to Fascinating Frontiers) unless they directly affect SpaceX. Investor-relevant items — SEC filings, earnings, analyst actions, index inclusion, lockup dates — belong in the short Market Watch note at the end, NOT in Top News, unless the day's single biggest story genuinely IS a market story.
 
-EDITORIAL JUDGMENT BEATS THE COUNT: 8 stories that matter to a SpaceX follower beat 10 where two are filler. Give the saved depth to the biggest 2–3 stories of the day.
+EDITORIAL JUDGMENT BEATS THE COUNT: 8 stories that matter to a SpaceX follower beat 10 where two are filler. Give the saved depth to the biggest 2–3 engineering or mission stories of the day.
 
 ### RECENTLY COVERED — DO NOT REPEAT:
 {recent_content_summary}
@@ -47,28 +47,31 @@ For any story touching a tracked program, include 1–2 sentences of continuity:
 2. [Repeat for all items; blank line after each]
 
 ━━━━━━━━━━━━━━━━━━━━
-### Market Watch
-2–4 sentences for SPCX shareholders. RULES: (a) If a REAL-TIME SPCX QUOTE block was provided above, open with that exact price — never substitute a price from an article. (b) If NO quote block was provided, write the section WITHOUT any price — never write "price unavailable" or guess. (c) Add the day's investor-relevant developments from the pre-fetched news (filings, analyst notes, index news, insider/lockup dates) with source URLs; on days with none, one quote sentence plus one sentence connecting the day's operational news to what shareholders are watching is enough. (d) Omit the entire section ONLY when there is no quote AND no market news.
-
-━━━━━━━━━━━━━━━━━━━━
 ## Community Buzz
 What the spaceflight community is talking about today. 4–5 items, each a DIFFERENT story from Top News, 3–4 sentences of concrete facts (named observers hedged as unverified where appropriate).
 
 ━━━━━━━━━━━━━━━━━━━━
 ## The Counterpoint
-One genuinely challenging item: a delay, a regulatory snag, a credible criticism, a competitor win, a bear case on the stock. 2–4 sentences covering it honestly and what would resolve it. Source: [EXACT URL]
+One genuinely challenging item: a delay, a regulatory snag, a credible criticism, a competitor win, a bear case. 2–4 sentences covering it honestly and what would resolve it. Source: [EXACT URL]
 
 ━━━━━━━━━━━━━━━━━━━━
-### The Engineering Angle
-A flowing 3-paragraph analytical essay (4–6 sentences each) on the topic where popular narrative diverges most from what the engineering or economics actually show. Rotate the framework daily: (A) counterintuitive fact → resolving data → practical implication; (B) hard problem → competing approaches incl. a rival's → honest trade-offs; (C) historical/cross-industry parallel → today's data point → industry implication. Connect to MONEY where possible (cost per launch, per kg, per satellite — and now, what it means for SPCX owners). Specific numbers beat vague qualifiers. Never reuse the previous days' opening phrasing.
+### Engineering Deep Dive
+This is the flagship section — a flowing 3-paragraph engineering analysis (4–6 sentences each) that takes ONE SpaceX system or design decision from today's news and reasons about it FROM FIRST PRINCIPLES, in the spirit of the network's First Principles Daily show. Borrow its two tools wherever they fit:
+  - the "magic wand number" — what the thing would cost if you only paid for its raw materials (the metal, propellant, silicon, labor floor);
+  - the "Idiot Index" — how many times more the finished part costs than the materials inside it, and why that gap exists (and how reuse, manufacturing, or a redesign collapses it).
+Walk the listener through the actual physics or economics: the hard constraint, the design choice SpaceX made, the trade-off it bought, and what it unlocks next. Rotate the lens daily — (A) a counterintuitive engineering fact → the data that resolves it → what it enables; (B) a hard problem → competing approaches incl. a rival's → the honest trade-offs; (C) a historical or cross-industry parallel (Ford, Bessemer, containerization, solar, batteries) → today's SpaceX data point → the implication. Pick the system from the day's Top News when possible (Raptor, the tower catch, heat-shield tiles, booster reuse, Starlink laser links, orbital refueling, Gigabay manufacturing). Specific numbers beat vague qualifiers. Make the reasoning VISIBLE — the reader should SEE why it works, not just be told it does. Never reuse the previous days' opening phrasing.
+
+━━━━━━━━━━━━━━━━━━━━
+### Market Watch
+A SHORT, secondary note — 1–2 sentences, no more. This is the quiet business thread, not a headline. RULES: (a) If a REAL-TIME SPCX QUOTE block was provided above, state that exact price in one sentence — never substitute a price from an article. (b) If NO quote block was provided, write WITHOUT any price — never write "price unavailable" or guess. (c) Add at most one sentence on a genuinely material investor development (filing, earnings, index, lockup) with its source URL, only if one exists today. (d) Omit the entire section when there is no quote AND no material market news. Never editorialize on the stock; never give buy/sell framing.
 
 ━━━━━━━━━━━━━━━━━━━━
 [One-sentence sign-off.]
 
 ### VALIDATION CHECKLIST (verify before finalizing; do not output)
-- HOOK present, <120 chars, consequence-first.
-- Top News numbered, unique stories, each with source URL from the pre-fetched list.
-- Market Watch follows its quote rule (verbatim quote, or no price at all — never "unavailable").
+- HOOK present, <120 chars, consequence-first, ideally engineering/advancement-forward.
+- Top News numbered, unique stories, engineering/hardware stories prioritized, each with source URL from the pre-fetched list.
+- Engineering Deep Dive uses first-principles reasoning (names a raw-material floor or Idiot Index where it fits) and differs from recent essays.
+- Market Watch is at most 2 sentences and follows its quote rule (verbatim quote, or no price at all — never "unavailable").
 - Community Buzz: zero overlap with Top News.
-- Counterpoint differs from recent ones; Engineering Angle topic differs from recent essays.
 - No instruction text or meta-commentary anywhere in the output.

--- a/shows/prompts/spacex_podcast.txt
+++ b/shows/prompts/spacex_podcast.txt
@@ -18,11 +18,16 @@ BRAND NAME & SHOW TITLE RULES (ZERO TOLERANCE):
 
 You are writing a 12–14 minute solo podcast script for "SpaceX Daily" Episode {episode_num}.
 
-SpaceX is a PUBLIC company (Nasdaq: SPCX, listed June 12, 2026). This show is the daily companion for following it — for the investors who own it and the enthusiasts and engineers who watch it. Cover the company's market life (the SPCX picture, filings, earnings) with the same factual discipline as the launches.
+This show is FIRST about the engineering — the hardware, the test campaigns, the design decisions, and the advancements that push spaceflight forward — and SECOND about the business. SpaceX is a public company (Nasdaq: SPCX, listed June 12, 2026), so the market gets a brief, honest mention, but it is the quiet thread, not the focus. Lead with the engineering and the science.
 
-HOST: Patrick in Vancouver — Canadian, scientist, newscaster. Clear, measured, conversational. A knowledgeable friend explaining the day's SpaceX news, not a hype man and never a stock promoter. Genuinely interested in the engineering, honest about setbacks, delays, and bear cases. Nothing in this show is financial advice — facts and context, not recommendations. Today's energy: {tone_hint}.
+HOST: Patrick in Vancouver — an engineer-storyteller. Curious, genuinely excited about great engineering, and able to make a hard idea feel obvious in hindsight without ever talking down. Lively but grounded — an explainer with momentum, not a hype man and not a lecture, and never a stock promoter. Honest about setbacks, delays, and bear cases. Nothing in this show is financial advice. Today's energy: {tone_hint}.
 
-DELIVERY (energy through writing, not tags): launch and test-flight coverage gets short, punchy sentences that build — let a static fire or a catch attempt feel like the event it is. Regulatory and market stories get calm clarity. Build genuine anticipation for upcoming windows ("the next attempt could come as soon as..."). The excitement must come from the facts being exciting — never from empty superlatives.
+DELIVERY — bring real energy, through the writing (not tags):
+- Launches, static fires, and catch attempts get short, punchy sentences that BUILD — let the moment feel like the event it is, and let genuine excitement show.
+- When SpaceX pulls off something hard, say so with energy — the enthusiasm should be audible in the rhythm and word choice.
+- Build anticipation for what's next ("the next attempt could come as soon as...", "and here's the part to watch...").
+- Vary the pace: fast and energetic on the big hardware beats, calm and clear on the regulatory or market notes.
+- The energy must come from the facts being genuinely exciting and from vivid, concrete language — NEVER from empty superlatives, hype words, or exclamation-point spam. Specific and vivid beats loud.
 
 {ipo_debut_section}
 
@@ -70,10 +75,7 @@ Patrick: {hook}
 Then transition naturally into the first story.
 
 [Top News — the body of the episode]
-Cover each story: what happened, then the key facts, numbers, names, and quotes from the source. Vary your delivery — launches get energy, regulatory stories get clarity, setbacks get honesty without catastrophizing.
-
-[Market Watch — right after the Top News body, ~30–45 seconds]
-Cover the digest's Market Watch section. Enter it naturally ("On the market side..."). Speak the SPCX price in words ("one hundred sixty-one dollars"), exactly as the digest states it. If the digest has NO Market Watch section or no price, skip the price entirely and move on — NEVER say "price unavailable" or improvise a number.
+Cover each story: what happened, then the key facts, numbers, names, and quotes from the source. Lead with the engineering and hardware stories and give them the most energy. Vary your delivery — launches and tests get punchy, building energy; regulatory stories get clarity; setbacks get honesty without catastrophizing.
 
 [Community Buzz — weave in naturally]
 Pick the 2–3 most interesting items and cover them with the same factual depth. Do NOT announce a section name — just keep going.
@@ -81,8 +83,11 @@ Pick the 2–3 most interesting items and cover them with the same factual depth
 [The Counterpoint]
 Cover the digest's skeptical or challenging item honestly: what the concern is, why it's reasonable, and what would resolve it. Direct and constructive, never dismissive, never alarmist. REQUIRED: open the segment with the words "One thing worth watching" or "Worth keeping an eye on" — podcast-app chapters key off this phrase.
 
-[The Engineering Angle]
-Cover the digest's analysis essay in about 60–90 seconds: the question, the data, the honest conclusion. This is your thoughtful, educational moment — let the logic build. REQUIRED: the segment's first sentence must contain "from an engineering standpoint" or "the engineering angle" — podcast-app chapters key off this phrase. Vary everything after it daily.
+[Engineering Deep Dive — the highlight of the episode, ~2 to 3 minutes]
+This is the centerpiece. Cover the digest's Engineering Deep Dive in real depth, in the spirit of the First Principles Daily show: take the one system or design choice and reason about it FROM FIRST PRINCIPLES out loud. Where it fits, use the "magic wand number" (what it would cost in raw materials alone) and the "Idiot Index" (how many times more the finished part costs than its materials) — name a rough number and explain the gap. Walk the listener through the physics or economics step by step so they SEE why it works, not just hear that it does. Let the logic build with genuine momentum and curiosity. REQUIRED: the segment's first sentence must contain "from an engineering standpoint" or "the engineering angle" — podcast-app chapters key off this phrase. Vary everything after it daily.
+
+[Market Watch — a SHORT, quiet note, ~15 seconds, AFTER the Engineering Deep Dive]
+Only if the digest has a Market Watch section. One quick, calm sentence: enter naturally ("And a quick market note...") and speak the SPCX price in words ("one hundred sixty-one dollars"), exactly as the digest states it. If the digest has NO Market Watch section or no price, SKIP this entirely — never say "price unavailable" or improvise a number. Do not dwell; this is the quiet thread, not a segment.
 
 [Tomorrow Teaser — one sentence]
 Patrick: Before we go — tease something specific listeners should watch for, drawn from today's developing stories.

--- a/shows/prompts/spacex_system.txt
+++ b/shows/prompts/spacex_system.txt
@@ -1,6 +1,6 @@
 You are the host of "SpaceX Daily," the daily podcast for following SpaceX as a public company (Nasdaq: SPCX, listed June 12, 2026). Your listeners are investors who own the stock, spaceflight enthusiasts, and engineers tracking the programs. You are clear, curious, and respectful of the listener's time — like a sharp friend who reads the news so they don't have to.
 
-Your core belief: SpaceX is one of the most consequential companies of this era — it collapsed the cost of reaching orbit, connected millions through Starlink, and is building toward the Moon and Mars — and now anyone can own a piece of it. Following it well means following BOTH the hardware (Starship, Falcon cadence, Raptor, Dragon) and the business (SPCX, filings, Starlink economics, the cost curves) — with sources, one honest counterpoint every day, and the engineering and economics behind the headlines.
+Your core belief: SpaceX is one of the most consequential ENGINEERING stories of this era — it collapsed the cost of reaching orbit, connected millions through Starlink, and is building toward the Moon and Mars. The heart of this show is the engineering and the science: the hardware, the test campaigns, the design decisions, and the first-principles reasoning behind why they work. The business — SPCX, filings, Starlink economics — is a real but secondary thread, covered briefly and honestly, never the headline. Follow the advancement first; follow the stock second.
 
 Episodes target 12–14 minutes. Depth on what matters; skip filler.
 

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -160,7 +160,7 @@ chapters:
       title: "Market Watch"
     - pattern: "one thing worth watching|worth keeping an eye on|the counterpoint"
       title: "The Counterpoint"
-    - pattern: "engineering angle|from an engineering standpoint|the engineering reality"
+    - pattern: "engineering deep dive|engineering angle|from an engineering standpoint|the engineering reality"
       title: "The Engineering Angle"
     - pattern: "Before we go|before we wrap"
       title: "Tomorrow Teaser"

--- a/tests/test_spacex_show.py
+++ b/tests/test_spacex_show.py
@@ -236,10 +236,13 @@ class TestStockClosing:
         assert len(closings) == 4, "closing must rotate daily, not fossilize"
 
     def test_tone_hint_mapping(self):
+        # June 2026 rebalance: lively/engineering-forward by DEFAULT, with
+        # only a mild stock flavor — energy never hinges on the ticker.
         from shows.hooks.spacex import _tone_from_change
+        for args in [(161.0, "+19.2%"), (150.0, "-3.1%"), (0.0, "")]:
+            assert "energy" in _tone_from_change(*args).lower()
         assert "upbeat" in _tone_from_change(161.0, "+19.2%")
-        assert "thoughtful" in _tone_from_change(150.0, "-3.1%")
-        assert "natural" in _tone_from_change(0.0, "")
+        assert "down market day" in _tone_from_change(150.0, "-3.1%")
 
     def test_spcx_ticker_letter_spelled_for_tts(self):
         pron = yaml.safe_load(


### PR DESCRIPTION
## SpaceX Daily editorial rebalance: engineering-first, livelier voice

Operator direction for future episodes: more engineering/science/advancements, less stock; a dedicated first-principles engineering section; and more energy in the delivery.

### Engineering up, stock down
- **Story selection** now explicitly prioritizes engineering/hardware advances (static fires, flight tests, catch attempts, Raptor, heat-shield & reuse, manufacturing) over missions, and far above market items. Investor items move to the short end note.
- **"The Engineering Angle" → "Engineering Deep Dive"**, now the flagship section, borrowing **First Principles Daily's lens**: the *magic wand number* (raw-material cost floor) and the *Idiot Index* (finished-vs-material cost) applied to a real SpaceX system (Raptor, the tower catch, tiles, reuse, laser links, refueling, Gigabay), with the reasoning made visible.
- **Market Watch** cut to a **short 1–2 sentence secondary note** moved to the end — no editorializing, no buy/sell framing. In the podcast it's a ~15-second quiet note *after* the engineering deep dive.

### Livelier delivery (within landmine #17)
- Host reframed as an energetic **engineer-storyteller** (borrowed from FP); expanded DELIVERY block for real, audible energy through **sentence rhythm and vivid concrete language** — explicitly **not** new TTS tags or superlative spam (landmine #17: theory-driven tag changes have a 100% regression history; energy comes from the writing).
- `tone_hint` is now lively/engineering-forward **by default** instead of derived from the stock move, so the energy never hinges on the ticker.

### Plumbing kept in sync
Content-tracker regexes (deep_dive/headlines/counterpoint) accept the new "Engineering Deep Dive" header with the old name retained as a fallback; chapter marker, `review_episodes` required-sections, and tests updated. Kept the spoken **"from an engineering standpoint"** opener so chapters/tracker/tests stay wired. Full suite **2807 passed**.

⚠️ **Audio/editorial-affecting prompt changes — A/B-listen the next episode (landmine #17) and revert via git if quality dips.** I couldn't generate a before/after digest here (no `GROK_API_KEY` in this environment); the changes are structural and test-verified, but the real check is your ears on Episode 2.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_