### PR TITLE
SpaceX launches-by-site breakdown + dashboard hub back-links

### DIFF
--- a/api/spacex_launches.json
+++ b/api/spacex_launches.json
@@ -459,6 +459,24 @@
     "starlink_launches_ytd": 56,
     "avg_days_between_last_365d": 2.2
   },
+  "pads": [
+    {
+      "site": "Vandenberg SLC-4E",
+      "count": 75
+    },
+    {
+      "site": "Cape Canaveral SLC-40",
+      "count": 74
+    },
+    {
+      "site": "Kennedy LC-39A",
+      "count": 14
+    },
+    {
+      "site": "Starbase, TX",
+      "count": 3
+    }
+  ],
   "fleet": {
     "window_days": 365,
     "by_vehicle": {
@@ -604,5 +622,5 @@
   },
   "total_launches": 689,
   "source": "thespacedevs_ll2",
-  "updated_at": "2026-06-13T23:33:38.391470+00:00"
+  "updated_at": "2026-06-14T00:01:50.395332+00:00"
 }

--- a/modern-investing-performance.html
+++ b/modern-investing-performance.html
@@ -786,6 +786,7 @@
   <div style="margin-top: var(--sp-8); font-size:0.85rem; color:var(--nn-text-muted); border-top:1px solid var(--nn-border); padding-top:var(--sp-4);">
     This page and the learning system behind it are part of our commitment to radical transparency in AI-assisted investing education.
     All data comes from the same tracker the podcast uses every day.
+    Explore every dashboard at the <a href="data.html" style="color:var(--show-color,#10b981);">Nerra data hub</a>.
   </div>
 
 </div>
@@ -916,6 +917,7 @@
                 <a href="ai-disclosure.html">AI Disclosure</a>
                 <a href="editorial.html">Editorial Process</a>
                 <a href="gallery.html">Image Gallery</a>
+                <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->

--- a/scripts/fetch_spacex_launches.py
+++ b/scripts/fetch_spacex_launches.py
@@ -227,6 +227,46 @@ def _stats(previous: List[Dict[str, Any]], now: _dt.datetime) -> Dict[str, Any]:
     }
 
 
