### PR TITLE
Decouple multilingual audio from the episode pipeline (fix timeout partial-publishes)

### DIFF
--- a/.github/workflows/multilingual.yml
+++ b/.github/workflows/multilingual.yml
@@ -1,0 +1,150 @@
+name: Generate Multilingual Audio
+
+# Decoupled multilingual (FR/RU/ES/ZH) audio generation (June 2026).
+#
+# This used to run INLINE inside run-show.yml after each episode published,
+# but four sequential Grok-TTS renders (~16 min) pushed video-heavy shows
+# (Tesla, SpaceX) past the 2400s episode-pipeline timeout — the SIGALRM fired
+# mid-render, run_show exited non-zero, and the episode's commit step was
+# skipped, leaving a partial publish (R2 + YouTube done, nothing committed).
+#
+# It now runs off the critical path here: a scheduled sweep (plus manual
+# dispatch) that runs the idempotent driver scripts/generate_translations.py
+# for each multilingual-enabled show. The driver skips (episode, language)
+# pairs already present, so re-runs are cheap and it naturally backfills any
+# tracks a prior run missed. The episode pipeline stays fast + durable.
+
+on:
+  schedule:
+    # After the morning show window (shows finish ~12-13 UTC; GitHub cron is
+    # often hours late, which is fine — the sweep is idempotent). Two passes
+    # catch stragglers + late-arriving episodes.
+    - cron: '7 14 * * *'
+    - cron: '7 18 * * *'
+  workflow_dispatch:
+    inputs:
+      show:
+        description: 'Show slug to translate (or "all" for every enabled show)'
+        required: true
+        default: all
+        type: string
+      latest:
+        description: 'How many recent episodes per show'
+        required: false
+        default: '3'
+        type: string
+
+# Serialize multilingual runs so two sweeps never fight over the same
+# summaries files / git push.
+concurrency:
+  group: multilingual
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: '3.12'
+          requirements-file: 'requirements.txt'
+          system-packages: 'ffmpeg'
+          skip-checkout: 'true'
+
+      - name: Resolve shows to translate
+        id: resolve
+        shell: python3 {0}
+        run: |
+          import json, os
+          from engine.config import discover_show_slugs, load_config
+
+          dispatch = "${{ github.event.inputs.show }}".strip()
+          if dispatch and dispatch not in ("", "all"):
+              # Explicit single-show dispatch — honor it even if auto is off.
+              shows = [dispatch]
+          else:
+              # Scheduled / "all": every show that opts into auto multilingual.
+              shows = []
+              for slug in discover_show_slugs():
+                  try:
+                      cfg = load_config(f"shows/{slug}.yaml")
+                  except Exception:
+                      continue
+                  ml = getattr(cfg, "multilingual", None)
+                  if ml and ml.enabled and getattr(ml, "auto", False):
+                      shows.append(slug)
+          print("Multilingual shows:", shows)
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"shows={json.dumps(shows)}\n")
+
+      - name: Generate translations
+        env:
+          GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          XAI_API_KEY: ${{ secrets.GROK_API_KEY }}
+          GROK_CLONED_VOICE_ID: ${{ secrets.GROK_CLONED_VOICE_ID }}
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: |
+          set +e
+          LATEST="${{ github.event.inputs.latest }}"
+          [ -z "$LATEST" ] && LATEST=3
+          SHOWS='${{ steps.resolve.outputs.shows }}'
+          echo "$SHOWS" | python3 -c "import sys,json; print('\n'.join(json.load(sys.stdin)))" | while read -r slug; do
+            [ -z "$slug" ] && continue
+            echo "::group::Translating $slug (--latest $LATEST)"
+            # --zh-approved: operator approved all four languages including ZH.
+            python scripts/generate_translations.py "$slug" --latest "$LATEST" --zh-approved || echo "::warning::Translation run failed for $slug (non-fatal)"
+            echo "::endgroup::"
+          done
+          exit 0
+
+      - name: Regenerate blogs so the language switcher appears
+        run: |
+          # Translations live in summaries_*.json; regenerate blog posts +
+          # indexes so the inline switcher + badges render. Non-fatal.
+          python generate_html.py --blogs --network --sitemap || \
+            echo "::warning::HTML regen failed — switcher will appear on the next nightly regen"
+
+      - name: Commit and push translations
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+
+          # The summaries JSONs carry the new translation tracks (source of
+          # truth the site reads); the blog/index HTML render the switcher.
+          git add 'digests/**/summaries_*.json' || true
+          git add 'blog/**' || true
+          git add '*.html' || true
+          git add 'blog/index.html' || true
+          git add index.html || true
+          git add sitemap.xml || true
+
+          if git diff --cached --quiet; then
+            echo "No new translations to commit."
+            exit 0
+          fi
+          git commit -m "Multilingual: add translation tracks $(date -u +%Y-%m-%d)"
+
+          # Drop any incidental unstaged regen so the rebase isn't blocked
+          # (same guard as run-show's finalize step).
+          git checkout -- . 2>/dev/null || true
+
+          for attempt in 1 2 3 4 5; do
+            if git pull --rebase origin main && git push origin main; then
+              echo "Push succeeded on attempt $attempt"
+              exit 0
+            fi
+            [ $attempt -lt 5 ] && sleep $((attempt * 3))
+          done
+          echo "::warning::Could not push multilingual updates after 5 attempts — next sweep will retry (idempotent)."
+          exit 0

