### PR TITLE
Image pipeline: strip publisher suffix from per-scene image contexts

### DIFF
--- a/engine/grok_imagine.py
+++ b/engine/grok_imagine.py
@@ -87,6 +87,28 @@ _HEADLINE_PATTERNS = (
 )
 
 
+def _strip_source_suffix(headline: str) -> str:
+    """Drop a trailing ``- Publisher`` / ``— Publisher`` / ``| Publisher``
+    segment from an extracted headline.
+
+    Digest headlines often carry the outlet name (Google-News "Headline -
+    Publisher" style, e.g. "…Vandenberg rocket launch - The Desert Sun"). As a
+    per-scene image context that publisher name is noise — it's not part of what
+    the slide should depict and nudges Grok toward rendering the outlet name as
+    on-image text. Strip it conservatively: only when the trailing segment is
+    short (publisher-length) and a substantial headline remains in front, so
+    headlines with meaningful internal dashes are left intact.
+    """
+    for sep in (" — ", " - ", " | "):
+        if sep in headline:
+            head, _, tail = headline.rpartition(sep)
+            head = head.strip()
+            tail = tail.strip()
+            if tail and len(tail) <= 35 and len(head) >= 20:
+                return head
+    return headline
+
+
 def extract_story_headlines(digest_text: str, max_count: int = 12) -> List[str]:
     """Pull per-story headlines out of an episode digest's markdown.
 
@@ -115,7 +137,7 @@ def extract_story_headlines(digest_text: str, max_count: int = 12) -> List[str]:
     seen: set[str] = set()
 
     def _add(raw: str) -> bool:
-        h = raw.strip().rstrip(":.,;").strip()
+        h = _strip_source_suffix(raw.strip()).rstrip(":.,;").strip()
         # Drop obvious junk: too short, too long, or already seen
         # (case-insensitive — same story sometimes appears in two
         # sections with slight casing changes).

--- a/tests/test_grok_imagine.py
+++ b/tests/test_grok_imagine.py
@@ -473,3 +473,42 @@ class TestNarrativeKeywordBiasing:
         for p in prompts:
             assert "professional editorial photography" in p
             assert "sharp focus" in p
+
+
+class TestSourceSuffixStripping:
+    """June 14 2026: per-scene image contexts must be pure story subjects, not
+    'Headline - Publisher'. The trailing outlet name is noise for image
+    generation and nudges Grok to render the publisher as on-image text."""
+
+    def test_strips_trailing_publisher(self):
+        from engine.grok_imagine import _strip_source_suffix
+        assert _strip_source_suffix(
+            "SpaceX prepares for Vandenberg rocket launch - The Desert Sun"
+        ) == "SpaceX prepares for Vandenberg rocket launch"
+        assert _strip_source_suffix(
+            "AI isn't replacing aerospace workers — SpaceNews"
+        ) == "AI isn't replacing aerospace workers"
+
+    def test_preserves_internal_dashes(self):
+        from engine.grok_imagine import _strip_source_suffix
+        h = ("Raptor 3 — the world's most powerful methane engine — "
+             "and what it means for investors - MEXC Exchange")
+        out = _strip_source_suffix(h)
+        assert out.endswith("what it means for investors")
+        assert "—" in out  # internal em-dashes intact
+
+    def test_guards_short_head_and_no_separator(self):
+        from engine.grok_imagine import _strip_source_suffix
+        assert _strip_source_suffix("AI - the future") == "AI - the future"
+        assert _strip_source_suffix("Starship and Mars") == "Starship and Mars"
+
+    def test_extraction_applies_suffix_strip(self):
+        from engine.grok_imagine import extract_story_headlines
+        digest = (
+            "1. **SpaceX catches its booster at the tower again - Ars Technica**\n"
+            "2. **Starlink crosses ten thousand active satellites — Space.com**\n"
+        )
+        hs = extract_story_headlines(digest)
+        assert "SpaceX catches its booster at the tower again" in hs
+        assert "Starlink crosses ten thousand active satellites" in hs
+        assert all(" - Ars Technica" not in h and " — Space.com" not in h for h in hs)


### PR DESCRIPTION
Continuing the image-pipeline improvements.

## Strip the publisher suffix from per-scene image contexts
Each slide's Grok prompt is steered by a per-story headline pulled from the digest. But those headlines often carry the **outlet name** in the Google-News "Headline - Publisher" style:

- "Here's how to watch live as SpaceX prepares for Vandenberg rocket launch **- The Desert Sun**"
- "In aerospace, AI isn't replacing workers. It's filling a shortage **— SpaceNews**"
- "…what it means for SPCX investors **- MEXC Exchange**"

As image context, the publisher name is pure noise — it's not part of what the slide should *depict*, and (given Grok's documented tendency to render context text as on-image banners) it nudges the model toward stamping the outlet name onto the picture.

`extract_story_headlines` now strips a trailing `- / — / | Publisher` segment, **conservatively**: only when the trailing segment is publisher-length (≤35 chars) and a substantial headline (≥20 chars) remains, so headlines with meaningful internal dashes/em-dashes are left fully intact (verified on the real SpaceX Ep002 digest). Result: cleaner, more on-story image prompts across every news show — and one less source of text leakage.

## Tests
+4 drift guards (strips trailing publisher for both dash and em-dash; preserves internal dashes; guards short-head/no-separator cases; extraction applies the strip). `ruff` clean; image suites green (60 passing).

Affects generated video imagery only — no audio path.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_