### PR TITLE
Fix multilingual workflow: repo root on sys.path in the resolve step

### DIFF
--- a/.github/workflows/multilingual.yml
+++ b/.github/workflows/multilingual.yml
@@ -64,7 +64,10 @@ jobs:
         id: resolve
         shell: python3 {0}
         run: |
-          import json, os
+          import json, os, sys
+          # `shell: python3 {0}` runs this from a temp file, so the repo root
+          # isn't on sys.path — add the workspace (cwd) so `engine` imports.
+          sys.path.insert(0, os.getcwd())
           from engine.config import discover_show_slugs, load_config
 
           dispatch = "${{ github.event.inputs.show }}".strip()


### PR DESCRIPTION
## The failure
The decoupled multilingual sweep (`.github/workflows/multilingual.yml`, added in #657) failed at its **Resolve shows to translate** step:
```
ModuleNotFoundError: No module named 'engine'
  from engine.config import discover_show_slugs, load_config
```
So no translations were being generated.

## Root cause
The step uses `shell: python3 {0}`, which GitHub runs as a script from a **temp file**. Python sets `sys.path[0]` to that temp dir (not the workspace), so the repo root isn't importable and `from engine.config import …` fails. (The `run-show.yml` gate step doesn't hit this because it only imports stdlib.)

## Fix
Insert the workspace (`os.getcwd()`, which GitHub sets to the repo root) at the front of `sys.path` before importing `engine`. One-line, scoped to that step — the workflow's other steps invoke `python scripts/…` / `generate_html.py`, which set their own paths.

## Verify
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/multilingual.yml'))"` — valid.
- Next sweep (or `workflow_dispatch`): the resolve step prints `Multilingual shows: [...]` and proceeds to generate translations.

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_