### PR TITLE
SpaceX dashboard: constellation-growth chart, recently-flown, vehicle-mix bar, count-ups

### DIFF
--- a/api/spacex_launches.json
+++ b/api/spacex_launches.json
@@ -134,6 +134,122 @@
       "info_url": null
     }
   ],
+  "recent": [
+    {
+      "id": "229267d8-74ca-4d0b-8711-b2efe621fc6b",
+      "name": "Falcon 9 Block 5 | Starlink Group 10-54",
+      "net": "2026-06-12T12:37:00Z",
+      "window_start": "2026-06-12T12:27:00Z",
+      "window_end": "2026-06-12T16:27:00Z",
+      "status": "Success",
+      "status_name": "Launch Successful",
+      "rocket": "Falcon 9",
+      "pad": "Space Launch Complex 40",
+      "location": "Cape Canaveral SFS, FL, USA",
+      "mission": "Starlink Group 10-54",
+      "mission_type": "Communications",
+      "mission_description": "A batch of 29 satellites for the Starlink mega-constellation - SpaceX's project for space-based Internet communication system.",
+      "orbit": "Low Earth Orbit",
+      "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/falcon2520925_image_20221009234147.png",
+      "webcast": null,
+      "info_url": null
+    },
+    {
+      "id": "c7b7e18f-1b42-467e-a8ed-181fb58080e8",
+      "name": "Falcon 9 Block 5 | Starlink Group 17-44",
+      "net": "2026-06-11T15:05:59Z",
+      "window_start": "2026-06-11T14:00:00Z",
+      "window_end": "2026-06-11T18:00:00Z",
+      "status": "Success",
+      "status_name": "Launch Successful",
+      "rocket": "Falcon 9",
+      "pad": "Space Launch Complex 4E",
+      "location": "Vandenberg SFB, CA, USA",
+      "mission": "Starlink Group 17-44",
+      "mission_type": "Communications",
+      "mission_description": "A batch of 24 satellites for the Starlink mega-constellation - SpaceX's project for space-based Internet communication system.",
+      "orbit": "Low Earth Orbit",
+      "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/falcon2520925_image_20221009234147.png",
+      "webcast": null,
+      "info_url": null
+    },
+    {
+      "id": "114577dc-7617-461c-aaeb-9bd0f64b5a4b",
+      "name": "Falcon 9 Block 5 | Starlink Group 10-35",
+      "net": "2026-06-08T10:13:50Z",
+      "window_start": "2026-06-08T10:07:00Z",
+      "window_end": "2026-06-08T14:07:00Z",
+      "status": "Success",
+      "status_name": "Launch Successful",
+      "rocket": "Falcon 9",
+      "pad": "Space Launch Complex 40",
+      "location": "Cape Canaveral SFS, FL, USA",
+      "mission": "Starlink Group 10-35",
+      "mission_type": "Communications",
+      "mission_description": "A batch of 29 satellites for the Starlink mega-constellation - SpaceX's project for space-based Internet communication system.",
+      "orbit": "Low Earth Orbit",
+      "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/falcon2520925_image_20221009234147.png",
+      "webcast": null,
+      "info_url": null
+    },
+    {
+      "id": "af8d71dd-f439-47b3-91ed-57f959a581e0",
+      "name": "Falcon 9 Block 5 | Starlink Group 17-43",
+      "net": "2026-06-07T04:24:45Z",
+      "window_start": "2026-06-07T02:00:00Z",
+      "window_end": "2026-06-07T06:00:00Z",
+      "status": "Success",
+      "status_name": "Launch Successful",
+      "rocket": "Falcon 9",
+      "pad": "Space Launch Complex 4E",
+      "location": "Vandenberg SFB, CA, USA",
+      "mission": "Starlink Group 17-43",
+      "mission_type": "Communications",
+      "mission_description": "A batch of 21 satellites for the Starlink mega-constellation - SpaceX's project for space-based Internet communication system.\r\n\r\n2 US military Starshield satellites are also on board.",
+      "orbit": "Low Earth Orbit",
+      "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/falcon2520925_image_20221009234147.png",
+      "webcast": null,
+      "info_url": null
+    },
+    {
+      "id": "cfff5e89-af2e-46b1-9446-7b0f18de4ef7",
+      "name": "Falcon 9 Block 5 | Starlink Group 10-43",
+      "net": "2026-06-04T10:26:30Z",
+      "window_start": "2026-06-04T08:00:00Z",
+      "window_end": "2026-06-04T12:00:00Z",
+      "status": "Success",
+      "status_name": "Launch Successful",
+      "rocket": "Falcon 9",
+      "pad": "Space Launch Complex 40",
+      "location": "Cape Canaveral SFS, FL, USA",
+      "mission": "Starlink Group 10-43",
+      "mission_type": "Communications",
+      "mission_description": "A batch of 29 satellites for the Starlink mega-constellation - SpaceX's project for space-based Internet communication system.",
+      "orbit": "Low Earth Orbit",
+      "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/falcon2520925_image_20221009234147.png",
+      "webcast": null,
+      "info_url": null
+    },
+    {
+      "id": "4936311a-af7c-4b05-8d7b-3eea59fc0f11",
+      "name": "Falcon 9 Block 5 | Starlink Group 17-47",
+      "net": "2026-06-03T15:40:39Z",
+      "window_start": "2026-06-03T14:00:00Z",
+      "window_end": "2026-06-03T18:00:00Z",
+      "status": "Success",
+      "status_name": "Launch Successful",
+      "rocket": "Falcon 9",
+      "pad": "Space Launch Complex 4E",
+      "location": "Vandenberg SFB, CA, USA",
+      "mission": "Starlink Group 17-47",
+      "mission_type": "Communications",
+      "mission_description": "A batch of 24 satellites for the Starlink mega-constellation - SpaceX's project for space-based Internet communication system.",
+      "orbit": "Low Earth Orbit",
+      "image": "https://thespacedevs-prod.nyc3.digitaloceanspaces.com/media/images/falcon2520925_image_20221009234147.png",
+      "webcast": null,
+      "info_url": null
+    }
+  ],
   "cadence_monthly": [
     {
       "month": "2025-07",
@@ -234,6 +350,56 @@
       "tonnes": 102
     }
   ],
