### PR TITLE
Show pages: declutter top nav + hero action hierarchy

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -115,12 +115,14 @@ button { font-family: var(--font-ui); cursor: pointer; }
   font-size: 1.25rem; font-weight: 700;
   color: var(--nn-white);
   text-decoration: none;
+  flex-shrink: 0;
+  margin-right: var(--sp-4);
 }
 .nn-nav-logo img {
   width: 36px; height: 36px; border-radius: 8px; object-fit: cover;
 }
 .nn-nav-links {
-  display: flex; align-items: center; gap: var(--sp-8);
+  display: flex; align-items: center; gap: var(--sp-6);
   list-style: none;
 }
 .nn-nav-links li { white-space: nowrap; }
@@ -679,6 +681,30 @@ button { font-family: var(--font-ui); cursor: pointer; }
 }
 .show-hero-actions {
   display: flex; gap: var(--sp-3); flex-wrap: wrap;
+}
+/* Secondary "subscribe on platform" row — lighter pill chips so the hero
+   action area reads as a hierarchy (one primary CTA + explore buttons, then
+   a quieter subscribe row) instead of a wall of identical buttons. */
+.show-hero-subscribe {
+  display: flex; gap: var(--sp-2); flex-wrap: wrap; align-items: center;
+  margin-top: var(--sp-4);
+}
+.show-hero-subscribe .subscribe-label {
+  font-family: var(--font-ui); font-size: 0.72rem; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--nn-text-muted); margin-right: var(--sp-1);
+}
+.nn-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 13px; border-radius: 999px;
+  font-family: var(--font-ui); font-size: 0.82rem; font-weight: 600;
+  border: 1px solid var(--nn-border);
+  background: transparent; color: var(--nn-text-muted);
+  transition: all var(--duration) var(--ease);
+}
+.nn-chip:hover {
+  color: var(--nn-text); border-color: var(--nn-border-hover);
+  background: var(--nn-surface); transform: translateY(-1px);
 }
 
 /* ---------- Latest Episode Player (Show Page) ---------- */

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -186,7 +186,7 @@
                Content Lake FTS index (scripts/build_search_index.py). Single
                fetch of a compact JSON; rich client ranking + all shows + entities.
                Zero ongoing backend cost (static site). #}
-            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.5rem;max-width:180px;flex:1 1 auto;min-width:120px;">
+            <div class="nn-global-search" style="position:relative;margin-left:auto;margin-right:0.5rem;max-width:200px;flex:0 1 200px;min-width:110px;">
                 <input type="search" id="nn-global-search-input"
                        placeholder="Search…"
                        style="width:100%;padding:6px 8px;border-radius:999px;border:1px solid var(--nn-border);background:var(--nn-surface);color:inherit;font-size:0.85rem;"

--- a/templates/show_page.html.j2
+++ b/templates/show_page.html.j2
@@ -45,21 +45,16 @@
    are the most reliable approach. #}
 {%- set _is_ru = (page_lang | default('en')) == 'ru' -%}
 
