### PR TITLE
Unblock the pipeline: finalize shared-pages push fix + First Principles queue restock

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -741,6 +741,19 @@ jobs:
 
           git commit -m "Update shared pages (network index, blog index, sitemap, search index) $(date +%Y-%m-%d)"
 
+          # The regeneration above (generate_html.py --network --blogs) also
+          # rewrites per-show pages — especially after a template change, where
+          # every page changes — leaving them modified-but-unstaged. This step
+          # deliberately commits only the CURATED shared pages above (committing
+          # per-show pages here would rebase-conflict with each show's own job).
+          # Those incidental unstaged changes must be discarded, or
+          # `git pull --rebase` aborts with "cannot pull with rebase: you have
+          # unstaged changes" and fails all 5 attempts (observed 2026-06-16).
+          # The per-show pages are owned + committed by each show's own job
+          # (generate_html.py --show <slug> --blogs), so discarding the redundant
+          # regen here is safe.
+          git checkout -- . 2>/dev/null || true
+
           # 5 attempts + slightly longer backoff for the shared-pages commit
           # (lower stakes than per-episode artifacts; pages are fully regenerable
           # from the per-show commits that already landed).

--- a/shows/topic_queues/first_principles.yaml
+++ b/shows/topic_queues/first_principles.yaml
@@ -216,3 +216,59 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
+- id: interchangeable-parts-armory
+  title: "Interchangeable Parts: Mass Production Before the Assembly Line"
+  brief: "Concrete example (historical). Long before Ford, gunsmiths built each musket as a one-off, hand-fitting every part, so a broken lock meant a custom repair and skilled fitters dominated the cost. Reasoning from the real constraint, armories pursued parts made to tight enough tolerances that any one fit any gun — jigs, gauges, and machine tools instead of master craftsmen. Trace how interchangeability attacked the labor-and-fitting term that set the Idiot Index, why the gauges and machines were the hard part rather than the metal, and how the idea generalized from guns to clocks to cars. The materials were always cheap; the precision interface was the unlock. Hedge the figures and note it took decades to fully achieve."
+  category: concrete_example
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: tunneling-transit-cost
+  title: "Why a Mile of Subway Costs What It Does"
+  brief: "Opportunity area. The raw inputs to a transit tunnel — concrete, steel, a boring machine, electricity — are a modest fraction of the delivered cost, yet a mile of urban subway can cost several times more in some cities than others for similar geology. Reason about the magic-wand floor (materials plus machine-hours of boring) versus the finished price, and locate where the Idiot Index actually sits: station design, utility relocation, procurement, change orders, soft costs, and risk premia rather than the digging itself. Lay out the from-first-principles levers — standardized stations, repeatable designs, fewer bespoke contracts — and the honest hard parts of politics and right-of-way. Flag every comparison as approximate."
+  category: opportunity_area
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: telegraph-undersea-cable
+  title: "The Telegraph: Pricing a Word Across an Ocean"
+  brief: "Concrete example (historical). Before the electric telegraph, a message crossed the Atlantic at the speed of a ship — roughly two weeks — so the binding constraint on information was physical transport, not the information itself. Reasoning that a signal could travel as electricity down a wire, engineers attacked the real problem: insulation, signal loss, and laying cable across an ocean floor. Trace how the telegraph and the first undersea cables collapsed message time from weeks to minutes and reshaped finance, news, and empire, and the hard engineering of repeaters and gutta-percha insulation that made it work. The content of a message barely changed; the cost and time of moving it cratered. Hedge the figures and note early cables that failed."
+  category: concrete_example
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: low-carbon-cement
+  title: "Cement: The Material Floor We Bake Twice"
+  brief: "Opportunity area. Concrete is mostly cheap rock and sand, but the cement that binds it is made by cooking limestone at high heat, which both burns fuel and releases the carbon dioxide locked in the stone — so the magic-wand floor is set by chemistry and heat, not scarcity. Reason about where the Idiot Index and the emissions actually live in the process, and examine first-principles levers: alternative chemistries that need less heat, supplementary materials that replace some clinker, electrified or carbon-captured kilns, and designing structures to use less cement for the same strength. Cover the honest constraints — standards, durability proof, and the sheer scale of the industry. Treat all figures as approximate."
+  category: opportunity_area
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: optical-fiber-bandwidth
+  title: "Optical Fiber: Bandwidth for the Cost of Glass"
+  brief: "Concrete example (modern). Moving data over copper is limited by the physics of electrical signals in metal, so the old way had a hard ceiling no amount of optimization could clear. Reasoning to light instead of electrons, engineers had to solve the real constraint: making glass pure enough that a pulse of light could travel kilometers without fading. Trace how ultra-pure optical fiber and cheap lasers drove the cost per bit down a steep, sustained curve and made global video and cloud computing possible, and why the breakthrough was a materials-purity problem rather than a cable-cost one. The glass is essentially sand; the Idiot Index lived in purity and the light source. Hedge the figures and note ongoing limits like amplification and trenching cost."
+  category: concrete_example
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: dental-care-access
+  title: "Dental Care: A High Idiot Index in the Mouth"
+  brief: "Opportunity area. Routine dental work uses modest materials and well-understood procedures, yet delivered cost and access vary enormously, so the magic-wand floor is not what sets the price. Reason about where the Idiot Index actually sits — chairside time of highly-trained clinicians, fragmented small practices, equipment, and billing overhead rather than the filling material itself. Examine first-principles levers: tasks safely shifted to hygienists and therapists, prevention that removes demand entirely, standardized imaging and tele-dentistry, and cheaper digital fabrication of crowns and aligners. Cover honest constraints around safety, licensing, and outcomes, and avoid giving medical advice. Treat all figures as approximate."
+  category: opportunity_area
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: jacquard-loom-programmable
+  title: "The Jacquard Loom: Weaving Patterns with Punched Cards"
+  brief: "Concrete example (historical). Weaving an intricate patterned fabric once required a skilled drawloom operator pulling threads by hand, so the binding constraint was expert labor per row and complex cloth was a luxury. Joseph-Marie Jacquard reasoned that the PATTERN was information that could be stored outside the weaver's head — on a chain of punched cards that mechanically selected threads. Trace how separating the design from the hand collapsed the labor cost of complex weaving, made patterned cloth ordinary, and planted the seed of programmable machines that later inspired early computing. The thread barely changed; encoding the instructions was the leap. Hedge the figures and note the displacement of skilled weavers."
+  category: concrete_example
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: last-mile-delivery
+  title: "The Last Mile: Where Cheap Shipping Gets Expensive"
+  brief: "Opportunity area. A package can cross an ocean for pennies per kilogram thanks to containerization, then absorb a large share of its total delivery cost in the final few kilometers to a doorstep — so the magic-wand floor of long-haul transport is already near solved while the Idiot Index has migrated to the last mile. Reason about why: many stops, low package density per stop, failed deliveries, labor, and idle vehicle time rather than fuel or the goods. Examine first-principles levers — route density, parcel lockers and pickup points, right-sized vehicles, and batching — and the honest constraints of geography, wages, and customer expectations. Flag all figures as approximate."
+  category: opportunity_area
+  produced: false
+  episode_number: null
+  produced_date: null


