### PR TITLE
Multilingual: offer blog + summaries as readable text in other languages

### DIFF
--- a/engine/blog.py
+++ b/engine/blog.py
@@ -703,6 +703,7 @@ def generate_blog_post_html(
     related_posts: Optional[list] = None,
     youtube_url: str = "",
     youtube_short_url: str = "",
+    translation_bodies: Optional[dict] = None,
 ) -> str:
     """Generate a complete blog post HTML page from digest markdown.
 
@@ -855,6 +856,9 @@ def generate_blog_post_html(
         # Per-language audio tracks (June 2026 multilingual). Empty/absent for
         # English-only episodes → the template renders no switcher.
         "translations": metadata.get("translations", {}) or {},
+        # Per-language readable BODY (rendered from each translated audio
+        # script). Empty when no translated script is on disk → English only.
+        "translation_bodies": translation_bodies or {},
         "transcript_url": f"{blog_url}#transcript" if transcript_text else "",
         # Russian shows render UI strings (incl. the AI badge) in Russian.
         "_is_ru": show_slug in ("finansy_prosto", "privet_russian"),

--- a/engine/multilingual.py
+++ b/engine/multilingual.py
@@ -179,6 +179,19 @@ def generate_for_episode(
         except OSError:
             size_bytes = 0
 
+        # Persist the translated SCRIPT text (speech tags stripped) next to the
+        # audio so the blog + summaries can offer the episode as READABLE text
+        # in this language — reusing the translation already produced for TTS,
+        # at no extra LLM cost. (Was previously discarded after synthesis.)
+        from engine.utils import strip_speech_tags
+        script_name = f"{tts_file.stem.replace('_tts', '')}.{lang}.txt"
+        try:
+            (output_dir / script_name).write_text(
+                strip_speech_tags(translated).strip() + "\n", encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Ep%s [%s]: could not save translated script: %s", episode_num, lang, exc)
+            script_name = ""
+
         en_dur = ffprobe_duration(english_url)
         if en_dur and dur:
             logger.info("Ep%s LENGTH [%s]: %.0fs vs EN %.0fs (%+.0f%%)",
@@ -209,6 +222,10 @@ def generate_for_episode(
             # (engine.language_feeds). Falls back to a duration estimate for
             # records that predate this field.
             "bytes": size_bytes,
+            # Filename of the persisted translated script (read by the blog
+            # generator to render the body in this language). Empty if the
+            # write failed.
+            "script_file": script_name,
             "generated_at": datetime.now(timezone.utc).isoformat(),
         })
         results[lang] = "done"

--- a/generate_html.py
+++ b/generate_html.py
@@ -2603,6 +2603,38 @@ def _attach_translations(slug, cfg, metas):
             meta["translations"] = tr
 
 
+def _plain_text_to_paragraphs(text: str) -> str:
+    """Render a plain translated script (blank-line-separated prose) to safe
+    HTML paragraphs for embedding as a blog body. No markdown — the translated
+    audio script is plain spoken prose."""
+    import html as _html
+
+    blocks = [b.strip() for b in re.split(r"\n\s*\n", text or "") if b.strip()]
+    out = []
+    for b in blocks:
+        # Preserve single newlines within a block as <br> (spoken-line breaks).
+        esc = _html.escape(b).replace("\n", "<br>")
+        out.append(f"<p>{esc}</p>")
+    return "\n".join(out)
+
+
+def _translated_bodies_for_episode(digest_dir, meta) -> dict:
+    """Read each language's saved translated script (``*.<lang>.txt`` next to
+    the audio) and render it to HTML paragraphs. Empty when none exist."""
+    bodies: dict = {}
+    for code, track in (meta.get("translations") or {}).items():
+        script_file = (track or {}).get("script_file")
+        if not script_file:
+            continue
+        p = digest_dir / script_file
+        if p.exists():
+            try:
+                bodies[code] = _plain_text_to_paragraphs(p.read_text(encoding="utf-8"))
+            except OSError:
+                continue
+    return bodies
+
+
 def generate_blog_posts(slug, *, dry_run=False, cross_show_posts=None):
     """Generate blog post HTML pages for all episodes of a show.
 
