### PR TITLE
Image pipeline: loud annotation when a Grok slideshow degrades to cover

### DIFF
--- a/run_show.py
+++ b/run_show.py
@@ -2748,6 +2748,30 @@ def run(args: argparse.Namespace) -> None:
                 "grok_image_failures",
                 youtube_urls["grok_image_failures"],
             )
+        # Loud, actionable signal when a Grok-enabled show ships a DEGRADED
+        # slideshow — i.e. Grok Imagine produced fewer than 2 usable images so
+        # the video fell back to the static cover. With six shows now on Grok,
+        # a silent outage (bad key / model id / rate limit) would quietly
+        # degrade many uploads; this surfaces it as a GitHub annotation +
+        # metric instead of hiding in the per-episode JSON. Only fires for
+        # grok/hybrid shows that actually published video.
+        _img_provider = str(youtube_urls.get("image_provider") or "")
+        if _img_provider in ("grok", "hybrid"):
+            _imgs = int(youtube_urls.get("grok_images_generated", 0) or 0)
+            metrics.record("grok_slideshow_degraded", _imgs < 2)
+            if _imgs < 2:
+                _why = "; ".join(youtube_urls.get("grok_image_failures") or []) \
+                    or "no failure detail captured"
+                print(
+                    f"::warning::Grok Imagine produced only {_imgs} image(s) "
+                    f"for {args.show} — the video shipped with the static cover "
+                    f"as a fallback. Cause: {_why}",
+                    flush=True,
+                )
+                logger.warning(
+                    "Grok slideshow degraded for %s: %d images (fell back to "
+                    "cover). Cause: %s", args.show, _imgs, _why,
+                )
     except Exception:
         logger.warning("post-publish step failed (non-fatal)", exc_info=True)
 

--- a/tests/test_youtube_quality_pass.py
+++ b/tests/test_youtube_quality_pass.py
@@ -73,3 +73,11 @@ class TestObservability:
     def test_shorts_captions_path_metric(self):
         src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
         assert 'result["shorts_captions_path"]' in src
+
+    def test_grok_degraded_slideshow_is_loud(self):
+        """June 14 2026: with six shows on Grok Imagine, a silent outage that
+        drops the slideshow to the static cover must surface as a GitHub
+        annotation + metric, not hide in the per-episode JSON."""
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "grok_slideshow_degraded" in src
+        assert "::warning::Grok Imagine produced only" in src


### PR DESCRIPTION
Continuing the image-pipeline improvements — observability for the expanded Grok footprint.

## Loud signal when a Grok slideshow silently degrades
The swap put **six shows** on Grok Imagine. If Grok has an outage (bad key, wrong model id, request-format change, rate limit), the slideshow falls back to the **static cover image** — the video still publishes, but as a single frame, with the cause buried in the per-episode JSON.

The post-publish step now, for any grok/hybrid show that published video:
- records a `grok_slideshow_degraded` metric (true when < 2 usable images were generated), and
- emits a GitHub **`::warning::`** annotation naming the show, the image count, and the captured failure cause when it degrades.

So a silent Grok outage surfaces immediately in the Actions log and the dashboard instead of quietly shipping single-frame videos across the network. Observability only — it never blocks publish, and the deliberate no-Pexels-fallback ("all Grok") policy is unchanged.

## Tests
+1 drift guard (the degraded-slideshow warning + metric are present). `ruff` clean; full suite **2893 passing**.

No audio path affected.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_