### PR TITLE
Show pages: embed per-show Grok Imagine gallery on all Grok shows

### DIFF
--- a/fascinating-frontiers.html
+++ b/fascinating-frontiers.html
@@ -509,6 +509,7 @@
                     
                     
                     
+                    
                     <a href="https://podcasts.apple.com/us/podcast/fascinating-frontiers/id1864803923?utm_source=nerranetwork&utm_medium=web&utm_campaign=fascinating_frontiers" class="nn-btn" target="_blank" rel="noopener" data-show="fascinating_frontiers">Apple Podcasts</a>
                     
                     
@@ -1102,7 +1103,32 @@
             </div>
         </div>
     </section>
-    <!-- More from Nerra Network --><section class="cross-network nn-section">
+    <section class="nn-section nn-gallery-section-wrap container">
+        
+<section class="nn-section nn-gallery-section" id="gallery">
+    
+    <header class="nn-section-header">
+        <h2 class="nn-section-title">Episode gallery</h2>
+        
+        <p class="nn-section-intro">AI-generated visuals from recent Fascinating Frontiers episodes. Click any image for a larger view; “Show prompt” reveals the text the image was generated from.</p>
+        
+    </header>
+    
+
+    <div data-nn-gallery
+         data-show-slug="fascinating_frontiers"
+         data-page-size="24"
+         data-controls="hide">
+        <p class="nn-gallery-loading">Loading gallery images… (refreshed automatically via nightly maintenance)</p>
+    </div>
+</section>
+
+<script>
+    window.NN_GALLERY_MANIFEST_URL = 'site/data/gallery-manifest.json';
+</script>
+<script defer src="assets/js/gallery.js"></script>
+
+    </section><!-- More from Nerra Network --><section class="cross-network nn-section">
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
@@ -1402,6 +1428,7 @@
                 <a href="ai-disclosure.html">AI Disclosure</a>
                 <a href="editorial.html">Editorial Process</a>
                 <a href="gallery.html">Image Gallery</a>
+                <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->

--- a/modern-investing.html
+++ b/modern-investing.html
@@ -507,6 +507,7 @@
                     
                     
                     
+                    
                     <a href="https://podcasts.apple.com/us/podcast/modern-investing-techniques/id1886870483?utm_source=nerranetwork&utm_medium=web&utm_campaign=modern_investing" class="nn-btn" target="_blank" rel="noopener" data-show="modern_investing">Apple Podcasts</a>
                     
                     
@@ -1917,7 +1918,32 @@
             </div>
         </div>
     </section>
-    <!-- More from Nerra Network --><section class="cross-network nn-section">
+    <section class="nn-section nn-gallery-section-wrap container">
+        
+<section class="nn-section nn-gallery-section" id="gallery">
+    
+    <header class="nn-section-header">
+        <h2 class="nn-section-title">Episode gallery</h2>
+        
+        <p class="nn-section-intro">AI-generated visuals from recent Modern Investing Techniques episodes. Click any image for a larger view; “Show prompt” reveals the text the image was generated from.</p>
+        
+    </header>
+    
+
+    <div data-nn-gallery
+         data-show-slug="modern_investing"
+         data-page-size="24"
+         data-controls="hide">
+        <p class="nn-gallery-loading">Loading gallery images… (refreshed automatically via nightly maintenance)</p>
+    </div>
+</section>
+
+<script>
+    window.NN_GALLERY_MANIFEST_URL = 'site/data/gallery-manifest.json';
+</script>
+<script defer src="assets/js/gallery.js"></script>
+
+    </section><!-- More from Nerra Network --><section class="cross-network nn-section">
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
@@ -2217,6 +2243,7 @@
                 <a href="ai-disclosure.html">AI Disclosure</a>
                 <a href="editorial.html">Editorial Process</a>
                 <a href="gallery.html">Image Gallery</a>
+                <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->

--- a/ru/finansy-prosto.html
+++ b/ru/finansy-prosto.html
@@ -218,6 +218,11 @@
                             First Principles Daily
                         </a>
                         
+                        <a href="../spacex.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="../assets/covers/spacex-400.webp"><img src="../assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily
+                        </a>
+                        
                     </div>
                 </li>
                 <li class="nn-nav-dropdown">
