### PR TITLE
Multilingual: publish per-language podcast RSS feeds (FR/RU/ES/ZH)

### DIFF
--- a/.github/workflows/multilingual.yml
+++ b/.github/workflows/multilingual.yml
@@ -111,6 +111,21 @@ jobs:
           done
           exit 0
 
+      - name: Build per-language podcast RSS feeds
+        env:
+          # Channel title/description are translated once and cached in
+          # digests/<slug>/channel_i18n.json; the key lets the first build
+          # populate that cache. Subsequent rebuilds are credit-free.
+          GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          XAI_API_KEY: ${{ secrets.GROK_API_KEY }}
+        run: |
+          # Rebuild every show's FR/RU/ES/ZH podcast feed from the canonical
+          # summaries JSON (idempotent; only writes a feed for a language that
+          # has at least one track). Non-fatal — a feed glitch must not block
+          # the translation commit.
+          python scripts/build_language_feeds.py --all || \
+            echo "::warning::Language-feed build failed — next sweep retries (idempotent)"
+
       - name: Regenerate blogs so the language switcher appears
         run: |
           # Translations live in summaries_*.json; regenerate blog posts +
@@ -126,6 +141,10 @@ jobs:
           # The summaries JSONs carry the new translation tracks (source of
           # truth the site reads); the blog/index HTML render the switcher.
           git add 'digests/**/summaries_*.json' || true
+          # Per-language podcast feeds + the cached channel title/description
+          # translations that back them (Apple/Spotify subscribe to these).
+          git add '*_podcast.*.rss' || true
+          git add 'digests/**/channel_i18n.json' || true
           git add 'blog/**' || true
           git add '*.html' || true
           git add 'blog/index.html' || true

--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -128,9 +128,21 @@ jobs:
           # Optionally regenerate full site if needed:
           # python generate_html.py --all
 
+      - name: Rebuild per-language podcast RSS feeds (safety net)
+        # The multilingual workflow rebuilds + commits these after each
+        # translation sweep; this nightly pass is a regenerable safety net
+        # (deterministic from summaries → usually a no-op diff). The key
+        # populates digests/<slug>/channel_i18n.json if a show is missing it.
+        env:
+          GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          XAI_API_KEY: ${{ secrets.GROK_API_KEY }}
+        run: python scripts/build_language_feeds.py --all || echo "::warning::Language-feed rebuild failed (non-fatal)"
+
       - uses: ./.github/actions/safe-commit-push
         with:
           add-paths: |
+            *_podcast.*.rss
+            digests/**/channel_i18n.json
             api/dashboard.json
             api/op3_stats.json
             api/buttondown_stats.json

--- a/docs/multilingual.md
+++ b/docs/multilingual.md
@@ -119,7 +119,50 @@ The per-episode blog page renders an inline `<audio>` player + language pills
 **only when a translation track exists** (English-only episodes show nothing
 new). It defaults to the visitor's `Accept-Language`, remembers the session
 choice, and swaps the audio + translated title/description on selection. Vanilla
-JS, no build step. The podcast RSS feed is unchanged (English remains canonical).
+JS, no build step. The **canonical English** podcast RSS feed
+(`<show>_podcast.rss`) is unchanged — English stays the master.
+
+## Per-language podcast feeds (Apple / Spotify)
+
+Each translation track is also published as a real, subscribable podcast in a
+**dedicated per-language feed** next to the English one:
+
+```
+spacex_podcast.rss        # English, canonical (untouched)
+spacex_podcast.fr.rss     # French tracks only
+spacex_podcast.es.rss     # Spanish tracks only  …
+```
+
+- Built by [`engine/language_feeds.py`](../engine/language_feeds.py) via
+  [`scripts/build_language_feeds.py`](../scripts/build_language_feeds.py),
+  **fresh from the canonical `summaries_<slug>.json`** each run (idempotent —
+  never depends on the prior feed file). A feed is written **only** for a
+  language that has at least one track (no empty feeds).
+- The channel **title + description are translated once** (via
+  `engine.translate.translate_metadata`) and cached in
+  `digests/<slug>/channel_i18n.json`, so nightly rebuilds cost no Grok credits.
+  With no key + no cache it degrades to an autonym-suffixed English title
+  (`SpaceX Daily (Français)`) so the build always ships a valid feed.
+- The channel `<language>` is region-qualified (`fr-fr`, `ru-ru`, `es-es`,
+  `zh-cn`) so directories shelve each feed in the right locale.
+- Per-episode **GUIDs are deterministic** (`<guid_prefix>-<lang>-ep<NNN>-<date>`)
+  so a rebuild never re-notifies subscribers or double-lists an episode.
+- Enclosure byte length comes from the track's `bytes` field (captured at
+  render time in `engine/multilingual.py`); older records fall back to a
+  duration estimate.
+
+**Pipeline wiring:** the multilingual sweep
+(`.github/workflows/multilingual.yml`) rebuilds + commits the feeds right after
+it generates tracks; the nightly maintenance workflow rebuilds them again as a
+regenerable safety net. Show pages and the How-to-Listen table link the
+available language feeds (`generate_html._collect_language_feeds`).
+
+**Operator:** submit each per-language feed URL
+(`https://nerranetwork.com/<show>_podcast.<lang>.rss`) to Apple Podcasts Connect
+and Spotify for Podcasters once, the same as the English feed. Run
+`python scripts/build_language_feeds.py --all` to print the full list.
+
+Drift guards: `tests/test_language_feeds.py`.
 
 ## Scope (this pass)
 

