### PR TITLE
Multilingual: fix per-show loop; + Omni View closing-chapter fix (unblocks CI)

### DIFF
--- a/.github/workflows/multilingual.yml
+++ b/.github/workflows/multilingual.yml
@@ -102,11 +102,19 @@ jobs:
           LATEST="${{ github.event.inputs.latest }}"
           [ -z "$LATEST" ] && LATEST=3
           SHOWS='${{ steps.resolve.outputs.shows }}'
-          echo "$SHOWS" | python3 -c "import sys,json; print('\n'.join(json.load(sys.stdin)))" | while read -r slug; do
+          # Parse the JSON list into a bash array and iterate with a for-loop
+          # (NOT `... | while read`). In the piped while-loop, ffmpeg/ffprobe
+          # invoked inside generate_translations.py read from the loop's stdin
+          # and drained the remaining show list, so the loop exited after the
+          # FIRST show — only env_intel translated on the 2026-06-17 sweep.
+          # The for-loop keeps the script's own stdin; `</dev/null` on the
+          # python call is belt-and-suspenders so no child can eat it.
+          mapfile -t SLUGS < <(echo "$SHOWS" | python3 -c "import sys,json; print('\n'.join(json.load(sys.stdin)))")
+          for slug in "${SLUGS[@]}"; do
             [ -z "$slug" ] && continue
             echo "::group::Translating $slug (--latest $LATEST)"
             # --zh-approved: operator approved all four languages including ZH.
-            python scripts/generate_translations.py "$slug" --latest "$LATEST" --zh-approved || echo "::warning::Translation run failed for $slug (non-fatal)"
+            python scripts/generate_translations.py "$slug" --latest "$LATEST" --zh-approved </dev/null || echo "::warning::Translation run failed for $slug (non-fatal)"
             echo "::endgroup::"
           done
           exit 0

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -253,11 +253,11 @@ chapters:
       title: "Main Stories"
     - pattern: "to really understand|to understand .{1,80}? more fully|most coverage leaves out|here's the thing that changes"
       title: "Understanding the Issue"
-    - pattern: "Before we go|before we wrap|Tomorrow, watch for"
-      title: "Tomorrow Teaser"
-      where: end
     - pattern: "That's Omni View|That wraps up today.?s Omni View|that wraps up today|until next time"
       title: "Closing"
+      where: end
+    - pattern: "Before we go|before we wrap|Tomorrow, watch for"
+      title: "Tomorrow Teaser"
       where: end
 
 newsletter:


### PR DESCRIPTION
## 1. Multilingual: per-show loop stopped after the first show

The 2026-06-17 sweep ([run 27687748927](https://github.com/Planetterrian/nerranetwork/actions/runs/27687748927)) reported success but only translated `env_intel`. SpaceX/Tesla/etc. got no tracks for today.

**Root cause:** the step pipes the show list into a `while read` loop; `ffmpeg`/`ffprobe` inside `generate_translations.py` read the loop's stdin and drained the slug list, so it exited after one show. Step still `exit 0`'d → CI green.

**Fix:** `for` loop over a `mapfile` array (keeps the script's stdin) + `</dev/null` on the python call. Verified locally it iterates every show. A corrected backfill sweep was dispatched from this branch ([run 27698956316](https://github.com/Planetterrian/nerranetwork/actions/runs/27698956316)).

## 2. Omni View: closing-chapter fix (was failing this PR's CI — and `main`)

The full suite caught a **pre-existing, unrelated** regression on today's Omni View Ep084: its closing merged the teaser + sign-off into one paragraph ("Tomorrow, watch for … **That's Omni View.** …"), and with `Tomorrow Teaser` listed before `Closing` the first-marker-per-line rule orphaned the Closing chapter — `test_omni_view_quality_pass` failed (would fail on any PR, since it reads committed episodes).

**Fix:** reorder the two `where: end` markers so **Closing precedes Tomorrow Teaser** — the exact fix already applied to Env Intel (landmine #19). Verified across the last 10 episodes: all keep a Closing chapter; the 9 with separate teaser/closing lines keep both. Metadata-only (chapters.json), no audio change.

Bundled here because it blocks this PR's CI (and main is currently red without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK