### PR TITLE
Multilingual (FR/RU/ES/ZH) audio + website language switcher

### DIFF
--- a/docs/env_var_inventory.md
+++ b/docs/env_var_inventory.md
@@ -51,6 +51,18 @@ Nightly audience stats (June 2026; both optional — scripts no-op when unset):
 
 ---
 
+## Multilingual audio (June 2026)
+
+| Variable | Required when |
+|----------|----------------|
+| `GROK_CLONED_VOICE_ID` | Running `scripts/generate_translations.py` (FR/RU/ES/ZH audio). The operator's cloned Grok voice ID — pasted into `.env`, **never** committed to git. The same voice is used for all four languages. The script fails loud if it's unset. |
+
+Reuses `GROK_API_KEY`/`XAI_API_KEY` (translation via `grok-latest` + Grok TTS)
+and the existing `R2_*` credentials (tracks upload to the same bucket as
+English audio).
+
+---
+
 ## Local development
 
 Copy `.env.example` if present, or set at minimum:

--- a/editorial.html
+++ b/editorial.html
@@ -790,6 +790,7 @@
                 <a href="ai-disclosure.html">AI Disclosure</a>
                 <a href="editorial.html">Editorial Process</a>
                 <a href="gallery.html">Image Gallery</a>
+                <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
             <!-- Newsletter Subscribe -->