@@ -288,6 +293,11 @@
                         <a href="../blog/first_principles/index.html">
                             <picture><source type="image/webp" srcset="../assets/covers/first-principles-daily-400.webp"><img src="../assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
                             First Principles Daily блог
+                        </a>
+                        
+                        <a href="../blog/spacex/index.html">
+                            <picture><source type="image/webp" srcset="../assets/covers/spacex-400.webp"><img src="../assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily блог
                         </a>
                         
                     </div>
@@ -386,6 +396,11 @@
                 First Principles Daily
             </a>
             
+            <a href="../spacex.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="../assets/covers/spacex-400.webp"><img src="../assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily
+            </a>
+            
         </div>
         <div class="nn-mobile-shows">
             <div class="nn-mobile-shows-title">Блоги</div>
@@ -453,6 +468,11 @@
                 First Principles Daily блог
             </a>
             
+            <a href="../blog/spacex/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="../assets/covers/spacex-400.webp"><img src="../assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily блог
+            </a>
+            
         </div>
     </div>
 
@@ -486,6 +506,8 @@
                     <a href="../ru/finansy-prosto-summaries.html" class="nn-btn">Все выпуски</a>
                     
                     
+                    
+                    
                     <a href="https://podcasts.apple.com/us/podcast/%D1%84%D0%B8%D0%BD%D0%B0%D0%BD%D1%81%D1%8B-%D0%BF%D1%80%D0%BE%D1%81%D1%82%D0%BE/id1885235226?utm_source=nerranetwork&utm_medium=web&utm_campaign=finansy_prosto" class="nn-btn" target="_blank" rel="noopener" data-show="finansy_prosto">Apple Podcasts</a>
                     
                     
@@ -507,6 +529,7 @@
   Создано с ИИ — прозрачно
 </a>
                 </div>
+                
                 
             </div>
         </div>
@@ -1040,7 +1063,32 @@
             </div>
         </div>
     </section>
-    <!-- More from Nerra Network --><section class="cross-network nn-section">
+    <section class="nn-section nn-gallery-section-wrap container">
+        
+<section class="nn-section nn-gallery-section" id="gallery">
+    
+    <header class="nn-section-header">
+        <h2 class="nn-section-title">Episode gallery</h2>
+        
+        <p class="nn-section-intro">AI-generated visuals from recent Финансы Просто episodes. Click any image for a larger view; “Show prompt” reveals the text the image was generated from.</p>
+        
+    </header>
+    
+
+    <div data-nn-gallery
+         data-show-slug="finansy_prosto"
+         data-page-size="24"
+         data-controls="hide">
+        <p class="nn-gallery-loading">Loading gallery images… (refreshed automatically via nightly maintenance)</p>
+    </div>
+</section>
+
+<script>
+    window.NN_GALLERY_MANIFEST_URL = '../site/data/gallery-manifest.json';
+</script>
+<script defer src="../assets/js/gallery.js"></script>
+
+    </section><!-- More from Nerra Network --><section class="cross-network nn-section">
         <div class="container">
             <div class="nn-section-header">
                 <h2>Другие подкасты Nerra Network</h2>
@@ -1078,7 +1126,7 @@
             <div class="nn-footer-grid">
                 <div>
                     <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span></div>
-                    <p class="nn-footer-desc">Подкастов: 12. Без рекламы. Независимая сеть из Ванкувера, Канада.</p>
+                    <p class="nn-footer-desc">Подкастов: 13. Без рекламы. Независимая сеть из Ванкувера, Канада.</p>
                 </div>
                 <div class="nn-footer-col">
                     <h4>Подкасты</h4>
@@ -1106,6 +1154,8 @@
                     <a href="../unintended-consequences.html">Unintended Consequences</a>
                     
                     <a href="../first-principles.html">First Principles Daily</a>
+                    
+                    <a href="../spacex.html">SpaceX Daily</a>
                     
                 </div>
                 <div class="nn-footer-col">
@@ -1135,6 +1185,8 @@
                     <a href="../blog/unintended_consequences/index.html">Unintended Consequences</a>
                     
                     <a href="../blog/first_principles/index.html">First Principles Daily</a>
+                    
+                    <a href="../blog/spacex/index.html">SpaceX Daily</a>
                     
                     <a href="../blog.rss">RSS блога (все подкасты)</a>
                 </div>
