### PR TITLE
Image pipeline: bias Grok visuals toward each show's tracked programs

### DIFF
--- a/run_show.py
+++ b/run_show.py
@@ -3809,18 +3809,35 @@ def _publish_youtube(
     except Exception:  # pragma: no cover — best-effort
         _scene_contexts = []
 
-    # For TST: bias Grok Imagine visuals toward currently active narrative programs
+    # Bias Grok Imagine visuals toward the show's currently-tracked narrative
+    # programs so the imagery reinforces the ongoing story, not only the day's
+    # hook. Tesla uses its bespoke memory module; the Phase-3 memory shows
+    # (SpaceX, Fascinating Frontiers, Models & Agents, Planetterrian) use the
+    # generalized engine. Best-effort — on any failure (or a show with no
+    # memory config) we fall back to hook-only prompts. Even with no live
+    # tracker the loader returns the seeded default programs, so the keywords
+    # are still meaningful on a brand-new show.
     narrative_keywords = None
-    if args.show == "tesla":
-        try:
+    try:
+        if args.show == "tesla":
             from engine import tesla_memory
             tracker = tesla_memory.load_narrative_tracker(Path(config.episode.output_dir))
-            narrative_keywords = [
-                p.get("display_name", k).lower()
-                for k, p in tracker.get("programs", {}).items()
-            ][:6]
-        except Exception:
-            narrative_keywords = None
+            programs = tracker.get("programs", {})
+        else:
+            from engine import show_memory
+            mcfg = show_memory.get_config(args.show)
+            programs = {}
+            if mcfg is not None:
+                tracker = show_memory.load_narrative_tracker(
+                    Path(config.episode.output_dir), mcfg
+                )
+                programs = tracker.get("programs", {})
+        narrative_keywords = [
+            (p.get("display_name") or k).lower()
+            for k, p in programs.items()
+        ][:6] or None
+    except Exception:  # pragma: no cover — best-effort
+        narrative_keywords = None
 
     def _run_grok_path(*, aspect: str, label_suffix: str) -> "list[Path]":
         from engine.grok_imagine import (

--- a/tests/test_grok_imagine.py
+++ b/tests/test_grok_imagine.py
@@ -427,3 +427,49 @@ class TestApiSizeForAspect:
     def test_square_returns_square(self):
         from engine.grok_imagine import _api_size_for_aspect
         assert _api_size_for_aspect("1:1") == "1024x1024"
+
+
+class TestNarrativeKeywordBiasing:
+    """June 14 2026: image generation biases toward each show's tracked
+    narrative programs (not just the day's hook) so the imagery reinforces the
+    ongoing story. Generalized from Tesla-only to every memory show (SpaceX +
+    FF are now YouTube-enabled on Grok)."""
+
+    def test_memory_shows_yield_program_keywords(self):
+        from pathlib import Path
+        from engine import show_memory
+        # Worst case: no live tracker → seeded default programs still give
+        # meaningful keywords for a brand-new show.
+        for slug in ("spacex", "fascinating_frontiers", "models_agents",
+                     "planetterrian"):
+            mcfg = show_memory.get_config(slug)
+            assert mcfg is not None, f"{slug} should have a memory config"
+            tracker = show_memory.load_narrative_tracker(
+                Path(f"/tmp/_nonexistent_{slug}"), mcfg
+            )
+            kws = [
+                (p.get("display_name") or k).lower()
+                for k, p in tracker.get("programs", {}).items()
+            ][:6]
+            assert kws, f"{slug} yielded no narrative keywords"
+
+    def test_run_show_generalizes_keyword_biasing_beyond_tesla(self):
+        # The narrative-keyword block must use the generalized show_memory
+        # engine, not be gated to Tesla alone.
+        src = (Path(__file__).resolve().parent.parent / "run_show.py").read_text(
+            encoding="utf-8"
+        )
+        assert "show_memory.get_config(args.show)" in src
+        assert "narrative_keywords" in src
+
+    def test_quality_cue_present_in_every_prompt(self):
+        # Network-wide visual-quality cue lifts every generated image.
+        from engine.grok_imagine import build_image_prompts
+        prompts = build_image_prompts(
+            hook="A booster catch", image_queries=["starship", "raptor"],
+            count=2, show_descriptor="cinematic spaceflight photo",
+        )
+        assert prompts
+        for p in prompts:
+            assert "professional editorial photography" in p
+            assert "sharp focus" in p


### PR DESCRIPTION
Continuing the image-generation pipeline improvements.

## Bias Grok Imagine toward each show's tracked narrative programs
`narrative_keywords` steers the Grok prompts toward a show's *ongoing story threads* (not just the day's hook) — e.g. so a Tesla image leans into the programs the show actively tracks. It was **Tesla-only**.

This generalizes it to every memory show via `engine/show_memory`, so the now-YouTube-enabled **SpaceX** and **Fascinating Frontiers** (plus Models & Agents, Planetterrian) get imagery biased toward their tracked programs:
- **SpaceX** → starship, starlink, falcon launch cadence & reuse, dragon & crew missions, raptor engine program, mars ambitions
- **FF** → starship & mars, artemis & the moon, JWST & exoplanets, commercial spaceflight, robotic exploration, cosmology

Best-effort, with a **seeded-default fallback** — even before a live narrative tracker exists, the loader returns the show's seeded programs, so the keywords are meaningful from episode 1. Falls back to hook-only prompts on any error or for shows without a memory config.

Combined with the per-scene story context and the network-wide quality cue from the last PR, this makes the imagery both visually polished and tied to the show's real narrative arc.

## Tests
+3 drift guards (memory shows yield keywords in the seeded-default worst case; run_show generalizes beyond Tesla; quality cue present in every prompt). `ruff` clean; full suite **2888 passing**.

Affects generated video imagery only — no audio path.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_