@@ -2675,6 +2707,7 @@ def generate_blog_posts(slug, *, dry_run=False, cross_show_posts=None):
             prev_post=prev_post,
             next_post=next_post,
             related_posts=_related,
+            translation_bodies=_translated_bodies_for_episode(digest_dir, meta),
         )
 
         ep_num = meta["episode_num"]

--- a/templates/blog_post.html.j2
+++ b/templates/blog_post.html.j2
@@ -665,6 +665,18 @@
             width: 100%;
             height: 38px;
         }
+        /* Per-language article bodies — only the active one shows. */
+        .blog-body-lang[hidden] { display: none !important; }
+        .blog-translated-note {
+            font-family: var(--font-ui);
+            font-size: 0.82rem;
+            color: var(--nn-text-muted);
+            border-left: 3px solid var(--show-color, #00D4FF);
+            padding: 6px 12px;
+            margin: 0 0 var(--sp-4);
+            background: var(--nn-surface);
+            border-radius: 0 8px 8px 0;
+        }
     </style>
 {% endblock %}
 
@@ -776,7 +788,19 @@
         {% endif %}
 
         <article class="blog-article">
+            {# Per-language body blocks. English is the default/visible one;
+               translated bodies (reused from the episode's translated audio
+               script) are hidden until the language switcher selects them.
+               Sources + transcript below stay shared. #}
+            <div class="blog-body-lang" data-lang="en">
             {{ blog_body }}
+            </div>
+            {% for code, body in (translation_bodies or {}).items() %}
+            <div class="blog-body-lang" data-lang="{{ code }}" hidden>
+                <p class="blog-translated-note">{{ _LANG_LABELS.get(code, code) }} — {% if _is_ru %}озвучка и текст переведены ИИ{% else %}AI-translated from the English episode{% endif %}.</p>
+                {{ body }}
+            </div>
+            {% endfor %}
 
             <!-- Sources -->
             {% if source_domains %}
@@ -960,6 +984,7 @@
     var titleEl = document.querySelector('.nn-i18n-title');
     var hookEl = document.querySelector('.blog-hero-hook');
     var pills = document.querySelectorAll('.nn-i18n-pill');
+    var bodyBlocks = document.querySelectorAll('.blog-body-lang');
     // Site-wide preference (localStorage) so a visitor picks their language
     // ONCE and every episode they open afterwards is already in it — the
     // choice persists across episodes and sessions. Falls back gracefully
@@ -986,6 +1011,14 @@
         }
         if (titleEl && t.title) titleEl.textContent = t.title;
         if (hookEl && t.desc) hookEl.textContent = t.desc;
+        // Swap the readable article body too — independent fallback so an
+        // episode with a translated track but no translated body (or vice
+        // versa) still degrades to English for the missing piece.
+        if (bodyBlocks.length) {
+            var hasBody = document.querySelector('.blog-body-lang[data-lang="' + code + '"]');
+            var bodyLang = hasBody ? code : 'en';
+            bodyBlocks.forEach(function(b) { b.hidden = (b.dataset.lang !== bodyLang); });
+        }
         document.documentElement.setAttribute('lang', code);
         pills.forEach(function(p) {
             p.setAttribute('aria-pressed', p.dataset.lang === code ? 'true' : 'false');

--- a/templates/summaries_page.html.j2
+++ b/templates/summaries_page.html.j2
@@ -314,18 +314,25 @@
                         </div>
                     ` : '';
 
-                    const titleHtml = title ? `<div style="font-weight:600;color:var(--show-color-text, var(--show-color));font-family:var(--font-ui);font-size:0.88rem;">${escapeHtml(title)}</div>` : '';
+                    const titleHtml = title ? `<div class="nn-summary-title" style="font-weight:600;color:var(--show-color-text, var(--show-color));font-family:var(--font-ui);font-size:0.88rem;">${escapeHtml(title)}</div>` : '<div class="nn-summary-title" hidden></div>';
 
-                    // Multilingual availability badges (June 2026): surface the
-                    // per-language audio tracks recorded on this episode.
-                    const LANG_LABELS = { fr: 'FR', ru: 'RU', es: 'ES', zh: '中文' };
+                    // Multilingual language buttons (June 2026): the episode's
+                    // per-language tracks. Clicking one swaps this card's title +
+                    // summary + audio to that language and sets the site-wide
+                    // preference; English is always offered. Driven by the global
+                    // `nn-pref-lang` so a choice sticks across the list + site.
+                    const LANG_LABELS = { en: 'EN', fr: 'FR', ru: 'RU', es: 'ES', zh: '中文' };
                     const tr = (s.translations && typeof s.translations === 'object') ? s.translations : {};
                     const langs = Object.keys(tr).filter(k => tr[k] && tr[k].audio_url);
-                    const badgeStyle = 'font-family:var(--font-ui);font-size:0.66rem;font-weight:600;padding:1px 7px;border-radius:100px;border:1px solid color-mix(in srgb, var(--show-color) 35%, transparent);color:var(--show-color-text, var(--show-color));background:color-mix(in srgb, var(--show-color) 10%, transparent);';
-                    const langsHtml = langs.length ? `<span class="nn-summary-langs" aria-label="Also available in other languages" style="display:inline-flex;gap:4px;margin-top:4px;">${langs.map(k => `<span style="${badgeStyle}">${LANG_LABELS[k] || k.toUpperCase()}</span>`).join('')}</span>` : '';
+                    // i18n payload the apply fn reads: English baseline + each track.
+                    const i18n = { en: { title: title, summary: content, url: audioUrl } };
+                    langs.forEach(k => { i18n[k] = { title: tr[k].title || title, summary: tr[k].description || '', url: tr[k].audio_url || audioUrl }; });
+                    const pillStyle = 'font-family:var(--font-ui);font-size:0.66rem;font-weight:600;padding:1px 8px;border-radius:100px;cursor:pointer;border:1px solid color-mix(in srgb, var(--show-color) 35%, transparent);color:var(--show-color-text, var(--show-color));background:color-mix(in srgb, var(--show-color) 10%, transparent);';
+                    const order = langs.length ? ['en'].concat(langs) : [];
+                    const langsHtml = order.length ? `<span class="nn-summary-langs" role="group" aria-label="Listen and read in another language" style="display:inline-flex;gap:4px;margin-top:4px;">${order.map(k => `<button type="button" class="nn-summary-lang" data-lang="${k}" style="${pillStyle}">${LANG_LABELS[k] || k.toUpperCase()}</button>`).join('')}</span>` : '';
 
                     return `
-                        <div class="nn-summary-item" data-date="${escapeAttr(date)}">
+                        <div class="nn-summary-item" data-date="${escapeAttr(date)}" data-i18n='${escapeAttr(JSON.stringify(i18n))}'>
                             <div class="nn-summary-header">
                                 <div>
                                     <div class="nn-summary-date">${formatDate(date)}</div>
@@ -337,6 +344,33 @@
                             <div class="nn-summary-content">${renderMarkdown(content)}</div>
                         </div>
                     `;
+                }
+
+                // Apply the site-wide language preference to one card: swap its
+                // title + summary + audio to the chosen language (falling back to
+                // English for any piece the episode doesn't have translated).
+                function applyCardLang(card, code) {
+                    let data;
+                    try { data = JSON.parse(card.getAttribute('data-i18n') || '{}'); } catch (e) { return; }
+                    const t = data[code] || data.en;
+                    if (!t) return;
+                    const titleEl = card.querySelector('.nn-summary-title');
+                    const contentEl = card.querySelector('.nn-summary-content');
+                    const audioEl = card.querySelector('.nn-summary-audio');
+                    if (titleEl && t.title) titleEl.textContent = t.title;
+                    if (contentEl) contentEl.innerHTML = renderMarkdown((t.summary && t.summary.trim()) ? t.summary : data.en.summary);
+                    if (audioEl && t.url) { const playing = !audioEl.paused; audioEl.src = t.url; if (playing) audioEl.play().catch(() => {}); }
+                    card.querySelectorAll('.nn-summary-lang').forEach(b => {
+                        b.setAttribute('aria-pressed', b.dataset.lang === code ? 'true' : 'false');
+                        b.style.outline = b.dataset.lang === code ? '2px solid var(--show-color)' : 'none';
+                    });
+                }
+                function savedLangPref() { try { return localStorage.getItem('nn-pref-lang') || 'en'; } catch (e) { return 'en'; } }
+                function applyAllCardsLang(code) {
+                    document.querySelectorAll('.nn-summary-item[data-i18n]').forEach(card => {
+                        const data = (() => { try { return JSON.parse(card.getAttribute('data-i18n') || '{}'); } catch (e) { return {}; } })();
+                        applyCardLang(card, (code === 'en' || data[code]) ? code : 'en');
+                    });
                 }
 
                 function renderPage() {
@@ -353,6 +387,7 @@
                     container.innerHTML = html;
                     initAudioUX(container);
                     initShareButtons(container);
+                    applyAllCardsLang(savedLangPref());
                     const loadMoreBtn = document.getElementById('loadMoreBtn');
                     if (loadMoreBtn) {
                         loadMoreBtn.addEventListener('click', () => {
@@ -363,6 +398,21 @@
                 }
 
                 renderPage();
+
+                // Per-card language buttons: set the site-wide preference, swap
+                // every card live, and notify the rest of the page/site.
+                container.addEventListener('click', (e) => {
+                    const btn = e.target.closest('.nn-summary-lang');
+                    if (!btn) return;
+                    const code = btn.dataset.lang || 'en';
+                    try { localStorage.setItem('nn-pref-lang', code); } catch (err) {}
+                    applyAllCardsLang(code);
+                    try { document.dispatchEvent(new CustomEvent('nn-langchange', { detail: { lang: code } })); } catch (err) {}
+                });
+                // React to the global header language control.
+                document.addEventListener('nn-langchange', (e) => {
+                    applyAllCardsLang((e.detail && e.detail.lang) || 'en');
+                });
 
                 // Populate year filter from available summary dates (newest first)
                 if (yearFilter) {


### PR DESCRIPTION
## Answer to "is the translation used for blog + summaries too?"
Previously **no** — translations localized only the **audio + title + one-line description**; the blog **article body** and the **summaries text** stayed English, and the full translated **script** was generated for TTS then **discarded**. This PR closes that gap by reusing that script (the cheap "script-reuse now" option you chose).

## Changes
- **Persist the translated script** — `engine/multilingual.py` now writes the translated script (speech tags stripped) next to the audio as `<stem>.<lang>.txt` and records `script_file` on the summaries record. Near-zero cost: it's the text the translator already produced for TTS.
- **Blog post body** — `generate_html`/`engine/blog.py` render each saved language script into a hidden per-language body block; the existing language switcher now swaps the **article body** (with a small "AI-translated from the English episode" note) alongside audio/title. Independent English fallback per piece, so an episode with a track but no saved body (or vice-versa) still degrades gracefully.
- **Summaries page** — the per-language availability badges are now **buttons** that swap each card's **title + summary + audio** to the chosen language and set the site-wide `nn-pref-lang`; cards also react to the global header language control.

English stays canonical; episodes with no saved translated script render exactly as before (so existing episodes are unaffected until re-translated).

## Scope / rollout
- This is the **spoken-script reading layer** (you selected "script now, article later"). The summaries card shows the translated **short description** as the in-language blurb + links to the full translated body on the blog. A richer article-level translation can be a follow-up.
- Today's already-translated episodes have **no saved script yet** (generated before this change), so the translated bodies appear once episodes are translated with this on disk. Independent of #672 (no file overlap) — they can merge in any order.

Verified: blog + summaries render cleanly, inline JS passes `node --check`, 86 tests pass (multilingual + blog growth + repositioning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_