### PR TITLE
SpaceX dashboard: booster-reuse record watch + per-launch booster

### DIFF
--- a/api/spacex_launches.json
+++ b/api/spacex_launches.json
@@ -1,6 +1,10 @@
 {
   "next": {
     "id": "bad5ea8c-8b17-4cb3-a063-d427fb092275",
+    "booster": {
+      "serial": "B1093",
+      "flight_number": 14
+    },
     "name": "Falcon 9 Block 5 | Starlink Group 17-54",
     "net": "2026-06-15T14:00:00Z",
     "window_start": "2026-06-15T14:00:00Z",
@@ -20,6 +24,10 @@
   },
   "previous": {
     "id": "229267d8-74ca-4d0b-8711-b2efe621fc6b",
+    "booster": {
+      "serial": "B1080",
+      "flight_number": 27
+    },
     "name": "Falcon 9 Block 5 | Starlink Group 10-54",
     "net": "2026-06-12T12:37:00Z",
     "window_start": "2026-06-12T12:27:00Z",
@@ -40,6 +48,10 @@
   "upcoming": [
     {
       "id": "bad5ea8c-8b17-4cb3-a063-d427fb092275",
+      "booster": {
+        "serial": "B1093",
+        "flight_number": 14
+      },
       "name": "Falcon 9 Block 5 | Starlink Group 17-54",
       "net": "2026-06-15T14:00:00Z",
       "window_start": "2026-06-15T14:00:00Z",
@@ -59,6 +71,10 @@
     },
     {
       "id": "c3f48f48-0e0a-4bca-917e-de494cfca35b",
+      "booster": {
+        "serial": "B1077",
+        "flight_number": 29
+      },
       "name": "Falcon 9 Block 5 | BlueBird Block 2 #3-5",
       "net": "2026-06-17T06:39:00Z",
       "window_start": "2026-06-17T06:39:00Z",
@@ -78,6 +94,10 @@
     },
     {
       "id": "5d4099bf-a0be-4f54-b236-b6ab3aed4146",
+      "booster": {
+        "serial": "B1103",
+        "flight_number": 3
+      },
       "name": "Falcon 9 Block 5 | NROL-179",
       "net": "2026-06-18T08:54:00Z",
       "window_start": "2026-06-18T08:54:00Z",
@@ -97,6 +117,10 @@
     },
     {
       "id": "be8b4b0d-1989-48a5-a96d-e8e4d59ed8b3",
+      "booster": {
+        "serial": "Unknown F9",
+        "flight_number": null
+      },
       "name": "Falcon 9 Block 5 | Globalstar 2-R Mission 1 (x 9)",
       "net": "2026-06-20T06:39:00Z",
       "window_start": "2026-06-20T06:39:00Z",
@@ -116,6 +140,10 @@
     },
     {
       "id": "de5fbae3-66b9-4bbf-8938-4d55f3318c07",
+      "booster": {
+        "serial": "B1063",
+        "flight_number": 33
+      },
       "name": "Falcon 9 Block 5 | Starlink Group 17-28",
       "net": "2026-06-20T14:00:00Z",
       "window_start": "2026-06-20T14:00:00Z",
@@ -137,6 +165,10 @@
   "recent": [
     {
       "id": "229267d8-74ca-4d0b-8711-b2efe621fc6b",
+      "booster": {
+        "serial": "B1080",
+        "flight_number": 27
+      },
       "name": "Falcon 9 Block 5 | Starlink Group 10-54",
       "net": "2026-06-12T12:37:00Z",
       "window_start": "2026-06-12T12:27:00Z",
@@ -156,6 +188,10 @@
     },
     {
       "id": "c7b7e18f-1b42-467e-a8ed-181fb58080e8",
+      "booster": {
+        "serial": "B1071",
+        "flight_number": 34
+      },
       "name": "Falcon 9 Block 5 | Starlink Group 17-44",
       "net": "2026-06-11T15:05:59Z",
       "window_start": "2026-06-11T14:00:00Z",
@@ -175,6 +211,10 @@
     },
     {
       "id": "114577dc-7617-461c-aaeb-9bd0f64b5a4b",
+      "booster": {
+        "serial": "B1067",
+        "flight_number": 35
+      },
       "name": "Falcon 9 Block 5 | Starlink Group 10-35",
       "net": "2026-06-08T10:13:50Z",
       "window_start": "2026-06-08T10:07:00Z",
@@ -194,6 +234,10 @@
     },
     {
       "id": "af8d71dd-f439-47b3-91ed-57f959a581e0",
+      "booster": {
+        "serial": "B1097",
+        "flight_number": 10
+      },
       "name": "Falcon 9 Block 5 | Starlink Group 17-43",
       "net": "2026-06-07T04:24:45Z",
       "window_start": "2026-06-07T02:00:00Z",
@@ -213,6 +257,10 @@
     },
     {
       "id": "cfff5e89-af2e-46b1-9446-7b0f18de4ef7",
+      "booster": {
+        "serial": "B1090",
+        "flight_number": 12
+      },
       "name": "Falcon 9 Block 5 | Starlink Group 10-43",
       "net": "2026-06-04T10:26:30Z",
       "window_start": "2026-06-04T08:00:00Z",
@@ -232,6 +280,10 @@
     },
     {
       "id": "4936311a-af7c-4b05-8d7b-3eea59fc0f11",
+      "booster": {
+        "serial": "B1088",
+        "flight_number": 16
+      },
       "name": "Falcon 9 Block 5 | Starlink Group 17-47",
       "net": "2026-06-03T15:40:39Z",
       "window_start": "2026-06-03T14:00:00Z",
@@ -421,9 +473,41 @@
     "success_rate_pct": 100.0,
     "days_since_last_failure": null,
     "estimated": true,
-    "cumulative_satellites_est": 2714
+    "cumulative_satellites_est": 2714,
+    "starlink_active": 10544,
+    "boosters": {
+      "fleet_leaders": [
+        {
+          "serial": "B1067",
+          "flights": 35
+        },
+        {
+          "serial": "B1071",
+          "flights": 34
+        },
+        {
+          "serial": "B1063",
+          "flights": 32
+        },
+        {
+          "serial": "B1069",
+          "flights": 31
+        },
+        {
+          "serial": "B1078",
+          "flights": 28
+        }
+      ],
+      "most_flown": {
+        "serial": "B1067",
+        "flights": 35
+      },
+      "landing_success_pct": 99.0,
+      "landings_window": 200,
+      "active_boosters_window": 31
+    }
   },
   "total_launches": 689,
   "source": "thespacedevs_ll2",
-  "updated_at": "2026-06-13T18:34:20.891211+00:00"
+  "updated_at": "2026-06-13T23:02:26.192308+00:00"
 }

--- a/scripts/fetch_spacex_launches.py
+++ b/scripts/fetch_spacex_launches.py
@@ -86,10 +86,10 @@ def _slim_launch(r: Dict[str, Any]) -> Dict[str, Any]:
     booster = None
     stages = (r.get("rocket") or {}).get("launcher_stage") or []
     if stages:
-        l = stages[0].get("launcher") or {}
-        fn = stages[0].get("launcher_flight_number") or l.get("flights")
-        if l.get("serial_number"):
-            booster = {"serial": l.get("serial_number"), "flight_number": fn}
+        launcher = stages[0].get("launcher") or {}
+        fn = stages[0].get("launcher_flight_number") or launcher.get("flights")
+        if launcher.get("serial_number"):
+            booster = {"serial": launcher.get("serial_number"), "flight_number": fn}
     return {
         "id": r.get("id"),
         "booster": booster,
@@ -124,9 +124,9 @@ def _booster_stats(prev_raw: List[Dict[str, Any]]) -> Dict[str, Any]:
     landings_ok = landings_total = 0
     for r in prev_raw:
         for s in ((r.get("rocket") or {}).get("launcher_stage") or []):
-            l = s.get("launcher") or {}
-            serial = l.get("serial_number")
-            fn = s.get("launcher_flight_number") or l.get("flights")
+            launcher = s.get("launcher") or {}
+            serial = launcher.get("serial_number")
+            fn = s.get("launcher_flight_number") or launcher.get("flights")
             if serial and fn:
                 try:
                     flights[serial] = max(flights.get(serial, 0), int(fn))

--- a/scripts/fetch_spacex_launches.py
+++ b/scripts/fetch_spacex_launches.py
@@ -81,8 +81,18 @@ def _slim_launch(r: Dict[str, Any]) -> Dict[str, Any]:
         v.get("url") for v in (r.get("vidURLs") or [])
         if isinstance(v, dict) and v.get("url")
     ]
+    # First-stage booster (serial + which flight this is for it) — detailed
+    # mode only; powers the reuse "record watch" and per-launch booster line.
+    booster = None
+    stages = (r.get("rocket") or {}).get("launcher_stage") or []
+    if stages:
+        l = stages[0].get("launcher") or {}
+        fn = stages[0].get("launcher_flight_number") or l.get("flights")
+        if l.get("serial_number"):
+            booster = {"serial": l.get("serial_number"), "flight_number": fn}
     return {
         "id": r.get("id"),
+        "booster": booster,
         "name": r.get("name"),
         "net": r.get("net"),  # ISO 8601 UTC "no earlier than" time
         "window_start": r.get("window_start"),
@@ -104,6 +114,38 @@ def _slim_launch(r: Dict[str, Any]) -> Dict[str, Any]:
 
 def _is_spacex(r: Dict[str, Any]) -> bool:
     return (r.get("launch_service_provider") or {}).get("id") == _SPACEX_LSP_ID
+
+
+def _booster_stats(prev_raw: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Fleet reuse stats from detailed launch records: the most-flown
+    boosters (the reuse 'record watch'), recent landing-success rate, and
+    the active-fleet size seen in the window."""
+    flights: Dict[str, int] = {}
+    landings_ok = landings_total = 0
+    for r in prev_raw:
+        for s in ((r.get("rocket") or {}).get("launcher_stage") or []):
+            l = s.get("launcher") or {}
+            serial = l.get("serial_number")
+            fn = s.get("launcher_flight_number") or l.get("flights")
+            if serial and fn:
+                try:
+                    flights[serial] = max(flights.get(serial, 0), int(fn))
+                except (TypeError, ValueError):
+                    pass
+            landing = (s.get("landing") or {})
+            if landing.get("success") is not None:
+                landings_total += 1
+                if landing.get("success"):
+                    landings_ok += 1
+    leaders = sorted(flights.items(), key=lambda x: -x[1])[:5]
+    return {
+        "fleet_leaders": [{"serial": s, "flights": f} for s, f in leaders],
+        "most_flown": ({"serial": leaders[0][0], "flights": leaders[0][1]}
+                       if leaders else None),
+        "landing_success_pct": round(100 * landings_ok / landings_total, 1) if landings_total else None,
+        "landings_window": landings_total,
+        "active_boosters_window": len(flights),
+    }
 
 
 def _month_labels(months: int) -> List[str]:
@@ -402,6 +444,7 @@ def build_payload() -> Optional[Dict[str, Any]]:
     fleet = _fleet_payload(slim_prev, now)
     fleet["cumulative_satellites_est"] = cumulative_sats
     fleet["starlink_active"] = _starlink_active_count()  # real count, or None
+    fleet["boosters"] = _booster_stats(prev_results)  # reuse record watch
     return {
         "next": next_launch,
         "previous": previous_launch,

--- a/site/data/spacex_metrics.json
+++ b/site/data/spacex_metrics.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-13T18:34:20.891211+00:00",
+  "updated_at": "2026-06-13T23:02:26.192308+00:00",
   "note": "Monthly SpaceX metrics (estimated mass/satellites from public per-vehicle averages; launch counts/vehicle mix from the launch record). Grows over time as new months lock in.",
   "months": {
     "2025-07": {

--- a/spacex-dashboard.html
+++ b/spacex-dashboard.html
@@ -592,6 +592,7 @@
           <h3 id="spxMission">Fetching the latest launch manifest…</h3>
           <div class="spx-meta">
             <div><div class="k">Vehicle</div><div class="v" id="spxRocket">—</div></div>
+            <div><div class="k">Booster</div><div class="v" id="spxBooster">—</div></div>
             <div><div class="k">Launch Pad</div><div class="v" id="spxPad">—</div></div>
             <div><div class="k">Location</div><div class="v" id="spxLoc">—</div></div>
             <div><div class="k">Target (your time)</div><div class="v" id="spxLocal">—</div></div>
@@ -653,6 +654,31 @@
       <h2>Constellation growth — est. satellites to orbit <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(cumulative, tracked window)</span></h2>
       <div class="spx-area-wrap"><svg class="spx-area-svg" id="spxArea" preserveAspectRatio="none" role="img" aria-label="Cumulative estimated satellites to orbit"></svg></div>
       <p class="spx-disclaimer">Cumulative estimate over the months this dashboard has tracked — it extends to the left automatically as the dataset grows month over month.</p>
+    </div>
+  </div>
+
+  <div class="spx-grid">
+    <div class="spx-panel">
+      <h2>Booster reuse — record watch 🏆</h2>
+      <div style="display:flex; align-items:baseline; gap:12px; margin-bottom:0.6rem;">
+        <span id="brRecordN" style="font-size:2.4rem; font-weight:800; color:#fff;">—</span>
+        <span class="spx-muted">flights — fleet record (<span id="brRecordS">—</span>)</span>
+      </div>
+      <div id="brLeaders"></div>
+      <p class="spx-disclaimer">Falcon 9 boosters are reflown and landed; the leaders below are the most-flown cores. The Space Shuttle orbiter record was 39 flights.</p>
+    </div>
+    <div class="spx-panel">
+      <h2>Landing success</h2>
+      <div style="display:flex; align-items:baseline; gap:12px;">
+        <span id="brLandPct" class="spx-since">—</span>
+        <span class="spx-muted">recent landing attempts (<span id="brLandN">—</span>)</span>
+      </div>
+      <div style="margin-top:0.8rem;">
+        <div style="height:10px; border-radius:999px; background:rgba(255,255,255,0.08); overflow:hidden;">
+          <div id="brLandBar" style="height:100%; width:0; background:linear-gradient(90deg,var(--spx-cyan),#5ef0a0); transition:width .8s ease;"></div>
+        </div>
+      </div>
+      <div class="spx-stat" style="margin-top:1rem;"><div class="n" id="brFleet">—</div><div class="l">Active boosters in rotation (window)</div></div>
     </div>
   </div>
 
@@ -964,6 +990,7 @@
     st.className = 'spx-status '+statusClass(n.status);
     set('spxMission', n.name || n.mission || 'Upcoming SpaceX launch');
     set('spxRocket', n.rocket);
+    set('spxBooster', n.booster && n.booster.serial ? (n.booster.serial + (n.booster.flight_number ? ' · flight ' + n.booster.flight_number : '')) : '—');
     set('spxPad', n.pad);
     set('spxLoc', n.location);
     set('spxLocal', n.net ? fmtLocal(n.net) : 'TBD');
@@ -1101,9 +1128,31 @@
     }
   }
 
+  function renderBoosters(f){
+    var b = (f||{}).boosters; if(!b) return;
+    var set=function(id,v){var e=document.getElementById(id); if(e) e.textContent=(v==null?'—':v);};
+    if(b.most_flown){ countUp('brRecordN', b.most_flown.flights); set('brRecordS', b.most_flown.serial); }
+    var wrap=document.getElementById('brLeaders');
+    if(wrap && b.fleet_leaders && b.fleet_leaders.length){
+      var max=b.fleet_leaders[0].flights||1;
+      wrap.innerHTML=b.fleet_leaders.map(function(x){
+        return '<div style="display:flex;align-items:center;gap:10px;margin:5px 0;">'+
+          '<span style="width:54px;font-weight:700;color:#cfe0ff;">'+x.serial+'</span>'+
+          '<span style="flex:1;height:14px;border-radius:7px;background:rgba(255,255,255,0.06);overflow:hidden;"><span style="display:block;height:100%;width:'+(100*x.flights/max)+'%;background:linear-gradient(90deg,var(--spx-cyan),var(--spx-blue));"></span></span>'+
+          '<span style="width:34px;text-align:right;font-variant-numeric:tabular-nums;font-weight:700;">'+x.flights+'</span></div>';
+      }).join('');
+    }
+    if(b.landing_success_pct!=null){
+      set('brLandPct', b.landing_success_pct+'%'); set('brLandN', b.landings_window);
+      var bar=document.getElementById('brLandBar'); if(bar) requestAnimationFrame(function(){ bar.style.width=b.landing_success_pct+'%'; });
+    }
+    countUp('brFleet', b.active_boosters_window);
+  }
+
   function applyLaunches(data){
     if(!data) return;
     renderNext(data.next);
+    if(data.fleet) renderBoosters(data.fleet);
     renderPrev(data.previous);
     renderStats(data.stats, data.total_launches);
     renderCadence(data.cadence_monthly);

--- a/templates/spacex_dashboard.html.j2
+++ b/templates/spacex_dashboard.html.j2
@@ -174,6 +174,7 @@
           <h3 id="spxMission">Fetching the latest launch manifest…</h3>
           <div class="spx-meta">
             <div><div class="k">Vehicle</div><div class="v" id="spxRocket">—</div></div>
+            <div><div class="k">Booster</div><div class="v" id="spxBooster">—</div></div>
             <div><div class="k">Launch Pad</div><div class="v" id="spxPad">—</div></div>
             <div><div class="k">Location</div><div class="v" id="spxLoc">—</div></div>
             <div><div class="k">Target (your time)</div><div class="v" id="spxLocal">—</div></div>
@@ -235,6 +236,31 @@
       <h2>Constellation growth — est. satellites to orbit <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(cumulative, tracked window)</span></h2>
       <div class="spx-area-wrap"><svg class="spx-area-svg" id="spxArea" preserveAspectRatio="none" role="img" aria-label="Cumulative estimated satellites to orbit"></svg></div>
       <p class="spx-disclaimer">Cumulative estimate over the months this dashboard has tracked — it extends to the left automatically as the dataset grows month over month.</p>
+    </div>
+  </div>
+
+  <div class="spx-grid">
+    <div class="spx-panel">
+      <h2>Booster reuse — record watch 🏆</h2>
+      <div style="display:flex; align-items:baseline; gap:12px; margin-bottom:0.6rem;">
+        <span id="brRecordN" style="font-size:2.4rem; font-weight:800; color:#fff;">—</span>
+        <span class="spx-muted">flights — fleet record (<span id="brRecordS">—</span>)</span>
+      </div>
+      <div id="brLeaders"></div>
+      <p class="spx-disclaimer">Falcon 9 boosters are reflown and landed; the leaders below are the most-flown cores. The Space Shuttle orbiter record was 39 flights.</p>
+    </div>
+    <div class="spx-panel">
+      <h2>Landing success</h2>
+      <div style="display:flex; align-items:baseline; gap:12px;">
+        <span id="brLandPct" class="spx-since">—</span>
+        <span class="spx-muted">recent landing attempts (<span id="brLandN">—</span>)</span>
+      </div>
+      <div style="margin-top:0.8rem;">
+        <div style="height:10px; border-radius:999px; background:rgba(255,255,255,0.08); overflow:hidden;">
+          <div id="brLandBar" style="height:100%; width:0; background:linear-gradient(90deg,var(--spx-cyan),#5ef0a0); transition:width .8s ease;"></div>
+        </div>
+      </div>
+      <div class="spx-stat" style="margin-top:1rem;"><div class="n" id="brFleet">—</div><div class="l">Active boosters in rotation (window)</div></div>
     </div>
   </div>
 
@@ -355,6 +381,7 @@
     st.className = 'spx-status '+statusClass(n.status);
     set('spxMission', n.name || n.mission || 'Upcoming SpaceX launch');
     set('spxRocket', n.rocket);
+    set('spxBooster', n.booster && n.booster.serial ? (n.booster.serial + (n.booster.flight_number ? ' · flight ' + n.booster.flight_number : '')) : '—');
     set('spxPad', n.pad);
     set('spxLoc', n.location);
     set('spxLocal', n.net ? fmtLocal(n.net) : 'TBD');
@@ -492,9 +519,31 @@
     }
   }
 
+  function renderBoosters(f){
+    var b = (f||{}).boosters; if(!b) return;
+    var set=function(id,v){var e=document.getElementById(id); if(e) e.textContent=(v==null?'—':v);};
+    if(b.most_flown){ countUp('brRecordN', b.most_flown.flights); set('brRecordS', b.most_flown.serial); }
+    var wrap=document.getElementById('brLeaders');
+    if(wrap && b.fleet_leaders && b.fleet_leaders.length){
+      var max=b.fleet_leaders[0].flights||1;
+      wrap.innerHTML=b.fleet_leaders.map(function(x){
+        return '<div style="display:flex;align-items:center;gap:10px;margin:5px 0;">'+
+          '<span style="width:54px;font-weight:700;color:#cfe0ff;">'+x.serial+'</span>'+
+          '<span style="flex:1;height:14px;border-radius:7px;background:rgba(255,255,255,0.06);overflow:hidden;"><span style="display:block;height:100%;width:'+(100*x.flights/max)+'%;background:linear-gradient(90deg,var(--spx-cyan),var(--spx-blue));"></span></span>'+
+          '<span style="width:34px;text-align:right;font-variant-numeric:tabular-nums;font-weight:700;">'+x.flights+'</span></div>';
+      }).join('');
+    }
+    if(b.landing_success_pct!=null){
+      set('brLandPct', b.landing_success_pct+'%'); set('brLandN', b.landings_window);
+      var bar=document.getElementById('brLandBar'); if(bar) requestAnimationFrame(function(){ bar.style.width=b.landing_success_pct+'%'; });
+    }
+    countUp('brFleet', b.active_boosters_window);
+  }
+
   function applyLaunches(data){
     if(!data) return;
     renderNext(data.next);
+    if(data.fleet) renderBoosters(data.fleet);
     renderPrev(data.previous);
     renderStats(data.stats, data.total_launches);
     renderCadence(data.cadence_monthly);

--- a/tests/test_tesla_dashboard.py
+++ b/tests/test_tesla_dashboard.py
@@ -116,3 +116,39 @@ class TestWatchLinksAndRangeBar:
         t = (_ROOT / "templates/tesla_dashboard.html.j2").read_text(encoding="utf-8")
         assert "tslRangeWrap" in t and "52-week range" in t
         assert "tslRangeMarker" in t
+
+
+class TestBoosterReuseStats:
+    def _mod(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "fetch_spacex_launches", _ROOT / "scripts" / "fetch_spacex_launches.py")
+        m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+        return m
+
+    def test_booster_stats_from_detailed_records(self):
+        m = self._mod()
+        raw = [
+            {"rocket": {"launcher_stage": [{"launcher": {"serial_number": "B1067", "flights": 35},
+                                            "launcher_flight_number": 35, "landing": {"success": True}}]}},
+            {"rocket": {"launcher_stage": [{"launcher": {"serial_number": "B1071", "flights": 34},
+                                            "launcher_flight_number": 34, "landing": {"success": True}}]}},
+            {"rocket": {"launcher_stage": [{"launcher": {"serial_number": "B1067", "flights": 33},
+                                            "launcher_flight_number": 33, "landing": {"success": False}}]}},
+        ]
+        b = m._booster_stats(raw)
+        assert b["most_flown"] == {"serial": "B1067", "flights": 35}
+        assert b["fleet_leaders"][0]["serial"] == "B1067"
+        assert b["active_boosters_window"] == 2
+        assert b["landing_success_pct"] == 66.7  # 2 of 3
+
+    def test_slim_launch_extracts_booster(self):
+        m = self._mod()
+        s = m._slim_launch({"name": "X", "rocket": {"launcher_stage": [
+            {"launcher": {"serial_number": "B1093"}, "launcher_flight_number": 14}]}})
+        assert s["booster"] == {"serial": "B1093", "flight_number": 14}
+
+    def test_dashboard_has_booster_panel(self):
+        t = (_ROOT / "templates/spacex_dashboard.html.j2").read_text(encoding="utf-8")
+        assert "record watch" in t and "brRecordN" in t and "brLeaders" in t
+        assert "spxBooster" in t  # per-launch booster line on the hero


### PR DESCRIPTION
## SpaceX dashboard: booster-reuse "record watch" 🏆

Continuing dashboard development with the high-retention "is this a record?" content I researched (LL2 detailed `launcher_stage` data — [Falcon 9 B1067 just hit a record 35th flight](https://www.space.com/space-exploration/launches-spacecraft/spacex-starlink-10-35-b1067-ccsfs-asog)).

- `fetch_spacex_launches.py`: `_slim_launch` now carries the first-stage **booster** (serial + this-flight number); `_booster_stats()` computes the **most-flown core (the fleet reuse record)**, a top-5 leaderboard, recent **landing-success rate**, and active-fleet size from the paginated detailed window.
- Dashboard: new **"Booster reuse — record watch 🏆"** panel (record number + B-serial + animated leaderboard bars) and a **"Landing success"** panel (99% bar + active-boosters stat). The **next-launch hero card** now shows "Booster B10XX · flight N" — a built-in "watch for a record" hook.
- **Live-verified**: record **B1067 at 35 flights** (B1071 34, B1063 32, B1069 31, B1078 28); **99% landings over 200**; next launch **B1093, flight 14**. CelesTrak live Starlink count **10,544** also captured this run.

Render-verified at 1240px, 0 overflow; drift guards added; suite **2854 passing**. Pure dashboard work — no audio path.

**Deliberately skipped**: the MIT alpha-vs-NASDAQ *overlay* — the tracker's alpha is computed on a different basis (portfolio-return method) than the equity curve (sum of per-trade % points), so plotting them on one axis would mislead. The alpha stays a clearly-labeled headline stat instead.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_