### PR TITLE
deps: bump google-auth floor to >=2.55.0 (lands stuck Dependabot #652)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ jinja2>=3.1.6
 boto3>=1.43.22
 faster-whisper>=1.0.0
 google-api-python-client>=2.197.0
-google-auth>=2.28.0
+google-auth>=2.55.0
 google-auth-oauthlib>=1.4.0
 google-auth-httplib2>=0.2.0


### PR DESCRIPTION
Lands the google-auth update from Dependabot **#652**, which was stuck on a `requirements.txt` context conflict after the sibling Dependabot bumps (#651/#653/#654/#655) merged and Dependabot didn't re-rebase. Same one-line floor bump (`google-auth>=2.28.0` → `>=2.55.0`), applied cleanly on current main.

Closes the intent of #652 (which can be closed once this merges).

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_