### PR TITLE
Dashboards: per-launch watch-live links + Tesla 52-week range bar

### DIFF
--- a/spacex-dashboard.html
+++ b/spacex-dashboard.html
@@ -196,6 +196,10 @@
   .spx-upcoming-item { display:flex; justify-content:space-between; gap:10px; padding:0.55rem 0; border-bottom:1px solid rgba(120,160,255,0.12); font-size:0.9rem; }
   .spx-upcoming-item:last-child{ border-bottom:none; }
   .spx-upcoming-item .when { color:#8ea3d6; white-space:nowrap; font-variant-numeric:tabular-nums; }
+  .spx-watch { display:inline-flex; align-items:center; gap:4px; margin-left:8px; font-size:0.72rem; font-weight:700; color:#031018; background:linear-gradient(135deg,var(--spx-cyan),#5ad0ff); padding:2px 9px; border-radius:999px; text-decoration:none; white-space:nowrap; vertical-align:middle; }
+  .spx-watch:hover { filter:brightness(1.08); }
+  .spx-watch.replay { color:var(--spx-cyan); background:transparent; border:1px solid rgba(120,160,255,0.35); }
+  .spx-upcoming-item .nmw { min-width:0; overflow:hidden; }
 
   .spx-spcx { display:flex; align-items:baseline; gap:12px; }
   .spx-spcx .px { font-size:2rem; font-weight:800; color:#fff; }
@@ -660,6 +664,10 @@
     <div class="spx-panel">
       <h2>Upcoming manifest</h2>
       <div id="spxUpcoming"><p class="spx-muted">Loading…</p></div>
+      <p class="spx-muted" style="margin-top:0.8rem; font-size:0.78rem;">Watch live on
+        <a href="https://www.spacex.com/launches/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">spacex.com/launches</a> ·
+        <a href="https://x.com/SpaceX" target="_blank" rel="noopener" style="color:var(--spx-cyan);">@SpaceX on X</a> ·
+        <a href="https://www.youtube.com/@SpaceX/streams" target="_blank" rel="noopener" style="color:var(--spx-cyan);">YouTube</a>. Webcasts usually go live ~15 minutes before liftoff.</p>
     </div>
   </div>
 
@@ -960,7 +968,12 @@
     set('spxLoc', n.location);
     set('spxLocal', n.net ? fmtLocal(n.net) : 'TBD');
     document.getElementById('spxDesc').textContent = n.mission_description || '';
-    if(n.webcast){ const w=document.getElementById('spxWebcast'); w.href=n.webcast; w.style.display='inline-flex'; }
+    // Always give a watch destination: the launch webcast once posted,
+    // else SpaceX's official launches hub (which carries the live stream).
+    const w=document.getElementById('spxWebcast');
+    if(w){ w.href=n.webcast || 'https://www.spacex.com/launches/';
+      w.textContent = n.webcast ? '▶ Watch the webcast' : '▶ Where to watch';
+      w.style.display='inline-flex'; }
     const more = n.info_url || 'https://www.spacex.com/launches/';
     const mEl=document.getElementById('spxMore'); mEl.href=more; mEl.style.display='inline-flex';
   }
@@ -1037,8 +1050,9 @@
     const cls=a=>{ a=(a||'').toLowerCase(); if(a==='success') return 'ok'; if(a.includes('fail')) return 'bad'; return 'tbd'; };
     wrap.innerHTML = list.map(x=>{
       const st=x.status||'—';
+      const replay = x.webcast ? '<a class="spx-watch replay" href="'+x.webcast+'" target="_blank" rel="noopener">▶ Replay</a>' : '';
       return '<div class="spx-rl"><span class="badge '+cls(st)+'">'+st+'</span>'+
-             '<span class="nm">'+(x.name||'Launch')+'</span>'+
+             '<span class="nm">'+(x.name||'Launch')+'</span>'+replay+
              '<span class="dt">'+(x.net?fmtLocal(x.net):'')+'</span></div>';
     }).join('');
   }
@@ -1047,7 +1061,15 @@
     const wrap=document.getElementById('spxUpcoming');
     if(!wrap) return;
     if(!list || !list.length){ wrap.innerHTML='<p class="spx-muted">No upcoming launches listed.</p>'; return; }
-    wrap.innerHTML = list.map(x=>'<div class="spx-upcoming-item"><span>'+(x.name||'Launch')+'</span><span class="when">'+(x.net?fmtLocal(x.net):'TBD')+'</span></div>').join('');
+    // Webcasts post ~24h out; until then link to SpaceX's official launches
+    // hub so every upcoming launch has a working "watch" destination.
+    const watchUrl=x=> x.webcast || x.info_url || 'https://www.spacex.com/launches/';
+    wrap.innerHTML = list.map(x=>{
+      const live = !!x.webcast;
+      return '<div class="spx-upcoming-item"><span class="nmw">'+(x.name||'Launch')+
+        '<a class="spx-watch'+(live?'':' replay')+'" href="'+watchUrl(x)+'" target="_blank" rel="noopener">'+(live?'▶ Watch live':'▶ Watch')+'</a></span>'+
+        '<span class="when">'+(x.net?fmtLocal(x.net):'TBD')+'</span></div>';
+    }).join('');
   }
 
   var VEHICLE_COLORS = {'Falcon 9':'#1A5CFF','Starship':'#00D4FF','Falcon Heavy':'#8ab4ff'};

