### PR TITLE
SpaceX dashboard: Starlink share of all active satellites + metrics lock fix

### DIFF
--- a/api/spacex_launches.json
+++ b/api/spacex_launches.json
@@ -492,7 +492,8 @@
     "days_since_last_failure": null,
     "estimated": true,
     "cumulative_satellites_est": 2714,
-    "starlink_active": 10544,
+    "starlink_active": 10546,
+    "total_active_satellites": 15699,
     "boosters": {
       "fleet_leaders": [
         {
@@ -622,5 +623,5 @@
   },
   "total_launches": 689,
   "source": "thespacedevs_ll2",
-  "updated_at": "2026-06-14T00:01:50.395332+00:00"
+  "updated_at": "2026-06-14T00:13:37.589689+00:00"
 }

--- a/scripts/fetch_spacex_launches.py
+++ b/scripts/fetch_spacex_launches.py
@@ -47,25 +47,42 @@ def _get(url: str) -> Optional[Dict[str, Any]]:
         return None
 
 
-_CELESTRAK_STARLINK = (
-    "https://celestrak.org/NORAD/elements/gp.php?GROUP=starlink&FORMAT=json"
+# One CelesTrak download (1/2h rate limit) of the full active-payload
+# catalogue gives BOTH the total active-satellite population and the
+# Starlink subset — so we fetch GROUP=active once and derive both, instead
+# of two rate-limited calls.
+_CELESTRAK_ACTIVE = (
+    "https://celestrak.org/NORAD/elements/gp.php?GROUP=active&FORMAT=json"
 )
 
 
-def _starlink_active_count() -> Optional[int]:
-    """Real count of active Starlink satellites on orbit, from CelesTrak's
-    free catalogue (one download / 2h update). Best-effort: returns None on
-    any failure so the dashboard falls back to the estimate."""
+def _satellite_counts() -> Dict[str, Optional[int]]:
+    """Real active-satellite counts from CelesTrak's free catalogue (one
+    download / 2h update): total active payloads + the Starlink subset.
+    Best-effort: returns Nones on any failure so the dashboard falls back."""
     try:
-        req = urllib.request.Request(_CELESTRAK_STARLINK, headers=_UA)
+        req = urllib.request.Request(_CELESTRAK_ACTIVE, headers=_UA)
         with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
             data = json.load(resp)
-        n = len(data) if isinstance(data, list) else 0
-        # Sanity band — the constellation is ~6k-30k this era; reject junk.
-        return n if 1000 <= n <= 60000 else None
+        if not isinstance(data, list):
+            return {"total": None, "starlink": None}
+        total = len(data)
+        starlink = sum(
+            1 for s in data
+            if isinstance(s, dict) and str(s.get("OBJECT_NAME", "")).upper().startswith("STARLINK")
+        )
+        # Sanity bands — total active payloads ~8k-50k this era; Starlink ~1k-60k.
+        total_ok = total if 5000 <= total <= 100000 else None
+        starlink_ok = starlink if 1000 <= starlink <= 60000 else None
+        return {"total": total_ok, "starlink": starlink_ok}
     except Exception as exc:
-        logger.info("CelesTrak Starlink count failed (non-fatal): %s", exc)
-        return None
+        logger.info("CelesTrak active-satellite fetch failed (non-fatal): %s", exc)
+        return {"total": None, "starlink": None}
+
+
+def _starlink_active_count() -> Optional[int]:
+    """Back-compat thin wrapper — the Starlink subset of the active catalogue."""
+    return _satellite_counts().get("starlink")
 
 
 def _slim_launch(r: Dict[str, Any]) -> Dict[str, Any]:
@@ -313,6 +330,14 @@ def _update_metrics_timeseries(monthly: List[Dict[str, Any]], now: _dt.datetime,
     months: Dict[str, Any] = existing.get("months") or {}
     for b in monthly:
         # Refresh the last-12 window each run; older months stay locked.
+        # Guard: as the date advances, the oldest month in the breakdown ages
+        # out of the LL2 detailed window and comes back with 0 launches. Never
+        # let that zero overwrite a previously-locked, non-zero month — that
+        # would corrupt the accumulated history (it did, for 2025-07).
+        prev_month = months.get(b["month"])
+        if (b.get("launches", 0) == 0 and isinstance(prev_month, dict)
+                and prev_month.get("launches", 0) > 0):
+            continue
         months[b["month"]] = {
             "launches": b["launches"],
             "mass_t": b["mass_t"],
@@ -515,7 +540,9 @@ def build_payload() -> Optional[Dict[str, Any]]:
     cumulative_sats, cumulative_series = _update_metrics_timeseries(monthly, now)
     fleet = _fleet_payload(slim_prev, now)
     fleet["cumulative_satellites_est"] = cumulative_sats
-    fleet["starlink_active"] = _starlink_active_count()  # real count, or None
+    sat_counts = _satellite_counts()  # one CelesTrak call → both numbers
+    fleet["starlink_active"] = sat_counts.get("starlink")  # real count, or None
+    fleet["total_active_satellites"] = sat_counts.get("total")  # real, or None
     fleet["boosters"] = _booster_stats(prev_results)  # reuse record watch
     return {
         "next": next_launch,
@@ -553,15 +580,16 @@ def main() -> int:
         logger.error("Launch fetch empty and no existing cache to keep.")
         return 0  # non-fatal: dashboard shows a friendly empty state
 
-    # Keep last-good for the live Starlink count: CelesTrak rate-limits (1 dl /
-    # 2h), so a transient None must not wipe a previously-fetched real number.
-    if (payload.get("fleet") or {}).get("starlink_active") is None and out_path.exists():
+    # Keep last-good for the live CelesTrak counts: it rate-limits (1 dl / 2h),
+    # so a transient None must not wipe previously-fetched real numbers.
+    if out_path.exists():
         try:
             prev = json.loads(out_path.read_text(encoding="utf-8"))
-            last = (prev.get("fleet") or {}).get("starlink_active")
-            if last:
-                payload["fleet"]["starlink_active"] = last
-                logger.info("Kept last-good Starlink count: %s", last)
+            prev_fleet = prev.get("fleet") or {}
+            for key in ("starlink_active", "total_active_satellites"):
+                if (payload.get("fleet") or {}).get(key) is None and prev_fleet.get(key):
+                    payload["fleet"][key] = prev_fleet[key]
+                    logger.info("Kept last-good %s: %s", key, prev_fleet[key])
         except Exception:
             pass
 

--- a/spacex-dashboard.html
+++ b/spacex-dashboard.html
@@ -655,9 +655,11 @@
       <div class="spx-cadence" id="spxMass"></div>
       <div class="spx-stats" style="margin-top:1.2rem;">
         <div class="spx-stat"><div class="n" id="flStarlinkActive">—</div><div class="l">Active Starlink satellites (live)</div></div>
+        <div class="spx-stat"><div class="n" id="flActiveSats">—</div><div class="l">All active satellites (live)</div></div>
+        <div class="spx-stat"><div class="n" id="flStarlinkOfActive">—</div><div class="l">Starlink % of all active sats</div></div>
         <div class="spx-stat"><div class="n" id="flMass">—</div><div class="l">Est. mass to orbit, 12 mo (t)</div></div>
         <div class="spx-stat"><div class="n" id="flSats">—</div><div class="l">Est. satellites deployed, 12 mo</div></div>
-        <div class="spx-stat"><div class="n" id="flStarShare">—</div><div class="l">Starlink share</div></div>
+        <div class="spx-stat"><div class="n" id="flStarShare">—</div><div class="l">Starlink launch share</div></div>
         <div class="spx-stat"><div class="n" id="flSuccess">—</div><div class="l">Success rate</div></div>
       </div>
       <div id="flVehicles" style="margin-top:1rem;"></div>
@@ -1167,6 +1169,11 @@
     // cumulative estimate if the live count is unavailable).
     if(f.starlink_active!=null) countUp('flStarlinkActive', f.starlink_active);
     else if(f.cumulative_satellites_est!=null) countUp('flStarlinkActive', f.cumulative_satellites_est);
+    // Real total active-satellite population + Starlink's share of it (CelesTrak).
+    if(f.total_active_satellites!=null) countUp('flActiveSats', f.total_active_satellites);
+    if(f.total_active_satellites>0 && f.starlink_active!=null){
+      set('flStarlinkOfActive', Math.round(100*f.starlink_active/f.total_active_satellites)+'%');
+    }
     countUp('flMass', f.est_mass_to_orbit_tonnes);
     countUp('flSats', f.est_satellites_deployed);
     set('flStarShare', f.starlink_share_pct!=null ? f.starlink_share_pct+'%' : '—');

--- a/templates/spacex_dashboard.html.j2
+++ b/templates/spacex_dashboard.html.j2
@@ -237,9 +237,11 @@
       <div class="spx-cadence" id="spxMass"></div>
       <div class="spx-stats" style="margin-top:1.2rem;">
         <div class="spx-stat"><div class="n" id="flStarlinkActive">—</div><div class="l">Active Starlink satellites (live)</div></div>
+        <div class="spx-stat"><div class="n" id="flActiveSats">—</div><div class="l">All active satellites (live)</div></div>
+        <div class="spx-stat"><div class="n" id="flStarlinkOfActive">—</div><div class="l">Starlink % of all active sats</div></div>
         <div class="spx-stat"><div class="n" id="flMass">—</div><div class="l">Est. mass to orbit, 12 mo (t)</div></div>
         <div class="spx-stat"><div class="n" id="flSats">—</div><div class="l">Est. satellites deployed, 12 mo</div></div>
-        <div class="spx-stat"><div class="n" id="flStarShare">—</div><div class="l">Starlink share</div></div>
+        <div class="spx-stat"><div class="n" id="flStarShare">—</div><div class="l">Starlink launch share</div></div>
         <div class="spx-stat"><div class="n" id="flSuccess">—</div><div class="l">Success rate</div></div>
       </div>
       <div id="flVehicles" style="margin-top:1rem;"></div>
@@ -557,6 +559,11 @@
     // cumulative estimate if the live count is unavailable).
     if(f.starlink_active!=null) countUp('flStarlinkActive', f.starlink_active);
     else if(f.cumulative_satellites_est!=null) countUp('flStarlinkActive', f.cumulative_satellites_est);
+    // Real total active-satellite population + Starlink's share of it (CelesTrak).
+    if(f.total_active_satellites!=null) countUp('flActiveSats', f.total_active_satellites);
+    if(f.total_active_satellites>0 && f.starlink_active!=null){
+      set('flStarlinkOfActive', Math.round(100*f.starlink_active/f.total_active_satellites)+'%');
+    }
     countUp('flMass', f.est_mass_to_orbit_tonnes);
     countUp('flSats', f.est_satellites_deployed);
     set('flStarShare', f.starlink_share_pct!=null ? f.starlink_share_pct+'%' : '—');

--- a/tests/test_tesla_dashboard.py
+++ b/tests/test_tesla_dashboard.py
@@ -102,6 +102,62 @@ class TestSpacexStarlinkCount:
         dash = (_ROOT / "templates/spacex_dashboard.html.j2").read_text(encoding="utf-8")
         assert "flStarlinkActive" in dash and "Active Starlink" in dash
 
+    def test_satellite_counts_single_fetch_derives_both(self, monkeypatch):
+        m = self._mod()
+        # One catalogue download yields total + the Starlink subset.
+        fake = [{"OBJECT_NAME": "STARLINK-1"}, {"OBJECT_NAME": "STARLINK-2"},
+                {"OBJECT_NAME": "ISS (ZARYA)"}, {"OBJECT_NAME": "ONEWEB-9"}] * 2000
+        import io, json as _json
+
+        class _Resp(io.BytesIO):
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+        monkeypatch.setattr(m.urllib.request, "urlopen",
+                            lambda *a, **k: _Resp(_json.dumps(fake).encode()))
+        c = m._satellite_counts()
+        assert c["total"] == 8000 and c["starlink"] == 4000
+        assert m._starlink_active_count() == 4000  # back-compat wrapper
+
+    def test_satellite_counts_rejects_junk(self, monkeypatch):
+        m = self._mod()
+        import io, json as _json
+
+        class _Resp(io.BytesIO):
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+        monkeypatch.setattr(m.urllib.request, "urlopen",
+                            lambda *a, **k: _Resp(_json.dumps([]).encode()))
+        c = m._satellite_counts()  # empty list → below sanity band
+        assert c["total"] is None and c["starlink"] is None
+
+    def test_aged_out_month_does_not_overwrite_locked_value(self, tmp_path):
+        # As the date advances the oldest month ages out of the LL2 window and
+        # returns 0 launches — that zero must NOT clobber a locked non-zero month.
+        m = self._mod()
+        import json as _json, datetime as dt
+        p = tmp_path / "spacex_metrics.json"
+        p.write_text(_json.dumps({"months": {"2025-07": {
+            "launches": 13, "mass_t": 181, "satellites": 184, "vehicles": {"Falcon 9": 13}}}}))
+        # New breakdown reports 2025-07 with 0 (aged out) + a fresh real month.
+        monthly = [
+            {"month": "2025-07", "launches": 0, "mass_t": 0, "satellites": 0, "vehicles": {}},
+            {"month": "2026-06", "launches": 6, "mass_t": 90, "satellites": 130, "vehicles": {"Falcon 9": 6}},
+        ]
+        m._update_metrics_timeseries(monthly, dt.datetime(2026, 6, 14, tzinfo=dt.timezone.utc), path=p)
+        saved = _json.loads(p.read_text())["months"]
+        assert saved["2025-07"]["launches"] == 13  # locked value preserved
+        assert saved["2026-06"]["launches"] == 6   # fresh month written
+
+    def test_dashboard_shows_active_satellite_share(self):
+        dash = (_ROOT / "templates/spacex_dashboard.html.j2").read_text(encoding="utf-8")
+        assert "flActiveSats" in dash and "flStarlinkOfActive" in dash
+        assert "total_active_satellites" in dash
+        # build_payload sets the new field + keep-last-good covers it.
+        m = self._mod()
+        import inspect
+        assert 'fleet["total_active_satellites"]' in inspect.getsource(m.build_payload)
+        assert "total_active_satellites" in inspect.getsource(m.main)
+
 
 class TestMitPerformanceCharts:
     def test_chart_data_is_finite_safe(self):
@@ -299,8 +355,9 @@ class TestStarshipTracker:
         m = self._mod()
         import inspect
         src = inspect.getsource(m.main)
-        assert 'starlink_active") is None' in src
-        assert "Kept last-good Starlink count" in src
+        # keep-last-good loop covers both CelesTrak-derived counts
+        assert '"starlink_active"' in src and "is None" in src
+        assert "Kept last-good" in src
 
     def test_dashboard_has_starship_panel(self):
         t = (_ROOT / "templates/spacex_dashboard.html.j2").read_text(encoding="utf-8")


### PR DESCRIPTION
## SpaceX: Starlink share of all active satellites + a data-integrity fix

### Starlink % of all active satellites (fully sourced)
Rather than a "share of global mass to orbit" stat I couldn't source precisely, this ships a striking number I *can* fully ground in real data: Starlink's share of every active satellite on orbit.
- Fetches the **full CelesTrak active catalogue once** and derives *both* the total active-satellite population and the Starlink subset from that single download — **halving** the rate-limited CelesTrak calls vs. two `GROUP` fetches.
- New dashboard tiles: **"All active satellites (live)"** and **"Starlink % of all active sats"**. Live this run: **10,546 of 15,699 = 67%**. The pre-existing launch-share tile was relabeled "Starlink launch share" to disambiguate.
- Keep-last-good extended to `total_active_satellites` (landmine #22).

### Data-integrity fix (caught while building this)
`_update_metrics_timeseries` was overwriting **locked historical months with zeros** as they aged out of the LL2 detailed fetch window — it had silently corrupted `2025-07` (13 launches → 0). The refresh now refuses to let a zero-launch (aged-out) month clobber a previously-locked non-zero month. This would have bitten the committed dataset on the nightly run regardless of this PR. Drift guard added.

Render-verified **0 overflow at 390px and 1240px**. `ruff` clean; **31 tests passing** in the dashboard suite (+4 new). Pure dashboard/data work — no audio path.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_