### PR TITLE
Merge SpaceX review fixes (supersedes #615): theme-miner + tf→tons-force

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -411,6 +411,30 @@ TST received a full recursive improvement architecture (analogous to MIT):
   only the brief — is capped; the digest-expansion retry is the deferred
   network lever, and the grok-4.3 narrative plateau is accepted. Closing-
   pool + prompt edits change shipped audio — A/B-listen per landmine #17.
+- **SpaceX** (SpaceX Daily) runs via `run_show.py` + `shows/spacex.yaml`;
+  engineering-first daily on SpaceX as a public company (Nasdaq: SPCX),
+  `memory_enabled`, X disabled. **June 13 2026 quality pass** (review:
+  [`docs/reviews/spacex_review_2026_06_13.md`](docs/reviews/spacex_review_2026_06_13.md);
+  drift guards: `tests/test_spacex_show.py`,
+  `tests/test_network_quality_pass.py`): two days post-launch, after the
+  operator's same-day fixes for the Ep2 AI-chapter `A I` spacing and the
+  AI-section accuracy guardrail (Colossus/Anthropic is real — do not
+  relitigate). The theme miner mined source-attribution LABELS — the
+  bare-URL strip in `engine/show_memory.py` missed the markdown
+  `[Google News](url)` label, so `"google spacex"` shipped as the #1
+  recurring theme (latent network-wide: FF `science nasa`, M&A `reddit
+  localllama`); now strips the whole `[label](url)` construct first, and
+  the polluted `spacex_theme_history.json` was rebuilt clean. The rocket
+  thrust unit `tf` (tonne-force) was spoken letter-by-letter ("280 T F",
+  twice in Ep2) — a per-show `pronunciation_overrides()` in
+  `shows/hooks/spacex.py` expands `tf → tons-force` (a unit expansion, not
+  a respelling — outside landmine #17; A/B-listen the audio change anyway).
+  Deferred with levers: the SPCX price is spoken twice/episode (Market
+  Watch segment + closing block) — the clean fix needs the Closing chapter
+  marker reordered ahead of Market Watch to avoid an orphan-closing
+  regression; and "AI & Compute" chapter lumping (swallows trailing Top
+  News when the LLM emits news after the editorial markers) — observe Ep3+
+  before a prompt change.
 - All shows delegate X posting to `engine.publisher.post_to_x()`
 - TST/FF/PT delegate voice normalization to `engine.audio.normalize_voice()`
 - All shows use `engine.audio.mix_with_music()` for music mixing (3 modes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,6 +392,30 @@ TST received a full recursive improvement architecture (analogous to MIT):
   only the brief — is capped; the digest-expansion retry is the deferred
   network lever, and the grok-4.3 narrative plateau is accepted. Closing-
   pool + prompt edits change shipped audio — A/B-listen per landmine #17.
+- **SpaceX** (SpaceX Daily) runs via `run_show.py` + `shows/spacex.yaml`;
+  engineering-first daily on SpaceX as a public company (Nasdaq: SPCX),
+  `memory_enabled`, X disabled. **June 13 2026 quality pass** (review:
+  [`docs/reviews/spacex_review_2026_06_13.md`](docs/reviews/spacex_review_2026_06_13.md);
+  drift guards: `tests/test_spacex_show.py`,
+  `tests/test_network_quality_pass.py`): two days post-launch, after the
+  operator's same-day fixes for the Ep2 AI-chapter `A I` spacing and the
+  AI-section accuracy guardrail (Colossus/Anthropic is real — do not
+  relitigate). The theme miner mined source-attribution LABELS — the
+  bare-URL strip in `engine/show_memory.py` missed the markdown
+  `[Google News](url)` label, so `"google spacex"` shipped as the #1
+  recurring theme (latent network-wide: FF `science nasa`, M&A `reddit
+  localllama`); now strips the whole `[label](url)` construct first, and
+  the polluted `spacex_theme_history.json` was rebuilt clean. The rocket
+  thrust unit `tf` (tonne-force) was spoken letter-by-letter ("280 T F",
+  twice in Ep2) — a per-show `pronunciation_overrides()` in
+  `shows/hooks/spacex.py` expands `tf → tons-force` (a unit expansion, not
+  a respelling — outside landmine #17; A/B-listen the audio change anyway).
+  Deferred with levers: the SPCX price is spoken twice/episode (Market
+  Watch segment + closing block) — the clean fix needs the Closing chapter
+  marker reordered ahead of Market Watch to avoid an orphan-closing
+  regression; and "AI & Compute" chapter lumping (swallows trailing Top
+  News when the LLM emits news after the editorial markers) — observe Ep3+
+  before a prompt change.
 - All shows delegate X posting to `engine.publisher.post_to_x()`
 - TST/FF/PT delegate voice normalization to `engine.audio.normalize_voice()`
 - All shows use `engine.audio.mix_with_music()` for music mixing (3 modes:

--- a/digests/spacex/spacex_theme_history.json
+++ b/digests/spacex/spacex_theme_history.json
@@ -1,37 +1,37 @@
 {
   "version": 1,
-  "last_updated": "2026-06-15T12:26:03.289977",
+  "last_updated": "2026-06-13T17:59:52.229473",
   "recurring_themes": {
-    "google google": 16,
-    "google spacex": 11,
-    "data center": 5,
-    "elon musk": 4,
-    "full flow": 4,
-    "flow staged": 4,
-    "staged combustion": 4,
-    "combustion cycle": 4,
-    "starship": 4,
-    "starbase": 4,
-    "falcon": 4,
-    "raptor": 4,
-    "booster": 4,
-    "launch": 4,
-    "catch": 4,
-    "orbit": 4,
-    "cape canaveral": 3,
-    "thousand starships": 3,
-    "floor space": 3,
-    "starlink": 3,
-    "spacex raptor": 3,
-    "uses same": 3,
-    "single most": 3,
-    "google spacenews": 3,
-    "recovery crane": 3,
-    "long beach": 3,
-    "future starship": 3,
+    "elon musk": 3,
+    "full flow": 3,
+    "flow staged": 3,
+    "staged combustion": 3,
+    "combustion cycle": 3,
+    "data center": 3,
     "voting control": 2,
     "seventy five": 2,
-    "five billion": 2
+    "five billion": 2,
+    "billion dollars": 2,
+    "starship development": 2,
+    "structure gives": 2,
+    "cape canaveral": 2,
+    "thousand starships": 2,
+    "floor space": 2,
+    "public listing": 2,
+    "starship": 2,
+    "starbase": 2,
+    "starlink": 2,
+    "falcon": 2,
+    "raptor": 2,
+    "booster": 2,
+    "launch": 2,
+    "catch": 2,
+    "orbit": 2,
+    "pad": 2,
+    "spacex raptor": 2,
+    "idiot index": 2,
+    "uses same": 2,
+    "chamber pressure": 2
   },
   "theme_evolution": [
     {
@@ -50,40 +50,14 @@
     {
       "episode": 2,
       "top_themes": [
-        "google spacex",
         "elon musk",
         "full flow",
         "flow staged",
         "staged combustion",
         "combustion cycle",
         "data center",
-        "voting control"
-      ]
-    },
-    {
-      "episode": 3,
-      "top_themes": [
-        "google google",
-        "google spacex",
-        "elon musk",
-        "full flow",
-        "flow staged",
-        "staged combustion",
-        "combustion cycle",
-        "data center"
-      ]
-    },
-    {
-      "episode": 4,
-      "top_themes": [
-        "google google",
-        "google spacex",
-        "data center",
-        "elon musk",
-        "full flow",
-        "flow staged",
-        "staged combustion",
-        "combustion cycle"
+        "voting control",
+        "seventy five"
       ]
     }
   ]

--- a/digests/spacex/spacex_theme_history.json
+++ b/digests/spacex/spacex_theme_history.json
@@ -1,8 +1,7 @@
 {
   "version": 1,
-  "last_updated": "2026-06-13T15:24:28.300030",
+  "last_updated": "2026-06-13T17:59:52.229473",
   "recurring_themes": {
-    "google spacex": 6,
     "elon musk": 3,
     "full flow": 3,
     "flow staged": 3,
@@ -31,7 +30,8 @@
     "pad": 2,
     "spacex raptor": 2,
     "idiot index": 2,
-    "uses same": 2
+    "uses same": 2,
+    "chamber pressure": 2
   },
   "theme_evolution": [
     {
@@ -50,14 +50,14 @@
     {
       "episode": 2,
       "top_themes": [
-        "google spacex",
         "elon musk",
         "full flow",
         "flow staged",
         "staged combustion",
         "combustion cycle",
         "data center",
-        "voting control"
+        "voting control",
+        "seventy five"
       ]
     }
   ]

--- a/docs/reviews/ledger/spacex.yaml
+++ b/docs/reviews/ledger/spacex.yaml
@@ -1,0 +1,37 @@
+reviews:
+  - date: 2026-06-13
+    pr: 615
+    doc: docs/reviews/spacex_review_2026_06_13.md
+    summary: >
+      First review, 2 days post-launch. Operator had already cleared the Ep2
+      AI-chapter spacing + AI-accuracy items same-day; this pass took the next
+      tier: theme-miner source-label pollution and a spoken thrust-unit garble.
+    shipped:
+      - theme miner strips markdown source-link labels (was leaking "google
+        spacex" as the #1 theme; latent on all memory shows) + rebuilt clean
+        spacex_theme_history.json
+      - "tf" thrust unit expanded to "tons-force" via per-show
+        pronunciation_overrides (was spoken "T F")
+    deferred:
+      - SPCX price spoken twice/episode (Market Watch segment + closing block);
+        clean fix needs Closing marker reordered ahead of Market Watch AND the
+        Market Watch spoken price dropped — coupled, own A/B pass
+      - chapter lumping — "AI & Compute" swallows trailing Top News after the
+        a-i marker fix; root cause LLM section-ordering; observe Ep3+ before
+        a prompt change
+      - cold-open hook leads with unglossed "Idiot Index" jargon (n=1)
+      - tomorrow-teaser "watch for the first …" tic (n=2)
+    predictions:
+      - metric: highest-weighted key in spacex_theme_history.json recurring_themes
+        baseline: "'google spacex' (count 6)"
+        expected: "no source-label token (google/news/com/gov/reddit) in any top-30 theme key after Ep3-Ep5 mine"
+        verdict: pending
+        evidence: null
+      - metric: count of "tf" / "T F" letter-spellings in spacex _tts.txt + transcripts
+        baseline: "2 (Ep2)"
+        expected: "0 — 'tf' renders as 'tons-force' going forward"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
+do_not_retry: []

--- a/docs/reviews/ledger/spacex.yaml
+++ b/docs/reviews/ledger/spacex.yaml
@@ -1,0 +1,37 @@
+reviews:
+  - date: 2026-06-13
+    pr: null   # set on PR open
+    doc: docs/reviews/spacex_review_2026_06_13.md
+    summary: >
+      First review, 2 days post-launch. Operator had already cleared the Ep2
+      AI-chapter spacing + AI-accuracy items same-day; this pass took the next
+      tier: theme-miner source-label pollution and a spoken thrust-unit garble.
+    shipped:
+      - theme miner strips markdown source-link labels (was leaking "google
+        spacex" as the #1 theme; latent on all memory shows) + rebuilt clean
+        spacex_theme_history.json
+      - "tf" thrust unit expanded to "tons-force" via per-show
+        pronunciation_overrides (was spoken "T F")
+    deferred:
+      - SPCX price spoken twice/episode (Market Watch segment + closing block);
+        clean fix needs Closing marker reordered ahead of Market Watch AND the
+        Market Watch spoken price dropped — coupled, own A/B pass
+      - chapter lumping — "AI & Compute" swallows trailing Top News after the
+        a-i marker fix; root cause LLM section-ordering; observe Ep3+ before
+        a prompt change
+      - cold-open hook leads with unglossed "Idiot Index" jargon (n=1)
+      - tomorrow-teaser "watch for the first …" tic (n=2)
+    predictions:
+      - metric: highest-weighted key in spacex_theme_history.json recurring_themes
+        baseline: "'google spacex' (count 6)"
+        expected: "no source-label token (google/news/com/gov/reddit) in any top-30 theme key after Ep3-Ep5 mine"
+        verdict: pending
+        evidence: null
+      - metric: count of "tf" / "T F" letter-spellings in spacex _tts.txt + transcripts
+        baseline: "2 (Ep2)"
+        expected: "0 — 'tf' renders as 'tons-force' going forward"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
+do_not_retry: []

--- a/docs/reviews/ledger/spacex.yaml
+++ b/docs/reviews/ledger/spacex.yaml
@@ -1,6 +1,6 @@
 reviews:
   - date: 2026-06-13
-    pr: null   # set on PR open
+    pr: 615
     doc: docs/reviews/spacex_review_2026_06_13.md
     summary: >
       First review, 2 days post-launch. Operator had already cleared the Ep2

--- a/docs/reviews/review_state.yaml
+++ b/docs/reviews/review_state.yaml
@@ -23,7 +23,7 @@ targets:
   finansy_prosto: 2026-06-10
   privet_russian: 2026-06-10
   env_intel: 2026-06-11
-  spacex: 2026-06-12
+  spacex: 2026-06-13
   first_principles: 2026-06-10
   omni_view: 2026-06-10
   unintended_consequences: 2026-06-12

--- a/docs/reviews/spacex_review_2026_06_13.md
+++ b/docs/reviews/spacex_review_2026_06_13.md
@@ -1,0 +1,129 @@
+# SpaceX Daily — quality review (2026-06-13)
+
+First scheduled review of **SpaceX Daily**, two days after launch (Ep1 + Ep2,
+both produced 2026-06-13 — launch turbulence is documented in `shows/spacex.yaml`:
+Ep1 double-ran and polluted the 7-day URL dedup, Ep2 was a thin Saturday).
+The operator had already done a same-day mini-pass (commits `20886ed2`,
+`68487c60`): the Ep2 **AI-chapter `A I` spacing** bug and the **AI-section
+accuracy guardrail** (Colossus/Anthropic is real news in this timeline, not a
+hallucination — do not relitigate) are both resolved. This review finds the
+next tier.
+
+Evidence: `shows/spacex.yaml`, all four prompts, `shows/hooks/spacex.py`,
+`assets/pronunciation.py`, `engine/chapters.py`, `engine/show_memory.py`, both
+episodes' digests + `_tts.txt` + Whisper transcripts + `chapters_ep00*.json`,
+the trackers, `spacex_podcast.rss`, and `tests/test_spacex_show.py`.
+`scripts/review_snapshot.py spacex`: ep1 1544w / ep2 1406w (both above the
+1300 floor), $0.132/ep, no OP3 data yet.
+
+## P0 — listener-facing bugs shipping today
+
+None. The operator's same-day pass cleared the AI-chapter and AI-accuracy
+issues; chapter shape is otherwise within tolerance on the two shipped
+episodes. (Two P1 quality items below ship in audio but are not failures.)
+
+## P1 — quality ceiling
+
+### 1. Theme miner mines source-attribution labels → "google spacex" is the #1 "theme" (SHIPPED)
+`engine/show_memory.update_theme_history_from_digest` stripped bare URLs
+before mining but **not** the markdown source-link LABEL. Digests format every
+source as `Source: [Google News](https://…)`; after the bare-URL strip the
+label `Google News` survived and the repeated source name paired with the next
+story's first word into junk bigrams. `digests/spacex/spacex_theme_history.json`
+shipped with **`"google spacex": 6`** as the single highest-weighted recurring
+theme (verified: `google spacex` counted 2× in Ep1's digest, 4× in Ep2's),
+ahead of every real theme (`full flow`, `staged combustion`, `idiot index`…).
+That polluted top theme feeds `{narrative_memory_section}` into the prompts.
+
+This is the **same class** as the network theme-pollution bugs prior passes
+fixed (Tesla "open questions" ×112; the June network pass's `_THEME_STOPWORDS`).
+The bare-URL strip was the documented fix then — it just didn't cover the
+markdown-link form. **It is latent on every memory show:** Fascinating
+Frontiers carries `science nasa` / `nasa` (from `[nasa.gov]`), Models & Agents
+carries `reddit localllama` (from `[reddit.com]`).
+
+**Fix:** strip the whole `[label](url)` construct before mining, then bare
+URLs (`engine/show_memory.py`). Confirmed it removes 100% of `google`-bigrams
+from both SpaceX digests and leaves real themes intact (`elon musk`, `staged
+combustion`…). Real in-content mentions (e.g. "NASA" spoken in a story) are
+unaffected — only the source-label inflation is removed. Rebuilt
+`spacex_theme_history.json` clean via the fixed miner (the one-time
+stopword scrub doesn't catch `google`, so the existing file was regenerated).
+Sibling histories left to re-balance naturally as clean episodes accumulate.
+Drift guard: `test_theme_mining_strips_source_attribution_labels`.
+
+### 2. Rocket-thrust unit "tf" spoken letter-by-letter as "T F" (SHIPPED)
+Ep2 `_tts.txt`: "Thrust now exceeds **280 tf**…" and "…survives the thermal
+environment at **280 tf**." The Whisper transcript rendered both as
+"**280 TF**" — i.e. the audio said "tee eff". `tf` (tonne-force, the standard
+unit for rocket-engine thrust) is not in `UNIT_ABBREVIATIONS`, so it reached
+Grok TTS and was read as letters. On an engineering-first show where thrust is
+core content, this recurs whenever the model copies `tf` from a source headline
+(Ep2 took it from the Raptor-3 MEXC piece).
+
+**Fix:** a per-show `pronunciation_overrides()` in `shows/hooks/spacex.py`
+(the existing `run_show._apply_pronunciation` mechanism) expanding
+`tf → tons-force`. This is a **unit expansion** (the `km→kilometers` class),
+NOT a phonetic respelling — outside the landmine #17 ban. Scoped to SpaceX
+(no shared-module change), whole-word/case-insensitive, verified not to touch
+`software`/`lift`. Drift guard: `test_tf_thrust_unit_expanded_for_tts`.
+⚠️ Audio-affecting — A/B-listen (landmine #17).
+
+## P2 / deferred (recommendations, not shipped)
+
+- **SPCX price spoken twice every episode.** The dedicated Market Watch
+  segment speaks the price (podcast prompt lines 93–94) AND the code-supplied
+  closing block appends a price sentence (`shows/hooks/spacex.py`
+  `_price_sentence`). Result: Ep1 "SPCX is at $160.95 … [≈15s] … SPCX closed
+  at $160.95"; Ep2 identical. Redundant, and over-weights the stock on a show
+  whose stated principle is "engineering first, the stock is the quiet thread."
+  **Deferred because the obvious fix is not cleanly safe:** removing the price
+  from the *closing* breaks three intended/tested behaviours
+  (`test_price_sentence_*`, `test_closing_rotates_by_date`); removing it from
+  the *Market Watch* spoken segment risks a chapter regression — with no
+  earlier "Market Watch" match, the closing's "S P C X **closed** at…" would be
+  grabbed by the Market Watch marker (`S ?P ?C ?X (closed|…)`, listed before
+  Closing) and the episode would ship with no Closing chapter (the orphan-
+  closing class). A correct fix needs to reorder the Closing marker ahead of
+  Market Watch (so `where: end` Closing wins the sign-off line) *and* drop the
+  Market Watch spoken price — a coupled change worth its own A/B pass. Lever
+  recorded for the next review.
+
+- **Chapter lumping: "AI & Compute" swallows trailing Top News.** Now that
+  today's `a ?i` marker fix lets "On the A I front" match, a fresh parse of
+  Ep2 puts 662 words (the lawsuits, the Fish & Wildlife suit, the LandSpace
+  item, the grid-fin and Boca-Chica buzz) under the **AI & Compute** chapter,
+  because the LLM emitted those news items *after* the AI marker rather than
+  before the Counterpoint/AI/Engineering editorial block. Root cause is
+  section-ordering adherence, not the markers. The marker fix is brand-new
+  (Ep3 is the first normal episode to even have an AI chapter), so **observe
+  Ep3+ before touching the prompt.** Lever: reinforce in the podcast prompt
+  that ALL Top News + Community Buzz come before the three editorial segments,
+  never interleaved. The next review scores whether the lump recurs.
+
+- **Cold-open hook leads with unglossed jargon.** Ep2's first spoken content
+  line: "…cut the **Idiot Index** on each engine" — the system prompt's own
+  "never use jargon without a plain-language gloss on first use" rule, violated
+  in the very first sentence. The Engineering Deep Dive later glosses it; the
+  hook does not. n=1; watch whether the digest HOOK keeps front-loading the
+  First-Principles terms.
+
+- **Tomorrow-teaser tic.** Both episodes opened the teaser "watch for the
+  first …" (Ep1 "first quarterly filing", Ep2 "first integrated test"). n=2;
+  monitor for a dead-rotation pattern.
+
+- **Ep1 Engineering Deep Dive was thin** (51s chapter, no magic-wand / Idiot
+  Index reasoning) — but Ep1 is the one-time IPO-debut episode with a
+  non-standard structure; not generalizable.
+
+## Hard guardrails honored
+No R2/RSS-enclosure changes, no MP3s, no `min_articles_skip` default change, no
+TTS-coupled-field flips, no voice/provider changes, no phonetic respellings
+(the `tf` fix is a unit expansion), no posting/sending/uploading/paid APIs.
+
+## Tests
+`tests/test_spacex_show.py` (44), `tests/test_network_quality_pass.py` (32),
+`test_show_memory.py`, `test_phase3_memory.py`, `test_prompt_fidelity.py`,
+`test_episode_validity.py`, `test_generator.py`,
+`test_four_show_quality_pass.py`, `test_fascinating_frontiers_quality_pass.py`
+— all pass (254 total).

--- a/engine/show_memory.py
+++ b/engine/show_memory.py
@@ -452,9 +452,16 @@ def update_theme_history_from_digest(output_dir: Path, cfg: MemoryConfig,
         elif noise_key in echo_bigrams or noise_key in self_ref_bigrams:
             del themes[noise_key]
 
-    # Strip URLs before mining — digests carry "Source: https://..."
-    # lines whose tokens otherwise become junk bigrams ("google https").
-    text_lower = re.sub(r"https?://\S+", " ", (digest_text or "").lower())
+    # Strip source attributions before mining. Digests format sources as
+    # "Source: [Google News](https://…)" markdown links; the bare-URL strip
+    # below missed the LABEL ("Google News", "nasa.gov", "reddit.com"), so
+    # the repeated source name paired with the next story's first word into
+    # junk bigrams — "google spacex" ranked #1 on SpaceX Daily, with "science
+    # nasa" / "reddit localllama" the same artifact on the sibling memory
+    # shows. Remove the whole [label](url) construct first, then any bare URL
+    # that survives (e.g. a plain "Source: https://…" with no markdown).
+    _no_links = re.sub(r"\[[^\]]*\]\([^)]*\)", " ", digest_text or "")
+    text_lower = re.sub(r"https?://\S+", " ", _no_links.lower())
     for kw in cfg.theme_keywords:
         if kw in text_lower:
             themes[kw] = themes.get(kw, 0) + 1

--- a/shows/hooks/spacex.py
+++ b/shows/hooks/spacex.py
@@ -77,6 +77,22 @@ def post_generate(config, *, digest_text: str = "", episode_num: int = 0) -> Non
     show_memory.memory_post_generate(config, "spacex", digest_text, episode_num)
 
 
+def pronunciation_overrides() -> dict:
+    """Per-show TTS pronunciation overrides (see run_show._apply_pronunciation).
+
+    "tf" — tonne-force, the standard unit for rocket-engine thrust — is read
+    letter-by-letter by Grok TTS: Ep2's "thrust now exceeds 280 tf" was
+    transcribed by Whisper as "280 TF" (i.e. the audio said "tee eff"), twice.
+    On a thrust-heavy engineering-first show this recurs whenever the model
+    copies "tf" from a source. Expand it to the spoken unit so the episode
+    says "two hundred eighty tons-force". This is a unit EXPANSION (the same
+    class as km→kilometers, already in assets.pronunciation.UNIT_ABBREVIATIONS),
+    NOT a phonetic respelling of a word — so it is outside the landmine #17 ban
+    on theory-driven respellings.
+    """
+    return {"extra_words": {"tf": "tons-force"}}
+
+
 # ---------------------------------------------------------------------------
 # SPCX quote (landmine #22 pattern, lean two-source chain)
 # ---------------------------------------------------------------------------

--- a/shows/hooks/tesla.py
+++ b/shows/hooks/tesla.py
@@ -44,7 +44,8 @@ def pre_fetch(config, *, episode_num: int | None = None, today_str: str | None =
     # Refresh the public Tesla data dashboard (best-effort, non-fatal):
     # live TSLA market data + 1y price history for tesla-dashboard.html.
     try:
-        import subprocess, sys as _sys
+        import subprocess
+        import sys as _sys
         subprocess.run(
             [_sys.executable, str(Path(__file__).resolve().parent.parent.parent
                                   / "scripts" / "fetch_tesla_dashboard.py")],

--- a/tests/test_network_quality_pass.py
+++ b/tests/test_network_quality_pass.py
@@ -65,6 +65,32 @@ class TestShowMemoryFixesPorted:
         for noise in ("open questions", "questions show", "narrative memory"):
             assert noise not in themes
 
+    def test_theme_mining_strips_source_attribution_labels(self, tmp_path):
+        """Markdown source links ("Source: [Google News](url)") must be
+        stripped LABEL-and-all before mining. The bare-URL strip alone left
+        the label, so the repeated source name paired with the next story's
+        first word into junk bigrams — "google spacex" ranked #1 on SpaceX
+        Daily (June 2026 review); "science nasa" / "reddit localllama" on the
+        sibling memory shows.
+        """
+        from engine import show_memory as sm
+        import json
+
+        cfg = sm.get_config("spacex")
+        assert cfg is not None
+        digest = (
+            "SpaceX flew a Falcon mission today.\n"
+            "Source: [Google News](https://news.google.com/rss/articles/abc)\n\n"
+            "Starship static-fired at Starbase.\n"
+            "Source: [Google News](https://news.google.com/rss/articles/def)\n"
+        )
+        sm.update_theme_history_from_digest(tmp_path, cfg, digest, 3)
+        themes = json.loads(
+            (tmp_path / cfg.theme_filename).read_text())["recurring_themes"]
+        # No theme may contain a source-label token from a stripped link.
+        for key in themes:
+            assert "google" not in key.split(), f"source-label leak: {key!r}"
+
     def test_auto_narrative_freshness_exists_and_runs(self, tmp_path):
         from engine import show_memory as sm
 

--- a/tests/test_spacex_show.py
+++ b/tests/test_spacex_show.py
@@ -253,6 +253,27 @@ class TestStockClosing:
         )
         assert pron["corrections"].get("SPCX") == "S P C X"
 
+    def test_tf_thrust_unit_expanded_for_tts(self):
+        """Ep2 lesson: "thrust now exceeds 280 tf" was spoken as "280 T F"
+        (Whisper transcribed letters, twice). The hook's pronunciation
+        override expands the rocket-thrust unit so it reads as a unit, not
+        spelled letters. A unit expansion (km→kilometers class), NOT a
+        phonetic respelling (landmine #17)."""
+        from shows.hooks.spacex import pronunciation_overrides
+        from assets.pronunciation import prepare_text_for_tts
+
+        ov = pronunciation_overrides()
+        assert ov["extra_words"]["tf"] == "tons-force"
+        out = prepare_text_for_tts(
+            "Thrust now exceeds 280 tf today.",
+            extra_words=ov["extra_words"],
+        )
+        assert "tons-force" in out
+        assert "280 tf " not in out + " "
+        # Must not maul real words that merely contain the letters.
+        assert "software" in prepare_text_for_tts(
+            "the software shipped", extra_words=ov["extra_words"])
+
 
 class TestEp001RegressionChapters:
     """Ep001 lesson: chapters parse the POST-pronunciation script, where


### PR DESCRIPTION
Brings the **SpaceX Daily review-agent fixes (originally PR #615)** onto the working branch and resolves its stale conflict, per your "merge it all now" call.

### What's included (from #615)
- **Theme miner strips full markdown source citations** (`[label](url)`) before mining, not just bare URLs — kills the `"google spacex"` pollution that was shipping as the #1 recurring theme into `{narrative_memory_section}`. Latent on every memory show (FF, M&A). **Non-audio.**
- **`tf → tons-force`** in `shows/hooks/spacex.py` `pronunciation_overrides` — a unit expansion fixing the confirmed "two hundred eighty **T F**" garble. ⚠️ **Changes shipped SpaceX audio** — you approved shipping it; A/B-listen the next SpaceX episode per landmine #17.
- Drift guards (`test_spacex_show.py`, `test_network_quality_pass.py`), review doc + ledger + rotation advance.
- `spacex_theme_history.json` taken from the clean rebuild (regenerates each run via the fixed miner).

### Why this branch instead of merging #615 directly
#615 was stale (created Jun 13, before all the recent SpaceX work) with a conflict in the generated `spacex_theme_history.json`, and I develop on this branch. I merged its content here, resolved the data-file conflict, and verified — #615 will be closed as superseded.

Also a tiny ruff E401 cleanup in `shows/hooks/tesla.py` (pre-existing multi-import line).

Tests: SpaceX/memory/network/smoke suites green (328 passed); `ruff` clean.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_