### PR TITLE
Add network Data & Dashboards hub page (/data.html)

### DIFF
--- a/data.html
+++ b/data.html
@@ -1,0 +1,713 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Live data dashboards from Nerra Network — SpaceX launch countdown and fleet records, Tesla TSLA price and deliveries, and the Modern Investing simulated-portfolio performance page.">
+    
+    
+    <title>Data & Dashboards | Nerra Network</title>
+    <meta name="theme-color" content="#6B47FF">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Data & Dashboards | Nerra Network">
+    <meta property="og:description" content="Live data dashboards from Nerra Network — SpaceX launch countdown and fleet records, Tesla TSLA price and deliveries, and the Modern Investing simulated-portfolio performance page.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://nerranetwork.com/assets/og-default.png">
+    <meta property="og:url" content="https://nerranetwork.com/data.html">
+    <meta property="og:site_name" content="Nerra Network">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Data & Dashboards | Nerra Network">
+    <meta name="twitter:description" content="Live data dashboards from Nerra Network — SpaceX launch countdown and fleet records, Tesla TSLA price and deliveries, and the Modern Investing simulated-portfolio performance page.">
+    <meta name="twitter:image" content="https://nerranetwork.com/assets/og-default.png">
+
+    <link rel="canonical" href="https://nerranetwork.com/data.html">
+    
+    
+    
+
+    <!-- Google Fonts: DM Sans + Source Serif 4 -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&display=swap" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%236B47FF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/><line x1='50' y1='50' x2='20' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='80' y2='30' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='25' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/><line x1='50' y1='50' x2='75' y2='75' stroke='%236B47FF' stroke-width='1.5' opacity='0.6'/></svg>">
+
+    
+    
+    <!-- Cookie consent (Google Consent Mode v2) — loads BEFORE gtag.js -->
+    <script src="assets/js/consent.js"></script>
+    <!-- gtag.js — covers both GA4 and Google Ads -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PWJCVQQ7B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-6PWJCVQQ7B', { 'anonymize_ip': true });
+      
+      
+    </script>
+    
+    
+    
+    <script defer src="assets/js/tracking.js"></script>
+
+    <!-- Shared CSS -->
+    <link rel="stylesheet" href="styles/main.css">
+
+    
+<style>
+  .dh-hero { position:relative; overflow:hidden;
+    background:
+      radial-gradient(1100px 520px at 50% -10%, rgba(107,71,255,0.22), transparent 60%),
+      linear-gradient(180deg, #060812 0%, #0c1020 60%, #0a0e1c 100%);
+    border-bottom:1px solid rgba(140,140,255,0.14); }
+  .dh-container { max-width:1120px; margin:0 auto; padding:calc(var(--nav-height) + 2.6rem) 1.25rem 2rem; position:relative; z-index:1; }
+  .dh-kicker { display:inline-flex; align-items:center; gap:8px; font-size:0.78rem; letter-spacing:0.14em; text-transform:uppercase; color:#9b8cff; font-weight:700; margin-bottom:0.5rem; }
+  .dh-h1 { font-size:clamp(1.9rem,4vw,2.9rem); line-height:1.05; margin:0 0 0.5rem; font-weight:800; letter-spacing:-0.02em; color:#fff; }
+  .dh-sub { color:#b9c0e0; font-size:1.04rem; max-width:64ch; margin:0 0 0.4rem; }
+
+  .dh-grid { max-width:1120px; margin:1.8rem auto; padding:0 1.25rem; display:grid; gap:1.2rem; grid-template-columns:minmax(0,1fr) minmax(0,1fr); }
+  @media (max-width:760px){ .dh-grid{ grid-template-columns:minmax(0,1fr); } }
+  .dh-card { display:block; text-decoration:none; color:inherit; border-radius:18px; padding:1.4rem 1.5rem;
+    border:1px solid rgba(140,140,255,0.16); background:var(--nn-surface,#0f1326);
+    transition:transform .18s ease, border-color .18s ease, box-shadow .18s ease; position:relative; overflow:hidden; }
+  .dh-card:hover { transform:translateY(-3px); border-color:var(--accent,#6B47FF); box-shadow:0 14px 40px rgba(0,0,0,0.4); }
+  .dh-card::before { content:""; position:absolute; inset:0 auto 0 0; width:5px; background:var(--accent,#6B47FF); }
+  .dh-card h2 { margin:0 0 0.3rem; font-size:1.3rem; color:#fff; letter-spacing:-0.01em; }
+  .dh-card .dh-tag { font-size:0.72rem; text-transform:uppercase; letter-spacing:0.1em; color:var(--accent,#9b8cff); font-weight:700; }
+  .dh-card p { color:#aeb6d8; font-size:0.94rem; margin:0.5rem 0 0.9rem; line-height:1.5; }
+  .dh-metrics { display:flex; flex-wrap:wrap; gap:8px; margin-top:0.4rem; }
+  .dh-chip { font-size:0.74rem; color:#cdd4f0; background:rgba(140,140,255,0.10); border:1px solid rgba(140,140,255,0.18); border-radius:999px; padding:3px 10px; }
+  .dh-go { display:inline-flex; align-items:center; gap:6px; margin-top:1rem; color:var(--accent,#9b8cff); font-weight:700; font-size:0.92rem; }
+  .dh-note { max-width:1120px; margin:0 auto 2.4rem; padding:0 1.25rem; color:#8b91b4; font-size:0.82rem; }
+</style>
+
+
+    
+    <style>
+        @media (max-width: 768px) {
+            .nn-footer-grid { grid-template-columns: 1fr; }
+            .nn-footer-col h4 {
+                cursor: pointer;
+                position: relative;
+                padding-right: 1.5rem;
+            }
+            .nn-footer-col h4::after {
+                content: '+';
+                position: absolute;
+                right: 0;
+                font-size: 1.2rem;
+                color: var(--nn-text-muted);
+            }
+            .nn-footer-col.expanded h4::after { content: '\2212'; }
+            .nn-footer-col > a,
+            .nn-footer-col > ul { display: none; }
+            .nn-footer-col.expanded > a,
+            .nn-footer-col.expanded > ul { display: block; }
+        }
+    </style>
+</head>
+<body><a href="#main-content" class="skip-link">Skip to content</a>
+    <!-- Navigation -->
+    <nav class="nn-nav" aria-label="Main navigation">
+        <div class="nn-nav-inner">
+            <a href="index.html" class="nn-nav-logo">
+                <img src="assets/nerra-logo-icon.svg" alt="Nerra Network" width="36" height="36">
+                <span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span>
+            </a>
+
+            
+            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.5rem;max-width:180px;flex:1 1 auto;min-width:120px;">
+                <input type="search" id="nn-global-search-input"
+                       placeholder="Search…"
+                       style="width:100%;padding:6px 8px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.85rem;"
+                       aria-label="Search all episodes across the network">
+                <div id="nn-global-search-results"
+                     style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:340px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
+            </div>
+
+            <ul class="nn-nav-links">
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Shows
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu" role="menu">
+                        
+                        <a href="models-agents.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents
+                        </a>
+                        
+                        <a href="planetterrian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily
+                        </a>
+                        
+                        <a href="omni-view.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View
+                        </a>
+                        
+                        <a href="models-agents-beginners.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners
+                        </a>
+                        
+                        <a href="fascinating-frontiers.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers
+                        </a>
+                        
+                        <a href="modern-investing.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques
+                        </a>
+                        
+                        <a href="tesla.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time
+                        </a>
+                        
+                        <a href="env-intel.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence
+                        </a>
+                        
+                        <a href="ru/finansy-prosto.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто
+                        </a>
+                        
+                        <a href="ru/privet-russian.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский!
+                        </a>
+                        
+                        <a href="unintended-consequences.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences
+                        </a>
+                        
+                        <a href="first-principles.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            First Principles Daily
+                        </a>
+                        
+                        <a href="spacex.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily
+                        </a>
+                        
+                    </div>
+                </li>
+                <li class="nn-nav-dropdown">
+                    <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
+                        Blog
+                        <svg viewBox="0 0 12 12" fill="none"><path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="nn-nav-dropdown-menu">
+                        <a href="blog/index.html" style="font-weight:600;border-bottom:1px solid var(--nn-border);padding-bottom:8px;margin-bottom:4px">
+                            All Blog Posts
+                        </a>
+                        
+                        <a href="blog/models_agents/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents Blog
+                        </a>
+                        
+                        <a href="blog/planetterrian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Planetterrian Daily Blog
+                        </a>
+                        
+                        <a href="blog/omni_view/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Omni View Blog
+                        </a>
+                        
+                        <a href="blog/models_agents_beginners/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Models & Agents for Beginners Blog
+                        </a>
+                        
+                        <a href="blog/fascinating_frontiers/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Fascinating Frontiers Blog
+                        </a>
+                        
+                        <a href="blog/modern_investing/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Modern Investing Techniques Blog
+                        </a>
+                        
+                        <a href="blog/tesla/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Tesla Shorts Time Blog
+                        </a>
+                        
+                        <a href="blog/env_intel/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Environmental Intelligence Blog
+                        </a>
+                        
+                        <a href="blog/finansy_prosto/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Финансы Просто Blog
+                        </a>
+                        
+                        <a href="blog/privet_russian/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Привет, Русский! Blog
+                        </a>
+                        
+                        <a href="blog/unintended_consequences/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            Unintended Consequences Blog
+                        </a>
+                        
+                        <a href="blog/first_principles/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            First Principles Daily Blog
+                        </a>
+                        
+                        <a href="blog/spacex/index.html">
+                            <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily Blog
+                        </a>
+                        
+                    </div>
+                </li>
+                
+                <li><a href="start-here.html">Start Here</a></li>
+                <li><a href="how-to-listen.html">Listen</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="player.html">Player</a></li>
+                <li><a href="index.html">Home</a></li>
+                
+            </ul>
+
+            <button class="nn-hamburger" aria-label="Toggle menu" aria-expanded="false" onclick="var m=document.getElementById('mobileMenu');m.classList.toggle('open');this.setAttribute('aria-expanded',m.classList.contains('open'));document.body.classList.toggle('menu-open')">&#9776;</button>
+        </div>
+    </nav>
+
+    <!-- Mobile Menu -->
+    <div id="mobileMenu" class="nn-mobile-menu">
+        
+        <a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Start Here</a>
+        <a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">How to Listen</a>
+        <a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">About</a>
+        <a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Player</a>
+        <a href="index.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Home</a>
+        
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">All Shows</div>
+            
+            <a href="models-agents.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents
+            </a>
+            
+            <a href="planetterrian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily
+            </a>
+            
+            <a href="omni-view.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View
+            </a>
+            
+            <a href="models-agents-beginners.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners
+            </a>
+            
+            <a href="fascinating-frontiers.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers
+            </a>
+            
+            <a href="modern-investing.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques
+            </a>
+            
+            <a href="tesla.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time
+            </a>
+            
+            <a href="env-intel.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence
+            </a>
+            
+            <a href="ru/finansy-prosto.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто
+            </a>
+            
+            <a href="ru/privet-russian.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский!
+            </a>
+            
+            <a href="unintended-consequences.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences
+            </a>
+            
+            <a href="first-principles.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                First Principles Daily
+            </a>
+            
+            <a href="spacex.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily
+            </a>
+            
+        </div>
+        <div class="nn-mobile-shows">
+            <div class="nn-mobile-shows-title">Blogs</div>
+            <a href="blog/index.html" class="nn-mobile-show-link" style="font-weight:600" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                All Blog Posts
+            </a>
+            
+            <a href="blog/models_agents/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-400.webp"><img src="assets/covers/models-agents.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents Blog
+            </a>
+            
+            <a href="blog/planetterrian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp"><img src="assets/covers/planetterrian-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Planetterrian Daily Blog
+            </a>
+            
+            <a href="blog/omni_view/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/omni-view-400.webp"><img src="assets/covers/omni-view.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Omni View Blog
+            </a>
+            
+            <a href="blog/models_agents_beginners/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp"><img src="assets/covers/models-agents-beginners.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Models & Agents for Beginners Blog
+            </a>
+            
+            <a href="blog/fascinating_frontiers/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp"><img src="assets/covers/fascinating-frontiers.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Fascinating Frontiers Blog
+            </a>
+            
+            <a href="blog/modern_investing/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/modern-investing-400.webp"><img src="assets/covers/modern-investing.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Modern Investing Techniques Blog
+            </a>
+            
+            <a href="blog/tesla/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp"><img src="assets/covers/tesla-shorts-time.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Tesla Shorts Time Blog
+            </a>
+            
+            <a href="blog/env_intel/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp"><img src="assets/covers/environmental-intelligence.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Environmental Intelligence Blog
+            </a>
+            
+            <a href="blog/finansy_prosto/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/finansy-prosto-400.webp"><img src="assets/covers/finansy-prosto.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Финансы Просто Blog
+            </a>
+            
+            <a href="blog/privet_russian/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/privet-russian-400.webp"><img src="assets/covers/privet-russian.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Привет, Русский! Blog
+            </a>
+            
+            <a href="blog/unintended_consequences/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp"><img src="assets/covers/unintended-consequences.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                Unintended Consequences Blog
+            </a>
+            
+            <a href="blog/first_principles/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp"><img src="assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                First Principles Daily Blog
+            </a>
+            
+            <a href="blog/spacex/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="assets/covers/spacex-400.webp"><img src="assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily Blog
+            </a>
+            
+        </div>
+    </div>
+
+    <main id="main-content">
+    
+<div class="dh-hero">
+  <div class="dh-container">
+    <div class="dh-kicker"><span>◆</span> Nerra Data</div>
+    <h1 class="dh-h1">Data &amp; Dashboards</h1>
+    <p class="dh-sub">Live, continuously-updated data behind the shows — launch countdowns, market prices, fleet records, and simulated-portfolio performance. Real numbers from public sources, refreshed every pipeline run; curated history is operator-maintained and clearly labelled.</p>
+  </div>
+</div>
+
+<div class="dh-grid">
+  <a class="dh-card" href="spacex-dashboard.html" style="--accent:#00D4FF;">
+    <span class="dh-tag">SpaceX Daily</span>
+    <h2>SpaceX Launch Dashboard</h2>
+    <p>Next-launch countdown, watch-live links, launch cadence, mass to orbit, the booster-reuse record watch, the Starship flight-test tracker, and live SPCX price.</p>
+    <div class="dh-metrics">
+      <span class="dh-chip">Live countdown</span>
+      <span class="dh-chip">Booster records</span>
+      <span class="dh-chip">Starship tracker</span>
+      <span class="dh-chip">SPCX price</span>
+    </div>
+    <span class="dh-go">Open dashboard →</span>
+  </a>
+
+  <a class="dh-card" href="tesla-dashboard.html" style="--accent:#E31937;">
+    <span class="dh-tag">Tesla Shorts Time</span>
+    <h2>Tesla Dashboard</h2>
+    <p>Live TSLA price with a 1-year chart and 52-week range, quarterly production &amp; deliveries, Supercharger network growth, energy-storage deployments, and milestones.</p>
+    <div class="dh-metrics">
+      <span class="dh-chip">Live TSLA</span>
+      <span class="dh-chip">Quarterly P&amp;D</span>
+      <span class="dh-chip">Supercharger growth</span>
+    </div>
+    <span class="dh-go">Open dashboard →</span>
+  </a>
+
+  <a class="dh-card" href="modern-investing-performance.html" style="--accent:#10b981;">
+    <span class="dh-tag">Modern Investing Techniques</span>
+    <h2>Performance &amp; Recursive Learning</h2>
+    <p>The simulated practice portfolio's cumulative return, monthly P&amp;L, win/loss split, sector breakdown, recent trades, and the operating principles the model derives from its own results. Education only.</p>
+    <div class="dh-metrics">
+      <span class="dh-chip">Equity curve</span>
+      <span class="dh-chip">Monthly P&amp;L</span>
+      <span class="dh-chip">Alpha vs NASDAQ</span>
+    </div>
+    <span class="dh-go">Open dashboard →</span>
+  </a>
+
+  <a class="dh-card" href="gallery.html" style="--accent:#6B47FF;">
+    <span class="dh-tag">Network</span>
+    <h2>Image Gallery</h2>
+    <p>Every AI-generated visual produced for the shows — filterable by show and date, free to download under CC BY-SA 4.0 with attribution.</p>
+    <div class="dh-metrics">
+      <span class="dh-chip">Filter by show</span>
+      <span class="dh-chip">CC BY-SA 4.0</span>
+    </div>
+    <span class="dh-go">Browse gallery →</span>
+  </a>
+</div>
+
+<p class="dh-note">
+  Sources: launch data from <a href="https://thespacedevs.com/" target="_blank" rel="noopener" style="color:#9b8cff;">The Space Devs</a> Launch Library 2, active-satellite counts from <a href="https://celestrak.org/" target="_blank" rel="noopener" style="color:#9b8cff;">CelesTrak</a>, and market quotes from Yahoo Finance — each refreshed on every pipeline run, with the last good value kept on a fetch hiccup. Estimated figures (mass to orbit, satellites deployed) use public per-vehicle averages and are labelled as estimates. Nothing here is financial advice.
+</p>
+
+    </main>
+
+    <!-- Footer -->
+    <footer class="nn-footer">
+        <div class="container">
+            <div class="nn-footer-grid">
+                <div>
+                    <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span></div>
+                    <p class="nn-footer-desc">13 shows. Zero fluff. Independent podcast network produced in Vancouver, Canada.</p>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Shows</h4>
+                    
+                    <a href="models-agents.html">Models & Agents</a>
+                    
+                    <a href="planetterrian.html">Planetterrian Daily</a>
+                    
+                    <a href="omni-view.html">Omni View</a>
+                    
+                    <a href="models-agents-beginners.html">Models & Agents for Beginners</a>
+                    
+                    <a href="fascinating-frontiers.html">Fascinating Frontiers</a>
+                    
+                    <a href="modern-investing.html">Modern Investing Techniques</a>
+                    
+                    <a href="tesla.html">Tesla Shorts Time</a>
+                    
+                    <a href="env-intel.html">Environmental Intelligence</a>
+                    
+                    <a href="ru/finansy-prosto.html">Финансы Просто</a>
+                    
+                    <a href="ru/privet-russian.html">Привет, Русский!</a>
+                    
+                    <a href="unintended-consequences.html">Unintended Consequences</a>
+                    
+                    <a href="first-principles.html">First Principles Daily</a>
+                    
+                    <a href="spacex.html">SpaceX Daily</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Blog</h4>
+                    <a href="blog/index.html">All Blog Posts</a>
+                    
+                    <a href="blog/models_agents/index.html">Models & Agents</a>
+                    
+                    <a href="blog/planetterrian/index.html">Planetterrian Daily</a>
+                    
+                    <a href="blog/omni_view/index.html">Omni View</a>
+                    
+                    <a href="blog/models_agents_beginners/index.html">Models & Agents for Beginners</a>
+                    
+                    <a href="blog/fascinating_frontiers/index.html">Fascinating Frontiers</a>
+                    
+                    <a href="blog/modern_investing/index.html">Modern Investing Techniques</a>
+                    
+                    <a href="blog/tesla/index.html">Tesla Shorts Time</a>
+                    
+                    <a href="blog/env_intel/index.html">Environmental Intelligence</a>
+                    
+                    <a href="blog/finansy_prosto/index.html">Финансы Просто</a>
+                    
+                    <a href="blog/privet_russian/index.html">Привет, Русский!</a>
+                    
+                    <a href="blog/unintended_consequences/index.html">Unintended Consequences</a>
+                    
+                    <a href="blog/first_principles/index.html">First Principles Daily</a>
+                    
+                    <a href="blog/spacex/index.html">SpaceX Daily</a>
+                    
+                    <a href="blog.rss">Blog RSS (All Shows)</a>
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Listen</h4>
+                    <a href="how-to-listen.html" style="font-weight:600">How to Listen</a>
+                    <a href="player.html" style="font-weight:600">Network Player</a>
+                    <a href="https://podcasts.apple.com/us/podcast/tesla-shorts-time/id1855142939?utm_source=nerranetwork&utm_medium=footer&utm_campaign=tesla" target="_blank" rel="noopener" data-show="tesla">Apple Podcasts</a>
+                    <a href="network.rss">Network RSS</a>
+                    
+                    <a href="models_agents_podcast.rss">Models & Agents RSS</a>
+                    
+                    <a href="planetterrian_podcast.rss">Planetterrian Daily RSS</a>
+                    
+                    <a href="omni_view_podcast.rss">Omni View RSS</a>
+                    
+                    <a href="models_agents_beginners_podcast.rss">Models & Agents for Beginners RSS</a>
+                    
+                    <a href="fascinating_frontiers_podcast.rss">Fascinating Frontiers RSS</a>
+                    
+                    <a href="modern_investing_podcast.rss">Modern Investing Techniques RSS</a>
+                    
+                    <a href="podcast.rss">Tesla Shorts Time RSS</a>
+                    
+                    <a href="env_intel_podcast.rss">Environmental Intelligence RSS</a>
+                    
+                    <a href="finansy_prosto_podcast.rss">Финансы Просто RSS</a>
+                    
+                    <a href="privet_russian_podcast.rss">Привет, Русский! RSS</a>
+                    
+                    <a href="unintended_consequences_podcast.rss">Unintended Consequences RSS</a>
+                    
+                    <a href="first_principles_podcast.rss">First Principles Daily RSS</a>
+                    
+                    <a href="spacex_podcast.rss">SpaceX Daily RSS</a>
+                    
+                </div>
+                <div class="nn-footer-col">
+                    <h4>Connect</h4>
+                    <a href="https://x.com/teslashortstime" target="_blank" rel="noopener">@teslashortstime</a>
+                    <a href="https://x.com/omniviewnews" target="_blank" rel="noopener">@omniviewnews</a>
+                    <a href="https://x.com/planetterrian" target="_blank" rel="noopener">@planetterrian</a>
+                </div>
+            </div>
+            <div class="nn-footer-col">
+                <h4>About</h4>
+                <a href="about.html">About Nerra Network</a>
+                <a href="start-here.html">Start Here</a>
+                <a href="how-to-listen.html">How to Listen</a>
+                <a href="faq.html">FAQ</a>
+                <a href="contact.html">Contact</a>
+                <a href="press.html">Press Kit</a>
+                <a href="privacy-policy.html">Privacy Policy</a>
+                <a href="terms-of-service.html">Terms of Service</a>
+                <a href="ai-disclosure.html">AI Disclosure</a>
+                <a href="editorial.html">Editorial Process</a>
+                <a href="gallery.html">Image Gallery</a>
+                <a href="data.html">Data &amp; Dashboards</a>
+                <a href="management.html">Network Status</a>
+            </div>
+            <!-- Newsletter Subscribe -->
+            <div class="nn-footer-subscribe">
+                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
+                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                    <h4>Get Show Updates</h4>
+                    <p>Pick the shows you want in your inbox:</p>
+                    <div class="nn-subscribe-tags"><label><input type="checkbox" name="tag" value="Tesla Shorts Time"> Tesla Shorts Time</label>
+                        <label><input type="checkbox" name="tag" value="Omni View"> Omni View</label>
+                        <label><input type="checkbox" name="tag" value="Fascinating Frontiers"> Fascinating Frontiers</label>
+                        <label><input type="checkbox" name="tag" value="Planetterrian Daily"> Planetterrian Daily</label>
+                        <label><input type="checkbox" name="tag" value="Environmental Intelligence"> Environmental Intelligence</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents"> Models &amp; Agents</label>
+                        <label><input type="checkbox" name="tag" value="Models & Agents for Beginners"> Models &amp; Agents for Beginners</label>
+                        <label><input type="checkbox" name="tag" value="Modern Investing Techniques"> Modern Investing Techniques</label>
+                        <label><input type="checkbox" name="tag" value="Unintended Consequences"> Unintended Consequences</label><label><input type="checkbox" name="tag" value="Finansy Prosto"> Финансы Просто</label>
+                        <label><input type="checkbox" name="tag" value="Privet Russian"> Привет, Русский!</label>
+                    </div>
+                    <div class="nn-subscribe-row">
+                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
+                        <input type="hidden" value="1" name="embed">
+                        <button type="submit">Subscribe</button>
+                    </div>
+                </form>
+            </div>
+            <div class="nn-footer-bottom">
+                <span>© 2026 Nerra Network. All shows independently produced.</span>
+                <a href="index.html">nerranetwork.com</a>
+            </div>
+            <div class="nn-footer-legal">
+                <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
+                <div>
+                    <a href="privacy-policy.html">Privacy</a> &middot;
+                    <a href="terms-of-service.html">Terms</a> &middot;
+                    <a href="ai-disclosure.html">AI Disclosure</a>
+                    <span style="opacity:0.5;">&middot;</span>
+                    <span style="font-size:0.7rem;opacity:0.6;">Automation: reliable nightly + post-publish pipeline</span>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    // Toggle aria-expanded on dropdown hover/focus
+    document.querySelectorAll('.nn-nav-dropdown').forEach(function(dd) {
+        var btn = dd.querySelector('.nn-nav-dropdown-btn');
+        if (!btn) return;
+        dd.addEventListener('mouseenter', function() { btn.setAttribute('aria-expanded', 'true'); });
+        dd.addEventListener('mouseleave', function() { btn.setAttribute('aria-expanded', 'false'); });
+        btn.addEventListener('focus', function() { btn.setAttribute('aria-expanded', 'true'); });
+        btn.addEventListener('blur', function() {
+            setTimeout(function() {
+                if (!dd.contains(document.activeElement)) btn.setAttribute('aria-expanded', 'false');
+            }, 100);
+        });
+    });
+    // Mobile footer accordions
+    if (window.innerWidth <= 768) {
+        document.querySelectorAll('.nn-footer-col h4').forEach(function(h4) {
+            h4.addEventListener('click', function() {
+                h4.parentElement.classList.toggle('expanded');
+            });
+        });
+    }
+    </script>
+    
+
+    <!-- Centralized, improved global search -->
+    <script src="assets/js/search.js" defer></script>
+</body>
+</html>

--- a/generate_html.py
+++ b/generate_html.py
@@ -2854,7 +2854,7 @@ def generate_sitemap(*, dry_run=False):
     for extra in ["modern-investing-resources.html", "start-here.html",
                   "about.html", "how-to-listen.html", "faq.html",
                   "press.html", "contact.html", "editorial.html",
-                  "gallery.html", "player.html",
+                  "gallery.html", "player.html", "data.html",
                   "modern-investing-performance.html",
                   "spacex-dashboard.html", "tesla-dashboard.html"]:
         if (ROOT / extra).exists():
@@ -2983,6 +2983,38 @@ def _count_languages() -> int:
         else:
             langs.add("en")
     return len(langs)
+
+
+def generate_data_hub_page(*, dry_run=False):
+    """Render the /data.html hub linking every public data dashboard
+    (SpaceX, Tesla, Modern Investing performance, gallery) so the audience
+    can discover them from one place. Static — no runtime data; the linked
+    dashboards read their own same-origin caches client-side."""
+    env = _get_jinja_env()
+    template = env.get_template("data_hub.html.j2")
+    context = {
+        "path_prefix": "",
+        "page_lang": "en",
+        "page_title": "Data & Dashboards | Nerra Network",
+        "meta_description": (
+            "Live data dashboards from Nerra Network — SpaceX launch countdown "
+            "and fleet records, Tesla TSLA price and deliveries, and the Modern "
+            "Investing simulated-portfolio performance page."
+        ),
+        "theme_color": "#6B47FF",
+        "og_image": f"{GITHUB_RAW}/assets/og-default.png",
+        "canonical_url": f"{GITHUB_RAW}/data.html",
+        "t": _NAV_T,
+        "all_shows": _build_all_shows_list(),
+    }
+    html = template.render(**context)
+    out_path = ROOT / "data.html"
+    if dry_run:
+        print(f"[dry-run] Would write {out_path} ({len(html):,} bytes)")
+        return out_path
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
+    print(f"Wrote {out_path} ({len(html):,} bytes)")
+    return out_path
 
 
 def generate_gallery_page(*, dry_run=False):
@@ -3379,6 +3411,7 @@ def main():
         generate_gallery_page(dry_run=args.dry_run)
         generate_spacex_dashboard(dry_run=args.dry_run)
         generate_tesla_dashboard(dry_run=args.dry_run)
+        generate_data_hub_page(dry_run=args.dry_run)
         generate_how_to_listen_page(dry_run=args.dry_run)
         generate_press_page(dry_run=args.dry_run)
         generate_contact_page(dry_run=args.dry_run)
@@ -3411,6 +3444,7 @@ def main():
         # runtime) so they're cheap to regenerate on every network rebuild.
         generate_spacex_dashboard(dry_run=args.dry_run)
         generate_tesla_dashboard(dry_run=args.dry_run)
+        generate_data_hub_page(dry_run=args.dry_run)
         # --network --blogs: regenerate network blog index only (not all posts)
         if args.blogs:
             generate_network_blog_index(dry_run=args.dry_run)

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -328,6 +328,7 @@
                 <a href="{{ path_prefix }}ai-disclosure.html">{{ t.footer_ai_disclosure }}</a>
                 <a href="{{ path_prefix }}editorial.html">{% if _is_ru %}Редакционная политика{% else %}Editorial Process{% endif %}</a>
                 <a href="{{ path_prefix }}gallery.html">{% if _is_ru %}Галерея{% else %}Image Gallery{% endif %}</a>
+                <a href="{{ path_prefix }}data.html">{% if _is_ru %}Данные и дашборды{% else %}Data &amp; Dashboards{% endif %}</a>
                 <a href="{{ path_prefix }}management.html">{{ t.footer_network_status }}</a>
             </div>
             <!-- Newsletter Subscribe -->

--- a/templates/data_hub.html.j2
+++ b/templates/data_hub.html.j2
@@ -1,0 +1,98 @@
+{% extends "base.html.j2" %}
+
+{% block title %}Data & Dashboards — Live SpaceX, Tesla & Investing Data | Nerra Network{% endblock %}
+
+{% block og_type %}website{% endblock %}
+
+{% block head_extra %}
+<style>
+  .dh-hero { position:relative; overflow:hidden;
+    background:
+      radial-gradient(1100px 520px at 50% -10%, rgba(107,71,255,0.22), transparent 60%),
+      linear-gradient(180deg, #060812 0%, #0c1020 60%, #0a0e1c 100%);
+    border-bottom:1px solid rgba(140,140,255,0.14); }
+  .dh-container { max-width:1120px; margin:0 auto; padding:calc(var(--nav-height) + 2.6rem) 1.25rem 2rem; position:relative; z-index:1; }
+  .dh-kicker { display:inline-flex; align-items:center; gap:8px; font-size:0.78rem; letter-spacing:0.14em; text-transform:uppercase; color:#9b8cff; font-weight:700; margin-bottom:0.5rem; }
+  .dh-h1 { font-size:clamp(1.9rem,4vw,2.9rem); line-height:1.05; margin:0 0 0.5rem; font-weight:800; letter-spacing:-0.02em; color:#fff; }
+  .dh-sub { color:#b9c0e0; font-size:1.04rem; max-width:64ch; margin:0 0 0.4rem; }
+
+  .dh-grid { max-width:1120px; margin:1.8rem auto; padding:0 1.25rem; display:grid; gap:1.2rem; grid-template-columns:minmax(0,1fr) minmax(0,1fr); }
+  @media (max-width:760px){ .dh-grid{ grid-template-columns:minmax(0,1fr); } }
+  .dh-card { display:block; text-decoration:none; color:inherit; border-radius:18px; padding:1.4rem 1.5rem;
+    border:1px solid rgba(140,140,255,0.16); background:var(--nn-surface,#0f1326);
+    transition:transform .18s ease, border-color .18s ease, box-shadow .18s ease; position:relative; overflow:hidden; }
+  .dh-card:hover { transform:translateY(-3px); border-color:var(--accent,#6B47FF); box-shadow:0 14px 40px rgba(0,0,0,0.4); }
+  .dh-card::before { content:""; position:absolute; inset:0 auto 0 0; width:5px; background:var(--accent,#6B47FF); }
+  .dh-card h2 { margin:0 0 0.3rem; font-size:1.3rem; color:#fff; letter-spacing:-0.01em; }
+  .dh-card .dh-tag { font-size:0.72rem; text-transform:uppercase; letter-spacing:0.1em; color:var(--accent,#9b8cff); font-weight:700; }
+  .dh-card p { color:#aeb6d8; font-size:0.94rem; margin:0.5rem 0 0.9rem; line-height:1.5; }
+  .dh-metrics { display:flex; flex-wrap:wrap; gap:8px; margin-top:0.4rem; }
+  .dh-chip { font-size:0.74rem; color:#cdd4f0; background:rgba(140,140,255,0.10); border:1px solid rgba(140,140,255,0.18); border-radius:999px; padding:3px 10px; }
+  .dh-go { display:inline-flex; align-items:center; gap:6px; margin-top:1rem; color:var(--accent,#9b8cff); font-weight:700; font-size:0.92rem; }
+  .dh-note { max-width:1120px; margin:0 auto 2.4rem; padding:0 1.25rem; color:#8b91b4; font-size:0.82rem; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="dh-hero">
+  <div class="dh-container">
+    <div class="dh-kicker"><span>◆</span> Nerra Data</div>
+    <h1 class="dh-h1">Data &amp; Dashboards</h1>
+    <p class="dh-sub">Live, continuously-updated data behind the shows — launch countdowns, market prices, fleet records, and simulated-portfolio performance. Real numbers from public sources, refreshed every pipeline run; curated history is operator-maintained and clearly labelled.</p>
+  </div>
+</div>
+
+<div class="dh-grid">
+  <a class="dh-card" href="{{ path_prefix }}spacex-dashboard.html" style="--accent:#00D4FF;">
+    <span class="dh-tag">SpaceX Daily</span>
+    <h2>SpaceX Launch Dashboard</h2>
+    <p>Next-launch countdown, watch-live links, launch cadence, mass to orbit, the booster-reuse record watch, the Starship flight-test tracker, and live SPCX price.</p>
+    <div class="dh-metrics">
+      <span class="dh-chip">Live countdown</span>
+      <span class="dh-chip">Booster records</span>
+      <span class="dh-chip">Starship tracker</span>
+      <span class="dh-chip">SPCX price</span>
+    </div>
+    <span class="dh-go">Open dashboard →</span>
+  </a>
+
+  <a class="dh-card" href="{{ path_prefix }}tesla-dashboard.html" style="--accent:#E31937;">
+    <span class="dh-tag">Tesla Shorts Time</span>
+    <h2>Tesla Dashboard</h2>
+    <p>Live TSLA price with a 1-year chart and 52-week range, quarterly production &amp; deliveries, Supercharger network growth, energy-storage deployments, and milestones.</p>
+    <div class="dh-metrics">
+      <span class="dh-chip">Live TSLA</span>
+      <span class="dh-chip">Quarterly P&amp;D</span>
+      <span class="dh-chip">Supercharger growth</span>
+    </div>
+    <span class="dh-go">Open dashboard →</span>
+  </a>
+
+  <a class="dh-card" href="{{ path_prefix }}modern-investing-performance.html" style="--accent:#10b981;">
+    <span class="dh-tag">Modern Investing Techniques</span>
+    <h2>Performance &amp; Recursive Learning</h2>
+    <p>The simulated practice portfolio's cumulative return, monthly P&amp;L, win/loss split, sector breakdown, recent trades, and the operating principles the model derives from its own results. Education only.</p>
+    <div class="dh-metrics">
+      <span class="dh-chip">Equity curve</span>
+      <span class="dh-chip">Monthly P&amp;L</span>
+      <span class="dh-chip">Alpha vs NASDAQ</span>
+    </div>
+    <span class="dh-go">Open dashboard →</span>
+  </a>
+
+  <a class="dh-card" href="{{ path_prefix }}gallery.html" style="--accent:#6B47FF;">
+    <span class="dh-tag">Network</span>
+    <h2>Image Gallery</h2>
+    <p>Every AI-generated visual produced for the shows — filterable by show and date, free to download under CC BY-SA 4.0 with attribution.</p>
+    <div class="dh-metrics">
+      <span class="dh-chip">Filter by show</span>
+      <span class="dh-chip">CC BY-SA 4.0</span>
+    </div>
+    <span class="dh-go">Browse gallery →</span>
+  </a>
+</div>
+
+<p class="dh-note">
+  Sources: launch data from <a href="https://thespacedevs.com/" target="_blank" rel="noopener" style="color:#9b8cff;">The Space Devs</a> Launch Library 2, active-satellite counts from <a href="https://celestrak.org/" target="_blank" rel="noopener" style="color:#9b8cff;">CelesTrak</a>, and market quotes from Yahoo Finance — each refreshed on every pipeline run, with the last good value kept on a fetch hiccup. Estimated figures (mass to orbit, satellites deployed) use public per-vehicle averages and are labelled as estimates. Nothing here is financial advice.
+</p>
+{% endblock %}

--- a/tests/test_tesla_dashboard.py
+++ b/tests/test_tesla_dashboard.py
@@ -138,6 +138,24 @@ class TestMitPerformanceCharts:
             assert needle in t, needle
 
 
+class TestDataHubPage:
+    def test_generator_and_links(self):
+        import generate_html as g
+        g.generate_data_hub_page(dry_run=True)  # smoke, no exception
+        t = (_ROOT / "templates/data_hub.html.j2").read_text(encoding="utf-8")
+        for href in ("spacex-dashboard.html", "tesla-dashboard.html",
+                     "modern-investing-performance.html", "gallery.html"):
+            assert href in t, href
+
+    def test_wired_into_build_and_sitemap_and_footer(self):
+        gh = (_ROOT / "generate_html.py").read_text(encoding="utf-8")
+        # rendered in both --all and --network, and listed in the sitemap
+        assert gh.count("generate_data_hub_page(dry_run=args.dry_run)") >= 2
+        assert '"data.html"' in gh
+        base = (_ROOT / "templates/base.html.j2").read_text(encoding="utf-8")
+        assert "data.html" in base  # footer discovery link on every page
+
+
 class TestWatchLinksAndRangeBar:
     def test_spacex_dashboard_has_watch_links(self):
         t = (_ROOT / "templates/spacex_dashboard.html.j2").read_text(encoding="utf-8")


### PR DESCRIPTION
## Data & Dashboards hub

The four public data surfaces (SpaceX launch dashboard, Tesla dashboard, Modern Investing performance, image gallery) were each reachable only from their own show pages — there was no single place to discover them. This adds a network **`/data.html`** hub.

- **New hub page** with one card per dashboard (accent-colored, hover-lifted), each summarizing what's inside (live countdown, booster records, Starship tracker / quarterly P&D, Supercharger growth / equity curve, monthly P&L) plus a sources/disclaimer note. Static — the linked dashboards still read their own same-origin caches client-side.
- **Discovery wiring**: rendered in both `--all` and `--network` regen, added to the sitemap, and a **"Data & Dashboards" footer link on every page** (EN + RU labels).
- Render-verified **0 overflow at 390px and 1240px**.

`ruff` clean; full suite **2864 passing** (+2 new drift guards). Pure web/discovery work — no audio path.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_