### PR TITLE
Source transparency: real Google News publishers + unique weekly recap titles

### DIFF
--- a/engine/fetcher.py
+++ b/engine/fetcher.py
@@ -174,6 +174,33 @@ def _get_source_name(feed_url: str, feed_title: str = "Unknown") -> str:
     return feed_title if feed_title != "Unknown" else "Unknown"
 
 
+def _publisher_from_entry(entry, title: str = "") -> Optional[str]:
+    """Recover the real publisher for a Google News aggregated item.
+
+    Google News RSS carries the original outlet in the per-item ``<source>``
+    element (feedparser → ``entry.source.title``) and appends it to the
+    headline as ``Headline - Publisher``. Surfacing it keeps sourcing
+    transparent — digests/blogs cite the actual outlet ("Space.com") instead
+    of the opaque "Google News" redirect, even when the redirect URL can't be
+    resolved from CI egress. Returns None when no reliable publisher is found.
+    """
+    src = entry.get("source") if hasattr(entry, "get") else None
+    if isinstance(src, dict):
+        t = (src.get("title") or "").strip()
+        if t:
+            return t
+    # Fallback: parse the trailing " - Publisher" Google News appends. Guard
+    # against grabbing a headline clause: publisher names are short and the
+    # split must leave a non-trivial headline in front.
+    title = title or (entry.get("title", "") if hasattr(entry, "get") else "")
+    if " - " in title:
+        head, _, cand = title.rpartition(" - ")
+        cand = cand.strip()
+        if cand and len(cand) <= 40 and len(head.strip()) >= 15:
+            return cand
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Date parsing
 # ---------------------------------------------------------------------------
