### PR TITLE
Image pipeline: cinematic image_queries for FF / MIT / FP / PR

### DIFF
--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -314,16 +314,17 @@ youtube:
   category_id: 28               # Science & Tech
   default_language: en
   privacy_status: public        # Phase-1 validated; uploads are public
-  # Space / frontier-science visuals. Pexels has strong coverage here so
-  # short, descriptive queries work well without prefix injection.
+  # Space / frontier-science visuals. June 14 2026 — upgraded from terse
+  # Pexels-search keywords to vivid, cinematic scene subjects now that imagery
+  # is Grok-generated (generation rewards descriptive scenes over noun tags).
   image_queries:
-    - space telescope
-    - galaxy nebula
-    - rocket launch
-    - astronaut spacewalk
-    - mars rover
-    - aurora borealis
-    - cosmic stars
+    - James Webb telescope in deep space
+    - spiral galaxy with glowing nebula
+    - astronaut on a spacewalk above Earth
+    - Mars rover crossing red rocky terrain
+    - aurora borealis over snowy mountains
+    - black hole bending starlight
+    - rocket lifting off through dramatic clouds
   image_query_prefix: ""
   # June 14 2026 — Grok Imagine for the Shorts imagery (was inheriting the
   # pexels default, so Shorts shipped stock photos). Unique, narrative-tied

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -293,16 +293,17 @@ youtube:
   category_id: 27               # Education (financial literacy — was 25/News, a misclassification)
   default_language: ru
   # Russian-language financial-literacy show for women in Canada.
-  # Pexels search is English-only despite the show's RU output, so
-  # queries stay in English.
+  # Image prompts stay in English (the generator + Pexels fallback are
+  # English). June 14 2026 — upgraded from terse keywords to warm, vivid
+  # personal-finance lifestyle scenes now that imagery is Grok-generated.
   image_queries:
-    - personal finance planning
-    - savings jar coins
-    - canadian dollars
-    - family budget
-    - investment chart
-    - bank meeting
-    - retirement planning
+    - woman planning finances at a bright kitchen table
+    - glass jar filling with coins beside a small plant
+    - Canadian dollars and coins on a desk
+    - family budgeting together at home
+    - upward investment growth chart on a laptop
+    - friendly financial advisor meeting a client
+    - couple planning retirement with a calculator
   image_query_prefix: ""
   # June 14 2026 — Grok Imagine for all imagery (was inheriting the pexels
   # default). Unique, narrative-tied finance visuals on @NerraRU.

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -299,17 +299,17 @@ youtube:
   channel: en
   category_id: 25               # News & Politics (markets/business)
   default_language: en
-  # Markets / Canadian + US investing imagery. Bare keywords like
-  # "growth" / "yield" / "bonds" return generic / off-topic results,
-  # so each query is grounded in finance context.
+  # Markets / Canadian + US investing imagery. June 14 2026 — upgraded from
+  # terse Pexels-search keywords to vivid, cinematic finance scenes now that
+  # imagery is Grok-generated.
   image_queries:
-    - stock market chart
-    - canadian stock exchange
-    - financial newspaper
-    - trading desk monitors
-    - investment portfolio
-    - federal reserve building
-    - bull and bear market
+    - glowing candlestick chart on a dark trading screen
+    - Toronto financial district skyline at dusk
+    - trader at a wall of market monitors
+    - golden bull and bear statues facing off
+    - rising stacks of coins with an upward growth arrow
+    - modern central bank building facade
+    - investor reviewing a portfolio on a tablet
   image_query_prefix: ""
   # June 14 2026 — Grok Imagine for the Shorts imagery (was inheriting the
   # pexels default, so Shorts shipped stock photos). Unique, narrative-tied

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -242,16 +242,17 @@ youtube:
   category_id: 27               # Education (language learning)
   default_language: ru
   # Bilingual Russian-language-learning show. Queries are English
-  # (Pexels search is English) and lean on culture / language /
-  # learning imagery rather than direct grammar terms.
+  # Culture / language / learning imagery (image prompts stay English).
+  # June 14 2026 — upgraded from terse keywords to vivid, cinematic scenes
+  # now that imagery is Grok-generated.
   image_queries:
-    - russian architecture
-    - moscow red square
-    - language learning books
-    - cyrillic alphabet
-    - russian culture
-    - student studying language
-    - saint petersburg
+    - Saint Basil's Cathedral on Red Square at golden hour
+    - colorful matryoshka nesting dolls close-up
+    - open textbook with Cyrillic letters and notes
+    - Saint Petersburg canal with historic architecture
+    - student studying with flashcards at a cozy desk
+    - steaming cup of tea beside an open Russian book
+    - Moscow skyline with onion-dome churches
   image_query_prefix: ""
   # June 14 2026 — Grok Imagine for all imagery (was inheriting the pexels
   # default). Unique, narrative-tied language-learning visuals on @NerraRU.


### PR DESCRIPTION
Continuing the image-pipeline improvements.

## Cinematic `image_queries` for FF / MIT / Финансы Просто / Привет
The overnight runs confirmed the pipeline works end-to-end — the gallery now has SpaceX, FF, MIT, and both RU shows' first Grok images. But those four shows still carried **terse Pexels-*search* keywords** that predate the Grok switch:

- FF: `space telescope`, `galaxy nebula`, `cosmic stars`
- MIT: `stock market chart`, `investment portfolio`, `bull and bear market`
- FP: `savings jar coins`, `family budget`, `retirement planning`
- PR: `russian architecture`, `cyrillic alphabet`, `russian culture`

Grok *generation* rewards vivid, descriptive scene subjects (the register SpaceX already uses — "Super Heavy booster tower catch"), so the bare tags were leaving image quality on the table. Upgraded each show's queries to cinematic, on-topic scenes, e.g.:
- FF → "James Webb telescope in deep space", "aurora borealis over snowy mountains", "black hole bending starlight"
- MIT → "glowing candlestick chart on a dark trading screen", "golden bull and bear statues facing off"
- FP → "woman planning finances at a bright kitchen table", "glass jar filling with coins beside a small plant"
- PR → "Saint Basil's Cathedral on Red Square at golden hour", "colorful matryoshka nesting dolls close-up"

**Tesla** (established flagship, 208 gallery images, working) and **SpaceX** (already cinematic) are left untouched. Layered with the per-scene story context, tracked-program keywords, and the network quality cue, these produce more striking, on-narrative imagery.

Verified prompts build cleanly; the existing `image_queries` structural guard still passes (105 tests green across visual-assets/config/schedule). A word-count guard was deliberately skipped — it would false-positive on Tesla's intentionally-terse queries.

Affects generated video imagery only — no audio path.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_