### PR DESCRIPTION
Two pipeline-health fixes. The second is what's currently turning **every PR's CI red**, so this PR unblocks the rest.

## 1. Finalize shared-pages push (`run-show.yml`)
The finalize "Commit and push shared pages" step failed all 5 attempts with `cannot pull with rebase: You have unstaged changes` (observed 2026-06-16 11:04). It regenerates the whole site but commits only a curated subset; the regenerated per-show pages are left modified-but-unstaged, so `git pull --rebase` aborts on the dirty tree. Recent template changes (e.g. the nav language control in `base.html.j2`, #648) touch every page, making this fail every run. **Fix:** `git checkout -- .` after the curated commit to drop the redundant per-show regen before the rebase (those pages are owned + committed by each show's own job). Episodes/per-show pages were unaffected; only the network index/sitemap/search-index push.

## 2. First Principles topic-queue restock
`tests/test_network_quality_pass.py::TestNarrativeQueueRunway` was **failing on main**: First Principles' unproduced queue had drawn down to 20 entries (2.857 weeks, min 3.0) through daily consumption — and that failing test blocks CI on **every** open PR. **Fix:** added 8 fresh, on-concept topics (alternating concrete-example / opportunity-area, magic-wand-number + Idiot-Index framing, hedged figures, no duplicate IDs), bringing unproduced to **28 (4.0 weeks)** — clear of the floor even after today's episode.

## Verify
- `pytest tests/test_scheduling_punctuality.py tests/test_schedule.py tests/test_network_quality_pass.py tests/test_first_principles_quality_pass.py` — all pass.
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/run-show.yml')); yaml.safe_load(open('shows/topic_queues/first_principles.yaml'))"` — valid.