@@ -292,6 +319,7 @@ def _fetch_single_feed(
             # network failure so we ship the redirect rather than
             # nothing.
             from engine.url_utils import (
+                is_google_news_url,
                 resolve_google_news_url,
                 sanitize_url,
             )
@@ -304,6 +332,19 @@ def _fetch_single_feed(
                 continue
             link = resolve_google_news_url(link_clean)
 
+            # Transparent sourcing: when this is a Google News item (the URL
+            # is still a redirect, or the feed itself is Google News), cite the
+            # real publisher rather than "Google News", and strip the
+            # "Headline - Publisher" suffix Google News appends to titles.
+            article_source = source_name
+            if is_google_news_url(link) or "google news" in source_name.lower():
+                publisher = _publisher_from_entry(entry, title)
+                if publisher:
+                    article_source = publisher
+                    suffix = f" - {publisher}"
+                    if title.endswith(suffix):
+                        title = title[: -len(suffix)].strip()
+
             # Keyword filtering (if keywords provided)
             if keywords:
                 text_lower = (title + " " + description).lower()
@@ -315,7 +356,7 @@ def _fetch_single_feed(
                     "title": title,
                     "description": description,
                     "url": link,
-                    "source_name": source_name,
+                    "source_name": article_source,
                     "published_date": (
                         published_time.isoformat()
                         if published_time

--- a/engine/weekly_recap.py
+++ b/engine/weekly_recap.py
@@ -156,7 +156,12 @@ def build_weekly_recap_digest(
     # "from <start> to <end>" open reads like a database query, not a digest).
     # The podcast prompt turns this hook into the spoken opener, so it stays
     # intuitive and theme-forward.
-    title = f"# {show_name} — Weekly Recap"
+    # The H1/blog title carries the week-ending date so each recap is a unique,
+    # archivable page (identical titles every week kill per-episode SEO). This
+    # is the WRITTEN title only — the spoken intro is driven by the hook +
+    # framing below and stays date-free/intuitive per operator feedback.
+    week_title_date = f"{week_ending.strftime('%B')} {week_ending.day}, {week_ending.year}"
+    title = f"# {show_name} — Weekly Recap (Week of {week_title_date})"
     hook = (
         "**HOOK:** The week's biggest developments, pulled together — "
         "what actually moved, why it matters, and what to watch next."

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -24,10 +24,33 @@ import pytest
 from engine.fetcher import (
     _get_source_name,
     _parse_entry_date,
+    _publisher_from_entry,
     _fetch_single_feed,
     fetch_rss_articles,
     _SOURCE_MAP,
 )
+
+
+class TestPublisherFromEntry:
+    """Transparent sourcing: recover the real outlet from a Google News item
+    so digests/blogs cite the publisher, not the opaque 'Google News' redirect
+    (June 14 2026)."""
+
+    def test_prefers_source_element(self):
+        entry = {"source": {"title": "Space.com", "href": "https://www.space.com"},
+                 "title": "A black hole at the dawn of time - Space.com"}
+        assert _publisher_from_entry(entry) == "Space.com"
+
+    def test_falls_back_to_title_suffix(self):
+        entry = {"title": "Japan's H3 rocket returns to flight successfully - Ars Technica"}
+        assert _publisher_from_entry(entry) == "Ars Technica"
+
+    def test_guards_against_headline_clause(self):
+        # Short head before the dash must NOT be mistaken for a headline.
+        assert _publisher_from_entry({"title": "AI - the future"}) is None
+
+    def test_none_when_no_publisher(self):
+        assert _publisher_from_entry({"title": "A plain headline with no dash"}) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_weekly_recap_validator_gate.py
+++ b/tests/test_weekly_recap_validator_gate.py
@@ -171,3 +171,27 @@ def test_run_show_republish_carries_sources_tail():
     source = _RUN_SHOW.read_text(encoding="utf-8")
     assert 'x_thread.split("## Sources", 1)' in source
     assert "_sources_tail" in source
+
+
+def test_recap_blog_title_is_unique_per_week():
+    """The recap H1/blog title must carry the week-ending date so each weekly
+    recap is a distinct, archivable page (identical titles every week kill
+    per-episode SEO). The spoken intro stays date-free — this is title-only."""
+    from unittest.mock import patch
+    from datetime import date
+    from engine import weekly_recap
+
+    eps = [
+        {"episode_num": 1, "date": "2026-06-12", "hook": "h",
+         "digest_md": "# X\n\nbody. Source: [a.com](https://a.com/x)"},
+        {"episode_num": 2, "date": "2026-06-13", "hook": "h2",
+         "digest_md": "# X\n\nbody2. Source: [b.com](https://b.com/y)"},
+    ]
+    with patch("engine.content_lake.query_show_range", return_value=eps):
+        a = weekly_recap.build_weekly_recap_digest("ff", "FF", date(2026, 6, 14))
+        b = weekly_recap.build_weekly_recap_digest("ff", "FF", date(2026, 6, 21))
+    line_a = a.splitlines()[0]
+    line_b = b.splitlines()[0]
+    assert line_a.startswith("# FF — Weekly Recap (Week of ")
+    assert "June 14, 2026" in line_a
+    assert line_a != line_b  # distinct week -> distinct title


### PR DESCRIPTION
Continuing improvements in the two areas from the last review: **source transparency** and **weekly episodes**.

## Source transparency — real Google News publishers
Some daily-digest items cite the opaque **"Google News"** label with a `news.google.com/rss/articles/CBMi…` redirect URL (e.g. FF Ep100 had two). `resolve_google_news_url` exists but is unreliable from CI egress (HEAD 405s), so those items keep the redirect.

The fetcher now recovers the **real outlet** for Google News items from:
1. the per-item `<source>` element (feedparser `entry.source.title`), and
2. the `Headline - Publisher` suffix Google News appends (with a length guard so a headline clause like "AI - the future" isn't mistaken for a publisher).

So digests/blogs cite **"Space.com" / "Ars Technica"** instead of "Google News" even when the redirect URL can't be resolved — and the redundant "- Publisher" suffix is stripped from the headline. The redirect link still works when clicked; this fixes the *label* that readers see.

## Weekly episodes — unique, archivable blog titles
After the last PR made the recap's spoken hook intuitive, every weekly recap shared one generic blog title. The recap H1/blog title now carries the week-ending date — **"… — Weekly Recap (Week of June 14, 2026)"** — so each week is a distinct, SEO-friendly archive page. This is the **written title only**; the spoken intro stays date-free/intuitive per your feedback.

## Tests
+5 drift guards (publisher recovery: source element / title suffix / headline-clause guard / none case; unique dated recap title). `ruff` clean; full suite **2883 passing**.

These are text/metadata changes — no audio path affected.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_