--- a/engine/blog.py
+++ b/engine/blog.py
@@ -767,6 +767,9 @@ def generate_blog_post_html(
         "page_url": blog_url,
         "date": metadata.get("date_iso", "") or metadata.get("date", ""),
         "audio_url": metadata.get("audio_url", ""),
+        # Per-language audio tracks (June 2026 multilingual). Empty/absent for
+        # English-only episodes → the template renders no switcher.
+        "translations": metadata.get("translations", {}) or {},
         "transcript_url": f"{blog_url}#transcript" if transcript_text else "",
         # Russian shows render UI strings (incl. the AI badge) in Russian.
         "_is_ru": show_slug in ("finansy_prosto", "privet_russian"),

--- a/engine/config.py
+++ b/engine/config.py
@@ -254,6 +254,30 @@ class StorageConfig:
 
 
 @dataclass
+class MultilingualConfig:
+    """Opt-in multilingual *audio* settings for a show (June 2026).
+
+    When ``enabled``, the post-hoc translation stage
+    (``scripts/generate_translations.py`` + ``engine/translate.py``) can
+    render alternate-language audio tracks of an already-finalized English
+    episode, voiced by the operator's cloned Grok voice. English remains
+    the canonical master + site fallback; translations are derived
+    artifacts surfaced on the website (never in the canonical podcast RSS).
+
+    Fields are declared here (not read via getattr on the raw dict) so
+    ``_build_nested`` doesn't silently drop them — see landmine #20.
+    """
+    enabled: bool = False
+    # BCP-47 codes to render. Default empty; the driver also accepts a
+    # ``--languages`` override so a show with no block can still be run.
+    languages: List[str] = field(default_factory=list)
+    # Name of the env var holding the cloned Grok voice ID. The ID itself
+    # is NEVER stored in YAML/git — it's pasted into ``.env``. The TTS
+    # call reads it at runtime and fails loud if unset.
+    cloned_voice_env: str = "GROK_CLONED_VOICE_ID"
+
+
+@dataclass
 class AnalyticsConfig:
     enabled: bool = False
     prefix_url: str = "https://op3.dev/e/"
@@ -555,6 +579,7 @@ class ShowConfig:
     slow_news: SlowNewsConfig = field(default_factory=SlowNewsConfig)
     content_freshness: ContentFreshnessConfig = field(default_factory=ContentFreshnessConfig)
     youtube: YouTubeConfig = field(default_factory=YouTubeConfig)
+    multilingual: MultilingualConfig = field(default_factory=MultilingualConfig)
     # Sunday weekly-recap mode. When ``true`` and the runner ticks on
     # a Sunday, the show skips the daily news fetch and instead
     # synthesises a recap from the past 7 days of episodes pulled
@@ -680,7 +705,8 @@ def discover_show_slugs(shows_dir: Path | None = None) -> list[str]:
     if shows_dir is None:
         shows_dir = Path(__file__).resolve().parent.parent / "shows"
 
-    NON_SHOW = {"pronunciation_map", "network_meta", "scaffold_pending"}
+    NON_SHOW = {"pronunciation_map", "network_meta", "scaffold_pending",
+                "translation_overrides"}
     slugs: list[str] = []
     for p in sorted(shows_dir.glob("*.yaml")):
         stem = p.stem
@@ -763,6 +789,7 @@ def load_config(yaml_path: str | Path) -> ShowConfig:
         slow_news=_build_nested(SlowNewsConfig, data.get("slow_news")),
         content_freshness=_build_nested(ContentFreshnessConfig, data.get("content_freshness")),
         youtube=_build_nested(YouTubeConfig, data.get("youtube")),
+        multilingual=_build_nested(MultilingualConfig, data.get("multilingual")),
         weekly_recap_on_sunday=bool(data.get("weekly_recap_on_sunday", False)),
         narrative_mode=bool(data.get("narrative_mode", False)),
         topic_queue_file=str(data.get("topic_queue_file", "") or ""),

--- a/engine/summaries_io.py
+++ b/engine/summaries_io.py
@@ -1,0 +1,52 @@
+"""Load/save helpers for a show's ``summaries_<show>.json`` file.
+
+The network stores per-show episode records either in the wrapped form
+``{"podcast": "<name>", "summaries": [ ... ]}`` (current standard) or as a
+bare list (a few legacy files). These helpers read either shape, hand back
+the records list for in-place edits, and write it back atomically in the
+same shape — used by the multilingual stage to attach ``translations`` to
+existing records without disturbing the rest of the file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+def load_summaries(path: Path) -> Tuple[Optional[dict], List[dict]]:
+    """Return ``(wrapper, records)``.
+
+    ``wrapper`` is the enclosing dict for the wrapped form (so ``save_summaries``
+    can preserve sibling keys like ``"podcast"``), or ``None`` for a bare list.
+    ``records`` is the list of episode dicts (a live reference into ``wrapper``
+    when wrapped) — mutate it, then pass both back to ``save_summaries``.
+    """
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if isinstance(data, dict) and isinstance(data.get("summaries"), list):
+        return data, data["summaries"]
+    if isinstance(data, list):
+        return None, data
+    raise ValueError(f"Unrecognized summaries shape in {path}")
+
+
+def save_summaries(path: Path, wrapper: Optional[dict], records: List[dict]) -> None:
+    """Atomically write ``records`` back, preserving the original shape."""
+    path = Path(path)
+    if wrapper is not None:
+        wrapper["summaries"] = records
+        payload = wrapper
+    else:
+        payload = records
+    text = json.dumps(payload, ensure_ascii=False, indent=2)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.remove(tmp)

--- a/engine/translate.py
+++ b/engine/translate.py
@@ -1,0 +1,199 @@
+"""Spoken-delivery translation stage for the multilingual audio pipeline.
+
+Takes a finalized English episode script (and its title/description) and
+produces natural, for-the-ear translations via Grok (``grok-latest``), one
+call per language. The English script stays the canonical master; these are
+derived artifacts that feed the per-language TTS render.
+
+Design notes
+------------
+- Model id is ``grok-latest`` per the network multilingual convention
+  (never a version-pinned string). This is scoped to the translation calls
+  only — it does NOT touch the English generation pipeline's ``grok-4.3``.
+- Proper nouns / tickers are preserved; a per-language phonetic overrides
+  map (``shows/translation_overrides.yaml``) is injected into the prompt as
+  guidance AND applied as a post-process safety net (mirrors
+  ``engine.utils.fix_phonetic_garbles`` but language-scoped — it never
+  touches the English path).
+- Prompt placeholders are substituted via ``str.replace`` (not
+  ``str.format``) so script content containing literal ``{`` / ``}`` can't
+  break substitution.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# Supported languages: BCP-47 code -> human-readable name for the prompt.
+LANGUAGE_NAMES: Dict[str, str] = {
+    "fr": "French",
+    "ru": "Russian",
+    "es": "Spanish",
+    "zh": "Simplified Chinese",
+}
+
+_TRANSLATION_MODEL = "grok-latest"
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_OVERRIDES_PATH = _REPO_ROOT / "shows" / "translation_overrides.yaml"
+_PROMPT_PATH = _REPO_ROOT / "shows" / "prompts" / "_shared" / "translation.txt"
+
+_OVERRIDES_CACHE: Optional[Dict[str, Dict[str, str]]] = None
+
+
+def supported_languages() -> Tuple[str, ...]:
+    """Return the BCP-47 codes this stage knows how to localize."""
+    return tuple(LANGUAGE_NAMES.keys())
+
+
+def language_name(lang: str) -> str:
+    """Human-readable name for a BCP-47 code (falls back to the code)."""
+    return LANGUAGE_NAMES.get(lang, lang)
+
+
+def _load_overrides() -> Dict[str, Dict[str, str]]:
+    """Load the term -> {lang: spelling} overrides map (cached)."""
+    global _OVERRIDES_CACHE
+    if _OVERRIDES_CACHE is not None:
+        return _OVERRIDES_CACHE
+    data: Dict[str, Dict[str, str]] = {}
+    try:
+        raw = yaml.safe_load(_OVERRIDES_PATH.read_text(encoding="utf-8")) or {}
+        data = raw.get("overrides", {}) or {}
+    except FileNotFoundError:
+        logger.info("No translation_overrides.yaml — proceeding with no overrides")
+    except Exception as exc:  # noqa: BLE001 — bad YAML shouldn't crash a run
+        logger.warning("Failed to load translation overrides: %s", exc)
+    _OVERRIDES_CACHE = data
+    return data
+
+
+def overrides_for_language(lang: str) -> Dict[str, str]:
+    """Return ``{term: spelling}`` for *lang* (terms with an entry only)."""
+    out: Dict[str, str] = {}
+    for term, per_lang in _load_overrides().items():
+        if isinstance(per_lang, dict) and per_lang.get(lang):
+            out[str(term)] = str(per_lang[lang])
+    return out
+
+
+def _format_overrides_block(lang: str) -> str:
+    items = overrides_for_language(lang)
+    if not items:
+        return "(none)"
+    return "\n".join(f"- {term} => {spelling}" for term, spelling in items.items())
+
+
+def apply_overrides(text: str, lang: str) -> str:
+    """Post-process: enforce per-language phonetic spellings in *text*.
+
+    Belt-and-suspenders over the prompt instruction. Word-boundary,
+    case-insensitive — only rewrites whole-word matches of the English term.
+    """
+    if not text:
+        return text
+    items = overrides_for_language(lang)
+    for term, spelling in items.items():
+        pattern = r"\b" + re.escape(term) + r"\b"
+        text = re.sub(pattern, spelling, text)
+    return text
+
+
+def _build_script_prompt(english_script: str, lang: str) -> str:
+    template = _PROMPT_PATH.read_text(encoding="utf-8")
+    return (
+        template
+        .replace("{language_name}", language_name(lang))
+        .replace("{bcp47}", lang)
+        .replace("{phonetic_overrides}", _format_overrides_block(lang))
+        .replace("{english_script}", english_script)
+    )
+
+
+def translate_script(
+    english_script: str,
+    lang: str,
+    *,
+    model: str = _TRANSLATION_MODEL,
+    max_tokens: int = 16000,
+) -> str:
+    """Localize a full English episode script into *lang* for spoken delivery.
+
+    Returns the translated script (overrides enforced). Raises if *lang* is
+    unsupported or the script is empty.
+    """
+    if lang not in LANGUAGE_NAMES:
+        raise ValueError(f"Unsupported language {lang!r}; supported: {supported_languages()}")
+    if not (english_script or "").strip():
+        raise ValueError("translate_script: empty english_script")
+
+    from digests.xai_grok import grok_generate_text
+
+    prompt = _build_script_prompt(english_script, lang)
+    logger.info("Translating script -> %s (%d chars in)", lang, len(english_script))
+    text, _meta = grok_generate_text(
+        prompt=prompt,
+        model=model,
+        temperature=0.4,
+        max_tokens=max_tokens,
+    )
+    text = (text or "").strip()
+    if not text:
+        raise RuntimeError(f"Empty translation returned for {lang}")
+    return apply_overrides(text, lang)
+
+
+def translate_metadata(
+    title: str,
+    description: str,
+    lang: str,
+    *,
+    model: str = _TRANSLATION_MODEL,
+) -> Tuple[str, str]:
+    """Translate an episode title + description into *lang*.
+
+    Same spoken/natural register as the script, tuned for the site + search
+    reach. Returns ``(title, description)``; on any parse failure falls back
+    to the English inputs so the caller always gets usable strings.
+    """
+    if lang not in LANGUAGE_NAMES:
+        raise ValueError(f"Unsupported language {lang!r}")
+    title = (title or "").strip()
+    description = (description or "").strip()
+    if not title and not description:
+        return title, description
+
+    from digests.xai_grok import grok_generate_text
+
+    name = language_name(lang)
+    prompt = (
+        f"Translate this podcast episode title and description into {name} "
+        f"(BCP-47 {lang}). Natural and idiomatic for a listing/search page; "
+        "keep proper nouns, brand names and tickers (Tesla, SpaceX, TSLA…) "
+        "intact. Return ONLY a JSON object with keys \"title\" and "
+        "\"description\", no other text.\n\n"
+        f"TITLE: {title}\n"
+        f"DESCRIPTION: {description}\n"
+    )
+    try:
+        raw, _meta = grok_generate_text(
+            prompt=prompt, model=model, temperature=0.4, max_tokens=1200,
+        )
+        raw = (raw or "").strip()
+        # Tolerate a ```json fence around the object.
+        m = re.search(r"\{.*\}", raw, re.DOTALL)
+        obj = json.loads(m.group(0) if m else raw)
+        t = str(obj.get("title") or title).strip()
+        d = str(obj.get("description") or description).strip()
+        return t, d
+    except Exception as exc:  # noqa: BLE001 — metadata is best-effort
+        logger.warning("Metadata translation (%s) failed, using English: %s", lang, exc)
+        return title, description

--- a/engine/tts.py
+++ b/engine/tts.py
@@ -53,6 +53,26 @@ def _ffmpeg_escape(path: Path) -> str:
     return str(path.absolute()).replace("'", "'\\''")
 
 
+def get_cloned_voice_id(env_var: str = "GROK_CLONED_VOICE_ID") -> str:
+    """Return the operator's cloned Grok voice ID from the environment.
+
+    Used by the multilingual audio stage (June 2026). The cloned voice ID
+    is NEVER hardcoded or committed — it's pasted into ``.env`` and read at
+    runtime. The same voice carries across all target languages (Grok keeps
+    one voice identity per language), so the host sounds like the operator
+    in every language. Raises ``RuntimeError`` if the env var is unset so a
+    misconfigured run fails loud instead of silently using the wrong voice.
+    """
+    import os
+    voice = (os.getenv(env_var) or "").strip()
+    if not voice:
+        raise RuntimeError(
+            f"Missing cloned voice ID: set {env_var} in .env "
+            "(the multilingual TTS stage will not run without it)."
+        )
+    return voice
+
+
 # ---------------------------------------------------------------------------
 # Pronunciation map + TTS text preparation
 # ---------------------------------------------------------------------------

--- a/generate_html.py
+++ b/generate_html.py
@@ -2599,6 +2599,34 @@ def generate_blog_posts(slug, *, dry_run=False, cross_show_posts=None):
     # Sort by episode number
     all_meta.sort(key=lambda m: m["episode_num"])
 
+    # Merge the summaries record's audio URL + any per-language translation
+    # tracks (June 2026 multilingual audio) into each episode's metadata, so
+    # the blog post can render an inline player + language switcher. The .md
+    # alone carries neither. English stays canonical; episodes with no
+    # ``translations`` key render exactly as before (no switcher).
+    _records_by_ep: dict[int, dict] = {}
+    _json_path = cfg.get("json_path")
+    if _json_path:
+        try:
+            from engine.summaries_io import load_summaries
+            _, _recs = load_summaries(ROOT / _json_path)
+            for _r in _recs:
+                _ep = _r.get("episode_num")
+                if isinstance(_ep, int):
+                    _records_by_ep[_ep] = _r
+        except FileNotFoundError:
+            pass
+        except Exception as _exc:  # noqa: BLE001 — never block blog gen
+            print(f"  Warning: could not load summaries for {slug}: {_exc}")
+    for meta in all_meta:
+        _rec = _records_by_ep.get(meta["episode_num"])
+        if _rec:
+            if not meta.get("audio_url"):
+                meta["audio_url"] = _rec.get("audio_url", "")
+            _tr = _rec.get("translations")
+            if isinstance(_tr, dict) and _tr:
+                meta["translations"] = _tr
+
     blog_dir = ROOT / "blog" / slug
     results = []
 

--- a/scripts/archive_old_data.py
+++ b/scripts/archive_old_data.py
@@ -40,7 +40,8 @@ _SHOW_DIR_OVERRIDES = {
     "tesla": "tesla_shorts_time",
 }
 
-_NON_SHOW_YAMLS = {"_defaults", "_blocked_sources", "pronunciation_map"}
+_NON_SHOW_YAMLS = {"_defaults", "_blocked_sources", "pronunciation_map",
+                   "translation_overrides"}
 
 
 def _discover_shows() -> List[str]:

--- a/scripts/backfill_content_lake.py
+++ b/scripts/backfill_content_lake.py
@@ -123,7 +123,8 @@ def main(argv=None):
 
     # Meta/config YAMLs that are not shows — loading them logs a noisy
     # "Loaded config for ''" line and scans the digests root pointlessly.
-    _NON_SHOW_YAMLS = {"network_meta", "pronunciation_map", "scaffold_pending"}
+    _NON_SHOW_YAMLS = {"network_meta", "pronunciation_map", "scaffold_pending",
+                       "translation_overrides"}
 
     for config_path in sorted(SHOWS_DIR.glob("*.yaml")):
         if config_path.stem.startswith("_") or config_path.stem in _NON_SHOW_YAMLS:

--- a/scripts/buttondown_tag_subscriber.py
+++ b/scripts/buttondown_tag_subscriber.py
@@ -63,7 +63,7 @@ def _load_show_tags() -> Dict[str, str]:
     """Return ``{slug: tag}`` for every show that has a newsletter tag."""
     tags: Dict[str, str] = {}
     for yaml_path in sorted(SHOWS_DIR.glob("*.yaml")):
-        if yaml_path.stem.startswith("_") or yaml_path.stem == "pronunciation_map":
+        if yaml_path.stem.startswith("_") or yaml_path.stem in ("pronunciation_map", "translation_overrides"):
             continue
         try:
             data = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}