-{# May 2026 operator request: top-right nav must carry the
-   ``Start Here / Listen / About / Player`` quartet across the
-   whole site for consistency. Layered IN FRONT OF the per-show
-   navigation (Blog / Summaries / RSS / @handle) so listeners on
-   a show page can still jump to that show's secondary surfaces
-   directly while also seeing the network-wide quartet. #}
+{# Top-right nav carries the network-wide ``Start Here / Listen / About /
+   Player`` quartet for consistency across the site. The show's own secondary
+   surfaces (Blog / Summaries / RSS / @handle) are NOT duplicated here — they
+   are prominent action buttons in the hero just below — which keeps the top
+   bar uncluttered. #}
 {% block nav_links %}
 <li><a href="{{ path_prefix }}start-here.html">{{ t.nav_start_here }}</a></li>
 <li><a href="{{ path_prefix }}how-to-listen.html">{{ t.nav_listen }}</a></li>
 <li><a href="{{ path_prefix }}about.html">{{ t.nav_about }}</a></li>
 <li><a href="{{ path_prefix }}player.html">{{ t.nav_player }}</a></li>
-<li><a href="{{ path_prefix }}{{ blog_page }}">{% if _is_ru %}Блог{% else %}Blog{% endif %}</a></li>
-<li><a href="{{ path_prefix }}{{ summaries_page }}">{% if _is_ru %}Выпуски{% else %}Summaries{% endif %}</a></li>
-<li><a href="{{ path_prefix }}{{ rss_file }}">RSS</a></li>
-{% if x_account %}<li><a href="https://x.com/{{ x_account }}" target="_blank" rel="noopener">@{{ x_account }}</a></li>{% endif %}
 {% endblock %}
 
 {% block mobile_nav_links %}
@@ -108,6 +103,9 @@
                 {% if audience %}
                 <p style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);margin-bottom:var(--sp-4);font-style:italic;">{{ audience }}</p>
                 {% endif %}
+                {# Primary actions: one filled CTA + a few "explore this show"
+                   buttons. Platform subscribe links live in the quieter chip
+                   row below so the hero isn't a wall of identical pills. #}
                 <div class="show-hero-actions">
                     <a href="#episodes" class="nn-btn nn-btn-primary">{% if _is_ru %}Слушать{% else %}Listen Now{% endif %}</a>
                     <a href="{{ path_prefix }}{{ blog_page }}" class="nn-btn">{% if _is_ru %}Читать блог{% else %}Read Blog{% endif %}</a>
@@ -121,20 +119,6 @@
                     {% if show_slug == 'tesla' %}
                     <a href="{{ path_prefix }}tesla-dashboard.html" class="nn-btn">📊 Tesla Dashboard</a>
                     {% endif %}
-                    {% if apple_podcasts_url %}
-                    <a href="{{ apple_podcasts_url | with_utm(campaign=show_slug) }}" class="nn-btn" target="_blank" rel="noopener" data-show="{{ show_slug }}">Apple Podcasts</a>
-                    {% endif %}
-                    {% if spotify_url %}
-                    <a href="{{ spotify_url | with_utm(campaign=show_slug) }}" class="nn-btn" target="_blank" rel="noopener" data-show="{{ show_slug }}">Spotify</a>
-                    {% endif %}
-                    <a href="{{ path_prefix }}{{ rss_file }}" class="nn-btn" data-show="{{ show_slug }}">{% if _is_ru %}RSS-канал{% else %}RSS Feed{% endif %}</a>
-                    {% if youtube_playlist_url %}
-                    <a href="{{ youtube_playlist_url }}" class="nn-btn" target="_blank" rel="noopener" data-show="{{ show_slug }}">{% if _is_ru %}YouTube{% else %}Watch on YouTube{% endif %}</a>
-                    {% endif %}
-                    {% if x_account %}
-                    <a href="https://x.com/{{ x_account }}" class="nn-btn" target="_blank" rel="noopener">@{{ x_account }}</a>
-                    {% endif %}
-
                     {% if show_slug == "modern_investing" %}
                     <a href="{{ path_prefix }}modern-investing-performance.html" class="nn-btn" style="background: var(--show-color, #047857); color: white;">
                         Performance &amp; Lessons
@@ -142,11 +126,29 @@
                     {% endif %}
                 </div>
 
+                {# Subscribe row — quieter chips, clearly grouped. #}
+                <div class="show-hero-subscribe">
+                    <span class="subscribe-label">{% if _is_ru %}Подписаться{% else %}Subscribe{% endif %}</span>
+                    {% if apple_podcasts_url %}
+                    <a href="{{ apple_podcasts_url | with_utm(campaign=show_slug) }}" class="nn-chip" target="_blank" rel="noopener" data-show="{{ show_slug }}">Apple Podcasts</a>
+                    {% endif %}
+                    {% if spotify_url %}
+                    <a href="{{ spotify_url | with_utm(campaign=show_slug) }}" class="nn-chip" target="_blank" rel="noopener" data-show="{{ show_slug }}">Spotify</a>
+                    {% endif %}
+                    <a href="{{ path_prefix }}{{ rss_file }}" class="nn-chip" data-show="{{ show_slug }}">{% if _is_ru %}RSS-канал{% else %}RSS{% endif %}</a>
+                    {% if youtube_playlist_url %}
+                    <a href="{{ youtube_playlist_url }}" class="nn-chip" target="_blank" rel="noopener" data-show="{{ show_slug }}">YouTube</a>
+                    {% endif %}
+                    {% if x_account %}
+                    <a href="https://x.com/{{ x_account }}" class="nn-chip" target="_blank" rel="noopener">@{{ x_account }}</a>
+                    {% endif %}
+                </div>
+
                 {% if language_feeds %}
-                <div class="nn-lang-feeds" style="margin-top:0.85rem;font-size:0.9rem;">
-                    <span style="color:var(--nn-text-muted);">{% if _is_ru %}Аудио на других языках (RSS):{% else %}Listen in another language (podcast RSS):{% endif %}</span>
+                <div class="show-hero-subscribe nn-lang-feeds" style="margin-top:0.55rem;">
+                    <span class="subscribe-label">{% if _is_ru %}Другие языки{% else %}In your language{% endif %}</span>
                     {% for f in language_feeds %}
-                    <a href="{{ f.url }}" class="nn-btn" data-show="{{ show_slug }}" data-lang="{{ f.lang }}" hreflang="{{ f.lang }}" style="padding:4px 10px;font-size:0.82rem;">{{ f.label }}</a>
+                    <a href="{{ f.url }}" class="nn-chip" data-show="{{ show_slug }}" data-lang="{{ f.lang }}" hreflang="{{ f.lang }}">{{ f.label }}</a>
                     {% endfor %}
                 </div>
                 {% endif %}


### PR DESCRIPTION
## What you reported
- The top bar on show pages is **busy and crowded** (the search box was even overlapping the "Network" logo).
- The language changer / per-language RSS feeds "don't do anything" on TST.

## Changes (this PR — visual)

**Top nav declutter**
- The show page was injecting a *second* set of links into the nav — Blog / Summaries / RSS / @handle — that **duplicate the buttons already in the hero**. Removed them; the nav now carries only the network quartet (Start Here / Listen / About / Player) + the Shows/Blog dropdowns. Verified the rendered Tesla nav now has 2 dropdowns + 4 links (was ~10 items).
- **Logo overlap fix:** the logo gets `flex-shrink:0` + a right margin so it can never be squished, and the global search is constrained to `flex:0 1 200px` instead of growing into the logo. Nav-link gap tightened (`sp-8`→`sp-6`).

**Hero hierarchy**
- The hero was a wall of ~11 identical pills. Split into: a **primary action group** (Listen Now + Read Blog / View Summaries / Story Tracker / Dashboard) and a quieter, grouped **"Subscribe"** chip row (Apple / Spotify / RSS / YouTube / @handle), plus an **"In your language"** chip row for the per-language feeds. New lightweight `.nn-chip` style.

Source-only — the pipeline regenerates show-page HTML (nightly + each show's next episode), so it propagates without committing HTML. I couldn't visually preview in this environment, so please eyeball the rendered result and I'll iterate on spacing/sizing to taste.

## On "the language changer does nothing" (not a code bug)
The globe writes a site-wide preference and the show-page/per-episode switchers respond — but only when the episode actually has translation tracks. **TST has none yet**: the corrected backfill sweep is still running and hasn't committed Tesla's translations. Once it lands (and the show page regenerates with the #667 per-episode switcher), TST's switcher + the per-language RSS chips will populate. `env_intel` already demonstrates the working switcher today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_