@@ -1169,6 +1221,8 @@
                     
                     <a href="../first_principles_podcast.rss">First Principles Daily RSS</a>
                     
+                    <a href="../spacex_podcast.rss">SpaceX Daily RSS</a>
+                    
                 </div>
                 <div class="nn-footer-col">
                     <h4>Контакты</h4>
@@ -1190,6 +1244,7 @@
                 <a href="../ai-disclosure.html">ИИ-раскрытие</a>
                 <a href="../editorial.html">Редакционная политика</a>
                 <a href="../gallery.html">Галерея</a>
+                <a href="../data.html">Данные и дашборды</a>
                 <a href="../management.html">Статус сети</a>
             </div>
             <!-- Newsletter Subscribe -->
@@ -1396,6 +1451,8 @@
             document.getElementById('latest-title').textContent = 'No episodes available yet';
             document.getElementById('episodes-grid').innerHTML = '<p style="color:var(--nn-text-muted);grid-column:1/-1;text-align:center;padding:2rem 0;">Episodes will appear here once available.</p>';
         }
+
+        
 
         
 

--- a/ru/privet-russian.html
+++ b/ru/privet-russian.html
@@ -218,6 +218,11 @@
                             First Principles Daily
                         </a>
                         
+                        <a href="../spacex.html" role="menuitem">
+                            <picture><source type="image/webp" srcset="../assets/covers/spacex-400.webp"><img src="../assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily
+                        </a>
+                        
                     </div>
                 </li>
                 <li class="nn-nav-dropdown">
@@ -288,6 +293,11 @@
                         <a href="../blog/first_principles/index.html">
                             <picture><source type="image/webp" srcset="../assets/covers/first-principles-daily-400.webp"><img src="../assets/covers/first-principles-daily.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
                             First Principles Daily блог
+                        </a>
+                        
+                        <a href="../blog/spacex/index.html">
+                            <picture><source type="image/webp" srcset="../assets/covers/spacex-400.webp"><img src="../assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                            SpaceX Daily блог
                         </a>
                         
                     </div>
@@ -386,6 +396,11 @@
                 First Principles Daily
             </a>
             
+            <a href="../spacex.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="../assets/covers/spacex-400.webp"><img src="../assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily
+            </a>
+            
         </div>
         <div class="nn-mobile-shows">
             <div class="nn-mobile-shows-title">Блоги</div>
@@ -453,6 +468,11 @@
                 First Principles Daily блог
             </a>
             
+            <a href="../blog/spacex/index.html" class="nn-mobile-show-link" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">
+                <picture><source type="image/webp" srcset="../assets/covers/spacex-400.webp"><img src="../assets/covers/spacex.jpg" alt="" width="1400" height="1400" loading="lazy"></picture>
+                SpaceX Daily блог
+            </a>
+            
         </div>
     </div>
 
@@ -486,6 +506,8 @@
                     <a href="../ru/privet-russian-summaries.html" class="nn-btn">Все выпуски</a>
                     
                     
+                    
+                    
                     <a href="https://podcasts.apple.com/us/podcast/%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82-%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9/id1885236720?utm_source=nerranetwork&utm_medium=web&utm_campaign=privet_russian" class="nn-btn" target="_blank" rel="noopener" data-show="privet_russian">Apple Podcasts</a>
                     
                     
@@ -507,6 +529,7 @@
   Создано с ИИ — прозрачно
 </a>
                 </div>
+                
                 
             </div>
         </div>
@@ -1034,7 +1057,32 @@
             </div>
         </div>
     </section>
-    <!-- More from Nerra Network --><section class="cross-network nn-section">
+    <section class="nn-section nn-gallery-section-wrap container">
+        
+<section class="nn-section nn-gallery-section" id="gallery">
+    
+    <header class="nn-section-header">
+        <h2 class="nn-section-title">Episode gallery</h2>
+        
+        <p class="nn-section-intro">AI-generated visuals from recent Привет, Русский! episodes. Click any image for a larger view; “Show prompt” reveals the text the image was generated from.</p>
+        
+    </header>
+    
+
+    <div data-nn-gallery
+         data-show-slug="privet_russian"
+         data-page-size="24"
+         data-controls="hide">
+        <p class="nn-gallery-loading">Loading gallery images… (refreshed automatically via nightly maintenance)</p>
+    </div>
+</section>
+
+<script>
+    window.NN_GALLERY_MANIFEST_URL = '../site/data/gallery-manifest.json';
+</script>
+<script defer src="../assets/js/gallery.js"></script>
+
+    </section><!-- More from Nerra Network --><section class="cross-network nn-section">
         <div class="container">
             <div class="nn-section-header">
                 <h2>Другие подкасты Nerra Network</h2>