--- a/scripts/fetch_op3_stats.py
+++ b/scripts/fetch_op3_stats.py
@@ -75,7 +75,7 @@ _PUBLIC_EPISODE_FIELDS = (
 
 _NON_SHOW_YAMLS = {
     "_defaults", "_blocked_sources", "pronunciation_map",
-    "network_meta", "scaffold_pending",
+    "network_meta", "scaffold_pending", "translation_overrides",
 }
 
 

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -79,7 +79,7 @@ HEAD_TIMEOUT = 5
 # state on the management dashboard workflow.
 _NON_SHOW_YAMLS = {
     "_defaults", "_blocked_sources", "pronunciation_map",
-    "network_meta", "scaffold_pending",
+    "network_meta", "scaffold_pending", "translation_overrides",
 }
 
 # Canonical Russian voice id (pulled from CLAUDE.md; shows/_defaults.yaml ships

--- a/scripts/generate_translations.py
+++ b/scripts/generate_translations.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Generate multilingual (FR / RU / ES / ZH) audio tracks for episodes.
+
+A post-hoc stage: it consumes a show's already-finalized English episode
+artifacts (the ``*_tts.txt`` script + the summaries record + the ``.md``
+digest for the hook) and, per language, translates the script via
+``grok-latest``, renders it to MP3 with the operator's cloned Grok voice,
+uploads the track to R2 alongside the English file, and records the track
+(audio URL + translated title/description) in the show's summaries JSON.
+
+English stays the canonical master + site fallback; translations are
+derived artifacts surfaced on the website only (not the podcast RSS).
+
+Usage
+-----
+    # Wire-up / proving runs
+    python scripts/generate_translations.py tesla --languages fr --latest 1
+    python scripts/generate_translations.py tesla --languages zh \
+        --episode 511 --sample-zh          # ONE short ZH clip, then STOP
+
+    # After listening to the ZH sample and approving it:
+    python scripts/generate_translations.py tesla \
+        --languages fr,ru,es,zh --latest 3 --zh-approved
+
+Idempotent: a (episode, language) already present in the summaries record is
+skipped unless ``--force``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+from urllib.parse import urlparse
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(PROJECT_ROOT / ".env")
+
+from engine import tts, translate  # noqa: E402
+from engine.config import load_config  # noqa: E402
+from engine.storage import upload_to_r2  # noqa: E402
+from engine.summaries_io import load_summaries, save_summaries  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(levelname)s %(message)s")
+logger = logging.getLogger("generate_translations")
+
+
+def _grok_api_key() -> str:
+    key = (os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY") or "").strip()
+    if not key:
+        raise RuntimeError("Missing GROK_API_KEY (or XAI_API_KEY) in .env")
+    return key
+
+
+def _ffprobe_duration(target: str) -> Optional[float]:
+    """Return media duration in seconds (works on a local path OR a URL)."""
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "default=noprint_wrappers=1:nokey=1", target],
+            capture_output=True, text=True, timeout=120,
+        )
+        val = out.stdout.strip()
+        return float(val) if val else None
+    except Exception:  # noqa: BLE001 — best-effort, used only for reporting
+        return None
+
+
+def _find_episode_file(output_dir: Path, episode_num: int, suffix_glob: str) -> Optional[Path]:
+    matches = sorted(output_dir.glob(f"*_Ep{episode_num:03d}_{suffix_glob}"))
+    return matches[-1] if matches else None
+
+
+def _english_hook(output_dir: Path, episode_num: int) -> str:
+    """Best-effort: pull the episode hook from the digest .md for descriptions."""
+    md = None
+    for p in sorted(output_dir.glob(f"*_Ep{episode_num:03d}_*.md")):
+        if not p.name.endswith("_tts.txt"):
+            md = p
+    if not md:
+        return ""
+    try:
+        from engine.blog import extract_blog_metadata
+        meta = extract_blog_metadata(md.read_text(encoding="utf-8"), "", md.name, md)
+        return meta.get("hook", "") or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _derive_track_key_url(english_audio_url: str, lang: str, public_base_url: str):
+    """Return ``(remote_key, public_url)`` for the *lang* track.
+
+    Derived from the English track's own URL so the translation lands in the
+    exact same R2 prefix regardless of slug/audio_subdir nuances.
+    """
+    base = (public_base_url or "").rstrip("/")
+    if base and english_audio_url.startswith(base + "/"):
+        key = english_audio_url[len(base) + 1:]
+    else:
+        key = urlparse(english_audio_url).path.lstrip("/")
+    if key.lower().endswith(".mp3"):
+        key = key[:-4]
+    remote_key = f"{key}.{lang}.mp3"
+    public_url = f"{base}/{remote_key}" if base else remote_key
+    return remote_key, public_url
+
+
+def _select_records(records: List[dict], latest: int, episode: Optional[int]) -> List[dict]:
+    """Pick target records: a specific --episode, else the latest N by number."""
+    have_num = [r for r in records if isinstance(r.get("episode_num"), int)]
+    if episode is not None:
+        return [r for r in have_num if r["episode_num"] == episode]
+    return sorted(have_num, key=lambda r: r["episode_num"], reverse=True)[:latest]
+
+
+def _render_track(
+    script_text: str, lang: str, voice_id: str, api_key: str,
+    out_path: Path, max_chars: int,
+) -> None:
+    tts.synthesize(
+        script_text, voice_id, out_path,
+        api_key=api_key, provider="grok",
+        max_chars=max_chars, language_code=lang,
+    )
+
+
+def _resolve_languages(args, config) -> List[str]:
+    if args.languages:
+        langs = [s.strip() for s in args.languages.split(",") if s.strip()]
+    elif getattr(config, "multilingual", None) and config.multilingual.languages:
+        langs = list(config.multilingual.languages)
+    else:
+        langs = list(translate.supported_languages())
+    unknown = [l for l in langs if l not in translate.supported_languages()]
+    if unknown:
+        raise SystemExit(f"Unsupported language(s): {unknown}; "
+                         f"supported: {translate.supported_languages()}")
+    return langs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("show", help="Show slug (e.g. tesla)")
+    ap.add_argument("--languages", default="", help="Comma list of BCP-47 codes (fr,ru,es,zh)")
+    ap.add_argument("--latest", type=int, default=3, help="Translate the latest N episodes")
+    ap.add_argument("--episode", type=int, default=None, help="Translate one specific episode number")
+    ap.add_argument("--force", action="store_true", help="Re-generate even if a track already exists")
+    ap.add_argument("--sample-zh", action="store_true",
+                    help="Render ONE short ZH clip from the latest episode, then STOP (no upload/record)")
+    ap.add_argument("--zh-approved", action="store_true",
+                    help="Confirm you've listened to a ZH sample — required to batch ZH")
+    ap.add_argument("--sample-chars", type=int, default=900, help="Char budget for --sample-zh clip")
+    ap.add_argument("--dry-run", action="store_true", help="Translate only; no TTS/upload/record")
+    args = ap.parse_args()
+
+    config = load_config(f"shows/{args.show}.yaml")
+    ml = getattr(config, "multilingual", None)
+    if not (ml and ml.enabled) and not args.languages:
+        raise SystemExit(
+            f"Multilingual audio is not enabled for '{args.show}'. "
+            "Enable it in the show YAML (multilingual.enabled: true) or pass "
+            "--languages to override for a one-off run."
+        )
+    output_dir = PROJECT_ROOT / config.episode.output_dir
+    summaries_path = PROJECT_ROOT / config.publishing.summaries_json
+    languages = _resolve_languages(args, config)
+    voice_env = (getattr(config, "multilingual", None) and config.multilingual.cloned_voice_env) \
+        or "GROK_CLONED_VOICE_ID"
+    max_chars = config.tts.max_chars or tts.GROK_MAX_CHARS_PER_REQUEST
+
+    wrapper, records = load_summaries(summaries_path)
+    targets = _select_records(records, args.latest, args.episode)
+    if not targets:
+        logger.error("No matching episode records in %s", summaries_path)
+        return 1
+
+    # ----- ZH STOP checkpoint -----------------------------------------
+    if args.sample_zh:
+        api_key = _grok_api_key()
+        voice_id = tts.get_cloned_voice_id(voice_env)
+        rec = targets[0]
+        ep = rec["episode_num"]
+        tts_file = _find_episode_file(output_dir, ep, "*_tts.txt")
+        if not tts_file:
+            logger.error("No _tts.txt for Ep%s in %s", ep, output_dir)
+            return 1
+        english_script = tts_file.read_text(encoding="utf-8").strip()
+        snippet = english_script[: args.sample_chars]
+        logger.info("ZH SAMPLE: localizing first ~%d chars of Ep%s", args.sample_chars, ep)
+        zh_text = translate.translate_script(snippet, "zh")
+        sample_mp3 = output_dir / f"{tts_file.stem.replace('_tts', '')}.zh.sample.mp3"
+        _render_track(zh_text, "zh", voice_id, api_key, sample_mp3, max_chars)
+        dur = _ffprobe_duration(str(sample_mp3))
+        logger.info("=" * 64)
+        logger.info("ZH SAMPLE READY: %s (%.1fs)", sample_mp3, dur or 0.0)
+        logger.info("LISTEN before batch-generating Chinese. Cloned English")
+        logger.info("voices can produce flat/incorrect Mandarin tones. If it")
+        logger.info("sounds right, re-run with --zh-approved.")
+        logger.info("=" * 64)
+        return 0
+
+    if "zh" in languages and not args.zh_approved and not args.dry_run:
+        logger.warning("ZH requested without --zh-approved. Skipping Chinese this run.")
+        logger.warning("Run:  python scripts/generate_translations.py %s "
+                       "--languages zh --episode %s --sample-zh", args.show, targets[0]["episode_num"])
+        logger.warning("listen, then re-run with --zh-approved to include ZH.")
+        languages = [l for l in languages if l != "zh"]
+        if not languages:
+            return 0
+
+    api_key = _grok_api_key()
+    voice_id = None if args.dry_run else tts.get_cloned_voice_id(voice_env)
+
+    # Length-calibration reporting: first rendered track per language.
+    reported_langs: set = set()
+    changed = False
+
+    for rec in targets:
+        ep = rec["episode_num"]
+        english_url = rec.get("audio_url", "")
+        tts_file = _find_episode_file(output_dir, ep, "*_tts.txt")
+        if not tts_file:
+            logger.warning("Ep%s: no _tts.txt found in %s — skipping", ep, output_dir)
+            continue
+        english_script = tts_file.read_text(encoding="utf-8").strip()
+        en_title = rec.get("episode_title", "") or ""
+        en_desc = _english_hook(output_dir, ep) or en_title
+        translations: Dict[str, dict] = rec.setdefault("translations", {})
+
+        for lang in languages:
+            if lang in translations and not args.force:
+                logger.info("Ep%s [%s]: already present — skipping (use --force)", ep, lang)
+                continue
+            logger.info("Ep%s [%s]: translating script…", ep, lang)
+            translated = translate.translate_script(english_script, lang)
+            t_title, t_desc = translate.translate_metadata(en_title, en_desc, lang)
+
+            if args.dry_run:
+                logger.info("Ep%s [%s]: DRY-RUN — %d chars, title=%r",
+                            ep, lang, len(translated), t_title[:60])
+                continue
+
+            if not english_url:
+                logger.warning("Ep%s [%s]: record has no audio_url — cannot place track; skipping",
+                               ep, lang)
+                continue
+
+            local_mp3 = output_dir / f"{tts_file.stem.replace('_tts', '')}.{lang}.mp3"
+            _render_track(translated, lang, voice_id, api_key, local_mp3, max_chars)
+            dur = _ffprobe_duration(str(local_mp3))
+
+            # Length calibration vs English (first track per language only).
+            if lang not in reported_langs:
+                reported_langs.add(lang)
+                en_dur = _ffprobe_duration(english_url)
+                if en_dur and dur:
+                    delta = (dur - en_dur) / en_dur * 100.0
+                    logger.info("LENGTH [%s]: %.0fs vs EN %.0fs (%+.0f%%)",
+                                lang, dur, en_dur, delta)
+                else:
+                    logger.info("LENGTH [%s]: %.0fs (EN duration unavailable for compare)",
+                                lang, dur or 0.0)
+
+            remote_key, public_url = _derive_track_key_url(
+                english_url, lang, config.storage.public_base_url)
+            endpoint = os.getenv(config.storage.endpoint_env, "").strip()
+            access_key = os.getenv(config.storage.access_key_env, "").strip()
+            secret_key = os.getenv(config.storage.secret_key_env, "").strip()
+            if all([endpoint, access_key, secret_key]):
+                upload_to_r2(
+                    local_mp3, remote_key,
+                    bucket=config.storage.bucket,
+                    endpoint_url=endpoint, access_key=access_key, secret_key=secret_key,
+                    public_base_url=config.storage.public_base_url,
+                )
+            else:
+                logger.warning("Ep%s [%s]: R2 creds unset — track left local at %s",
+                               ep, lang, local_mp3)
+
+            translations[lang] = {
+                "audio_url": public_url,
+                "title": t_title,
+                "description": t_desc,
+                "duration_sec": round(dur, 1) if dur else 0,
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+            }
+            changed = True
+            logger.info("Ep%s [%s]: done → %s", ep, lang, public_url)
+
+    if changed and not args.dry_run:
+        save_summaries(summaries_path, wrapper, records)
+        logger.info("Updated summaries: %s", summaries_path)
+    elif not changed:
+        logger.info("Nothing to do (all requested tracks already present).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_translations.py
+++ b/scripts/generate_translations.py
@@ -33,7 +33,6 @@ import logging
 import os
 import subprocess
 import sys
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -142,7 +141,7 @@ def _resolve_languages(args, config) -> List[str]:
         langs = list(config.multilingual.languages)
     else:
         langs = list(translate.supported_languages())
-    unknown = [l for l in langs if l not in translate.supported_languages()]
+    unknown = [code for code in langs if code not in translate.supported_languages()]
     if unknown:
         raise SystemExit(f"Unsupported language(s): {unknown}; "
                          f"supported: {translate.supported_languages()}")
@@ -216,7 +215,7 @@ def main() -> int:
         logger.warning("Run:  python scripts/generate_translations.py %s "
                        "--languages zh --episode %s --sample-zh", args.show, targets[0]["episode_num"])
         logger.warning("listen, then re-run with --zh-approved to include ZH.")
-        languages = [l for l in languages if l != "zh"]
+        languages = [code for code in languages if code != "zh"]
         if not languages:
             return 0
 

--- a/scripts/run_weekly_newsletters.py
+++ b/scripts/run_weekly_newsletters.py
@@ -24,7 +24,7 @@ def _discover_shows() -> list:
     shows_dir = Path(__file__).resolve().parent.parent / "shows"
     slugs = []
     for f in sorted(shows_dir.glob("*.yaml")):
-        if f.name.startswith("_") or f.name == "pronunciation_map.yaml":
+        if f.name.startswith("_") or f.name in ("pronunciation_map.yaml", "translation_overrides.yaml"):
             continue
         if f.parent.name != "shows":
             continue

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -147,6 +147,18 @@ storage:
   secret_key_env: R2_SECRET_ACCESS_KEY
   public_base_url: "https://audio.nerranetwork.com"
 
+# Multilingual *audio* (June 2026). When enabled, the post-hoc translation
+# stage (scripts/generate_translations.py) can render FR/RU/ES/ZH tracks of
+# an English episode with the operator's cloned Grok voice, surfaced on the
+# website (English stays canonical + the podcast-RSS feed). All English
+# shows inherit this; the two Russian shows opt OUT (their source is already
+# Russian). The cloned voice ID lives in .env (GROK_CLONED_VOICE_ID), never
+# in git.
+multilingual:
+  enabled: true
+  languages: [fr, ru, es, zh]
+  cloned_voice_env: GROK_CLONED_VOICE_ID
+
 publishing:
   rss_author: Nerra Network
   rss_email: patrick@planetterrian.com

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -192,6 +192,11 @@ tts:
   language_code: ru
   max_chars: 10000
 
+# Opt OUT of the network multilingual-audio default — this show's source
+# content is already Russian (June 2026).
+multilingual:
+  enabled: false
+
 audio:
   music_file: "assets/music/Финансы Просто.mp3"
   transition_sting: assets/music/transition_sting.mp3

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -132,6 +132,11 @@ tts:
   language_code: ru
   max_chars: 10000
 
+# Opt OUT of the network multilingual-audio default — this is a
+# Russian-language teaching show (June 2026).
+multilingual:
+  enabled: false
+
 audio:
   music_file: "assets/music/ПриветРусский.mp3"
   # May 12 2026 retune (see shows/_defaults.yaml).

--- a/shows/prompts/_shared/translation.txt
+++ b/shows/prompts/_shared/translation.txt
@@ -1,0 +1,33 @@
+You are a professional podcast localizer. Translate the following English
+podcast script into {language_name} (BCP-47 code: {bcp47}) for SPOKEN
+DELIVERY by a voice host.
+
+This is a localization for the EAR, not a literal translation:
+- Produce natural, idiomatic {language_name} that a native host would
+  actually say out loud. Prioritize how it SOUNDS over word-for-word
+  fidelity.
+- Preserve the host's pacing, tone, energy, and paragraph/sentence rhythm.
+  Keep the same number of beats and the same conversational flow.
+- Keep it the same episode: do not add, remove, summarize, or invent
+  content. Every fact, number, and segment stays.
+
+Proper nouns, tickers, and brand names:
+- Keep company names, product names, people's names, and stock tickers
+  intact (e.g. Tesla, SpaceX, Optimus, TSLA) — do NOT translate them.
+- For terms a {language_name} speaker would likely mispronounce, use the
+  phonetic spelling given in the overrides below so the host says them
+  correctly. Apply an override ONLY for terms that appear in the script.
+
+Phonetic spelling overrides for {language_name} (term => spell it this way):
+{phonetic_overrides}
+
+Formatting:
+- Preserve any bracketed speech tags exactly as they appear (e.g. [pause],
+  [breath], <emphasis>...</emphasis>) — do not translate or remove them.
+- Output ONLY the translated script text. No preamble, no notes, no
+  markdown fences, no English original.
+
+English script to localize:
+---
+{english_script}
+---

--- a/shows/translation_overrides.yaml
+++ b/shows/translation_overrides.yaml
@@ -1,0 +1,46 @@
+# Per-language phonetic / spelling overrides for the multilingual audio
+# stage (June 2026). Maps an English term to how it should be SPELLED in
+# the translated script so the cloned Grok voice pronounces it correctly
+# in the target language.
+#
+# This is DISTINCT from shows/pronunciation_map.yaml, which is the
+# English-only letter-spell layer (landmine #17 keeps phonetic respellings
+# OUT of the English path). Here, the override is written into the
+# target-language script text only — it never touches English audio.
+#
+# Each entry: <English term> -> { fr:, ru:, es:, zh: }
+# - Provide a key only for languages where the default reading is wrong.
+# - Tickers/brand names that read fine as-is can be omitted entirely.
+# - The translation PROMPT is told to preserve proper nouns/tickers and is
+#   handed these overrides as guidance; engine/translate.py also applies
+#   them as a post-process safety net (word-boundary, case-insensitive).
+#
+# Maintainership: add a term here once you hear a mispronunciation in a
+# rendered track. Keep it small and evidence-driven.
+
+overrides:
+  # Tickers — letter-spell so they aren't read as words in any language.
+  TSLA:
+    fr: "T-S-L-A"
+    ru: "Ти-Эс-Эл-Эй"
+    es: "T-S-L-A"
+    zh: "T-S-L-A"
+  SPCX:
+    ru: "Эс-Пи-Си-Экс"
+  NASA:
+    fr: "NASA"
+    ru: "НАСА"
+    es: "NASA"
+    zh: "NASA"
+  # Brand / proper nouns prone to target-language misreading.
+  Tesla:
+    ru: "Тесла"
+    zh: "特斯拉"
+  SpaceX:
+    ru: "Спейс-Экс"
+    zh: "SpaceX"
+  xAI:
+    fr: "X-A-I"
+    ru: "Экс-Эй-Ай"
+    es: "X-A-I"
+    zh: "X-A-I"

--- a/templates/blog_post.html.j2
+++ b/templates/blog_post.html.j2
@@ -611,6 +611,60 @@
                 max-width: 90vw;
             }
         }
