### PR TITLE
🚨 Fix smoke-test blocker stopping all episodes from publishing

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -803,7 +803,8 @@ class TestYouTubeImageProviderConfig:
         gallery R2 bucket). MAB keeps ``grok`` in its YAML even while its
         YouTube is paused, so re-enabling it stays a one-line flip."""
         for slug in ("tesla", "spacex", "fascinating_frontiers",
-                     "modern_investing", "finansy_prosto", "privet_russian"):
+                     "modern_investing", "finansy_prosto", "privet_russian",
+                     "first_principles"):
             cfg = load_config(SHOWS_DIR / f"{slug}.yaml")
             assert cfg.youtube.image_provider == "grok", (
                 f"{slug} is YouTube-enabled but not on Grok Imagine"
@@ -813,10 +814,12 @@ class TestYouTubeImageProviderConfig:
         """Shows that don't publish to YouTube stay on the free Pexels
         default — image generation only runs for YouTube-enabled shows, so
         this just guards against accidental drift / surprise Grok cost if one
-        is later enabled without a deliberate provider choice."""
+        is later enabled without a deliberate provider choice.
+
+        (first_principles moved to the grok list above — the operator enabled
+        its YouTube, podcast-only/long-form, on Jun 14 2026.)"""
         for slug in ("omni_view", "planetterrian", "env_intel",
-                     "models_agents", "unintended_consequences",
-                     "first_principles"):
+                     "models_agents", "unintended_consequences"):
             cfg = load_config(SHOWS_DIR / f"{slug}.yaml")
             assert cfg.youtube.image_provider == "pexels", (
                 f"{slug} drifted off pexels — would silently incur Grok "


### PR DESCRIPTION
## 🚨 Unblocks the network — every episode is currently failing to publish

### What's wrong
No episodes have published today. Investigation:

1. **Scheduled runs are delayed** (GitHub-side): no `schedule` events have fired yet today — consistent with GitHub's documented 1–6 h cron-delivery lag (landmine #24). The workflow is `active`; the morning slots simply haven't been delivered. They'll trickle in.

2. **The real blocker (this PR):** even when a run fires, it **fails at the smoke-test step** → the whole pipeline is skipped → nothing publishes. The operator's manual SpaceX dispatch at 08:32 UTC failed for exactly this reason.

### Root cause
On Jun 14 the operator enabled **first_principles** YouTube (podcast-only / long-form) and set `image_provider: grok` — correctly satisfying my `test_all_youtube_shows_use_grok_imagine` guard and updating `YOUTUBE_ENABLED_SHOWS` in `test_schedule.py`. But my **other** #628 guard, `test_non_youtube_shows_remain_on_pexels`, still listed first_principles in the pexels-required set, so it asserted `'grok' == 'pexels'` and failed. That smoke test runs first on **every** show, so its failure skipped the pipeline network-wide.

This is my stale-guard bug — I added a guard that pinned a specific pexels set without anticipating first_principles being enabled.

### Fix
Move `first_principles` from the non-youtube pexels list into the youtube-enabled grok list, matching its new `enabled: true` + `grok` state. The full CI smoke-test set is now green (**623 passed**).

### Note for the operator
first_principles being YouTube-enabled (long-form) adds to the @NerraNetwork EN-channel quota, which was already over the conservative paper budget (landmine #20). The preflight `::error::` is advisory/non-blocking and you kept Shorts off to limit it — flagging for awareness, not changing your decision.

**Please merge promptly** — until this lands, scheduled runs will keep failing the smoke step and no episodes will publish.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_