### PR TITLE
Multilingual: concurrency-safe writes + website surfacing & SEO

### DIFF
--- a/engine/blog.py
+++ b/engine/blog.py
@@ -536,7 +536,8 @@ def convert_md_to_blog_html(md_text: str) -> tuple[str, list[dict]]:
 
 def _build_jsonld(metadata: dict, show_name: str, blog_url: str,
                    show_config: dict | None = None,
-                   *, transcript_url: str = "", audio_url: str = "") -> str:
+                   *, transcript_url: str = "", audio_url: str = "",
+                   translations: dict | None = None) -> str:
     """Build Schema.org JSON-LD: BlogPosting + PodcastEpisode (as array).
 
     PodcastEpisode enables Google's podcast features in Search results, links
@@ -597,7 +598,19 @@ def _build_jsonld(metadata: dict, show_name: str, blog_url: str,
     if transcript_url:
         podcast_episode["transcript"] = transcript_url
     if audio_url:
-        podcast_episode["associatedMedia"] = {"@type": "MediaObject", "contentUrl": audio_url}
+        # The English track plus any per-language audio versions (June 2026
+        # multilingual). Listing each track with its inLanguage lets search
+        # engines surface the episode's FR/RU/ES/ZH availability. Single track
+        # stays a lone object (back-compat); multiple becomes a list.
+        media = [{"@type": "MediaObject", "contentUrl": audio_url, "inLanguage": in_language}]
+        for code, track in (translations or {}).items():
+            t_url = (track or {}).get("audio_url")
+            if t_url:
+                media.append({"@type": "MediaObject", "contentUrl": t_url, "inLanguage": code})
+        podcast_episode["associatedMedia"] = media if len(media) > 1 else media[0]
+        if len(media) > 1:
+            # availableLanguage advertises every language the episode plays in.
+            podcast_episode["availableLanguage"] = [m["inLanguage"] for m in media]
 
     # ``ensure_ascii=False`` so Cyrillic show names ("Финансы Просто",
     # "Привет, Русский!") render as readable Unicode in the page source
@@ -705,6 +718,7 @@ def generate_blog_post_html(
     jsonld = _build_jsonld(
         metadata, show_config["name"], blog_url, show_config,
         transcript_url=_transcript_url, audio_url=_audio_url,
+        translations=metadata.get("translations", {}) or {},
     )
 
     template = template_env.get_template("blog_post.html.j2")

--- a/engine/summaries_io.py
+++ b/engine/summaries_io.py
@@ -33,6 +33,25 @@ def load_summaries(path: Path) -> Tuple[Optional[dict], List[dict]]:
     raise ValueError(f"Unrecognized summaries shape in {path}")
 
 
+def upsert_translation(path: Path, episode_num: int, lang: str, entry: dict) -> bool:
+    """Concurrency-safe write of one translation track to the summaries file.
+
+    Re-reads the file fresh, sets ``record.translations[lang] = entry`` on the
+    matching episode, and saves — so a translation run never clobbers a record
+    the live English cron appended between the run's initial load and its save
+    (the failure mode of holding an in-memory snapshot and overwriting the
+    whole file at the end of a long batch). Returns True if the episode was
+    found and written, False otherwise.
+    """
+    wrapper, records = load_summaries(path)
+    for rec in records:
+        if rec.get("episode_num") == episode_num:
+            rec.setdefault("translations", {})[lang] = entry
+            save_summaries(path, wrapper, records)
+            return True
+    return False
+
+
 def save_summaries(path: Path, wrapper: Optional[dict], records: List[dict]) -> None:
     """Atomically write ``records`` back, preserving the original shape."""
     path = Path(path)

--- a/generate_html.py
+++ b/generate_html.py
@@ -2546,6 +2546,42 @@ def _pick_cross_show_related(slug, cross_show_posts, *, want=3):
     return related
 
 
+def _attach_translations(slug, cfg, metas):
+    """Merge each episode's summaries record (audio URL + per-language
+    translation tracks, June 2026 multilingual) into its blog metadata.
+
+    The episode ``.md`` carries neither the audio URL nor the translations;
+    they live in the show's ``summaries_<show>.json``. English stays canonical
+    — episodes with no ``translations`` key render exactly as before. Used by
+    both the blog-post and blog-index generators so language badges + the
+    inline switcher appear consistently.
+    """
+    records_by_ep: dict[int, dict] = {}
+    json_path = cfg.get("json_path")
+    if json_path:
+        try:
+            from engine.summaries_io import load_summaries
+            _, recs = load_summaries(ROOT / json_path)
+            for r in recs:
+                ep = r.get("episode_num")
+                if isinstance(ep, int):
+                    records_by_ep[ep] = r
+        except FileNotFoundError:
+            return
+        except Exception as exc:  # noqa: BLE001 — never block HTML gen
+            print(f"  Warning: could not load summaries for {slug}: {exc}")
+            return
+    for meta in metas:
+        rec = records_by_ep.get(meta.get("episode_num"))
+        if not rec:
+            continue
+        if not meta.get("audio_url"):
+            meta["audio_url"] = rec.get("audio_url", "")
+        tr = rec.get("translations")
+        if isinstance(tr, dict) and tr:
+            meta["translations"] = tr
+
+
 def generate_blog_posts(slug, *, dry_run=False, cross_show_posts=None):
     """Generate blog post HTML pages for all episodes of a show.
 
@@ -2599,33 +2635,7 @@ def generate_blog_posts(slug, *, dry_run=False, cross_show_posts=None):
     # Sort by episode number
     all_meta.sort(key=lambda m: m["episode_num"])
 
-    # Merge the summaries record's audio URL + any per-language translation
-    # tracks (June 2026 multilingual audio) into each episode's metadata, so
-    # the blog post can render an inline player + language switcher. The .md
-    # alone carries neither. English stays canonical; episodes with no
-    # ``translations`` key render exactly as before (no switcher).
-    _records_by_ep: dict[int, dict] = {}
-    _json_path = cfg.get("json_path")
-    if _json_path:
-        try:
-            from engine.summaries_io import load_summaries
-            _, _recs = load_summaries(ROOT / _json_path)
-            for _r in _recs:
-                _ep = _r.get("episode_num")
-                if isinstance(_ep, int):
-                    _records_by_ep[_ep] = _r
-        except FileNotFoundError:
-            pass
-        except Exception as _exc:  # noqa: BLE001 — never block blog gen
-            print(f"  Warning: could not load summaries for {slug}: {_exc}")
-    for meta in all_meta:
-        _rec = _records_by_ep.get(meta["episode_num"])
-        if _rec:
-            if not meta.get("audio_url"):
-                meta["audio_url"] = _rec.get("audio_url", "")
-            _tr = _rec.get("translations")
-            if isinstance(_tr, dict) and _tr:
-                meta["translations"] = _tr
+    _attach_translations(slug, cfg, all_meta)
 
     blog_dir = ROOT / "blog" / slug
     results = []
@@ -2689,6 +2699,7 @@ def generate_blog_index(slug, *, dry_run=False, posts=None):
                 else:
                     seen_eps[ep] = meta
             posts = list(seen_eps.values())
+            _attach_translations(slug, cfg, posts)
 
     # Sort newest first for index display
     posts_sorted = sorted(posts, key=lambda m: m.get("episode_num", 0), reverse=True)

--- a/scripts/generate_translations.py
+++ b/scripts/generate_translations.py
@@ -49,7 +49,7 @@ load_dotenv(PROJECT_ROOT / ".env")
 from engine import tts, translate  # noqa: E402
 from engine.config import load_config  # noqa: E402
 from engine.storage import upload_to_r2  # noqa: E402
-from engine.summaries_io import load_summaries, save_summaries  # noqa: E402
+from engine.summaries_io import load_summaries, upsert_translation  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(levelname)s %(message)s")
 logger = logging.getLogger("generate_translations")
@@ -211,7 +211,7 @@ def main() -> int:
         or "GROK_CLONED_VOICE_ID"
     max_chars = config.tts.max_chars or tts.GROK_MAX_CHARS_PER_REQUEST
 
-    wrapper, records = load_summaries(summaries_path)
+    _wrapper, records = load_summaries(summaries_path)
     targets = _select_records(records, args.latest, args.episode)
     if not targets:
         logger.error("No matching episode records in %s", summaries_path)
@@ -273,7 +273,6 @@ def main() -> int:
         en_title = rec.get("episode_title", "") or ""
         en_desc = _english_hook(output_dir, ep) or en_title
         translations: Dict[str, dict] = rec.setdefault("translations", {})
-        ep_changed = False
 
         for lang in languages:
             if lang in translations and not args.force:
@@ -330,22 +329,23 @@ def main() -> int:
                 logger.warning("Ep%s [%s]: R2 creds unset — track left local at %s",
                                ep, lang, local_mp3)
 
