### PR TITLE
Multilingual UX: per-episode language switcher on show pages + translate right after publish

### DIFF
--- a/.github/workflows/multilingual.yml
+++ b/.github/workflows/multilingual.yml
@@ -15,6 +15,15 @@ name: Generate Multilingual Audio
 # tracks a prior run missed. The episode pipeline stays fast + durable.
 
 on:
+  # Fire right after an episode publishes so the latest episode is translated
+  # within minutes (not hours). The episode pipeline ("Run Podcast Show") is a
+  # separate workflow; its completion triggers a sweep here. The sweep is
+  # idempotent (skips already-translated episodes), so the once-per-show-run
+  # fan-out is mostly fast no-ops, and the concurrency group below serializes
+  # them. The scheduled passes stay as a safety net for any run this misses.
+  workflow_run:
+    workflows: ["Run Podcast Show"]
+    types: [completed]
   schedule:
     # After the morning show window (shows finish ~12-13 UTC; GitHub cron is
     # often hours late, which is fine — the sweep is idempotent). Two passes
@@ -46,6 +55,10 @@ permissions:
 jobs:
   translate:
     runs-on: ubuntu-latest
+    # On the workflow_run trigger, only proceed if the episode pipeline that
+    # triggered us actually succeeded — no point translating a failed/partial
+    # publish. Schedule + manual dispatch always run.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     timeout-minutes: 330
     steps:
       - name: Checkout

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -872,42 +872,55 @@
                 card.className = 'episode-card glass-card';
                 card.innerHTML = `
                     <div class="episode-card-date">${formatDate(ep.date)}</div>
-                    <div class="episode-card-title">${escapeHtml(ep.episode_title || 'Episode')}</div>
+                    <div class="episode-card-title" data-role="title">${escapeHtml(ep.episode_title || 'Episode')}</div>
                     <div style="color:var(--nn-text-muted);font-size:0.85rem;margin-bottom:var(--sp-3);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;">${escapeHtml(getPreviewText(ep.content))}</div>
-                    <audio controls preload="none" src="${ep.audio_url || ''}" aria-label="Play ${escapeHtml(ep.episode_title || 'episode')}" style="width:100%;height:36px;border-radius:8px;"></audio>
+                    <audio controls preload="none" data-role="audio" src="${ep.audio_url || ''}" aria-label="Play ${escapeHtml(ep.episode_title || 'episode')}" style="width:100%;height:36px;border-radius:8px;"></audio>
+                    <div data-role="langs" style="display:none;margin-top:6px;"></div>
                 `;
                 grid.appendChild(card);
+                // Per-episode language switcher (any translated archive episode,
+                // not just the latest) — directly addresses "listen to older
+                // episodes in another language" on the show page.
+                const tr = ep.translations || {};
+                if (Object.keys(tr).some((l) => tr[l] && tr[l].audio_url)) {
+                    attachLangSwitcher({
+                        box: card.querySelector('[data-role=langs]'),
+                        audioEl: card.querySelector('[data-role=audio]'),
+                        titleEl: card.querySelector('[data-role=title]'),
+                        enUrl: ep.audio_url || '',
+                        enTitle: ep.episode_title || 'Episode',
+                        translations: tr,
+                    });
+                }
             });
         }
 
