### PR TITLE
Harden multilingual pipeline: translation validation, retries, resilient batching

### DIFF
--- a/docs/multilingual.md
+++ b/docs/multilingual.md
@@ -1,0 +1,107 @@
+# Multilingual audio (FR / RU / ES / ZH)
+
+A post-hoc stage that produces alternate-language **audio** versions of an
+already-finalized English episode, voiced by the operator's cloned Grok voice,
+and surfaces a language switcher on the website. English stays the canonical
+master and the fallback everywhere; translations are derived artifacts.
+
+The English generation pipeline is untouched — this is an additive branch.
+
+## One-time setup
+
+1. Paste the cloned Grok voice ID into `.env`:
+   ```
+   GROK_CLONED_VOICE_ID=<your cloned voice id>
+   ```
+   The same voice is used for all four languages. The driver fails loud if it's
+   unset (it is never hardcoded or committed).
+2. Reuses existing secrets: `GROK_API_KEY`/`XAI_API_KEY` (translation +
+   TTS) and `R2_*` (track upload). No new credentials beyond the voice ID.
+
+## Generate
+
+```bash
+# 1) STOP-and-listen: one short Chinese sample, then it stops.
+python scripts/generate_translations.py tesla --languages zh --episode <N> --sample-zh
+#    A cloned English voice can mis-handle Mandarin tones — listen first.
+
+# 2) A single full track end to end (proving run):
+python scripts/generate_translations.py tesla --languages fr --latest 1
+
+# 3) The first-pass batch once ZH is approved:
+python scripts/generate_translations.py <show> --languages fr,ru,es,zh --latest 3 --zh-approved
+
+# 4) Re-render the site so the switcher appears:
+python generate_html.py --shows <show>     # or --all on the nightly job
+```
+
+Flags: `--latest N` (default 3) or `--episode N`; `--force` to regenerate an
+existing track; `--dry-run` to translate + project cost without TTS/upload;
+`--zh-approved` (required to batch Chinese after the sample); `--sample-chars`
+(length of the `--sample-zh` clip).
+
+## What each run does, per (episode, language)
+
+1. **Translate** the finalized English `_tts.txt` script + title/description
+   via `grok-latest` (`engine/translate.py`) — spoken-delivery, proper
+   nouns/tickers preserved, per-language phonetic overrides applied.
+2. **Validate** the result (`validate_translation`) — rejects an empty output,
+   a model refusal, an untranslated English echo, a too-short stub, or a
+   wrong-script result (e.g. ZH that came back in Latin). A rejected track is
+   skipped and logged; the rest of the batch continues.
+3. **TTS** with the cloned voice, BCP-47 pinned, MP3 out (existing
+   chunk+concat path).
+4. **Upload** to R2 next to the English file as `…/<file>.<lang>.mp3`.
+5. **Record** the track + translated title/description on the episode's
+   summaries record under `translations.<lang>`, checkpointed after each
+   episode (a crash mid-batch keeps finished work).
+
+## Idempotency & cost
+
+- Re-running skips any `(episode, language)` already recorded unless `--force`.
+- Each run logs a rough character + `$` projection up front (`--dry-run` to see
+  it without spending). Grok TTS is ~$4.20 / 1M chars; a 4-language batch is
+  ~4× the English character volume per episode plus translation tokens.
+
+## Operator notes (length & quality)
+
+- The first track per language logs its **runtime delta vs the English track**
+  — RU/FR commonly run long. Informational only; no length is forced.
+- **A/B-listen** new tracks before trusting them, per landmine #17 — especially
+  the ZH sample.
+
+## Per-language phonetic overrides
+
+`shows/translation_overrides.yaml` maps `<term> -> { fr:, ru:, es:, zh: }`. Add
+an entry when you hear a ticker/brand mispronounced in a target language; the
+spelling is written into that language's script only (never the English path).
+
+## Configuration
+
+`multilingual:` in a show YAML (declared on `MultilingualConfig`):
+
+```yaml
+multilingual:
+  enabled: true
+  languages: [fr, ru, es, zh]
+  cloned_voice_env: GROK_CLONED_VOICE_ID
+```
+
+Enabled network-wide in `shows/_defaults.yaml`; the two Russian shows opt out
+(`enabled: false`). A disabled show needs an explicit `--languages` to run.
+
+## Website behavior
+
+The per-episode blog page renders an inline `<audio>` player + language pills
+**only when a translation track exists** (English-only episodes show nothing
+new). It defaults to the visitor's `Accept-Language`, remembers the session
+choice, and swaps the audio + translated title/description on selection. Vanilla
+JS, no build step. The podcast RSS feed is unchanged (English remains canonical).
+
+## Scope (this pass)
+
+Newest episodes first; the back-catalog stays English-only until generated. Out
+of scope: YouTube multi-language upload, back-catalog bulk generation, and any
+change to the English generation pipeline.
+
+Drift guards: `tests/test_multilingual.py`.

