### PR TITLE
🚨 Fix 2nd publish blocker: honor title-named cover (first_principles)

### DIFF
--- a/engine/youtube_preflight.py
+++ b/engine/youtube_preflight.py
@@ -20,15 +20,24 @@ def validate_youtube_show_ready(
         return issues
 
     slug = getattr(config, "slug", "show")
-    for name in (
-        f"{slug.replace('_', '-')}.jpg",
-        f"{slug}.jpg",
-    ):
+    candidates = [f"{slug.replace('_', '-')}.jpg", f"{slug}.jpg"]
+    # Also accept the cover the show actually references in its RSS
+    # <itunes:image> — some shows name the file after the title rather than the
+    # slug (e.g. first_principles → first-principles-daily.jpg). Without this,
+    # enabling YouTube on such a show hard-fails preflight even though a valid
+    # cover exists. Strictly additive: an unset/foreign rss_image just falls
+    # through to the slug-derived names.
+    rss_image = getattr(getattr(config, "publishing", None), "rss_image", "") or ""
+    rss_basename = rss_image.rstrip("/").rsplit("/", 1)[-1]
+    if rss_basename:
+        candidates.append(rss_basename)
+    for name in candidates:
         if (project_root / "assets" / "covers" / name).exists():
             break
     else:
         issues.append(
-            f"YouTube enabled but no cover at assets/covers/ for slug={slug}"
+            f"YouTube enabled but no cover at assets/covers/ for slug={slug} "
+            f"(checked: {', '.join(candidates)})"
         )
 
     channel = (getattr(yt, "channel", "en") or "en").lower()

--- a/run_show.py
+++ b/run_show.py
@@ -3672,13 +3672,20 @@ def _publish_youtube(
         logger.info("YouTube publishing skipped — no final mp3.")
         return result
 
-    # Resolve cover image. We fall back to whatever the show used in the
-    # RSS <itunes:image> tag if a local file isn't obvious from the slug.
+    # Resolve cover image. Prefer the slug-derived name; then fall back to the
+    # basename the show references in its RSS <itunes:image> (some shows name
+    # the file after the title, e.g. first-principles-daily.jpg) so a YouTube-
+    # enabled show with a title-named cover still gets its art instead of
+    # silently skipping the upload.
     cover_path = None
     cover_candidates = [
         PROJECT_ROOT / "assets" / "covers" / f"{config.slug.replace('_', '-')}.jpg",
         PROJECT_ROOT / "assets" / "covers" / f"{config.slug}.jpg",
     ]
+    _rss_image = getattr(config.publishing, "rss_image", "") or ""
+    _rss_basename = _rss_image.rstrip("/").rsplit("/", 1)[-1]
+    if _rss_basename:
+        cover_candidates.append(PROJECT_ROOT / "assets" / "covers" / _rss_basename)
     for candidate in cover_candidates:
         if candidate.exists():
             cover_path = candidate

--- a/tests/test_youtube_preflight.py
+++ b/tests/test_youtube_preflight.py
@@ -25,3 +25,53 @@ def test_enabled_show_requires_cover_and_queries(tmp_path, monkeypatch):
     monkeypatch.setenv("PEXELS_API_KEY", "pex")
     issues = validate_youtube_show_ready(cfg, root)
     assert any("cover" in i.lower() for i in issues)
+
+
+def _full_creds(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_CLIENT_ID", "id")
+    monkeypatch.setenv("YOUTUBE_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("YOUTUBE_REFRESH_TOKEN_EN", "token")
+    monkeypatch.setenv("PEXELS_API_KEY", "pex")
+    monkeypatch.setenv("GROK_API_KEY", "grok")
+
+
+def test_cover_accepts_rss_image_basename(tmp_path, monkeypatch):
+    """A YouTube-enabled show whose cover is named after the title (not the
+    slug) must still pass — the validator accepts the basename referenced in
+    publishing.rss_image. Regression guard for the Jun 15 2026 first_principles
+    outage (cover was first-principles-daily.jpg; slug-derived check failed)."""
+    root = tmp_path / "repo"
+    (root / "assets" / "covers").mkdir(parents=True)
+    # Only the title-named cover exists — NOT the slug-derived name.
+    (root / "assets" / "covers" / "first-principles-daily.jpg").write_bytes(b"\xff\xd8\xff")
+    cfg = SimpleNamespace(
+        slug="first_principles",
+        publishing=SimpleNamespace(
+            rss_image="https://nerranetwork.com/assets/covers/first-principles-daily.jpg",
+        ),
+        youtube=SimpleNamespace(
+            enabled=True, channel="en", privacy_status="public",
+            image_provider="grok", image_queries=["rocket engine factory"],
+        ),
+    )
+    _full_creds(monkeypatch)
+    issues = validate_youtube_show_ready(cfg, root)
+    assert not any("cover" in i.lower() for i in issues), issues
+
+
+def test_cover_still_fails_when_no_cover_anywhere(tmp_path, monkeypatch):
+    """Sanity: with neither a slug-derived nor an rss_image cover present, the
+    cover check still fails (the fallback is additive, not a bypass)."""
+    root = tmp_path / "repo"
+    (root / "assets" / "covers").mkdir(parents=True)
+    cfg = SimpleNamespace(
+        slug="ghost_show",
+        publishing=SimpleNamespace(rss_image=""),
+        youtube=SimpleNamespace(
+            enabled=True, channel="en", privacy_status="public",
+            image_provider="grok", image_queries=["x"],
+        ),
+    )
+    _full_creds(monkeypatch)
+    issues = validate_youtube_show_ready(cfg, root)
+    assert any("cover" in i.lower() for i in issues)


### PR DESCRIPTION
## Second publish blocker (follow-up to #636)

After #636 cleared the smoke-test failure, the first_principles run reached pre-flight and **hard-failed**:

```
[ERROR] Pre-flight check FAILED: YouTube enabled but no cover at assets/covers/ for slug=first_principles
Pre-flight validation failed with 1 issue(s)
```

### Root cause
Every other YouTube show's cover is slug-named (`tesla.jpg`, `spacex.jpg`…), but first_principles' cover is **title-named** — `first-principles-daily.jpg` (referenced in `publishing.rss_image`). Two places only checked the slug-derived names and missed it:

1. `engine/youtube_preflight.validate_youtube_show_ready` → **hard-fails the whole run**.
2. `run_show._publish_youtube` cover resolution → would **silently skip** the YouTube upload. (Its comment even claimed an RSS-image fallback that was never implemented.)

### Fix
Both now append the **basename of `publishing.rss_image`** to the cover-candidate list — strictly additive (an unset/foreign rss_image just falls through to the slug names). So first_principles passes pre-flight **and** gets its art on the upload, with no duplicate cover file. This also prevents the whole class of bug for any future title-named-cover show, and makes the resolver's comment finally true.

### Tests
+2 guards: the validator accepts the rss_image basename; it still fails when no cover exists anywhere (the fallback is additive, not a bypass). Smoke-relevant suites green (106 passed).

**Please merge** — this is the second of two blockers in today's publish outage; with #636 + this, the pipeline runs clean end-to-end for every show including the newly-enabled first_principles.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_