### PR TITLE
Grok Imagine: adopt grok-imagine-image-quality + fix stale pricing

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -475,9 +475,10 @@ class YouTubeConfig:
     #               without paying for long-form re-rendering.
     image_provider: str = "pexels"
     # ``grok-imagine-image`` ($0.02/image, 300 req/min) is the safe
-    # default. ``grok-imagine-image-pro`` ($0.07/image, 30 req/min)
-    # is the higher-quality tier — use only on a show flagged for
-    # quality emphasis since it's 3.5× the cost.
+    # default for new shows. ``grok-imagine-image-quality`` ($0.05/image,
+    # 300 req/min; released 2026-04-03, supersedes the old
+    # ``grok-imagine-image-pro`` id) is the higher-quality tier the
+    # YouTube-image shows opt into via their YAML.
     grok_image_model: str = "grok-imagine-image"
     # Optional one-line tone descriptor injected into every Grok prompt.
     # Defaults to a generic photojournalism cue; shows can override

--- a/engine/grok_imagine.py
+++ b/engine/grok_imagine.py
@@ -8,10 +8,11 @@ opt-in via each show's ``youtube.image_provider`` config knob:
                 Shorts via Grok Imagine, prompted from the day's hook
   ``hybrid``  — Pexels for long-form, Grok for Shorts (cheaper test)
 
-Pricing (verified May 2026, see CLAUDE.md landmine on this rollout):
+Pricing (verified against xAI docs, June 2026 — see CLAUDE.md landmine):
 
-  ``grok-imagine-image``       $0.02 / image  (300 req/min)
-  ``grok-imagine-image-pro``   $0.07 / image  ( 30 req/min)
+  ``grok-imagine-image``           $0.02 / image  (300 req/min, alias …-2026-03-02)
+  ``grok-imagine-image-quality``   $0.05 / image  (300 req/min, released 2026-04-03;
+                                   ``grok-imagine-image-pro`` is now an alias of it)
 
 At 8 images per format × 2 formats × ~52 episodes/month for Tesla + MAB
 (the only YouTube-enabled shows) the standard model lands at ~$17/mo.
@@ -60,10 +61,16 @@ DEFAULT_TIMEOUT_S = 60
 # flips between standard and pro.
 MODEL_COST_USD = {
     "grok-imagine-image": 0.02,
-    "grok-imagine-image-pro": 0.07,
+    # Higher-quality tier (released 2026-04-03). xAI made the old
+    # "-pro" id an alias of "-quality" and dropped the price 0.07 -> 0.05
+    # at the higher 300 req/min rate.
+    "grok-imagine-image-quality": 0.05,
+    "grok-imagine-image-quality-latest": 0.05,
+    "grok-imagine-image-pro": 0.05,
     # Aliases the operator might type in YAML.
     "grok-imagine-standard": 0.02,
-    "grok-imagine-pro": 0.07,
+    "grok-imagine-quality": 0.05,
+    "grok-imagine-pro": 0.05,
 }
 
 

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -356,7 +356,7 @@ youtube:
   # pexels default, so Shorts shipped stock photos). Unique, narrative-tied
   # space/science visuals + feeds the gallery pipeline.
   image_provider: grok
-  grok_image_model: grok-imagine-image
+  grok_image_model: grok-imagine-image-quality
   grok_image_descriptor: "cinematic, awe-inspiring space and science photo, dramatic lighting, ultra-detailed"
   tags:
     - space

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -313,7 +313,7 @@ youtube:
   # June 14 2026 — Grok Imagine for all imagery (was inheriting the pexels
   # default). Unique, narrative-tied finance visuals on @NerraRU.
   image_provider: grok
-  grok_image_model: grok-imagine-image
+  grok_image_model: grok-imagine-image-quality
   grok_image_descriptor: "cinematic, polished personal-finance lifestyle photo, dramatic lighting, ultra-detailed"
   tags:
     - финансы

--- a/shows/first_principles.yaml
+++ b/shows/first_principles.yaml
@@ -190,7 +190,7 @@ youtube:
   # Grok Imagine for podcast-format imagery (long-form slideshow only since
   # Shorts are off). Required by test_all_youtube_shows_use_grok_imagine.
   image_provider: grok
-  grok_image_model: grok-imagine-image
+  grok_image_model: grok-imagine-image-quality
   grok_image_descriptor: "documentary-style engineering photo, dramatic lighting, technical, ultra-detailed"
   tags:
     - first principles

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -315,7 +315,7 @@ youtube:
   # pexels default, so Shorts shipped stock photos). Unique, narrative-tied
   # markets/finance visuals + feeds the gallery pipeline.
   image_provider: grok
