### PR TITLE
Auto-generate FR/RU/ES/ZH audio for every English episode

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -403,9 +403,9 @@ jobs:
           # on disk, no indentation-sensitive shell hack.
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
-          # Cloned Grok voice ID for multilingual audio (multilingual.auto).
-          # When unset the auto step no-ops with a warning; the English
-          # publish is unaffected.
+          # OPTIONAL override for multilingual audio: a different cloned Grok
+          # voice for the translated tracks. Unset (the default) → the show's
+          # existing tts.voice_id (kdif6sqjcyiq) is reused across all languages.
           GROK_CLONED_VOICE_ID: ${{ secrets.GROK_CLONED_VOICE_ID }}
           X_CONSUMER_KEY: ${{ secrets.X_CONSUMER_KEY }}
           X_CONSUMER_SECRET: ${{ secrets.X_CONSUMER_SECRET }}

--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -403,6 +403,10 @@ jobs:
           # on disk, no indentation-sensitive shell hack.
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+          # Cloned Grok voice ID for multilingual audio (multilingual.auto).
+          # When unset the auto step no-ops with a warning; the English
+          # publish is unaffected.
+          GROK_CLONED_VOICE_ID: ${{ secrets.GROK_CLONED_VOICE_ID }}
           X_CONSUMER_KEY: ${{ secrets.X_CONSUMER_KEY }}
           X_CONSUMER_SECRET: ${{ secrets.X_CONSUMER_SECRET }}
           X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}

--- a/docs/env_var_inventory.md
+++ b/docs/env_var_inventory.md
@@ -55,7 +55,7 @@ Nightly audience stats (June 2026; both optional — scripts no-op when unset):
 
 | Variable | Required when |
 |----------|----------------|
