### PR TITLE
Website: global audio-language control in the nav + discoverability

### DIFF
--- a/assets/js/language-control.js
+++ b/assets/js/language-control.js
@@ -1,0 +1,93 @@
+/* Global audio-language control (multilingual audio, June 2026).
+ *
+ * A small header control that sets a SITE-WIDE preference for which language
+ * episode AUDIO plays in. It does NOT translate the page text — only the audio
+ * track on episode / show pages. The preference is stored in localStorage under
+ * `nn-pref-lang` (the same key the blog-post and show-page players read), and on
+ * change it dispatches a `nn-langchange` CustomEvent so an on-page player can
+ * switch live without a reload.
+ *
+ * Mirrors the safe try/catch localStorage pattern used by consent.js / search.js.
+ */
+(function () {
+  "use strict";
+
+  var PREF_KEY = "nn-pref-lang";
+  // Short labels shown on the toggle pill per language.
+  var SHORT = { en: "EN", fr: "FR", es: "ES", ru: "RU", zh: "中文" };
+
+  function read() {
+    try {
+      var v = localStorage.getItem(PREF_KEY);
+      return v && SHORT[v] ? v : "en";
+    } catch (e) {
+      return "en";
+    }
+  }
+
+  function write(lang) {
+    try { localStorage.setItem(PREF_KEY, lang); } catch (e) {}
+  }
+
+  function init() {
+    var toggle = document.getElementById("nn-lang-toggle");
+    var menu = document.getElementById("nn-lang-menu");
+    var current = document.getElementById("nn-lang-current");
+    if (!toggle || !menu || !current) return;
+
+    var opts = menu.querySelectorAll(".nn-lang-opt");
+
+    function reflect(lang) {
+      current.textContent = SHORT[lang] || "EN";
+      opts.forEach(function (o) {
+        o.setAttribute("aria-checked", o.dataset.lang === lang ? "true" : "false");
+      });
+    }
+
+    function open() {
+      menu.style.display = "block";
+      toggle.setAttribute("aria-expanded", "true");
+    }
+    function close() {
+      menu.style.display = "none";
+      toggle.setAttribute("aria-expanded", "false");
+    }
+    function isOpen() {
+      return menu.style.display === "block";
+    }
+
+    reflect(read());
+
+    toggle.addEventListener("click", function (e) {
+      e.stopPropagation();
+      isOpen() ? close() : open();
+    });
+
+    opts.forEach(function (o) {
+      o.addEventListener("click", function () {
+        var lang = o.dataset.lang;
+        write(lang);
+        reflect(lang);
+        close();
+        // Tell any on-page player (blog post / show page) to switch live.
+        try {
+          document.dispatchEvent(new CustomEvent("nn-langchange", { detail: { lang: lang } }));
+        } catch (e) {}
+      });
+    });
+
+    // Close on outside click / Escape.
+    document.addEventListener("click", function (e) {
+      if (isOpen() && !menu.contains(e.target) && e.target !== toggle) close();
+    });
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && isOpen()) close();
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -195,6 +195,35 @@
                      style="display:none;position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);max-height:340px;overflow:auto;z-index:1000;font-size:0.85rem;"></div>
             </div>
 
+            {# Audio-language control (multilingual audio, June 2026). Sets a
+               site-wide preference for which language episode AUDIO plays in —
+               the page text is unaffected (hence the "Audio" label). Reads/
+               writes the same `nn-pref-lang` localStorage key the episode +
+               show-page players use, and dispatches `nn-langchange` so an
+               on-page player switches live. Wired by assets/js/language-control.js. #}
+            <style>
+                #nn-lang-menu .nn-lang-opt{display:block;width:100%;text-align:left;padding:7px 12px;background:none;border:none;color:inherit;font-size:0.85rem;cursor:pointer;}
+                #nn-lang-menu .nn-lang-opt:hover{background:var(--nn-card);}
+                #nn-lang-menu .nn-lang-opt[aria-checked="true"]{color:var(--nn-purple,#a78bfa);font-weight:600;}
+            </style>
+            <div class="nn-lang-control" style="position:relative;margin-right:0.5rem;flex:0 0 auto;">
+                <button type="button" id="nn-lang-toggle" aria-haspopup="true" aria-expanded="false"
+                        aria-label="Audio language for episodes" title="Choose the audio language for episodes (page text stays the same)"
+                        style="display:inline-flex;align-items:center;gap:5px;padding:6px 10px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.8rem;cursor:pointer;">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                    <span id="nn-lang-current">EN</span>
+                </button>
+                <div id="nn-lang-menu" role="menu" aria-label="Audio language"
+                     style="display:none;position:absolute;top:100%;right:0;margin-top:4px;min-width:160px;background:var(--nn-surface);border:1px solid var(--nn-border);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.25);z-index:1000;overflow:hidden;padding-bottom:4px;">
+                    <div style="padding:8px 12px 4px;font-size:0.66rem;text-transform:uppercase;letter-spacing:0.06em;color:var(--nn-text-muted);">Episode audio language</div>
+                    <button type="button" role="menuitemradio" data-lang="en" class="nn-lang-opt" aria-checked="true">English</button>
+                    <button type="button" role="menuitemradio" data-lang="fr" class="nn-lang-opt" aria-checked="false">Français</button>
+                    <button type="button" role="menuitemradio" data-lang="es" class="nn-lang-opt" aria-checked="false">Español</button>
+                    <button type="button" role="menuitemradio" data-lang="ru" class="nn-lang-opt" aria-checked="false">Русский</button>
+                    <button type="button" role="menuitemradio" data-lang="zh" class="nn-lang-opt" aria-checked="false">中文</button>
+                </div>
+            </div>
+
             <ul class="nn-nav-links">
                 <li class="nn-nav-dropdown">
                     <button class="nn-nav-dropdown-btn" aria-expanded="false" aria-haspopup="true">
@@ -418,5 +447,6 @@
 
     <!-- Centralized, improved global search -->
     <script src="{{ path_prefix }}assets/js/search.js" defer></script>
+    <script src="{{ path_prefix }}assets/js/language-control.js" defer></script>
 </body>
 </html>

--- a/templates/blog_post.html.j2
+++ b/templates/blog_post.html.j2
@@ -995,6 +995,12 @@
     pills.forEach(function(p) {
         p.addEventListener('click', function() { apply(p.dataset.lang, true); });
     });
+    // Live-switch when the global header language control changes (no reload).
+    // Falls back to English if this episode lacks the chosen track.
+    document.addEventListener('nn-langchange', function(e) {
+        var lang = (e.detail && e.detail.lang) || 'en';
+        apply(tracks[lang] ? lang : 'en', false);
+    });
     apply(preferred(), false);
 })();
 </script>

--- a/templates/how_to_listen.html.j2
+++ b/templates/how_to_listen.html.j2
@@ -227,6 +227,14 @@
                 </div>
             </div>
 
+            <p style="margin-top:var(--sp-6);color:var(--nn-text-muted);font-size:0.95rem;">
+                <strong>Prefer another language?</strong> New episodes are produced
+                in English, Fran&ccedil;ais, Русский, Espa&ntilde;ol and 中文. On the
+                website, use the globe control in the top menu (or the language
+                buttons on any episode page) to pick your audio language &mdash; it's
+                remembered across the site.
+            </p>
+
             <section class="htl-shows-section">
                 <h2>All {{ all_shows|length }} shows</h2>
                 <p>Tap a platform link to open the show in the corresponding app.</p>

--- a/templates/network_page.html.j2
+++ b/templates/network_page.html.j2
@@ -329,7 +329,7 @@
                 <div class="feature-card glass-card">
                     <div class="feature-icon">&#128266;</div>
                     <h3>Multilingual</h3>
-                    <p>Shows in English and Russian, with more languages planned. Knowledge shouldn't have a language barrier.</p>
+                    <p>New episodes are available in English, Fran&ccedil;ais, Русский, Espa&ntilde;ol and 中文 &mdash; pick your language with the globe in the menu. Knowledge shouldn't have a language barrier.</p>
                 </div>
             </div>
         </div>

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -925,6 +925,11 @@
                 b.addEventListener('click', () => apply(code, true));
                 box.appendChild(b);
             });