@@ -1072,7 +1120,7 @@
             <div class="nn-footer-grid">
                 <div>
                     <div class="nn-footer-brand"><span class="gradient-text">Nerra</span> <span class="nn-wordmark-rest">Network</span></div>
-                    <p class="nn-footer-desc">Подкастов: 12. Без рекламы. Независимая сеть из Ванкувера, Канада.</p>
+                    <p class="nn-footer-desc">Подкастов: 13. Без рекламы. Независимая сеть из Ванкувера, Канада.</p>
                 </div>
                 <div class="nn-footer-col">
                     <h4>Подкасты</h4>
@@ -1100,6 +1148,8 @@
                     <a href="../unintended-consequences.html">Unintended Consequences</a>
                     
                     <a href="../first-principles.html">First Principles Daily</a>
+                    
+                    <a href="../spacex.html">SpaceX Daily</a>
                     
                 </div>
                 <div class="nn-footer-col">
@@ -1129,6 +1179,8 @@
                     <a href="../blog/unintended_consequences/index.html">Unintended Consequences</a>
                     
                     <a href="../blog/first_principles/index.html">First Principles Daily</a>
+                    
+                    <a href="../blog/spacex/index.html">SpaceX Daily</a>
                     
                     <a href="../blog.rss">RSS блога (все подкасты)</a>
                 </div>
@@ -1163,6 +1215,8 @@
                     
                     <a href="../first_principles_podcast.rss">First Principles Daily RSS</a>
                     
+                    <a href="../spacex_podcast.rss">SpaceX Daily RSS</a>
+                    
                 </div>
                 <div class="nn-footer-col">
                     <h4>Контакты</h4>
@@ -1184,6 +1238,7 @@
                 <a href="../ai-disclosure.html">ИИ-раскрытие</a>
                 <a href="../editorial.html">Редакционная политика</a>
                 <a href="../gallery.html">Галерея</a>
+                <a href="../data.html">Данные и дашборды</a>
                 <a href="../management.html">Статус сети</a>
             </div>
             <!-- Newsletter Subscribe -->
@@ -1390,6 +1445,8 @@
             document.getElementById('latest-title').textContent = 'No episodes available yet';
             document.getElementById('episodes-grid').innerHTML = '<p style="color:var(--nn-text-muted);grid-column:1/-1;text-align:center;padding:2rem 0;">Episodes will appear here once available.</p>';
         }
+
+        
 
         
 

--- a/spacex.html
+++ b/spacex.html
@@ -1068,7 +1068,32 @@
             </div>
         </div>
     </section>
-    <!-- More from Nerra Network --><section class="cross-network nn-section">
+    <section class="nn-section nn-gallery-section-wrap container">
+        
+<section class="nn-section nn-gallery-section" id="gallery">
+    
+    <header class="nn-section-header">
+        <h2 class="nn-section-title">Episode gallery</h2>
+        
+        <p class="nn-section-intro">AI-generated visuals from recent SpaceX Daily episodes. Click any image for a larger view; “Show prompt” reveals the text the image was generated from.</p>
+        
+    </header>
+    
+
+    <div data-nn-gallery
+         data-show-slug="spacex"
+         data-page-size="24"
+         data-controls="hide">
+        <p class="nn-gallery-loading">Loading gallery images… (refreshed automatically via nightly maintenance)</p>
+    </div>
+</section>
+
+<script>
+    window.NN_GALLERY_MANIFEST_URL = 'site/data/gallery-manifest.json';
+</script>
+<script defer src="assets/js/gallery.js"></script>
+
+    </section><!-- More from Nerra Network --><section class="cross-network nn-section">
         <div class="container">
             <div class="nn-section-header">
                 <h2>More from Nerra Network</h2>
