### PR TITLE
Multilingual: harden translation quality (fix Chinese English-bleed)

### DIFF
--- a/engine/translate.py
+++ b/engine/translate.py
@@ -44,6 +44,52 @@ LANGUAGE_NAMES: Dict[str, str] = {
 
 _TRANSLATION_MODEL = "grok-latest"
 
+# Per-language guidance injected into the translation prompt. Pointed, native-
+# broadcaster notes — the Chinese block is the most detailed because that's
+# where English was bleeding into shipped tracks (June 2026).
+_LANGUAGE_GUIDANCE: Dict[str, str] = {
+    "zh": (
+        "SIMPLIFIED CHINESE GUIDANCE (read carefully — this is where quality "
+        "slips):\n"
+        "- The output must be natural Mandarin. Do NOT leave English sentences, "
+        "clauses, or phrases in the text, and never mix English and Chinese "
+        "inside one sentence. If you are tempted to keep an English phrase, "
+        "translate it into Mandarin. Only the specific proper nouns/tickers "
+        "listed above may remain in Latin letters.\n"
+        "- Use full-width Chinese punctuation （，。！？、；：“”）, never English "
+        "punctuation between Chinese clauses.\n"
+        "- Write every number, year, price, and percentage in Chinese spoken "
+        "form (e.g. 第513集、百分之五、二十亿美元、二〇二六年).\n"
+        "- When a Latin brand name sits in a Chinese sentence, set it off "
+        "naturally with surrounding Chinese (e.g. 特斯拉的 FSD 系统).\n"
+        "- Translate the WHOLE script — Chinese is compact, but every English "
+        "sentence must have a Mandarin counterpart. Do not condense or drop "
+        "segments to make it shorter."
+    ),
+    "ru": (
+        "RUSSIAN GUIDANCE:\n"
+        "- Decline names and nouns naturally; keep idiomatic broadcast Russian.\n"
+        "- Use Russian quotation marks «…» and spell numbers, prices, and "
+        "percentages the natural spoken Russian way.\n"
+        "- Do not leave English clauses in the text — only the allowed proper "
+        "nouns/tickers stay in Latin."
+    ),
+    "fr": (
+        "FRENCH GUIDANCE:\n"
+        "- Natural broadcast French (radio register); use « » quotation marks "
+        "and spell numbers, prices, and percentages the spoken French way.\n"
+        "- Do not leave English clauses in the text — only the allowed proper "
+        "nouns/tickers stay as-is."
+    ),
+    "es": (
+        "SPANISH GUIDANCE:\n"
+        "- Neutral, international broadcast Spanish; spell numbers, prices, and "
+        "percentages the spoken Spanish way.\n"
+        "- Do not leave English clauses in the text — only the allowed proper "
+        "nouns/tickers stay as-is."
+    ),
+}
+
 
 class TranslationError(RuntimeError):
     """A translation came back unusable (empty, too short, or untranslated)."""
@@ -102,6 +148,11 @@ def _format_overrides_block(lang: str) -> str:
     return "\n".join(f"- {term} => {spelling}" for term, spelling in items.items())
 
 
+def language_guidance(lang: str) -> str:
+    """Per-language broadcaster guidance injected into the prompt (or '')."""
+    return _LANGUAGE_GUIDANCE.get(lang, "")
+
+
 def apply_overrides(text: str, lang: str) -> str:
     """Post-process: enforce per-language phonetic spellings in *text*.
 
@@ -145,7 +196,11 @@ def _is_cjk(c: str) -> bool:
 # Minimum target-script ratio for languages whose script differs from English.
 # Latin-script targets (fr/es) can't be distinguished from an English echo by
 # script alone, so they rely on the echo + length-floor checks instead.
-_MIN_SCRIPT_RATIO = {"ru": 0.5, "zh": 0.3}
+# Raised June 2026 after TST Chinese tracks shipped with English clauses
+# bleeding in (the 0.3 floor let a half-English "translation" pass). A clean
+# zh/ru prose track is ~95%+ target-script even with a handful of Latin brand
+# tokens, so 0.6/0.55 rejects real code-switching without false positives.
+_MIN_SCRIPT_RATIO = {"ru": 0.55, "zh": 0.6}
 # A translation shorter than this fraction of the source is almost certainly
 # truncated or a stub, not a faithful for-the-ear localization.
 _MIN_LENGTH_FRACTION = 0.25
@@ -210,10 +265,28 @@ def _build_script_prompt(english_script: str, lang: str) -> str:
     template = _PROMPT_PATH.read_text(encoding="utf-8")
     return (
         template
+        # Substitute the script LAST so script content containing literal
+        # ``{...}`` (or another placeholder's name) can't corrupt the prompt.
         .replace("{language_name}", language_name(lang))
         .replace("{bcp47}", lang)
         .replace("{phonetic_overrides}", _format_overrides_block(lang))
+        .replace("{language_specific_guidance}", language_guidance(lang))
         .replace("{english_script}", english_script)
+    )
+
+
+def _retry_correction(lang: str) -> str:
+    """Corrective suffix appended on a second attempt after a failed validation
+    (wrong script / English echo / suspiciously short = code-switching or a
+    condensed/partial translation)."""
+    name = language_name(lang)
+    return (
+        f"\n\nCORRECTION — your previous attempt was REJECTED because it was "
+        f"not entirely in {name} (it left English in the text and/or dropped "
+        f"content). Re-translate the ENTIRE script above into {name} ONLY: "
+        f"every sentence rendered in {name}, no English words or phrases "
+        f"remaining anywhere, nothing summarized or omitted. Output only the "
+        f"translated script."
     )
 
 
@@ -236,10 +309,24 @@ def translate_script(
 
     prompt = _build_script_prompt(english_script, lang)
     logger.info("Translating script -> %s (%d chars in)", lang, len(english_script))
-    text = _generate(prompt, model, max_tokens)
-    # Reject refusals / wrong-script / echoes BEFORE they reach TTS.
-    text = validate_translation(text, lang, english_script)
-    return apply_overrides(text, lang)
+
+    # Validation-driven retry: a wrong-script / English-echo / too-short result
+    # (i.e. code-switching or a condensed/partial translation — the ZH failure
+    # mode) gets ONE more attempt with a strong corrective before we give up,
+    # instead of silently dropping the language for the episode.
+    last_err: Optional[Exception] = None
+    for attempt in range(2):
+        p = prompt if attempt == 0 else prompt + _retry_correction(lang)
+        text = _generate(p, model, max_tokens)
+        try:
+            text = validate_translation(text, lang, english_script)
+            return apply_overrides(text, lang)
+        except TranslationError as exc:
+            last_err = exc
+            logger.warning("Translation validation failed for %s (attempt %d/2): %s",
+                           lang, attempt + 1, exc)
+    assert last_err is not None
+    raise last_err
 
 
 def translate_metadata(

--- a/shows/prompts/_shared/translation.txt
+++ b/shows/prompts/_shared/translation.txt
@@ -1,31 +1,45 @@
-You are a professional podcast localizer. Translate the following English
-podcast script into {language_name} (BCP-47 code: {bcp47}) for SPOKEN
-DELIVERY by a voice host.
+You are an expert podcast localizer and a native {language_name} broadcaster.
+Localize the English podcast script below into {language_name} (BCP-47 code:
+{bcp47}) for SPOKEN delivery by a {language_name} voice host.
 
-This is a localization for the EAR, not a literal translation:
-- Produce natural, idiomatic {language_name} that a native host would
-  actually say out loud. Prioritize how it SOUNDS over word-for-word
-  fidelity.
-- Preserve the host's pacing, tone, energy, and paragraph/sentence rhythm.
-  Keep the same number of beats and the same conversational flow.
-- Keep it the same episode: do not add, remove, summarize, or invent
-  content. Every fact, number, and segment stays.
+This is a localization FOR THE EAR, not a literal translation.
 
-Proper nouns, tickers, and brand names:
-- Keep company names, product names, people's names, and stock tickers
-  intact (e.g. Tesla, SpaceX, Optimus, TSLA) — do NOT translate them.
-- For terms a {language_name} speaker would likely mispronounce, use the
-  phonetic spelling given in the overrides below so the host says them
-  correctly. Apply an override ONLY for terms that appear in the script.
+ABSOLUTE RULES (most important first):
+1. OUTPUT 100% IN {language_name}. Every sentence, clause, connective word,
+   and description must be in {language_name}. Do NOT leave English words,
+   phrases, or sentences in the output, and never mix English with
+   {language_name} inside a sentence (no code-switching). The ONLY Latin-
+   script text allowed is the specific proper nouns / tickers listed under
+   "KEEP AS-IS" below.
+2. TRANSLATE THE ENTIRE SCRIPT, start to finish. Do NOT summarize, shorten,
+   condense, paraphrase away, merge, or skip any sentence or segment. Keep
+   every fact, number, name, and beat. Match the English length and density —
+   a host should speak for about as long in {language_name} as in English.
+3. SOUND LIKE A NATIVE HOST: natural, idiomatic, fluent {language_name} with
+   the host's pacing, tone, energy, and paragraph/sentence rhythm. Prioritize
+   how it SOUNDS aloud over word-for-word fidelity.
 
-Phonetic spelling overrides for {language_name} (term => spell it this way):
+NUMBERS, DATES, UNITS:
+- Render every number, year, date, price, and percentage the natural SPOKEN
+  way a {language_name} host would say it aloud — not as raw English.
+
+KEEP AS-IS (do not translate; render as proper nouns):
+- Company, product, and people's names and stock tickers (e.g. Tesla, SpaceX,
+  Optimus, TSLA). Where an established {language_name} name or a phonetic
+  spelling is given in the overrides below, use THAT so the host pronounces it
+  correctly. Apply an override only to terms that actually appear in the
+  script.
+
+Phonetic / localized spellings for {language_name} (term => use this):
 {phonetic_overrides}
 
-Formatting:
+{language_specific_guidance}
+
+FORMATTING:
 - Preserve any bracketed speech tags exactly as they appear (e.g. [pause],
   [breath], <emphasis>...</emphasis>) — do not translate or remove them.
-- Output ONLY the translated script text. No preamble, no notes, no
-  markdown fences, no English original.
+- Output ONLY the translated script text. No preamble, no notes, no language
+  label, no markdown fences, and never the English original.
 
 English script to localize:
 ---

--- a/shows/translation_overrides.yaml
+++ b/shows/translation_overrides.yaml
@@ -36,6 +36,15 @@ overrides:
   Tesla:
     ru: "Тесла"
     zh: "特斯拉"
+  # People — high-frequency on Tesla/SpaceX shows; left in Latin they read in
+  # an English accent. "Elon Musk" is listed BEFORE "Musk" so the full-name
+  # replacement wins first (overrides apply in file order).
+  Elon Musk:
+    ru: "Илон Маск"
+    zh: "埃隆·马斯克"
+  Musk:
+    ru: "Маск"
+    zh: "马斯克"
   SpaceX:
     ru: "Спейс-Экс"
     zh: "SpaceX"

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -145,6 +145,40 @@ class TestTranslationValidation:
         en = "Today Tesla expanded its robotaxi program across Texas."
         assert validate_translation(fr, "fr", en) == fr
 
+    def test_chinese_with_heavy_english_bleed_rejected(self):
+        # The shipped-TST failure mode (June 2026): a "Chinese" track that is
+        # really half English clauses. The tightened zh ratio floor (0.6) must
+        # reject it so the retry fires instead of voicing English.
+        from engine.translate import TranslationError, validate_translation
+        bleed = ("今天的新闻 Tesla is urging owners to oppose the New Jersey bill "
+                 "before it advances 这很重要 and here is why it matters to drivers")
+        with pytest.raises(TranslationError):
+            validate_translation(bleed, "zh", "x" * 200)
+
+
+# ---------------------------------------------------------------------------
+# Translation prompt guidance (June 2026 quality pass)
+# ---------------------------------------------------------------------------
+
+class TestTranslationGuidance:
+    def test_every_supported_language_has_guidance(self):
+        from engine.translate import language_guidance, supported_languages
+        for lang in supported_languages():
+            assert language_guidance(lang).strip(), lang
+
+    def test_zh_guidance_bans_english_and_is_injected(self):
+        from engine.translate import _build_script_prompt, language_guidance
+        g = language_guidance("zh")
+        assert "Mandarin" in g and "English" in g
+        prompt = _build_script_prompt("Elon Musk likes Tesla.", "zh")
+        assert g.split("\n", 1)[0] in prompt  # guidance is actually injected
+        assert "{language_specific_guidance}" not in prompt  # placeholder filled
+
+    def test_people_overrides_localize_musk(self):
+        from engine.translate import apply_overrides
+        assert apply_overrides("Elon Musk", "zh") == "埃隆·马斯克"
+        assert apply_overrides("Musk", "ru") == "Маск"
+
 
 # ---------------------------------------------------------------------------
 # R2 key / URL derivation


### PR DESCRIPTION
## Problem
You flagged the other-language TST tracks — especially **Chinese, where English was bleeding in** and the audio sounded structurally off. The data confirms it: today's TST Ep513 Chinese track is **412s** vs **686 / 700 / 773s** for FR / RU / ES (env_intel's ZH ran ≈ equal to English, so this isn't just Chinese being compact). The ZH **script** was code-switching English clauses and dropping content. Two root causes:
1. The validator's CJK floor was **0.3** — a half-English "translation" passed.
2. A rejected translation was **silently skipped**, with no retry.

## Changes (these alter translated audio — A/B-listen before relying on them)

**Prompt rewrite** (`shows/prompts/_shared/translation.txt`):
- **No code-switching:** output must be 100% in the target language; the only Latin allowed is the listed proper nouns/tickers.
- **Completeness:** translate the *entire* script, never summarize/condense/drop, and match the English length/density (a host should speak ~as long).
- Numbers/dates/prices rendered the natural **spoken** way in-language.

**Per-language guidance** (new `{language_specific_guidance}` block in `engine/translate.py`):
- Chinese gets the most detail — full-width punctuation (，。！？), numbers in Chinese, no English prose, natural brand-name setting (e.g. `特斯拉的 FSD 系统`). RU/FR/ES get register + quotation/number notes.

**Validation hardening** (`engine/translate.py`):
- Wrong-script floor raised: **zh 0.3→0.6, ru 0.5→0.55** (a clean prose track is ~95%+ target-script even with brand tokens, so this rejects real bleed without false positives).
- **Validation-driven retry:** a rejected result (wrong-script / English echo / too short) gets one more attempt with a strong corrective ("re-translate the ENTIRE script ONLY in {language}…") instead of being dropped.

**Overrides** (`shows/translation_overrides.yaml`): localize **Elon Musk / Musk** for zh + ru (left in Latin they read in an English accent).

## Tests
`tests/test_multilingual.py`: ZH heavy-English-bleed now rejected; every supported language has guidance and it's injected into the prompt; people overrides localize Musk. Full multilingual + prompt-fidelity suites pass (91).

## How to verify
After merge, the post-publish trigger / next sweep will regenerate tracks with the new instructions. The clearest signal the fix worked: the ZH track duration should jump from ~412s toward the FR/RU/ES range, and the audio should be fully Mandarin. I can dispatch a fresh TST translation (`--force`) once merged so you can A/B-listen the new ZH/RU/ES/FR tracks against today's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_