-| `GROK_CLONED_VOICE_ID` | Running `scripts/generate_translations.py` (FR/RU/ES/ZH audio). The operator's cloned Grok voice ID — pasted into `.env`, **never** committed to git. The same voice is used for all four languages. The script fails loud if it's unset. |
+| `GROK_CLONED_VOICE_ID` | FR/RU/ES/ZH audio. Required by the daily `run-show.yml` workflow (the `multilingual.auto` step, network default) **and** the manual `scripts/generate_translations.py`. The operator's cloned Grok voice ID — pasted into `.env` locally / set as a GitHub **secret** for CI, **never** committed. Same voice for all four languages. The auto step no-ops (with a warning) when unset; the manual driver fails loud. |
 
 Reuses `GROK_API_KEY`/`XAI_API_KEY` (translation via `grok-latest` + Grok TTS)
 and the existing `R2_*` credentials (tracks upload to the same bucket as

--- a/docs/env_var_inventory.md
+++ b/docs/env_var_inventory.md
@@ -55,7 +55,7 @@ Nightly audience stats (June 2026; both optional — scripts no-op when unset):
 
 | Variable | Required when |
 |----------|----------------|
-| `GROK_CLONED_VOICE_ID` | FR/RU/ES/ZH audio. Required by the daily `run-show.yml` workflow (the `multilingual.auto` step, network default) **and** the manual `scripts/generate_translations.py`. The operator's cloned Grok voice ID — pasted into `.env` locally / set as a GitHub **secret** for CI, **never** committed. Same voice for all four languages. The auto step no-ops (with a warning) when unset; the manual driver fails loud. |
+| `GROK_CLONED_VOICE_ID` | **Optional** override for multilingual audio (FR/RU/ES/ZH). By default the translated tracks reuse the show's existing `tts.voice_id` (`kdif6sqjcyiq`), so this is **not required**. Set it (in `.env` locally / GitHub secret for CI, never committed) only to voice the translations with a *different* cloned Grok voice. |
 
 Reuses `GROK_API_KEY`/`XAI_API_KEY` (translation via `grok-latest` + Grok TTS)
 and the existing `R2_*` credentials (tracks upload to the same bucket as

--- a/docs/multilingual.md
+++ b/docs/multilingual.md
@@ -9,14 +9,14 @@ The English generation pipeline is untouched — this is an additive branch.
 
 ## One-time setup
 
-1. Paste the cloned Grok voice ID into `.env`:
-   ```
-   GROK_CLONED_VOICE_ID=<your cloned voice id>
-   ```
-   The same voice is used for all four languages. The driver fails loud if it's
-   unset (it is never hardcoded or committed).
-2. Reuses existing secrets: `GROK_API_KEY`/`XAI_API_KEY` (translation +
-   TTS) and `R2_*` (track upload). No new credentials beyond the voice ID.
+Nothing required beyond what the network already has. The translated tracks
+reuse each show's **existing Grok voice** (`tts.voice_id`, `kdif6sqjcyiq`) and
+existing secrets (`GROK_API_KEY`/`XAI_API_KEY` for translation + TTS, `R2_*`
+for upload). No new credentials.
+
+**Optional:** to voice the translations with a *different* cloned voice, set
+`GROK_CLONED_VOICE_ID` (in `.env` locally, or as a GitHub secret for CI). When
+unset, the show's existing voice is used.
 
 ## Automatic generation (default)
 
@@ -27,11 +27,13 @@ for each newly published episode automatically:
 - `run_show.py` calls `engine.multilingual.auto_generate_after_publish()` right
   after the episode's summaries record is written and **before** the blog post,
   so today's post + index immediately show the language switcher and badges.
-- It is **best-effort and non-blocking** — a translation failure (or an unset
-  `GROK_CLONED_VOICE_ID`) can never break the English publish.
-- Requires the `GROK_CLONED_VOICE_ID` secret in the `run-show.yml` workflow
-  (already wired in the step env). Until that secret is set, the auto step
-  no-ops with a warning and episodes ship English-only.
+- It is **best-effort and non-blocking** — a translation failure can never
+  break the English publish.
+- **Voice:** the translated tracks reuse the show's **existing Grok voice**
+  (`tts.voice_id`, e.g. `kdif6sqjcyiq`) by default — Grok carries one voice
+  across languages, so the host sounds like the operator in every language with
+  no extra setup or secret. `GROK_CLONED_VOICE_ID` is only an **optional
+  override** to point translations at a different cloned voice.
 - Cost: ~$0.18/episode (≈4× the English TTS character volume + translation
   tokens) — roughly **$50–55/month** network-wide. See the cost note below.
 

--- a/docs/multilingual.md
+++ b/docs/multilingual.md
@@ -18,7 +18,28 @@ The English generation pipeline is untouched — this is an additive branch.
 2. Reuses existing secrets: `GROK_API_KEY`/`XAI_API_KEY` (translation +
    TTS) and `R2_*` (track upload). No new credentials beyond the voice ID.
 
-## Generate
+## Automatic generation (default)
+
+As of June 2026 every English show has `multilingual.auto: true` in
+`shows/_defaults.yaml`, so the daily pipeline generates **all four languages**
+for each newly published episode automatically:
+
+- `run_show.py` calls `engine.multilingual.auto_generate_after_publish()` right
+  after the episode's summaries record is written and **before** the blog post,
+  so today's post + index immediately show the language switcher and badges.
+- It is **best-effort and non-blocking** — a translation failure (or an unset
+  `GROK_CLONED_VOICE_ID`) can never break the English publish.
+- Requires the `GROK_CLONED_VOICE_ID` secret in the `run-show.yml` workflow
+  (already wired in the step env). Until that secret is set, the auto step
+  no-ops with a warning and episodes ship English-only.
+- Cost: ~$0.18/episode (≈4× the English TTS character volume + translation
+  tokens) — roughly **$50–55/month** network-wide. See the cost note below.
+
+Disable for a single show by setting `multilingual.auto: false` (or
+`enabled: false`) in its YAML. The manual driver below still works regardless,
+for back-fill or one-offs.
+
+## Generate (manual / back-fill)
 
 ```bash
 # 1) STOP-and-listen: one short Chinese sample, then it stops.

--- a/engine/config.py
+++ b/engine/config.py
@@ -268,6 +268,11 @@ class MultilingualConfig:
     ``_build_nested`` doesn't silently drop them — see landmine #20.
     """
     enabled: bool = False
+    # When True, the daily pipeline (run_show.py) auto-generates the
+    # configured languages for each newly published episode — best-effort
+    # and non-blocking (a failure never breaks the English publish). When
+    # False, translations are produced only via the manual driver.
+    auto: bool = False
     # BCP-47 codes to render. Default empty; the driver also accepts a
     # ``--languages`` override so a show with no block can still be run.
     languages: List[str] = field(default_factory=list)

--- a/engine/multilingual.py
+++ b/engine/multilingual.py
@@ -1,0 +1,223 @@
+"""Reusable per-episode multilingual audio generation.
+
+Shared core used by BOTH the manual driver (``scripts/generate_translations.py``)
+and the daily pipeline's auto step (``run_show.py``). Given a finalized English
+episode, it translates the script + metadata, renders each language to MP3 with
+the cloned Grok voice, uploads to R2 alongside the English file, and records the
+track on the episode (concurrency-safe upsert).
+
+English stays the canonical master; translations are derived artifacts surfaced
+on the website. See ``docs/multilingual.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+from urllib.parse import urlparse
+
+from engine import translate, tts
+from engine.storage import upload_to_r2
+from engine.summaries_io import load_summaries, upsert_translation
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def grok_api_key() -> str:
+    key = (os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY") or "").strip()
+    if not key:
+        raise RuntimeError("Missing GROK_API_KEY (or XAI_API_KEY)")
+    return key
+
+
+def ffprobe_duration(target: str) -> Optional[float]:
+    """Media duration in seconds (works on a local path OR a URL); None on error."""
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "default=noprint_wrappers=1:nokey=1", target],
+            capture_output=True, text=True, timeout=120,
+        )
+        val = out.stdout.strip()
+        return float(val) if val else None
+    except Exception:  # noqa: BLE001 — best-effort, reporting only
+        return None
+
+
+def find_tts_file(output_dir: Path, episode_num: int) -> Optional[Path]:
+    matches = sorted(output_dir.glob(f"*_Ep{episode_num:03d}_*_tts.txt"))
+    return matches[-1] if matches else None
+
+
+def english_hook(output_dir: Path, episode_num: int) -> str:
+    """Best-effort episode hook from the digest .md (for track descriptions)."""
+    md = None
+    for p in sorted(output_dir.glob(f"*_Ep{episode_num:03d}_*.md")):
+        if not p.name.endswith("_tts.txt"):
+            md = p
+    if not md:
+        return ""
+    try:
+        from engine.blog import extract_blog_metadata
+        meta = extract_blog_metadata(md.read_text(encoding="utf-8"), "", md.name, md)
+        return meta.get("hook", "") or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def derive_track_key_url(english_audio_url: str, lang: str, public_base_url: str):
+    """``(remote_key, public_url)`` for the *lang* track, derived from the
+    English track's own URL so it lands in the same R2 prefix."""
+    base = (public_base_url or "").rstrip("/")
+    if base and english_audio_url.startswith(base + "/"):
+        key = english_audio_url[len(base) + 1:]
+    else:
+        key = urlparse(english_audio_url).path.lstrip("/")
+    if key.lower().endswith(".mp3"):
+        key = key[:-4]
+    remote_key = f"{key}.{lang}.mp3"
+    public_url = f"{base}/{remote_key}" if base else remote_key
+    return remote_key, public_url
+
+
+def render_track(script_text: str, lang: str, voice_id: str, api_key: str,
+                 out_path: Path, max_chars: int) -> None:
+    tts.synthesize(
+        script_text, voice_id, out_path,
+        api_key=api_key, provider="grok",
+        max_chars=max_chars, language_code=lang,
+    )
+
+
+def generate_for_episode(
+    config,
+    episode_num: int,
+    languages: List[str],
+    *,
+    voice_id: str,
+    api_key: str,
+    force: bool = False,
+    dry_run: bool = False,
+) -> Dict[str, str]:
+    """Generate the requested language tracks for one episode.
+
+    Re-reads the summaries record fresh, finds the finalized ``_tts.txt``, and
+    for each language translates → validates → TTS → uploads → upserts the
+    track. Returns a ``{lang: status}`` map where status is one of
+    ``done`` / ``skip`` / ``rejected`` / ``dryrun`` / ``no_audio_url``. A
+    per-language failure never aborts the others.
+    """
+    output_dir = PROJECT_ROOT / config.episode.output_dir
+    summaries_path = PROJECT_ROOT / config.publishing.summaries_json
+    max_chars = config.tts.max_chars or tts.GROK_MAX_CHARS_PER_REQUEST
+
+    _wrapper, records = load_summaries(summaries_path)
+    rec = next((r for r in records if r.get("episode_num") == episode_num), None)
+    if rec is None:
+        logger.warning("multilingual: no summaries record for Ep%s", episode_num)
+        return {}
+    english_url = rec.get("audio_url", "")
+    tts_file = find_tts_file(output_dir, episode_num)
+    if not tts_file:
+        logger.warning("multilingual: no _tts.txt for Ep%s in %s", episode_num, output_dir)
+        return {}
+
+    english_script = tts_file.read_text(encoding="utf-8").strip()
+    en_title = rec.get("episode_title", "") or ""
+    en_desc = english_hook(output_dir, episode_num) or en_title
+    existing = rec.get("translations", {}) or {}
+
+    results: Dict[str, str] = {}
+    for lang in languages:
+        if lang in existing and not force:
+            results[lang] = "skip"
+            continue
+        try:
+            translated = translate.translate_script(english_script, lang)
+            t_title, t_desc = translate.translate_metadata(en_title, en_desc, lang)
+        except translate.TranslationError as exc:
+            logger.error("Ep%s [%s]: translation rejected — %s", episode_num, lang, exc)
+            results[lang] = "rejected"
+            continue
+
+        if dry_run:
+            results[lang] = "dryrun"
+            continue
+        if not english_url:
+            logger.warning("Ep%s [%s]: no English audio_url — cannot place track", episode_num, lang)
+            results[lang] = "no_audio_url"
+            continue
+
+        local_mp3 = output_dir / f"{tts_file.stem.replace('_tts', '')}.{lang}.mp3"
+        render_track(translated, lang, voice_id, api_key, local_mp3, max_chars)
+        dur = ffprobe_duration(str(local_mp3))
+
+        en_dur = ffprobe_duration(english_url)
+        if en_dur and dur:
+            logger.info("Ep%s LENGTH [%s]: %.0fs vs EN %.0fs (%+.0f%%)",
+                        episode_num, lang, dur, en_dur, (dur - en_dur) / en_dur * 100.0)
+
+        remote_key, public_url = derive_track_key_url(
+            english_url, lang, config.storage.public_base_url)
+        endpoint = os.getenv(config.storage.endpoint_env, "").strip()
+        access_key = os.getenv(config.storage.access_key_env, "").strip()
+        secret_key = os.getenv(config.storage.secret_key_env, "").strip()
+        if all([endpoint, access_key, secret_key]):
+            upload_to_r2(
+                local_mp3, remote_key,
+                bucket=config.storage.bucket,
+                endpoint_url=endpoint, access_key=access_key, secret_key=secret_key,
+                public_base_url=config.storage.public_base_url,
+            )
+        else:
+            logger.warning("Ep%s [%s]: R2 creds unset — track left local at %s",
+                           episode_num, lang, local_mp3)
+
+        upsert_translation(summaries_path, episode_num, lang, {
+            "audio_url": public_url,
+            "title": t_title,
+            "description": t_desc,
+            "duration_sec": round(dur, 1) if dur else 0,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        })
+        results[lang] = "done"
+        logger.info("Ep%s [%s]: done → %s", episode_num, lang, public_url)
+
+    return results
+
+
+def auto_generate_after_publish(config, episode_num: int) -> Dict[str, str]:
+    """Daily-pipeline entry point: generate all configured languages for the
+    just-published episode when the show opts into ``multilingual.auto``.
+
+    Fully non-blocking and self-guarding — returns an empty map (never raises)
+    when multilingual is disabled, ``auto`` is off, the cloned voice ID isn't
+    set, or anything fails. The caller must treat translation as best-effort so
+    it can never break the English publish.
+    """
+    ml = getattr(config, "multilingual", None)
+    if not (ml and ml.enabled and getattr(ml, "auto", False)):
+        return {}
+    languages = list(ml.languages) or list(translate.supported_languages())
+    try:
+        voice_id = tts.get_cloned_voice_id(ml.cloned_voice_env)
+        api_key = grok_api_key()
+    except RuntimeError as exc:
+        logger.warning("multilingual auto: skipping Ep%s — %s", episode_num, exc)
+        return {}
+    try:
+        results = generate_for_episode(
+            config, episode_num, languages, voice_id=voice_id, api_key=api_key,
+        )
+        done = sorted(k for k, v in results.items() if v == "done")
+        logger.info("multilingual auto: Ep%s generated %s", episode_num, done or "nothing new")
+        return results
+    except Exception as exc:  # noqa: BLE001 — translation must never block publish
+        logger.error("multilingual auto: Ep%s failed (non-fatal) — %s", episode_num, exc)
+        return {}

--- a/engine/multilingual.py
+++ b/engine/multilingual.py
@@ -36,6 +36,23 @@ def grok_api_key() -> str:
     return key
 
 
+def resolve_multilingual_voice(config) -> str:
+    """Voice ID for the translated tracks.
+
+    Grok carries a single voice identity across languages, so by default the
+    multilingual tracks reuse the show's EXISTING Grok voice (``tts.voice_id``,
+    e.g. the operator's custom ``kdif6sqjcyiq``) — the host sounds like the
+    operator in every language with no extra setup. The ``cloned_voice_env``
+    env var (default ``GROK_CLONED_VOICE_ID``) is an optional override for
+    pointing the translations at a different cloned voice; when it's unset the
+    existing show voice is used. Returns "" only if neither is configured.
+    """
+    ml = getattr(config, "multilingual", None)
+    env_name = (ml and ml.cloned_voice_env) or "GROK_CLONED_VOICE_ID"
+    override = (os.getenv(env_name) or "").strip()
+    return override or (getattr(config.tts, "voice_id", "") or "").strip()
+
+
 def ffprobe_duration(target: str) -> Optional[float]:
     """Media duration in seconds (works on a local path OR a URL); None on error."""
     try:
@@ -205,8 +222,12 @@ def auto_generate_after_publish(config, episode_num: int) -> Dict[str, str]:
     if not (ml and ml.enabled and getattr(ml, "auto", False)):
         return {}
     languages = list(ml.languages) or list(translate.supported_languages())
+    voice_id = resolve_multilingual_voice(config)
+    if not voice_id:
+        logger.warning("multilingual auto: skipping Ep%s — no voice_id (set the "
+                       "show's tts.voice_id or %s)", episode_num, ml.cloned_voice_env)
+        return {}
     try:
-        voice_id = tts.get_cloned_voice_id(ml.cloned_voice_env)
         api_key = grok_api_key()
     except RuntimeError as exc:
         logger.warning("multilingual auto: skipping Ep%s — %s", episode_num, exc)

--- a/run_show.py
+++ b/run_show.py
@@ -2937,6 +2937,19 @@ def run(args: argparse.Namespace) -> None:
         rss_url=f"{config.publishing.base_url}/{config.publishing.rss_file}",
     )
 
+    # 11c. Multilingual audio (June 2026). For shows with multilingual.auto,
+    # render the configured languages for this episode now — AFTER the summaries
+    # record exists (the translation upserts into it) and BEFORE the blog post
+    # below, so today's post + index immediately show the language switcher and
+    # badges. Fully non-blocking: a failure (or an unset GROK_CLONED_VOICE_ID)
+    # can never break the English publish. Skipped in test/dry-run.
+    if not args.test and not args.dry_run:
+        try:
+            from engine.multilingual import auto_generate_after_publish
+            auto_generate_after_publish(config, episode_num)
+        except Exception as _ml_exc:  # noqa: BLE001 — translation must never block publish
+            logger.error("Multilingual auto step failed (non-fatal): %s", _ml_exc)
+
     # 12a. Generate blog post
     try:
         from engine.blog import extract_blog_metadata, generate_blog_post_html
@@ -2946,6 +2959,13 @@ def run(args: argparse.Namespace) -> None:
             _blog_env = _get_jinja_env()
             _blog_meta = extract_blog_metadata(x_thread, config.slug, digest_md.name if digest_md else "", file_path=digest_md)
             _blog_meta["episode_num"] = episode_num
+            # Merge any just-generated translation tracks so the switcher +
+            # badges render on today's post (the .md/x_thread carry neither).
+            try:
+                from generate_html import _attach_translations
+                _attach_translations(config.slug, _NS[config.slug], [_blog_meta])
+            except Exception:  # noqa: BLE001 — non-fatal SEO/UX enhancement
+                pass
             _blog_html = generate_blog_post_html(
                 x_thread, _blog_meta, _NS[config.slug], _blog_env,
                 youtube_url=youtube_long_url,

--- a/scripts/generate_translations.py
+++ b/scripts/generate_translations.py
@@ -1,42 +1,32 @@
 #!/usr/bin/env python3
 """Generate multilingual (FR / RU / ES / ZH) audio tracks for episodes.
 
-A post-hoc stage: it consumes a show's already-finalized English episode
-artifacts (the ``*_tts.txt`` script + the summaries record + the ``.md``
-digest for the hook) and, per language, translates the script via
-``grok-latest``, renders it to MP3 with the operator's cloned Grok voice,
-uploads the track to R2 alongside the English file, and records the track
-(audio URL + translated title/description) in the show's summaries JSON.
+A post-hoc driver over ``engine.multilingual``: it consumes a show's
+already-finalized English episode artifacts (the ``*_tts.txt`` script + the
+summaries record + the ``.md`` digest hook) and, per language, translates the
+script via ``grok-latest``, renders it with the cloned Grok voice, uploads the
+track to R2 alongside the English file, and records it on the episode.
 
-English stays the canonical master + site fallback; translations are
-derived artifacts surfaced on the website only (not the podcast RSS).
+English stays the canonical master + site fallback; translations are derived
+artifacts surfaced on the website. The same per-episode core runs automatically
+in the daily pipeline (``run_show.py``) for shows with ``multilingual.auto``.
 
 Usage
 -----
-    # Wire-up / proving runs
     python scripts/generate_translations.py tesla --languages fr --latest 1
-    python scripts/generate_translations.py tesla --languages zh \
-        --episode 511 --sample-zh          # ONE short ZH clip, then STOP
+    python scripts/generate_translations.py tesla --languages zh --episode 511 --sample-zh
+    python scripts/generate_translations.py <show> --languages fr,ru,es,zh --latest 3 --zh-approved
 
-    # After listening to the ZH sample and approving it:
-    python scripts/generate_translations.py tesla \
-        --languages fr,ru,es,zh --latest 3 --zh-approved
-
-Idempotent: a (episode, language) already present in the summaries record is
-skipped unless ``--force``.
+Idempotent: a (episode, language) already present is skipped unless ``--force``.
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
-import os
-import subprocess
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional
-from urllib.parse import urlparse
+from typing import List, Optional
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
@@ -46,124 +36,22 @@ from dotenv import load_dotenv  # noqa: E402
 
 load_dotenv(PROJECT_ROOT / ".env")
 
-from engine import tts, translate  # noqa: E402
+from engine import multilingual, translate, tts  # noqa: E402
 from engine.config import load_config  # noqa: E402
-from engine.storage import upload_to_r2  # noqa: E402
-from engine.summaries_io import load_summaries, upsert_translation  # noqa: E402
+from engine.summaries_io import load_summaries  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(levelname)s %(message)s")
 logger = logging.getLogger("generate_translations")
 
-
-def _grok_api_key() -> str:
-    key = (os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY") or "").strip()
-    if not key:
-        raise RuntimeError("Missing GROK_API_KEY (or XAI_API_KEY) in .env")
-    return key
-
-
-def _ffprobe_duration(target: str) -> Optional[float]:
-    """Return media duration in seconds (works on a local path OR a URL)."""
-    try:
-        out = subprocess.run(
-            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
-             "-of", "default=noprint_wrappers=1:nokey=1", target],
-            capture_output=True, text=True, timeout=120,
-        )
-        val = out.stdout.strip()
-        return float(val) if val else None
-    except Exception:  # noqa: BLE001 — best-effort, used only for reporting
-        return None
-
-
-def _find_episode_file(output_dir: Path, episode_num: int, suffix_glob: str) -> Optional[Path]:
-    matches = sorted(output_dir.glob(f"*_Ep{episode_num:03d}_{suffix_glob}"))
-    return matches[-1] if matches else None
-
-
-def _english_hook(output_dir: Path, episode_num: int) -> str:
-    """Best-effort: pull the episode hook from the digest .md for descriptions."""
-    md = None
-    for p in sorted(output_dir.glob(f"*_Ep{episode_num:03d}_*.md")):
-        if not p.name.endswith("_tts.txt"):
-            md = p
-    if not md:
-        return ""
-    try:
-        from engine.blog import extract_blog_metadata
-        meta = extract_blog_metadata(md.read_text(encoding="utf-8"), "", md.name, md)
-        return meta.get("hook", "") or ""
-    except Exception:  # noqa: BLE001
-        return ""
-
-
-def _derive_track_key_url(english_audio_url: str, lang: str, public_base_url: str):
-    """Return ``(remote_key, public_url)`` for the *lang* track.
-
-    Derived from the English track's own URL so the translation lands in the
-    exact same R2 prefix regardless of slug/audio_subdir nuances.
-    """
-    base = (public_base_url or "").rstrip("/")
-    if base and english_audio_url.startswith(base + "/"):
-        key = english_audio_url[len(base) + 1:]
-    else:
-        key = urlparse(english_audio_url).path.lstrip("/")
-    if key.lower().endswith(".mp3"):
-        key = key[:-4]
-    remote_key = f"{key}.{lang}.mp3"
-    public_url = f"{base}/{remote_key}" if base else remote_key
-    return remote_key, public_url
+# Grok TTS list price (~$4.20 / 1M chars) for the up-front projection.
+_TTS_USD_PER_MILLION = 4.20
 
 
 def _select_records(records: List[dict], latest: int, episode: Optional[int]) -> List[dict]:
-    """Pick target records: a specific --episode, else the latest N by number."""
     have_num = [r for r in records if isinstance(r.get("episode_num"), int)]
     if episode is not None:
         return [r for r in have_num if r["episode_num"] == episode]
     return sorted(have_num, key=lambda r: r["episode_num"], reverse=True)[:latest]
-
-
-def _render_track(
-    script_text: str, lang: str, voice_id: str, api_key: str,
-    out_path: Path, max_chars: int,
-) -> None:
-    tts.synthesize(
-        script_text, voice_id, out_path,
-        api_key=api_key, provider="grok",
-        max_chars=max_chars, language_code=lang,
-    )
-
-
-# Grok TTS list price (per CLAUDE.md / engine.tracking): ~$4.20 per 1M chars.
-_TTS_USD_PER_MILLION = 4.20
-
-
-def _log_cost_projection(targets, languages, output_dir, force) -> None:
-    """Log a rough projected character + $ footprint before generating."""
-    total_chars = 0
-    tracks = 0
-    for rec in targets:
-        ep = rec.get("episode_num")
-        tf = _find_episode_file(output_dir, ep, "*_tts.txt")
-        if not tf:
-            continue
-        n = len(tf.read_text(encoding="utf-8"))
-        existing = rec.get("translations", {}) or {}
-        for lang in languages:
-            if lang in existing and not force:
-                continue
-            total_chars += n
-            tracks += 1
-    if not tracks:
-        return
-    # TTS bills the translated text (~English length); translation LLM adds
-    # roughly the same character volume on input. Report the TTS line only.
-    tts_cost = total_chars / 1_000_000 * _TTS_USD_PER_MILLION
-    logger.info(
-        "Projection: %d track(s), ~%s TTS chars, ~$%.2f Grok TTS "
-        "(+ translation LLM tokens). Use --dry-run to preview without spending.",
-        tracks, f"{total_chars:,}", tts_cost,
-    )
 
 
 def _resolve_languages(args, config) -> List[str]:
@@ -180,6 +68,27 @@ def _resolve_languages(args, config) -> List[str]:
     return langs
 
 
+def _log_cost_projection(targets, languages, output_dir, force) -> None:
+    total_chars, tracks = 0, 0
+    for rec in targets:
+        tf = multilingual.find_tts_file(output_dir, rec.get("episode_num"))
+        if not tf:
+            continue
+        n = len(tf.read_text(encoding="utf-8"))
+        existing = rec.get("translations", {}) or {}
+        for lang in languages:
+            if lang in existing and not force:
+                continue
+            total_chars += n
+            tracks += 1
+    if not tracks:
+        return
+    cost = total_chars / 1_000_000 * _TTS_USD_PER_MILLION
+    logger.info("Projection: %d track(s), ~%s TTS chars, ~$%.2f Grok TTS "
+                "(+ translation LLM tokens). --dry-run previews without spending.",
+                tracks, f"{total_chars:,}", cost)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -187,11 +96,11 @@ def main() -> int:
     ap.add_argument("--languages", default="", help="Comma list of BCP-47 codes (fr,ru,es,zh)")
     ap.add_argument("--latest", type=int, default=3, help="Translate the latest N episodes")
     ap.add_argument("--episode", type=int, default=None, help="Translate one specific episode number")
-    ap.add_argument("--force", action="store_true", help="Re-generate even if a track already exists")
+    ap.add_argument("--force", action="store_true", help="Regenerate even if a track exists")
     ap.add_argument("--sample-zh", action="store_true",
-                    help="Render ONE short ZH clip from the latest episode, then STOP (no upload/record)")
+                    help="Render ONE short ZH clip from the latest episode, then STOP")
     ap.add_argument("--zh-approved", action="store_true",
-                    help="Confirm you've listened to a ZH sample — required to batch ZH")
+                    help="Confirm you've listened to a ZH sample — required to batch ZH manually")
     ap.add_argument("--sample-chars", type=int, default=900, help="Char budget for --sample-zh clip")
     ap.add_argument("--dry-run", action="store_true", help="Translate only; no TTS/upload/record")
     args = ap.parse_args()
@@ -200,16 +109,13 @@ def main() -> int:
     ml = getattr(config, "multilingual", None)
     if not (ml and ml.enabled) and not args.languages:
         raise SystemExit(
-            f"Multilingual audio is not enabled for '{args.show}'. "
-            "Enable it in the show YAML (multilingual.enabled: true) or pass "
-            "--languages to override for a one-off run."
+            f"Multilingual audio is not enabled for '{args.show}'. Enable it in "
+            "the show YAML (multilingual.enabled: true) or pass --languages."
         )
     output_dir = PROJECT_ROOT / config.episode.output_dir
     summaries_path = PROJECT_ROOT / config.publishing.summaries_json
     languages = _resolve_languages(args, config)
-    voice_env = (getattr(config, "multilingual", None) and config.multilingual.cloned_voice_env) \
-        or "GROK_CLONED_VOICE_ID"
-    max_chars = config.tts.max_chars or tts.GROK_MAX_CHARS_PER_REQUEST
+    voice_env = (ml and ml.cloned_voice_env) or "GROK_CLONED_VOICE_ID"
 
     _wrapper, records = load_summaries(summaries_path)
     targets = _select_records(records, args.latest, args.episode)
@@ -219,138 +125,51 @@ def main() -> int:
 
     # ----- ZH STOP checkpoint -----------------------------------------
     if args.sample_zh:
-        api_key = _grok_api_key()
+        api_key = multilingual.grok_api_key()
         voice_id = tts.get_cloned_voice_id(voice_env)
-        rec = targets[0]
-        ep = rec["episode_num"]
-        tts_file = _find_episode_file(output_dir, ep, "*_tts.txt")
-        if not tts_file:
+        ep = targets[0]["episode_num"]
+        tf = multilingual.find_tts_file(output_dir, ep)
+        if not tf:
             logger.error("No _tts.txt for Ep%s in %s", ep, output_dir)
             return 1
-        english_script = tts_file.read_text(encoding="utf-8").strip()
-        snippet = english_script[: args.sample_chars]
+        snippet = tf.read_text(encoding="utf-8").strip()[: args.sample_chars]
         logger.info("ZH SAMPLE: localizing first ~%d chars of Ep%s", args.sample_chars, ep)
         zh_text = translate.translate_script(snippet, "zh")
-        sample_mp3 = output_dir / f"{tts_file.stem.replace('_tts', '')}.zh.sample.mp3"
-        _render_track(zh_text, "zh", voice_id, api_key, sample_mp3, max_chars)
-        dur = _ffprobe_duration(str(sample_mp3))
-        logger.info("=" * 64)
-        logger.info("ZH SAMPLE READY: %s (%.1fs)", sample_mp3, dur or 0.0)
-        logger.info("LISTEN before batch-generating Chinese. Cloned English")
-        logger.info("voices can produce flat/incorrect Mandarin tones. If it")
-        logger.info("sounds right, re-run with --zh-approved.")
-        logger.info("=" * 64)
+        sample_mp3 = output_dir / f"{tf.stem.replace('_tts', '')}.zh.sample.mp3"
+        multilingual.render_track(zh_text, "zh", voice_id, api_key, sample_mp3,
+                                  config.tts.max_chars or tts.GROK_MAX_CHARS_PER_REQUEST)
+        dur = multilingual.ffprobe_duration(str(sample_mp3))
+        logger.info("=" * 60)
+        logger.info("ZH SAMPLE READY: %s (%.1fs) — LISTEN before batch ZH. Re-run "
+                    "with --zh-approved if it sounds right.", sample_mp3, dur or 0.0)
+        logger.info("=" * 60)
         return 0
 
     if "zh" in languages and not args.zh_approved and not args.dry_run:
-        logger.warning("ZH requested without --zh-approved. Skipping Chinese this run.")
-        logger.warning("Run:  python scripts/generate_translations.py %s "
-                       "--languages zh --episode %s --sample-zh", args.show, targets[0]["episode_num"])
-        logger.warning("listen, then re-run with --zh-approved to include ZH.")
+        logger.warning("ZH requested without --zh-approved. Skipping Chinese this run. "
+                       "Run --sample-zh first, listen, then re-run with --zh-approved.")
         languages = [code for code in languages if code != "zh"]
         if not languages:
             return 0
 
-    api_key = _grok_api_key()
+    _log_cost_projection(targets, languages, output_dir, args.force)
+    api_key = multilingual.grok_api_key()
     voice_id = None if args.dry_run else tts.get_cloned_voice_id(voice_env)
 
-    # Length-calibration reporting: first rendered track per language.
-    reported_langs: set = set()
-    changed = False
-
-    # Cost / volume projection (rough, informational) — translation + TTS both
-    # bill per character; a 4-language batch across several shows adds up.
-    _log_cost_projection(targets, languages, output_dir, args.force)
-
+    any_done = False
     for rec in targets:
         ep = rec["episode_num"]
-        english_url = rec.get("audio_url", "")
-        tts_file = _find_episode_file(output_dir, ep, "*_tts.txt")
-        if not tts_file:
-            logger.warning("Ep%s: no _tts.txt found in %s — skipping", ep, output_dir)
-            continue
-        english_script = tts_file.read_text(encoding="utf-8").strip()
-        en_title = rec.get("episode_title", "") or ""
-        en_desc = _english_hook(output_dir, ep) or en_title
-        translations: Dict[str, dict] = rec.setdefault("translations", {})
+        logger.info("Ep%s: generating %s …", ep, languages)
+        results = multilingual.generate_for_episode(
+            config, ep, languages,
+            voice_id=voice_id or "", api_key=api_key,
+            force=args.force, dry_run=args.dry_run,
+        )
+        if any(v == "done" for v in results.values()):
+            any_done = True
 
-        for lang in languages:
-            if lang in translations and not args.force:
-                logger.info("Ep%s [%s]: already present — skipping (use --force)", ep, lang)
-                continue
-            logger.info("Ep%s [%s]: translating script…", ep, lang)
-            try:
-                translated = translate.translate_script(english_script, lang)
-                t_title, t_desc = translate.translate_metadata(en_title, en_desc, lang)
-            except translate.TranslationError as exc:
-                # Bad/refused translation: skip THIS track, keep the batch going.
-                logger.error("Ep%s [%s]: translation rejected — %s", ep, lang, exc)
-                continue
-
-            if args.dry_run:
-                logger.info("Ep%s [%s]: DRY-RUN — %d chars, title=%r",
-                            ep, lang, len(translated), t_title[:60])
-                continue
-
-            if not english_url:
-                logger.warning("Ep%s [%s]: record has no audio_url — cannot place track; skipping",
-                               ep, lang)
-                continue
-
-            local_mp3 = output_dir / f"{tts_file.stem.replace('_tts', '')}.{lang}.mp3"
-            _render_track(translated, lang, voice_id, api_key, local_mp3, max_chars)
-            dur = _ffprobe_duration(str(local_mp3))
-
-            # Length calibration vs English (first track per language only).
-            if lang not in reported_langs:
-                reported_langs.add(lang)
-                en_dur = _ffprobe_duration(english_url)
-                if en_dur and dur:
-                    delta = (dur - en_dur) / en_dur * 100.0
-                    logger.info("LENGTH [%s]: %.0fs vs EN %.0fs (%+.0f%%)",
-                                lang, dur, en_dur, delta)
-                else:
-                    logger.info("LENGTH [%s]: %.0fs (EN duration unavailable for compare)",
-                                lang, dur or 0.0)
-
-            remote_key, public_url = _derive_track_key_url(
-                english_url, lang, config.storage.public_base_url)
-            endpoint = os.getenv(config.storage.endpoint_env, "").strip()
-            access_key = os.getenv(config.storage.access_key_env, "").strip()
-            secret_key = os.getenv(config.storage.secret_key_env, "").strip()
-            if all([endpoint, access_key, secret_key]):
-                upload_to_r2(
-                    local_mp3, remote_key,
-                    bucket=config.storage.bucket,
-                    endpoint_url=endpoint, access_key=access_key, secret_key=secret_key,
-                    public_base_url=config.storage.public_base_url,
-                )
-            else:
-                logger.warning("Ep%s [%s]: R2 creds unset — track left local at %s",
-                               ep, lang, local_mp3)
-
-            entry = {
-                "audio_url": public_url,
-                "title": t_title,
-                "description": t_desc,
-                "duration_sec": round(dur, 1) if dur else 0,
-                "generated_at": datetime.now(timezone.utc).isoformat(),
-            }
-            # Keep the in-memory copy current (skip-check + projection within
-            # this run), but PERSIST via a fresh read-modify-write per track so
-            # the live English cron can't have a record we appended clobbered
-            # by a stale in-memory snapshot (and a crash keeps finished work).
-            translations[lang] = entry
-            if not upsert_translation(summaries_path, ep, lang, entry):
-                logger.warning("Ep%s [%s]: record vanished from %s during run — "
-                               "track uploaded but not recorded", ep, lang, summaries_path)
-            changed = True
-            logger.info("Ep%s [%s]: done → %s", ep, lang, public_url)
-
-    if changed and not args.dry_run:
-        logger.info("Done. Updated summaries: %s", summaries_path)
-    elif not changed:
-        logger.info("Nothing to do (all requested tracks already present).")
+    if not any_done and not args.dry_run:
+        logger.info("Nothing new generated (all requested tracks already present).")
     return 0
 
 

--- a/scripts/generate_translations.py
+++ b/scripts/generate_translations.py
@@ -115,7 +115,9 @@ def main() -> int:
     output_dir = PROJECT_ROOT / config.episode.output_dir
     summaries_path = PROJECT_ROOT / config.publishing.summaries_json
     languages = _resolve_languages(args, config)
-    voice_env = (ml and ml.cloned_voice_env) or "GROK_CLONED_VOICE_ID"
+    # Reuses the show's existing Grok voice (tts.voice_id) by default; the
+    # GROK_CLONED_VOICE_ID env var is an optional override.
+    voice_id_resolved = multilingual.resolve_multilingual_voice(config)
 
     _wrapper, records = load_summaries(summaries_path)
     targets = _select_records(records, args.latest, args.episode)
@@ -126,7 +128,9 @@ def main() -> int:
     # ----- ZH STOP checkpoint -----------------------------------------
     if args.sample_zh:
         api_key = multilingual.grok_api_key()
-        voice_id = tts.get_cloned_voice_id(voice_env)
+        voice_id = voice_id_resolved
+        if not voice_id:
+            raise SystemExit("No voice_id: set the show's tts.voice_id or GROK_CLONED_VOICE_ID")
         ep = targets[0]["episode_num"]
         tf = multilingual.find_tts_file(output_dir, ep)
         if not tf:
@@ -154,7 +158,9 @@ def main() -> int:
 
     _log_cost_projection(targets, languages, output_dir, args.force)
     api_key = multilingual.grok_api_key()
-    voice_id = None if args.dry_run else tts.get_cloned_voice_id(voice_env)
+    if not args.dry_run and not voice_id_resolved:
+        raise SystemExit("No voice_id: set the show's tts.voice_id or GROK_CLONED_VOICE_ID")
+    voice_id = "" if args.dry_run else voice_id_resolved
 
     any_done = False
     for rec in targets:

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -156,6 +156,12 @@ storage:
 # in git.
 multilingual:
   enabled: true
+  # Auto-generate the languages below for every newly published episode
+  # (operator decision, June 2026 — "all English shows, all languages,
+  # automatic"). Best-effort + non-blocking in run_show.py; no-op when
+  # GROK_CLONED_VOICE_ID is unset. Russian shows set enabled:false so this
+  # never runs for them. ~$0.18/episode (≈4× English TTS chars + translation).
+  auto: true
   languages: [fr, ru, es, zh]
   cloned_voice_env: GROK_CLONED_VOICE_ID
 

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -158,11 +158,16 @@ multilingual:
   enabled: true
   # Auto-generate the languages below for every newly published episode
   # (operator decision, June 2026 — "all English shows, all languages,
-  # automatic"). Best-effort + non-blocking in run_show.py; no-op when
-  # GROK_CLONED_VOICE_ID is unset. Russian shows set enabled:false so this
-  # never runs for them. ~$0.18/episode (≈4× English TTS chars + translation).
+  # automatic"). Best-effort + non-blocking in run_show.py. By default the
+  # translated tracks reuse the show's EXISTING Grok voice (tts.voice_id,
+  # kdif6sqjcyiq) — Grok carries one voice across languages, so the host
+  # sounds like the operator in every language with no extra setup. Russian
+  # shows set enabled:false so this never runs for them. ~$0.18/episode
+  # (≈4× English TTS chars + translation).
   auto: true
   languages: [fr, ru, es, zh]
+  # Optional override: name of an env var holding a DIFFERENT cloned voice ID
+  # for the translations. Unset → the show's tts.voice_id is used.
   cloned_voice_env: GROK_CLONED_VOICE_ID
 
 publishing:

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -40,6 +40,16 @@ class TestMultilingualConfig:
             cfg = load_config(f"shows/{slug}.yaml")
             assert cfg.multilingual.enabled is False, slug
 
+    def test_auto_enabled_for_english_shows(self):
+        from engine.config import load_config
+        assert load_config("shows/tesla.yaml").multilingual.auto is True
+
+    def test_russian_shows_have_auto_off_via_disabled(self):
+        # Russian shows opt out of multilingual entirely, so auto never runs.
+        from engine.config import load_config
+        cfg = load_config("shows/finansy_prosto.yaml")
+        assert cfg.multilingual.enabled is False
+
     def test_no_silent_key_drop(self):
         # Every field set in YAML must be DECLARED on the dataclass
         # (landmine #20) — loading without a warning-only fallback means
@@ -142,13 +152,8 @@ class TestTranslationValidation:
 
 class TestTrackKeyDerivation:
     def _fn(self):
-        import importlib.util
-        spec = importlib.util.spec_from_file_location(
-            "generate_translations", PROJECT_ROOT / "scripts" / "generate_translations.py"
-        )
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod._derive_track_key_url
+        from engine.multilingual import derive_track_key_url
+        return derive_track_key_url
 
     def test_suffix_before_extension(self):
         fn = self._fn()
@@ -357,6 +362,67 @@ class TestJsonLdMultilingual:
         assert any(u.endswith(".ru.mp3") for u in urls)
         langs = {m["inLanguage"] for m in ep["associatedMedia"]}
         assert langs == {"en", "fr", "ru"}
+
+
+class TestAutoGeneration:
+    def _fake_config(self, tmp_path, *, enabled=True, auto=True):
+        from types import SimpleNamespace
+        return SimpleNamespace(
+            slug="tshow",
+            episode=SimpleNamespace(output_dir=str(tmp_path)),
+            publishing=SimpleNamespace(summaries_json=str(tmp_path / "s.json")),
+            tts=SimpleNamespace(max_chars=10000),
+            storage=SimpleNamespace(
+                public_base_url="https://audio.nerranetwork.com",
+                endpoint_env="R2_ENDPOINT_URL", access_key_env="R2_ACCESS_KEY_ID",
+                secret_key_env="R2_SECRET_ACCESS_KEY", bucket="b"),
+            multilingual=SimpleNamespace(
+                enabled=enabled, auto=auto, languages=["fr", "ru"],
+                cloned_voice_env="GROK_CLONED_VOICE_ID"),
+        )
+
+    def _lay_episode(self, tmp_path):
+        (tmp_path / "X_Ep005_20260101_tts.txt").write_text("English script.", encoding="utf-8")
+        (tmp_path / "s.json").write_text(json.dumps({"podcast": "t", "summaries": [
+            {"episode_num": 5,
+             "audio_url": "https://audio.nerranetwork.com/tshow/X_Ep005_20260101.mp3",
+             "episode_title": "Title"}]}), encoding="utf-8")
+
+    def test_generate_for_episode_records_tracks(self, tmp_path, monkeypatch):
+        from engine import multilingual, translate
+        self._lay_episode(tmp_path)
+        cfg = self._fake_config(tmp_path)
+        # Mock out the network/heavy calls.
+        monkeypatch.setattr(translate, "translate_script", lambda s, lang, **k: f"[{lang}]script")
+        monkeypatch.setattr(translate, "translate_metadata", lambda t, d, lang, **k: (f"T{lang}", f"D{lang}"))
+        monkeypatch.setattr(multilingual, "render_track",
+                            lambda *a, **k: Path(a[4]).write_bytes(b"x"))
+        monkeypatch.setattr(multilingual, "ffprobe_duration", lambda *a, **k: 120.0)
+        # No R2 creds → upload skipped, but record still written with derived URL.
+        monkeypatch.setattr(multilingual, "PROJECT_ROOT", Path("/"))
+        for v in ("R2_ENDPOINT_URL", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY"):
+            monkeypatch.delenv(v, raising=False)
+
+        res = multilingual.generate_for_episode(
+            cfg, 5, ["fr", "ru"], voice_id="vid", api_key="k")
+        assert res == {"fr": "done", "ru": "done"}
+        data = json.loads((tmp_path / "s.json").read_text(encoding="utf-8"))
+        tr = data["summaries"][0]["translations"]
+        assert tr["fr"]["audio_url"].endswith("X_Ep005_20260101.fr.mp3")
+        assert tr["ru"]["title"] == "Tru"
+
+    def test_auto_skips_when_disabled(self, tmp_path):
+        from engine import multilingual
+        cfg = self._fake_config(tmp_path, enabled=False)
+        assert multilingual.auto_generate_after_publish(cfg, 5) == {}
+
+    def test_auto_skips_when_voice_unset(self, tmp_path, monkeypatch):
+        from engine import multilingual
+        monkeypatch.delenv("GROK_CLONED_VOICE_ID", raising=False)
+        monkeypatch.setenv("GROK_API_KEY", "k")
+        cfg = self._fake_config(tmp_path, enabled=True, auto=True)
+        # Voice id unset → non-blocking skip, empty result, no raise.
+        assert multilingual.auto_generate_after_publish(cfg, 5) == {}
 
 
 class TestBlogIndexBadges:

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -365,13 +365,13 @@ class TestJsonLdMultilingual:
 
 
 class TestAutoGeneration:
-    def _fake_config(self, tmp_path, *, enabled=True, auto=True):
+    def _fake_config(self, tmp_path, *, enabled=True, auto=True, voice_id="kdif6sqjcyiq"):
         from types import SimpleNamespace
         return SimpleNamespace(
             slug="tshow",
             episode=SimpleNamespace(output_dir=str(tmp_path)),
             publishing=SimpleNamespace(summaries_json=str(tmp_path / "s.json")),
-            tts=SimpleNamespace(max_chars=10000),
+            tts=SimpleNamespace(max_chars=10000, voice_id=voice_id),
             storage=SimpleNamespace(
                 public_base_url="https://audio.nerranetwork.com",
                 endpoint_env="R2_ENDPOINT_URL", access_key_env="R2_ACCESS_KEY_ID",
@@ -416,12 +416,24 @@ class TestAutoGeneration:
         cfg = self._fake_config(tmp_path, enabled=False)
         assert multilingual.auto_generate_after_publish(cfg, 5) == {}
 
-    def test_auto_skips_when_voice_unset(self, tmp_path, monkeypatch):
+    def test_resolve_voice_defaults_to_show_voice(self, tmp_path, monkeypatch):
         from engine import multilingual
         monkeypatch.delenv("GROK_CLONED_VOICE_ID", raising=False)
-        monkeypatch.setenv("GROK_API_KEY", "k")
-        cfg = self._fake_config(tmp_path, enabled=True, auto=True)
-        # Voice id unset → non-blocking skip, empty result, no raise.
+        cfg = self._fake_config(tmp_path, voice_id="kdif6sqjcyiq")
+        # No env override → reuse the show's existing Grok voice.
+        assert multilingual.resolve_multilingual_voice(cfg) == "kdif6sqjcyiq"
+
+    def test_resolve_voice_env_override_wins(self, tmp_path, monkeypatch):
+        from engine import multilingual
+        monkeypatch.setenv("GROK_CLONED_VOICE_ID", "other-voice")
+        cfg = self._fake_config(tmp_path, voice_id="kdif6sqjcyiq")
+        assert multilingual.resolve_multilingual_voice(cfg) == "other-voice"
+
+    def test_auto_skips_when_no_voice_anywhere(self, tmp_path, monkeypatch):
+        from engine import multilingual
+        monkeypatch.delenv("GROK_CLONED_VOICE_ID", raising=False)
+        cfg = self._fake_config(tmp_path, enabled=True, auto=True, voice_id="")
+        # Neither a show voice nor an override → non-blocking skip.
         assert multilingual.auto_generate_after_publish(cfg, 5) == {}
 
 


### PR DESCRIPTION
Per your decision — **all English shows auto-produce all four languages** on every newly published episode, voiced by your **existing cloned Grok voice**. Until now the translation stage was manual-only; this wires it into the daily pipeline.

## How it works
- **`engine/multilingual.py`** (new) — reusable per-episode core: translate → validate → cloned-voice Grok TTS → R2 upload → concurrency-safe upsert. Shared by the manual driver and the daily pipeline.
  - `generate_for_episode()` — one episode across languages.
  - `auto_generate_after_publish()` — the daily entry point: **best-effort and non-blocking**. Never raises; no-ops when multilingual is disabled or `auto` is off.
- **Voice** — translated tracks reuse the show's **existing Grok voice** (`tts.voice_id`, `kdif6sqjcyiq`) by default. Grok carries one voice identity across languages, so the host sounds like you in every language with **no extra setup**. `GROK_CLONED_VOICE_ID` is an optional override only.
- **`run_show.py`** — runs the auto step right after the summaries record is written and **before** the blog post, so today's post + index immediately show the language switcher and badges. Skipped in `--test`/`--dry-run`; a translation failure can never break the English publish.
- **Config** — `multilingual.auto` set **true network-wide** in `_defaults.yaml`. Russian shows stay `enabled: false`, so it never runs for them. Disable any show with one flag.
- **Driver refactor** — `scripts/generate_translations.py` now sits on `engine.multilingual` (CLI, cost projection, ZH `--sample-zh` checkpoint unchanged).

## Activation
**No secret or setup needed** — it activates on merge using your existing voice. (Optionally set `GROK_CLONED_VOICE_ID` to voice the translations with a *different* cloned voice.)

## Cost
~**$0.18/episode** (≈4× English TTS character volume + translation tokens) → roughly **$50–55/month** network-wide. You confirmed you're OK with this. Each show's job runtime grows by a few minutes (4 TTS renders).

## Notes
- **ZH included** per your call — auto-publishes without a prior sample listen (cloned-English-voice Mandarin tone is the known quality risk; set a show to `languages: [fr, ru, es]` to hold ZH back).

## Verify
```
pytest tests/test_multilingual.py     # 38 guards (auto config, voice resolver,
                                      # mocked generate_for_episode, non-blocking skips)
ruff check engine/ run_show.py scripts/   # clean
```
`test_config`, `test_schedule`, `test_generator`, `test_blog`, `test_prompt_fidelity`, `test_network_quality_pass`, `test_website_quality_pass` all pass locally; Tesla blog/index/summaries render end-to-end.