-        // Latest-episode language switcher. Shows pills only when the episode
-        // has translation tracks, and swaps the latest player's audio + title
-        // + summary in place. Uses the site-wide `nn-pref-lang` preference so a
-        // visitor's language choice (here or on any blog post) sticks
-        // everywhere. Russian shows opt out of multilingual, so this no-ops.
-        function renderLatestLangs(latest) {
-            const box = document.getElementById('latest-langs');
+        // Shared per-player language switcher. Builds EN + available-language
+        // pills for ONE episode and swaps that player's audio/title/summary in
+        // place. Honors the site-wide `nn-pref-lang` and live `nn-langchange`,
+        // so it works for the latest player AND every archive card. Russian
+        // shows opt out of multilingual, so this no-ops (no translations).
+        function attachLangSwitcher(opts) {
+            const box = opts.box;
             if (!box) return;
-            const tr = (latest && latest.translations) || {};
+            const tr = opts.translations || {};
             const langs = Object.keys(tr).filter((l) => tr[l] && tr[l].audio_url);
             if (!langs.length) { box.style.display = 'none'; return; }
             const LABELS = { en: 'English', fr: 'Français', ru: 'Русский', es: 'Español', zh: '中文' };
             const order = ['en'].concat(langs);
-            const titleEl = document.getElementById('latest-title');
-            const audioEl = document.getElementById('latest-audio');
-            const summaryEl = document.getElementById('latest-summary');
-            const enTitle = latest.episode_title || 'Latest Episode';
-            const enSummary = summaryEl ? summaryEl.textContent : '';
+            const audioEl = opts.audioEl, titleEl = opts.titleEl, summaryEl = opts.summaryEl;
+            const enTitle = opts.enTitle || 'Episode';
+            const enSummary = opts.enSummary || (summaryEl ? summaryEl.textContent : '');
             const track = (code) => {
-                if (code === 'en') return { url: latest.audio_url || '', title: enTitle, desc: enSummary };
+                if (code === 'en') return { url: opts.enUrl || '', title: enTitle, desc: enSummary };
                 const t = tr[code] || {};
                 return { url: t.audio_url || '', title: t.title || enTitle, desc: t.description || enSummary };
             };
             const savedPref = () => { try { return localStorage.getItem('nn-pref-lang') || ''; } catch (e) { return ''; } };
             const apply = (code, persist) => {
                 const t = track(code);
-                if (audioEl && t.url) { const playing = !audioEl.paused; audioEl.src = t.url; if (playing) audioEl.play().catch(() => {}); }
-                if (titleEl) titleEl.textContent = t.title;
+                if (audioEl && t.url) { const playing = !audioEl.paused && !audioEl.ended; audioEl.src = t.url; if (playing) audioEl.play().catch(() => {}); }
+                if (titleEl && t.title) titleEl.textContent = t.title;
                 if (summaryEl && t.desc) summaryEl.textContent = t.desc;
                 box.querySelectorAll('button[data-lang]').forEach((b) => {
                     const on = b.dataset.lang === code;
@@ -920,9 +933,12 @@
             };
             box.innerHTML = '';
             box.style.display = 'flex';
+            box.style.alignItems = 'center';
+            box.style.flexWrap = 'wrap';
+            box.style.gap = '6px';
             const label = document.createElement('span');
-            label.textContent = 'Listen in:';
-            label.style.cssText = 'font-size:0.8rem;color:var(--nn-text-muted);';
+            label.textContent = opts.labelText || 'Listen in:';
+            label.style.cssText = 'font-size:0.78rem;color:var(--nn-text-muted);';
             box.appendChild(label);
             order.forEach((code) => {
                 const b = document.createElement('button');
@@ -930,7 +946,7 @@
                 b.dataset.lang = code;
                 b.textContent = LABELS[code] || code.toUpperCase();
                 b.setAttribute('aria-pressed', 'false');
-                b.style.cssText = 'font:600 0.8rem/1.5 var(--font-ui,sans-serif);padding:2px 12px;border-radius:100px;border:1px solid var(--nn-border);background:var(--nn-card);color:var(--nn-text-muted);cursor:pointer;';
+                b.style.cssText = 'font:600 0.78rem/1.4 var(--font-ui,sans-serif);padding:2px 11px;border-radius:100px;border:1px solid var(--nn-border);background:var(--nn-card);color:var(--nn-text-muted);cursor:pointer;';
                 b.addEventListener('click', () => apply(code, true));
                 box.appendChild(b);
             });
@@ -941,6 +957,20 @@
             });
             const pref = savedPref();
             apply((pref && (pref === 'en' || tr[pref])) ? pref : 'en', false);
+        }
+
+        function renderLatestLangs(latest) {
+            const summaryEl = document.getElementById('latest-summary');
+            attachLangSwitcher({
+                box: document.getElementById('latest-langs'),
+                audioEl: document.getElementById('latest-audio'),
+                titleEl: document.getElementById('latest-title'),
+                summaryEl: summaryEl,
+                enUrl: latest.audio_url || '',
+                enTitle: latest.episode_title || 'Latest Episode',
+                enSummary: summaryEl ? summaryEl.textContent : '',
+                translations: (latest && latest.translations) || {},
+            });
         }
 
         function loadFromRSS() {


### PR DESCRIPTION
## Why

After the per-language feeds shipped, the on-site language experience looked broken across all shows and showed nothing for TST. Root cause: the show-page switcher only appeared on each show's **latest** episode, and the latest episode is the one most likely to be untranslated (translations are produced out-of-band, after publish). So right after each daily publish, every show page had no language option. (TST additionally had never completed a successful translation sweep — fixed separately by the loop fix + backfill.)

This PR hardens the experience so it doesn't depend on the latest episode being translated yet.

## Changes

1. **Per-episode language switcher on show pages.** Refactored the latest-episode switcher into a shared `attachLangSwitcher(...)` used by both the latest player **and every archive episode card**. Any translated episode in the archive now gets its own EN/FR/RU/ES/ZH pills that swap that card's audio + title in place. Honors the site-wide `nn-pref-lang` and live `nn-langchange` from the header globe.

2. **Always-show language options.** With per-card switchers, any recent translated episode surfaces pills even when today's episode isn't translated yet; the per-language podcast RSS links row already renders whenever feeds exist. The page no longer looks empty during the daily translation lag.

3. **Cut the translation lag.** `multilingual.yml` now also triggers on `workflow_run` completion of **"Run Podcast Show"** (gated on `conclusion == 'success'`), so a freshly published episode is translated within minutes instead of waiting for the 2×/day schedule. Idempotent and serialized by the existing `multilingual` concurrency group; the scheduled passes stay as a safety net.

## Verification

- Show-page renders cleanly; inline JS passes `node --check`; `attachLangSwitcher` wired for both latest + cards; archive cards carry the `data-role=langs` box.
- `test_multilingual`, `test_language_feeds`, `test_website_quality_pass` all pass.
- Triggers (`workflow_run`) only take effect once on `main` (default-branch rule).

Note: the running backfill is what populates today's translations (incl. TST Ep513); this PR makes the surface robust to the lag going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_