### PR TITLE
SpaceX hook: speak the current SPCX price, not the prior daily close

### DIFF
--- a/shows/hooks/spacex.py
+++ b/shows/hooks/spacex.py
@@ -6,8 +6,10 @@ Fascinating Frontiers), plus two SpaceX-specific injections:
 * ``spcx_market_block`` — real-time SPCX quote for the digest's Market
   Watch section. SpaceX listed on Nasdaq June 12 2026 (the show's launch
   day); the fetcher mirrors the hard-won TSLA lessons from landmine #22:
-  yfinance ``history()`` primary, ``fast_info`` secondary, ``0.0`` treated
-  as falsy, sanity band + deviation guard vs the last cached quote, and a
+  yfinance ``fast_info`` (live last trade) primary so the spoken price is
+  the CURRENT market price, ``history()`` (last daily close) as fallback,
+  ``0.0`` treated as falsy, sanity band + deviation guard vs the last cached
+  quote, and a
   failed fetch NEVER overwrites the previous-good cache. A failed/invalid
   quote renders an EMPTY block — the prompts instruct the model to omit
   the price line entirely rather than speak "price unavailable".
@@ -99,12 +101,20 @@ def pronunciation_overrides() -> dict:
 
 def _fetch_spcx_quote() -> tuple[float, str, str]:
     """Return ``(price, change_str, source)`` or ``(0.0, "", "")`` when no
-    source yields a quote that passes validation. ``source`` lets callers
-    phrase honestly: a ``history`` bar is a close; a ``fast_info`` quote at
-    the ~12:07 UTC run time is a live pre-market price, not a close."""
+    source yields a quote that passes validation.
+
+    Order matters: try ``fast_info`` FIRST so the show speaks the CURRENT /
+    live last trade when the run happens during (or near) market hours —
+    previously ``history`` ran first and always returned the prior *daily
+    close*, so the episode spoke a stale price and never reached the live
+    quote. ``fast_info`` treats ``0.0`` (the degraded-response failure mode,
+    landmine #22) as falsy and falls through to ``history`` (the last daily
+    close), which is the honest fallback when the market is closed or the
+    live quote is unavailable. ``source`` lets the spoken line phrase it
+    correctly — "is trading at" for a live quote, "closed at" for a bar."""
     for source_name, fetch in (
-        ("yfinance_history", _quote_from_history),
         ("yfinance_fast_info", _quote_from_fast_info),
+        ("yfinance_history", _quote_from_history),
     ):
         try:
             result = fetch()


### PR DESCRIPTION
## The bug (corrected scope)
The **podcast script** spoke a stale SPCX price — the prior day's close — instead of the current market price when the show runs.

**Root cause:** `shows/hooks/spacex.py:_fetch_spcx_quote` tried yfinance `history()` **first**, which returns the last **daily close**. Since `history()` almost always succeeds, the chain returned the close (spoken as *"closed at …"*) and **never reached the live `fast_info` quote** — even when the run lands during market hours (the cron is frequently hours late, landmine #24).

## Fix
Reorder the source chain to prefer the **live `fast_info` last trade first**, with `history` (last daily close) as the fallback:
- `fast_info` already treats a `0.0` degraded response as falsy and falls through to `history` (landmine #22), and the sanity-band + deviation guard still gate every source — so robustness is preserved.
- The existing `_price_sentence` already phrases a live quote as *"S P C X is trading at …"* vs a bar as *"closed at …"*, so the spoken line is now both **current** and honestly phrased.
- `api/spcx.json` (read by the dashboard) now caches the live price too.

No phrasing/structure change; one-line reorder + docs.

## Verify
- `pytest tests/test_spacex_show.py` — 44 pass (the phrasing-by-source guards are unaffected).
- `ruff check shows/hooks/spacex.py` — clean.
- Next SpaceX run during market hours: the episode says *"SPCX is trading at \<current price\>"* instead of *"closed at \<prior close\>"*.

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_