--- a/engine/translate.py
+++ b/engine/translate.py
@@ -25,10 +25,12 @@ from __future__ import annotations
 import json
 import logging
 import re
+import unicodedata
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import Callable, Dict, Optional, Tuple
 
 import yaml
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +43,14 @@ LANGUAGE_NAMES: Dict[str, str] = {
 }
 
 _TRANSLATION_MODEL = "grok-latest"
+
+
+class TranslationError(RuntimeError):
+    """A translation came back unusable (empty, too short, or untranslated)."""
+
+
+class TranslationRefusalError(TranslationError):
+    """The model refused to translate — must NOT be rendered to audio."""
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _OVERRIDES_PATH = _REPO_ROOT / "shows" / "translation_overrides.yaml"
@@ -107,6 +117,95 @@ def apply_overrides(text: str, lang: str) -> str:
     return text
 
 
+# ---------------------------------------------------------------------------
+# Output validation — never let a refusal / wrong-script / echo reach TTS
+# ---------------------------------------------------------------------------
+
+def _collapse_ws(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "")).strip()
+
+
+def _script_ratio(text: str, predicate: Callable[[str], bool]) -> float:
+    """Fraction of alphabetic chars in *text* satisfying *predicate* (0 if none)."""
+    alpha = [c for c in text if c.isalpha()]
+    if not alpha:
+        return 0.0
+    return sum(1 for c in alpha if predicate(c)) / len(alpha)
+
+
+def _is_cyrillic(c: str) -> bool:
+    return "CYRILLIC" in unicodedata.name(c, "")
+
+
+def _is_cjk(c: str) -> bool:
+    o = ord(c)
+    return 0x4E00 <= o <= 0x9FFF or 0x3400 <= o <= 0x4DBF or 0xF900 <= o <= 0xFAFF
+
+
+# Minimum target-script ratio for languages whose script differs from English.
+# Latin-script targets (fr/es) can't be distinguished from an English echo by
+# script alone, so they rely on the echo + length-floor checks instead.
+_MIN_SCRIPT_RATIO = {"ru": 0.5, "zh": 0.3}
+# A translation shorter than this fraction of the source is almost certainly
+# truncated or a stub, not a faithful for-the-ear localization.
+_MIN_LENGTH_FRACTION = 0.25
+
+
+def validate_translation(text: str, lang: str, english_script: str = "") -> str:
+    """Return *text* if it's a usable translation, else raise.
+
+    Catches the four real failure modes seen with one-shot LLM translation:
+    an empty/blank result, a model refusal (which must never be voiced), an
+    untranslated English echo, and a wrong-script result (e.g. ZH that came
+    back in Latin letters). Cheap, deterministic, no network.
+    """
+    t = (text or "").strip()
+    if not t:
+        raise TranslationError(f"{lang}: empty translation")
+
+    head = t[:500]
+    from engine.generator import _REFUSAL_PATTERNS
+    for pat in _REFUSAL_PATTERNS:
+        m = re.search(pat, head, re.MULTILINE)
+        if m:
+            raise TranslationRefusalError(f"{lang}: model refused — {m.group(0)[:120]!r}")
+
+    en = (english_script or "").strip()
+    if en and len(t) < _MIN_LENGTH_FRACTION * len(en):
+        raise TranslationError(
+            f"{lang}: translation suspiciously short ({len(t)} vs English {len(en)} chars)"
+        )
+    if en and _collapse_ws(t) == _collapse_ws(en):
+        raise TranslationError(f"{lang}: output identical to English (untranslated echo)")
+
+    floor = _MIN_SCRIPT_RATIO.get(lang)
+    if floor is not None:
+        predicate = _is_cyrillic if lang == "ru" else _is_cjk
+        ratio = _script_ratio(t, predicate)
+        if ratio < floor:
+            raise TranslationError(
+                f"{lang}: expected target-script ratio >= {floor}, got {ratio:.2f} "
+                "(translation likely came back in the wrong script)"
+            )
+    return t
+
+
+@retry(stop=stop_after_attempt(3),
+       wait=wait_exponential(multiplier=2, min=4, max=30),
+       reraise=True)
+def _generate(prompt: str, model: str, max_tokens: int) -> str:
+    """Grok text call with transient-error retry (mirrors the rest of the repo).
+
+    Retries only the API call; output validation happens by the caller, so a
+    deterministic refusal isn't retried 3× (it returns text, not an exception).
+    """
+    from digests.xai_grok import grok_generate_text
+    text, _meta = grok_generate_text(
+        prompt=prompt, model=model, temperature=0.4, max_tokens=max_tokens,
+    )
+    return (text or "").strip()
+
+
 def _build_script_prompt(english_script: str, lang: str) -> str:
     template = _PROMPT_PATH.read_text(encoding="utf-8")
     return (
@@ -135,19 +234,11 @@ def translate_script(
     if not (english_script or "").strip():
         raise ValueError("translate_script: empty english_script")
 
-    from digests.xai_grok import grok_generate_text
-
     prompt = _build_script_prompt(english_script, lang)
     logger.info("Translating script -> %s (%d chars in)", lang, len(english_script))
-    text, _meta = grok_generate_text(
-        prompt=prompt,
-        model=model,
-        temperature=0.4,
-        max_tokens=max_tokens,
-    )
-    text = (text or "").strip()
-    if not text:
-        raise RuntimeError(f"Empty translation returned for {lang}")
+    text = _generate(prompt, model, max_tokens)
+    # Reject refusals / wrong-script / echoes BEFORE they reach TTS.
+    text = validate_translation(text, lang, english_script)
     return apply_overrides(text, lang)
 
 
@@ -171,8 +262,6 @@ def translate_metadata(
     if not title and not description:
         return title, description
 
-    from digests.xai_grok import grok_generate_text
-
     name = language_name(lang)
     prompt = (
         f"Translate this podcast episode title and description into {name} "
@@ -184,10 +273,7 @@ def translate_metadata(
         f"DESCRIPTION: {description}\n"
     )
     try:
-        raw, _meta = grok_generate_text(
-            prompt=prompt, model=model, temperature=0.4, max_tokens=1200,
-        )
-        raw = (raw or "").strip()
+        raw = _generate(prompt, model, 1200)
         # Tolerate a ```json fence around the object.
         m = re.search(r"\{.*\}", raw, re.DOTALL)
         obj = json.loads(m.group(0) if m else raw)

--- a/scripts/generate_translations.py
+++ b/scripts/generate_translations.py
@@ -134,6 +134,38 @@ def _render_track(
     )
 
 
+# Grok TTS list price (per CLAUDE.md / engine.tracking): ~$4.20 per 1M chars.
+_TTS_USD_PER_MILLION = 4.20
+
+
+def _log_cost_projection(targets, languages, output_dir, force) -> None:
+    """Log a rough projected character + $ footprint before generating."""
+    total_chars = 0
+    tracks = 0
+    for rec in targets:
+        ep = rec.get("episode_num")
+        tf = _find_episode_file(output_dir, ep, "*_tts.txt")
+        if not tf:
+            continue
+        n = len(tf.read_text(encoding="utf-8"))
+        existing = rec.get("translations", {}) or {}
+        for lang in languages:
+            if lang in existing and not force:
+                continue
+            total_chars += n
+            tracks += 1
+    if not tracks:
+        return
+    # TTS bills the translated text (~English length); translation LLM adds
+    # roughly the same character volume on input. Report the TTS line only.
+    tts_cost = total_chars / 1_000_000 * _TTS_USD_PER_MILLION
+    logger.info(
+        "Projection: %d track(s), ~%s TTS chars, ~$%.2f Grok TTS "
+        "(+ translation LLM tokens). Use --dry-run to preview without spending.",
+        tracks, f"{total_chars:,}", tts_cost,
+    )
+
+
 def _resolve_languages(args, config) -> List[str]:
     if args.languages:
         langs = [s.strip() for s in args.languages.split(",") if s.strip()]
@@ -226,6 +258,10 @@ def main() -> int:
     reported_langs: set = set()
     changed = False
 
+    # Cost / volume projection (rough, informational) — translation + TTS both
+    # bill per character; a 4-language batch across several shows adds up.
+    _log_cost_projection(targets, languages, output_dir, args.force)
+
     for rec in targets:
         ep = rec["episode_num"]
         english_url = rec.get("audio_url", "")
@@ -237,14 +273,20 @@ def main() -> int:
         en_title = rec.get("episode_title", "") or ""
         en_desc = _english_hook(output_dir, ep) or en_title
         translations: Dict[str, dict] = rec.setdefault("translations", {})
+        ep_changed = False
 
         for lang in languages:
             if lang in translations and not args.force:
                 logger.info("Ep%s [%s]: already present — skipping (use --force)", ep, lang)
                 continue
             logger.info("Ep%s [%s]: translating script…", ep, lang)
-            translated = translate.translate_script(english_script, lang)
-            t_title, t_desc = translate.translate_metadata(en_title, en_desc, lang)
+            try:
+                translated = translate.translate_script(english_script, lang)
+                t_title, t_desc = translate.translate_metadata(en_title, en_desc, lang)
+            except translate.TranslationError as exc:
+                # Bad/refused translation: skip THIS track, keep the batch going.
+                logger.error("Ep%s [%s]: translation rejected — %s", ep, lang, exc)
+                continue
 
             if args.dry_run:
                 logger.info("Ep%s [%s]: DRY-RUN — %d chars, title=%r",
@@ -296,11 +338,17 @@ def main() -> int:
                 "generated_at": datetime.now(timezone.utc).isoformat(),
             }
             changed = True
+            ep_changed = True
             logger.info("Ep%s [%s]: done → %s", ep, lang, public_url)
 
+        # Persist after each EPISODE so a crash mid-batch keeps finished work
+        # (the R2 object is already up; the record is what makes it idempotent).
+        if ep_changed and not args.dry_run:
+            save_summaries(summaries_path, wrapper, records)
+            logger.info("Ep%s: summaries checkpointed", ep)
+
     if changed and not args.dry_run:
-        save_summaries(summaries_path, wrapper, records)
-        logger.info("Updated summaries: %s", summaries_path)
+        logger.info("Done. Updated summaries: %s", summaries_path)
     elif not changed:
         logger.info("Nothing to do (all requested tracks already present).")
     return 0

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -80,6 +80,62 @@ class TestOverrides:
             translate_script("hello", "de")
 
 
+class TestTranslationValidation:
+    def test_empty_rejected(self):
+        from engine.translate import TranslationError, validate_translation
+        with pytest.raises(TranslationError):
+            validate_translation("   ", "fr", "Some English source text.")
+
+    def test_refusal_rejected(self):
+        from engine.translate import TranslationRefusalError, validate_translation
+        with pytest.raises(TranslationRefusalError):
+            validate_translation(
+                "I'm sorry, but I cannot generate this podcast episode.", "fr", "x" * 200
+            )
+
+    def test_untranslated_echo_rejected(self):
+        from engine.translate import TranslationError, validate_translation
+        src = "Tesla expanded its robotaxi program across Texas today."
+        with pytest.raises(TranslationError):
+            validate_translation(src, "fr", src)
+
+    def test_too_short_rejected(self):
+        from engine.translate import TranslationError, validate_translation
+        with pytest.raises(TranslationError):
+            validate_translation("Bonjour.", "fr", "x" * 500)
+
+    def test_wrong_script_rejected_for_ru(self):
+        from engine.translate import TranslationError, validate_translation
+        # Latin text claiming to be Russian → wrong script.
+        latin = "This is clearly English text, not Russian at all, repeated. " * 5
+        with pytest.raises(TranslationError):
+            validate_translation(latin, "ru", latin.replace("Russian", "x"))
+
+    def test_wrong_script_rejected_for_zh(self):
+        from engine.translate import TranslationError, validate_translation
+        latin = "This is English not Chinese characters here. " * 5
+        with pytest.raises(TranslationError):
+            validate_translation(latin, "zh", "y" * 400)
+
+    def test_valid_russian_passes(self):
+        from engine.translate import validate_translation
+        ru = ("Сегодня Тесла расширила программу роботакси по всему Техасу, "
+              "и это важная новость для инвесторов и водителей.")
+        assert validate_translation(ru, "ru", "x" * 80) == ru
+
+    def test_valid_chinese_passes(self):
+        from engine.translate import validate_translation
+        zh = "今天特斯拉在德克萨斯州扩展了它的无人驾驶出租车项目，这对投资者来说是重要消息。"
+        assert validate_translation(zh, "zh", "x" * 40) == zh
+
+    def test_valid_french_passes(self):
+        from engine.translate import validate_translation
+        fr = ("Aujourd'hui, Tesla a étendu son programme de robotaxi à travers "
+              "le Texas, une nouvelle importante pour les investisseurs.")
+        en = "Today Tesla expanded its robotaxi program across Texas."
+        assert validate_translation(fr, "fr", en) == fr
+
+
 # ---------------------------------------------------------------------------
 # R2 key / URL derivation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Builds on the merged multilingual audio stage (#642) with reliability + operability hardening. **No behavior change to the happy path** — these are guardrails for the failure cases and long batches.

## Why
The first cut translated → TTS'd → uploaded with no check that the translation was actually usable, no retry on a transient Grok blip, and only persisted progress at the very end of a batch. Across 4 languages × many episodes × several shows, those gaps turn into shipped-garbage audio, spurious whole-batch failures, and lost work.

## What changed

### `engine/translate.py`
- **`validate_translation()`** — rejects the four real one-shot-LLM failure modes *before* they reach TTS:
  - empty output
  - a **model refusal** (reuses the generator's `_REFUSAL_PATTERNS`, so a refusal is never voiced — same discipline as the English pipeline)
  - an **untranslated English echo** (model returned the source unchanged)
  - a **too-short stub** (< 25% of source length)
  - a **wrong-script** result (Cyrillic ratio for `ru`, CJK ratio for `zh`; Latin targets `fr`/`es` rely on the echo + length checks)

  Raises `TranslationError` / `TranslationRefusalError`.
- **Transient-error retry** on the Grok text call (`tenacity`, 3 attempts, expo backoff) — matching the rest of the repo. Validation runs *after* the retry so a deterministic refusal isn't retried 3×.

### `scripts/generate_translations.py`
- **Per-track error isolation** — a rejected/failed language is logged and skipped; the batch keeps going instead of aborting.
- **Incremental persistence** — summaries are checkpointed after **each episode**, so a crash mid-batch keeps finished tracks (the R2 object is already up; the record is what makes re-runs idempotent).
- **Up-front cost/volume projection** — chars + `~$` at Grok TTS list price; `--dry-run` previews it without spending.

### Docs
- `docs/multilingual.md` — operator guide (setup, generate, the ZH stop-checkpoint, idempotency, cost, overrides, website behavior, scope).

## Verify
```
pytest tests/test_multilingual.py   # 24 guards (9 new: empty/refusal/echo/
                                    # too-short/wrong-script ru+zh/valid fr+ru+zh)
ruff check engine/ run_show.py scripts/    # clean
```
Affected suites (`test_config`, `test_blog`, `test_generator`, `test_prompt_fidelity`, `test_multilingual`) all pass locally; ruff clean.

## Out of scope (unchanged)
YouTube multi-language upload, back-catalog bulk generation, any change to the English generation pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_