-            translations[lang] = {
+            entry = {
                 "audio_url": public_url,
                 "title": t_title,
                 "description": t_desc,
                 "duration_sec": round(dur, 1) if dur else 0,
                 "generated_at": datetime.now(timezone.utc).isoformat(),
             }
+            # Keep the in-memory copy current (skip-check + projection within
+            # this run), but PERSIST via a fresh read-modify-write per track so
+            # the live English cron can't have a record we appended clobbered
+            # by a stale in-memory snapshot (and a crash keeps finished work).
+            translations[lang] = entry
+            if not upsert_translation(summaries_path, ep, lang, entry):
+                logger.warning("Ep%s [%s]: record vanished from %s during run — "
+                               "track uploaded but not recorded", ep, lang, summaries_path)
             changed = True
-            ep_changed = True
             logger.info("Ep%s [%s]: done → %s", ep, lang, public_url)
-
-        # Persist after each EPISODE so a crash mid-batch keeps finished work
-        # (the R2 object is already up; the record is what makes it idempotent).
-        if ep_changed and not args.dry_run:
-            save_summaries(summaries_path, wrapper, records)
-            logger.info("Ep%s: summaries checkpointed", ep)
 
     if changed and not args.dry_run:
         logger.info("Done. Updated summaries: %s", summaries_path)

--- a/templates/blog_index.html.j2
+++ b/templates/blog_index.html.j2
@@ -62,6 +62,25 @@
             background: color-mix(in srgb, var(--show-color) 20%, transparent);
             border-color: var(--show-color);
         }
+        /* Multilingual availability badges (June 2026) */
+        .blog-idx-langs {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            margin: var(--sp-2) 0 var(--sp-1);
+            color: var(--nn-text-muted);
+        }
+        .blog-idx-langs .lang-badge {
+            font-family: var(--font-ui);
+            font-size: 0.68rem;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            padding: 1px 7px;
+            border-radius: 100px;
+            border: 1px solid color-mix(in srgb, var(--show-color) 35%, transparent);
+            color: var(--show-color-text, var(--show-color));
+            background: color-mix(in srgb, var(--show-color) 10%, transparent);
+        }
     </style>
 {% endblock %}
 
@@ -98,6 +117,13 @@
             <h2>{{ post.title }}{% if post.title == show_name %} — Ep {{ post.episode_num }}{% endif %}</h2>
             {% if post.hook %}
             <p>{{ post.hook[:160] }}{% if post.hook|length > 160 %}&hellip;{% endif %}</p>
+            {% endif %}
+            {% if post.translations %}
+            {%- set _LANG_LABELS = {"fr": "FR", "ru": "RU", "es": "ES", "zh": "中文"} -%}
+            <span class="blog-idx-langs" aria-label="Also available in other languages">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                {% for code, t in post.translations.items() if t.audio_url %}<span class="lang-badge">{{ _LANG_LABELS.get(code, code|upper) }}</span>{% endfor %}
+            </span>
             {% endif %}
             <span class="blog-idx-read-more">Read article &rarr;</span>
         </a>

--- a/templates/summaries_page.html.j2
+++ b/templates/summaries_page.html.j2
@@ -316,12 +316,21 @@
 
                     const titleHtml = title ? `<div style="font-weight:600;color:var(--show-color-text, var(--show-color));font-family:var(--font-ui);font-size:0.88rem;">${escapeHtml(title)}</div>` : '';
 
