### PR TITLE
SpaceX dashboard: Starship flight-test tracker + mobile grid fix

### DIFF
--- a/api/spacex_launches.json
+++ b/api/spacex_launches.json
@@ -507,7 +507,69 @@
       "active_boosters_window": 31
     }
   },
+  "starship": {
+    "note": "Curated Starship integrated flight-test record (operator-maintained \u2014 append the newest flight after each test). Outcomes: success / partial / failure. The dashboard charts whatever is listed here.",
+    "flights": [
+      {
+        "flight": "IFT-1",
+        "date": "2023-04-20",
+        "outcome": "failure",
+        "milestone": "First integrated flight. Cleared the pad; multiple engines out; lost in flight termination at ~T+4 min."
+      },
+      {
+        "flight": "IFT-2",
+        "date": "2023-11-18",
+        "outcome": "partial",
+        "milestone": "First successful hot-staging separation; both stages reached space before being lost."
+      },
+      {
+        "flight": "IFT-3",
+        "date": "2024-03-14",
+        "outcome": "partial",
+        "milestone": "Reached orbital-insertion velocity; first propellant transfer demo; ship lost on reentry."
+      },
+      {
+        "flight": "IFT-4",
+        "date": "2024-06-06",
+        "outcome": "success",
+        "milestone": "Booster soft splashdown in the Gulf; ship survived peak reentry heating and splashed down."
+      },
+      {
+        "flight": "IFT-5",
+        "date": "2024-10-13",
+        "outcome": "success",
+        "booster_caught": true,
+        "milestone": "First-ever 'Mechazilla' tower catch of the returning Super Heavy booster."
+      },
+      {
+        "flight": "IFT-6",
+        "date": "2024-11-19",
+        "outcome": "partial",
+        "milestone": "Ship splashdown in the Indian Ocean; in-space Raptor relight; booster catch waved off to a water landing."
+      },
+      {
+        "flight": "IFT-7",
+        "date": "2025-01-16",
+        "outcome": "partial",
+        "booster_caught": true,
+        "milestone": "Block 2 ship debut; booster caught at the tower; ship lost over the Caribbean."
+      },
+      {
+        "flight": "IFT-8",
+        "date": "2025-03-06",
+        "outcome": "partial",
+        "booster_caught": true,
+        "milestone": "Second booster tower catch; upper stage lost again early in the burn."
+      },
+      {
+        "flight": "IFT-9",
+        "date": "2025-05-27",
+        "outcome": "partial",
+        "milestone": "First flight of a reflown Super Heavy booster; ship reached space but lost attitude control before splashdown."
+      }
+    ]
+  },
   "total_launches": 689,
   "source": "thespacedevs_ll2",
-  "updated_at": "2026-06-13T23:02:26.192308+00:00"
+  "updated_at": "2026-06-13T23:13:54.821532+00:00"
 }