@@ -1368,6 +1393,7 @@
                 <a href="ai-disclosure.html">AI Disclosure</a>
                 <a href="editorial.html">Editorial Process</a>
                 <a href="gallery.html">Image Gallery</a>
+                <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->

--- a/tests/test_gallery_render.py
+++ b/tests/test_gallery_render.py
@@ -208,3 +208,44 @@ def test_read_show_image_provider_defaults_to_pexels_for_unknown_show():
         sys.path.insert(0, str(PROJECT_ROOT))
     from generate_html import _read_show_image_provider
     assert _read_show_image_provider("__nonexistent__") == "pexels"
+
+
+def test_all_grok_youtube_shows_are_gallery_enabled():
+    """June 14 2026 (operator request): every YouTube-enabled Grok show must
+    embed the per-show gallery section (like Tesla), so its generated imagery
+    is browsable on the show page — especially SpaceX Daily + Fascinating
+    Frontiers. Guards against a regeneration that drops the section."""
+    import sys
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    from generate_html import _read_show_image_provider, _read_show_youtube
+    for slug in ("tesla", "spacex", "fascinating_frontiers", "modern_investing",
+                 "finansy_prosto", "privet_russian"):
+        yt = _read_show_youtube(slug)
+        provider = _read_show_image_provider(slug)
+        gallery_enabled = (
+            bool(yt.get("youtube_enabled")) and provider in ("grok", "hybrid")
+        )
+        assert gallery_enabled, (
+            f"{slug} should embed the per-show gallery (youtube_enabled + grok), "
+            f"got youtube_enabled={yt.get('youtube_enabled')} provider={provider!r}"
+        )
+
+
+def test_committed_show_pages_have_gallery_mount():
+    """The regenerated show pages for the Grok shows carry the gallery mount
+    so the section is live on the site now (not only after the next nightly)."""
+    pages = {
+        "spacex.html": "spacex",
+        "fascinating-frontiers.html": "fascinating_frontiers",
+        "modern-investing.html": "modern_investing",
+        "ru/finansy-prosto.html": "finansy_prosto",
+        "ru/privet-russian.html": "privet_russian",
+    }
+    for rel, slug in pages.items():
+        p = PROJECT_ROOT / rel
+        if not p.exists():
+            continue
+        html = p.read_text(encoding="utf-8")
+        assert "data-nn-gallery" in html, f"{rel} missing gallery mount"
+        assert f'data-show-slug="{slug}"' in html, f"{rel} wrong/absent show slug"


### PR DESCRIPTION
## Per-show Grok Imagine gallery on every Grok show page

You asked for the per-show Grok Imagine gallery (like the Tesla show page has) on the other Grok-enabled shows — especially **SpaceX Daily** and **Fascinating Frontiers** — plus the network gallery.

The gating logic was already correct after the Grok swap (#628): `gallery_enabled = youtube.enabled AND image_provider == grok`, which is now true for SpaceX/FF/MIT/RU. But their **committed show-page HTML predated the flip**, so only Tesla actually rendered the section. This regenerates those five pages so each embeds the gallery mount (`data-nn-gallery` + `data-show-slug`) exactly like Tesla:

- `spacex.html`, `fascinating-frontiers.html`, `modern-investing.html`, `ru/finansy-prosto.html`, `ru/privet-russian.html`

The section hydrates client-side from the network manifest filtered to that show — same mechanism as Tesla.

### Important: when images actually appear
The manifest currently holds **351 images, from Tesla (200) + MAB (151) only**. SpaceX/FF/MIT/RU have **zero** because their past episodes ran on **Pexels** (which never lands in the gallery bucket) — they only just switched to Grok. The upload step + manifest wiring are already live from #628, so **each show's imagery flows to both its show-page gallery and the network gallery on its next episode run**. I can't backfill images that were never generated (historical scene dirs are gitignored). So the sections are ready now and self-populate as SpaceX/FF/etc. publish.

MAB's section correctly stays hidden (YouTube paused), though its 151 existing images remain browsable in the network gallery.

### Tests
+2 drift guards: all six Grok YouTube shows compute `gallery_enabled=True`; the committed Grok show pages carry the gallery mount with the correct show slug. Gallery/config/schedule suites green (129 passing).

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_