### PR TITLE
Weekly recap: transparent sourcing + deeper, less formulaic episodes

### DIFF
--- a/engine/weekly_recap.py
+++ b/engine/weekly_recap.py
@@ -40,32 +40,75 @@ _PRICE_HDR_RE = re.compile(
 )
 
 
-def _sanitize_recap_body(text: str) -> str:
-    """Strip source-link / stock-price residue from a per-episode recap body.
+# Matches a properly-attributed source citation: ``Source: [label](url)`` or
+# a bare ``Source: https://…``. The published blog/summary/RSS all render these
+# as real links, so the weekly recap must PRESERVE them (transparent sourcing),
+# not strip them — the June-2026 strip was the cause of the unsourced Sunday blog.
+_SOURCE_CITE_RE = re.compile(
+    r"Source:\s*(?:\[([^\]]+)\]\((https?://[^)\s]+)\)|(https?://[^)\s]+))",
+    re.IGNORECASE,
+)
 
-    The recap scaffold feeds both the podcast LLM and (historically) the
-    published digest, so any raw HTML anchor, markdown link, "Read more"
-    line, or "REAL-TIME TSLA price:" header that rode along from the source
-    digest showed up as garbage. Markdown links collapse to their visible
-    text; tags / bare URLs / source + price lines are removed outright.
+
+def _sanitize_recap_body(text: str, keep_links: bool = True) -> str:
+    """Clean a per-episode recap body of residue that reads badly aloud while
+    PRESERVING proper markdown source citations so the blog/summary stay sourced.
+
+    The recap scaffold feeds the podcast LLM, the blog, and the summary/RSS. Raw
+    HTML anchors, "Read more" lines, stock-price headers, and bare URLs read as
+    garbage and are removed. Markdown links (``[label](url)``) are kept by
+    default so the published surfaces render clickable sources — the spoken
+    script omits them because the host framing instructs the LLM not to read
+    URLs aloud (same contract as a daily digest). Pass ``keep_links=False`` for
+    plain-text contexts (e.g. a story title line).
     """
     if not text:
         return text
-    text = _MD_LINK_RE.sub(r"\1", text)      # [Google News](url) -> Google News
+    # Protect markdown links from the bare-URL strip (their URLs would match).
+    stash: dict[str, str] = {}
+
+    def _hide(m):
+        key = f"\0L{len(stash)}\0"
+        stash[key] = m.group(0)
+        return key
+
+    if keep_links:
+        text = _MD_LINK_RE.sub(_hide, text)
+    else:
+        text = _MD_LINK_RE.sub(r"\1", text)  # [Google News](url) -> Google News
     text = _HTML_TAG_RE.sub("", text)        # drop <a ...>, </a>, etc.
     text = _READ_MORE_RE.sub("", text)       # drop "Read more (sources): ..."
     text = _PRICE_HDR_RE.sub("", text)       # drop "REAL-TIME TSLA price:" lines
     text = _BARE_URL_RE.sub("", text)        # drop any leftover bare URLs
+    for key, val in stash.items():           # restore protected markdown links
+        text = text.replace(key, val)
     # Collapse the blank lines the removals leave behind.
     text = re.sub(r"\n{3,}", "\n\n", text)
     text = re.sub(r"[ \t]{2,}", " ", text)
     return text.strip()
 
 
+def _extract_sources(digest_md: str) -> list[tuple[str, str]]:
+    """Pull every ``Source:`` citation from an episode digest as (label, url)
+    pairs (label falls back to the publisher domain for bare-URL citations)."""
+    out: list[tuple[str, str]] = []
+    for m in _SOURCE_CITE_RE.finditer(digest_md or ""):
+        label, url_md, url_bare = m.group(1), m.group(2), m.group(3)
+        url = url_md or url_bare
+        if not url:
+            continue
+        if not label:
+            # Derive a readable label from the domain for bare-URL citations.
+            label = re.sub(r"^www\.", "", url.split("//", 1)[-1].split("/", 1)[0])
+        out.append((label.strip(), url.strip()))
+    return out
+
+
 def build_weekly_recap_digest(
     show_slug: str,
     show_name: str,
     week_ending: date,
+    articles: Optional[list] = None,
 ) -> Optional[str]:
     """Build a digest-shaped markdown summary of the past 7 days for
     *show_slug*. Returns ``None`` if the content lake has fewer than