+# Friendly short labels for the four active SpaceX pads (LL2 names are long).
+_PAD_LABELS = (
+    ("39", "Kennedy LC-39A"),
+    ("40", "Cape Canaveral SLC-40"),
+    ("4e", "Vandenberg SLC-4E"),
+    ("4 e", "Vandenberg SLC-4E"),
+    ("orbital launch", "Starbase, TX"),
+    ("starbase", "Starbase, TX"),
+)
+
+
+def _pad_label(pad: Optional[str], location: Optional[str]) -> str:
+    p = (pad or "").lower()
+    for needle, label in _PAD_LABELS:
+        if needle in p:
+            return label
+    # Fall back to the raw pad name, or the location, or a generic label.
+    return pad or location or "Other"
+
+
+def _pad_breakdown(previous: List[Dict[str, Any]], now: _dt.datetime) -> List[Dict[str, Any]]:
+    """Launch counts by pad over the last 365 days — real, from the LL2
+    detailed records (not estimated). Powers the 'Launches by site' chart."""
+    def _parse(net: Optional[str]) -> Optional[_dt.datetime]:
+        try:
+            return _dt.datetime.fromisoformat((net or "").replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            return None
+
+    counts: Dict[str, int] = {}
+    for r in previous:
+        d = _parse(r.get("net"))
+        if not d or (now - d).days > 365:
+            continue
+        label = _pad_label(r.get("pad"), r.get("location"))
+        counts[label] = counts.get(label, 0) + 1
+    return [{"site": k, "count": v}
+            for k, v in sorted(counts.items(), key=lambda kv: kv[1], reverse=True)]
+
+
 # Representative payload-to-orbit per vehicle/mission, in tonnes. Used ONLY
 # for the clearly-labelled "estimated mass to orbit" headline — SpaceX
 # doesn't publish per-flight mass, so these are conservative public
@@ -486,6 +526,7 @@ def build_payload() -> Optional[Dict[str, Any]]:
         "mass_monthly": [{"month": b["month"], "tonnes": b["mass_t"]} for b in monthly],
         "sats_cumulative_monthly": cumulative_series,
         "stats": _stats(slim_prev, now),
+        "pads": _pad_breakdown(slim_prev, now),
         "fleet": fleet,
         "starship": _starship_flights(),
         "annual_launches": _annual_launches(),

--- a/spacex-dashboard.html
+++ b/spacex-dashboard.html
@@ -643,6 +643,14 @@
 
   <div class="spx-grid" style="grid-template-columns:minmax(0,1fr);">
     <div class="spx-panel">
+      <h2>Launches by site <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(last 12 months)</span></h2>
+      <div id="spxPads"></div>
+      <p class="spx-disclaimer">Where SpaceX flew over the past year, from the launch record — the West Coast (Vandenberg) and Florida (Cape Canaveral SLC-40, Kennedy LC-39A) pads plus Starbase, TX for Starship.</p>
+    </div>
+  </div>
+
+  <div class="spx-grid" style="grid-template-columns:minmax(0,1fr);">
+    <div class="spx-panel">
       <h2>Mass to orbit — last 12 months <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(estimated, tonnes)</span></h2>
       <div class="spx-cadence" id="spxMass"></div>
       <div class="spx-stats" style="margin-top:1.2rem;">
@@ -719,7 +727,7 @@
   </div>
 
   <p class="spx-foot-note">
-    Launch data from <a href="https://thespacedevs.com/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">The Space Devs</a> Launch Library 2 (updated each pipeline run). Times are “no earlier than” and slip often — always confirm against the official <a href="https://www.spacex.com/launches/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">SpaceX launch schedule</a> and webcast. Full source links live on the <a href="spacex.html#resources" style="color:var(--spx-cyan);">SpaceX Daily resources</a> page.
+    Launch data from <a href="https://thespacedevs.com/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">The Space Devs</a> Launch Library 2 (updated each pipeline run). Times are “no earlier than” and slip often — always confirm against the official <a href="https://www.spacex.com/launches/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">SpaceX launch schedule</a> and webcast. Full source links live on the <a href="spacex.html#resources" style="color:var(--spx-cyan);">SpaceX Daily resources</a> page. Explore every dashboard at the <a href="data.html" style="color:var(--spx-cyan);">Nerra data hub</a>.
   </p>
 </div>
 
@@ -849,6 +857,7 @@
                 <a href="ai-disclosure.html">AI Disclosure</a>
                 <a href="editorial.html">Editorial Process</a>
                 <a href="gallery.html">Image Gallery</a>
+                <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->
@@ -988,6 +997,21 @@
       return '<div class="spx-bar-wrap"><div class="spx-bar" style="height:0" data-h="'+h+'"><span class="cnt">'+v.toLocaleString()+'</span></div><div class="spx-bar-label">'+lab+'</div></div>';
     }).join('');
     requestAnimationFrame(()=>{ wrap.querySelectorAll('.spx-bar').forEach(b=>{ b.style.height=b.dataset.h+'px'; }); });