--- a/templates/spacex_dashboard.html.j2
+++ b/templates/spacex_dashboard.html.j2
@@ -139,6 +139,10 @@
   .spx-upcoming-item { display:flex; justify-content:space-between; gap:10px; padding:0.55rem 0; border-bottom:1px solid rgba(120,160,255,0.12); font-size:0.9rem; }
   .spx-upcoming-item:last-child{ border-bottom:none; }
   .spx-upcoming-item .when { color:#8ea3d6; white-space:nowrap; font-variant-numeric:tabular-nums; }
+  .spx-watch { display:inline-flex; align-items:center; gap:4px; margin-left:8px; font-size:0.72rem; font-weight:700; color:#031018; background:linear-gradient(135deg,var(--spx-cyan),#5ad0ff); padding:2px 9px; border-radius:999px; text-decoration:none; white-space:nowrap; vertical-align:middle; }
+  .spx-watch:hover { filter:brightness(1.08); }
+  .spx-watch.replay { color:var(--spx-cyan); background:transparent; border:1px solid rgba(120,160,255,0.35); }
+  .spx-upcoming-item .nmw { min-width:0; overflow:hidden; }
 
   .spx-spcx { display:flex; align-items:baseline; gap:12px; }
   .spx-spcx .px { font-size:2rem; font-weight:800; color:#fff; }
@@ -242,6 +246,10 @@
     <div class="spx-panel">
       <h2>Upcoming manifest</h2>
       <div id="spxUpcoming"><p class="spx-muted">Loading…</p></div>
+      <p class="spx-muted" style="margin-top:0.8rem; font-size:0.78rem;">Watch live on
+        <a href="https://www.spacex.com/launches/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">spacex.com/launches</a> ·
+        <a href="https://x.com/SpaceX" target="_blank" rel="noopener" style="color:var(--spx-cyan);">@SpaceX on X</a> ·
+        <a href="https://www.youtube.com/@SpaceX/streams" target="_blank" rel="noopener" style="color:var(--spx-cyan);">YouTube</a>. Webcasts usually go live ~15 minutes before liftoff.</p>
     </div>
   </div>
 
@@ -351,7 +359,12 @@
     set('spxLoc', n.location);
     set('spxLocal', n.net ? fmtLocal(n.net) : 'TBD');
     document.getElementById('spxDesc').textContent = n.mission_description || '';
-    if(n.webcast){ const w=document.getElementById('spxWebcast'); w.href=n.webcast; w.style.display='inline-flex'; }
+    // Always give a watch destination: the launch webcast once posted,
+    // else SpaceX's official launches hub (which carries the live stream).
+    const w=document.getElementById('spxWebcast');
+    if(w){ w.href=n.webcast || 'https://www.spacex.com/launches/';
+      w.textContent = n.webcast ? '▶ Watch the webcast' : '▶ Where to watch';
+      w.style.display='inline-flex'; }
     const more = n.info_url || 'https://www.spacex.com/launches/';
     const mEl=document.getElementById('spxMore'); mEl.href=more; mEl.style.display='inline-flex';
   }
@@ -428,8 +441,9 @@
     const cls=a=>{ a=(a||'').toLowerCase(); if(a==='success') return 'ok'; if(a.includes('fail')) return 'bad'; return 'tbd'; };
     wrap.innerHTML = list.map(x=>{
       const st=x.status||'—';
+      const replay = x.webcast ? '<a class="spx-watch replay" href="'+x.webcast+'" target="_blank" rel="noopener">▶ Replay</a>' : '';
       return '<div class="spx-rl"><span class="badge '+cls(st)+'">'+st+'</span>'+
-             '<span class="nm">'+(x.name||'Launch')+'</span>'+
+             '<span class="nm">'+(x.name||'Launch')+'</span>'+replay+
              '<span class="dt">'+(x.net?fmtLocal(x.net):'')+'</span></div>';
     }).join('');
   }
@@ -438,7 +452,15 @@
     const wrap=document.getElementById('spxUpcoming');
     if(!wrap) return;
     if(!list || !list.length){ wrap.innerHTML='<p class="spx-muted">No upcoming launches listed.</p>'; return; }
-    wrap.innerHTML = list.map(x=>'<div class="spx-upcoming-item"><span>'+(x.name||'Launch')+'</span><span class="when">'+(x.net?fmtLocal(x.net):'TBD')+'</span></div>').join('');
+    // Webcasts post ~24h out; until then link to SpaceX's official launches
+    // hub so every upcoming launch has a working "watch" destination.
+    const watchUrl=x=> x.webcast || x.info_url || 'https://www.spacex.com/launches/';
+    wrap.innerHTML = list.map(x=>{
+      const live = !!x.webcast;
+      return '<div class="spx-upcoming-item"><span class="nmw">'+(x.name||'Launch')+
+        '<a class="spx-watch'+(live?'':' replay')+'" href="'+watchUrl(x)+'" target="_blank" rel="noopener">'+(live?'▶ Watch live':'▶ Watch')+'</a></span>'+
+        '<span class="when">'+(x.net?fmtLocal(x.net):'TBD')+'</span></div>';
+    }).join('');
   }
 
   var VEHICLE_COLORS = {'Falcon 9':'#1A5CFF','Starship':'#00D4FF','Falcon Heavy':'#8ab4ff'};

