### PR TITLE
Multilingual: add a force input to re-translate existing episodes

### DIFF
--- a/.github/workflows/multilingual.yml
+++ b/.github/workflows/multilingual.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: '3'
         type: string
+      force:
+        description: 'Re-translate even if a track already exists (passes --force). Use to refresh episodes after a prompt change.'
+        required: false
+        default: false
+        type: boolean
 
 # Serialize multilingual runs so two sweeps never fight over the same
 # summaries files / git push.
@@ -145,9 +150,13 @@ jobs:
         run: |
           LATEST="${{ github.event.inputs.latest }}"
           [ -z "$LATEST" ] && LATEST=3
+          # Operator-set --force re-translates episodes that already have tracks
+          # (e.g. to refresh them after a translation-prompt change).
+          FORCE=""
+          [ "${{ github.event.inputs.force }}" = "true" ] && FORCE="--force"
           # --zh-approved: operator approved all four languages including ZH.
           # `</dev/null`: keep ffmpeg/ffprobe from consuming the step's stdin.
-          python scripts/generate_translations.py "${{ matrix.show }}" --latest "$LATEST" --zh-approved </dev/null
+          python scripts/generate_translations.py "${{ matrix.show }}" --latest "$LATEST" --zh-approved $FORCE </dev/null
 
       - name: Build ${{ matrix.show }} language feeds
         if: always()


### PR DESCRIPTION
Adds a `force` boolean input to the multilingual `workflow_dispatch`. When true it passes `--force` to `generate_translations.py`, re-translating episodes that already have tracks.

**Why:** after a translation-prompt change (e.g. the #672 Chinese-quality fix), the latest episode is already translated, so the idempotent sweep skips it — there's no way to refresh it short of waiting for the next episode. `force` lets the operator re-translate recent episodes with the new instructions on demand.

Default `false` → existing scheduled/post-publish/normal-dispatch behavior is unchanged. YAML validated.

I've dispatched this from the branch (`show=tesla, latest=1, force=true`) to re-translate today's TST Ep513 with the improved prompt + save the translated scripts, so the new audio + the translated blog/summaries text land for A/B review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_