+  }
+
+  function renderPads(pads){
+    var list = pads||[];
+    var wrap = document.getElementById('spxPads');
+    if(!wrap || !list.length) return;
+    var max = Math.max(1, ...list.map(function(x){ return x.count||0; }));
+    wrap.innerHTML = list.map(function(x){
+      var pct = 100*(x.count||0)/max;
+      return '<div style="display:flex;align-items:center;gap:10px;margin:7px 0;">'+
+        '<span style="width:160px;flex:0 0 160px;color:#cfe0ff;font-size:0.86rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">'+x.site+'</span>'+
+        '<span style="flex:1;min-width:0;height:16px;border-radius:8px;background:rgba(255,255,255,0.06);overflow:hidden;"><span style="display:block;height:100%;width:0;background:linear-gradient(90deg,var(--spx-cyan),var(--spx-blue));transition:width .7s cubic-bezier(.2,.7,.2,1);" data-w="'+pct+'"></span></span>'+
+        '<span style="width:34px;text-align:right;font-weight:700;font-variant-numeric:tabular-nums;">'+x.count+'</span></div>';
+    }).join('');
+    requestAnimationFrame(function(){ wrap.querySelectorAll('span[data-w]').forEach(function(b){ b.style.width=b.dataset.w+'%'; }); });
   }
 
   function renderAnnual(al){
@@ -1220,6 +1244,7 @@
     renderStats(data.stats, data.total_launches);
     renderCadence(data.cadence_monthly);
     renderAnnual(data.annual_launches);
+    renderPads(data.pads);
     renderBars('spxMass', data.mass_monthly, 'tonnes');
     renderArea(data.sats_cumulative_monthly);
     renderFleet(data.fleet);

--- a/templates/mit_performance_page.html.j2
+++ b/templates/mit_performance_page.html.j2
@@ -292,6 +292,7 @@
   <div style="margin-top: var(--sp-8); font-size:0.85rem; color:var(--nn-text-muted); border-top:1px solid var(--nn-border); padding-top:var(--sp-4);">
     This page and the learning system behind it are part of our commitment to radical transparency in AI-assisted investing education.
     All data comes from the same tracker the podcast uses every day.
+    Explore every dashboard at the <a href="{{ path_prefix }}data.html" style="color:var(--show-color,#10b981);">Nerra data hub</a>.
   </div>
 
 </div>

--- a/templates/spacex_dashboard.html.j2
+++ b/templates/spacex_dashboard.html.j2
@@ -225,6 +225,14 @@
 
   <div class="spx-grid" style="grid-template-columns:minmax(0,1fr);">
     <div class="spx-panel">
+      <h2>Launches by site <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(last 12 months)</span></h2>
+      <div id="spxPads"></div>
+      <p class="spx-disclaimer">Where SpaceX flew over the past year, from the launch record — the West Coast (Vandenberg) and Florida (Cape Canaveral SLC-40, Kennedy LC-39A) pads plus Starbase, TX for Starship.</p>
+    </div>
+  </div>
+
+  <div class="spx-grid" style="grid-template-columns:minmax(0,1fr);">
+    <div class="spx-panel">
       <h2>Mass to orbit — last 12 months <span class="spx-muted" style="font-size:0.7rem;font-weight:400;">(estimated, tonnes)</span></h2>
       <div class="spx-cadence" id="spxMass"></div>
       <div class="spx-stats" style="margin-top:1.2rem;">
@@ -301,7 +309,7 @@
   </div>
 
   <p class="spx-foot-note">
-    Launch data from <a href="https://thespacedevs.com/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">The Space Devs</a> Launch Library 2 (updated each pipeline run). Times are “no earlier than” and slip often — always confirm against the official <a href="https://www.spacex.com/launches/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">SpaceX launch schedule</a> and webcast. Full source links live on the <a href="{{ path_prefix }}spacex.html#resources" style="color:var(--spx-cyan);">SpaceX Daily resources</a> page.
+    Launch data from <a href="https://thespacedevs.com/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">The Space Devs</a> Launch Library 2 (updated each pipeline run). Times are “no earlier than” and slip often — always confirm against the official <a href="https://www.spacex.com/launches/" target="_blank" rel="noopener" style="color:var(--spx-cyan);">SpaceX launch schedule</a> and webcast. Full source links live on the <a href="{{ path_prefix }}spacex.html#resources" style="color:var(--spx-cyan);">SpaceX Daily resources</a> page. Explore every dashboard at the <a href="{{ path_prefix }}data.html" style="color:var(--spx-cyan);">Nerra data hub</a>.
   </p>
 </div>
 {% endblock %}
@@ -379,6 +387,21 @@
       return '<div class="spx-bar-wrap"><div class="spx-bar" style="height:0" data-h="'+h+'"><span class="cnt">'+v.toLocaleString()+'</span></div><div class="spx-bar-label">'+lab+'</div></div>';
     }).join('');
     requestAnimationFrame(()=>{ wrap.querySelectorAll('.spx-bar').forEach(b=>{ b.style.height=b.dataset.h+'px'; }); });