--- a/templates/tesla_dashboard.html.j2
+++ b/templates/tesla_dashboard.html.j2
@@ -77,6 +77,17 @@
     <div class="tsl-panel">
       <h2>TSLA — last 12 months</h2>
       <div class="tsl-area-wrap"><svg class="tsl-area-svg" id="tslArea" preserveAspectRatio="none" role="img" aria-label="TSLA price, last 12 months"></svg></div>
+      <div id="tslRangeWrap" style="margin:1rem 0 0; display:none;">
+        <div style="display:flex; justify-content:space-between; font-size:0.72rem; color:#c79aa3; margin-bottom:4px;">
+          <span>52-week range</span><span id="tslRangePos"></span>
+        </div>
+        <div style="position:relative; height:8px; border-radius:999px; background:linear-gradient(90deg,#7efbb0,#ffd27a,#ff8a8a);">
+          <div id="tslRangeMarker" style="position:absolute; top:-3px; width:3px; height:14px; border-radius:2px; background:#fff; box-shadow:0 0 6px rgba(255,255,255,0.7);"></div>
+        </div>
+        <div style="display:flex; justify-content:space-between; font-size:0.72rem; color:#a8838c; margin-top:3px;">
+          <span id="tslRangeLow"></span><span id="tslRangeHigh"></span>
+        </div>
+      </div>
       <div class="tsl-stats" style="margin-top:1rem;">
         <div class="tsl-stat"><div class="n" id="tslHigh">—</div><div class="l">52-week high</div></div>
         <div class="tsl-stat"><div class="n" id="tslLow">—</div><div class="l">52-week low</div></div>