+  "sats_cumulative_monthly": [
+    {
+      "month": "2025-07",
+      "total": 184
+    },
+    {
+      "month": "2025-08",
+      "total": 391
+    },
+    {
+      "month": "2025-09",
+      "total": 644
+    },
+    {
+      "month": "2025-10",
+      "total": 920
+    },
+    {
+      "month": "2025-11",
+      "total": 1150
+    },
+    {
+      "month": "2025-12",
+      "total": 1426
+    },
+    {
+      "month": "2026-01",
+      "total": 1633
+    },
+    {
+      "month": "2026-02",
+      "total": 1886
+    },
+    {
+      "month": "2026-03",
+      "total": 2185
+    },
+    {
+      "month": "2026-04",
+      "total": 2392
+    },
+    {
+      "month": "2026-05",
+      "total": 2576
+    },
+    {
+      "month": "2026-06",
+      "total": 2714
+    }
+  ],
   "stats": {
     "launches_ytd": 70,
     "launches_last_30d": 14,
@@ -259,5 +425,5 @@
   },
   "total_launches": 689,
   "source": "thespacedevs_ll2",
-  "updated_at": "2026-06-13T16:05:51.158276+00:00"
+  "updated_at": "2026-06-13T18:34:20.891211+00:00"
 }

--- a/scripts/fetch_spacex_launches.py
+++ b/scripts/fetch_spacex_launches.py
@@ -242,7 +242,10 @@ def _update_metrics_timeseries(monthly: List[Dict[str, Any]], now: _dt.datetime,
         logger.info("Updated metrics time-series %s (%d months)", path, len(months))
     except Exception as exc:
         logger.warning("Could not write metrics time-series (non-fatal): %s", exc)
-    return cum  # latest cumulative estimated-satellites total
+    # Return the latest cumulative total + the ordered cumulative series
+    # (so the dashboard can chart growth-over-time from one file).
+    cumulative_series = [{"month": k, "total": cumulative[k]} for k, _ in ordered]
+    return cum, cumulative_series
 
 
 def _fleet_payload(previous: List[Dict[str, Any]], now: _dt.datetime) -> Dict[str, Any]:
@@ -367,19 +370,24 @@ def build_payload() -> Optional[Dict[str, Any]]:
 
     previous_launch = _slim_launch(prev_results[0]) if prev_results else None
     upcoming_list = [_slim_launch(r) for r in up_results][:5]
+    # Most-recent launched missions (with outcome) for the "recently flown"
+    # panel. prev_results is newest-first.
+    recent_list = [_slim_launch(r) for r in prev_results][:6]
 
     slim_prev = [_slim_launch(r) for r in prev_results]
     monthly = _monthly_breakdown(slim_prev)
     # Merge the fresh 12-month window into the growing committed dataset.
-    cumulative_sats = _update_metrics_timeseries(monthly, now)
+    cumulative_sats, cumulative_series = _update_metrics_timeseries(monthly, now)
     fleet = _fleet_payload(slim_prev, now)
     fleet["cumulative_satellites_est"] = cumulative_sats
     return {
         "next": next_launch,
         "previous": previous_launch,
         "upcoming": upcoming_list,
+        "recent": recent_list,
         "cadence_monthly": [{"month": b["month"], "count": b["launches"]} for b in monthly],
         "mass_monthly": [{"month": b["month"], "tonnes": b["mass_t"]} for b in monthly],
+        "sats_cumulative_monthly": cumulative_series,
         "stats": _stats(slim_prev, now),
         "fleet": fleet,
         "total_launches": prev_total,

--- a/site/data/spacex_metrics.json
+++ b/site/data/spacex_metrics.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-13T16:05:51.158276+00:00",
+  "updated_at": "2026-06-13T18:34:20.891211+00:00",
   "note": "Monthly SpaceX metrics (estimated mass/satellites from public per-vehicle averages; launch counts/vehicle mix from the launch record). Grows over time as new months lock in.",
   "months": {
     "2025-07": {

--- a/spacex-dashboard.html
+++ b/spacex-dashboard.html
@@ -162,6 +162,36 @@
   .spx-bar-label { font-size:0.58rem; color:#7f93c4; white-space:nowrap; max-width:100%; overflow:hidden; text-overflow:clip; }
   @media (max-width: 520px){ .spx-bar-label { font-size:0.5rem; letter-spacing:-0.03em; } .spx-cadence{ gap:4px; } }
 
+  /* cumulative growth area chart */
+  .spx-area-wrap { position:relative; }
+  .spx-area-svg { width:100%; height:200px; display:block; overflow:visible; }
+  .spx-area-svg .grid { stroke:rgba(120,160,255,0.12); stroke-width:1; }
+  .spx-area-svg .gridlabel { fill:#7f93c4; font-size:10px; }
+  .spx-area-svg .xlabel { fill:#7f93c4; font-size:10px; text-anchor:middle; }
+  .spx-area-svg .areapath { transition: opacity .8s ease; }
+  .spx-area-svg .linepath { fill:none; stroke:var(--spx-cyan); stroke-width:2.5;
+    stroke-linejoin:round; stroke-linecap:round;
+    filter: drop-shadow(0 2px 8px rgba(0,212,255,0.4)); }
+  .spx-area-svg .dot { fill:#fff; stroke:var(--spx-blue); stroke-width:2; }
+
+  /* vehicle-mix segmented bar */
+  .spx-mixbar { display:flex; height:26px; border-radius:8px; overflow:hidden; margin:4px 0 10px; }
+  .spx-mixseg { height:100%; min-width:2px; }
+  .spx-mixlegend { display:flex; flex-wrap:wrap; gap:10px 18px; font-size:0.8rem; }
+  .spx-mixlegend .it { display:flex; align-items:center; gap:6px; color:#cfe0ff; }
+  .spx-mixlegend .sw { width:11px; height:11px; border-radius:3px; flex:0 0 auto; }
+  .spx-mixlegend .ct { color:#8ea3d6; font-variant-numeric:tabular-nums; }
+
+  /* recently flown */
+  .spx-rl { display:flex; align-items:center; gap:10px; padding:0.5rem 0; border-bottom:1px solid rgba(120,160,255,0.12); font-size:0.88rem; }
+  .spx-rl:last-child{ border-bottom:none; }
+  .spx-rl .nm { flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .spx-rl .badge { font-size:0.64rem; font-weight:700; text-transform:uppercase; letter-spacing:0.05em; padding:2px 7px; border-radius:999px; white-space:nowrap; }
+  .spx-rl .badge.ok { color:#7efbb0; background:rgba(40,200,120,0.14); }
+  .spx-rl .badge.bad { color:#ff9a9a; background:rgba(255,80,80,0.14); }
+  .spx-rl .badge.tbd { color:#ffd27a; background:rgba(255,180,40,0.14); }
+  .spx-rl .dt { color:#8ea3d6; white-space:nowrap; font-variant-numeric:tabular-nums; font-size:0.78rem; }
+
   .spx-since { font-size: clamp(1.4rem,3.5vw,2rem); font-weight:800; font-variant-numeric:tabular-nums; color:#fff; }
   .spx-upcoming-item { display:flex; justify-content:space-between; gap:10px; padding:0.55rem 0; border-bottom:1px solid rgba(120,160,255,0.12); font-size:0.9rem; }
   .spx-upcoming-item:last-child{ border-bottom:none; }
@@ -616,6 +646,18 @@
 
   <div class="spx-grid" style="grid-template-columns:1fr;">
     <div class="spx-panel">
+      <h2>Constellation growth — est. satellites to orbit <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(cumulative, tracked window)</span></h2>
+      <div class="spx-area-wrap"><svg class="spx-area-svg" id="spxArea" preserveAspectRatio="none" role="img" aria-label="Cumulative estimated satellites to orbit"></svg></div>
+      <p class="spx-disclaimer">Cumulative estimate over the months this dashboard has tracked — it extends to the left automatically as the dataset grows month over month.</p>
+    </div>
+  </div>
+
+  <div class="spx-grid">
+    <div class="spx-panel">
+      <h2>Recently flown</h2>
+      <div id="spxRecent"><p class="spx-muted">Loading…</p></div>
+    </div>
+    <div class="spx-panel">
       <h2>Upcoming manifest</h2>
       <div id="spxUpcoming"><p class="spx-muted">Loading…</p></div>
     </div>
@@ -930,10 +972,75 @@
     if(el) el.textContent = (p.name||'Last launch') + (p.net ? ' · '+fmtLocal(p.net) : '');
   }
 
+  // Animated count-up for a stat number. Respects reduced-motion.
+  function countUp(id, target, suffix){
+    const el=document.getElementById(id); if(!el || target==null) return;
+    suffix = suffix||'';
+    const reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const isFloat = !Number.isInteger(target);
+    if(reduce){ el.textContent=(isFloat?target.toFixed(1):Math.round(target).toLocaleString())+suffix; return; }
+    const dur=900, t0=performance.now();
+    function step(t){
+      const k=Math.min(1,(t-t0)/dur), e=1-Math.pow(1-k,3), v=target*e;
+      el.textContent=(isFloat?v.toFixed(1):Math.round(v).toLocaleString())+suffix;
+      if(k<1) requestAnimationFrame(step);
+    }
+    requestAnimationFrame(step);
+  }
+
   function renderStats(s, total){
     const set=(id,v)=>{const e=document.getElementById(id); if(e) e.textContent=(v==null?'—':v);};
-    if(s){ set('stYtd',s.launches_ytd); set('st30',s.launches_last_30d); set('stAvg',s.avg_days_between_last_365d); set('stStar',s.starlink_launches_ytd); }
-    set('stTotal', total!=null ? total.toLocaleString() : '—');
+    if(s){ countUp('stYtd', s.launches_ytd); countUp('st30', s.launches_last_30d);
+           set('stAvg', s.avg_days_between_last_365d); countUp('stStar', s.starlink_launches_ytd); }
+    if(total!=null) countUp('stTotal', total); else set('stTotal','—');
+  }
+
+  // SVG area+line chart of a cumulative series [{month,total}].
+  function renderArea(series){
+    const svg=document.getElementById('spxArea');
+    if(!svg || !series || series.length<2) return;
+    const W=1000, H=200, padL=44, padR=8, padT=12, padB=22;
+    const xs=W-padL-padR, ys=H-padT-padB;
+    const vals=series.map(p=>p.total);
+    const max=Math.max(...vals), min=Math.min(0, ...vals);
+    const n=series.length;
+    const X=i=> padL + (n===1?0:(i/(n-1))*xs);
+    const Y=v=> padT + ys - ((v-min)/((max-min)||1))*ys;
+    let line='', area='M'+X(0)+','+(padT+ys);
+    series.forEach((p,i)=>{ const x=X(i),y=Y(p.total); line+=(i?'L':'M')+x+','+y+' '; area+='L'+x+','+y+' '; });
+    area+='L'+X(n-1)+','+(padT+ys)+'Z';
+    // y gridlines (0, mid, max)
+    let grid='';
+    [0,0.5,1].forEach(f=>{ const v=min+(max-min)*f, y=Y(v);
+      grid+='<line class="grid" x1="'+padL+'" y1="'+y+'" x2="'+(W-padR)+'" y2="'+y+'"/>'+
+            '<text class="gridlabel" x="0" y="'+(y+3)+'">'+Math.round(v).toLocaleString()+'</text>'; });
+    // a few x labels
+    let xl=''; const step=Math.max(1,Math.floor(n/4));
+    for(let i=0;i<n;i+=step){ xl+='<text class="xlabel" x="'+X(i)+'" y="'+(H-6)+'">'+series[i].month.slice(2).replace('-','/')+'</text>'; }
+    const last=series[n-1];
+    svg.setAttribute('viewBox','0 0 '+W+' '+H);
+    svg.innerHTML =
+      '<defs><linearGradient id="spxAreaGrad" x1="0" y1="0" x2="0" y2="1">'+
+      '<stop offset="0%" stop-color="rgba(0,212,255,0.45)"/><stop offset="100%" stop-color="rgba(26,92,255,0.02)"/>'+
+      '</linearGradient></defs>'+grid+
+      '<path class="areapath" d="'+area+'" fill="url(#spxAreaGrad)"/>'+
+      '<path class="linepath" d="'+line+'"/>'+
+      '<circle class="dot" cx="'+X(n-1)+'" cy="'+Y(last.total)+'" r="4"/>'+
+      '<text x="'+X(n-1)+'" y="'+(Y(last.total)-10)+'" text-anchor="end" fill="#fff" font-size="12" font-weight="700">'+last.total.toLocaleString()+'</text>'+
+      xl;
+  }
+
+  function renderRecent(list){
+    const wrap=document.getElementById('spxRecent');
+    if(!wrap) return;
+    if(!list || !list.length){ wrap.innerHTML='<p class="spx-muted">No recent launches.</p>'; return; }
+    const cls=a=>{ a=(a||'').toLowerCase(); if(a==='success') return 'ok'; if(a.includes('fail')) return 'bad'; return 'tbd'; };
+    wrap.innerHTML = list.map(x=>{
+      const st=x.status||'—';
+      return '<div class="spx-rl"><span class="badge '+cls(st)+'">'+st+'</span>'+
+             '<span class="nm">'+(x.name||'Launch')+'</span>'+
+             '<span class="dt">'+(x.net?fmtLocal(x.net):'')+'</span></div>';
+    }).join('');
   }
 
   function renderUpcoming(list){
@@ -943,21 +1050,28 @@
     wrap.innerHTML = list.map(x=>'<div class="spx-upcoming-item"><span>'+(x.name||'Launch')+'</span><span class="when">'+(x.net?fmtLocal(x.net):'TBD')+'</span></div>').join('');
   }
 
+  var VEHICLE_COLORS = {'Falcon 9':'#1A5CFF','Starship':'#00D4FF','Falcon Heavy':'#8ab4ff'};
+  var VEHICLE_FALLBACK = ['#a78bfa','#7efbb0','#ffd27a','#ff9a9a'];
+
   function renderFleet(f){
     if(!f) return;
     const set=(id,v)=>{const e=document.getElementById(id); if(e) e.textContent=(v==null?'—':v);};
-    set('flMass', f.est_mass_to_orbit_tonnes!=null ? Number(f.est_mass_to_orbit_tonnes).toLocaleString() : '—');
-    set('flSats', f.est_satellites_deployed!=null ? Number(f.est_satellites_deployed).toLocaleString() : '—');
-    set('flCumSats', f.cumulative_satellites_est!=null ? Number(f.cumulative_satellites_est).toLocaleString() : '—');
+    countUp('flMass', f.est_mass_to_orbit_tonnes);
+    countUp('flSats', f.est_satellites_deployed);
+    countUp('flCumSats', f.cumulative_satellites_est);
     set('flStarShare', f.starlink_share_pct!=null ? f.starlink_share_pct+'%' : '—');
     set('flSuccess', f.success_rate_pct!=null ? f.success_rate_pct+'%' : '—');
     const bv = f.by_vehicle || {};
     const wrap = document.getElementById('flVehicles');
     if(wrap){
       const entries = Object.entries(bv).sort((a,b)=>b[1]-a[1]);
+      const total = entries.reduce((s,[,v])=>s+v,0) || 1;
       if(entries.length){
+        const color=(k,i)=>VEHICLE_COLORS[k]||VEHICLE_FALLBACK[i%VEHICLE_FALLBACK.length];
+        const segs = entries.map(([k,v],i)=>'<div class="spx-mixseg" style="width:'+(100*v/total)+'%;background:'+color(k,i)+';" title="'+k+': '+v+'"></div>').join('');
+        const legend = entries.map(([k,v],i)=>'<span class="it"><span class="sw" style="background:'+color(k,i)+'"></span>'+k+' <span class="ct">'+v+'</span></span>').join('');
         wrap.innerHTML = '<div class="spx-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.1em;margin-bottom:6px;">Launches by vehicle</div>' +
-          entries.map(([k,v])=>'<div class="spx-upcoming-item"><span>'+k+'</span><span class="when">'+v+'</span></div>').join('');
+          '<div class="spx-mixbar">'+segs+'</div><div class="spx-mixlegend">'+legend+'</div>';
       }
     }
   }
@@ -969,7 +1083,9 @@
     renderStats(data.stats, data.total_launches);
     renderCadence(data.cadence_monthly);
     renderBars('spxMass', data.mass_monthly, 'tonnes');
+    renderArea(data.sats_cumulative_monthly);
     renderFleet(data.fleet);
+    renderRecent(data.recent);
     renderUpcoming(data.upcoming);
   }
 

--- a/templates/spacex_dashboard.html.j2
+++ b/templates/spacex_dashboard.html.j2
@@ -105,6 +105,36 @@
   .spx-bar-label { font-size:0.58rem; color:#7f93c4; white-space:nowrap; max-width:100%; overflow:hidden; text-overflow:clip; }
   @media (max-width: 520px){ .spx-bar-label { font-size:0.5rem; letter-spacing:-0.03em; } .spx-cadence{ gap:4px; } }
 
+  /* cumulative growth area chart */
+  .spx-area-wrap { position:relative; }
+  .spx-area-svg { width:100%; height:200px; display:block; overflow:visible; }
+  .spx-area-svg .grid { stroke:rgba(120,160,255,0.12); stroke-width:1; }
+  .spx-area-svg .gridlabel { fill:#7f93c4; font-size:10px; }
+  .spx-area-svg .xlabel { fill:#7f93c4; font-size:10px; text-anchor:middle; }
+  .spx-area-svg .areapath { transition: opacity .8s ease; }
+  .spx-area-svg .linepath { fill:none; stroke:var(--spx-cyan); stroke-width:2.5;
+    stroke-linejoin:round; stroke-linecap:round;
+    filter: drop-shadow(0 2px 8px rgba(0,212,255,0.4)); }
+  .spx-area-svg .dot { fill:#fff; stroke:var(--spx-blue); stroke-width:2; }
+
+  /* vehicle-mix segmented bar */
+  .spx-mixbar { display:flex; height:26px; border-radius:8px; overflow:hidden; margin:4px 0 10px; }
+  .spx-mixseg { height:100%; min-width:2px; }
+  .spx-mixlegend { display:flex; flex-wrap:wrap; gap:10px 18px; font-size:0.8rem; }
+  .spx-mixlegend .it { display:flex; align-items:center; gap:6px; color:#cfe0ff; }
+  .spx-mixlegend .sw { width:11px; height:11px; border-radius:3px; flex:0 0 auto; }
+  .spx-mixlegend .ct { color:#8ea3d6; font-variant-numeric:tabular-nums; }
+
+  /* recently flown */
+  .spx-rl { display:flex; align-items:center; gap:10px; padding:0.5rem 0; border-bottom:1px solid rgba(120,160,255,0.12); font-size:0.88rem; }
+  .spx-rl:last-child{ border-bottom:none; }
+  .spx-rl .nm { flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .spx-rl .badge { font-size:0.64rem; font-weight:700; text-transform:uppercase; letter-spacing:0.05em; padding:2px 7px; border-radius:999px; white-space:nowrap; }
+  .spx-rl .badge.ok { color:#7efbb0; background:rgba(40,200,120,0.14); }
+  .spx-rl .badge.bad { color:#ff9a9a; background:rgba(255,80,80,0.14); }
+  .spx-rl .badge.tbd { color:#ffd27a; background:rgba(255,180,40,0.14); }
+  .spx-rl .dt { color:#8ea3d6; white-space:nowrap; font-variant-numeric:tabular-nums; font-size:0.78rem; }
+
   .spx-since { font-size: clamp(1.4rem,3.5vw,2rem); font-weight:800; font-variant-numeric:tabular-nums; color:#fff; }
   .spx-upcoming-item { display:flex; justify-content:space-between; gap:10px; padding:0.55rem 0; border-bottom:1px solid rgba(120,160,255,0.12); font-size:0.9rem; }
   .spx-upcoming-item:last-child{ border-bottom:none; }
@@ -197,6 +227,18 @@
   </div>
 
   <div class="spx-grid" style="grid-template-columns:1fr;">
+    <div class="spx-panel">
+      <h2>Constellation growth — est. satellites to orbit <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(cumulative, tracked window)</span></h2>
+      <div class="spx-area-wrap"><svg class="spx-area-svg" id="spxArea" preserveAspectRatio="none" role="img" aria-label="Cumulative estimated satellites to orbit"></svg></div>
+      <p class="spx-disclaimer">Cumulative estimate over the months this dashboard has tracked — it extends to the left automatically as the dataset grows month over month.</p>
+    </div>
+  </div>
+
+  <div class="spx-grid">
+    <div class="spx-panel">
+      <h2>Recently flown</h2>
+      <div id="spxRecent"><p class="spx-muted">Loading…</p></div>
+    </div>
     <div class="spx-panel">
       <h2>Upcoming manifest</h2>
       <div id="spxUpcoming"><p class="spx-muted">Loading…</p></div>
@@ -321,10 +363,75 @@
     if(el) el.textContent = (p.name||'Last launch') + (p.net ? ' · '+fmtLocal(p.net) : '');
   }
 
+  // Animated count-up for a stat number. Respects reduced-motion.
+  function countUp(id, target, suffix){
+    const el=document.getElementById(id); if(!el || target==null) return;
+    suffix = suffix||'';
+    const reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const isFloat = !Number.isInteger(target);
+    if(reduce){ el.textContent=(isFloat?target.toFixed(1):Math.round(target).toLocaleString())+suffix; return; }
+    const dur=900, t0=performance.now();
+    function step(t){
+      const k=Math.min(1,(t-t0)/dur), e=1-Math.pow(1-k,3), v=target*e;
+      el.textContent=(isFloat?v.toFixed(1):Math.round(v).toLocaleString())+suffix;
+      if(k<1) requestAnimationFrame(step);
+    }
+    requestAnimationFrame(step);
+  }
+
   function renderStats(s, total){
     const set=(id,v)=>{const e=document.getElementById(id); if(e) e.textContent=(v==null?'—':v);};
-    if(s){ set('stYtd',s.launches_ytd); set('st30',s.launches_last_30d); set('stAvg',s.avg_days_between_last_365d); set('stStar',s.starlink_launches_ytd); }
-    set('stTotal', total!=null ? total.toLocaleString() : '—');
+    if(s){ countUp('stYtd', s.launches_ytd); countUp('st30', s.launches_last_30d);
+           set('stAvg', s.avg_days_between_last_365d); countUp('stStar', s.starlink_launches_ytd); }
+    if(total!=null) countUp('stTotal', total); else set('stTotal','—');
+  }
+
+  // SVG area+line chart of a cumulative series [{month,total}].
+  function renderArea(series){
+    const svg=document.getElementById('spxArea');
+    if(!svg || !series || series.length<2) return;
+    const W=1000, H=200, padL=44, padR=8, padT=12, padB=22;
+    const xs=W-padL-padR, ys=H-padT-padB;
+    const vals=series.map(p=>p.total);
+    const max=Math.max(...vals), min=Math.min(0, ...vals);
+    const n=series.length;
+    const X=i=> padL + (n===1?0:(i/(n-1))*xs);
+    const Y=v=> padT + ys - ((v-min)/((max-min)||1))*ys;
+    let line='', area='M'+X(0)+','+(padT+ys);
+    series.forEach((p,i)=>{ const x=X(i),y=Y(p.total); line+=(i?'L':'M')+x+','+y+' '; area+='L'+x+','+y+' '; });
+    area+='L'+X(n-1)+','+(padT+ys)+'Z';
+    // y gridlines (0, mid, max)
+    let grid='';
+    [0,0.5,1].forEach(f=>{ const v=min+(max-min)*f, y=Y(v);
+      grid+='<line class="grid" x1="'+padL+'" y1="'+y+'" x2="'+(W-padR)+'" y2="'+y+'"/>'+
+            '<text class="gridlabel" x="0" y="'+(y+3)+'">'+Math.round(v).toLocaleString()+'</text>'; });
+    // a few x labels
+    let xl=''; const step=Math.max(1,Math.floor(n/4));
+    for(let i=0;i<n;i+=step){ xl+='<text class="xlabel" x="'+X(i)+'" y="'+(H-6)+'">'+series[i].month.slice(2).replace('-','/')+'</text>'; }
+    const last=series[n-1];
+    svg.setAttribute('viewBox','0 0 '+W+' '+H);
+    svg.innerHTML =
+      '<defs><linearGradient id="spxAreaGrad" x1="0" y1="0" x2="0" y2="1">'+
+      '<stop offset="0%" stop-color="rgba(0,212,255,0.45)"/><stop offset="100%" stop-color="rgba(26,92,255,0.02)"/>'+
+      '</linearGradient></defs>'+grid+
+      '<path class="areapath" d="'+area+'" fill="url(#spxAreaGrad)"/>'+
+      '<path class="linepath" d="'+line+'"/>'+
+      '<circle class="dot" cx="'+X(n-1)+'" cy="'+Y(last.total)+'" r="4"/>'+
+      '<text x="'+X(n-1)+'" y="'+(Y(last.total)-10)+'" text-anchor="end" fill="#fff" font-size="12" font-weight="700">'+last.total.toLocaleString()+'</text>'+
+      xl;
+  }
+
+  function renderRecent(list){
+    const wrap=document.getElementById('spxRecent');
+    if(!wrap) return;
+    if(!list || !list.length){ wrap.innerHTML='<p class="spx-muted">No recent launches.</p>'; return; }
+    const cls=a=>{ a=(a||'').toLowerCase(); if(a==='success') return 'ok'; if(a.includes('fail')) return 'bad'; return 'tbd'; };
+    wrap.innerHTML = list.map(x=>{
+      const st=x.status||'—';
+      return '<div class="spx-rl"><span class="badge '+cls(st)+'">'+st+'</span>'+
+             '<span class="nm">'+(x.name||'Launch')+'</span>'+
+             '<span class="dt">'+(x.net?fmtLocal(x.net):'')+'</span></div>';
+    }).join('');
   }
 
   function renderUpcoming(list){
@@ -334,21 +441,28 @@
     wrap.innerHTML = list.map(x=>'<div class="spx-upcoming-item"><span>'+(x.name||'Launch')+'</span><span class="when">'+(x.net?fmtLocal(x.net):'TBD')+'</span></div>').join('');
   }
 
+  var VEHICLE_COLORS = {'Falcon 9':'#1A5CFF','Starship':'#00D4FF','Falcon Heavy':'#8ab4ff'};
+  var VEHICLE_FALLBACK = ['#a78bfa','#7efbb0','#ffd27a','#ff9a9a'];
+
   function renderFleet(f){
     if(!f) return;
     const set=(id,v)=>{const e=document.getElementById(id); if(e) e.textContent=(v==null?'—':v);};
-    set('flMass', f.est_mass_to_orbit_tonnes!=null ? Number(f.est_mass_to_orbit_tonnes).toLocaleString() : '—');
-    set('flSats', f.est_satellites_deployed!=null ? Number(f.est_satellites_deployed).toLocaleString() : '—');
-    set('flCumSats', f.cumulative_satellites_est!=null ? Number(f.cumulative_satellites_est).toLocaleString() : '—');
+    countUp('flMass', f.est_mass_to_orbit_tonnes);
+    countUp('flSats', f.est_satellites_deployed);
+    countUp('flCumSats', f.cumulative_satellites_est);
     set('flStarShare', f.starlink_share_pct!=null ? f.starlink_share_pct+'%' : '—');
     set('flSuccess', f.success_rate_pct!=null ? f.success_rate_pct+'%' : '—');
     const bv = f.by_vehicle || {};
     const wrap = document.getElementById('flVehicles');
     if(wrap){
       const entries = Object.entries(bv).sort((a,b)=>b[1]-a[1]);
+      const total = entries.reduce((s,[,v])=>s+v,0) || 1;
       if(entries.length){
+        const color=(k,i)=>VEHICLE_COLORS[k]||VEHICLE_FALLBACK[i%VEHICLE_FALLBACK.length];
+        const segs = entries.map(([k,v],i)=>'<div class="spx-mixseg" style="width:'+(100*v/total)+'%;background:'+color(k,i)+';" title="'+k+': '+v+'"></div>').join('');
+        const legend = entries.map(([k,v],i)=>'<span class="it"><span class="sw" style="background:'+color(k,i)+'"></span>'+k+' <span class="ct">'+v+'</span></span>').join('');
         wrap.innerHTML = '<div class="spx-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.1em;margin-bottom:6px;">Launches by vehicle</div>' +
-          entries.map(([k,v])=>'<div class="spx-upcoming-item"><span>'+k+'</span><span class="when">'+v+'</span></div>').join('');
+          '<div class="spx-mixbar">'+segs+'</div><div class="spx-mixlegend">'+legend+'</div>';
       }
     }
   }
@@ -360,7 +474,9 @@
     renderStats(data.stats, data.total_launches);
     renderCadence(data.cadence_monthly);
     renderBars('spxMass', data.mass_monthly, 'tonnes');
+    renderArea(data.sats_cumulative_monthly);
     renderFleet(data.fleet);
+    renderRecent(data.recent);
     renderUpcoming(data.upcoming);
   }
 

--- a/tests/test_spacex_show.py
+++ b/tests/test_spacex_show.py
@@ -454,7 +454,8 @@ class TestGrowingMetricsDataset:
         path.write_text('{"months": {"2020-01": {"launches": 5, "mass_t": 80, "satellites": 100, "vehicles": {}}}}')
         mb = mod._monthly_breakdown([{"net": now.strftime("%Y-%m") + "-01T00:00:00Z",
                                       "rocket": "Falcon 9", "name": "Starlink", "status": "Success"}])
-        cum = mod._update_metrics_timeseries(mb, now, path=path)
+        cum, series = mod._update_metrics_timeseries(mb, now, path=path)
+        assert isinstance(series, list) and series and "total" in series[-1]
         import json
         data = json.loads(path.read_text())
         assert "2020-01" in data["months"], "old month must persist"
@@ -472,3 +473,32 @@ class TestGrowingMetricsDataset:
         meta = y.safe_load((_ROOT / "shows/network_meta.yaml").read_text(encoding="utf-8"))
         about = meta["spacex"]["about_text"].lower()
         assert "ai" in about and ("xai" in about or "compute" in about)
+
+
+class TestDashboardV2Visuals:
+    """June 13 2026 dashboard build-out: cumulative growth area chart,
+    recently-flown panel, vehicle-mix segmented bar, animated count-ups."""
+
+    def test_dashboard_template_has_new_panels(self):
+        t = (_ROOT / "templates/spacex_dashboard.html.j2").read_text(encoding="utf-8")
+        for needle in ('id="spxArea"', 'id="spxRecent"', "Constellation growth",
+                       "Recently flown", "function renderArea", "function renderRecent",
+                       "function countUp", "spx-mixbar"):
+            assert needle in t, needle
+
+    def test_payload_exposes_growth_and_recent(self):
+        # _monthly_breakdown + timeseries feed the cumulative series the
+        # area chart reads; recent list feeds the recently-flown panel.
+        import importlib.util, datetime as dt
+        spec = importlib.util.spec_from_file_location(
+            "fetch_spacex_launches", _ROOT / "scripts" / "fetch_spacex_launches.py")
+        mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+        import tempfile, pathlib
+        now = dt.datetime.now(dt.timezone.utc)
+        mb = mod._monthly_breakdown([
+            {"net": now.strftime("%Y-%m") + "-01T00:00:00Z", "rocket": "Falcon 9",
+             "name": "Starlink", "status": "Success"}])
+        with tempfile.TemporaryDirectory() as d:
+            cum, series = mod._update_metrics_timeseries(
+                mb, now, path=pathlib.Path(d) / "m.json")
+        assert series and series[-1]["total"] == cum


### PR DESCRIPTION
## SpaceX dashboard build-out + beautification

Continuing the dashboard with new visuals and depth:

### New "Constellation growth" area chart 📈
An SVG area chart (gradient fill, glowing cyan line, y-gridlines, month labels, latest-point dot) plotting **cumulative estimated satellites to orbit** from the growing time-series. It **lengthens automatically as the dataset accrues months** — the visualization of SpaceX growth over time you asked for. (Render-verified climbing 0 → 2,714 with axes.)

### New "Recently flown" panel
Last 6 missions with **Success / Failure / TBD status badges**, paired with the Upcoming manifest in a two-column grid.

### Vehicle mix → segmented bar
The plain "launches by vehicle" rows are now a colored **segmented bar + legend** (Falcon 9 / Starship / Falcon Heavy).

### Animated count-ups
The headline stats (launches, mass to orbit, satellites, cumulative) **count up** on load, respecting `prefers-reduced-motion`.

### Data
The fetcher now emits `sats_cumulative_monthly` (from the growing dataset) and a `recent[]` list; `_update_metrics_timeseries` returns the ordered cumulative series.

Render-verified at 1240px; drift guards added; suite **2841 passing**. Pure dashboard/data work — no audio path touched.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_