### PR TITLE
Dashboard: surface multilingual coverage + 7-day spend

### DIFF
--- a/management.html
+++ b/management.html
@@ -205,6 +205,11 @@
   </section>
 
   <section class="mgmt-section">
+    <h2>Multilingual coverage <span id="multilingual-status-pill" style="font-size:12px;font-weight:normal;color:#94a3b8;margin-left:8px;"></span></h2>
+    <div id="multilingual-coverage"></div>
+  </section>
+
+  <section class="mgmt-section">
     <h2>Pipeline p50 duration per show</h2>
     <div id="pipeline-sparklines"></div>
   </section>
@@ -483,6 +488,40 @@
       text: money((costPerShow[s.slug] || {}).last_30_days && (costPerShow[s.slug] || {}).last_30_days.total) + " · 30d" }));
     costSparks.appendChild(row);
   });
+
+  // Multilingual coverage — per-show language badges (count in the last N
+  // episodes), % of recent episodes with all languages, and 7-day spend.
+  const mlWrap = $("#multilingual-coverage");
+  const ml = data.multilingual;
+  if (mlWrap) {
+    if (!ml || !ml.per_show || !Object.keys(ml.per_show).length) {
+      mlWrap.appendChild(h("div", { class: "muted",
+        text: "No multilingual data yet — translations populate as episodes publish." }));
+    } else {
+      const pill = $("#multilingual-status-pill");
+      if (pill) pill.textContent = money(ml.network_cost_7d_usd) + " · 7d · last " + (ml.recent_n || 10) + " eps";
+      shows.forEach((s) => {
+        const c = (ml.per_show || {})[s.slug];
+        if (!c) return;  // disabled / Russian shows are excluded
+        const row = h("div", { class: "sparkline-row" });
+        row.appendChild(h("div", { class: "label", text: s.name || s.slug }));
+        const badges = h("div", { style: "flex:1;display:flex;gap:6px;flex-wrap:wrap;" });
+        (ml.languages || []).forEach((lang) => {
+          const n = (c.per_language || {})[lang] || 0;
+          const on = n > 0;
+          badges.appendChild(h("span", {
+            style: "font:600 11px/1.6 ui-monospace,monospace;padding:1px 7px;border-radius:100px;"
+              + (on ? "background:#0e7490;color:#e0f2fe;" : "background:#1e293b;color:#64748b;"),
+            text: lang.toUpperCase() + (on ? " " + n : ""),
+          }));
+        });
+        row.appendChild(badges);
+        row.appendChild(h("div", { class: "value",
+          text: (c.coverage_pct || 0) + "% all · " + money(c.cost_7d_usd) + " 7d" }));
+        mlWrap.appendChild(row);
+      });
+    }
+  }
 
   const pipeSparks = $("#pipeline-sparklines");
   const health = data.pipeline_health || {};

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1173,6 +1173,99 @@ def aggregate_costs(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
+_ML_LANGS = ("fr", "ru", "es", "zh")
+
+
+def aggregate_multilingual(
+    root: Path, shows: List[Dict[str, Any]], recent_n: int = 10
+) -> Dict[str, Any]:
+    """Per-show multilingual coverage + 7-day cost (June 2026).
+
+    Coverage comes from each show's ``summaries_<show>.json`` ``translations``
+    map (how many of the last *recent_n* episodes have each language / all
+    languages). The 7-day cost reads ``services.multilingual.estimated_cost_usd``
+    from the recent ``credit_usage_*.json`` files (0 until cost-tracked
+    episodes exist — read defensively). Shows with ``multilingual.enabled``
+    false (the Russian shows) are excluded.
+    """
+    from engine.summaries_io import load_summaries  # local import — script boot
+
+    today = _dt.date.today()
+    d7 = today - _dt.timedelta(days=7)
+    per_show: Dict[str, Any] = {}
+    network_cost_7 = 0.0
+
+    for s in shows:
+        cfg = s.get("cfg")
+        ml = getattr(cfg, "multilingual", None) if cfg else None
+        if not (ml and getattr(ml, "enabled", False)):
+            continue  # disabled / Russian shows
+        slug = s["slug"]
+
+        # Coverage from the summaries translations map.
+        per_language = {lang: 0 for lang in _ML_LANGS}
+        all_languages = 0
+        checked = 0
+        summ = cfg.publishing.summaries_json or ""
+        summ_path = root / summ if summ else None
+        if summ_path and summ_path.exists():
+            try:
+                _w, records = load_summaries(summ_path)
+                recs = sorted(
+                    (r for r in records if isinstance(r.get("episode_num"), int)),
+                    key=lambda r: r["episode_num"], reverse=True,
+                )[:recent_n]
+                checked = len(recs)
+                for r in recs:
+                    tr = r.get("translations") or {}
+                    present = [
+                        lang for lang in _ML_LANGS
+                        if isinstance(tr.get(lang), dict) and tr[lang].get("audio_url")
+                    ]
+                    for lang in present:
+                        per_language[lang] += 1
+                    if len(present) == len(_ML_LANGS):
+                        all_languages += 1
+            except Exception:
+                pass
+        coverage_pct = round(all_languages / checked * 100, 1) if checked else 0.0
+
+        # 7-day multilingual spend (defensive: section absent on old trackers).
+        cost_7 = 0.0
+        ddir = _digests_dir_for(slug, root)
+        if ddir.exists():
+            for f in sorted(ddir.glob("credit_usage_*.json")):
+                try:
+                    data = json.loads(f.read_text(encoding="utf-8"))
+                    when = _dt.date.fromisoformat(data.get("date") or "")
+                except Exception:
+                    continue
+                if when >= d7:
+                    cost_7 += float(
+                        ((data.get("services") or {}).get("multilingual") or {})
+                        .get("estimated_cost_usd") or 0.0
+                    )
+        cost_7 = round(cost_7, 4)
+        network_cost_7 += cost_7
+
+        per_show[slug] = {
+            "languages": list(ml.languages) if getattr(ml, "languages", None) else list(_ML_LANGS),
+            "auto": bool(getattr(ml, "auto", False)),
+            "episodes_checked": checked,
+            "per_language": per_language,
+            "all_languages": all_languages,
+            "coverage_pct": coverage_pct,
+            "cost_7d_usd": cost_7,
+        }
+
+    return {
+        "languages": list(_ML_LANGS),
+        "recent_n": recent_n,
+        "per_show": per_show,
+        "network_cost_7d_usd": round(network_cost_7, 4),
+    }
+
+
 def extract_critical_alerts(
     landmines: List[Dict[str, Any]],
     costs: Dict[str, Any],
@@ -1519,6 +1612,7 @@ def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optiona
         "alerts": alerts,
         "voice_config": voice,
         "cost_rollup": costs,
+        "multilingual": aggregate_multilingual(root, shows),
         "pipeline_health": metrics,
         "rss_audit": rss,
         "mit_performance": aggregate_mit_performance(root),

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -359,3 +359,53 @@ def test_management_html_renders_audience_card():
     html = (ROOT / "management.html").read_text(encoding="utf-8")
     assert 'id="audience-section"' in html
     assert "data.audience" in html
+
+
+# ---------------------------------------------------------------------------
+# Multilingual coverage card (June 2026)
+# ---------------------------------------------------------------------------
+
+def test_multilingual_section_present_and_shaped():
+    data = gd.build_dashboard(ROOT, offline=True)
+    assert "multilingual" in data, "dashboard must emit a multilingual section"
+    ml = data["multilingual"]
+    assert ml["languages"] == ["fr", "ru", "es", "zh"]
+    assert isinstance(ml["per_show"], dict) and ml["per_show"]
+    # Enabled English shows present; Russian shows excluded (multilingual off).
+    assert "tesla" in ml["per_show"]
+    assert "finansy_prosto" not in ml["per_show"]
+    assert "privet_russian" not in ml["per_show"]
+    entry = ml["per_show"]["tesla"]
+    for k in ("episodes_checked", "per_language", "all_languages",
+              "coverage_pct", "cost_7d_usd", "languages"):
+        assert k in entry, k
+    assert set(entry["per_language"]) == {"fr", "ru", "es", "zh"}
+
+
+def test_aggregate_multilingual_counts_coverage(tmp_path):
+    import json as _json
+    from engine.config import load_config
+    cfg = load_config("shows/tesla.yaml")
+    cfg.publishing.summaries_json = "summaries.json"
+    (tmp_path / "summaries.json").write_text(_json.dumps({
+        "podcast": "t",
+        "summaries": [
+            {"episode_num": 2, "translations": {
+                "fr": {"audio_url": "a"}, "ru": {"audio_url": "b"},
+                "es": {"audio_url": "c"}, "zh": {"audio_url": "d"}}},
+            {"episode_num": 1, "translations": {"fr": {"audio_url": "a"}}},
+        ],
+    }), encoding="utf-8")
+    out = gd.aggregate_multilingual(tmp_path, [{"slug": "tesla", "cfg": cfg}])
+    e = out["per_show"]["tesla"]
+    assert e["episodes_checked"] == 2
+    assert e["all_languages"] == 1          # only ep2 has all four
+    assert e["per_language"]["fr"] == 2     # both episodes have FR
+    assert e["per_language"]["zh"] == 1
+    assert e["coverage_pct"] == 50.0
+
+
+def test_management_html_renders_multilingual_card():
+    html = (ROOT / "management.html").read_text(encoding="utf-8")
+    assert 'id="multilingual-coverage"' in html
+    assert "data.multilingual" in html


### PR DESCRIPTION
Closes the observability loop on the multilingual arc (#642–#645 + the cost-tracking PR in review). The stage runs network-wide and its cost is already in each episode's total, but the operator had **no view** of per-show language coverage or the multilingual line item. This adds a **Multilingual** card to the management dashboard.

## What
- **`scripts/generate_dashboard.py`** — `aggregate_multilingual(root, shows)`: for each enabled English show, counts how many of the last N (=10) episodes carry **each** language and **all four** (from the summaries `translations` map via `engine.summaries_io.load_summaries`), and sums the **7-day** `services.multilingual.estimated_cost_usd` from `credit_usage_*.json`. Russian/disabled shows are excluded. Wired into `build_dashboard()` under a new top-level `multilingual` key.
- **`management.html`** — a "Multilingual coverage" section + vanilla-JS renderer (mirrors the existing cost-sparklines pattern): per-language badges with counts, % of recent episodes with all languages, and 7-day spend per show, plus a network 7-day total in the header pill. Clean empty-state when the key is absent (older dashboard JSON).
- **`tests/test_dashboard.py`** — section shape + RU-exclusion guard, a coverage-counting unit on `aggregate_multilingual`, and the `management.html` wiring guard.

## Notes
- **No double-counting / no breaker rewiring:** multilingual cost is already inside `total_estimated_cost_usd`, so the existing cost rollup and weekly-cost breaker already account for it. This PR only *reads* the `services.multilingual` sub-field for the disaggregated card, defensively (0 until cost-tracked episodes exist — independent of the cost-tracking PR's merge order; no file overlap with it).
- Verified live: `build_dashboard(ROOT, offline=True)` emits the section for all 11 English shows, excludes both Russian shows, correct shape.

## Verify
```
pytest tests/test_dashboard.py        # 16 pass (1 pre-existing skip)
ruff check scripts/                   # clean
```
`test_multilingual` + `test_config` also pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_