### PR TITLE
Blog: populate the Sources section for every show (fix empty source links)

### DIFF
--- a/engine/blog.py
+++ b/engine/blog.py
@@ -56,9 +56,60 @@ _EPISODE_RE = re.compile(r"Ep(\d+)")
 # Date from filename: ..._20260322.md → (2026, 03, 22)
 _FILENAME_DATE_RE = re.compile(r"(\d{4})(\d{2})(\d{2})\.md$")
 
-# Source URLs in digest text
-# Supports both bare URLs and Markdown links: Source: https://... or Source: [text](https://...)
-_SOURCE_URL_RE = re.compile(r"Source:\s*(?:\[.*?\]\()?(https?://[^\s\)]+)")
+# Source URLs in digest text.
+# Two formats are used across the network and BOTH must be captured so every
+# blog post's "Sources" section is populated (June 2026 fix — Models & Agents,
+# MAB, Planetterrian and Omni View list sources as a trailing "## Sources"
+# markdown list with NO "Source:" prefix, so the prefix-only regex missed them
+# and their Sources section rendered empty):
+#   1. inline per-story:   ... Source: https://...   /   Source: [domain](url)
+#   2. a trailing section: "## Sources" (or "Read more" / "References")
+#                          followed by "- [domain](url)" / bare-URL bullets.
+_SOURCE_URL_RE = re.compile(r"(?:Source/Post|Source):\s*(?:\[.*?\]\()?(https?://[^\s\)]+)")
+# A heading that introduces the trailing sources list — matched WHOLE-LINE so a
+# mid-article "## Sources of funding" story heading is never mistaken for it.
+_SOURCES_HEADING_RE = re.compile(
+    r"^\s*(?:#{1,6}\s*|\*\*\s*)?(?:sources?|references?|read\s*more(?:\s*\(sources?\))?)\s*:?\s*\**\s*$",
+    re.IGNORECASE,
+)
+_ANY_HEADING_RE = re.compile(r"^\s*#{1,6}\s+\S")
+# URL inside a markdown link target, or a bare URL.
+_URL_IN_LINE_RE = re.compile(r"\[[^\]]*\]\((https?://[^)\s]+)\)|(https?://[^\s)\]]+)")
+
+
+def _extract_source_urls(md_text: str) -> list[str]:
+    """Collect every source URL from a digest, deduped, in document order.
+
+    Captures both the inline ``Source:`` form and the trailing ``## Sources``
+    (markdown-link or bare) list, so the blog "Sources" section is consistent
+    across all shows regardless of which format the show's prompt emits.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+
+    def add(url: str) -> None:
+        url = (url or "").rstrip(").,;")
+        if url and url not in seen:
+            seen.add(url)
+            out.append(url)
+
+    # 1. Inline "Source:" / "Source/Post:" links.
+    for m in _SOURCE_URL_RE.finditer(md_text):
+        add(m.group(1))
+
+    # 2. Trailing sources section (until the next heading or EOF).
+    in_sources = False
+    for line in md_text.split("\n"):
+        if _SOURCES_HEADING_RE.match(line):
+            in_sources = True
+            continue
+        if in_sources:
+            if _ANY_HEADING_RE.match(line):  # a new section ends the list
+                in_sources = False
+                continue
+            for mm in _URL_IN_LINE_RE.finditer(line):
+                add(mm.group(1) or mm.group(2))
+    return out
 
 # Date string → datetime
 _DATE_FORMATS = [
@@ -228,8 +279,8 @@ def extract_blog_metadata(
             hook = clean[:200] + ("..." if len(clean) > 200 else "")
             break
 
-    # Source URLs
-    source_urls = _SOURCE_URL_RE.findall(md_text)
+    # Source URLs — both inline "Source:" and trailing "## Sources" formats.
+    source_urls = _extract_source_urls(md_text)
 
     # Word count and reading time
     word_count = len(md_text.split())
@@ -268,9 +319,25 @@ def clean_digest_for_blog(md_text: str) -> str:
     lines = md_text.split("\n")
     cleaned = []
     skip_hook_line = False
+    in_sources = False
 
     for line in lines:
         stripped = line.strip()
+
+        # Drop the trailing "## Sources" / "Read more" / "References" list from
+        # the article body — the favicon "Sources" section below the article
+        # now displays those links (built from the same URLs), so keeping the
+        # raw list here would duplicate the heading and dump a long bullet list
+        # of URLs into the prose. Ends at the next heading (defensive; the list
+        # is normally the final block).
+        if _SOURCES_HEADING_RE.match(line):
+            in_sources = True
+            continue
+        if in_sources:
+            if _ANY_HEADING_RE.match(line):
+                in_sources = False  # fall through to emit this new heading
+            else:
+                continue
 
         # Remove unicode box-drawing separators
         if stripped and all(c in "━─═" for c in stripped):
@@ -683,14 +750,18 @@ def generate_blog_post_html(
     elif not _extracted:
         metadata["title"] = _show
 
-    # Source domains for display
+    # Source cards for the "Sources" section. Dedupe by URL (not by domain) so
+    # every DISTINCT article is linked — shows that cite many articles from one
+    # publisher (e.g. several reddit.com threads) keep all of them instead of
+    # collapsing to a single card. Same URL cited by multiple stories still
+    # shows once.
     source_domains = []
-    seen_domains = set()
+    seen_urls = set()
     for url in metadata.get("source_urls", []):
-        domain = _domain_from_url(url)
-        if domain not in seen_domains:
-            seen_domains.add(domain)
-            source_domains.append({"url": url, "domain": domain})
+        if url in seen_urls:
+            continue
+        seen_urls.add(url)
+        source_domains.append({"url": url, "domain": _domain_from_url(url)})
 
     # Load transcript (TTS script) if available — scan digest dir for
     # a *_Ep{NNN}_*_tts.txt file matching this episode number. The TTS

--- a/tests/test_blog_sources.py
+++ b/tests/test_blog_sources.py
@@ -1,0 +1,95 @@
+"""Source-linking guards for blog posts (June 2026).
+
+The network uses two source formats and BOTH must populate the "Sources"
+section so no blog article ships without linked sources:
+  1. inline ``Source: [domain](url)`` per story, and
+  2. a trailing ``## Sources`` markdown list (Models & Agents / MAB /
+     Planetterrian / Omni View) with no ``Source:`` prefix.
+The trailing list must move into the favicon Sources section (deduped by URL),
+not be duplicated as a raw list in the article body.
+"""
+
+from __future__ import annotations
+
+
+class TestSourceExtraction:
+    def test_inline_source_prefix(self):
+        from engine.blog import _extract_source_urls
+        md = "1. **Story** — text. Source: [reddit.com](https://reddit.com/r/x/1)\n"
+        assert _extract_source_urls(md) == ["https://reddit.com/r/x/1"]
+
+    def test_trailing_sources_list_markdown(self):
+        from engine.blog import _extract_source_urls
+        md = (
+            "## Top News\n- a story\n\n"
+            "## Sources\n"
+            "- [phys.org](https://phys.org/a)\n"
+            "- [reddit.com](https://www.reddit.com/r/s/2)\n"
+        )
+        assert _extract_source_urls(md) == [
+            "https://phys.org/a",
+            "https://www.reddit.com/r/s/2",
+        ]
+
+    def test_read_more_heading_variant(self):
+        from engine.blog import _extract_source_urls
+        md = "Read more\n- [x.com](https://x.com/a/1)\n"
+        assert _extract_source_urls(md) == ["https://x.com/a/1"]
+
+    def test_dedupes_repeated_url(self):
+        from engine.blog import _extract_source_urls
+        md = ("Source: https://reddit.com/r/x/1\n"
+              "Source: https://reddit.com/r/x/1\n")
+        assert _extract_source_urls(md) == ["https://reddit.com/r/x/1"]
+
+    def test_mid_article_sources_heading_not_treated_as_list(self):
+        # "## Sources of funding" is a real story heading, not the sources list.
+        from engine.blog import _extract_source_urls
+        md = "## Sources of funding\nThe program https://example.com/grant matters.\n"
+        assert _extract_source_urls(md) == []
+
+    def test_body_strips_trailing_sources_list(self):
+        from engine.blog import clean_digest_for_blog
+        md = ("# Show\n\nBody paragraph.\n\n"
+              "## Sources\n- [phys.org](https://phys.org/a)\n- [x.com](https://x.com/b)\n")
+        cleaned = clean_digest_for_blog(md)
+        assert "## Sources" not in cleaned
+        assert "phys.org/a" not in cleaned
+        assert "Body paragraph." in cleaned
+
+    def test_inline_source_pills_kept_in_body(self):
+        # Per-story inline sources are NOT a trailing list — keep them.
+        from engine.blog import clean_digest_for_blog
+        md = "1. **Story** text. Source: [reddit.com](https://reddit.com/r/x/1)\n"
+        cleaned = clean_digest_for_blog(md)
+        assert "reddit.com/r/x/1" in cleaned
+
+
+class TestSourceCardsDedupeByUrl:
+    def test_distinct_urls_same_domain_all_kept(self):
+        from engine.blog import generate_blog_post_html
+        captured = {}
+
+        class _T:
+            def render(self, **kw):
+                captured.update(kw); return "<html></html>"
+
+        class _Env:
+            def get_template(self, name): return _T()
+
+        from generate_html import NETWORK_SHOWS
+        meta = {
+            "episode_num": 1, "date": "2026-06-15", "date_iso": "2026-06-15",
+            "hook": "h", "title": "T",
+            "source_urls": [
+                "https://www.reddit.com/r/a/1",
+                "https://www.reddit.com/r/a/2",
+                "https://www.reddit.com/r/a/1",  # dup of #1
+            ],
+        }
+        generate_blog_post_html("## Body\n\ntext", meta, NETWORK_SHOWS["tesla"], _Env())
+        urls = [s["url"] for s in captured["source_domains"]]
+        assert urls == [
+            "https://www.reddit.com/r/a/1",
+            "https://www.reddit.com/r/a/2",
+        ]


### PR DESCRIPTION
Fixes the reported issue: **some blog posts had no linked story sources.**

## Root cause
Source-URL extraction (`engine/blog.py`) required a literal **`Source:`** prefix. But the network uses **two** source formats:
- **Inline** (Tesla, Env Intel, Fascinating Frontiers, Modern Investing, Finansy Prosto, SpaceX): `… Source: [domain](url)` per story.
- **Trailing list** (**Models & Agents, MAB, Planetterrian, Omni View**): a `## Sources` markdown list of `- [domain](url)` with **no `Source:` prefix**.

The prefix-only regex missed the trailing-list format, so those four shows rendered an **empty favicon "Sources" section** (their links only appeared as a raw bullet list in the body — and some episodes looked source-less).

## Fix (`engine/blog.py`)
- **`_extract_source_urls()`** (new) captures **both** formats — inline `Source:`/`Source/Post:` **and** a trailing `Sources` / `Read more` / `References` section (markdown-link or bare URLs) — deduped by URL in document order. The sources-heading is matched **whole-line**, so a mid-article `## Sources of funding` story heading is never mistaken for the list.
- **`clean_digest_for_blog()`** strips that trailing list from the article **body** (the favicon Sources section now shows the same links) — no duplicate "Sources" heading, no long raw URL list dumped into the prose. Inline per-story `Source:` pills are kept.
- **Source cards dedupe by URL, not domain** — every distinct article is linked instead of collapsing many articles from one publisher into a single card.

## Coverage of the full request
- **Blog articles** — fixed: every show renders exactly one populated Sources section. Verified M&A=55, Omni View=14, FF=15, Tesla cards render; exactly one "Sources" heading each; no links lost.
- **Summaries** — already correct: the summaries page `renderMarkdown`/`linkify` converts both markdown links and bare URLs client-side (verified the summaries JSON `content` carries the URLs). No change needed.
- **Transcripts** — the transcript is the **verbatim spoken script** (`_tts.txt`); URLs are intentionally not spoken, so they're not in the transcript. Sources belong to the article, which is now consistent. (Injecting URLs into the spoken transcript would be incorrect.)

## Verify
```
pytest tests/test_blog_sources.py tests/test_blog.py   # 8 new guards + existing
python -c "import generate_html as g; [g.generate_blog_posts(s, dry_run=True) for s in ('models_agents','omni_view','tesla','planetterrian')]"
```
`test_phase2_growth`, `test_phase4_repositioning`, `test_episode_validity`, `test_website_quality_pass` all pass; ruff clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_