### PR TITLE
SpaceX takes MAB's YouTube slot (all-Grok imagery) + weekly recap recurring-threads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,8 +451,10 @@ The network-wide page is
 [`templates/gallery_page.html.j2`](templates/gallery_page.html.j2)
 rendered to `/gallery.html` by `generate_gallery_page()` in
 `generate_html.py`. Per-show galleries are embedded on each show page
-when `gallery_enabled` is true (today: any show with
-`youtube.enabled: true`, currently Tesla + MAB — see landmine #20).
+when `gallery_enabled` is true (any show with `youtube.enabled: true`
+AND `image_provider: grok`; as of June 14 2026 that's Tesla, SpaceX,
+Fascinating Frontiers, Modern Investing + the two RU shows — MAB's
+YouTube is paused so its gallery auto-hides — see landmine #20).
 Prompt visibility is a per-image **toggle** (hidden by default in the
 lightbox).
 
@@ -1505,7 +1507,8 @@ decision); everything else has a live status card.
     for in the coming weeks. Drift guards in `tests/test_schedule.py`
     pin: cron consistency, the 7 daily shows carrying the recap flag,
     alt-cadence shows NOT carrying it, and the YouTube quota cap
-    (only TST and MAB enabled — see also landmine #20).
+    (the EN full-format pair is Tesla + SpaceX as of June 14 2026,
+    MAB paused — see also landmine #20).
 
 20. **YouTube quota cap (May 2026; four-show expansion June 2026)** —
     the YouTube Data API quota is 10,000 units/day **per channel**;
@@ -1534,6 +1537,19 @@ decision); everything else has a live status card.
     `test_only_tst_and_mab_enable_youtube` pins the exact enabled set,
     `test_youtube_expansion_quota_shape` pins the 1-Short /
     Shorts-only / ru-channel shape so a partial revert fails CI.
+    - **June 14 2026 — SpaceX Daily swapped in for MAB.** SpaceX Daily
+      took MAB's EN-channel **full-format** slot (long-form + 1 Short);
+      MAB's `youtube.enabled` flipped to `false` (rest of its block
+      retained for a one-line re-enable). Same per-episode EN footprint,
+      so the 11,000/day paper-math and the expected preflight `::error::`
+      are unchanged. The EN full-format pair is now **Tesla + SpaceX**;
+      FF + MIT stay Shorts-only; RU shows unchanged. `YOUTUBE_ENABLED_SHOWS`
+      in `tests/test_schedule.py` updated accordingly. **All YouTube-enabled
+      shows now generate imagery with Grok Imagine** (FF/MIT/RU previously
+      inherited the `pexels` default → stock Shorts; now `image_provider:
+      grok` is pinned, guarded by `test_all_youtube_shows_use_grok_imagine`).
+      Operator one-time setup pending: create the SpaceX podcast playlist in
+      Studio + flag it (landmine #15); uploads publish without it (warned).
 
 21. **`min_articles_skip` is tuned per-show, not per-network (May 2026)**
     — `engine/config.py` defaults `min_articles_skip` to `3` (a show

--- a/engine/grok_imagine.py
+++ b/engine/grok_imagine.py
@@ -171,6 +171,14 @@ def build_image_prompts(
         if is_vertical
         else "wide cinematic 16:9 framing, photojournalism style"
     )
+    # Network-wide visual-quality cue (June 14 2026): a compact, tasteful set of
+    # modifiers so every generated image reads as a polished editorial photo
+    # rather than a flat stock render. Kept short so it sharpens look without
+    # overriding the subject/narrative the rest of the prompt carries.
+    quality_hint = (
+        "dramatic natural lighting, rich depth of field, sharp focus, "
+        "high detail, vivid color grading, professional editorial photography"
+    )
     # Operator caught: Grok Imagine renders any free-text "context" hint
     # as a banner / on-image text overlay. Telling it explicitly to
     # produce a clean image stops the headline appearing as a chyron
@@ -207,7 +215,7 @@ def build_image_prompts(
         q = (raw_query or "").strip()
         if not q:
             continue
-        parts = [q, descriptor, framing_hint, no_text_hint]
+        parts = [q, descriptor, framing_hint, quality_hint, no_text_hint]
         ctx = _context_for(len(prompts))
         if ctx:
             parts.append(f"depicting: {ctx}")
@@ -223,7 +231,7 @@ def build_image_prompts(
         q = (image_queries[idx] or "").strip()
         if not q:
             break
-        parts = [q, descriptor, framing_hint, no_text_hint, f"variant {len(prompts) + 1}"]
+        parts = [q, descriptor, framing_hint, quality_hint, no_text_hint, f"variant {len(prompts) + 1}"]
         ctx = _context_for(len(prompts))
         if ctx:
             parts.append(f"depicting: {ctx}")

--- a/engine/weekly_recap.py
+++ b/engine/weekly_recap.py
@@ -151,6 +151,20 @@ def build_weekly_recap_digest(
         key=lambda ep: (ep.get("date") or "", ep.get("episode_num") or 0),
     )
 
+    # Deterministic "biggest events" signal: an entity covered on multiple days
+    # is, by definition, the week's most consequential ongoing thread. Counting
+    # per-episode recurrence (from the content lake's stored entities) gives the
+    # host concrete grounding for the deep-dive beats instead of leaving "what
+    # was biggest" entirely to LLM judgment.
+    from collections import Counter
+    _ent_days: Counter = Counter()
+    for ep in episodes:
+        ents = ep.get("entities") or []
+        if isinstance(ents, list):
+            for ent in {str(e).strip() for e in ents if str(e).strip()}:
+                _ent_days[ent] += 1
+    recurring_threads = [ent for ent, n in _ent_days.most_common() if n >= 2][:5]
+
     # Headline: a recap-flavoured one-liner that signals this isn't a normal
     # daily WITHOUT reciting the date range (operator feedback: the formulaic
     # "from <start> to <end>" open reads like a database query, not a digest).
@@ -252,9 +266,14 @@ def build_weekly_recap_digest(
             "### Fresh this week (not yet covered)",
             "\n".join(fresh_items),
         ]
-    parts += [
-        "━━━━━━━━━━━━━━━━━━━━",
-        "## Recap framing for the host",
+    framing_parts = ["━━━━━━━━━━━━━━━━━━━━", "## Recap framing for the host"]
+    if recurring_threads:
+        framing_parts.append(
+            "BIGGEST RECURRING THREADS THIS WEEK (each appeared across 2+ "
+            "episodes — these are the strongest candidates for your deep-dive "
+            "segments): " + ", ".join(recurring_threads) + "."
+        )
+    parts += framing_parts + [
         (
             "This is a Sunday weekly recap — a 'where we are now' episode, "
             "NOT a flat list of news items, and NOT a database-style readout. "

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -325,6 +325,12 @@ youtube:
     - aurora borealis
     - cosmic stars
   image_query_prefix: ""
+  # June 14 2026 — Grok Imagine for the Shorts imagery (was inheriting the
+  # pexels default, so Shorts shipped stock photos). Unique, narrative-tied
+  # space/science visuals + feeds the gallery pipeline.
+  image_provider: grok
+  grok_image_model: grok-imagine-image
+  grok_image_descriptor: "cinematic, awe-inspiring space and science photo, dramatic lighting, ultra-detailed"
   tags:
     - space
     - astronomy

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -304,6 +304,11 @@ youtube:
     - bank meeting
     - retirement planning
   image_query_prefix: ""
+  # June 14 2026 — Grok Imagine for all imagery (was inheriting the pexels
+  # default). Unique, narrative-tied finance visuals on @NerraRU.
+  image_provider: grok
+  grok_image_model: grok-imagine-image
+  grok_image_descriptor: "cinematic, polished personal-finance lifestyle photo, dramatic lighting, ultra-detailed"
   tags:
     - финансы
     - инвестиции

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -252,7 +252,11 @@ slow_news:
 
 youtube:
   podcast_playlist_id: PLRHMnzNNXPYBFcirj6Ivq6PxZealY8fAp
-  enabled: true                 # Phase-1 rollout show (replaces models_agents)
+  # June 14 2026 — YouTube PAUSED for MAB: SpaceX Daily takes this EN-channel
+  # slot (full format: long-form + 1 Short) until the @NerraNetwork quota
+  # increase lands. The rest of this block is retained so re-enabling MAB is a
+  # one-line `enabled: true` flip. See shows/spacex.yaml + landmine #20.
+  enabled: false
   channel: en
   category_id: 27               # Education (beginner / teen-focused)
   default_language: en

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -311,6 +311,12 @@ youtube:
     - federal reserve building
     - bull and bear market
   image_query_prefix: ""
+  # June 14 2026 — Grok Imagine for the Shorts imagery (was inheriting the
+  # pexels default, so Shorts shipped stock photos). Unique, narrative-tied
+  # markets/finance visuals + feeds the gallery pipeline.
+  image_provider: grok
+  grok_image_model: grok-imagine-image
+  grok_image_descriptor: "cinematic, polished financial-news photo, dramatic lighting, ultra-detailed"
   tags:
     - investing
     - canadian investing

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -253,6 +253,11 @@ youtube:
     - student studying language
     - saint petersburg
   image_query_prefix: ""
+  # June 14 2026 — Grok Imagine for all imagery (was inheriting the pexels
+  # default). Unique, narrative-tied language-learning visuals on @NerraRU.
+  image_provider: grok
+  grok_image_model: grok-imagine-image
+  grok_image_descriptor: "cinematic, warm language-learning lifestyle photo, dramatic lighting, ultra-detailed"
   tags:
     - learn russian
     - russian for beginners

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -236,14 +236,55 @@ content_tracking:
   section_patterns: {}
 
 youtube:
-  enabled: false
+  # OPERATOR SETUP (one-time, landmine #15): create the SpaceX Daily podcast
+  # playlist in YouTube Studio on @NerraNetwork and paste its PL... id here,
+  # then flag it as a podcast. Until set, uploads still publish — they just
+  # won't appear in the Podcasts surface (a non-fatal warning logs).
+  # podcast_playlist_id: PL...
+  # June 14 2026 — SpaceX Daily takes MAB's EN-channel YouTube slot (full
+  # format: long-form + 1 Short) until the @NerraNetwork quota increase lands.
+  # Mirrors the Tesla block; same per-episode footprint MAB had, so the EN
+  # channel quota math (landmine #20) is unchanged by the swap.
+  enabled: true
   channel: en
-  category_id: 28
+  category_id: 28               # Science & Technology
+  default_language: en
   privacy_status: public
+  # Auto-pick the Shorts start at the most engaging beat (numeric reveal,
+  # "the kicker is…" framing, surprise hook) instead of the legacy voice-intro
+  # start. Falls back to voice mode when the heuristic can't find a winner.
+  shorts_start_mode: smart
+  shorts_per_episode: 1         # 1 Short/episode while the quota increase is pending
+  short_duration_seconds: 40    # 30-45 s Shorts sweet spot for completion rate
+  # SpaceX stories are narrative/measured like Tesla's; lower the smart-selector
+  # floor from the 5.0 default so good-but-not-perfect beats still win over the
+  # boilerplate voice-intro start. See engine/shorts_selector.py.
+  shorts_min_score_threshold: 3.5
+  # Grok Imagine for all imagery (long-form slideshow + Shorts) — unique,
+  # narrative-tied spaceflight visuals and feeds the gallery pipeline. ~$0.32/
+  # episode (8 imgs × 2 formats × $0.02 standard model).
+  image_provider: grok
+  grok_image_model: grok-imagine-image
+  grok_image_descriptor: "cinematic, high-energy spaceflight photo, dramatic lighting, ultra-detailed"
+  # Curated, disambiguated subjects spanning the whole SpaceX business so the
+  # slideshow matches the day's narrative (rockets, Starship, Raptor, launch
+  # sites, Starlink, crewed flight). Per-scene narrative context + the episode
+  # hook are layered on top at prompt-build time.
   image_queries:
-    - spacex rocket launch
-    - starship rocket
-    - falcon 9 landing
-    - rocket engine test
+    - Falcon 9 rocket night launch
+    - Starship on the launch pad
+    - Super Heavy booster tower catch
+    - Raptor engine static fire
+    - Starlink satellites deploying in orbit
+    - Dragon capsule docking with space station
+    - rocket booster landing on droneship
   image_query_prefix: ""
-  image_provider: pexels
+  tags:
+    - spacex
+    - starship
+    - falcon 9
+    - spaceflight
+    - rocket launch
+    - starlink
+    - spacex news
+    - space podcast

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -796,32 +796,31 @@ class TestYouTubeImageProviderConfig:
         cfg = load_config(SHOWS_DIR / "tesla.yaml")
         assert cfg.youtube.image_provider == "grok"
 
-    def test_mab_yaml_uses_grok_image_provider(self):
-        """MAB ran on ``pexels`` for the May 2026 A/B test against
-        Tesla on Grok Imagine; operator concluded the A/B was
-        inconclusive AND the Phase 1 gallery uploader is wired only
-        into the Grok Imagine code path (Pexels images never reach
-        the gallery R2 bucket). MAB flipped back to ``grok`` so the
-        per-show gallery embed on the MAB show page actually has
-        images to render. Cost: ~$0.16/episode added (8 images ×
-        $0.02 standard model). Flip the YAML AND this assertion in
-        the same commit if the show ever moves back to Pexels."""
-        cfg = load_config(SHOWS_DIR / "models_agents_beginners.yaml")
-        assert cfg.youtube.image_provider == "grok"
+    def test_youtube_enabled_shows_use_grok_image_provider(self):
+        """Operator directive (June 14 2026): every YouTube-enabled show
+        generates imagery with Grok Imagine — unique, narrative-tied visuals
+        that also feed the gallery pipeline (Pexels images never reach the
+        gallery R2 bucket). MAB keeps ``grok`` in its YAML even while its
+        YouTube is paused, so re-enabling it stays a one-line flip."""
+        for slug in ("tesla", "spacex", "fascinating_frontiers",
+                     "modern_investing", "finansy_prosto", "privet_russian"):
+            cfg = load_config(SHOWS_DIR / f"{slug}.yaml")
+            assert cfg.youtube.image_provider == "grok", (
+                f"{slug} is YouTube-enabled but not on Grok Imagine"
+            )
 
-    def test_other_shows_remain_on_pexels(self):
-        """Every other show (the 9 that aren't YouTube-enabled today,
-        plus any future YouTube-enabled show) must stay on Pexels
-        until the operator explicitly flips them. Pexels is free;
-        Grok costs $0.32/episode."""
-        for slug in ("omni_view", "fascinating_frontiers", "planetterrian",
-                     "env_intel", "models_agents", "modern_investing",
-                     "finansy_prosto", "privet_russian",
-                     "unintended_consequences"):
+    def test_non_youtube_shows_remain_on_pexels(self):
+        """Shows that don't publish to YouTube stay on the free Pexels
+        default — image generation only runs for YouTube-enabled shows, so
+        this just guards against accidental drift / surprise Grok cost if one
+        is later enabled without a deliberate provider choice."""
+        for slug in ("omni_view", "planetterrian", "env_intel",
+                     "models_agents", "unintended_consequences",
+                     "first_principles"):
             cfg = load_config(SHOWS_DIR / f"{slug}.yaml")
             assert cfg.youtube.image_provider == "pexels", (
                 f"{slug} drifted off pexels — would silently incur Grok "
-                f"Imagine cost"
+                f"Imagine cost if YouTube is enabled"
             )
 
 

--- a/tests/test_gallery_render.py
+++ b/tests/test_gallery_render.py
@@ -176,25 +176,28 @@ def test_gallery_enabled_requires_grok_image_provider():
         f"Tesla expected on grok provider, got {tesla_provider!r}"
     assert tesla_enabled, "Tesla should have gallery_enabled=True"
 
+    # June 14 2026 — SpaceX Daily took MAB's YouTube slot (full format on Grok),
+    # so SpaceX is now the gallery-enabled show and MAB's gallery auto-hides
+    # (YouTube paused). SpaceX keeps Grok imagery so its gallery embed populates.
+    spacex_yt = _read_show_youtube("spacex")
+    spacex_provider = _read_show_image_provider("spacex")
+    spacex_enabled = (
+        bool(spacex_yt.get("youtube_enabled"))
+        and spacex_provider in ("grok", "hybrid")
+    )
+    assert spacex_provider == "grok", \
+        f"SpaceX expected on grok provider, got {spacex_provider!r}"
+    assert spacex_enabled is True, "SpaceX gallery_enabled must be True"
+
+    # MAB's YouTube is paused — its gallery must auto-hide (no uploads → empty
+    # embed otherwise). The image_provider stays 'grok' in the YAML so
+    # re-enabling MAB later is a one-line flip that restores the gallery.
     mab_yt = _read_show_youtube("models_agents_beginners")
-    mab_provider = _read_show_image_provider("models_agents_beginners")
     mab_enabled = (
         bool(mab_yt.get("youtube_enabled"))
-        and mab_provider in ("grok", "hybrid")
+        and _read_show_image_provider("models_agents_beginners") in ("grok", "hybrid")
     )
-    # MAB was flipped to ``grok`` after the May 2026 A/B vs Tesla;
-    # Pexels images don't flow into the gallery bucket so MAB on
-    # Pexels would have rendered an empty gallery embed forever.
-    # If MAB ever moves back to Pexels, flip this assertion AND the
-    # YAML in the same commit (the section will auto-hide either
-    # way thanks to the provider gate added in PR #412).
-    assert mab_provider in ("grok", "hybrid"), (
-        f"MAB expected on grok / hybrid, got {mab_provider!r}. If "
-        "you intentionally moved MAB back to Pexels, flip this "
-        "assertion to expect 'pexels' and the gallery section will "
-        "auto-hide on the MAB show page."
-    )
-    assert mab_enabled is True, "MAB gallery_enabled must be True"
+    assert mab_enabled is False, "MAB gallery must auto-hide while YouTube is paused"
 
 
 def test_read_show_image_provider_defaults_to_pexels_for_unknown_show():

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -197,8 +197,11 @@ def test_daily_narrative_show_runs_daily_without_recap(slug):
 # Investing launched Shorts-only (publish_long_form: false) on
 # @NerraNetwork while the quota-increase request is pending; both Russian
 # shows launched full-format on @NerraRU, which has its own 10k/day quota.
+# June 14 2026: SpaceX Daily took MAB's EN-channel full-format slot (long-form
+# + 1 Short); MAB YouTube paused. Same EN per-episode footprint, so the quota
+# math is unchanged by the swap.
 YOUTUBE_ENABLED_SHOWS = {
-    "tesla", "models_agents_beginners",
+    "tesla", "spacex",
     "fascinating_frontiers", "modern_investing",
     "finansy_prosto", "privet_russian",
 }
@@ -363,11 +366,16 @@ def test_youtube_expansion_quota_shape():
             encoding="utf-8")) or {}
         return cfg.get("youtube") or {}
 
-    for slug in ("tesla", "models_agents_beginners"):
+    for slug in ("tesla", "spacex"):
         assert int(yt(slug).get("shorts_per_episode", 1)) == 1, (
             f"{slug} must stay at 1 Short/episode until the quota "
             f"increase is granted"
         )
+    # MAB YouTube is paused (SpaceX took its slot) — re-enabling it without
+    # freeing a slot would overrun the EN channel.
+    assert yt("models_agents_beginners").get("enabled") is False, (
+        "MAB YouTube must stay paused while SpaceX holds the EN-channel slot"
+    )
     for slug in ("fascinating_frontiers", "modern_investing"):
         assert yt(slug).get("publish_long_form") is False, (
             f"{slug} launched Shorts-only; long-form flips on only after "
@@ -378,3 +386,22 @@ def test_youtube_expansion_quota_shape():
             f"{slug} must upload to @NerraRU (its own quota), never the "
             f"EN channel"
         )
+
+
+def test_all_youtube_shows_use_grok_imagine():
+    """Every YouTube-enabled show must generate imagery with Grok Imagine
+    (operator directive June 14 2026: all Shorts/long-form imagery is
+    Grok-generated — unique, narrative-tied, and feeds the gallery pipeline).
+    A show inheriting the ``pexels`` default would silently ship stock photos."""
+    import yaml as _yaml
+    for cfg_path in SHOWS_DIR.glob("*.yaml"):
+        if cfg_path.name.startswith("_"):
+            continue
+        cfg = _yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+        yt = cfg.get("youtube") or {}
+        if yt.get("enabled") is True:
+            assert yt.get("image_provider") == "grok", (
+                f"{cfg.get('slug')} has YouTube enabled but image_provider="
+                f"{yt.get('image_provider')!r} — must be 'grok' so imagery is "
+                f"Grok-generated, not stock Pexels."
+            )

--- a/tests/test_weekly_recap_validator_gate.py
+++ b/tests/test_weekly_recap_validator_gate.py
@@ -195,3 +195,27 @@ def test_recap_blog_title_is_unique_per_week():
     assert line_a.startswith("# FF — Weekly Recap (Week of ")
     assert "June 14, 2026" in line_a
     assert line_a != line_b  # distinct week -> distinct title
+
+
+def test_recap_surfaces_recurring_threads_for_deep_dives():
+    """Deterministic 'biggest events' signal: entities covered on 2+ days are
+    surfaced to the host as deep-dive candidates (grounds the deep-dive beat in
+    data, not only LLM judgment). Single-day entities are excluded."""
+    from unittest.mock import patch
+    from datetime import date
+    from engine import weekly_recap
+
+    eps = [
+        {"episode_num": 1, "date": "2026-06-10", "hook": "h",
+         "entities": ["Starship", "Artemis"], "digest_md": "# X\n\nb. Source: [a.com](https://a.com/1)"},
+        {"episode_num": 2, "date": "2026-06-11", "hook": "h",
+         "entities": ["Starship", "NASA"], "digest_md": "# X\n\nb. Source: [b.com](https://b.com/2)"},
+        {"episode_num": 3, "date": "2026-06-12", "hook": "h",
+         "entities": ["Starship", "NASA"], "digest_md": "# X\n\nb. Source: [c.com](https://c.com/3)"},
+    ]
+    with patch("engine.content_lake.query_show_range", return_value=eps):
+        out = weekly_recap.build_weekly_recap_digest("ff", "FF", date(2026, 6, 14))
+    line = [ln for ln in out.splitlines() if "BIGGEST RECURRING THREADS" in ln]
+    assert line, "recurring-threads grounding line missing"
+    assert "Starship" in line[0] and "NASA" in line[0]  # 3x and 2x
+    assert "Artemis" not in line[0]  # only 1x → excluded


### PR DESCRIPTION
Two changes on the shared work branch (they merge together).

## 1. YouTube: SpaceX Daily replaces MAB; all imagery via Grok Imagine
Operator directive — SpaceX Daily takes MAB's EN-channel YouTube slot until the @NerraNetwork quota increase lands.
- **MAB** `youtube.enabled → false` (rest of its block retained, so re-enabling is a one-line flip).
- **SpaceX** gets the full EN-channel YouTube config (long-form + 1 Short, smart Shorts, category 28, SpaceX tags, cover art exists) mirroring the Tesla block. **Same per-episode EN footprint**, so the 11,000/day quota paper-math (landmine #20) and the expected preflight `::error::` are unchanged. *Operator one-time setup pending:* create + flag the SpaceX podcast playlist in Studio (landmine #15); uploads publish without it (logged warning).
- **All Shorts now use Grok Imagine.** FF, MIT, and both RU shows were silently inheriting the `pexels` default → stock-photo Shorts. Pinned `image_provider: grok` (+ model + a per-show "visually stunning" descriptor) on every YouTube-enabled show, so imagery is unique, narrative-tied, and feeds the gallery pipeline.
- **Network-wide image quality**: `build_image_prompts` now adds a compact quality cue (dramatic lighting, depth of field, sharp focus, vivid grading, editorial photography) so every generated image reads as a polished editorial photo, not a flat render. Per-scene narrative context + the episode hook are still layered on for relevance.

Drift guards: `YOUTUBE_ENABLED_SHOWS` swapped MAB→SpaceX; quota-shape test checks Tesla+SpaceX at 1 Short and MAB paused; new `test_all_youtube_shows_use_grok_imagine`; config + gallery-render provider tests updated to the new policy; landmine #20 + gallery docs updated.

## 2. Weekly recap: deterministic "biggest events" from recurring threads
The recap now counts per-episode entity recurrence from the content lake — an entity covered on 2+ days is, by definition, the week's most consequential ongoing thread — and surfaces the top recurring threads to the host as concrete deep-dive candidates, grounding the "go deep on the biggest events" beat in data instead of pure LLM judgment.

## Tests
`ruff` clean; full suite **2885 passing** (+ new drift guards).

⚠️ The weekly-recap framing edit affects the *spoken* script — A/B-listen next Sunday's recap per landmine #17. The YouTube/imagery changes affect generated video imagery (not the audio path).

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_