### PR TITLE
Fix NameError (missing re import) breaking blog generation

### DIFF
--- a/generate_html.py
+++ b/generate_html.py
@@ -2608,6 +2608,7 @@ def _plain_text_to_paragraphs(text: str) -> str:
     HTML paragraphs for embedding as a blog body. No markdown — the translated
     audio script is plain spoken prose."""
     import html as _html
+    import re
 
     blocks = [b.strip() for b in re.split(r"\n\s*\n", text or "") if b.strip()]
     out = []


### PR DESCRIPTION
## Bug (regression from #673)
`generate_html.py` blog generation crashes with:
```
NameError: name 're' is not defined
  File ".../generate_html.py", line 2612, in _plain_text_to_paragraphs
    blocks = [b.strip() for b in re.split(r"\n\s*\n", text or "") if b.strip()]
```
`_plain_text_to_paragraphs` (added in #673) uses `re.split`, but `generate_html.py` doesn't import `re` at module level. It only triggers once a show has translated script files on disk — which is now the case for the shows translated today — so it surfaced across **run-show's blog-regen step, the multilingual per-show regen, and the nightly site rebuild**.

## Fix
Add a local `import re` in the function (mirrors the existing local `import html`). One line.

Verified: `generate_html.py --show fascinating_frontiers --blogs` now exits 0 and embeds the translated body blocks (en + fr/ru/es/zh).

> Separately, today's translation runs also hit transient `RemoteDisconnected` errors from the Grok TTS API — a side effect of the burst of post-publish multilingual runs when many shows were triggered at once. Those are idempotent and retry on the next sweep; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_