+
+        /* Multilingual audio player + language switcher (June 2026) */
+        .nn-i18n {
+            max-width: 760px;
+            margin: 0 auto var(--sp-4);
+            padding: 0 var(--sp-6);
+        }
+        .nn-i18n-inner {
+            background: var(--nn-card);
+            border: 1px solid var(--nn-border);
+            border-radius: 12px;
+            padding: var(--sp-4) var(--sp-5);
+        }
+        .nn-i18n-row {
+            display: flex;
+            align-items: center;
+            gap: var(--sp-2);
+            flex-wrap: wrap;
+            margin-bottom: var(--sp-3);
+        }
+        .nn-i18n-label {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--sp-1);
+            font-family: var(--font-ui);
+            font-size: 0.8rem;
+            color: var(--nn-text-muted);
+            margin-right: var(--sp-1);
+        }
+        .nn-i18n-pill {
+            padding: var(--sp-1) var(--sp-4);
+            border-radius: 100px;
+            border: 1px solid var(--nn-border);
+            background: var(--nn-surface, transparent);
+            color: var(--nn-text-muted);
+            font-family: var(--font-ui);
+            font-size: 0.82rem;
+            cursor: pointer;
+            transition: all var(--duration) var(--ease);
+        }
+        .nn-i18n-pill:hover {
+            border-color: var(--show-color);
+            color: var(--nn-white);
+        }
+        .nn-i18n-pill[aria-pressed="true"] {
+            border-color: var(--show-color);
+            background: color-mix(in srgb, var(--show-color) 18%, transparent);
+            color: var(--show-color-text, var(--show-color));
+            font-weight: 600;
+        }
+        .nn-i18n-audio {
+            width: 100%;
+            height: 38px;
+        }
     </style>
 {% endblock %}
 