+            // Live-switch when the global header language control changes.
+            document.addEventListener('nn-langchange', (e) => {
+                const lang = (e.detail && e.detail.lang) || 'en';
+                apply((lang === 'en' || tr[lang]) ? lang : 'en', false);
+            });
             const pref = savedPref();
             apply((pref && (pref === 'en' || tr[pref])) ? pref : 'en', false);
         }

--- a/templates/start_here.html.j2
+++ b/templates/start_here.html.j2
@@ -295,7 +295,7 @@
                 <div class="start-cat-icon" style="background: color-mix(in srgb, #EF4444 15%, transparent);">&#x1F1F7;&#x1F1FA;</div>
                 <div>
                     <h2>Russian Language</h2>
-                    <p>Learn Russian or enjoy Russian-language content from a Canadian perspective.</p>
+                    <p>Learn Russian or enjoy Russian-language content from a Canadian perspective. Many English shows also offer audio in Fran&ccedil;ais, Русский, Espa&ntilde;ol and 中文 &mdash; choose your language with the globe in the top menu.</p>
                 </div>
             </div>
             <div class="start-shows-row">

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -483,3 +483,28 @@ class TestLanguageSwitcherUX:
         assert "renderLatestLangs" in html
         # Shares the same site-wide preference key as the blog switcher.
         assert "nn-pref-lang" in html