@@ -108,34 +151,41 @@ def build_weekly_recap_digest(
         key=lambda ep: (ep.get("date") or "", ep.get("episode_num") or 0),
     )
 
-    # Headline: the most recent hook is usually the freshest, but
-    # listeners benefit from a recap-flavoured one-liner that signals
-    # this isn't a normal daily.
-    week_label = f"{start_date} to {end_date}"
+    # Headline: a recap-flavoured one-liner that signals this isn't a normal
+    # daily WITHOUT reciting the date range (operator feedback: the formulaic
+    # "from <start> to <end>" open reads like a database query, not a digest).
+    # The podcast prompt turns this hook into the spoken opener, so it stays
+    # intuitive and theme-forward.
     title = f"# {show_name} — Weekly Recap"
     hook = (
-        f"**HOOK:** Looking back at {len(episodes)} episodes from "
-        f"{week_label} — the stories that mattered, what we learned, "
-        f"and what to watch next."
+        "**HOOK:** The week's biggest developments, pulled together — "
+        "what actually moved, why it matters, and what to watch next."
     )
 
-    # Each episode contributes a "Top Story" entry. We use the
-    # episode's own hook + the first paragraph of its digest_md so
-    # the LLM sees coherent prose, not a bag of bullet points.
+    # Each episode contributes a "Top Story" entry AND its source citations.
+    # We collect every source across the week so the published recap (blog +
+    # summary + RSS) is fully, transparently sourced — the daily contract.
     items: list[str] = []
+    sources: list[tuple[str, str]] = []
+    seen_urls: set[str] = set()
     for idx, ep in enumerate(episodes, start=1):
         ep_num = ep.get("episode_num") or "?"
         ep_date = ep.get("date") or ""
         ep_hook = (ep.get("hook") or "").strip()
         digest_md = (ep.get("digest_md") or "").strip()
 
-        # Pull the first 2 substantive paragraphs of the canonical
-        # digest as the body — caps each entry around ~1000 chars
-        # so the synthesised digest stays under the LLM context
-        # window even with a full 7-episode week.
+        # Harvest sources from the FULL digest (not just the trimmed body) so
+        # the week's Sources section is comprehensive even when prose is cut.
+        for label, url in _extract_sources(digest_md):
+            if url not in seen_urls:
+                seen_urls.add(url)
+                sources.append((label, url))
+
+        # Pull the first 3 substantive paragraphs of the canonical digest as
+        # the body — more than before so the host has material for a genuine
+        # deep dive, capped ~1500 chars to stay within the LLM context window
+        # across a full 7-episode week. Source citations are PRESERVED.
         paragraphs = [p.strip() for p in digest_md.split("\n\n") if p.strip()]
