### PR TITLE
Newsletters: dashboard "By the numbers" block + activate SpaceX & First Principles

### DIFF
--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -388,6 +388,17 @@ def send_newsletter(
         return None
 
 
+def _dashboard_stats_for(slug: str) -> List[Dict[str, str]]:
+    """Best-effort dashboard stat tiles for the newsletter 'By the numbers'
+    block. Import-guarded so a refactor of the dashboard module can never
+    break a send."""
+    try:
+        from engine.newsletter_dashboard import build_dashboard_stats
+        return build_dashboard_stats(slug)
+    except Exception:  # pragma: no cover — never block a send
+        return []
+
+
 def send_show_newsletter(
     digest_text: str,
     config,
@@ -527,6 +538,11 @@ def send_show_newsletter(
         daily_date=_today,
         adjacent_shows=adjacent_shows,
         requires_financial_disclaimer=requires_disc,
+        # Surface the show's live dashboard data as a "By the numbers" block
+        # under the hero (SpaceX: SPCX/launches/Starlink; Tesla: TSLA/deliveries;
+        # Modern Investing: alpha/win-rate/trades). Best-effort + empty for shows
+        # with no dashboard mapping, so this is a no-op everywhere else.
+        by_the_numbers=_dashboard_stats_for(slug),
         # Daily emails count by episode, not by weeks-since-launch.
         # The latter (compute_issue_number) is for weekly synthesis
         # newsletters; on a daily it produces "Issue #1" for any show

--- a/engine/newsletter_dashboard.py
+++ b/engine/newsletter_dashboard.py
@@ -1,0 +1,114 @@
+"""Per-show dashboard stats for the newsletter "By the numbers" block.
+
+Reads the same live data files the public dashboards use (``api/*.json``,
+``site/data/*.json``) and returns up to three ``{"value", "label"}`` tiles for
+``wrap_with_branding(by_the_numbers=...)``. Strictly best-effort: any missing
+file, unreadable JSON, or non-finite number is skipped, so the newsletter send
+is never blocked by a stale/absent dashboard cache. Shows without a mapping
+return ``[]`` (no block rendered).
+
+Added June 2026 (operator request: surface dashboard data in the SpaceX, Tesla,
+and Modern Investing newsletters).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load(root: Path, rel: str) -> Optional[Any]:
+    try:
+        return json.loads((root / rel).read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _finite(v: Any) -> Optional[float]:
+    """Return a finite float or None (guards the yfinance-NaN class so a bad
+    cache value never reaches the email as 'nan')."""
+    try:
+        f = float(v)
+        return f if math.isfinite(f) else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _tile(value: str, label: str) -> Dict[str, str]:
+    return {"value": value, "label": label}
+
+
+def _spacex_stats(root: Path) -> List[Dict[str, str]]:
+    out: List[Dict[str, str]] = []
+    spcx = _load(root, "api/spcx.json") or {}
+    price = _finite(spcx.get("price"))
+    if price and price > 0:
+        out.append(_tile(f"${price:,.2f}", "SPCX price"))
+    launches = _load(root, "api/spacex_launches.json") or {}
+    ytd = launches.get("stats", {}).get("launches_ytd") if isinstance(launches.get("stats"), dict) else None
+    if isinstance(ytd, int) and ytd > 0:
+        out.append(_tile(str(ytd), "Launches this year"))
+    fleet = launches.get("fleet") if isinstance(launches.get("fleet"), dict) else {}
+    starlink = fleet.get("starlink_active")
+    if isinstance(starlink, int) and starlink > 0:
+        out.append(_tile(f"{starlink:,}", "Active Starlink sats"))
+    return out[:3]
+
+
+def _tesla_stats(root: Path) -> List[Dict[str, str]]:
+    out: List[Dict[str, str]] = []
+    dash = _load(root, "api/tesla_dashboard.json") or {}
+    price = _finite(dash.get("price"))
+    if price and price > 0:
+        out.append(_tile(f"${price:,.2f}", "TSLA price"))
+    chg = _finite(dash.get("change_pct"))
+    if chg is not None:
+        out.append(_tile(f"{chg:+.2f}%", "TSLA today"))
+    metrics = _load(root, "site/data/tesla_metrics.json") or {}
+    annual = metrics.get("deliveries_annual") if isinstance(metrics.get("deliveries_annual"), list) else []
+    if annual:
+        last = annual[-1]
+        vehicles = _finite(last.get("vehicles"))
+        if vehicles and vehicles > 0:
+            out.append(_tile(f"{vehicles / 1e6:.2f}M", f"{last.get('year')} deliveries"))
+    return out[:3]
+
+
+def _modern_investing_stats(root: Path) -> List[Dict[str, str]]:
+    out: List[Dict[str, str]] = []
+    dash = _load(root, "api/dashboard.json") or {}
+    perf = dash.get("mit_performance") if isinstance(dash.get("mit_performance"), dict) else {}
+    summary = perf.get("summary") if isinstance(perf.get("summary"), dict) else {}
+    alpha = _finite(summary.get("cumulative_alpha_vs_nasdaq"))
+    if alpha is not None:
+        out.append(_tile(f"{alpha:+.1f}%", "Alpha vs NASDAQ"))
+    win_rate = _finite(summary.get("win_rate_pct"))
+    if win_rate is not None:
+        out.append(_tile(f"{win_rate:.0f}%", "Win rate"))
+    trades = summary.get("total_trades")
+    if isinstance(trades, int) and trades > 0:
+        out.append(_tile(str(trades), "Simulated trades"))
+    return out[:3]
+
+
+_BUILDERS = {
+    "spacex": _spacex_stats,
+    "tesla": _tesla_stats,
+    "modern_investing": _modern_investing_stats,
+}
+
+
+def build_dashboard_stats(slug: str, root: Optional[Path] = None) -> List[Dict[str, str]]:
+    """Up to 3 dashboard stat tiles for *slug*'s newsletter, or [] if the show
+    has no mapping or its data is unavailable. Never raises."""
+    builder = _BUILDERS.get(slug)
+    if builder is None:
+        return []
+    try:
+        return builder(Path(root) if root else _REPO_ROOT)
+    except Exception:
+        return []

--- a/shows/first_principles.yaml
+++ b/shows/first_principles.yaml
@@ -135,9 +135,19 @@ chapters:
       where: end
 
 newsletter:
-  # Off at launch (operator decision). Flip ``enabled: true`` + add a
-  # Buttondown tag/start_date to turn on per-episode email later.
-  enabled: false
+  # Turned on June 15 2026 (operator created the "First Principles Daily"
+  # Buttondown tag). Per-episode email like the other shows. Narrative show,
+  # not financial — no disclaimer.
+  enabled: true
+  platform: buttondown
+  api_key_env: BUTTONDOWN_API_KEY
+  status: about_to_send
+  tag: "First Principles Daily"        # must match the Buttondown Tags page exactly
+  short_label: "First Principles"
+  emoji: "💡"
+  newsletter_start_date: "2026-06-15"
+  requires_financial_disclaimer: false
+  length_target_words: 1200
 
 content_tracking:
   enabled: true

--- a/tests/test_newsletter_dashboard.py
+++ b/tests/test_newsletter_dashboard.py
@@ -78,3 +78,22 @@ def test_block_renders_in_branded_body():
     stats = [{"value": "$160.95", "label": "SPCX price"}]
     body = wrap_with_branding("spacex", "Body.", daily_label="Ep 4", by_the_numbers=stats)
     assert "By the numbers" in body and "SPCX price" in body
+
+
+def test_spacex_and_first_principles_newsletters_configured():
+    """June 15 2026: operator created the 'SpaceX Daily' + 'First Principles
+    Daily' Buttondown tags and asked for both shows' newsletters live. Pin that
+    each is enabled with a tag that matches the created Buttondown tag exactly
+    (a mismatch silently blocks the send — see the Jun 15 SpaceX incident)."""
+    from engine.config import load_config
+    expected = {
+        "spacex": "SpaceX Daily",
+        "first_principles": "First Principles Daily",
+    }
+    for slug, tag in expected.items():
+        cfg = load_config(Path(__file__).resolve().parent.parent / "shows" / f"{slug}.yaml")
+        n = cfg.newsletter
+        assert n.enabled is True, f"{slug} newsletter must be enabled"
+        assert n.tag == tag, f"{slug} tag {n.tag!r} must match Buttondown tag {tag!r}"
+        assert n.api_key_env == "BUTTONDOWN_API_KEY"
+        assert n.short_label and n.emoji, f"{slug} needs short_label + emoji"

--- a/tests/test_newsletter_dashboard.py
+++ b/tests/test_newsletter_dashboard.py
@@ -1,0 +1,80 @@
+"""Guards for the per-show newsletter 'By the numbers' dashboard block
+(June 2026: surface live dashboard data in the SpaceX/Tesla/MIT newsletters)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from engine.newsletter_dashboard import build_dashboard_stats
+
+
+def _write(root: Path, rel: str, obj) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def test_spacex_stats(tmp_path):
+    _write(tmp_path, "api/spcx.json", {"price": 160.95, "prev_close": None})
+    _write(tmp_path, "api/spacex_launches.json",
+           {"stats": {"launches_ytd": 70}, "fleet": {"starlink_active": 10544}})
+    stats = build_dashboard_stats("spacex", tmp_path)
+    labels = {s["label"]: s["value"] for s in stats}
+    assert labels["SPCX price"] == "$160.95"
+    assert labels["Launches this year"] == "70"
+    assert labels["Active Starlink sats"] == "10,544"
+    assert len(stats) <= 3
+
+
+def test_tesla_stats(tmp_path):
+    _write(tmp_path, "api/tesla_dashboard.json", {"price": 406.43, "change_pct": 0.08})
+    _write(tmp_path, "site/data/tesla_metrics.json",
+           {"deliveries_annual": [{"year": "2023", "vehicles": 1808581},
+                                   {"year": "2024", "vehicles": 1789226}]})
+    labels = {s["label"]: s["value"] for s in build_dashboard_stats("tesla", tmp_path)}
+    assert labels["TSLA price"] == "$406.43"
+    assert labels["TSLA today"] == "+0.08%"
+    assert labels["2024 deliveries"] == "1.79M"
+
+
+def test_modern_investing_stats(tmp_path):
+    _write(tmp_path, "api/dashboard.json", {"mit_performance": {"summary": {
+        "cumulative_alpha_vs_nasdaq": 21.23, "win_rate_pct": 58.8, "total_trades": 34}}})
+    labels = {s["label"]: s["value"] for s in build_dashboard_stats("modern_investing", tmp_path)}
+    assert labels["Alpha vs NASDAQ"] == "+21.2%"
+    assert labels["Win rate"] == "59%"
+    assert labels["Simulated trades"] == "34"
+
+
+def test_unmapped_show_returns_empty(tmp_path):
+    assert build_dashboard_stats("omni_view", tmp_path) == []
+
+
+def test_missing_data_is_safe(tmp_path):
+    # No data files at all → empty, never raises.
+    assert build_dashboard_stats("spacex", tmp_path) == []
+
+
+def test_nan_and_zero_values_skipped(tmp_path):
+    # Non-finite / zero prices must not render as 'nan' or '$0.00'.
+    _write(tmp_path, "api/spcx.json", {"price": 0})
+    _write(tmp_path, "api/spacex_launches.json", {"stats": {"launches_ytd": 0}, "fleet": {}})
+    assert build_dashboard_stats("spacex", tmp_path) == []
+    _write(tmp_path, "api/dashboard.json", {"mit_performance": {"summary": {
+        "cumulative_alpha_vs_nasdaq": float("nan"), "win_rate_pct": 58.8}}})
+    labels = {s["label"] for s in build_dashboard_stats("modern_investing", tmp_path)}
+    assert "Alpha vs NASDAQ" not in labels  # NaN dropped
+    assert "Win rate" in labels
+
+
+def test_wired_into_send_show_newsletter():
+    src = (Path(__file__).resolve().parent.parent / "engine" / "newsletter.py").read_text(encoding="utf-8")
+    assert "by_the_numbers=_dashboard_stats_for(slug)" in src
+
+
+def test_block_renders_in_branded_body():
+    from engine.newsletter_template import wrap_with_branding
+    stats = [{"value": "$160.95", "label": "SPCX price"}]
+    body = wrap_with_branding("spacex", "Body.", daily_label="Ep 4", by_the_numbers=stats)
+    assert "By the numbers" in body and "SPCX price" in body


### PR DESCRIPTION
Two related newsletter changes (operator requests).

## 1. Dashboard "By the numbers" block (SpaceX / Tesla / MIT)
The newsletter template already had a 3-tile block under the hero (`wrap_with_branding(by_the_numbers=…)`) that `send_show_newsletter` never populated. New `engine/newsletter_dashboard.build_dashboard_stats(slug)` fills it from the same live data the public dashboards use:

| Show | Tiles (live values) |
|---|---|
| **SpaceX Daily** | $160.95 SPCX · 70 Launches this year · 10,544 Active Starlink sats |
| **Tesla Shorts Time** | $406.43 TSLA · +0.08% TSLA today · 1.79M 2024 deliveries |
| **Modern Investing** | +21.2% Alpha vs NASDAQ · 59% Win rate · 34 Simulated trades |

Best-effort + safe (NaN/zero/missing skipped; unmapped shows → no block; import-guarded so it can't block a send).

## 2. Activate SpaceX + First Principles newsletters
Operator created the `SpaceX Daily` and `First Principles Daily` Buttondown tags.
- **SpaceX** was already fully configured — with the tag now live it sends on its next episode (and gets the dashboard block above).
- **First Principles** was `newsletter.enabled: false` (distribution-off at launch). Built out its full config: enabled, Buttondown, `tag: "First Principles Daily"` (exact match), `short_label`, 💡 emoji, start date, no financial disclaimer (narrative show), 1200-word target.

A drift guard pins both shows enabled with tags matching the created Buttondown tags exactly — a mismatch silently blocks the send (the Jun 15 SpaceX incident).

## Tests
+9 drift guards; newsletter / config / integration / pipeline suites green (322+ passed); `ruff` clean. No audio path affected.

https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zw9QwC6BiWfSWztBRrME5)_