--- a/run_show.py
+++ b/run_show.py
@@ -2937,18 +2937,15 @@ def run(args: argparse.Namespace) -> None:
         rss_url=f"{config.publishing.base_url}/{config.publishing.rss_file}",
     )
 
-    # 11c. Multilingual audio (June 2026). For shows with multilingual.auto,
-    # render the configured languages for this episode now — AFTER the summaries
-    # record exists (the translation upserts into it) and BEFORE the blog post
-    # below, so today's post + index immediately show the language switcher and
-    # badges. Fully non-blocking: a failure (or an unset GROK_CLONED_VOICE_ID)
-    # can never break the English publish. Skipped in test/dry-run.
-    if not args.test and not args.dry_run:
-        try:
-            from engine.multilingual import auto_generate_after_publish
-            auto_generate_after_publish(config, episode_num)
-        except Exception as _ml_exc:  # noqa: BLE001 — translation must never block publish
-            logger.error("Multilingual auto step failed (non-fatal): %s", _ml_exc)
+    # 11c. Multilingual audio (FR/RU/ES/ZH) is generated OUT OF BAND by a
+    # separate workflow (.github/workflows/multilingual.yml) running the
+    # idempotent driver scripts/generate_translations.py. It used to run
+    # inline here, but four sequential TTS renders (~16 min) pushed
+    # video-heavy shows (e.g. Tesla) past the 2400s pipeline timeout — the
+    # SIGALRM fired mid-render, run_show exited non-zero, and the episode's
+    # git commit step was skipped, leaving a partial publish (R2 + YouTube
+    # done, nothing committed). Decoupling keeps the episode pipeline fast +
+    # durable; translations land shortly after via the dedicated workflow.
 
     # 12a. Generate blog post
     try:

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -508,3 +508,23 @@ class TestGlobalLanguageControl:
     def test_homepage_card_lists_languages(self):
         html = (PROJECT_ROOT / "templates" / "network_page.html.j2").read_text(encoding="utf-8")
         assert "中文" in html  # multilingual card now names the audio languages
+
+
+class TestMultilingualDecoupled:
+    """June 2026: multilingual generation was moved OUT of the inline episode
+    pipeline (it busted the 2400s timeout on video-heavy shows, leaving partial
+    publishes) into a dedicated workflow. Guard against regressing to inline."""
+
+    def test_run_show_does_not_call_auto_inline(self):
+        src = (PROJECT_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "auto_generate_after_publish(" not in src, (
+            "multilingual must NOT run inline in run_show.py — it caused "
+            "pipeline-timeout partial publishes; use the multilingual.yml workflow"
+        )
+
+    def test_decoupled_workflow_exists_and_runs_driver(self):
+        wf = PROJECT_ROOT / ".github" / "workflows" / "multilingual.yml"
+        assert wf.exists(), "decoupled multilingual workflow missing"
+        text = wf.read_text(encoding="utf-8")
+        assert "scripts/generate_translations.py" in text
+        assert "--zh-approved" in text  # operator approved all four languages


### PR DESCRIPTION
## The bug (observed live, Tesla Ep512, 2026-06-16)
Inline multilingual auto-generation (#645) ran 4 sequential Grok-TTS renders (~16 min) **inside** `run_show.py` after publish. Video-heavy shows already run ~25–30 min, so this pushed them past the **2400s (40-min) pipeline SIGALRM**. The alarm fired mid-`es` render, `run_show` exited non-zero, and the workflow's commit step was skipped — leaving a **partial publish**: audio on R2 + video on YouTube, but **nothing committed to git** (no `.md`/RSS/summaries). The episode was invisible to the site **and** would regenerate as a duplicate (next run sees no committed Ep512). FR/RU generated; ES/ZH lost.

## Fix — move it off the critical path
- **`run_show.py`** — remove the inline `auto_generate_after_publish` call. Episodes publish fast + durably and `run_show` exits 0, so the commit step always runs.
- **`.github/workflows/multilingual.yml`** (new) — a scheduled sweep (14:07 + 18:07 UTC) + `workflow_dispatch` that runs the existing **idempotent** driver `scripts/generate_translations.py --latest 3 --zh-approved` for each multilingual-enabled+auto show, regenerates blogs (so the switcher renders), and commits the `summaries_*.json` translation tracks. Idempotent → it **backfills** any tracks a prior run missed (incl. today's lost ES/ZH); own 330-min timeout; serialized via a `concurrency` group; rebase-retry push with the same dirty-tree guard as the finalize step.

`multilingual.enabled` / `auto` stay `true` — they now gate the decoupled workflow rather than an inline step. No change to the translation logic, R2 layout, or website switcher.

## Verify
- `pytest tests/test_multilingual.py` (46 pass, incl. `TestMultilingualDecoupled`: run_show no longer calls it inline; the workflow exists + runs the driver with `--zh-approved`).
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/multilingual.yml'))"` — valid; `run_show.py` syntax ok; ruff clean.

## Follow-up (operator-approved)
Re-run Tesla once this merges to reconcile the partial Ep512 (regenerates + commits properly; the orphaned first YouTube upload needs manual deletion in Studio).

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_