+                    // Multilingual availability badges (June 2026): surface the
+                    // per-language audio tracks recorded on this episode.
+                    const LANG_LABELS = { fr: 'FR', ru: 'RU', es: 'ES', zh: '中文' };
+                    const tr = (s.translations && typeof s.translations === 'object') ? s.translations : {};
+                    const langs = Object.keys(tr).filter(k => tr[k] && tr[k].audio_url);
+                    const badgeStyle = 'font-family:var(--font-ui);font-size:0.66rem;font-weight:600;padding:1px 7px;border-radius:100px;border:1px solid color-mix(in srgb, var(--show-color) 35%, transparent);color:var(--show-color-text, var(--show-color));background:color-mix(in srgb, var(--show-color) 10%, transparent);';
+                    const langsHtml = langs.length ? `<span class="nn-summary-langs" aria-label="Also available in other languages" style="display:inline-flex;gap:4px;margin-top:4px;">${langs.map(k => `<span style="${badgeStyle}">${LANG_LABELS[k] || k.toUpperCase()}</span>`).join('')}</span>` : '';
+
                     return `
                         <div class="nn-summary-item" data-date="${escapeAttr(date)}">
                             <div class="nn-summary-header">
                                 <div>
                                     <div class="nn-summary-date">${formatDate(date)}</div>
                                     ${titleHtml}
+                                    ${langsHtml}
                                 </div>
                                 ${audioHtml}
                             </div>

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -184,6 +184,50 @@ class TestSummariesIO:
         assert again["podcast"] == "tesla"  # sibling key preserved
         assert again["summaries"][0]["translations"]["fr"]["audio_url"] == "u.fr.mp3"
 
+    def test_upsert_translation_targets_one_record(self, tmp_path: Path):
+        from engine.summaries_io import upsert_translation
+        p = tmp_path / "s.json"
+        p.write_text(json.dumps({
+            "podcast": "tesla",
+            "summaries": [
+                {"episode_num": 10, "audio_url": "a"},
+                {"episode_num": 11, "audio_url": "b"},
+            ],
+        }), encoding="utf-8")
+        ok = upsert_translation(p, 11, "fr", {"audio_url": "b.fr.mp3"})
+        assert ok is True
+        data = json.loads(p.read_text(encoding="utf-8"))
+        assert data["summaries"][1]["translations"]["fr"]["audio_url"] == "b.fr.mp3"
+        assert "translations" not in data["summaries"][0]  # only ep11 touched
+
+    def test_upsert_translation_missing_episode_returns_false(self, tmp_path: Path):
+        from engine.summaries_io import upsert_translation
+        p = tmp_path / "s.json"
+        p.write_text(json.dumps({"podcast": "t", "summaries": [{"episode_num": 1}]}),
+                     encoding="utf-8")
+        assert upsert_translation(p, 999, "fr", {"audio_url": "x"}) is False
+
+    def test_upsert_preserves_concurrently_added_record(self, tmp_path: Path):
+        # Simulates the live English cron appending a NEW episode between a
+        # translation run's initial load and its per-track write. Because
+        # upsert re-reads fresh, the new record must survive.
+        from engine.summaries_io import load_summaries, upsert_translation
+        p = tmp_path / "s.json"
+        p.write_text(json.dumps({"podcast": "t", "summaries": [{"episode_num": 5}]}),
+                     encoding="utf-8")
+        _wrapper, _stale = load_summaries(p)  # translation run's initial snapshot
+        # Concurrent writer appends episode 6.
+        cur = json.loads(p.read_text(encoding="utf-8"))
+        cur["summaries"].append({"episode_num": 6, "audio_url": "new"})
+        p.write_text(json.dumps(cur), encoding="utf-8")
+        # Translation run now writes its track for episode 5.
+        assert upsert_translation(p, 5, "ru", {"audio_url": "5.ru.mp3"}) is True
+        data = json.loads(p.read_text(encoding="utf-8"))
+        nums = {r["episode_num"] for r in data["summaries"]}
+        assert nums == {5, 6}  # episode 6 NOT clobbered
+        ep5 = next(r for r in data["summaries"] if r["episode_num"] == 5)
+        assert ep5["translations"]["ru"]["audio_url"] == "5.ru.mp3"
+
     def test_bare_list_roundtrip(self, tmp_path: Path):
         from engine.summaries_io import load_summaries, save_summaries
         p = tmp_path / "s.json"

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -322,3 +322,65 @@ class TestSwitcherGating:
         data = json.loads(m.group(1))
         assert set(data.keys()) == {"en", "fr"}
         assert data["fr"]["url"].endswith(".fr.mp3")
+
+
+class TestJsonLdMultilingual:
+    def _podcast_episode(self, html):
+        for raw in re.findall(
+            r'<script type="application/ld\+json">\s*(.*?)\s*</script>', html, re.DOTALL
+        ):
+            try:
+                data = json.loads(raw)
+            except Exception:
+                continue
+            for item in (data if isinstance(data, list) else [data]):
+                if item.get("@type") == "PodcastEpisode":
+                    return item
+        return None
+
+    def test_english_only_has_single_media_no_availablelanguage(self):
+        ep = self._podcast_episode(_render(None))
+        assert ep is not None
+        assert "availableLanguage" not in ep
+        # Single track stays a lone object, not a list (back-compat).
+        assert isinstance(ep.get("associatedMedia"), dict)
+
+    def test_translations_listed_in_jsonld(self):
+        tr = {
+            "fr": {"audio_url": "https://audio.nerranetwork.com/x/Ep.fr.mp3"},
+            "ru": {"audio_url": "https://audio.nerranetwork.com/x/Ep.ru.mp3"},
+        }
+        ep = self._podcast_episode(_render(tr))
+        assert set(ep["availableLanguage"]) == {"en", "fr", "ru"}
+        urls = {m["contentUrl"] for m in ep["associatedMedia"]}
+        assert any(u.endswith(".fr.mp3") for u in urls)
+        assert any(u.endswith(".ru.mp3") for u in urls)
+        langs = {m["inLanguage"] for m in ep["associatedMedia"]}
+        assert langs == {"en", "fr", "ru"}
+
+
+class TestBlogIndexBadges:
+    def _render_index(self, posts):
+        from engine.blog import generate_blog_index_html
+        from generate_html import NETWORK_SHOWS, _get_jinja_env
+        return generate_blog_index_html(posts, NETWORK_SHOWS["tesla"], _get_jinja_env())
+
+    def _post(self, ep, translations=None):
+        p = {"episode_num": ep, "date": "2026-06-15", "title": "A title",
+             "hook": "A hook.", "reading_time_min": 3, "filename": f"ep{ep}.md"}
+        if translations:
+            p["translations"] = translations
+        return p
+
+    def test_badges_shown_when_translations(self):
+        html = self._render_index([self._post(5, {"fr": {"audio_url": "a.fr.mp3"},
+                                                   "zh": {"audio_url": "a.zh.mp3"}})])
+        # The rendered badge ROW (not just the CSS rule) must be present.
+        assert '<span class="blog-idx-langs"' in html
+        assert ">FR<" in html and "中文" in html
+
+    def test_no_badges_for_english_only(self):
+        # CSS defining `.blog-idx-langs`/`.lang-badge` always ships; assert the
+        # rendered badge markup is absent for an English-only post.
+        html = self._render_index([self._post(6)])
+        assert '<span class="blog-idx-langs"' not in html


### PR DESCRIPTION
Follow-up to the merged multilingual work (#642, #643). Two themes: a data-safety fix for the generator, and making the language availability visible on the site + to search engines.

## 1. Concurrency-safe summaries writes
The driver previously held an in-memory snapshot of `summaries_<show>.json` and overwrote the whole file at end-of-batch. If the **live English cron appended a new episode** mid-run, that record would be clobbered.

- New `engine.summaries_io.upsert_translation(path, episode_num, lang, entry)` — a fresh **read-modify-write per track** keyed by `episode_num`. The driver now persists each track through it, so a concurrent append survives and a crash keeps every finished track.
- Guards: targeted single-record write, missing-episode → `False`, and a **concurrent-append survival** test (simulates the cron adding ep 6 between the run's load and its write — ep 6 is not dropped).

## 2. Website surfacing + SEO
Until now the only sign of a translation was the inline player on the blog post. This adds discovery and machine-readable signals:

- **PodcastEpisode JSON-LD** (`engine/blog.py`): `associatedMedia` now lists **every track with its `inLanguage`** (English + each translation) plus an `availableLanguage` array — search engines can surface FR/RU/ES/ZH availability. Single-track episodes keep the lone-object shape (back-compat).
- **Blog index**: compact language badges (`FR · RU · ES · 中文`) on cards that have translations.
- **Summaries page**: the same badges on the JS-hydrated cards (the manifest already carries `translations`).
- **`generate_html.py`**: extracted the summaries→metadata merge into a shared `_attach_translations()` helper used by **both** the blog-post and blog-index generators, so badges + the switcher appear consistently (the standalone index path had neither before).

English-only episodes render exactly as before — no badges, single-track JSON-LD, no switcher.

## Verify
```
pytest tests/test_multilingual.py            # 31 guards (upsert + concurrency,
                                             # JSON-LD language list, index badges)
ruff check engine/ run_show.py scripts/      # clean
python generate_html.py --shows tesla        # blog posts + index + summaries render
```
End-to-end render of Tesla blog posts / index / summaries page succeeds; `test_website_quality_pass`, `test_phase2_growth`, `test_phase4_repositioning`, `test_blog` all pass locally.

## Out of scope (unchanged)
YouTube multi-language upload, back-catalog bulk generation, any change to the English generation pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_