+  }
+
+  function renderPads(pads){
+    var list = pads||[];
+    var wrap = document.getElementById('spxPads');
+    if(!wrap || !list.length) return;
+    var max = Math.max(1, ...list.map(function(x){ return x.count||0; }));
+    wrap.innerHTML = list.map(function(x){
+      var pct = 100*(x.count||0)/max;
+      return '<div style="display:flex;align-items:center;gap:10px;margin:7px 0;">'+
+        '<span style="width:160px;flex:0 0 160px;color:#cfe0ff;font-size:0.86rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">'+x.site+'</span>'+
+        '<span style="flex:1;min-width:0;height:16px;border-radius:8px;background:rgba(255,255,255,0.06);overflow:hidden;"><span style="display:block;height:100%;width:0;background:linear-gradient(90deg,var(--spx-cyan),var(--spx-blue));transition:width .7s cubic-bezier(.2,.7,.2,1);" data-w="'+pct+'"></span></span>'+
+        '<span style="width:34px;text-align:right;font-weight:700;font-variant-numeric:tabular-nums;">'+x.count+'</span></div>';
+    }).join('');
+    requestAnimationFrame(function(){ wrap.querySelectorAll('span[data-w]').forEach(function(b){ b.style.width=b.dataset.w+'%'; }); });
   }
 
   function renderAnnual(al){
@@ -611,6 +634,7 @@
     renderStats(data.stats, data.total_launches);
     renderCadence(data.cadence_monthly);
     renderAnnual(data.annual_launches);
+    renderPads(data.pads);
     renderBars('spxMass', data.mass_monthly, 'tonnes');
     renderArea(data.sats_cumulative_monthly);
     renderFleet(data.fleet);

--- a/templates/tesla_dashboard.html.j2
+++ b/templates/tesla_dashboard.html.j2
@@ -178,7 +178,7 @@
   </div>
 
   <p class="tsl-foot-note">
-    Live TSLA data via Yahoo Finance (refreshed each run). Operating metrics are from Tesla's published reports and operator-maintained. This is the data companion to <a href="{{ path_prefix }}tesla.html" style="color:var(--tsl-glow);">Tesla Shorts Time</a> — full resources on the <a href="{{ path_prefix }}tesla.html#resources" style="color:var(--tsl-glow);">show page</a>. Nothing here is financial advice.
+    Live TSLA data via Yahoo Finance (refreshed each run). Operating metrics are from Tesla's published reports and operator-maintained. This is the data companion to <a href="{{ path_prefix }}tesla.html" style="color:var(--tsl-glow);">Tesla Shorts Time</a> — full resources on the <a href="{{ path_prefix }}tesla.html#resources" style="color:var(--tsl-glow);">show page</a>. Explore every dashboard at the <a href="{{ path_prefix }}data.html" style="color:var(--tsl-glow);">Nerra data hub</a>. Nothing here is financial advice.
   </p>
 </div>
 {% endblock %}

--- a/tesla-dashboard.html
+++ b/tesla-dashboard.html
@@ -693,7 +693,7 @@
   </div>
 
   <p class="tsl-foot-note">
-    Live TSLA data via Yahoo Finance (refreshed each run). Operating metrics are from Tesla's published reports and operator-maintained. This is the data companion to <a href="tesla.html" style="color:var(--tsl-glow);">Tesla Shorts Time</a> — full resources on the <a href="tesla.html#resources" style="color:var(--tsl-glow);">show page</a>. Nothing here is financial advice.
+    Live TSLA data via Yahoo Finance (refreshed each run). Operating metrics are from Tesla's published reports and operator-maintained. This is the data companion to <a href="tesla.html" style="color:var(--tsl-glow);">Tesla Shorts Time</a> — full resources on the <a href="tesla.html#resources" style="color:var(--tsl-glow);">show page</a>. Explore every dashboard at the <a href="data.html" style="color:var(--tsl-glow);">Nerra data hub</a>. Nothing here is financial advice.
   </p>
 </div>
 
@@ -823,6 +823,7 @@
                 <a href="ai-disclosure.html">AI Disclosure</a>
                 <a href="editorial.html">Editorial Process</a>
                 <a href="gallery.html">Image Gallery</a>
+                <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->

--- a/tests/test_tesla_dashboard.py
+++ b/tests/test_tesla_dashboard.py
@@ -138,6 +138,56 @@ class TestMitPerformanceCharts:
             assert needle in t, needle
 
 
+class TestPadBreakdown:
+    def _mod(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "fetch_spacex_launches", _ROOT / "scripts" / "fetch_spacex_launches.py")
+        m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+        return m
+
+    def test_pad_label_friendly_names(self):
+        m = self._mod()
+        assert m._pad_label("Space Launch Complex 40", "Cape Canaveral SFS") == "Cape Canaveral SLC-40"
+        assert m._pad_label("Launch Complex 39A", "Kennedy Space Center") == "Kennedy LC-39A"
+        assert m._pad_label("Space Launch Complex 4E", "Vandenberg SFB") == "Vandenberg SLC-4E"
+        assert m._pad_label("Orbital Launch Mount A", "SpaceX Starbase") == "Starbase, TX"
+        # Unknown pad falls back to its raw name, never crashes.
+        assert m._pad_label(None, "Somewhere") == "Somewhere"
+
+    def test_pad_breakdown_counts_and_sorts(self):
+        import datetime as dt
+        m = self._mod()
+        now = dt.datetime(2026, 6, 14, tzinfo=dt.timezone.utc)
+        prev = [
+            {"net": "2026-06-01T00:00:00Z", "pad": "Space Launch Complex 40", "location": "Cape"},
+            {"net": "2026-05-01T00:00:00Z", "pad": "Space Launch Complex 40", "location": "Cape"},
+            {"net": "2026-04-01T00:00:00Z", "pad": "Space Launch Complex 4E", "location": "Vandenberg"},
+            {"net": "2020-01-01T00:00:00Z", "pad": "Launch Complex 39A", "location": "KSC"},  # >365d, excluded
+        ]
+        out = m._pad_breakdown(prev, now)
+        assert out[0] == {"site": "Cape Canaveral SLC-40", "count": 2}  # most, sorted first
+        sites = {r["site"]: r["count"] for r in out}
+        assert sites.get("Vandenberg SLC-4E") == 1
+        assert "Kennedy LC-39A" not in sites  # outside the 365d window
+
+    def test_dashboard_renders_pads_and_hub_link(self):
+        m = self._mod()
+        import inspect
+        assert '"pads": _pad_breakdown(slim_prev, now)' in inspect.getsource(m.build_payload)
+        t = (_ROOT / "templates/spacex_dashboard.html.j2").read_text(encoding="utf-8")
+        assert 'id="spxPads"' in t and "renderPads" in t and "data.pads" in t
+        assert 'data.html' in t  # back-link to the hub
+
+
+class TestDashboardHubBackLinks:
+    def test_each_dashboard_links_to_hub(self):
+        for tpl in ("spacex_dashboard.html.j2", "tesla_dashboard.html.j2",
+                    "mit_performance_page.html.j2"):
+            t = (_ROOT / "templates" / tpl).read_text(encoding="utf-8")
+            assert "data.html" in t, tpl
+
+
 class TestDataHubPage:
     def test_generator_and_links(self):
         import generate_html as g


### PR DESCRIPTION
## SpaceX "launches by site" + dashboard hub back-links

### Launches by site (real data)
- `_pad_breakdown` counts SpaceX launches by pad over the last 365 days straight from the LL2 detailed records — **real data, not estimated**. `_pad_label` maps LL2's long pad names to friendly labels (Vandenberg SLC-4E, Cape Canaveral SLC-40, Kennedy LC-39A, Starbase TX), with a safe fallback for anything unknown.
- New "Launches by site" horizontal-bar panel on the SpaceX dashboard. Live this run: Vandenberg 75, Cape Canaveral SLC-40 74, Kennedy LC-39A 14, Starbase 3 — a nice read on SpaceX's bicoastal cadence.

### Hub back-links
Now that the `/data.html` hub exists, each dashboard (SpaceX, Tesla, MIT performance) links back to it from its footer note — bidirectional discovery so visitors can hop between dashboards.

Render-verified **0 overflow at 390px and 1240px**. `ruff` clean; **70 tests passing** in `tests/test_tesla_dashboard.py` (+5 new). Pure dashboard/data work — no audio path.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_