@@ -637,7 +691,7 @@
                 <picture><source type="image/webp" srcset="{{ path_prefix }}{{ podcast_image[:-4] if podcast_image.endswith('.jpg') else podcast_image }}-400.webp"><img src="{{ path_prefix }}{{ podcast_image }}" alt="{{ show_name }}" width="40" height="40"></picture>
                 {{ show_name }} Blog
             </a>
-            <h1>{{ episode_title }} — Episode {{ episode_num }}</h1>
+            <h1><span class="nn-i18n-title">{{ episode_title }}</span> — Episode {{ episode_num }}</h1>
             {% if hook %}
             <p class="blog-hero-hook">{{ hook }}</p>
             {% endif %}
@@ -678,6 +732,35 @@
             </div>
         </div>
     </header>
+
+    {# Multilingual audio player + language switcher (June 2026).
+       Only rendered when this episode actually has alternate-language
+       tracks AND an English audio URL — English-only episodes show
+       nothing here (no empty/disabled control). #}
+    {% if translations and audio_url %}
+    {%- set _LANG_LABELS = {"en": "English", "fr": "Français", "ru": "Русский", "es": "Español", "zh": "中文"} -%}
+    <section class="nn-i18n" aria-label="Listen in another language">
+        <div class="nn-i18n-inner">
+            <div class="nn-i18n-row">
+                <span class="nn-i18n-label">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                    Listen in
+                </span>
+                <button type="button" class="nn-i18n-pill" data-lang="en" aria-pressed="true">English</button>
+                {% for code, t in translations.items() if t.audio_url %}
+                <button type="button" class="nn-i18n-pill" data-lang="{{ code }}" aria-pressed="false">{{ _LANG_LABELS.get(code, code) }}</button>
+                {% endfor %}
+            </div>
+            <audio id="nn-i18n-audio" class="nn-i18n-audio" controls preload="none" src="{{ audio_url }}"></audio>
+        </div>
+        <script type="application/json" id="nn-i18n-tracks">
+{
+  "en": {"url": {{ audio_url | tojson }}, "title": {{ episode_title | tojson }}, "desc": {{ hook | tojson }}}{% for code, t in translations.items() if t.audio_url %},
+  {{ code | tojson }}: {"url": {{ t.audio_url | tojson }}, "title": {{ (t.title or episode_title) | tojson }}, "desc": {{ (t.description or hook) | tojson }}}{% endfor %}
+}
+        </script>
+    </section>
+    {% endif %}
 
     <!-- Article with TOC sidebar -->
     <div class="blog-article-wrap">
@@ -863,6 +946,50 @@
     }
     window.addEventListener('scroll', onScroll, { passive: true });
     onScroll();