+
+
+class TestGlobalLanguageControl:
+    def test_nav_control_in_base_and_script_loaded(self):
+        base = (PROJECT_ROOT / "templates" / "base.html.j2").read_text(encoding="utf-8")
+        assert 'id="nn-lang-toggle"' in base
+        assert 'id="nn-lang-menu"' in base
+        assert "assets/js/language-control.js" in base
+        # Clearly an AUDIO control, not a page-translation control.
+        assert "Audio language" in base
+
+    def test_language_control_js_contract(self):
+        js = (PROJECT_ROOT / "assets" / "js" / "language-control.js").read_text(encoding="utf-8")
+        assert "nn-pref-lang" in js
+        assert "localStorage" in js
+        assert "nn-langchange" in js  # dispatches the live-switch event
+
+    def test_players_listen_for_langchange(self):
+        for tpl in ("blog_post.html.j2", "show_page.html.j2"):
+            html = (PROJECT_ROOT / "templates" / tpl).read_text(encoding="utf-8")
+            assert "nn-langchange" in html, tpl
+
+    def test_homepage_card_lists_languages(self):
+        html = (PROJECT_ROOT / "templates" / "network_page.html.j2").read_text(encoding="utf-8")
+        assert "中文" in html  # multilingual card now names the audio languages


### PR DESCRIPTION
Makes switching languages reachable from **anywhere on the site**, not just episode/show pages — the next "easy to switch languages" step after the persistent per-page switcher (#647).

## What
- **`assets/js/language-control.js`** (new) — a header **globe control** that sets the site-wide `nn-pref-lang` preference (the same key the episode + show-page players already read) and dispatches an `nn-langchange` event. Mirrors the `consent.js`/`search.js` localStorage try/catch pattern; closes on outside-click / Escape.
- **`templates/base.html.j2`** — the control sits next to search in the header on **every page**, clearly labeled **"Audio language"** (`aria-label` + a "Episode audio language" menu caption) so it's not mistaken for translating the page text. Loads the new script beside `search.js`.
- **Live sync** — `blog_post.html.j2` and `show_page.html.j2` players now listen for `nn-langchange` and switch the current track **live, no reload** (reusing each file's existing `apply()`); they fall back to English when an episode lacks the chosen track.
- **Discoverability** — refreshed the homepage "Multilingual" card (was "English and Russian"), added a Start-Here callout and a How-to-Listen note, all naming EN / Français / Русский / Español / 中文 and pointing to the globe control.

## Design notes
- **Audio-only by design**: the control changes which audio track plays; page chrome/text is unchanged. It's orthogonal to the server-side `page_lang`/`_is_ru` site-edition flag (no conflict).
- Set it once from any page's header → every player (episode pages + each show's "Latest Episode") follows, persisted across pages and sessions.

## Verify
```
pytest tests/test_multilingual.py tests/test_website_quality_pass.py   # green
python -c "import generate_html as g; [f(dry_run=True) for f in (g.generate_start_here_page, g.generate_how_to_listen_page)]; g.generate_show_page('tesla', dry_run=True); g.generate_blog_posts('tesla', dry_run=True)"
```
`test_blog` and `test_phase2_growth` also pass locally; all affected pages render and English-only context is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_