@@ -177,13 +188,24 @@
     if(!d || !(d.price>0)) return;
     countUp('tslPrice', d.price, money);
     if(d.change_pct!=null){ const up=d.change_pct>=0; const el=document.getElementById('tslChg');
-      el.textContent=(up?'+':'')+d.change_pct.toFixed(2)+'%'; el.className='tsl-chg '+(up?'up':'down'); }
+      const dollar = d.prev_close ? (up?'+':'')+'$'+Math.abs(d.price-d.prev_close).toFixed(2)+' ' : '';
+      el.textContent=dollar+'('+(up?'+':'')+d.change_pct.toFixed(2)+'%)'; el.className='tsl-chg '+(up?'up':'down'); }
     if(d.market_cap){ document.getElementById('tslMcap').textContent='Market cap '+big(d.market_cap);
       const m2=document.getElementById('tslMcap2'); if(m2) m2.textContent=big(d.market_cap); }
     if(d.updated_at){ try{ document.getElementById('tslUpdated').textContent='Updated '+new Date(d.updated_at).toLocaleString([], {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'})+' · not financial advice'; }catch(_){} }
     const set=(id,v,f)=>{const e=document.getElementById(id); if(e&&v!=null) e.textContent=f?f(v):v;};
     set('tslHigh', d.year_high, money); set('tslLow', d.year_low, money);
     set('tslVol', d.avg_volume_10d||d.day_volume, vol);
+    // 52-week range position marker
+    if(d.year_high && d.year_low && d.year_high>d.year_low){
+      const pos=Math.max(0,Math.min(100,(d.price-d.year_low)/(d.year_high-d.year_low)*100));
+      const wrap=document.getElementById('tslRangeWrap');
+      if(wrap){ wrap.style.display='block';
+        document.getElementById('tslRangeMarker').style.left='calc('+pos+'% - 1px)';
+        document.getElementById('tslRangePos').textContent=Math.round(pos)+'% of range';
+        document.getElementById('tslRangeLow').textContent=money(d.year_low);
+        document.getElementById('tslRangeHigh').textContent=money(d.year_high); }
+    }
     renderArea(d.price_history);
   }
 

--- a/tesla-dashboard.html
+++ b/tesla-dashboard.html
@@ -496,6 +496,17 @@
     <div class="tsl-panel">
       <h2>TSLA — last 12 months</h2>
       <div class="tsl-area-wrap"><svg class="tsl-area-svg" id="tslArea" preserveAspectRatio="none" role="img" aria-label="TSLA price, last 12 months"></svg></div>
+      <div id="tslRangeWrap" style="margin:1rem 0 0; display:none;">
+        <div style="display:flex; justify-content:space-between; font-size:0.72rem; color:#c79aa3; margin-bottom:4px;">
+          <span>52-week range</span><span id="tslRangePos"></span>
+        </div>
+        <div style="position:relative; height:8px; border-radius:999px; background:linear-gradient(90deg,#7efbb0,#ffd27a,#ff8a8a);">
+          <div id="tslRangeMarker" style="position:absolute; top:-3px; width:3px; height:14px; border-radius:2px; background:#fff; box-shadow:0 0 6px rgba(255,255,255,0.7);"></div>
+        </div>
+        <div style="display:flex; justify-content:space-between; font-size:0.72rem; color:#a8838c; margin-top:3px;">
+          <span id="tslRangeLow"></span><span id="tslRangeHigh"></span>
+        </div>
+      </div>
       <div class="tsl-stats" style="margin-top:1rem;">
         <div class="tsl-stat"><div class="n" id="tslHigh">—</div><div class="l">52-week high</div></div>
         <div class="tsl-stat"><div class="n" id="tslLow">—</div><div class="l">52-week low</div></div>
@@ -809,13 +820,24 @@
     if(!d || !(d.price>0)) return;
     countUp('tslPrice', d.price, money);
     if(d.change_pct!=null){ const up=d.change_pct>=0; const el=document.getElementById('tslChg');
-      el.textContent=(up?'+':'')+d.change_pct.toFixed(2)+'%'; el.className='tsl-chg '+(up?'up':'down'); }
+      const dollar = d.prev_close ? (up?'+':'')+'$'+Math.abs(d.price-d.prev_close).toFixed(2)+' ' : '';
+      el.textContent=dollar+'('+(up?'+':'')+d.change_pct.toFixed(2)+'%)'; el.className='tsl-chg '+(up?'up':'down'); }
     if(d.market_cap){ document.getElementById('tslMcap').textContent='Market cap '+big(d.market_cap);
       const m2=document.getElementById('tslMcap2'); if(m2) m2.textContent=big(d.market_cap); }
     if(d.updated_at){ try{ document.getElementById('tslUpdated').textContent='Updated '+new Date(d.updated_at).toLocaleString([], {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'})+' · not financial advice'; }catch(_){} }
     const set=(id,v,f)=>{const e=document.getElementById(id); if(e&&v!=null) e.textContent=f?f(v):v;};
     set('tslHigh', d.year_high, money); set('tslLow', d.year_low, money);
     set('tslVol', d.avg_volume_10d||d.day_volume, vol);
+    // 52-week range position marker
+    if(d.year_high && d.year_low && d.year_high>d.year_low){
+      const pos=Math.max(0,Math.min(100,(d.price-d.year_low)/(d.year_high-d.year_low)*100));
+      const wrap=document.getElementById('tslRangeWrap');
+      if(wrap){ wrap.style.display='block';
+        document.getElementById('tslRangeMarker').style.left='calc('+pos+'% - 1px)';
+        document.getElementById('tslRangePos').textContent=Math.round(pos)+'% of range';
+        document.getElementById('tslRangeLow').textContent=money(d.year_low);
+        document.getElementById('tslRangeHigh').textContent=money(d.year_high); }
+    }
     renderArea(d.price_history);
   }
 

--- a/tests/test_tesla_dashboard.py
+++ b/tests/test_tesla_dashboard.py
@@ -102,3 +102,17 @@ class TestMitPerformanceCharts:
         for needle in ('id="mitEquity"', 'id="mitSectors"', 'id="mitWL"', "mit-chart-data",
                        "Cumulative return", "Simulated P&amp;L"):
             assert needle in t, needle
+
+
+class TestWatchLinksAndRangeBar:
+    def test_spacex_dashboard_has_watch_links(self):
+        t = (_ROOT / "templates/spacex_dashboard.html.j2").read_text(encoding="utf-8")
+        # per-upcoming watch link + official-stream how-to-watch note
+        assert "spx-watch" in t
+        assert "Watch live on" in t and "x.com/SpaceX" in t and "youtube.com/@SpaceX" in t
+        assert "Where to watch" in t  # hero fallback when no webcast yet
+
+    def test_tesla_dashboard_has_range_bar(self):
+        t = (_ROOT / "templates/tesla_dashboard.html.j2").read_text(encoding="utf-8")
+        assert "tslRangeWrap" in t and "52-week range" in t
+        assert "tslRangeMarker" in t


### PR DESCRIPTION
## Per-launch watch-live links + dashboard improvements

### SpaceX — watch-live links for every upcoming launch (operator ask)
- Each **upcoming-manifest row** gets a **"▶ Watch"** pill: links the launch webcast when posted (LL2 vidURLs, ~24h out) and otherwise falls back to SpaceX's official launches hub — so every upcoming launch always has a working watch destination ("▶ Watch live" vs "▶ Watch" by availability).
- **Recently-flown** rows get a **"▶ Replay"** link when a webcast URL exists.
- Hero next-launch button always shows ("Watch the webcast" / "Where to watch" fallback).
- A **"Watch live on spacex.com/launches · @SpaceX on X · YouTube"** note (webcasts go live ~15 min before liftoff).

### Tesla dashboard
- New **52-week range position bar** — green→amber→red gradient from low to high with a marker at the current price + "% of range" (render-verified: 56%). At-a-glance context for where TSLA sits in its yearly range.
- Day change now shows **dollars + percent** ("+$7.43 (+1.86%)").

### Market research (continued)
Verified sources in use: CelesTrak (real Starlink count), The Space Devs LL2 (launches + webcasts), Yahoo/yfinance (TSLA). New source identified for a future "booster reuse record" stat: [Orbit Codex booster tracker](https://orbitcodex.com/boosters) / LL2 detailed `launcher_stage` flight counts (B1067 hit a 35th flight, June 2026) — strong retention content, queued.

Render-verified at 1240px; drift guards added; suite **2851 passing**. Pure dashboard work — no audio path.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_