-        # Skip leading metadata paragraphs (title heading, **HOOK:**
-        # label, **Date:** line, TSLA price line) that aren't prose.
         body_paragraphs: list[str] = []
         for p in paragraphs:
             if (
@@ -146,51 +196,105 @@ def build_weekly_recap_digest(
             ):
                 continue
             body_paragraphs.append(p)
-            if len(body_paragraphs) >= 2:
+            if len(body_paragraphs) >= 3:
                 break
-        body = _sanitize_recap_body("\n\n".join(body_paragraphs))[:1000]
+        body = _sanitize_recap_body("\n\n".join(body_paragraphs))[:1500]
 
-        title_line = _sanitize_recap_body(ep_hook) or f"Episode {ep_num}"
+        title_line = _sanitize_recap_body(ep_hook, keep_links=False) or f"Episode {ep_num}"
         items.append(
             f"{idx}. **From Ep {ep_num} ({ep_date}): {title_line}**\n"
             f"   {body}"
         )
 
-    recap = "\n\n".join([
+    # NEW: fresh developments. On Sunday the pipeline still fetches the day's
+    # news (the recap just normally ignores it). Surfacing the freshest,
+    # not-yet-covered items lets the weekly episode break genuinely new ground
+    # instead of only rehashing — each carried with its source link.
+    fresh_items: list[str] = []
+    for art in (articles or [])[:6]:
+        if not isinstance(art, dict):
+            continue
+        a_title = (art.get("title") or "").strip()
+        a_url = (art.get("url") or art.get("link") or "").strip()
+        if not a_title:
+            continue
+        a_src = (art.get("source") or "").strip()
+        if a_url and a_url not in seen_urls:
+            seen_urls.add(a_url)
+            label = a_src or re.sub(r"^www\.", "", a_url.split("//", 1)[-1].split("/", 1)[0])
+            sources.append((label, a_url))
+        cite = f" Source: [{a_src or 'link'}]({a_url})" if a_url else ""
+        fresh_items.append(f"- {a_title}{cite}")
+
+    # The published "Sources" section — every citation, deduplicated. This is
+    # what guarantees the recap blog/summary is sourced as transparently as a
+    # daily episode (the bug this fix closes).
+    sources_block = ""
+    if sources:
+        lines = [f"- [{label}]({url})" for label, url in sources]
+        sources_block = "## Sources\n" + "\n".join(lines)
+
+    parts: list[str] = [
         title,
         hook,
         "━━━━━━━━━━━━━━━━━━━━",
         "### This Week's Top Stories",
         *items,
+    ]
+    if fresh_items:
+        parts += [
+            "━━━━━━━━━━━━━━━━━━━━",
+            "### Fresh this week (not yet covered)",
+            "\n".join(fresh_items),
+        ]
+    parts += [
         "━━━━━━━━━━━━━━━━━━━━",
         "## Recap framing for the host",
         (
             "This is a Sunday weekly recap — a 'where we are now' episode, "
-            "NOT a list of news items. Weave the stories above into one "
-            "coherent narrative built on these four beats:\n\n"
-            "1. CONTINUITY — situate each major thread in its ongoing arc so "
-            "a returning listener feels the through-line. Use natural "
-            "'where we are now' language: 'since we last covered...', 'the "
-            "ongoing story of...', 'an update on...', 'where the story "
-            "stands now'. Group related threads rather than walking episode "
-            "by episode.\n"
-            "2. STAKES — for each major thread, say plainly WHY THIS MATTERS: "
-            "'what this means for' owners / investors / fans, and the "
-            "practical consequence. Don't just report that something "
-            "happened; explain why a listener should care.\n"
-            "3. SPECIFICS — keep the concrete numbers from the week (prices, "
-            "percentages, counts, dates). Specific figures are what make a "
-            "recap credible and memorable.\n"
-            "4. FORWARD LOOK — close by calling out the single most "
-            "consequential development of the week, then an explicit "
-            "'what to watch for next week' beat and the biggest open "
-            "question heading into next week, and finish with one practical "
+            "NOT a flat list of news items, and NOT a database-style readout. "
+            "Open INTUITIVELY: lead with the single most important theme or "
+            "development of the week in a natural, conversational hook — do "
+            "NOT open by reciting the calendar date range ('from June 8th to "
+            "June 14th'). Then weave the stories into one coherent narrative "
+            "built on these beats:\n\n"
+            "1. GO DEEP ON THE BIGGEST EVENTS — identify the 2-3 single most "
+            "consequential developments of the week and give each a genuine "
+            "deep-dive segment: the full context, the mechanism, the "
+            "competing interpretations, and the second-order implications. "
+            "Do not treat every story equally — the biggest events earn real "
+            "airtime; minor items get a sentence or a quick round-up.\n"
+            "2. CONTINUITY — situate each major thread in its ongoing arc so a "
+            "returning listener feels the through-line. Use natural language: "
+            "'since we last covered...', 'the ongoing story of...', 'where "
+            "the story stands now'. Group related threads rather than walking "
+            "episode by episode.\n"
+            "3. NEW GROUND — if a 'Fresh this week' section is present above, "
+            "work those genuinely new developments into the narrative so the "
+            "recap advances the story rather than only looking backward. "
+            "Attribute them to their sources; never invent details beyond "
+            "what the source supports.\n"
+            "4. STAKES — for each major thread, say plainly WHY THIS MATTERS "
+            "for the listener and the practical consequence. Don't just "
+            "report that something happened; explain why they should care.\n"
+            "5. SPECIFICS — keep the concrete numbers from the week (prices, "
+            "percentages, counts). Specific figures make a recap credible.\n"
+            "6. FORWARD LOOK — close by naming the single most consequential "
+            "development, an explicit 'what to watch for next week' beat, the "
+            "biggest open question heading into next week, and one practical "
             "takeaway listeners can use.\n\n"
+            "SOURCING: the stories above carry their source citations and a "
+            "Sources list follows — these exist for the written blog/show "
+            "notes and must stay accurate, but NEVER read URLs or 'Source: ...' "
+            "links aloud in the spoken script. Reference outlets by name in "
+            "speech where natural ('according to NASA', 'Ars Technica reported').\n\n"
             "Keep the same voice and pacing as a daily episode, and give the "
-            "week the depth it deserves — this is a full-length episode, not "
-            "a quick skim."
+            "week the depth it deserves — this is a full-length episode, not a "
+            "quick skim."
         ),
-    ])
+    ]
+
+    recap = "\n\n".join(parts)
 
     # TST-specific enhancement: inject narrative memory framing when available.
     # This is intentionally best-effort (the narrative tracker lives in the
@@ -241,5 +345,13 @@ def build_weekly_recap_digest(
                 "Narrative injection into weekly recap failed for %s "
                 "(recap ships without it): %s", show_slug, exc,
             )
+
+    # The Sources block is appended LAST (after host framing + narrative memory)
+    # so the runner can lift it verbatim onto the republished recap digest —
+    # the published blog/summary/RSS stay transparently sourced even though the
+    # spoken script (which becomes the rest of the published digest) carries no
+    # URLs. The "## Sources" marker is the agreed handoff between the two files.
+    if sources_block:
+        recap += "\n\n━━━━━━━━━━━━━━━━━━━━\n\n" + sources_block
 
     return recap

--- a/run_show.py
+++ b/run_show.py
@@ -1196,8 +1196,13 @@ def run(args: argparse.Namespace) -> None:
         if is_weekly_recap:
             logger.info("Sunday weekly-recap mode active for %s.", config.slug)
             from engine.weekly_recap import build_weekly_recap_digest
+            # Pass the freshly-fetched news so the recap can surface genuinely
+            # new, not-yet-covered developments (Sunday still fetches; the recap
+            # historically discarded it). Falls back to a pure look-back when
+            # the fetch was empty / topic-driven.
             x_thread = build_weekly_recap_digest(
                 config.slug, config.name, today,
+                articles=articles if not _topic_driven else None,
             )
             if not x_thread:
                 logger.warning(
@@ -2161,7 +2166,14 @@ def run(args: argparse.Namespace) -> None:
                     if _ln.startswith("# ") or _ln.startswith("**HOOK:"):
                         _hdr_lines.append(_ln)
                 _recap_header = "\n".join(_hdr_lines).strip() or f"# {config.name} — Weekly Recap"
-                x_thread = _recap_header + "\n\n" + podcast_script.strip()
+                # Carry the scaffold's "## Sources" block onto the published
+                # digest so the recap blog / summary / RSS stay transparently
+                # sourced (the spoken script the LLM wrote carries no URLs by
+                # design). The scaffold appends Sources as its final block.
+                _sources_tail = ""
+                if "## Sources" in x_thread:
+                    _sources_tail = "\n\n## Sources" + x_thread.split("## Sources", 1)[1].rstrip()
+                x_thread = _recap_header + "\n\n" + podcast_script.strip() + _sources_tail
                 try:
                     from engine.utils import strip_lone_surrogates as _scrub_sur
                     digest_md.write_text(_scrub_sur(x_thread), encoding="utf-8")

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -336,14 +336,18 @@ class TestWeeklyRecapHelper:
         # Continuity ('where we are now') cues.
         assert "where we are now" in low
         assert "since we last" in low
-        assert "update on" in low
+        assert "where the story stands now" in low
         # Stakes framing.
         assert "why this matters" in low
-        assert "what this means for" in low
         # Specifics + forward look.
         assert "numbers" in low
         assert "watch for next week" in low
         assert "open question" in low
+        # June 14 2026 improvements: go deep on the biggest events, open
+        # intuitively (not by reciting the date range), and never read URLs aloud.
+        assert "go deep on the biggest events" in low
+        assert "do not open by reciting the calendar date range" in low
+        assert "never read urls" in low
 
 
 def test_youtube_expansion_quota_shape():

--- a/tests/test_weekly_recap_sanitize.py
+++ b/tests/test_weekly_recap_sanitize.py
@@ -30,11 +30,30 @@ def test_drops_realtime_tsla_price_header():
     assert "Tesla launched a sunshade" in out
 
 
-def test_markdown_links_collapse_to_text():
-    src = "See [Google News](https://news.google.com/x) and [EVChargingStations.com](https://ev.com)."
+def test_markdown_links_preserved_by_default():
+    # June 14 2026: the recap must stay transparently sourced — proper markdown
+    # source citations are PRESERVED so the blog/summary render clickable links
+    # (the prior collapse-to-text was the cause of the unsourced Sunday blog).
+    src = "Detail. Source: [space.com](https://www.space.com/x)."
     out = _sanitize_recap_body(src)
+    assert "[space.com](https://www.space.com/x)" in out  # link intact
+
+
+def test_markdown_links_collapse_when_keep_links_false():
+    # Plain-text contexts (e.g. a story title line) still collapse links.
+    src = "See [Google News](https://news.google.com/x) and [EVChargingStations.com](https://ev.com)."
+    out = _sanitize_recap_body(src, keep_links=False)
     assert "](http" not in out and "https://" not in out
     assert "Google News" in out and "EVChargingStations.com" in out
+
+
+def test_bare_urls_dropped_but_markdown_link_urls_kept():
+    # A bare URL reads badly aloud and is dropped; a markdown-link URL is part
+    # of a citation and must survive (the bare-URL strip must not corrupt it).
+    src = "Body https://bare.example.com more. Source: [nasa.gov](https://nasa.gov/r)."
+    out = _sanitize_recap_body(src)
+    assert "https://bare.example.com" not in out
+    assert "[nasa.gov](https://nasa.gov/r)" in out
 
 
 def test_drops_read_more_sources_line():

--- a/tests/test_weekly_recap_validator_gate.py
+++ b/tests/test_weekly_recap_validator_gate.py
@@ -92,5 +92,82 @@ def test_recap_digest_has_recap_shape_not_daily():
     assert "— Weekly Recap" in out
     # Recap-shaped section — distinct from "Top 10 News Items".
     assert "This Week's Top Stories" in out
-    # Hook explicitly references the look-back framing.
-    assert "Looking back at" in out
+    # Hook is recap-flavoured but INTUITIVE — it must not recite the calendar
+    # date range (operator feedback June 14 2026: the old "Looking back at N
+    # episodes from <start> to <end>" read like a database query).
+    assert "Looking back at" not in out
+    assert "2026-05-04 to 2026-05-10" not in out
+    assert "**HOOK:**" in out and "biggest developments" in out
+
+
+def _build_sourced_recap():
+    """Helper: build a recap from episodes that carry inline source citations
+    plus a fresh-news article, mirroring the real daily-digest shape."""
+    from unittest.mock import patch
+    from datetime import date
+    from engine import weekly_recap
+
+    eps = [
+        {"episode_num": 98, "date": "2026-06-11", "hook": "Ancient quasar",
+         "digest_md": "# FF\n\n1. **Quasar**\n   Existed 12.9 Gyr ago. "
+                      "Source: [space.com](https://www.space.com/quasar)"},
+        {"episode_num": 99, "date": "2026-06-12", "hook": "Orbital data centers",
+         "digest_md": "# FF\n\n1. **Orbital DCs**\n   Bright moving sources. "
+                      "Source: [spacenews.com](https://spacenews.com/dc)"},
+    ]
+    arts = [{"title": "New exoplanet found", "url": "https://phys.org/exo",
+             "source": "phys.org"}]
+    with patch("engine.content_lake.query_show_range", return_value=eps):
+        return weekly_recap.build_weekly_recap_digest(
+            "fascinating_frontiers", "Fascinating Frontiers",
+            date(2026, 6, 14), articles=arts,
+        )
+
+
+def test_recap_preserves_source_links_and_sources_section():
+    """Transparent sourcing: the recap must keep markdown source citations and
+    emit a '## Sources' block (June 14 2026 — the unsourced Sunday-blog fix).
+    The prior behaviour collapsed links to dead text, so the blog/summary/RSS
+    rendered no clickable sources. This guard blocks that regression."""
+    out = _build_sourced_recap()
+    # Inline citations preserved (not collapsed to plain text).
+    assert "[space.com](https://www.space.com/quasar)" in out
+    assert "[spacenews.com](https://spacenews.com/dc)" in out
+    # A deduplicated Sources section exists as the final block.
+    assert "## Sources" in out
+    sources_block = out.split("## Sources", 1)[1]
+    assert "https://www.space.com/quasar" in sources_block
+    assert "https://spacenews.com/dc" in sources_block
+
+
+def test_recap_surfaces_fresh_news_with_sources():
+    """The weekly recap can break new ground: fresh, not-yet-covered news is
+    surfaced (with its source link) instead of only rehashing the week."""
+    out = _build_sourced_recap()
+    assert "Fresh this week" in out
+    assert "New exoplanet found" in out
+    assert "https://phys.org/exo" in out  # carried into the Sources block too
+
+
+def test_republished_recap_keeps_sources_without_scaffold_leak():
+    """Mirror run_show.py's recap republish: header + clean spoken script +
+    the scaffold's '## Sources' tail. The blog renders THIS, so the Sources
+    must survive while the host-framing / narrative-memory scaffold must not."""
+    scaffold = _build_sourced_recap()
+    assert "## Sources" in scaffold
+    sources_tail = "\n\n## Sources" + scaffold.split("## Sources", 1)[1].rstrip()
+    published = "# Fascinating Frontiers — Weekly Recap\n\nClean narration, no urls." + sources_tail
+    # Sources reach the published digest…
+    assert "[space.com](https://www.space.com/quasar)" in published
+    # …without leaking the host-only scaffold.
+    assert "Recap framing for the host" not in published
+    assert "GO DEEP ON THE BIGGEST EVENTS" not in published
+    assert "NARRATIVE MEMORY" not in published
+
+
+def test_run_show_republish_carries_sources_tail():
+    """Pin the run_show.py republish step that lifts the Sources block onto the
+    published recap digest — without it, the blog loses all source links."""
+    source = _RUN_SHOW.read_text(encoding="utf-8")
+    assert 'x_thread.split("## Sources", 1)' in source
+    assert "_sources_tail" in source


### PR DESCRIPTION
## Fixes the unsourced Sunday blog + improves weekly episodes

Operator caught today's Fascinating Frontiers (a Sunday weekly recap) blog shipping with **no source hyperlinks**, and flagged the weekly episodes as shallow/formulaic.

### Root cause of the missing links
Daily blogs are properly sourced — every item carries `Source: [name](url)`, which the blog renders as a link. But the **weekly recap** had two strips:
1. `_sanitize_recap_body` collapsed every markdown link to dead text (`[space.com](url)` → `space.com`).
2. `run_show.py` republishes the recap digest as **header + spoken podcast script** (which, by design, contains no URLs).

So the recap blog/summary/RSS rendered zero clickable sources.

### Sourcing fix (transparent sourcing, always)
- Source citations are now **preserved** through the sanitizer (bare URLs / HTML / "Read more" / price headers still stripped — and the bare-URL strip no longer corrupts markdown-link URLs).
- The recap **harvests every source across the week** into a deduplicated `## Sources` block.
- `run_show.py` lifts that block onto the republished digest, so the **spoken script stays URL-free while the blog/summary/RSS are fully sourced** — the same contract as a daily episode. Verified end-to-end: the blog renders the Sources as clickable links.

### Weekly-episode quality (operator feedback)
- **New news**: the recap now accepts the freshly-fetched articles (Sunday still fetches news; the recap previously discarded it) and surfaces a **"Fresh this week (not yet covered)"** section so the episode breaks new ground instead of only rehashing.
- **Deeper dives**: host framing now requires going **deep on the 2-3 biggest events** (context, mechanism, competing interpretations, second-order effects) rather than flat equal coverage; per-episode source material widened (2→3 paragraphs, 1000→1500 chars).
- **Less formulaic open**: dropped the `Looking back at N episodes from <start> to <end>` hook; framing now mandates an **intuitive, theme-led opener** and explicitly bans reciting the calendar date range. Added a "never read URLs aloud" rule.

### Tests
Updated the three guards that pinned the old behavior; added new guards: sources preserved + `## Sources` emitted, fresh-news surfaced, and the run_show republish carries the Sources block without leaking the host-only scaffold. `ruff` clean; full suite **2878 passing**.

⚠️ **A/B-listen note (landmine #17)**: this changes the weekly-recap *spoken* script (intro shape + depth). The Sources/blog changes are text-only, but the framing edits affect generated audio — A/B-listen the next Sunday recap before trusting the output change.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_