--- a/engine/language_feeds.py
+++ b/engine/language_feeds.py
@@ -1,0 +1,293 @@
+"""Per-language podcast RSS feeds (June 2026 multilingual distribution).
+
+Background
+----------
+The multilingual stage (``scripts/generate_translations.py`` +
+``engine/translate.py``) renders alternate-language audio tracks of each
+finalized English episode and records them on the show's summaries record
+under ``translations[<lang>]`` (``audio_url`` / ``title`` / ``description`` /
+``duration_sec``). Until now those tracks were surfaced on the website only
+(the on-site language player) — never as a subscribable podcast feed.
+
+This module emits a **standalone Apple/Spotify-ready RSS feed per
+(show, language)** so each translation track is a real podcast episode in a
+real feed: ``<show>_podcast.fr.rss`` next to the canonical English
+``<show>_podcast.rss``. Each feed:
+
+* carries a **translated channel title + description** (cached in
+  ``digests/<slug>/channel_i18n.json`` so nightly rebuilds cost no Grok
+  credits; falls back to an autonym-suffixed English title when no cache and
+  no API key),
+* declares the correct BCP-47 ``<language>`` so directories shelve it in the
+  right locale,
+* lists **only** the episodes that actually have a track in that language,
+* uses a **stable, deterministic GUID** per (episode, language) so a rebuild
+  never re-notifies subscribers or duplicates an episode.
+
+Unlike ``engine.publisher.update_rss_feed`` (incremental, parses+preserves
+the prior file per episode), these feeds are rebuilt **fresh from the
+canonical summaries JSON** every run — they are fully regenerable, so the
+build is idempotent and never depends on the previous feed file.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+
+from engine.summaries_io import load_summaries
+
+logger = logging.getLogger(__name__)
+
+# BCP-47 code -> (autonym for the channel-title suffix, full locale tag for
+# the RSS <language> element). Apple/Spotify shelve a feed by its <language>,
+# so we emit a region-qualified tag rather than the bare subtag.
+LANGUAGE_META: Dict[str, Tuple[str, str]] = {
+    "fr": ("Français", "fr-fr"),
+    "ru": ("Русский", "ru-ru"),
+    "es": ("Español", "es-es"),
+    "zh": ("中文", "zh-cn"),
+}
+
+# Advisory enclosure byte-length estimate when a track record predates the
+# ``bytes`` field. The network encodes spoken-word+music VBR ~245 kbps
+# (~30 KB/s); the enclosure length is advisory only, so an estimate is the
+# standard fallback when the exact size is unknown.
+_EST_BYTES_PER_SEC = 30_000
+
+
+def supported_feed_languages() -> Tuple[str, ...]:
+    return tuple(LANGUAGE_META.keys())
+
+
+def language_autonym(lang: str) -> str:
+    return LANGUAGE_META.get(lang, (lang, lang))[0]
+
+
+def feed_locale(lang: str) -> str:
+    return LANGUAGE_META.get(lang, (lang, lang))[1]
+
+
+def feed_filename(english_rss_file: str, lang: str) -> str:
+    """``spacex_podcast.rss`` + ``fr`` -> ``spacex_podcast.fr.rss``."""
+    name = english_rss_file
+    if name.lower().endswith(".rss"):
+        return f"{name[:-4]}.{lang}.rss"
+    return f"{name}.{lang}.rss"
+
+
+# ---------------------------------------------------------------------------
+# Channel-title/description i18n cache
+# ---------------------------------------------------------------------------
+
+def _channel_i18n_path(summaries_path: Path) -> Path:
+    return Path(summaries_path).parent / "channel_i18n.json"
+
+
+def load_channel_i18n(summaries_path: Path) -> Dict[str, dict]:
+    path = _channel_i18n_path(summaries_path)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception as exc:  # noqa: BLE001 — best-effort cache
+        logger.warning("Could not read channel i18n cache %s: %s", path, exc)
+        return {}
+
+
+def save_channel_i18n(summaries_path: Path, data: Dict[str, dict]) -> None:
+    path = _channel_i18n_path(summaries_path)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def resolve_channel_i18n(
+    summaries_path: Path,
+    lang: str,
+    en_title: str,
+    en_description: str,
+    *,
+    translate_fn: Optional[Callable[[str, str, str], Tuple[str, str]]] = None,
+    refresh: bool = False,
+) -> Tuple[str, str]:
+    """Return ``(channel_title, channel_description)`` for *lang*.
+
+    Uses the on-disk cache first. When the cache is missing for *lang* (or
+    *refresh*) and a ``translate_fn`` is supplied, translates once and writes
+    the cache. With no cache and no ``translate_fn`` it degrades to an
+    autonym-suffixed English title + the English description, so a nightly
+    rebuild with no Grok key still produces a valid, shippable feed.
+
+    ``translate_fn`` has the shape ``(title, description, lang) ->
+    (title, description)`` — i.e. ``engine.translate.translate_metadata``.
+    """
+    cache = load_channel_i18n(summaries_path)
+    cached = cache.get(lang)
+    if cached and not refresh and cached.get("title"):
+        return cached["title"], cached.get("description") or en_description
+
+    if translate_fn is not None:
+        try:
+            t_title, t_desc = translate_fn(en_title, en_description, lang)
+            if t_title:
+                cache[lang] = {
+                    "title": t_title,
+                    "description": t_desc,
+                    "generated_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+                }
+                save_channel_i18n(summaries_path, cache)
+                return t_title, t_desc
+        except Exception as exc:  # noqa: BLE001 — fall through to autonym
+            logger.warning("Channel metadata translation (%s) failed: %s", lang, exc)
+
+    # Deterministic fallback: keep the brand, signal the language.
+    return f"{en_title} ({language_autonym(lang)})", en_description
+
+
+# ---------------------------------------------------------------------------
+# Feed construction
+# ---------------------------------------------------------------------------
+
+def _records_for_language(records: List[dict], lang: str) -> List[dict]:
+    """Episode records that carry a usable track for *lang*, newest first."""
+    out: List[dict] = []
+    for rec in records:
+        tr = (rec.get("translations") or {}).get(lang) or {}
+        if tr.get("audio_url"):
+            out.append(rec)
+    out.sort(key=lambda r: r.get("episode_num") or 0, reverse=True)
+    return out
+
+
+def _pub_datetime(rec: dict) -> _dt.datetime:
+    """08:00 UTC on the episode date (matches the English feed convention)."""
+    raw = str(rec.get("date") or "").strip()
+    try:
+        d = _dt.date.fromisoformat(raw[:10])
+    except ValueError:
+        d = _dt.date.today()
+    return _dt.datetime.combine(d, _dt.time(8, 0, 0), tzinfo=_dt.timezone.utc)
+
+
+def _enclosure_length(track: dict) -> str:
+    raw = track.get("bytes")
+    if isinstance(raw, int) and raw > 0:
+        return str(raw)
+    dur = track.get("duration_sec") or 0
+    try:
+        return str(int(float(dur) * _EST_BYTES_PER_SEC)) if dur else "0"
+    except (TypeError, ValueError):
+        return "0"
+
+
+def build_language_feed(
+    *,
+    slug: str,
+    lang: str,
+    summaries_path: Path,
+    out_path: Path,
+    guid_prefix: str,
+    channel_title: str,
+    channel_description: str,
+    channel_link: str,
+    channel_author: str,
+    channel_email: str,
+    channel_image: str = "",
+    channel_category: str = "Technology",
+    channel_subcategory: str = "",
+    base_url: str = "https://nerranetwork.com",
+) -> Optional[Tuple[Path, int]]:
+    """Write ``out_path`` as a podcast RSS feed of *lang* tracks.
+
+    Returns ``(out_path, episode_count)`` on success, or ``None`` when the
+    show has no episodes translated into *lang* yet (no feed is written —
+    we never publish an empty feed).
+    """
+    from feedgen.feed import FeedGenerator
+
+    from engine.audio import format_duration
+    from engine.publisher import _inject_podcast_locked_tag, _markdown_to_rss_html
+
+    if lang not in LANGUAGE_META:
+        raise ValueError(f"Unsupported feed language {lang!r}")
+
+    _wrapper, records = load_summaries(summaries_path)
+    targets = _records_for_language(records, lang)
+    if not targets:
+        logger.info("[%s/%s] no translated episodes — skipping feed", slug, lang)
+        return None
+
+    fg = FeedGenerator()
+    fg.load_extension("podcast")
+    fg.title(channel_title)
+    fg.description(channel_description)
+    fg.language(feed_locale(lang))
+
+    rss_self_url = f"{base_url.rstrip('/')}/{out_path.name}"
+    fg.link(href="https://pubsubhubbub.appspot.com/", rel="hub")
+    fg.link(href=rss_self_url, rel="self")
+    fg.link(href=channel_link or base_url)
+    fg.copyright(f"Copyright {_dt.date.today().year}")
+    fg.podcast.itunes_author(channel_author)
+    fg.podcast.itunes_summary(channel_description)
+    fg.podcast.itunes_owner(name=channel_author, email=channel_email)
+    if channel_image:
+        fg.podcast.itunes_image(channel_image)
+    if channel_subcategory:
+        fg.podcast.itunes_category({"cat": channel_category, "sub": channel_subcategory})
+    else:
+        fg.podcast.itunes_category(channel_category)
+    fg.podcast.itunes_explicit("no")
+
+    for rec in targets:
+        track = rec["translations"][lang]
+        num = int(rec.get("episode_num") or 0)
+        pub = _pub_datetime(rec)
+        # Deterministic GUID: stable across rebuilds so subscribers are never
+        # re-notified and the platform never double-lists the episode.
+        guid = f"{guid_prefix}-{lang}-ep{num:03d}-{pub:%Y%m%d}"
+
+        # ``targets`` is newest-first; append (not the feedgen default
+        # prepend) so the emitted order stays newest-first like the
+        # English feed and what podcast clients expect.
+        fe = fg.add_entry(order="append")
+        fe.id(guid)
+        fe.guid(guid, permalink=False)
+        title = track.get("title") or rec.get("episode_title") or f"Episode {num}"
+        desc = track.get("description") or title
+        fe.title(title)
+        fe.description(_markdown_to_rss_html(desc))
+        fe.enclosure(track["audio_url"], _enclosure_length(track), "audio/mpeg")
+        fe.published(pub)
+        fe.podcast.itunes_title(title)
+        fe.podcast.itunes_summary(desc)
+        fe.podcast.itunes_episode(num)
+        fe.podcast.itunes_episode_type("full")
+        fe.podcast.itunes_explicit("no")
+        dur = track.get("duration_sec")
+        if dur:
+            try:
+                fe.podcast.itunes_duration(format_duration(float(dur)))
+            except Exception:  # noqa: BLE001 — duration is advisory
+                pass
+
+    fg.lastBuildDate(_dt.datetime.now(_dt.timezone.utc))
+
+    import os
+    import tempfile
+
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".rss", dir=str(out_path.parent))
+    os.close(tmp_fd)
+    try:
+        fg.rss_file(tmp_path, pretty=True)
+        _inject_podcast_locked_tag(Path(tmp_path), channel_email or "patrick@planetterrian.com")
+        os.replace(tmp_path, str(out_path))
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+    logger.info("[%s/%s] wrote %s (%d episodes)", slug, lang, out_path.name, len(targets))
+    return out_path, len(targets)

--- a/engine/multilingual.py
+++ b/engine/multilingual.py
@@ -174,6 +174,10 @@ def generate_for_episode(
         local_mp3 = output_dir / f"{tts_file.stem.replace('_tts', '')}.{lang}.mp3"
         render_track(translated, lang, voice_id, api_key, local_mp3, max_chars)
         dur = ffprobe_duration(str(local_mp3))
+        try:
+            size_bytes = local_mp3.stat().st_size
+        except OSError:
+            size_bytes = 0
 
         en_dur = ffprobe_duration(english_url)
         if en_dur and dur:
@@ -201,6 +205,10 @@ def generate_for_episode(
             "title": t_title,
             "description": t_desc,
             "duration_sec": round(dur, 1) if dur else 0,
+            # Exact enclosure byte length for the per-language podcast feed
+            # (engine.language_feeds). Falls back to a duration estimate for
+            # records that predate this field.
+            "bytes": size_bytes,
             "generated_at": datetime.now(timezone.utc).isoformat(),
         })
         results[lang] = "done"

--- a/env_intel_podcast.es.rss
+++ b/env_intel_podcast.es.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Environmental Intelligence (Español)</title>
+    <link>https://nerranetwork.com/env-intel.html</link>
+    <description>The environmental compliance briefing for Canadian practitioners, published every other weekday. Each episode opens with a scannable Compliance Brief you can forward to your team, then regulatory updates across provincial and federal jurisdictions, contaminated sites and remediation news, and a practitioner field lesson with the most common mistake and its fix.</description>
+    <atom:link href="https://nerranetwork.com/env_intel_podcast.es.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>es-es</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Environmental Intelligence</itunes:author>
+    <itunes:category text="Science">
+      <itunes:category text="Earth Sciences" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/environmental-intelligence.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Environmental Intelligence</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>The environmental compliance briefing for Canadian practitioners, published every other weekday. Each episode opens with a scannable Compliance Brief you can forward to your team, then regulatory updates across provincial and federal jurisdictions, contaminated sites and remediation news, and a practitioner field lesson with the most common mistake and its fix.</itunes:summary>
+    <item>
+      <title>Ep 45: Newfoundland avanza en la remediación de 25 años de un sitio de salsa de pescado que requiere 200 viajes de camiones volquete en St. Mary’s</title>
+      <description>Newfoundland avanza en la remediación de 25 años de un sitio de salsa de pescado que requiere 200 viajes de camiones volquete en St. Mary’s</description>
+      <guid isPermaLink="false">env-intel-es-ep045-20260615</guid>
+      <enclosure url="https://audio.nerranetwork.com/env_intel/Env_Intel_Ep045_20260615.es.mp3" length="16551000" type="audio/mpeg" />
+      <pubDate>Mon, 15 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>09:11</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Newfoundland avanza en la remediación de 25 años de un sitio de salsa de pescado que requiere 200 viajes de camiones volquete en St. Mary’s</itunes:summary>
+      <itunes:episode>45</itunes:episode>
+      <itunes:title>Ep 45: Newfoundland avanza en la remediación de 25 años de un sitio de salsa de pescado que requiere 200 viajes de camiones volquete en St. Mary’s</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/env_intel_podcast.fr.rss
+++ b/env_intel_podcast.fr.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Environmental Intelligence (Français)</title>
+    <link>https://nerranetwork.com/env-intel.html</link>
+    <description>The environmental compliance briefing for Canadian practitioners, published every other weekday. Each episode opens with a scannable Compliance Brief you can forward to your team, then regulatory updates across provincial and federal jurisdictions, contaminated sites and remediation news, and a practitioner field lesson with the most common mistake and its fix.</description>
+    <atom:link href="https://nerranetwork.com/env_intel_podcast.fr.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>fr-fr</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Environmental Intelligence</itunes:author>
+    <itunes:category text="Science">
+      <itunes:category text="Earth Sciences" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/environmental-intelligence.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Environmental Intelligence</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>The environmental compliance briefing for Canadian practitioners, published every other weekday. Each episode opens with a scannable Compliance Brief you can forward to your team, then regulatory updates across provincial and federal jurisdictions, contaminated sites and remediation news, and a practitioner field lesson with the most common mistake and its fix.</itunes:summary>
+    <item>
+      <title>Ép 45 : Newfoundland fait progresser la remédiation d’un site de sauce de poisson vieille de 25 ans, nécessitant 200 allers-retours de camions-bennes à St. Mary’s</title>
+      <description>Newfoundland fait progresser la remédiation d’un site de sauce de poisson vieille de 25 ans, nécessitant 200 allers-retours de camions-bennes à St. Mary’s.</description>
+      <guid isPermaLink="false">env-intel-fr-ep045-20260615</guid>
+      <enclosure url="https://audio.nerranetwork.com/env_intel/Env_Intel_Ep045_20260615.fr.mp3" length="13491000" type="audio/mpeg" />
+      <pubDate>Mon, 15 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>07:29</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Newfoundland fait progresser la remédiation d’un site de sauce de poisson vieille de 25 ans, nécessitant 200 allers-retours de camions-bennes à St. Mary’s.</itunes:summary>
+      <itunes:episode>45</itunes:episode>
+      <itunes:title>Ép 45 : Newfoundland fait progresser la remédiation d’un site de sauce de poisson vieille de 25 ans, nécessitant 200 allers-retours de camions-bennes à St. Mary’s</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/env_intel_podcast.ru.rss
+++ b/env_intel_podcast.ru.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Environmental Intelligence (Русский)</title>
+    <link>https://nerranetwork.com/env-intel.html</link>
+    <description>The environmental compliance briefing for Canadian practitioners, published every other weekday. Each episode opens with a scannable Compliance Brief you can forward to your team, then regulatory updates across provincial and federal jurisdictions, contaminated sites and remediation news, and a practitioner field lesson with the most common mistake and its fix.</description>
+    <atom:link href="https://nerranetwork.com/env_intel_podcast.ru.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>ru-ru</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Environmental Intelligence</itunes:author>
+    <itunes:category text="Science">
+      <itunes:category text="Earth Sciences" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/environmental-intelligence.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Environmental Intelligence</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>The environmental compliance briefing for Canadian practitioners, published every other weekday. Each episode opens with a scannable Compliance Brief you can forward to your team, then regulatory updates across provincial and federal jurisdictions, contaminated sites and remediation news, and a practitioner field lesson with the most common mistake and its fix.</itunes:summary>
+    <item>
+      <title>Эп 45: Ньюфаундленд продвигает 25-летнюю рекультивацию участка по производству рыбного соуса — потребуется 200 рейсов самосвалов в Сент-Мэрис</title>
+      <description>Ньюфаундленд продвигает 25-летнюю рекультивацию участка по производству рыбного соуса — потребуется 200 рейсов самосвалов в Сент-Мэрис</description>
+      <guid isPermaLink="false">env-intel-ru-ep045-20260615</guid>
+      <enclosure url="https://audio.nerranetwork.com/env_intel/Env_Intel_Ep045_20260615.ru.mp3" length="13227000" type="audio/mpeg" />
+      <pubDate>Mon, 15 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>07:20</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Ньюфаундленд продвигает 25-летнюю рекультивацию участка по производству рыбного соуса — потребуется 200 рейсов самосвалов в Сент-Мэрис</itunes:summary>
+      <itunes:episode>45</itunes:episode>
+      <itunes:title>Эп 45: Ньюфаундленд продвигает 25-летнюю рекультивацию участка по производству рыбного соуса — потребуется 200 рейсов самосвалов в Сент-Мэрис</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/fascinating_frontiers_podcast.es.rss
+++ b/fascinating_frontiers_podcast.es.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Fascinating Frontiers (Español)</title>
+    <link>https://nerranetwork.com/fascinating_frontiers.html</link>
+    <description>Daily space and astronomy news: NASA and SpaceX missions, ESA operations, exoplanet and James Webb discoveries, and the engineering behind humanity's push into the cosmos — with ongoing story tracking across Starship, Artemis, and deep-space science. For space enthusiasts, engineers, and the curious.</description>
+    <atom:link href="https://nerranetwork.com/fascinating_frontiers_podcast.es.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>es-es</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Science">
+      <itunes:category text="Astronomy" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/fascinating-frontiers.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily space and astronomy news: NASA and SpaceX missions, ESA operations, exoplanet and James Webb discoveries, and the engineering behind humanity's push into the cosmos — with ongoing story tracking across Starship, Artemis, and deep-space science. For space enthusiasts, engineers, and the curious.</itunes:summary>
+    <item>
+      <title>Ep 103: La sonda Tianwen-2 de China realiza una serie de encendidos precisos para llegar a su asteroide objetivo el próximo mes.</title>
+      <description>La sonda Tianwen-2 de China realiza una serie de encendidos precisos para llegar a su asteroide objetivo el próximo mes.</description>
+      <guid isPermaLink="false">fascinating-frontiers-es-ep103-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep103_20260616.es.mp3" length="23427000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>13:00</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>La sonda Tianwen-2 de China realiza una serie de encendidos precisos para llegar a su asteroide objetivo el próximo mes.</itunes:summary>
+      <itunes:episode>103</itunes:episode>
+      <itunes:title>Ep 103: La sonda Tianwen-2 de China realiza una serie de encendidos precisos para llegar a su asteroide objetivo el próximo mes.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/fascinating_frontiers_podcast.fr.rss
+++ b/fascinating_frontiers_podcast.fr.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Fascinating Frontiers (Français)</title>
+    <link>https://nerranetwork.com/fascinating_frontiers.html</link>
+    <description>Daily space and astronomy news: NASA and SpaceX missions, ESA operations, exoplanet and James Webb discoveries, and the engineering behind humanity's push into the cosmos — with ongoing story tracking across Starship, Artemis, and deep-space science. For space enthusiasts, engineers, and the curious.</description>
+    <atom:link href="https://nerranetwork.com/fascinating_frontiers_podcast.fr.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>fr-fr</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Science">
+      <itunes:category text="Astronomy" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/fascinating-frontiers.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily space and astronomy news: NASA and SpaceX missions, ESA operations, exoplanet and James Webb discoveries, and the engineering behind humanity's push into the cosmos — with ongoing story tracking across Starship, Artemis, and deep-space science. For space enthusiasts, engineers, and the curious.</itunes:summary>
+    <item>
+      <title>Ép 103 : La sonde chinoise Tianwen-2 effectue une série de corrections de trajectoire précises pour rejoindre son astéroïde cible le mois prochain.</title>
+      <description>La sonde chinoise Tianwen-2 effectue une série de corrections de trajectoire précises pour rejoindre son astéroïde cible le mois prochain.</description>
+      <guid isPermaLink="false">fascinating-frontiers-fr-ep103-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep103_20260616.fr.mp3" length="21717000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>12:03</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>La sonde chinoise Tianwen-2 effectue une série de corrections de trajectoire précises pour rejoindre son astéroïde cible le mois prochain.</itunes:summary>
+      <itunes:episode>103</itunes:episode>
+      <itunes:title>Ép 103 : La sonde chinoise Tianwen-2 effectue une série de corrections de trajectoire précises pour rejoindre son astéroïde cible le mois prochain.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/fascinating_frontiers_podcast.ru.rss
+++ b/fascinating_frontiers_podcast.ru.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Fascinating Frontiers (Русский)</title>
+    <link>https://nerranetwork.com/fascinating_frontiers.html</link>
+    <description>Daily space and astronomy news: NASA and SpaceX missions, ESA operations, exoplanet and James Webb discoveries, and the engineering behind humanity's push into the cosmos — with ongoing story tracking across Starship, Artemis, and deep-space science. For space enthusiasts, engineers, and the curious.</description>
+    <atom:link href="https://nerranetwork.com/fascinating_frontiers_podcast.ru.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>ru-ru</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Science">
+      <itunes:category text="Astronomy" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/fascinating-frontiers.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily space and astronomy news: NASA and SpaceX missions, ESA operations, exoplanet and James Webb discoveries, and the engineering behind humanity's push into the cosmos — with ongoing story tracking across Starship, Artemis, and deep-space science. For space enthusiasts, engineers, and the curious.</itunes:summary>
+    <item>
+      <title>Ep 103: Китайский зонд Tianwen-2 выполняет серию точных коррекций, чтобы достичь целевого астероида в следующем месяце</title>
+      <description>Китайский зонд Tianwen-2 выполняет серию точных коррекций, чтобы достичь целевого астероида в следующем месяце</description>
+      <guid isPermaLink="false">fascinating-frontiers-ru-ep103-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep103_20260616.ru.mp3" length="19167000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>10:38</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Китайский зонд Tianwen-2 выполняет серию точных коррекций, чтобы достичь целевого астероида в следующем месяце</itunes:summary>
+      <itunes:episode>103</itunes:episode>
+      <itunes:title>Ep 103: Китайский зонд Tianwen-2 выполняет серию точных коррекций, чтобы достичь целевого астероида в следующем месяце</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/fascinating_frontiers_podcast.zh.rss
+++ b/fascinating_frontiers_podcast.zh.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Fascinating Frontiers (中文)</title>
+    <link>https://nerranetwork.com/fascinating_frontiers.html</link>
+    <description>Daily space and astronomy news: NASA and SpaceX missions, ESA operations, exoplanet and James Webb discoveries, and the engineering behind humanity's push into the cosmos — with ongoing story tracking across Starship, Artemis, and deep-space science. For space enthusiasts, engineers, and the curious.</description>
+    <atom:link href="https://nerranetwork.com/fascinating_frontiers_podcast.zh.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>zh-cn</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Science">
+      <itunes:category text="Astronomy" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/fascinating-frontiers.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily space and astronomy news: NASA and SpaceX missions, ESA operations, exoplanet and James Webb discoveries, and the engineering behind humanity's push into the cosmos — with ongoing story tracking across Starship, Artemis, and deep-space science. For space enthusiasts, engineers, and the curious.</itunes:summary>
+    <item>
+      <title>Ep 103: 中国的Tianwen-2探测器正执行一系列精细轨道机动，计划下个月抵达目标小行星</title>
+      <description>中国的Tianwen-2探测器正执行一系列精细轨道机动，计划下个月抵达目标小行星</description>
+      <guid isPermaLink="false">fascinating-frontiers-zh-ep103-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep103_20260616.zh.mp3" length="20388000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>11:19</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>中国的Tianwen-2探测器正执行一系列精细轨道机动，计划下个月抵达目标小行星</itunes:summary>
+      <itunes:episode>103</itunes:episode>
+      <itunes:title>Ep 103: 中国的Tianwen-2探测器正执行一系列精细轨道机动，计划下个月抵达目标小行星</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/first_principles_podcast.es.rss
+++ b/first_principles_podcast.es.rss
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>First Principles Daily (Español)</title>
+    <link>https://nerranetwork.com/first-principles.html</link>
+    <description>A daily narrative podcast that reasons about the world from first principles — the 'magic wand number' and the 'Idiot Index'. Episodes alternate between a concrete example of first-principles thinking in action (historical and modern — Ford, Bessemer, the shipping container, solar, batteries, and sometimes Musk's teams) and a deep exposé on an industry ripe for the same treatment.</description>
+    <atom:link href="https://nerranetwork.com/first_principles_podcast.es.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>es-es</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/first-principles-daily.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>A daily narrative podcast that reasons about the world from first principles — the 'magic wand number' and the 'Idiot Index'. Episodes alternate between a concrete example of first-principles thinking in action (historical and modern — Ford, Bessemer, the shipping container, solar, batteries, and sometimes Musk's teams) and a deep exposé on an industry ripe for the same treatment.</itunes:summary>
+    <item>
+      <title>Ep 11: Las líneas de transmisión que podrían costar solo unas pocas veces su cobre y acero ahora cuestan muchas veces más, porque el gasto real está en permisos, colas y construcciones a medida.</title>
+      <description>Las líneas de transmisión que podrían costar solo unas pocas veces su cobre y acero ahora cuestan muchas veces más, porque el gasto real está en permisos, colas y construcciones a medida.</description>
+      <guid isPermaLink="false">first-principles-es-ep011-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/first_principles/First_Principles_Ep011_20260616.es.mp3" length="15324000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>08:30</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Las líneas de transmisión que podrían costar solo unas pocas veces su cobre y acero ahora cuestan muchas veces más, porque el gasto real está en permisos, colas y construcciones a medida.</itunes:summary>
+      <itunes:episode>11</itunes:episode>
+      <itunes:title>Ep 11: Las líneas de transmisión que podrían costar solo unas pocas veces su cobre y acero ahora cuestan muchas veces más, porque el gasto real está en permisos, colas y construcciones a medida.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/first_principles_podcast.fr.rss
+++ b/first_principles_podcast.fr.rss
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>First Principles Daily (Français)</title>
+    <link>https://nerranetwork.com/first-principles.html</link>
+    <description>A daily narrative podcast that reasons about the world from first principles — the 'magic wand number' and the 'Idiot Index'. Episodes alternate between a concrete example of first-principles thinking in action (historical and modern — Ford, Bessemer, the shipping container, solar, batteries, and sometimes Musk's teams) and a deep exposé on an industry ripe for the same treatment.</description>
+    <atom:link href="https://nerranetwork.com/first_principles_podcast.fr.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>fr-fr</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/first-principles-daily.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>A daily narrative podcast that reasons about the world from first principles — the 'magic wand number' and the 'Idiot Index'. Episodes alternate between a concrete example of first-principles thinking in action (historical and modern — Ford, Bessemer, the shipping container, solar, batteries, and sometimes Musk's teams) and a deep exposé on an industry ripe for the same treatment.</itunes:summary>
+    <item>
+      <title>Ép 11 : Les lignes de transport qui ne devraient coûter que quelques fois le prix de leur cuivre et acier finissent par en coûter plusieurs fois plus, car les vraies dépenses se trouvent dans les permis, les files d’attente et les constructions sur mesure.</title>
+      <description>Les lignes de transport qui ne devraient coûter que quelques fois le prix de leur cuivre et acier finissent par en coûter plusieurs fois plus, car les vraies dépenses se trouvent dans les permis, les files d’attente et les constructions sur mesure.</description>
+      <guid isPermaLink="false">first-principles-fr-ep011-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/first_principles/First_Principles_Ep011_20260616.fr.mp3" length="243000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>00:08</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Les lignes de transport qui ne devraient coûter que quelques fois le prix de leur cuivre et acier finissent par en coûter plusieurs fois plus, car les vraies dépenses se trouvent dans les permis, les files d’attente et les constructions sur mesure.</itunes:summary>
+      <itunes:episode>11</itunes:episode>
+      <itunes:title>Ép 11 : Les lignes de transport qui ne devraient coûter que quelques fois le prix de leur cuivre et acier finissent par en coûter plusieurs fois plus, car les vraies dépenses se trouvent dans les permis, les files d’attente et les constructions sur mesure.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/first_principles_podcast.ru.rss
+++ b/first_principles_podcast.ru.rss
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>First Principles Daily (Русский)</title>
+    <link>https://nerranetwork.com/first-principles.html</link>
+    <description>A daily narrative podcast that reasons about the world from first principles — the 'magic wand number' and the 'Idiot Index'. Episodes alternate between a concrete example of first-principles thinking in action (historical and modern — Ford, Bessemer, the shipping container, solar, batteries, and sometimes Musk's teams) and a deep exposé on an industry ripe for the same treatment.</description>
+    <atom:link href="https://nerranetwork.com/first_principles_podcast.ru.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>ru-ru</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/first-principles-daily.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>A daily narrative podcast that reasons about the world from first principles — the 'magic wand number' and the 'Idiot Index'. Episodes alternate between a concrete example of first-principles thinking in action (historical and modern — Ford, Bessemer, the shipping container, solar, batteries, and sometimes Musk's teams) and a deep exposé on an industry ripe for the same treatment.</itunes:summary>
+    <item>
+      <title>Эп. 11: Линии электропередачи, которые могли бы стоить в несколько раз дороже меди и стали, теперь обходятся во много раз дороже — основные расходы приходятся на разрешения, очереди и индивидуальные проекты.</title>
+      <description>Линии электропередачи, которые могли бы стоить в несколько раз дороже меди и стали, теперь обходятся во много раз дороже — основные расходы приходятся на разрешения, очереди и индивидуальные проекты.</description>
+      <guid isPermaLink="false">first-principles-ru-ep011-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/first_principles/First_Principles_Ep011_20260616.ru.mp3" length="13512000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>07:30</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Линии электропередачи, которые могли бы стоить в несколько раз дороже меди и стали, теперь обходятся во много раз дороже — основные расходы приходятся на разрешения, очереди и индивидуальные проекты.</itunes:summary>
+      <itunes:episode>11</itunes:episode>
+      <itunes:title>Эп. 11: Линии электропередачи, которые могли бы стоить в несколько раз дороже меди и стали, теперь обходятся во много раз дороже — основные расходы приходятся на разрешения, очереди и индивидуальные проекты.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/first_principles_podcast.zh.rss
+++ b/first_principles_podcast.zh.rss
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>First Principles Daily (中文)</title>
+    <link>https://nerranetwork.com/first-principles.html</link>
+    <description>A daily narrative podcast that reasons about the world from first principles — the 'magic wand number' and the 'Idiot Index'. Episodes alternate between a concrete example of first-principles thinking in action (historical and modern — Ford, Bessemer, the shipping container, solar, batteries, and sometimes Musk's teams) and a deep exposé on an industry ripe for the same treatment.</description>
+    <atom:link href="https://nerranetwork.com/first_principles_podcast.zh.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>zh-cn</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/first-principles-daily.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>A daily narrative podcast that reasons about the world from first principles — the 'magic wand number' and the 'Idiot Index'. Episodes alternate between a concrete example of first-principles thinking in action (historical and modern — Ford, Bessemer, the shipping container, solar, batteries, and sometimes Musk's teams) and a deep exposé on an industry ripe for the same treatment.</itunes:summary>
+    <item>
+      <title>Ep 11：输电线路原本只需铜和钢材成本的几倍，如今费用却高出许多，真正的开支在于许可、排队和定制建造。</title>
+      <description>输电线路原本只需铜和钢材成本的几倍，如今费用却高出许多，真正的开支在于许可、排队和定制建造。</description>
+      <guid isPermaLink="false">first-principles-zh-ep011-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/first_principles/First_Principles_Ep011_20260616.zh.mp3" length="12972000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>07:12</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>输电线路原本只需铜和钢材成本的几倍，如今费用却高出许多，真正的开支在于许可、排队和定制建造。</itunes:summary>
+      <itunes:episode>11</itunes:episode>
+      <itunes:title>Ep 11：输电线路原本只需铜和钢材成本的几倍，如今费用却高出许多，真正的开支在于许可、排队和定制建造。</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/generate_html.py
+++ b/generate_html.py
@@ -107,6 +107,25 @@ def _read_show_image_provider(slug: str) -> str:
     return (yt.get("image_provider") or "pexels").strip().lower() or "pexels"
 
 
+def _collect_language_feeds(rss_file: str, prefix: str) -> list:
+    """Return the per-language podcast feeds that exist for a show.
+
+    Scans for ``<rss_stem>.<lang>.rss`` siblings of the English feed (built
+    by ``scripts/build_language_feeds.py``) and returns a list of
+    ``{"lang", "label", "url"}`` for the show page / how-to-listen table.
+    Empty when no translated feed has been built yet, so the template
+    renders nothing for English-only shows.
+    """
+    from engine.language_feeds import LANGUAGE_META, feed_filename
+
+    feeds = []
+    for lang, (autonym, _locale) in LANGUAGE_META.items():
+        fname = feed_filename(rss_file, lang)
+        if (ROOT / fname).exists():
+            feeds.append({"lang": lang, "label": autonym, "url": f"{prefix}{fname}"})
+    return feeds
+
+
 # ---------------------------------------------------------------------------
 # Marketing / Analytics configuration
 # ---------------------------------------------------------------------------
@@ -1547,6 +1566,7 @@ def _build_all_shows_list():
             "summaries_page": cfg["summaries_page"],
             "podcast_image": cfg["podcast_image"],
             "rss_file": cfg["rss_file"],
+            "language_feeds": _collect_language_feeds(cfg["rss_file"], ""),
             "brand_color": cfg["brand_color"],
             "tagline": cfg["tagline"],
             "schedule": cfg.get("schedule", "Daily"),
@@ -2251,6 +2271,7 @@ def generate_show_page(slug, *, dry_run=False):
         "schema_web_feed": f"{GITHUB_RAW}/{cfg['rss_file']}",
         "schema_image_url": f"{GITHUB_RAW}/{cfg['podcast_image'].lstrip('/')}",
         "rss_url": f"{prefix}{cfg['rss_file']}",
+        "language_feeds": _collect_language_feeds(cfg["rss_file"], prefix),
         "related_show": related_show_data,
         "blog_page": f"blog/{cfg['slug']}/index.html",
         "latest_blog_posts": latest_blog_posts,

--- a/models_agents_beginners_podcast.es.rss
+++ b/models_agents_beginners_podcast.es.rss
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Models &amp; Agents for Beginners (Español)</title>
+    <link>https://nerranetwork.com/models-agents-beginners.html</link>
+    <description>AI for beginners and teens — daily episodes that explain how models and agents actually work, with free hands-on experiments you can try in minutes, no coding needed. Our sister show Models &amp; Agents covers the expert builder view; this is the same AI universe explained for everyone. Every expert started exactly here.</description>
+    <atom:link href="https://nerranetwork.com/models_agents_beginners_podcast.es.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>es-es</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/models-agents-beginners.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>AI for beginners and teens — daily episodes that explain how models and agents actually work, with free hands-on experiments you can try in minutes, no coding needed. Our sister show Models &amp; Agents covers the expert builder view; this is the same AI universe explained for everyone. Every expert started exactly here.</itunes:summary>
+    <item>
+      <title>Ep 73: Un nuevo modelo de IA acaba de dar un gran salto adelante, y puede que ya estés usando algo similar sin saberlo.</title>
+      <description>Un nuevo modelo de IA acaba de dar un gran salto adelante, y puede que ya estés usando algo similar sin saberlo.</description>
+      <guid isPermaLink="false">mab-es-ep073-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep073_20260616.es.mp3" length="13713000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>07:37</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Un nuevo modelo de IA acaba de dar un gran salto adelante, y puede que ya estés usando algo similar sin saberlo.</itunes:summary>
+      <itunes:episode>73</itunes:episode>
+      <itunes:title>Ep 73: Un nuevo modelo de IA acaba de dar un gran salto adelante, y puede que ya estés usando algo similar sin saberlo.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/models_agents_beginners_podcast.fr.rss
+++ b/models_agents_beginners_podcast.fr.rss
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Models &amp; Agents for Beginners (Français)</title>
+    <link>https://nerranetwork.com/models-agents-beginners.html</link>
+    <description>AI for beginners and teens — daily episodes that explain how models and agents actually work, with free hands-on experiments you can try in minutes, no coding needed. Our sister show Models &amp; Agents covers the expert builder view; this is the same AI universe explained for everyone. Every expert started exactly here.</description>
+    <atom:link href="https://nerranetwork.com/models_agents_beginners_podcast.fr.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>fr-fr</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/models-agents-beginners.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>AI for beginners and teens — daily episodes that explain how models and agents actually work, with free hands-on experiments you can try in minutes, no coding needed. Our sister show Models &amp; Agents covers the expert builder view; this is the same AI universe explained for everyone. Every expert started exactly here.</itunes:summary>
+    <item>
+      <title>Ép 73 : Un nouveau modèle d’IA vient de faire un bond en avant majeur, et vous en utilisez peut-être déjà un sans le savoir</title>
+      <description>Un nouveau modèle d’IA vient de faire un bond en avant majeur, et vous en utilisez peut-être déjà un sans le savoir</description>
+      <guid isPermaLink="false">mab-fr-ep073-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep073_20260616.fr.mp3" length="12222000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>06:47</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Un nouveau modèle d’IA vient de faire un bond en avant majeur, et vous en utilisez peut-être déjà un sans le savoir</itunes:summary>
+      <itunes:episode>73</itunes:episode>
+      <itunes:title>Ép 73 : Un nouveau modèle d’IA vient de faire un bond en avant majeur, et vous en utilisez peut-être déjà un sans le savoir</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/models_agents_beginners_podcast.ru.rss
+++ b/models_agents_beginners_podcast.ru.rss
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Models &amp; Agents for Beginners (Русский)</title>
+    <link>https://nerranetwork.com/models-agents-beginners.html</link>
+    <description>AI for beginners and teens — daily episodes that explain how models and agents actually work, with free hands-on experiments you can try in minutes, no coding needed. Our sister show Models &amp; Agents covers the expert builder view; this is the same AI universe explained for everyone. Every expert started exactly here.</description>
+    <atom:link href="https://nerranetwork.com/models_agents_beginners_podcast.ru.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>ru-ru</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/models-agents-beginners.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>AI for beginners and teens — daily episodes that explain how models and agents actually work, with free hands-on experiments you can try in minutes, no coding needed. Our sister show Models &amp; Agents covers the expert builder view; this is the same AI universe explained for everyone. Every expert started exactly here.</itunes:summary>
+    <item>
+      <title>Эп. 73: Новая модель ИИ совершила огромный прорыв, и вы, возможно, уже пользуетесь чем-то подобным, даже не зная об этом</title>
+      <description>Новая модель ИИ совершила огромный прорыв, и вы, возможно, уже пользуетесь чем-то подобным, даже не зная об этом</description>
+      <guid isPermaLink="false">mab-ru-ep073-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep073_20260616.ru.mp3" length="11154000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>06:11</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Новая модель ИИ совершила огромный прорыв, и вы, возможно, уже пользуетесь чем-то подобным, даже не зная об этом</itunes:summary>
+      <itunes:episode>73</itunes:episode>
+      <itunes:title>Эп. 73: Новая модель ИИ совершила огромный прорыв, и вы, возможно, уже пользуетесь чем-то подобным, даже не зная об этом</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/models_agents_beginners_podcast.zh.rss
+++ b/models_agents_beginners_podcast.zh.rss
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Models &amp; Agents for Beginners (中文)</title>
+    <link>https://nerranetwork.com/models-agents-beginners.html</link>
+    <description>AI for beginners and teens — daily episodes that explain how models and agents actually work, with free hands-on experiments you can try in minutes, no coding needed. Our sister show Models &amp; Agents covers the expert builder view; this is the same AI universe explained for everyone. Every expert started exactly here.</description>
+    <atom:link href="https://nerranetwork.com/models_agents_beginners_podcast.zh.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>zh-cn</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/models-agents-beginners.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>AI for beginners and teens — daily episodes that explain how models and agents actually work, with free hands-on experiments you can try in minutes, no coding needed. Our sister show Models &amp; Agents covers the expert builder view; this is the same AI universe explained for everyone. Every expert started exactly here.</itunes:summary>
+    <item>
+      <title>Ep 73：一款新 AI 模型取得重大飞跃，你可能已在不知情中使用类似产品</title>
+      <description>一款新 AI 模型取得重大飞跃，你可能已在不知情中使用类似产品</description>
+      <guid isPermaLink="false">mab-zh-ep073-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep073_20260616.zh.mp3" length="11778000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>06:32</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>一款新 AI 模型取得重大飞跃，你可能已在不知情中使用类似产品</itunes:summary>
+      <itunes:episode>73</itunes:episode>
+      <itunes:title>Ep 73：一款新 AI 模型取得重大飞跃，你可能已在不知情中使用类似产品</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/models_agents_podcast.es.rss
+++ b/models_agents_podcast.es.rss
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Models &amp; Agents (Español)</title>
+    <link>https://nerranetwork.com/models-agents.html</link>
+    <description>Your daily briefing on AI models and agents: new releases from the frontier labs, open-weight drops, agent frameworks, benchmarks, pricing, and practical tools you can use the same day — with long-running program tracking so you always know where the big stories stand. For developers, builders, and AI practitioners.</description>
+    <atom:link href="https://nerranetwork.com/models_agents_podcast.es.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>es-es</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/models-agents.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Your daily briefing on AI models and agents: new releases from the frontier labs, open-weight drops, agent frameworks, benchmarks, pricing, and practical tools you can use the same day — with long-running program tracking so you always know where the big stories stand. For developers, builders, and AI practitioners.</itunes:summary>
+    <item>
+      <title>Ep 82: Los controles de exportación sobre Fable-5 ya bloquean los flujos de trabajo de corrección de código en los que los defensores confían a diario.</title>
+      <description>Los controles de exportación sobre Fable-5 ya bloquean los flujos de trabajo de corrección de código en los que los defensores confían a diario.</description>
+      <guid isPermaLink="false">models-agents-es-ep082-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/models_agents/Models_Agents_Ep082_20260616.es.mp3" length="22719000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>12:37</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Los controles de exportación sobre Fable-5 ya bloquean los flujos de trabajo de corrección de código en los que los defensores confían a diario.</itunes:summary>
+      <itunes:episode>82</itunes:episode>
+      <itunes:title>Ep 82: Los controles de exportación sobre Fable-5 ya bloquean los flujos de trabajo de corrección de código en los que los defensores confían a diario.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/models_agents_podcast.fr.rss
+++ b/models_agents_podcast.fr.rss
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Models &amp; Agents (Français)</title>
+    <link>https://nerranetwork.com/models-agents.html</link>
+    <description>Your daily briefing on AI models and agents: new releases from the frontier labs, open-weight drops, agent frameworks, benchmarks, pricing, and practical tools you can use the same day — with long-running program tracking so you always know where the big stories stand. For developers, builders, and AI practitioners.</description>
+    <atom:link href="https://nerranetwork.com/models_agents_podcast.fr.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>fr-fr</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/models-agents.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Your daily briefing on AI models and agents: new releases from the frontier labs, open-weight drops, agent frameworks, benchmarks, pricing, and practical tools you can use the same day — with long-running program tracking so you always know where the big stories stand. For developers, builders, and AI practitioners.</itunes:summary>
+    <item>
+      <title>Ép 82 : Les contrôles à l’exportation sur Fable-5 bloquent désormais les flux de travail exacts de correction de code dont les défenseurs dépendent au quotidien.</title>
+      <description>Les contrôles à l’exportation sur Fable-5 bloquent désormais les flux de travail exacts de correction de code dont les défenseurs dépendent au quotidien.</description>
+      <guid isPermaLink="false">models-agents-fr-ep082-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/models_agents/Models_Agents_Ep082_20260616.fr.mp3" length="20574000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>11:25</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Les contrôles à l’exportation sur Fable-5 bloquent désormais les flux de travail exacts de correction de code dont les défenseurs dépendent au quotidien.</itunes:summary>
+      <itunes:episode>82</itunes:episode>
+      <itunes:title>Ép 82 : Les contrôles à l’exportation sur Fable-5 bloquent désormais les flux de travail exacts de correction de code dont les défenseurs dépendent au quotidien.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/models_agents_podcast.ru.rss
+++ b/models_agents_podcast.ru.rss
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Models &amp; Agents (Русский)</title>
+    <link>https://nerranetwork.com/models-agents.html</link>
+    <description>Your daily briefing on AI models and agents: new releases from the frontier labs, open-weight drops, agent frameworks, benchmarks, pricing, and practical tools you can use the same day — with long-running program tracking so you always know where the big stories stand. For developers, builders, and AI practitioners.</description>
+    <atom:link href="https://nerranetwork.com/models_agents_podcast.ru.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>ru-ru</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/models-agents.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Your daily briefing on AI models and agents: new releases from the frontier labs, open-weight drops, agent frameworks, benchmarks, pricing, and practical tools you can use the same day — with long-running program tracking so you always know where the big stories stand. For developers, builders, and AI practitioners.</itunes:summary>
+    <item>
+      <title>Эп. 82: Ограничения экспорта Fable-5 теперь блокируют те самые рабочие процессы по исправлению кода, на которые ежедневно полагаются защитники</title>
+      <description>Ограничения экспорта Fable-5 теперь блокируют те самые рабочие процессы по исправлению кода, на которые ежедневно полагаются защитники.</description>
+      <guid isPermaLink="false">models-agents-ru-ep082-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/models_agents/Models_Agents_Ep082_20260616.ru.mp3" length="18144000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>10:04</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Ограничения экспорта Fable-5 теперь блокируют те самые рабочие процессы по исправлению кода, на которые ежедневно полагаются защитники.</itunes:summary>
+      <itunes:episode>82</itunes:episode>
+      <itunes:title>Эп. 82: Ограничения экспорта Fable-5 теперь блокируют те самые рабочие процессы по исправлению кода, на которые ежедневно полагаются защитники</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/models_agents_podcast.zh.rss
+++ b/models_agents_podcast.zh.rss
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Models &amp; Agents (中文)</title>
+    <link>https://nerranetwork.com/models-agents.html</link>
+    <description>Your daily briefing on AI models and agents: new releases from the frontier labs, open-weight drops, agent frameworks, benchmarks, pricing, and practical tools you can use the same day — with long-running program tracking so you always know where the big stories stand. For developers, builders, and AI practitioners.</description>
+    <atom:link href="https://nerranetwork.com/models_agents_podcast.zh.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>zh-cn</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/models-agents.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Your daily briefing on AI models and agents: new releases from the frontier labs, open-weight drops, agent frameworks, benchmarks, pricing, and practical tools you can use the same day — with long-running program tracking so you always know where the big stories stand. For developers, builders, and AI practitioners.</itunes:summary>
+    <item>
+      <title>第82集：Fable-5 出口管制现已阻断防御者日常依赖的代码修复工作流</title>
+      <description>Fable-5 出口管制现已阻断防御者日常依赖的代码修复工作流</description>
+      <guid isPermaLink="false">models-agents-zh-ep082-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/models_agents/Models_Agents_Ep082_20260616.zh.mp3" length="18792000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>10:26</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Fable-5 出口管制现已阻断防御者日常依赖的代码修复工作流</itunes:summary>
+      <itunes:episode>82</itunes:episode>
+      <itunes:title>第82集：Fable-5 出口管制现已阻断防御者日常依赖的代码修复工作流</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/modern_investing_podcast.es.rss
+++ b/modern_investing_podcast.es.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Modern Investing Techniques (Español)</title>
+    <link>https://nerranetwork.com/modern-investing.html</link>
+    <description>Daily investing podcast using AI-driven analysis and modern tools to identify market opportunities, track simulated trades, and teach strategies that aim to outperform index funds. Covering Canadian and US markets with actionable picks, performance tracking, and lessons learned.</description>
+    <atom:link href="https://nerranetwork.com/modern_investing_podcast.es.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>es-es</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Modern Investing Techniques</itunes:author>
+    <itunes:category text="Business">
+      <itunes:category text="Investing" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/modern-investing.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Modern Investing Techniques</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily investing podcast using AI-driven analysis and modern tools to identify market opportunities, track simulated trades, and teach strategies that aim to outperform index funds. Covering Canadian and US markets with actionable picks, performance tracking, and lessons learned.</itunes:summary>
+    <item>
+      <title>Ep 78: Los inversores canadienses con exposición al sector energético deben vigilar de cerca la moderación de los precios del petróleo mientras el acuerdo entre EE.UU. e Irán avanza hacia su firma formal, con el plazo de reapertura del Estrecho de Ormuz aún incierto.</title>
+      <description>Los inversores canadienses con exposición al sector energético deben vigilar de cerca la moderación de los precios del petróleo mientras el acuerdo entre EE.UU. e Irán avanza hacia su firma formal, con el plazo de reapertura del Estrecho de Ormuz aún incierto.</description>
+      <guid isPermaLink="false">modern-investing-es-ep078-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep078_20260616.es.mp3" length="26454000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>14:41</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Los inversores canadienses con exposición al sector energético deben vigilar de cerca la moderación de los precios del petróleo mientras el acuerdo entre EE.UU. e Irán avanza hacia su firma formal, con el plazo de reapertura del Estrecho de Ormuz aún incierto.</itunes:summary>
+      <itunes:episode>78</itunes:episode>
+      <itunes:title>Ep 78: Los inversores canadienses con exposición al sector energético deben vigilar de cerca la moderación de los precios del petróleo mientras el acuerdo entre EE.UU. e Irán avanza hacia su firma formal, con el plazo de reapertura del Estrecho de Ormuz aún incierto.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/modern_investing_podcast.fr.rss
+++ b/modern_investing_podcast.fr.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Modern Investing Techniques (Français)</title>
+    <link>https://nerranetwork.com/modern-investing.html</link>
+    <description>Daily investing podcast using AI-driven analysis and modern tools to identify market opportunities, track simulated trades, and teach strategies that aim to outperform index funds. Covering Canadian and US markets with actionable picks, performance tracking, and lessons learned.</description>
+    <atom:link href="https://nerranetwork.com/modern_investing_podcast.fr.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>fr-fr</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Modern Investing Techniques</itunes:author>
+    <itunes:category text="Business">
+      <itunes:category text="Investing" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/modern-investing.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Modern Investing Techniques</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily investing podcast using AI-driven analysis and modern tools to identify market opportunities, track simulated trades, and teach strategies that aim to outperform index funds. Covering Canadian and US markets with actionable picks, performance tracking, and lessons learned.</itunes:summary>
+    <item>
+      <title>Ép 78 : Les investisseurs canadiens exposés à l’énergie doivent surveiller de près le repli des cours du pétrole, alors que l’accord États-Unis-Iran s’apprête à être signé officiellement et que le calendrier de réouverture du détroit d’Ormuz reste incertain.</title>
+      <description>Les investisseurs canadiens exposés à l’énergie doivent surveiller de près le repli des cours du pétrole, alors que l’accord États-Unis-Iran s’apprête à être signé officiellement et que le calendrier de réouverture du détroit d’Ormuz reste incertain.</description>
+      <guid isPermaLink="false">modern-investing-fr-ep078-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep078_20260616.fr.mp3" length="25143000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>13:58</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Les investisseurs canadiens exposés à l’énergie doivent surveiller de près le repli des cours du pétrole, alors que l’accord États-Unis-Iran s’apprête à être signé officiellement et que le calendrier de réouverture du détroit d’Ormuz reste incertain.</itunes:summary>
+      <itunes:episode>78</itunes:episode>
+      <itunes:title>Ép 78 : Les investisseurs canadiens exposés à l’énergie doivent surveiller de près le repli des cours du pétrole, alors que l’accord États-Unis-Iran s’apprête à être signé officiellement et que le calendrier de réouverture du détroit d’Ormuz reste incertain.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/modern_investing_podcast.ru.rss
+++ b/modern_investing_podcast.ru.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Modern Investing Techniques (Русский)</title>
+    <link>https://nerranetwork.com/modern-investing.html</link>
+    <description>Daily investing podcast using AI-driven analysis and modern tools to identify market opportunities, track simulated trades, and teach strategies that aim to outperform index funds. Covering Canadian and US markets with actionable picks, performance tracking, and lessons learned.</description>
+    <atom:link href="https://nerranetwork.com/modern_investing_podcast.ru.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>ru-ru</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Modern Investing Techniques</itunes:author>
+    <itunes:category text="Business">
+      <itunes:category text="Investing" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/modern-investing.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Modern Investing Techniques</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily investing podcast using AI-driven analysis and modern tools to identify market opportunities, track simulated trades, and teach strategies that aim to outperform index funds. Covering Canadian and US markets with actionable picks, performance tracking, and lessons learned.</itunes:summary>
+    <item>
+      <title>Эп 78: Канадским инвесторам с экспозицией в энергетике стоит внимательно следить за коррекцией цен на нефть — сделка США с Ираном приближается к официальному подписанию, а сроки повторного открытия Ормузского пролива остаются неопределёнными</title>
+      <description>Канадским инвесторам с экспозицией в энергетике стоит внимательно следить за коррекцией цен на нефть — сделка США с Ираном приближается к официальному подписанию, а сроки повторного открытия Ормузского пролива остаются неопределёнными</description>
+      <guid isPermaLink="false">modern-investing-ru-ep078-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep078_20260616.ru.mp3" length="21228000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>11:47</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Канадским инвесторам с экспозицией в энергетике стоит внимательно следить за коррекцией цен на нефть — сделка США с Ираном приближается к официальному подписанию, а сроки повторного открытия Ормузского пролива остаются неопределёнными</itunes:summary>
+      <itunes:episode>78</itunes:episode>
+      <itunes:title>Эп 78: Канадским инвесторам с экспозицией в энергетике стоит внимательно следить за коррекцией цен на нефть — сделка США с Ираном приближается к официальному подписанию, а сроки повторного открытия Ормузского пролива остаются неопределёнными</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/modern_investing_podcast.zh.rss
+++ b/modern_investing_podcast.zh.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Modern Investing Techniques (中文)</title>
+    <link>https://nerranetwork.com/modern-investing.html</link>
+    <description>Daily investing podcast using AI-driven analysis and modern tools to identify market opportunities, track simulated trades, and teach strategies that aim to outperform index funds. Covering Canadian and US markets with actionable picks, performance tracking, and lessons learned.</description>
+    <atom:link href="https://nerranetwork.com/modern_investing_podcast.zh.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>zh-cn</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Modern Investing Techniques</itunes:author>
+    <itunes:category text="Business">
+      <itunes:category text="Investing" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/modern-investing.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Modern Investing Techniques</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily investing podcast using AI-driven analysis and modern tools to identify market opportunities, track simulated trades, and teach strategies that aim to outperform index funds. Covering Canadian and US markets with actionable picks, performance tracking, and lessons learned.</itunes:summary>
+    <item>
+      <title>Ep 78: 美伊协议即将正式签署，霍尔木兹海峡重启时间表仍不确定，加拿大能源投资者需密切留意油价缓和走势</title>
+      <description>加拿大能源投资者应密切关注油价缓和，因为美伊协议正朝正式签署推进，而霍尔木兹海峡重启的时间表仍不确定。</description>
+      <guid isPermaLink="false">modern-investing-zh-ep078-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep078_20260616.zh.mp3" length="22422000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>12:27</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>加拿大能源投资者应密切关注油价缓和，因为美伊协议正朝正式签署推进，而霍尔木兹海峡重启的时间表仍不确定。</itunes:summary>
+      <itunes:episode>78</itunes:episode>
+      <itunes:title>Ep 78: 美伊协议即将正式签署，霍尔木兹海峡重启时间表仍不确定，加拿大能源投资者需密切留意油价缓和走势</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/omni_view_podcast.es.rss
+++ b/omni_view_podcast.es.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Omni View - Balanced News Perspectives (Español)</title>
+    <link>https://nerranetwork.com/omni-view.html</link>
+    <description>Daily world news where every story is presented from the strongest case each side can make — the version its most thoughtful advocates actually argue, never a caricature. Sources attributed, both sides steel-manned, so you decide. You shouldn't be able to tell which side we favor.</description>
+    <atom:link href="https://nerranetwork.com/omni_view_podcast.es.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>es-es</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Omni View</itunes:author>
+    <itunes:category text="News">
+      <itunes:category text="Daily News" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/omni-view.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Omni View</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily world news where every story is presented from the strongest case each side can make — the version its most thoughtful advocates actually argue, never a caricature. Sources attributed, both sides steel-manned, so you decide. You shouldn't be able to tell which side we favor.</itunes:summary>
+    <item>
+      <title>Ep 83: La muerte de una niña australiana de nueve años durante una operación policial en Pakistán ha renovado el escrutinio sobre las tácticas de seguridad y la responsabilidad transfronteriza.</title>
+      <description>La muerte de una niña australiana de nueve años durante una operación policial en Pakistán ha renovado el escrutinio sobre las tácticas de seguridad y la responsabilidad transfronteriza.</description>
+      <guid isPermaLink="false">omni-view-es-ep083-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/omni_view/Omni_View_Ep083_20260616.es.mp3" length="24093000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>13:23</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>La muerte de una niña australiana de nueve años durante una operación policial en Pakistán ha renovado el escrutinio sobre las tácticas de seguridad y la responsabilidad transfronteriza.</itunes:summary>
+      <itunes:episode>83</itunes:episode>
+      <itunes:title>Ep 83: La muerte de una niña australiana de nueve años durante una operación policial en Pakistán ha renovado el escrutinio sobre las tácticas de seguridad y la responsabilidad transfronteriza.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/omni_view_podcast.fr.rss
+++ b/omni_view_podcast.fr.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Omni View - Balanced News Perspectives (Français)</title>
+    <link>https://nerranetwork.com/omni-view.html</link>
+    <description>Daily world news where every story is presented from the strongest case each side can make — the version its most thoughtful advocates actually argue, never a caricature. Sources attributed, both sides steel-manned, so you decide. You shouldn't be able to tell which side we favor.</description>
+    <atom:link href="https://nerranetwork.com/omni_view_podcast.fr.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>fr-fr</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Omni View</itunes:author>
+    <itunes:category text="News">
+      <itunes:category text="Daily News" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/omni-view.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Omni View</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily world news where every story is presented from the strongest case each side can make — the version its most thoughtful advocates actually argue, never a caricature. Sources attributed, both sides steel-manned, so you decide. You shouldn't be able to tell which side we favor.</itunes:summary>
+    <item>
+      <title>Ep 83: La mort d’une fillette australienne de neuf ans lors d’une opération de police au Pakistan relance l’examen des tactiques de sécurité et de la responsabilité transfrontalière.</title>
+      <description>La mort d’une fillette australienne de neuf ans lors d’une opération de police au Pakistan relance l’examen des tactiques de sécurité et de la responsabilité transfrontalière.</description>
+      <guid isPermaLink="false">omni-view-fr-ep083-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/omni_view/Omni_View_Ep083_20260616.fr.mp3" length="21000000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>11:40</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>La mort d’une fillette australienne de neuf ans lors d’une opération de police au Pakistan relance l’examen des tactiques de sécurité et de la responsabilité transfrontalière.</itunes:summary>
+      <itunes:episode>83</itunes:episode>
+      <itunes:title>Ep 83: La mort d’une fillette australienne de neuf ans lors d’une opération de police au Pakistan relance l’examen des tactiques de sécurité et de la responsabilité transfrontalière.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/omni_view_podcast.ru.rss
+++ b/omni_view_podcast.ru.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Omni View - Balanced News Perspectives (Русский)</title>
+    <link>https://nerranetwork.com/omni-view.html</link>
+    <description>Daily world news where every story is presented from the strongest case each side can make — the version its most thoughtful advocates actually argue, never a caricature. Sources attributed, both sides steel-manned, so you decide. You shouldn't be able to tell which side we favor.</description>
+    <atom:link href="https://nerranetwork.com/omni_view_podcast.ru.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>ru-ru</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Omni View</itunes:author>
+    <itunes:category text="News">
+      <itunes:category text="Daily News" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/omni-view.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Omni View</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily world news where every story is presented from the strongest case each side can make — the version its most thoughtful advocates actually argue, never a caricature. Sources attributed, both sides steel-manned, so you decide. You shouldn't be able to tell which side we favor.</itunes:summary>
+    <item>
+      <title>Ep 83: Смерть девятилетней австралийской девочки во время полицейской операции в Пакистане вновь привлекла внимание к тактике силовиков и трансграничной ответственности</title>
+      <description>Смерть девятилетней австралийской девочки во время полицейской операции в Пакистане вновь привлекла внимание к тактике силовиков и трансграничной ответственности</description>
+      <guid isPermaLink="false">omni-view-ru-ep083-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/omni_view/Omni_View_Ep083_20260616.ru.mp3" length="21054000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>11:41</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Смерть девятилетней австралийской девочки во время полицейской операции в Пакистане вновь привлекла внимание к тактике силовиков и трансграничной ответственности</itunes:summary>
+      <itunes:episode>83</itunes:episode>
+      <itunes:title>Ep 83: Смерть девятилетней австралийской девочки во время полицейской операции в Пакистане вновь привлекла внимание к тактике силовиков и трансграничной ответственности</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/omni_view_podcast.zh.rss
+++ b/omni_view_podcast.zh.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Omni View - Balanced News Perspectives (中文)</title>
+    <link>https://nerranetwork.com/omni-view.html</link>
+    <description>Daily world news where every story is presented from the strongest case each side can make — the version its most thoughtful advocates actually argue, never a caricature. Sources attributed, both sides steel-manned, so you decide. You shouldn't be able to tell which side we favor.</description>
+    <atom:link href="https://nerranetwork.com/omni_view_podcast.zh.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>zh-cn</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Omni View</itunes:author>
+    <itunes:category text="News">
+      <itunes:category text="Daily News" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/omni-view.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Omni View</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily world news where every story is presented from the strongest case each side can make — the version its most thoughtful advocates actually argue, never a caricature. Sources attributed, both sides steel-manned, so you decide. You shouldn't be able to tell which side we favor.</itunes:summary>
+    <item>
+      <title>Ep 83: 一名9岁澳大利亚女孩在巴基斯坦警方行动中身亡，重新引发对安保策略与跨境问责的关注</title>
+      <description>一名9岁澳大利亚女孩在巴基斯坦警方行动中身亡，重新引发对安保策略与跨境问责的关注。</description>
+      <guid isPermaLink="false">omni-view-zh-ep083-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/omni_view/Omni_View_Ep083_20260616.zh.mp3" length="20598000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>11:26</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>一名9岁澳大利亚女孩在巴基斯坦警方行动中身亡，重新引发对安保策略与跨境问责的关注。</itunes:summary>
+      <itunes:episode>83</itunes:episode>
+      <itunes:title>Ep 83: 一名9岁澳大利亚女孩在巴基斯坦警方行动中身亡，重新引发对安保策略与跨境问责的关注</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/planetterrian_podcast.es.rss
+++ b/planetterrian_podcast.es.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Planetterrian Daily (Español)</title>
+    <link>https://nerranetwork.com/planetterrian.html</link>
+    <description>Daily science, longevity, and health discoveries across neuroscience, microbiome, cellular aging biology, sleep research, nutrition science, genetics, and regenerative biology. We deliberately minimize drug-industry dealmaking in favour of the broader research shaping how we understand the body.</description>
+    <atom:link href="https://nerranetwork.com/planetterrian_podcast.es.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>es-es</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Science">
+      <itunes:category text="Life Sciences" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/planetterrian-daily.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily science, longevity, and health discoveries across neuroscience, microbiome, cellular aging biology, sleep research, nutrition science, genetics, and regenerative biology. We deliberately minimize drug-industry dealmaking in favour of the broader research shaping how we understand the body.</itunes:summary>
+    <item>
+      <title>Ep 91: Los modelos indican que un impactador del tamaño de la Luna provocó que Venus girara en sentido retrógrado en sus primeros 50 millones de años</title>
+      <description>Los modelos indican que un impactador del tamaño de la Luna provocó que Venus girara en sentido retrógrado en sus primeros 50 millones de años</description>
+      <guid isPermaLink="false">planetterrian-daily-es-ep091-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep091_20260616.es.mp3" length="20661000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>11:28</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Los modelos indican que un impactador del tamaño de la Luna provocó que Venus girara en sentido retrógrado en sus primeros 50 millones de años</itunes:summary>
+      <itunes:episode>91</itunes:episode>
+      <itunes:title>Ep 91: Los modelos indican que un impactador del tamaño de la Luna provocó que Venus girara en sentido retrógrado en sus primeros 50 millones de años</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/planetterrian_podcast.fr.rss
+++ b/planetterrian_podcast.fr.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Planetterrian Daily (Français)</title>
+    <link>https://nerranetwork.com/planetterrian.html</link>
+    <description>Daily science, longevity, and health discoveries across neuroscience, microbiome, cellular aging biology, sleep research, nutrition science, genetics, and regenerative biology. We deliberately minimize drug-industry dealmaking in favour of the broader research shaping how we understand the body.</description>
+    <atom:link href="https://nerranetwork.com/planetterrian_podcast.fr.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>fr-fr</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Science">
+      <itunes:category text="Life Sciences" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/planetterrian-daily.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily science, longevity, and health discoveries across neuroscience, microbiome, cellular aging biology, sleep research, nutrition science, genetics, and regenerative biology. We deliberately minimize drug-industry dealmaking in favour of the broader research shaping how we understand the body.</itunes:summary>
+    <item>
+      <title>Ep 91 : Des modèles indiquent qu’un impacteur de la taille de la Lune a mis Vénus en rotation rétrograde dans ses 50 premiers millions d’années.</title>
+      <description>Des modèles indiquent qu’un impacteur de la taille de la Lune a mis Vénus en rotation rétrograde dans ses 50 premiers millions d’années.</description>
+      <guid isPermaLink="false">planetterrian-daily-fr-ep091-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep091_20260616.fr.mp3" length="18423000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>10:14</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Des modèles indiquent qu’un impacteur de la taille de la Lune a mis Vénus en rotation rétrograde dans ses 50 premiers millions d’années.</itunes:summary>
+      <itunes:episode>91</itunes:episode>
+      <itunes:title>Ep 91 : Des modèles indiquent qu’un impacteur de la taille de la Lune a mis Vénus en rotation rétrograde dans ses 50 premiers millions d’années.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/planetterrian_podcast.ru.rss
+++ b/planetterrian_podcast.ru.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Planetterrian Daily (Русский)</title>
+    <link>https://nerranetwork.com/planetterrian.html</link>
+    <description>Daily science, longevity, and health discoveries across neuroscience, microbiome, cellular aging biology, sleep research, nutrition science, genetics, and regenerative biology. We deliberately minimize drug-industry dealmaking in favour of the broader research shaping how we understand the body.</description>
+    <atom:link href="https://nerranetwork.com/planetterrian_podcast.ru.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>ru-ru</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Science">
+      <itunes:category text="Life Sciences" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/planetterrian-daily.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily science, longevity, and health discoveries across neuroscience, microbiome, cellular aging biology, sleep research, nutrition science, genetics, and regenerative biology. We deliberately minimize drug-industry dealmaking in favour of the broader research shaping how we understand the body.</itunes:summary>
+    <item>
+      <title>Эп. 91: Модели показывают, что ударник размером с Луну придал Венере ретроградное вращение уже в первые 50 млн лет</title>
+      <description>Модели показывают, что ударник размером с Луну придал Венере ретроградное вращение уже в первые 50 млн лет</description>
+      <guid isPermaLink="false">planetterrian-daily-ru-ep091-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep091_20260616.ru.mp3" length="18588000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>10:19</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Модели показывают, что ударник размером с Луну придал Венере ретроградное вращение уже в первые 50 млн лет</itunes:summary>
+      <itunes:episode>91</itunes:episode>
+      <itunes:title>Эп. 91: Модели показывают, что ударник размером с Луну придал Венере ретроградное вращение уже в первые 50 млн лет</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/planetterrian_podcast.zh.rss
+++ b/planetterrian_podcast.zh.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Planetterrian Daily (中文)</title>
+    <link>https://nerranetwork.com/planetterrian.html</link>
+    <description>Daily science, longevity, and health discoveries across neuroscience, microbiome, cellular aging biology, sleep research, nutrition science, genetics, and regenerative biology. We deliberately minimize drug-industry dealmaking in favour of the broader research shaping how we understand the body.</description>
+    <atom:link href="https://nerranetwork.com/planetterrian_podcast.zh.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>zh-cn</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Science">
+      <itunes:category text="Life Sciences" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/planetterrian-daily.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Daily science, longevity, and health discoveries across neuroscience, microbiome, cellular aging biology, sleep research, nutrition science, genetics, and regenerative biology. We deliberately minimize drug-industry dealmaking in favour of the broader research shaping how we understand the body.</itunes:summary>
+    <item>
+      <title>第91集：模型显示，一颗月球大小的撞击体在金星形成的前5000万年内使其自转变为逆行。</title>
+      <description>模型显示，一颗月球大小的撞击体在金星形成的前5000万年内使其自转变为逆行。</description>
+      <guid isPermaLink="false">planetterrian-daily-zh-ep091-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep091_20260616.zh.mp3" length="17160000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>09:32</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>模型显示，一颗月球大小的撞击体在金星形成的前5000万年内使其自转变为逆行。</itunes:summary>
+      <itunes:episode>91</itunes:episode>
+      <itunes:title>第91集：模型显示，一颗月球大小的撞击体在金星形成的前5000万年内使其自转变为逆行。</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/scripts/build_language_feeds.py
+++ b/scripts/build_language_feeds.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Build per-language podcast RSS feeds for the multilingual shows.
+
+For each multilingual-enabled show and each language that has at least one
+translated episode track (recorded in the show's ``summaries_<slug>.json``),
+emit a standalone Apple/Spotify-ready feed next to the English one:
+
+    spacex_podcast.rss        (English, canonical — untouched)
+    spacex_podcast.fr.rss     (French tracks only)
+    spacex_podcast.es.rss     (Spanish tracks only)
+    ...
+
+The feeds are rebuilt **fresh from the canonical summaries JSON** every run
+(idempotent), so this is safe to run nightly. Channel title/description are
+translated **once** and cached in ``digests/<slug>/channel_i18n.json``; with
+no Grok key set the build still produces valid feeds with an autonym-suffixed
+English title.
+
+Usage
+-----
+    python scripts/build_language_feeds.py --all
+    python scripts/build_language_feeds.py spacex
+    python scripts/build_language_feeds.py spacex --languages fr,es
+    python scripts/build_language_feeds.py --all --refresh-channel-i18n
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(PROJECT_ROOT / ".env")
+except Exception:  # noqa: BLE001 — dotenv optional in CI
+    pass
+
+from engine import language_feeds  # noqa: E402
+from engine.config import load_config  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(levelname)s %(message)s")
+logger = logging.getLogger("build_language_feeds")
+
+
+def _discover_show_slugs() -> List[str]:
+    slugs = []
+    for path in sorted((PROJECT_ROOT / "shows").glob("*.yaml")):
+        name = path.stem
+        if name.startswith("_") or name in {"network_meta"}:
+            continue
+        slugs.append(name)
+    return slugs
+
+
+def _grok_available() -> bool:
+    return bool((os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY") or "").strip())
+
+
+def build_for_show(
+    slug: str,
+    languages: Optional[List[str]],
+    *,
+    refresh_channel_i18n: bool,
+    allow_translate: bool,
+) -> List[str]:
+    """Build all enabled-language feeds for one show. Returns public URLs."""
+    config = load_config(f"shows/{slug}.yaml")
+    ml = getattr(config, "multilingual", None)
+    if not (ml and ml.enabled):
+        logger.info("[%s] multilingual disabled — skipping", slug)
+        return []
+
+    summaries_path = PROJECT_ROOT / config.publishing.summaries_json
+    if not summaries_path.exists():
+        logger.warning("[%s] no summaries file at %s — skipping", slug, summaries_path)
+        return []
+
+    langs = languages or list(ml.languages) or list(language_feeds.supported_feed_languages())
+    langs = [c for c in langs if c in language_feeds.supported_feed_languages()]
+
+    translate_fn = None
+    if allow_translate and _grok_available():
+        from engine.translate import translate_metadata
+
+        translate_fn = translate_metadata
+
+    base_url = config.publishing.base_url.rstrip("/")
+    urls: List[str] = []
+    for lang in langs:
+        ch_title, ch_desc = language_feeds.resolve_channel_i18n(
+            summaries_path,
+            lang,
+            config.publishing.rss_title,
+            config.publishing.rss_description.strip(),
+            translate_fn=translate_fn,
+            refresh=refresh_channel_i18n,
+        )
+        out_path = PROJECT_ROOT / language_feeds.feed_filename(config.publishing.rss_file, lang)
+        result = language_feeds.build_language_feed(
+            slug=slug,
+            lang=lang,
+            summaries_path=summaries_path,
+            out_path=out_path,
+            guid_prefix=config.publishing.guid_prefix,
+            channel_title=ch_title,
+            channel_description=ch_desc,
+            channel_link=config.publishing.rss_link,
+            channel_author=config.publishing.rss_author,
+            channel_email=config.publishing.rss_email,
+            channel_image=config.publishing.rss_image,
+            channel_category=config.publishing.rss_category,
+            channel_subcategory=getattr(config.publishing, "rss_subcategory", ""),
+            base_url=base_url,
+        )
+        if result:
+            urls.append(f"{base_url}/{out_path.name}")
+    return urls
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("show", nargs="?", help="Show slug (omit with --all)")
+    ap.add_argument("--all", action="store_true", help="Build feeds for every multilingual show")
+    ap.add_argument("--languages", default="", help="Comma list of BCP-47 codes to limit to")
+    ap.add_argument(
+        "--refresh-channel-i18n",
+        action="store_true",
+        help="Re-translate cached channel title/description (needs GROK_API_KEY)",
+    )
+    ap.add_argument(
+        "--no-translate",
+        action="store_true",
+        help="Never call Grok; use cached channel i18n or the autonym fallback",
+    )
+    args = ap.parse_args()
+
+    if not args.all and not args.show:
+        ap.error("pass a show slug or --all")
+
+    langs = [s.strip() for s in args.languages.split(",") if s.strip()] or None
+    slugs = _discover_show_slugs() if args.all else [args.show]
+
+    all_urls: List[str] = []
+    for slug in slugs:
+        try:
+            all_urls.extend(
+                build_for_show(
+                    slug,
+                    langs,
+                    refresh_channel_i18n=args.refresh_channel_i18n,
+                    allow_translate=not args.no_translate,
+                )
+            )
+        except FileNotFoundError:
+            logger.warning("[%s] config not found — skipping", slug)
+        except Exception as exc:  # noqa: BLE001 — one show must not block the rest
+            logger.error("[%s] feed build failed: %s", slug, exc)
+
+    if all_urls:
+        logger.info("=" * 64)
+        logger.info("Built %d language feed(s):", len(all_urls))
+        for url in all_urls:
+            logger.info("  %s", url)
+        logger.info("Submit each to Apple Podcasts Connect / Spotify for Podcasters.")
+    else:
+        logger.info("No language feeds built (no translated episodes yet).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spacex_podcast.es.rss
+++ b/spacex_podcast.es.rss
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>SpaceX Daily (Español)</title>
+    <link>https://nerranetwork.com/spacex.html</link>
+    <description>The daily companion for following SpaceX as a public company (Nasdaq: SPCX). Starship, Falcon, Starlink, Dragon, the SPCX market picture, and the engineering and economics behind the push to make life multiplanetary — with sources, community buzz, one honest counterpoint every day, and a daily engineering deep dive. Not financial advice.</description>
+    <atom:link href="https://nerranetwork.com/spacex_podcast.es.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>es-es</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/spacex.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>The daily companion for following SpaceX as a public company (Nasdaq: SPCX). Starship, Falcon, Starlink, Dragon, the SPCX market picture, and the engineering and economics behind the push to make life multiplanetary — with sources, community buzz, one honest counterpoint every day, and a daily engineering deep dive. Not financial advice.</itunes:summary>
+    <item>
+      <title>Ep 5: El objetivo de Shotwell de un Starship por mes ahora depende de si las nuevas plataformas de Florida pueden soportar la misma carga rápida de propelente y el turnaround del booster ya probado en Starbase.</title>
+      <description>El objetivo de Shotwell de un Starship por mes ahora depende de si las nuevas plataformas de Florida pueden soportar la misma carga rápida de propelente y el turnaround del booster ya probado en Starbase.</description>
+      <guid isPermaLink="false">spacex-es-ep005-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep005_20260616.es.mp3" length="16133999" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>08:57</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>El objetivo de Shotwell de un Starship por mes ahora depende de si las nuevas plataformas de Florida pueden soportar la misma carga rápida de propelente y el turnaround del booster ya probado en Starbase.</itunes:summary>
+      <itunes:episode>5</itunes:episode>
+      <itunes:title>Ep 5: El objetivo de Shotwell de un Starship por mes ahora depende de si las nuevas plataformas de Florida pueden soportar la misma carga rápida de propelente y el turnaround del booster ya probado en Starbase.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+    <item>
+      <title>Ep 4: El primer vuelo del Falcon 9 tras su debut en el Nasdaq pone a prueba si los mercados públicos alteran en algo el ritmo de lanzamientos de la compañía.</title>
+      <description>El primer vuelo del Falcon 9 tras su debut en el Nasdaq pone a prueba si los mercados públicos alteran en algo el ritmo de lanzamientos de la compañía.</description>
+      <guid isPermaLink="false">spacex-es-ep004-20260615</guid>
+      <enclosure url="https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep004_20260615.es.mp3" length="13401000" type="audio/mpeg" />
+      <pubDate>Mon, 15 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>07:26</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>El primer vuelo del Falcon 9 tras su debut en el Nasdaq pone a prueba si los mercados públicos alteran en algo el ritmo de lanzamientos de la compañía.</itunes:summary>
+      <itunes:episode>4</itunes:episode>
+      <itunes:title>Ep 4: El primer vuelo del Falcon 9 tras su debut en el Nasdaq pone a prueba si los mercados públicos alteran en algo el ritmo de lanzamientos de la compañía.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+    <item>
+      <title>Ep 3: Los mayores avances de la semana, recopilados: qué se movió realmente, por qué importa y qué seguir a continuación</title>
+      <description>Bienvenidos de nuevo a SpaceX Daily, episodio 3. Es el 14 de junio de 2026 y soy Patrick desde Vancouver. Vamos a repasar los desarrollos de SpaceX de hoy.</description>
+      <guid isPermaLink="false">spacex-es-ep003-20260614</guid>
+      <enclosure url="https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep003_20260614.es.mp3" length="14700000" type="audio/mpeg" />
+      <pubDate>Sun, 14 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>08:10</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Bienvenidos de nuevo a SpaceX Daily, episodio 3. Es el 14 de junio de 2026 y soy Patrick desde Vancouver. Vamos a repasar los desarrollos de SpaceX de hoy.</itunes:summary>
+      <itunes:episode>3</itunes:episode>
+      <itunes:title>Ep 3: Los mayores avances de la semana, recopilados: qué se movió realmente, por qué importa y qué seguir a continuación</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/spacex_podcast.fr.rss
+++ b/spacex_podcast.fr.rss
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>SpaceX Daily (Français)</title>
+    <link>https://nerranetwork.com/spacex.html</link>
+    <description>The daily companion for following SpaceX as a public company (Nasdaq: SPCX). Starship, Falcon, Starlink, Dragon, the SPCX market picture, and the engineering and economics behind the push to make life multiplanetary — with sources, community buzz, one honest counterpoint every day, and a daily engineering deep dive. Not financial advice.</description>
+    <atom:link href="https://nerranetwork.com/spacex_podcast.fr.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>fr-fr</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/spacex.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>The daily companion for following SpaceX as a public company (Nasdaq: SPCX). Starship, Falcon, Starlink, Dragon, the SPCX market picture, and the engineering and economics behind the push to make life multiplanetary — with sources, community buzz, one honest counterpoint every day, and a daily engineering deep dive. Not financial advice.</itunes:summary>
+    <item>
+      <title>Ép 5 : L’objectif d’un Starship par mois de Shotwell dépend désormais de la capacité des nouveaux pads en Floride à supporter le même chargement rapide de propergol et le même turnaround du booster déjà prouvés à Starbase</title>
+      <description>L’objectif d’un Starship par mois de Shotwell dépend désormais de la capacité des nouveaux pads en Floride à supporter le même chargement rapide de propergol et le même turnaround du booster déjà prouvés à Starbase</description>
+      <guid isPermaLink="false">spacex-fr-ep005-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep005_20260616.fr.mp3" length="14427000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>08:00</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>L’objectif d’un Starship par mois de Shotwell dépend désormais de la capacité des nouveaux pads en Floride à supporter le même chargement rapide de propergol et le même turnaround du booster déjà prouvés à Starbase</itunes:summary>
+      <itunes:episode>5</itunes:episode>
+      <itunes:title>Ép 5 : L’objectif d’un Starship par mois de Shotwell dépend désormais de la capacité des nouveaux pads en Floride à supporter le même chargement rapide de propergol et le même turnaround du booster déjà prouvés à Starbase</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+    <item>
+      <title>Ép 4 : Le premier vol de Falcon 9 après son entrée au Nasdaq teste si les marchés publics modifient le rythme de lancement de la société</title>
+      <description>Le premier vol de Falcon 9 après son entrée au Nasdaq teste si les marchés publics modifient le rythme de lancement de la société</description>
+      <guid isPermaLink="false">spacex-fr-ep004-20260615</guid>
+      <enclosure url="https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep004_20260615.fr.mp3" length="10431000" type="audio/mpeg" />
+      <pubDate>Mon, 15 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>05:47</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Le premier vol de Falcon 9 après son entrée au Nasdaq teste si les marchés publics modifient le rythme de lancement de la société</itunes:summary>
+      <itunes:episode>4</itunes:episode>
+      <itunes:title>Ép 4 : Le premier vol de Falcon 9 après son entrée au Nasdaq teste si les marchés publics modifient le rythme de lancement de la société</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+    <item>
+      <title>Ép 3 : Les plus gros développements de la semaine réunis — ce qui a vraiment bougé, pourquoi ça compte et ce qu’il faut surveiller ensuite</title>
+      <description>Bienvenue de nouveau sur SpaceX Daily, épisode 3. Nous sommes le 14 juin 2026 et je suis Patrick à Vancouver. Plongeons dans les développements SpaceX du jour.</description>
+      <guid isPermaLink="false">spacex-fr-ep003-20260614</guid>
+      <enclosure url="https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep003_20260614.fr.mp3" length="14793000" type="audio/mpeg" />
+      <pubDate>Sun, 14 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>08:13</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Bienvenue de nouveau sur SpaceX Daily, épisode 3. Nous sommes le 14 juin 2026 et je suis Patrick à Vancouver. Plongeons dans les développements SpaceX du jour.</itunes:summary>
+      <itunes:episode>3</itunes:episode>
+      <itunes:title>Ép 3 : Les plus gros développements de la semaine réunis — ce qui a vraiment bougé, pourquoi ça compte et ce qu’il faut surveiller ensuite</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/spacex_podcast.ru.rss
+++ b/spacex_podcast.ru.rss
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>SpaceX Daily (Русский)</title>
+    <link>https://nerranetwork.com/spacex.html</link>
+    <description>The daily companion for following SpaceX as a public company (Nasdaq: SPCX). Starship, Falcon, Starlink, Dragon, the SPCX market picture, and the engineering and economics behind the push to make life multiplanetary — with sources, community buzz, one honest counterpoint every day, and a daily engineering deep dive. Not financial advice.</description>
+    <atom:link href="https://nerranetwork.com/spacex_podcast.ru.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>ru-ru</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/spacex.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>The daily companion for following SpaceX as a public company (Nasdaq: SPCX). Starship, Falcon, Starlink, Dragon, the SPCX market picture, and the engineering and economics behind the push to make life multiplanetary — with sources, community buzz, one honest counterpoint every day, and a daily engineering deep dive. Not financial advice.</itunes:summary>
+    <item>
+      <title>Эп. 5: Цель Шотвелл по одному Starship в месяц теперь зависит от того, смогут ли новые площадки во Флориде обеспечить ту же быструю заправку пропеллентом и оборот бустера, которые уже доказаны на Starbase</title>
+      <description>Цель Шотвелл по одному Starship в месяц теперь зависит от того, смогут ли новые площадки во Флориде обеспечить ту же быструю заправку пропеллентом и оборот бустера, которые уже доказаны на Starbase</description>
+      <guid isPermaLink="false">spacex-ru-ep005-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep005_20260616.ru.mp3" length="15213000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>08:27</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Цель Шотвелл по одному Starship в месяц теперь зависит от того, смогут ли новые площадки во Флориде обеспечить ту же быструю заправку пропеллентом и оборот бустера, которые уже доказаны на Starbase</itunes:summary>
+      <itunes:episode>5</itunes:episode>
+      <itunes:title>Эп. 5: Цель Шотвелл по одному Starship в месяц теперь зависит от того, смогут ли новые площадки во Флориде обеспечить ту же быструю заправку пропеллентом и оборот бустера, которые уже доказаны на Starbase</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+    <item>
+      <title>Эп. 4: Первый полёт Falcon 9 после дебюта на Nasdaq покажет, изменят ли публичные рынки темп запусков компании</title>
+      <description>Первый полёт Falcon 9 после дебюта на Nasdaq покажет, изменят ли публичные рынки темп запусков компании</description>
+      <guid isPermaLink="false">spacex-ru-ep004-20260615</guid>
+      <enclosure url="https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep004_20260615.ru.mp3" length="11379000" type="audio/mpeg" />
+      <pubDate>Mon, 15 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>06:19</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Первый полёт Falcon 9 после дебюта на Nasdaq покажет, изменят ли публичные рынки темп запусков компании</itunes:summary>
+      <itunes:episode>4</itunes:episode>
+      <itunes:title>Эп. 4: Первый полёт Falcon 9 после дебюта на Nasdaq покажет, изменят ли публичные рынки темп запусков компании</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+    <item>
+      <title>Эп. 3: Главные события недели в обзоре — что произошло, почему это важно и на что смотреть дальше</title>
+      <description>С возвращением в SpaceX Daily, эпизод 3. Сегодня 14 июня 2026 года, это Патрик из Ванкувера. Разберём сегодняшние события SpaceX.</description>
+      <guid isPermaLink="false">spacex-ru-ep003-20260614</guid>
+      <enclosure url="https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep003_20260614.ru.mp3" length="13116000" type="audio/mpeg" />
+      <pubDate>Sun, 14 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>07:17</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>С возвращением в SpaceX Daily, эпизод 3. Сегодня 14 июня 2026 года, это Патрик из Ванкувера. Разберём сегодняшние события SpaceX.</itunes:summary>
+      <itunes:episode>3</itunes:episode>
+      <itunes:title>Эп. 3: Главные события недели в обзоре — что произошло, почему это важно и на что смотреть дальше</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/spacex_podcast.zh.rss
+++ b/spacex_podcast.zh.rss
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>SpaceX Daily (中文)</title>
+    <link>https://nerranetwork.com/spacex.html</link>
+    <description>The daily companion for following SpaceX as a public company (Nasdaq: SPCX). Starship, Falcon, Starlink, Dragon, the SPCX market picture, and the engineering and economics behind the push to make life multiplanetary — with sources, community buzz, one honest counterpoint every day, and a daily engineering deep dive. Not financial advice.</description>
+    <atom:link href="https://nerranetwork.com/spacex_podcast.zh.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>zh-cn</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Technology" />
+    <itunes:image href="https://nerranetwork.com/assets/covers/spacex.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>The daily companion for following SpaceX as a public company (Nasdaq: SPCX). Starship, Falcon, Starlink, Dragon, the SPCX market picture, and the engineering and economics behind the push to make life multiplanetary — with sources, community buzz, one honest counterpoint every day, and a daily engineering deep dive. Not financial advice.</itunes:summary>
+    <item>
+      <title>第 5 集：Shotwell 的 Starship 每月一艘目标，如今取决于佛罗里达新发射台能否实现 Starbase 已验证的快速推进剂加注与助推器周转。</title>
+      <description>Shotwell 的 Starship 每月一艘目标，如今取决于佛罗里达新发射台能否实现 Starbase 已验证的快速推进剂加注与助推器周转。</description>
+      <guid isPermaLink="false">spacex-zh-ep005-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep005_20260616.zh.mp3" length="13350000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>07:25</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Shotwell 的 Starship 每月一艘目标，如今取决于佛罗里达新发射台能否实现 Starbase 已验证的快速推进剂加注与助推器周转。</itunes:summary>
+      <itunes:episode>5</itunes:episode>
+      <itunes:title>第 5 集：Shotwell 的 Starship 每月一艘目标，如今取决于佛罗里达新发射台能否实现 Starbase 已验证的快速推进剂加注与助推器周转。</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+    <item>
+      <title>Ep 4: Nasdaq 上市后 Falcon 9 的首次飞行，测试公开市场是否会改变公司的发射节奏。</title>
+      <description>Falcon 9 在 Nasdaq 上市后的首次飞行，测试公开市场是否会改变公司的发射节奏。</description>
+      <guid isPermaLink="false">spacex-zh-ep004-20260615</guid>
+      <enclosure url="https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep004_20260615.zh.mp3" length="10896000" type="audio/mpeg" />
+      <pubDate>Mon, 15 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>06:03</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Falcon 9 在 Nasdaq 上市后的首次飞行，测试公开市场是否会改变公司的发射节奏。</itunes:summary>
+      <itunes:episode>4</itunes:episode>
+      <itunes:title>Ep 4: Nasdaq 上市后 Falcon 9 的首次飞行，测试公开市场是否会改变公司的发射节奏。</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+    <item>
+      <title>第3集：本周最大进展汇总——实际动向、为何重要及接下来要关注什么</title>
+      <description>欢迎回到 SpaceX Daily，第3集。今天是2026年6月14日，我是温哥华的Patrick。让我们来聊聊今天的SpaceX动态。</description>
+      <guid isPermaLink="false">spacex-zh-ep003-20260614</guid>
+      <enclosure url="https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep003_20260614.zh.mp3" length="12315000" type="audio/mpeg" />
+      <pubDate>Sun, 14 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>06:50</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>欢迎回到 SpaceX Daily，第3集。今天是2026年6月14日，我是温哥华的Patrick。让我们来聊聊今天的SpaceX动态。</itunes:summary>
+      <itunes:episode>3</itunes:episode>
+      <itunes:title>第3集：本周最大进展汇总——实际动向、为何重要及接下来要关注什么</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/templates/how_to_listen.html.j2
+++ b/templates/how_to_listen.html.j2
@@ -232,7 +232,10 @@
                 in English, Fran&ccedil;ais, Русский, Espa&ntilde;ol and 中文. On the
                 website, use the globe control in the top menu (or the language
                 buttons on any episode page) to pick your audio language &mdash; it's
-                remembered across the site.
+                remembered across the site. To subscribe in your language inside a
+                podcast app, each show also publishes a dedicated per-language RSS
+                feed &mdash; the language codes under <em>Feed</em> in the table below
+                link straight to them.
             </p>
 
             <section class="htl-shows-section">
@@ -273,6 +276,11 @@
                                 {% if s.rss_file %}
                                 <a href="{{ path_prefix }}{{ s.rss_file }}" class="plat-link">Feed</a>
                                 {% else %}<span class="na">—</span>{% endif %}
+                                {% if s.language_feeds %}
+                                <span class="lang-feeds" style="display:block;margin-top:3px;font-size:0.78rem;">
+                                    {% for f in s.language_feeds %}<a href="{{ path_prefix }}{{ f.url }}" class="plat-link" hreflang="{{ f.lang }}" title="{{ s.name }} — {{ f.label }}">{{ f.lang|upper }}</a>{% if not loop.last %} {% endif %}{% endfor %}
+                                </span>
+                                {% endif %}
                             </td>
                         </tr>
                         {% endfor %}

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -141,6 +141,15 @@
                     </a>
                     {% endif %}
                 </div>
+
+                {% if language_feeds %}
+                <div class="nn-lang-feeds" style="margin-top:0.85rem;font-size:0.9rem;">
+                    <span style="color:var(--nn-text-muted);">{% if _is_ru %}Аудио на других языках (RSS):{% else %}Listen in another language (podcast RSS):{% endif %}</span>
+                    {% for f in language_feeds %}
+                    <a href="{{ f.url }}" class="nn-btn" data-show="{{ show_slug }}" data-lang="{{ f.lang }}" hreflang="{{ f.lang }}" style="padding:4px 10px;font-size:0.82rem;">{{ f.label }}</a>
+                    {% endfor %}
+                </div>
+                {% endif %}
                 <div style="margin-top:var(--sp-3);">
                     {{ ai_badge(path_prefix=path_prefix, is_ru=_is_ru) }}
                 </div>

--- a/tests/test_language_feeds.py
+++ b/tests/test_language_feeds.py
@@ -1,0 +1,265 @@
+"""Drift guards for the per-language podcast RSS feeds (June 2026).
+
+The multilingual stage records FR/RU/ES/ZH tracks on each episode's
+summaries record; ``engine.language_feeds`` turns those into standalone
+Apple/Spotify-subscribable feeds (``<show>_podcast.<lang>.rss``). These
+tests pin the contract without spending Grok credits or hitting the network.
+"""
+
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+ITUNES = "http://www.itunes.com/dtds/podcast-1.0.dtd"
+
+pytest.importorskip("feedgen", reason="feedgen required to build feeds")
+
+
+def _write_summaries(path: Path, records) -> None:
+    path.write_text(
+        json.dumps({"podcast": "demo", "summaries": records}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _two_lang_records():
+    return [
+        {
+            "date": "2026-06-15",
+            "episode_num": 4,
+            "episode_title": "Ep 4: English title",
+            "audio_url": "https://audio.nerranetwork.com/demo/Ep004.mp3",
+            "translations": {
+                "fr": {
+                    "audio_url": "https://audio.nerranetwork.com/demo/Ep004.fr.mp3",
+                    "title": "Ép 4 : titre français",
+                    "description": "description française",
+                    "duration_sec": 347.7,
+                },
+            },
+        },
+        {
+            "date": "2026-06-14",
+            "episode_num": 3,
+            "episode_title": "Ep 3: English title",
+            "audio_url": "https://audio.nerranetwork.com/demo/Ep003.mp3",
+            "translations": {
+                "fr": {
+                    "audio_url": "https://audio.nerranetwork.com/demo/Ep003.fr.mp3",
+                    "title": "Ép 3 : titre français",
+                    "description": "description française 3",
+                    "duration_sec": 493.1,
+                    "bytes": 15000000,
+                },
+                # An English-only language (no track) must be skipped.
+            },
+        },
+        {
+            "date": "2026-06-13",
+            "episode_num": 2,
+            "episode_title": "Ep 2: English only",
+            "audio_url": "https://audio.nerranetwork.com/demo/Ep002.mp3",
+            # No translations at all.
+        },
+    ]
+
+
+def _build(tmp_path, lang="fr"):
+    from engine import language_feeds
+
+    summaries = tmp_path / "summaries_demo.json"
+    _write_summaries(summaries, _two_lang_records())
+    out = tmp_path / language_feeds.feed_filename("demo_podcast.rss", lang)
+    result = language_feeds.build_language_feed(
+        slug="demo",
+        lang=lang,
+        summaries_path=summaries,
+        out_path=out,
+        guid_prefix="demo",
+        channel_title="Demo Show (Français)",
+        channel_description="desc",
+        channel_link="https://nerranetwork.com/demo.html",
+        channel_author="Patrick",
+        channel_email="patrick@planetterrian.com",
+        channel_image="https://nerranetwork.com/cover.jpg",
+    )
+    return out, result
+
+
+# ---------------------------------------------------------------------------
+# Naming + locale helpers
+# ---------------------------------------------------------------------------
+
+class TestHelpers:
+    def test_feed_filename_inserts_lang(self):
+        from engine.language_feeds import feed_filename
+
+        assert feed_filename("spacex_podcast.rss", "fr") == "spacex_podcast.fr.rss"
+        assert feed_filename("podcast.rss", "zh") == "podcast.zh.rss"
+
+    def test_supported_languages(self):
+        from engine.language_feeds import supported_feed_languages
+
+        assert set(supported_feed_languages()) == {"fr", "ru", "es", "zh"}
+
+    def test_locale_is_region_qualified(self):
+        from engine.language_feeds import feed_locale
+
+        assert feed_locale("fr") == "fr-fr"
+        assert feed_locale("zh") == "zh-cn"
+
+
+# ---------------------------------------------------------------------------
+# Feed construction
+# ---------------------------------------------------------------------------
+
+class TestBuildFeed:
+    def test_builds_and_returns_count(self, tmp_path):
+        out, result = _build(tmp_path)
+        assert result is not None
+        path, count = result
+        # Ep4 + Ep3 have FR tracks; Ep2 has none.
+        assert count == 2
+        assert out.exists()
+
+    def test_only_translated_episodes_listed(self, tmp_path):
+        out, _ = _build(tmp_path)
+        root = ET.parse(out).getroot()
+        items = root.find("channel").findall("item")
+        assert len(items) == 2
+        titles = [it.find("title").text for it in items]
+        assert all("français" in t.lower() for t in titles)
+
+    def test_newest_episode_first(self, tmp_path):
+        out, _ = _build(tmp_path)
+        root = ET.parse(out).getroot()
+        eps = [
+            int(it.find(f"{{{ITUNES}}}episode").text)
+            for it in root.find("channel").findall("item")
+        ]
+        assert eps == [4, 3]
+
+    def test_enclosure_points_at_lang_track(self, tmp_path):
+        out, _ = _build(tmp_path)
+        root = ET.parse(out).getroot()
+        for it in root.find("channel").findall("item"):
+            url = it.find("enclosure").get("url")
+            assert url.endswith(".fr.mp3"), url
+
+    def test_channel_language_is_locale(self, tmp_path):
+        out, _ = _build(tmp_path)
+        root = ET.parse(out).getroot()
+        assert root.find("channel/language").text == "fr-fr"
+
+    def test_guid_is_deterministic_across_rebuilds(self, tmp_path):
+        out, _ = _build(tmp_path)
+        guids_a = [
+            it.find("guid").text for it in ET.parse(out).getroot().find("channel").findall("item")
+        ]
+        _build(tmp_path)  # rebuild
+        guids_b = [
+            it.find("guid").text for it in ET.parse(out).getroot().find("channel").findall("item")
+        ]
+        assert guids_a == guids_b
+        assert guids_a[0] == "demo-fr-ep004-20260615"
+
+    def test_enclosure_length_uses_bytes_when_present(self, tmp_path):
+        out, _ = _build(tmp_path)
+        root = ET.parse(out).getroot()
+        # Ep3 carries an explicit bytes field.
+        ep3 = [
+            it for it in root.find("channel").findall("item")
+            if it.find(f"{{{ITUNES}}}episode").text == "3"
+        ][0]
+        assert ep3.find("enclosure").get("length") == "15000000"
+
+    def test_no_feed_for_language_without_tracks(self, tmp_path):
+        from engine import language_feeds
+
+        summaries = tmp_path / "summaries_demo.json"
+        _write_summaries(summaries, _two_lang_records())
+        out = tmp_path / "demo_podcast.zh.rss"
+        result = language_feeds.build_language_feed(
+            slug="demo",
+            lang="zh",
+            summaries_path=summaries,
+            out_path=out,
+            guid_prefix="demo",
+            channel_title="x",
+            channel_description="y",
+            channel_link="https://nerranetwork.com/demo.html",
+            channel_author="Patrick",
+            channel_email="patrick@planetterrian.com",
+        )
+        assert result is None
+        assert not out.exists()
+
+    def test_feed_is_valid_xml_with_locked_tag(self, tmp_path):
+        out, _ = _build(tmp_path)
+        root = ET.parse(out).getroot()  # raises on invalid XML
+        PODCAST = "https://podcastindex.org/namespace/1.0"
+        assert root.find(f"channel/{{{PODCAST}}}locked") is not None
+
+
+# ---------------------------------------------------------------------------
+# Channel i18n cache
+# ---------------------------------------------------------------------------
+
+class TestChannelI18n:
+    def test_fallback_when_no_cache_no_translate(self, tmp_path):
+        from engine import language_feeds
+
+        summaries = tmp_path / "summaries_demo.json"
+        _write_summaries(summaries, [])
+        title, desc = language_feeds.resolve_channel_i18n(
+            summaries, "fr", "Demo Show", "English description",
+        )
+        assert title == "Demo Show (Français)"
+        assert desc == "English description"
+
+    def test_uses_cache_without_calling_translate(self, tmp_path):
+        from engine import language_feeds
+
+        summaries = tmp_path / "summaries_demo.json"
+        _write_summaries(summaries, [])
+        language_feeds.save_channel_i18n(
+            summaries, {"fr": {"title": "Démo", "description": "desc fr"}}
+        )
+
+        def _boom(*a, **k):  # must NOT be called when cache hits
+            raise AssertionError("translate_fn called despite cache hit")
+
+        title, desc = language_feeds.resolve_channel_i18n(
+            summaries, "fr", "Demo Show", "English", translate_fn=_boom,
+        )
+        assert title == "Démo"
+        assert desc == "desc fr"
+
+    def test_translate_fn_populates_cache(self, tmp_path):
+        from engine import language_feeds
+
+        summaries = tmp_path / "summaries_demo.json"
+        _write_summaries(summaries, [])
+        calls = []
+
+        def _fake(t, d, lang):
+            calls.append(lang)
+            return f"{t}-{lang}", f"{d}-{lang}"
+
+        title, desc = language_feeds.resolve_channel_i18n(
+            summaries, "es", "Demo", "Desc", translate_fn=_fake,
+        )
+        assert title == "Demo-es"
+        assert calls == ["es"]
+        # Second call hits the now-populated cache (no second translate).
+        title2, _ = language_feeds.resolve_channel_i18n(
+            summaries, "es", "Demo", "Desc", translate_fn=_fake,
+        )
+        assert title2 == "Demo-es"
+        assert calls == ["es"]

--- a/unintended_consequences_podcast.es.rss
+++ b/unintended_consequences_podcast.es.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Unintended Consequences (Español)</title>
+    <link>https://nerranetwork.com/unintended-consequences.html</link>
+    <description>Every weekday, one true story of good intentions gone sideways. From cobra bounties in colonial Delhi to recommendation algorithms, each episode follows a single case through the original idea, how it rolled out, the unintended fallout, and the lessons that still apply — told with empathy for the people who tried.</description>
+    <atom:link href="https://nerranetwork.com/unintended_consequences_podcast.es.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>es-es</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Education">
+      <itunes:category text="Self-Improvement" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/unintended-consequences.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Every weekday, one true story of good intentions gone sideways. From cobra bounties in colonial Delhi to recommendation algorithms, each episode follows a single case through the original idea, how it rolled out, the unintended fallout, and the lessons that still apply — told with empathy for the people who tried.</itunes:summary>
+    <item>
+      <title>Ep 31: Un sedante promocionado como seguro para embarazadas en los años 50 provocó la mayor epidemia registrada de defectos de nacimiento por medicamentos antes de que cambiaran las normas de pruebas.</title>
+      <description>Un sedante promocionado como seguro para embarazadas en los años 50 provocó la mayor epidemia registrada de defectos de nacimiento por medicamentos antes de que cambiaran las normas de pruebas.</description>
+      <guid isPermaLink="false">unintended-consequences-es-ep031-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep031_20260616.es.mp3" length="13908000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>07:43</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Un sedante promocionado como seguro para embarazadas en los años 50 provocó la mayor epidemia registrada de defectos de nacimiento por medicamentos antes de que cambiaran las normas de pruebas.</itunes:summary>
+      <itunes:episode>31</itunes:episode>
+      <itunes:title>Ep 31: Un sedante promocionado como seguro para embarazadas en los años 50 provocó la mayor epidemia registrada de defectos de nacimiento por medicamentos antes de que cambiaran las normas de pruebas.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/unintended_consequences_podcast.fr.rss
+++ b/unintended_consequences_podcast.fr.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Unintended Consequences (Français)</title>
+    <link>https://nerranetwork.com/unintended-consequences.html</link>
+    <description>Every weekday, one true story of good intentions gone sideways. From cobra bounties in colonial Delhi to recommendation algorithms, each episode follows a single case through the original idea, how it rolled out, the unintended fallout, and the lessons that still apply — told with empathy for the people who tried.</description>
+    <atom:link href="https://nerranetwork.com/unintended_consequences_podcast.fr.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>fr-fr</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Education">
+      <itunes:category text="Self-Improvement" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/unintended-consequences.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Every weekday, one true story of good intentions gone sideways. From cobra bounties in colonial Delhi to recommendation algorithms, each episode follows a single case through the original idea, how it rolled out, the unintended fallout, and the lessons that still apply — told with empathy for the people who tried.</itunes:summary>
+    <item>
+      <title>Ep 31 : Un sédatif présenté comme sûr pour les femmes enceintes dans les années 1950 a provoqué la plus grande épidémie de malformations congénitales liée à un médicament jamais enregistrée, avant que les règles de test ne changent.</title>
+      <description>Un sédatif présenté comme sûr pour les femmes enceintes dans les années 1950 a provoqué la plus grande épidémie de malformations congénitales liée à un médicament jamais enregistrée, avant que les règles de test ne changent.</description>
+      <guid isPermaLink="false">unintended-consequences-fr-ep031-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep031_20260616.fr.mp3" length="72000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>00:02</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Un sédatif présenté comme sûr pour les femmes enceintes dans les années 1950 a provoqué la plus grande épidémie de malformations congénitales liée à un médicament jamais enregistrée, avant que les règles de test ne changent.</itunes:summary>
+      <itunes:episode>31</itunes:episode>
+      <itunes:title>Ep 31 : Un sédatif présenté comme sûr pour les femmes enceintes dans les années 1950 a provoqué la plus grande épidémie de malformations congénitales liée à un médicament jamais enregistrée, avant que les règles de test ne changent.</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/unintended_consequences_podcast.ru.rss
+++ b/unintended_consequences_podcast.ru.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Unintended Consequences (Русский)</title>
+    <link>https://nerranetwork.com/unintended-consequences.html</link>
+    <description>Every weekday, one true story of good intentions gone sideways. From cobra bounties in colonial Delhi to recommendation algorithms, each episode follows a single case through the original idea, how it rolled out, the unintended fallout, and the lessons that still apply — told with empathy for the people who tried.</description>
+    <atom:link href="https://nerranetwork.com/unintended_consequences_podcast.ru.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>ru-ru</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Education">
+      <itunes:category text="Self-Improvement" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/unintended-consequences.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Every weekday, one true story of good intentions gone sideways. From cobra bounties in colonial Delhi to recommendation algorithms, each episode follows a single case through the original idea, how it rolled out, the unintended fallout, and the lessons that still apply — told with empathy for the people who tried.</itunes:summary>
+    <item>
+      <title>Эп 31: Седативное средство, которое в 1950-х продвигали как безопасное для беременных, вызвало крупнейшую эпидемию врождённых дефектов, связанную с лекарствами, до ужесточения правил тестирования</title>
+      <description>Седативное средство, которое в 1950-х продвигали как безопасное для беременных, вызвало крупнейшую эпидемию врождённых дефектов, связанную с лекарствами, до ужесточения правил тестирования</description>
+      <guid isPermaLink="false">unintended-consequences-ru-ep031-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep031_20260616.ru.mp3" length="11163000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>06:12</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>Седативное средство, которое в 1950-х продвигали как безопасное для беременных, вызвало крупнейшую эпидемию врождённых дефектов, связанную с лекарствами, до ужесточения правил тестирования</itunes:summary>
+      <itunes:episode>31</itunes:episode>
+      <itunes:title>Эп 31: Седативное средство, которое в 1950-х продвигали как безопасное для беременных, вызвало крупнейшую эпидемию врождённых дефектов, связанную с лекарствами, до ужесточения правил тестирования</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>

--- a/unintended_consequences_podcast.zh.rss
+++ b/unintended_consequences_podcast.zh.rss
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Unintended Consequences (中文)</title>
+    <link>https://nerranetwork.com/unintended-consequences.html</link>
+    <description>Every weekday, one true story of good intentions gone sideways. From cobra bounties in colonial Delhi to recommendation algorithms, each episode follows a single case through the original idea, how it rolled out, the unintended fallout, and the lessons that still apply — told with empathy for the people who tried.</description>
+    <atom:link href="https://nerranetwork.com/unintended_consequences_podcast.zh.rss" rel="self" />
+    <copyright>Copyright 2026</copyright>
+    <docs>http://www.rssboard.org/rss-specification</docs>
+    <generator>python-feedgen</generator>
+    <language>zh-cn</language>
+    <lastBuildDate>Wed, 17 Jun 2026 04:45:51 +0000</lastBuildDate>
+    <itunes:author>Patrick</itunes:author>
+    <itunes:category text="Education">
+      <itunes:category text="Self-Improvement" />
+    </itunes:category>
+    <itunes:image href="https://nerranetwork.com/assets/covers/unintended-consequences.jpg" />
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Patrick</itunes:name>
+      <itunes:email>patrick@planetterrian.com</itunes:email>
+    </itunes:owner>
+    <itunes:summary>Every weekday, one true story of good intentions gone sideways. From cobra bounties in colonial Delhi to recommendation algorithms, each episode follows a single case through the original idea, how it rolled out, the unintended fallout, and the lessons that still apply — told with empathy for the people who tried.</itunes:summary>
+    <item>
+      <title>Ep 31: 20世纪50年代被宣传为孕妇安全用药的镇静剂，在药物测试规定改变前引发了有记录以来最大规模的药物相关出生缺陷流行。</title>
+      <description>20世纪50年代被宣传为孕妇安全用药的镇静剂，在药物测试规定改变前引发了有记录以来最大规模的药物相关出生缺陷流行。</description>
+      <guid isPermaLink="false">unintended-consequences-zh-ep031-20260616</guid>
+      <enclosure url="https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep031_20260616.zh.mp3" length="11283000" type="audio/mpeg" />
+      <pubDate>Tue, 16 Jun 2026 08:00:00 +0000</pubDate>
+      <itunes:duration>06:16</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:summary>20世纪50年代被宣传为孕妇安全用药的镇静剂，在药物测试规定改变前引发了有记录以来最大规模的药物相关出生缺陷流行。</itunes:summary>
+      <itunes:episode>31</itunes:episode>
+      <itunes:title>Ep 31: 20世纪50年代被宣传为孕妇安全用药的镇静剂，在药物测试规定改变前引发了有记录以来最大规模的药物相关出生缺陷流行。</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>
+  <podcast:locked owner="patrick@planetterrian.com">yes</podcast:locked></channel>
+</rss>


### PR DESCRIPTION
## What

Turns each multilingual **audio track** into a real, **subscribable podcast** by publishing a dedicated per-language RSS feed next to the canonical English one:

```
spacex_podcast.rss        # English, canonical — untouched
spacex_podcast.fr.rss     # French tracks only
spacex_podcast.es.rss     # Spanish tracks only  …
```

Until now the FR/RU/ES/ZH tracks were surfaced on the website player only. Now Apple Podcasts / Spotify can subscribe **per language**. The English feed is byte-for-byte unchanged.

39 feeds are included in this PR (11 English shows × the languages that already have ≥1 track; SpaceX has 3 episodes, the rest 1 each from the first translation sweep).

## How it works

- **`engine/language_feeds.py`** — builds a feed **fresh from the canonical `summaries_<slug>.json`** each run (idempotent, never depends on the prior file). Lists **only** episodes that actually have a track in that language; writes **no** feed for a language with zero tracks.
  - Region-qualified channel `<language>` (`fr-fr` / `ru-ru` / `es-es` / `zh-cn`) so directories shelve each feed in the right locale.
  - **Deterministic per-episode GUIDs** (`<guid_prefix>-<lang>-ep<NNN>-<date>`) → a rebuild never re-notifies subscribers or double-lists an episode.
  - **Translated channel title + description**, translated **once** via `engine.translate.translate_metadata` and cached in `digests/<slug>/channel_i18n.json` (nightly rebuilds cost no Grok credits). Degrades to an autonym-suffixed English title (`SpaceX Daily (Français)`) when no key + no cache, so the build always ships a valid feed.
- **`scripts/build_language_feeds.py`** — per-show / `--all` driver; prints the feed URLs to submit.
- **`engine/multilingual.py`** — captures the exact track byte size so the enclosure `length` is precise (older records fall back to a duration estimate).

## Pipeline wiring

- **`multilingual.yml`** rebuilds + commits the feeds right after each translation sweep generates tracks (extends the commit's `git add` to `*_podcast.*.rss` + `channel_i18n.json`).
- **`nightly-maintenance.yml`** rebuilds them again as a regenerable safety net.
- **Web:** show pages and the How-to-Listen table link each available language feed (`generate_html._collect_language_feeds`).

## Operator

Submit each per-language feed URL (`https://nerranetwork.com/<show>_podcast.<lang>.rss`) to Apple Podcasts Connect / Spotify for Podcasters once — same as the English feed. `python scripts/build_language_feeds.py --all` prints the full list. The first CI run with a Grok key populates the translated channel metadata cache.

## Tests

- `tests/test_language_feeds.py` — 15 drift guards (filename/locale helpers, only-translated-episodes listing, newest-first order, deterministic GUIDs, byte-length, empty-language skip, valid XML + `podcast:locked`, channel-i18n cache hit/populate/fallback). All pass alongside `test_multilingual`, `test_rss`, `test_website_quality_pass`, `test_phase2_growth`.
- The 39 generated feeds all parse as valid XML.

> Note: YouTube multi-language distribution is intentionally **out of scope** here (RSS-for-Apple/Spotify only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_