--- a/scripts/fetch_spacex_launches.py
+++ b/scripts/fetch_spacex_launches.py
@@ -298,6 +298,9 @@ def _update_metrics_timeseries(monthly: List[Dict[str, Any]], now: _dt.datetime,
         # (e.g. xAI Colossus GPU counts, datacenter buildouts). Preserved
         # across runs so it accrues without being overwritten by the fetch.
         "infrastructure": existing.get("infrastructure", []),
+        # Curated Starship integrated flight-test record (operator-maintained;
+        # outside the Falcon launch window). Preserved across runs.
+        "starship_flights": existing.get("starship_flights", {}),
     }
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -309,6 +312,19 @@ def _update_metrics_timeseries(monthly: List[Dict[str, Any]], now: _dt.datetime,
     # (so the dashboard can chart growth-over-time from one file).
     cumulative_series = [{"month": k, "total": cumulative[k]} for k, _ in ordered]
     return cum, cumulative_series
+
+
+def _starship_flights(path: Path = _METRICS_PATH) -> Dict[str, Any]:
+    """Read the curated Starship flight-test record from the committed metrics
+    file (operator-maintained; not derivable from the Falcon launch window)."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+        sf = data.get("starship_flights") if isinstance(data, dict) else None
+        if isinstance(sf, dict) and isinstance(sf.get("flights"), list):
+            return sf
+    except Exception as exc:
+        logger.warning("Could not read starship_flights (non-fatal): %s", exc)
+    return {"flights": []}
 
 
 def _fleet_payload(previous: List[Dict[str, Any]], now: _dt.datetime) -> Dict[str, Any]:
@@ -455,6 +471,7 @@ def build_payload() -> Optional[Dict[str, Any]]:
         "sats_cumulative_monthly": cumulative_series,
         "stats": _stats(slim_prev, now),
         "fleet": fleet,
+        "starship": _starship_flights(),
         "total_launches": prev_total,
         "source": "thespacedevs_ll2",
         "updated_at": now.isoformat(),
@@ -477,6 +494,18 @@ def main() -> int:
             return 0
         logger.error("Launch fetch empty and no existing cache to keep.")
         return 0  # non-fatal: dashboard shows a friendly empty state
+
+    # Keep last-good for the live Starlink count: CelesTrak rate-limits (1 dl /
+    # 2h), so a transient None must not wipe a previously-fetched real number.
+    if (payload.get("fleet") or {}).get("starlink_active") is None and out_path.exists():
+        try:
+            prev = json.loads(out_path.read_text(encoding="utf-8"))
+            last = (prev.get("fleet") or {}).get("starlink_active")
+            if last:
+                payload["fleet"]["starlink_active"] = last
+                logger.info("Kept last-good Starlink count: %s", last)
+        except Exception:
+            pass
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")

--- a/site/data/spacex_metrics.json
+++ b/site/data/spacex_metrics.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-13T23:02:26.192308+00:00",
+  "updated_at": "2026-06-13T23:13:54.821532+00:00",
   "note": "Monthly SpaceX metrics (estimated mass/satellites from public per-vehicle averages; launch counts/vehicle mix from the launch record). Grows over time as new months lock in.",
   "months": {
     "2025-07": {
@@ -118,5 +118,67 @@
     "2026-05": 2576,
     "2026-06": 2714
   },
-  "infrastructure": []
+  "infrastructure": [],
+  "starship_flights": {
+    "note": "Curated Starship integrated flight-test record (operator-maintained \u2014 append the newest flight after each test). Outcomes: success / partial / failure. The dashboard charts whatever is listed here.",
+    "flights": [
+      {
+        "flight": "IFT-1",
+        "date": "2023-04-20",
+        "outcome": "failure",
+        "milestone": "First integrated flight. Cleared the pad; multiple engines out; lost in flight termination at ~T+4 min."
+      },
+      {
+        "flight": "IFT-2",
+        "date": "2023-11-18",
+        "outcome": "partial",
+        "milestone": "First successful hot-staging separation; both stages reached space before being lost."
+      },
+      {
+        "flight": "IFT-3",
+        "date": "2024-03-14",
+        "outcome": "partial",
+        "milestone": "Reached orbital-insertion velocity; first propellant transfer demo; ship lost on reentry."
+      },
+      {
+        "flight": "IFT-4",
+        "date": "2024-06-06",
+        "outcome": "success",
+        "milestone": "Booster soft splashdown in the Gulf; ship survived peak reentry heating and splashed down."
+      },
+      {
+        "flight": "IFT-5",
+        "date": "2024-10-13",
+        "outcome": "success",
+        "booster_caught": true,
+        "milestone": "First-ever 'Mechazilla' tower catch of the returning Super Heavy booster."
+      },
+      {
+        "flight": "IFT-6",
+        "date": "2024-11-19",
+        "outcome": "partial",
+        "milestone": "Ship splashdown in the Indian Ocean; in-space Raptor relight; booster catch waved off to a water landing."
+      },
+      {
+        "flight": "IFT-7",
+        "date": "2025-01-16",
+        "outcome": "partial",
+        "booster_caught": true,
+        "milestone": "Block 2 ship debut; booster caught at the tower; ship lost over the Caribbean."
+      },
+      {
+        "flight": "IFT-8",
+        "date": "2025-03-06",
+        "outcome": "partial",
+        "booster_caught": true,
+        "milestone": "Second booster tower catch; upper stage lost again early in the burn."
+      },
+      {
+        "flight": "IFT-9",
+        "date": "2025-05-27",
+        "outcome": "partial",
+        "milestone": "First flight of a reflown Super Heavy booster; ship reached space but lost attitude control before splashdown."
+      }
+    ]
+  }
 }

--- a/spacex-dashboard.html
+++ b/spacex-dashboard.html
@@ -136,8 +136,8 @@
   }
   .spx-btn.ghost { background: transparent; border:1px solid rgba(120,160,255,0.4); box-shadow:none; }
 
-  .spx-grid { max-width:1120px; margin: 1.5rem auto; padding: 0 1.25rem; display:grid; gap:1.1rem; grid-template-columns: 1fr 1fr; }
-  @media (max-width: 760px){ .spx-grid{ grid-template-columns:1fr; } }
+  .spx-grid { max-width:1120px; margin: 1.5rem auto; padding: 0 1.25rem; display:grid; gap:1.1rem; grid-template-columns: minmax(0,1fr) minmax(0,1fr); }
+  @media (max-width: 760px){ .spx-grid{ grid-template-columns:minmax(0,1fr); } }
   .spx-panel {
     background: var(--nn-surface, #0f1830); border:1px solid rgba(120,160,255,0.16);
     border-radius:16px; padding:1.1rem 1.2rem;
@@ -619,7 +619,7 @@
     </div>
   </div>
 
-  <div class="spx-grid" style="grid-template-columns:1fr;">
+  <div class="spx-grid" style="grid-template-columns:minmax(0,1fr);">
     <div class="spx-panel">
       <h2>Launch cadence — last 12 months</h2>
       <div class="spx-cadence" id="spxCadence"></div>
@@ -633,7 +633,7 @@
     </div>
   </div>
 
-  <div class="spx-grid" style="grid-template-columns:1fr;">
+  <div class="spx-grid" style="grid-template-columns:minmax(0,1fr);">
     <div class="spx-panel">
       <h2>Mass to orbit — last 12 months <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(estimated, tonnes)</span></h2>
       <div class="spx-cadence" id="spxMass"></div>
@@ -649,11 +649,24 @@
     </div>
   </div>
 
-  <div class="spx-grid" style="grid-template-columns:1fr;">
+  <div class="spx-grid" style="grid-template-columns:minmax(0,1fr);">
     <div class="spx-panel">
       <h2>Constellation growth — est. satellites to orbit <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(cumulative, tracked window)</span></h2>
       <div class="spx-area-wrap"><svg class="spx-area-svg" id="spxArea" preserveAspectRatio="none" role="img" aria-label="Cumulative estimated satellites to orbit"></svg></div>
       <p class="spx-disclaimer">Cumulative estimate over the months this dashboard has tracked — it extends to the left automatically as the dataset grows month over month.</p>
+    </div>
+  </div>
+
+  <div class="spx-grid" style="grid-template-columns:minmax(0,1fr);">
+    <div class="spx-panel">
+      <h2>Starship flight-test tracker 🚀 <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(integrated flight tests)</span></h2>
+      <div style="display:flex; gap:1.4rem; flex-wrap:wrap; margin-bottom:0.9rem;">
+        <div class="spx-stat"><div class="n" id="ssTotal">—</div><div class="l">Integrated flights</div></div>
+        <div class="spx-stat"><div class="n" id="ssCatches">—</div><div class="l">Booster tower catches</div></div>
+        <div class="spx-stat"><div class="n" id="ssLatest">—</div><div class="l">Latest flight</div></div>
+      </div>
+      <div id="ssTimeline"><p class="spx-muted">Loading…</p></div>
+      <p class="spx-disclaimer">Curated record of Starship's integrated flight tests (Super Heavy + Ship). Outcome reflects the primary test objectives; "partial" means key milestones were hit even where a stage was lost. The path to a fully reusable, rapidly-flown super-heavy-lift vehicle.</p>
     </div>
   </div>
 
@@ -1149,9 +1162,38 @@
     countUp('brFleet', b.active_boosters_window);
   }
 
+  function renderStarship(s){
+    var flights = ((s||{}).flights)||[];
+    if(!flights.length) return;
+    var ch = {success:'#5ef0a0', partial:'var(--spx-cyan)', failure:'#ff7a7a'};
+    var lbl = {success:'Success', partial:'Partial', failure:'Failure'};
+    countUp('ssTotal', flights.length);
+    var catches = flights.filter(function(f){ return f.booster_caught===true; }).length;
+    countUp('ssCatches', catches);
+    var last = flights[flights.length-1];
+    var el = document.getElementById('ssLatest'); if(el) el.textContent = last.flight||'—';
+    var wrap = document.getElementById('ssTimeline'); if(!wrap) return;
+    // Newest first for the timeline.
+    var rows = flights.slice().reverse();
+    wrap.innerHTML = rows.map(function(f){
+      var c = ch[f.outcome]||'#cfe0ff';
+      return '<div style="display:flex; gap:12px; padding:10px 0; border-bottom:1px solid rgba(255,255,255,0.06);">'+
+        '<span style="flex:0 0 8px; width:8px; border-radius:4px; background:'+c+'; align-self:stretch;"></span>'+
+        '<div style="flex:1; min-width:0;">'+
+          '<div style="display:flex; align-items:baseline; gap:10px; flex-wrap:wrap;">'+
+            '<span style="font-weight:800; color:#fff;">'+(f.flight||'')+'</span>'+
+            '<span class="spx-muted" style="font-size:0.8rem;">'+(f.date||'')+'</span>'+
+            '<span style="font-size:0.72rem; font-weight:700; color:'+c+'; border:1px solid '+c+'; border-radius:999px; padding:1px 8px;">'+(lbl[f.outcome]||f.outcome||'')+'</span>'+
+          '</div>'+
+          '<div style="color:#cfe0ff; font-size:0.9rem; margin-top:3px;">'+(f.milestone||'')+'</div>'+
+        '</div></div>';
+    }).join('');
+  }
+
   function applyLaunches(data){
     if(!data) return;
     renderNext(data.next);
+    if(data.starship) renderStarship(data.starship);
     if(data.fleet) renderBoosters(data.fleet);
     renderPrev(data.previous);
     renderStats(data.stats, data.total_launches);

--- a/spacex.html
+++ b/spacex.html
@@ -493,9 +493,9 @@
                 <h1>SpaceX Daily</h1>
                 <p class="show-hero-tagline">Follow SpaceX as a public company — launches, Starlink, Starship, and the SPCX market picture, every day.</p>
                 <div style="display:flex;gap:var(--sp-2);align-items:center;margin-bottom:var(--sp-3);font-family:var(--font-ui);font-size:0.85rem;color:var(--nn-text-muted);"><span style="background:var(--nn-card);border:1px solid var(--nn-border);padding:2px 10px;border-radius:6px;">Daily</span>
-                    <span style="background:var(--nn-card);border:1px solid var(--nn-border);padding:2px 10px;border-radius:6px;">~12-14 min</span>
+                    <span style="background:var(--nn-card);border:1px solid var(--nn-border);padding:2px 10px;border-radius:6px;">~11-14 min</span>
                 </div>
-                <p class="show-hero-desc">The daily companion for following SpaceX as a public company (Nasdaq: SPCX). Launched the day of the largest IPO in history, the show covers Starship development, Falcon launch cadence, Starlink, Dragon missions, the SPCX market picture, and the engineering and economics behind the push to make life multiplanetary. Every day: the developments with sources, what the spaceflight community is buzzing about, one honest counterpoint, and an engineering deep dive. Not financial advice.</p>
+                <p class="show-hero-desc">The daily companion for following SpaceX as a public company (Nasdaq: SPCX). Launched the day of the largest IPO in history, the show covers the whole business — Starship development, Raptor and launch infrastructure, Falcon cadence, Starlink and Dragon — plus the fast-growing AI and compute thread where SpaceX meets the rest of the Musk stack: orbital data centers and AI satellites, Starlink as the backhaul, and the xAI / Grok / X ecosystem the IPO's AI-infrastructure spend ties into. Every day: the developments with sources, what the spaceflight community is buzzing about, one honest counterpoint, a dedicated AI & Compute segment, a first-principles engineering deep dive, and the SPCX market picture. Not financial advice.</p>
                 
                 <p style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);margin-bottom:var(--sp-4);font-style:italic;">SPCX investors, spaceflight enthusiasts, and engineers following the newly public SpaceX</p>
                 
@@ -508,6 +508,7 @@
                     
                     
                     <a href="spacex-dashboard.html" class="nn-btn">🚀 Launch Dashboard</a>
+                    
                     
                     
                     
@@ -634,7 +635,7 @@
                 <h2>About SpaceX Daily</h2>
             </div>
             <div class="about-section-text">
-                <p>The daily companion for following SpaceX as a public company (Nasdaq: SPCX). Launched the day of the largest IPO in history, the show covers Starship development, Falcon launch cadence, Starlink, Dragon missions, the SPCX market picture, and the engineering and economics behind the push to make life multiplanetary. Every day: the developments with sources, what the spaceflight community is buzzing about, one honest counterpoint, and an engineering deep dive. Not financial advice.</p>
+                <p>The daily companion for following SpaceX as a public company (Nasdaq: SPCX). Launched the day of the largest IPO in history, the show covers the whole business — Starship development, Raptor and launch infrastructure, Falcon cadence, Starlink and Dragon — plus the fast-growing AI and compute thread where SpaceX meets the rest of the Musk stack: orbital data centers and AI satellites, Starlink as the backhaul, and the xAI / Grok / X ecosystem the IPO's AI-infrastructure spend ties into. Every day: the developments with sources, what the spaceflight community is buzzing about, one honest counterpoint, a dedicated AI & Compute segment, a first-principles engineering deep dive, and the SPCX market picture. Not financial advice.</p>
                 
                 <p>Hosted by Patrick in Vancouver.</p>
                 

--- a/templates/spacex_dashboard.html.j2
+++ b/templates/spacex_dashboard.html.j2
@@ -79,8 +79,8 @@
   }
   .spx-btn.ghost { background: transparent; border:1px solid rgba(120,160,255,0.4); box-shadow:none; }
 
-  .spx-grid { max-width:1120px; margin: 1.5rem auto; padding: 0 1.25rem; display:grid; gap:1.1rem; grid-template-columns: 1fr 1fr; }
-  @media (max-width: 760px){ .spx-grid{ grid-template-columns:1fr; } }
+  .spx-grid { max-width:1120px; margin: 1.5rem auto; padding: 0 1.25rem; display:grid; gap:1.1rem; grid-template-columns: minmax(0,1fr) minmax(0,1fr); }
+  @media (max-width: 760px){ .spx-grid{ grid-template-columns:minmax(0,1fr); } }
   .spx-panel {
     background: var(--nn-surface, #0f1830); border:1px solid rgba(120,160,255,0.16);
     border-radius:16px; padding:1.1rem 1.2rem;
@@ -201,7 +201,7 @@
     </div>
   </div>
 
-  <div class="spx-grid" style="grid-template-columns:1fr;">
+  <div class="spx-grid" style="grid-template-columns:minmax(0,1fr);">
     <div class="spx-panel">
       <h2>Launch cadence — last 12 months</h2>
       <div class="spx-cadence" id="spxCadence"></div>
@@ -215,7 +215,7 @@
     </div>
   </div>
 
-  <div class="spx-grid" style="grid-template-columns:1fr;">
+  <div class="spx-grid" style="grid-template-columns:minmax(0,1fr);">
     <div class="spx-panel">
       <h2>Mass to orbit — last 12 months <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(estimated, tonnes)</span></h2>
       <div class="spx-cadence" id="spxMass"></div>
@@ -231,11 +231,24 @@
     </div>
   </div>
 
-  <div class="spx-grid" style="grid-template-columns:1fr;">
+  <div class="spx-grid" style="grid-template-columns:minmax(0,1fr);">
     <div class="spx-panel">
       <h2>Constellation growth — est. satellites to orbit <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(cumulative, tracked window)</span></h2>
       <div class="spx-area-wrap"><svg class="spx-area-svg" id="spxArea" preserveAspectRatio="none" role="img" aria-label="Cumulative estimated satellites to orbit"></svg></div>
       <p class="spx-disclaimer">Cumulative estimate over the months this dashboard has tracked — it extends to the left automatically as the dataset grows month over month.</p>
+    </div>
+  </div>
+
+  <div class="spx-grid" style="grid-template-columns:minmax(0,1fr);">
+    <div class="spx-panel">
+      <h2>Starship flight-test tracker 🚀 <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(integrated flight tests)</span></h2>
+      <div style="display:flex; gap:1.4rem; flex-wrap:wrap; margin-bottom:0.9rem;">
+        <div class="spx-stat"><div class="n" id="ssTotal">—</div><div class="l">Integrated flights</div></div>
+        <div class="spx-stat"><div class="n" id="ssCatches">—</div><div class="l">Booster tower catches</div></div>
+        <div class="spx-stat"><div class="n" id="ssLatest">—</div><div class="l">Latest flight</div></div>
+      </div>
+      <div id="ssTimeline"><p class="spx-muted">Loading…</p></div>
+      <p class="spx-disclaimer">Curated record of Starship's integrated flight tests (Super Heavy + Ship). Outcome reflects the primary test objectives; "partial" means key milestones were hit even where a stage was lost. The path to a fully reusable, rapidly-flown super-heavy-lift vehicle.</p>
     </div>
   </div>
 
@@ -540,9 +553,38 @@
     countUp('brFleet', b.active_boosters_window);
   }
 
+  function renderStarship(s){
+    var flights = ((s||{}).flights)||[];
+    if(!flights.length) return;
+    var ch = {success:'#5ef0a0', partial:'var(--spx-cyan)', failure:'#ff7a7a'};
+    var lbl = {success:'Success', partial:'Partial', failure:'Failure'};
+    countUp('ssTotal', flights.length);
+    var catches = flights.filter(function(f){ return f.booster_caught===true; }).length;
+    countUp('ssCatches', catches);
+    var last = flights[flights.length-1];
+    var el = document.getElementById('ssLatest'); if(el) el.textContent = last.flight||'—';
+    var wrap = document.getElementById('ssTimeline'); if(!wrap) return;
+    // Newest first for the timeline.
+    var rows = flights.slice().reverse();
+    wrap.innerHTML = rows.map(function(f){
+      var c = ch[f.outcome]||'#cfe0ff';
+      return '<div style="display:flex; gap:12px; padding:10px 0; border-bottom:1px solid rgba(255,255,255,0.06);">'+
+        '<span style="flex:0 0 8px; width:8px; border-radius:4px; background:'+c+'; align-self:stretch;"></span>'+
+        '<div style="flex:1; min-width:0;">'+
+          '<div style="display:flex; align-items:baseline; gap:10px; flex-wrap:wrap;">'+
+            '<span style="font-weight:800; color:#fff;">'+(f.flight||'')+'</span>'+
+            '<span class="spx-muted" style="font-size:0.8rem;">'+(f.date||'')+'</span>'+
+            '<span style="font-size:0.72rem; font-weight:700; color:'+c+'; border:1px solid '+c+'; border-radius:999px; padding:1px 8px;">'+(lbl[f.outcome]||f.outcome||'')+'</span>'+
+          '</div>'+
+          '<div style="color:#cfe0ff; font-size:0.9rem; margin-top:3px;">'+(f.milestone||'')+'</div>'+
+        '</div></div>';
+    }).join('');
+  }
+
   function applyLaunches(data){
     if(!data) return;
     renderNext(data.next);
+    if(data.starship) renderStarship(data.starship);
     if(data.fleet) renderBoosters(data.fleet);
     renderPrev(data.previous);
     renderStats(data.stats, data.total_launches);

--- a/tests/test_tesla_dashboard.py
+++ b/tests/test_tesla_dashboard.py
@@ -152,3 +152,64 @@ class TestBoosterReuseStats:
         t = (_ROOT / "templates/spacex_dashboard.html.j2").read_text(encoding="utf-8")
         assert "record watch" in t and "brRecordN" in t and "brLeaders" in t
         assert "spxBooster" in t  # per-launch booster line on the hero
+
+
+class TestStarshipTracker:
+    def _mod(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "fetch_spacex_launches", _ROOT / "scripts" / "fetch_spacex_launches.py")
+        m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+        return m
+
+    def test_metrics_has_curated_starship_record(self):
+        data = json.loads((_ROOT / "site/data/spacex_metrics.json").read_text(encoding="utf-8"))
+        sf = data.get("starship_flights") or {}
+        flights = sf.get("flights") or []
+        assert len(flights) >= 9, "Starship IFT record should be seeded"
+        # Schema + value sanity on every curated entry.
+        valid_outcomes = {"success", "partial", "failure"}
+        seen = set()
+        for f in flights:
+            assert f.get("flight") and f.get("date") and f.get("milestone")
+            assert f["outcome"] in valid_outcomes, f["outcome"]
+            assert f["flight"] not in seen, f"duplicate {f['flight']}"
+            seen.add(f["flight"])
+        # The three confirmed tower catches carry the explicit, non-prose flag.
+        caught = {f["flight"] for f in flights if f.get("booster_caught") is True}
+        assert {"IFT-5", "IFT-7", "IFT-8"}.issubset(caught), caught
+
+    def test_fetcher_reads_and_preserves_starship(self):
+        m = self._mod()
+        sf = m._starship_flights()
+        assert isinstance(sf, dict) and len(sf.get("flights", [])) >= 9
+        # The fetcher must carry it into the launches payload (so the dashboard
+        # — which only fetches api/spacex_launches.json — can read it).
+        import inspect
+        src = inspect.getsource(m.build_payload)
+        assert '"starship": _starship_flights()' in src
+        # And the metrics-rewrite must preserve it across runs (not wipe it).
+        rewrite = inspect.getsource(m._update_metrics_timeseries)
+        assert 'existing.get("starship_flights"' in rewrite
+
+    def test_main_keeps_last_good_starlink_count(self):
+        # A transient CelesTrak rate-limit (None) must not wipe a real count.
+        m = self._mod()
+        import inspect
+        src = inspect.getsource(m.main)
+        assert 'starlink_active") is None' in src
+        assert "Kept last-good Starlink count" in src
+
+    def test_dashboard_has_starship_panel(self):
+        t = (_ROOT / "templates/spacex_dashboard.html.j2").read_text(encoding="utf-8")
+        assert "Starship flight-test tracker" in t
+        assert "ssTimeline" in t and "renderStarship" in t
+        assert "data.starship" in t  # wired into applyLaunches
+        # Catch count must be the deterministic flag, not prose-matching.
+        assert "f.booster_caught===true" in t
+
+    def test_grid_uses_minmax_zero_for_mobile_safety(self):
+        # minmax(0,1fr) prevents grid items overflowing on narrow viewports.
+        t = (_ROOT / "templates/spacex_dashboard.html.j2").read_text(encoding="utf-8")
+        assert "minmax(0,1fr)" in t
+        assert "grid-template-columns: 1fr 1fr;" not in t  # legacy overflow shape


### PR DESCRIPTION
## SpaceX dashboard: Starship flight-test tracker 🚀

Continuing dashboard development with the single most-watched SpaceX program — Starship. Audience-magnet "story" content that directly serves "capture all parts of the SpaceX business."

### New: Starship flight-test tracker
- **Curated, operator-extendable record** in `site/data/spacex_metrics.json` (`starship_flights`) — same pattern as the Tesla curated datasets. Seeded with the verifiable public IFT-1 → IFT-9 record (date, outcome, milestone). Outside the Falcon launch window, so it's operator-maintained: append each new flight after it flies.
- **Preserved across fetch runs** (like the `infrastructure` block) — the nightly Falcon fetch can't wipe it.
- **Timeline panel** on the dashboard: newest-first flights with color-coded outcome chips (success / partial / failure) + headline stats (integrated flights · **booster tower catches** · latest flight). The catch count is an **explicit `booster_caught` flag**, not fragile prose-matching, so it can't silently miscount (confirmed catches: IFT-5, IFT-7, IFT-8 = 3).

### Fixes
- **Mobile overflow** in the dashboard grid: `1fr` tracks won't shrink below their content's min-content width, so the "Recently flown" rows pushed the panel ~95px past a 390px viewport. Switched to `minmax(0,1fr)` (same fix used on the cross-network grid). Render-verified: **0 overflow at 390px and 1240px**.
- **Keep last-good Starlink count**: CelesTrak rate-limits (1 download / 2h), so a transient `None` was overwriting the real committed count. `main()` now carries the last-good value forward (landmine #22 reliability contract).

### Verification
- Render-verified (headless Chromium): 9 flights, 3 catches, IFT-9 latest; no overflow on mobile or desktop.
- `ruff check` clean; full suite **2858 passing** (+5 new drift guards in `tests/test_tesla_dashboard.py`).

Pure dashboard/data work — no audio path.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_