-  grok_image_model: grok-imagine-image
+  grok_image_model: grok-imagine-image-quality
   grok_image_descriptor: "cinematic, polished financial-news photo, dramatic lighting, ultra-detailed"
   tags:
     - investing

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -262,7 +262,7 @@ youtube:
   # June 14 2026 — Grok Imagine for all imagery (was inheriting the pexels
   # default). Unique, narrative-tied language-learning visuals on @NerraRU.
   image_provider: grok
-  grok_image_model: grok-imagine-image
+  grok_image_model: grok-imagine-image-quality
   grok_image_descriptor: "cinematic, warm language-learning lifestyle photo, dramatic lighting, ultra-detailed"
   tags:
     - learn russian

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -264,7 +264,7 @@ youtube:
   # narrative-tied spaceflight visuals and feeds the gallery pipeline. ~$0.32/
   # episode (8 imgs × 2 formats × $0.02 standard model).
   image_provider: grok
-  grok_image_model: grok-imagine-image
+  grok_image_model: grok-imagine-image-quality
   grok_image_descriptor: "cinematic, high-energy spaceflight photo, dramatic lighting, ultra-detailed"
   # Curated, disambiguated subjects spanning the whole SpaceX business so the
   # slideshow matches the day's narrative (rockets, Starship, Raptor, launch

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -326,7 +326,7 @@ youtube:
   # ``grok-imagine-image`` rate (8 imgs × 2 formats × $0.02). Flip
   # back to ``pexels`` if engagement metrics don't justify the spend.
   image_provider: grok
-  grok_image_model: grok-imagine-image
+  grok_image_model: grok-imagine-image-quality
   grok_image_descriptor: "high-energy Tesla news photo"
   tags:
     - tesla

--- a/tests/test_grok_imagine.py
+++ b/tests/test_grok_imagine.py
@@ -290,18 +290,21 @@ class TestCostTable:
         from engine.grok_imagine import MODEL_COST_USD
         assert MODEL_COST_USD["grok-imagine-image"] == 0.02
 
-    def test_pro_price_is_seven_cents(self):
+    def test_quality_tier_price_is_five_cents(self):
+        # The higher-quality tier (released 2026-04-03). xAI made the old
+        # "-pro" id an alias of "-quality" at $0.05 (was $0.07).
         from engine.grok_imagine import MODEL_COST_USD
-        assert MODEL_COST_USD["grok-imagine-image-pro"] == 0.07
+        assert MODEL_COST_USD["grok-imagine-image-quality"] == 0.05
+        assert MODEL_COST_USD["grok-imagine-image-pro"] == 0.05
 
     def test_aliases_map_to_same_prices(self):
         """Operators sometimes type ``grok-imagine-standard`` /
-        ``grok-imagine-pro`` instead of the API IDs. The cost table
+        ``grok-imagine-quality`` instead of the API IDs. The cost table
         recognises both spellings so cost tracking stays accurate
         regardless."""
         from engine.grok_imagine import MODEL_COST_USD
         assert MODEL_COST_USD["grok-imagine-standard"] == MODEL_COST_USD["grok-imagine-image"]
-        assert MODEL_COST_USD["grok-imagine-pro"] == MODEL_COST_USD["grok-imagine-image-pro"]
+        assert MODEL_COST_USD["grok-imagine-quality"] == MODEL_COST_USD["grok-imagine-image-quality"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
You spotted a Grok Imagine update — confirmed against the live xAI docs. The higher-quality image tier is now **`grok-imagine-image-quality`** (released **2026-04-03**, **$0.05/image**, 300 req/min). The old `grok-imagine-image-pro` id is now just an **alias** of it, at the lower **$0.05** (was $0.07) and a higher rate limit — so our cost map and comments were stale.

## Changes (operator decision: "fix + upgrade all")
- **`engine/grok_imagine.py`** — recognize `grok-imagine-image-quality` (+ `-latest`) at $0.05; correct `-pro` $0.07 → $0.05; refresh docstring pricing.
- **`engine/config.py`** — refresh the `grok_image_model` comment; **default stays the $0.02 standard** model (safe for new shows).
- **All 7 image-generating shows** (tesla, spacex, fascinating_frontiers, modern_investing, finansy_prosto, privet_russian, first_principles) switched to `grok-imagine-image-quality` for better slideshow stills (**+$0.03/image**).
- **Tests** updated to the new $0.05 quality price.

Other models reviewed and **current** (no change): `grok-4.3` (LLM + synth), `grok-4.20-reasoning` (fallback), `grok-4-1-fast-non-reasoning` (reviewer), `grok-latest` (translation). `grok-imagine-video-1.5` exists but we build slideshows from stills, so it's N/A.

Image-only change (no audio). A/B the new stills; revert any show's YAML to `grok-imagine-image` if the cost isn't worth it. 118 image/config/visual tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_