+})();
+
+// Multilingual audio: swap track + translated title/description (June 2026).
+(function() {
+    var el = document.getElementById('nn-i18n-tracks');
+    if (!el) return;
+    var tracks;
+    try { tracks = JSON.parse(el.textContent); } catch (e) { return; }
+    var codes = Object.keys(tracks);
+    if (codes.length < 2) return;  // English-only → nothing to switch
+    var audio = document.getElementById('nn-i18n-audio');
+    var titleEl = document.querySelector('.nn-i18n-title');
+    var hookEl = document.querySelector('.blog-hero-hook');
+    var pills = document.querySelectorAll('.nn-i18n-pill');
+    var key = 'nn-i18n-lang:' + location.pathname;
+
+    function preferred() {
+        try {
+            var saved = sessionStorage.getItem(key);
+            if (saved && tracks[saved]) return saved;
+        } catch (e) {}
+        var nav = (navigator.language || 'en').slice(0, 2).toLowerCase();
+        return tracks[nav] ? nav : 'en';
+    }
+    function apply(code, persist) {
+        var t = tracks[code];
+        if (!t) return;
+        if (audio && t.url) {
+            var wasPlaying = audio && !audio.paused;
+            audio.src = t.url;
+            if (wasPlaying) { audio.play().catch(function(){}); }
+        }
+        if (titleEl && t.title) titleEl.textContent = t.title;
+        if (hookEl && t.desc) hookEl.textContent = t.desc;
+        document.documentElement.setAttribute('lang', code);
+        pills.forEach(function(p) {
+            p.setAttribute('aria-pressed', p.dataset.lang === code ? 'true' : 'false');
+        });
+        if (persist) { try { sessionStorage.setItem(key, code); } catch (e) {} }
+    }
+    pills.forEach(function(p) {
+        p.addEventListener('click', function() { apply(p.dataset.lang, true); });
+    });
+    apply(preferred(), false);
 })();
 </script>
 {% endblock %}

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -1,0 +1,224 @@
+"""Drift guards for the multilingual audio pipeline (June 2026).
+
+Covers the additive, non-breaking pieces so a regression is caught without
+spending Grok credits or hitting the network:
+  * MultilingualConfig round-trips through load_config (no silent key drop).
+  * Per-language phonetic overrides load + apply (word-boundary).
+  * R2 key derivation suffixes the language correctly.
+  * summaries_io round-trips both shapes and persists edits.
+  * The blog post renders the switcher only when translations exist — and
+    never for an English-only episode.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+TESLA_DIGESTS = PROJECT_ROOT / "digests" / "tesla_shorts_time"
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+class TestMultilingualConfig:
+    def test_english_show_inherits_enabled_default(self):
+        from engine.config import load_config
+        cfg = load_config("shows/tesla.yaml")
+        assert cfg.multilingual.enabled is True
+        assert cfg.multilingual.languages == ["fr", "ru", "es", "zh"]
+        assert cfg.multilingual.cloned_voice_env == "GROK_CLONED_VOICE_ID"
+
+    def test_russian_shows_opt_out(self):
+        from engine.config import load_config
+        for slug in ("finansy_prosto", "privet_russian"):
+            cfg = load_config(f"shows/{slug}.yaml")
+            assert cfg.multilingual.enabled is False, slug
+
+    def test_no_silent_key_drop(self):
+        # Every field set in YAML must be DECLARED on the dataclass
+        # (landmine #20) — loading without a warning-only fallback means
+        # the round-trip is faithful.
+        from engine.config import MultilingualConfig
+        fields = set(MultilingualConfig.__dataclass_fields__)
+        assert {"enabled", "languages", "cloned_voice_env"} <= fields
+
+
+# ---------------------------------------------------------------------------
+# Phonetic overrides
+# ---------------------------------------------------------------------------
+
+class TestOverrides:
+    def test_overrides_yaml_loads(self):
+        from engine.translate import overrides_for_language
+        ru = overrides_for_language("ru")
+        assert "TSLA" in ru and ru["TSLA"]
+
+    def test_language_scoping(self):
+        from engine.translate import overrides_for_language
+        # A term present only for some languages must not leak to others.
+        ru = overrides_for_language("ru")
+        es = overrides_for_language("es")
+        assert ru.get("Tesla")  # has a Cyrillic spelling
+        assert "Tesla" not in es  # no es override for the plain brand name
+
+    def test_apply_overrides_word_boundary(self):
+        from engine.translate import apply_overrides
+        out = apply_overrides("Acheter des actions TSLA aujourd'hui.", "fr")
+        assert "T-S-L-A" in out
+        # Must not rewrite a substring inside another token.
+        assert apply_overrides("TSLAX fund", "fr") == "TSLAX fund"
+
+    def test_unsupported_language_rejected(self):
+        from engine.translate import translate_script
+        with pytest.raises(ValueError):
+            translate_script("hello", "de")
+
+
+# ---------------------------------------------------------------------------
+# R2 key / URL derivation
+# ---------------------------------------------------------------------------
+
+class TestTrackKeyDerivation:
+    def _fn(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "generate_translations", PROJECT_ROOT / "scripts" / "generate_translations.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod._derive_track_key_url
+
+    def test_suffix_before_extension(self):
+        fn = self._fn()
+        base = "https://audio.nerranetwork.com"
+        url = f"{base}/tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep511_20260615.mp3"
+        key, public = fn(url, "fr", base)
+        assert key == "tesla_shorts_time/Tesla_Shorts_Time_Pod_Ep511_20260615.fr.mp3"
+        assert public == f"{base}/{key}"
+
+    def test_falls_back_to_path_when_base_mismatch(self):
+        fn = self._fn()
+        url = "https://cdn.example.com/x/Ep1_2026.mp3"
+        key, public = fn(url, "zh", "https://audio.nerranetwork.com")
+        assert key == "x/Ep1_2026.zh.mp3"
+
+
+# ---------------------------------------------------------------------------
+# summaries_io
+# ---------------------------------------------------------------------------
+
+class TestSummariesIO:
+    def test_wrapped_roundtrip_persists_edit(self, tmp_path: Path):
+        from engine.summaries_io import load_summaries, save_summaries
+        p = tmp_path / "s.json"
+        p.write_text(json.dumps({
+            "podcast": "tesla",
+            "summaries": [{"episode_num": 1, "audio_url": "u"}],
+        }), encoding="utf-8")
+        wrapper, records = load_summaries(p)
+        records[0].setdefault("translations", {})["fr"] = {"audio_url": "u.fr.mp3"}
+        save_summaries(p, wrapper, records)
+        again = json.loads(p.read_text(encoding="utf-8"))
+        assert again["podcast"] == "tesla"  # sibling key preserved
+        assert again["summaries"][0]["translations"]["fr"]["audio_url"] == "u.fr.mp3"
+
+    def test_bare_list_roundtrip(self, tmp_path: Path):
+        from engine.summaries_io import load_summaries, save_summaries
+        p = tmp_path / "s.json"
+        p.write_text(json.dumps([{"episode_num": 2}]), encoding="utf-8")
+        wrapper, records = load_summaries(p)
+        assert wrapper is None
+        save_summaries(p, wrapper, records)
+        assert json.loads(p.read_text(encoding="utf-8")) == [{"episode_num": 2}]
+
+
+# ---------------------------------------------------------------------------
+# Cloned voice env helper
+# ---------------------------------------------------------------------------
+
+class TestClonedVoice:
+    def test_missing_env_fails_loud(self, monkeypatch):
+        from engine.tts import get_cloned_voice_id
+        monkeypatch.delenv("GROK_CLONED_VOICE_ID", raising=False)
+        with pytest.raises(RuntimeError):
+            get_cloned_voice_id("GROK_CLONED_VOICE_ID")
+
+    def test_reads_env(self, monkeypatch):
+        from engine.tts import get_cloned_voice_id
+        monkeypatch.setenv("GROK_CLONED_VOICE_ID", "abc123")
+        assert get_cloned_voice_id("GROK_CLONED_VOICE_ID") == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# Blog template — switcher gating
+# ---------------------------------------------------------------------------
+
+_MD = "## Top Story\n\nTesla expanded its robotaxi program today. " * 5
+
+
+def _ep_with_tts():
+    for tts in sorted(TESLA_DIGESTS.glob("*_tts.txt")):
+        m = re.search(r"_Ep(\d+)_", tts.stem)
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def _metadata(ep_num, translations=None):
+    meta = {
+        "episode_num": ep_num,
+        "date": "2026-06-15",
+        "date_iso": "2026-06-15",
+        "hook": "A uniquely worded hook about Tesla robotaxis.",
+        "source_urls": [],
+        "word_count": 500,
+        "reading_time_min": 3,
+        "audio_url": "https://audio.nerranetwork.com/tesla_shorts_time/Ep_x.mp3",
+        "_md_path": str(TESLA_DIGESTS / "probe.md"),
+    }
+    if translations is not None:
+        meta["translations"] = translations
+    return meta
+
+
+def _render(translations):
+    from engine.blog import generate_blog_post_html
+    from generate_html import NETWORK_SHOWS, _get_jinja_env
+    ep = _ep_with_tts()
+    assert ep is not None, "expected at least one Tesla _tts.txt"
+    return generate_blog_post_html(
+        _MD, _metadata(ep, translations), NETWORK_SHOWS["tesla"], _get_jinja_env()
+    )
+
+
+class TestSwitcherGating:
+    def test_no_switcher_for_english_only(self):
+        html = _render(None)
+        # The switcher SECTION + JSON island must not render. (The swap JS
+        # lives in the scripts block unconditionally and early-returns when
+        # the island is absent — so we check the rendered markup, not the
+        # JS source which always mentions the element id.)
+        assert 'class="nn-i18n"' not in html
+        assert 'id="nn-i18n-tracks"' not in html
+
+    def test_switcher_present_with_translations(self):
+        tr = {
+            "fr": {"audio_url": "https://audio.nerranetwork.com/tesla_shorts_time/Ep_x.fr.mp3",
+                   "title": "Titre FR", "description": "Desc FR"},
+        }
+        html = _render(tr)
+        assert "nn-i18n-tracks" in html
+        assert 'data-lang="fr"' in html
+        # The JSON island must be valid JSON with both languages.
+        m = re.search(r'<script type="application/json" id="nn-i18n-tracks">\s*(\{.*?\})\s*</script>',
+                      html, re.DOTALL)
+        assert m, "tracks JSON island not found"
+        data = json.loads(m.group(1))
+        assert set(data.keys()) == {"en", "fr"}
+        assert data["fr"]["url"].endswith(".fr.mp3")

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -742,7 +742,7 @@ def test_contrast_failure_blocks_send_and_logs_error(monkeypatch, caplog):
 
 _NON_SHOW_YAML_STEMS = {
     "_defaults", "_blocked_sources", "pronunciation_map",
-    "network_meta", "scaffold_pending",
+    "network_meta", "scaffold_pending", "translation_overrides",
 }
 
 

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -21,7 +21,8 @@ PLAYBOOK_PATH = ROOT / ".claude" / "commands" / "review-show.md"
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "show-review.yml"
 
 # shows/*.yaml files that are not show configs.
-NON_SHOW_YAMLS = {"network_meta", "pronunciation_map", "scaffold_pending"}
+NON_SHOW_YAMLS = {"network_meta", "pronunciation_map", "scaffold_pending",
+                  "translation_overrides"}
 
 
 def _load_picker():

--- a/tests/test_visual_assets.py
+++ b/tests/test_visual_assets.py
@@ -568,6 +568,7 @@ def test_every_show_yaml_has_image_queries():
         "pronunciation_map.yaml",
         "network_meta.yaml",     # scaffold tool registry
         "scaffold_pending.yaml", # pending cron entries from scaffold_show.py
+        "translation_overrides.yaml",  # multilingual phonetic map (June 2026)
     }
     show_files = sorted(
         f for f in shows_dir.glob("*.yaml")


### PR DESCRIPTION
## What this does

Adds French, Russian, Spanish, and Simplified-Chinese **audio** versions of episodes, voiced by the cloned Grok voice, with a natural language switcher on the website. Newest-episodes-first; English stays the canonical master and the fallback everywhere. **Purely additive — the English generation pipeline is untouched.**

### One correction to the brief
The site is **not Next.js** — it's static HTML generated by `generate_html.py` + Jinja2 templates with a vanilla-JS player; episode data lives in per-show `summaries_*.json` + RSS. The switcher is built natively into that stack.

### Decisions confirmed with the operator
- **TTS:** reuse the existing chunk-on-sentence + crossfade path (no streaming infra exists; this is the spec's allowed fallback).
- **Switcher UI:** inline `<audio>` + language pills on the per-episode blog page.
- **Reach:** website-only (English podcast RSS stays canonical; RSS allows one enclosure per item).
- **First batch scope:** latest 3 episodes of every English show (wired so the back-catalog fills later with no rework).

## How it works
A **post-hoc** stage consumes a finalized English episode (`_tts.txt` script + summaries record + `.md` hook) and, per language:
1. **Translate** script + title/description via `grok-latest` (`engine/translate.py`) — spoken-delivery, proper nouns/tickers preserved, per-language phonetic overrides (`shows/translation_overrides.yaml`) applied as prompt guidance **and** a regex safety net.
2. **TTS** with the cloned voice (`GROK_CLONED_VOICE_ID` from `.env`, never hardcoded; BCP-47 pinned), reusing `engine/tts.synthesize(provider="grok")`.
3. **Upload** to R2 alongside the English file as `…/<file>.<lang>.mp3` (key derived from the English `audio_url`).
4. **Record** the track + translated title/description on the episode (`engine/summaries_io.py`).

Driver: `scripts/generate_translations.py` — idempotent (`--force` to override).

### Two operator checkpoints (built into the driver)
- 🛑 **`--sample-zh`** renders one short Chinese clip and stops — listen before batch ZH (cloned English voice → Mandarin tone is the main quality risk); the full ZH batch requires `--zh-approved`.
- 📏 First track per language logs **runtime delta vs the English track** (RU/FR tend to run long) — informational, no length forcing.

## Website
The blog post renders an inline player + language pills **only when an alternate track exists** (English-only episodes show nothing new — no empty/disabled control). Defaults to the visitor's `Accept-Language`, remembers the session choice, swaps audio + translated title/description on click. Vanilla JS, no build step.

## Config
`MultilingualConfig` (declared fields → no silent `_build_nested` drop, landmine #20). Enabled network-wide in `_defaults.yaml`; the two Russian shows opt out. `translation_overrides.yaml` added to the non-show YAML exclusion lists (`discover_show_slugs` + the scripts/tests that roll their own).

## Verify
```
pytest tests/test_multilingual.py            # 15 drift guards (config, overrides,
                                             # R2 key, summaries IO, switcher gating)
# Set GROK_CLONED_VOICE_ID in .env, then:
python scripts/generate_translations.py tesla --languages zh --episode <N> --sample-zh
python scripts/generate_translations.py tesla --languages fr --latest 1   # full track
python generate_html.py --shows tesla        # renders the inline switcher
```
Full suite: my changed-area suites pass; remaining failures are pre-existing missing optional deps (`google`, `yfinance`, `PIL`, ffmpeg) unrelated to this PR.

## ⚠️ Operator notes
- Paste the cloned voice ID into `.env` as `GROK_CLONED_VOICE_ID` before running.
- **A/B-listen the ZH sample** before the batch (per the checkpoint above) — landmine #17 discipline.

## Out of scope (unchanged from brief)
YouTube multi-language upload, back-catalog bulk generation, any change to the English generation pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_