### PR TITLE
[show-review] SpaceX Daily quality pass (2026-06-18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,6 +493,25 @@ TST received a full recursive improvement architecture (analogous to MIT):
   regression; and "AI & Compute" chapter lumping (swallows trailing Top
   News when the LLM emits news after the editorial markers) — observe Ep3+
   before a prompt change.
+  **June 18 2026 second pass** (review:
+  [`docs/reviews/spacex_review_2026_06_18.md`](docs/reviews/spacex_review_2026_06_18.md);
+  drift guard: `tests/test_spacex_show.py::TestClosingBeforeMarketWatch`):
+  both June-13 predictions HIT (themes clean, no `tf`/`T F`). Found + fixed a
+  P0 the snapshot's "clean chapters" check missed — **weekly-recap episodes
+  shipped with NO Closing chapter** (`chapters_ep003.json` ended at a
+  mis-titled "Market Watch"). The code-supplied closing block appends the
+  SPCX price into the sign-off, the Market Watch marker matches that price
+  phrase, and Market Watch was listed before Closing; dailies escaped via
+  the real Market Watch segment consuming the marker first (once-per-title),
+  but recaps have no such segment. Fixed by ordering the **Closing marker
+  ahead of Market Watch** (`where: end` keeps it pinned to the sign-off) —
+  metadata-only, no audio, zero regression on all 7 scripts. This also
+  clears the chapter blocker on the deferred price-twice fix. Deferred
+  (evidence strengthened): chronic under-length is the **Engineering Deep
+  Dive under-delivering its own spec** (140-181w vs the digest prompt's "3
+  paragraphs of 4-6 sentences" ~250-360w) — the expand-the-deep-dive lever
+  stays deferred pending the network four-show length A/B. The AI-lumping
+  and hook-jargon June-13 deferrals did NOT recur.
 - All shows delegate X posting to `engine.publisher.post_to_x()`
 - TST/FF/PT delegate voice normalization to `engine.audio.normalize_voice()`
 - All shows use `engine.audio.mix_with_music()` for music mixing (3 modes:

--- a/docs/reviews/ledger/spacex.yaml
+++ b/docs/reviews/ledger/spacex.yaml
@@ -7,11 +7,11 @@ reviews:
       AI-chapter spacing + AI-accuracy items same-day; this pass took the next
       tier: theme-miner source-label pollution and a spoken thrust-unit garble.
     shipped:
-      - theme miner strips markdown source-link labels (was leaking "google
-        spacex" as the #1 theme; latent on all memory shows) + rebuilt clean
+      - theme miner strips markdown source-link labels (was leaking google
+        spacex as the top theme; latent on all memory shows) + rebuilt clean
         spacex_theme_history.json
-      - "tf" thrust unit expanded to "tons-force" via per-show
-        pronunciation_overrides (was spoken "T F")
+      - tf thrust unit expanded to tons-force via per-show
+        pronunciation_overrides (was spoken T F)
     deferred:
       - SPCX price spoken twice/episode (Market Watch segment + closing block);
         clean fix needs Closing marker reordered ahead of Market Watch AND the
@@ -25,11 +25,52 @@ reviews:
       - metric: highest-weighted key in spacex_theme_history.json recurring_themes
         baseline: "'google spacex' (count 6)"
         expected: "no source-label token (google/news/com/gov/reddit) in any top-30 theme key after Ep3-Ep5 mine"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-06-18: top themes all real (data center 8, starship/starlink/falcon/launch 5, elon musk 4); no source-label token in top 30."
       - metric: count of "tf" / "T F" letter-spellings in spacex _tts.txt + transcripts
         baseline: "2 (Ep2)"
         expected: "0 — 'tf' renders as 'tons-force' going forward"
+        verdict: hit
+        evidence: "2026-06-18: 'tf' only in pre-fix Ep2 _tts.txt; no 'T F' in any Ep3-7 transcript."
+
+  - date: 2026-06-18
+    pr: null
+    doc: docs/reviews/spacex_review_2026_06_18.md
+    summary: >
+      Second review. Both prior predictions HIT. Found + fixed a P0: weekly-
+      recap episodes shipped with NO Closing chapter — the price-carrying
+      sign-off was grabbed by the Market Watch marker (orphan-closing class).
+      Reordered Closing ahead of Market Watch (metadata-only, no audio).
+      Documented deep-dive-under-delivery as the root cause of chronic under-
+      length (deferred — four-show length A/B pending) and noted the P0
+      reorder now clears the chapter blocker on the deferred price-twice fix.
+    shipped:
+      - Closing chapter marker reordered before Market Watch in shows/spacex.yaml
+        so the price-carrying sign-off keeps its Closing chapter (fixes Ep3
+        weekly-recap orphan-closing; verified zero regression on all 7 scripts)
+    deferred:
+      - Engineering Deep Dive under-delivers its own spec (140-181w vs the
+        digest prompt's "3 paragraphs of 4-6 sentences" ~250-360w) -> chronic
+        under-length; expand-the-deep-dive lever stays deferred pending the
+        network four-show length A/B, evidence strengthened (short vs its OWN
+        per-section spec). Attack — explicit ~280-340w deep-dive floor in
+        digest + podcast prompts; A/B.
+      - SPCX price spoken twice/episode (Market Watch segment + closing block,
+        7/7). Chapter blocker now cleared by this pass's Closing/Market Watch
+        reorder; next pass can make the Market Watch note qualitative (no
+        repeated number), single precise quote in the closing. Observe Ep8+
+        first; audio-affecting -> A/B.
+      - tomorrow-teaser "Watch for the [first/next] <test>" frame now 5/7;
+        monitor for dead rotation (P2).
+    predictions:
+      - metric: Closing chapter present in chapters_ep*.json for the next weekly-recap + all dailies
+        baseline: "Ep3 (2026-06-14 recap) shipped with NO Closing chapter"
+        expected: "every episode incl. the next weekly recap has a Closing chapter; dailies keep Market Watch too"
+        verdict: pending
+        evidence: null
+      - metric: Engineering Deep Dive word count in digests (Ep8+)
+        baseline: "Ep4-7 deep dive 140-276w vs ~250-360 spec"
+        expected: "still <250w on most episodes UNLESS the deferred deep-dive floor ships (scores the digest-ceiling thesis)"
         verdict: pending
         evidence: null
     agent_cost_usd: null

--- a/docs/reviews/review_state.yaml
+++ b/docs/reviews/review_state.yaml
@@ -23,7 +23,7 @@ targets:
   finansy_prosto: 2026-06-16
   privet_russian: 2026-06-10
   env_intel: 2026-06-15
-  spacex: 2026-06-13
+  spacex: 2026-06-18
   first_principles: 2026-06-10
   omni_view: 2026-06-10
   unintended_consequences: 2026-06-12

--- a/docs/reviews/spacex_review_2026_06_18.md
+++ b/docs/reviews/spacex_review_2026_06_18.md
@@ -1,0 +1,116 @@
+# SpaceX Daily — quality review (2026-06-18)
+
+Second scheduled review. Five more episodes have shipped since the
+2026-06-13 pass (Ep3 weekly-recap, Ep4–7 normal dailies), so the deferred
+levers now have real n.
+
+Evidence: `scripts/review_snapshot.py spacex` (ep lengths, repeated-phrase
+detector, cost, OP3), `shows/spacex.yaml`, all four prompts,
+`shows/hooks/spacex.py`, `engine/chapters.py`, the last 7 `_tts.txt` scripts
++ Whisper transcripts + `chapters_ep00*.json`, the digests, the trackers,
+`spacex_podcast.rss`, and `tests/test_spacex_show.py`. OP3 now shows
+**31 downloads / 7d** (first real audience signal).
+
+## Scoring the 2026-06-13 predictions
+
+- **Theme history no source-label tokens — HIT.** Top recurring themes are
+  now all real (`data center` 8, `starship`/`starlink`/`falcon`/`launch` 5,
+  `elon musk` 4, `full flow`/`flow staged` 3). No `google`/`news`/`com`/
+  `gov`/`reddit` token in the top 30.
+- **`tf` → tons-force, 0 letter-spellings — HIT.** `tf` appears only in the
+  pre-fix Ep2 `_tts.txt`; no `T F` in any Ep3–7 transcript.
+
+## P0 — listener-facing bug shipping today
+
+### Weekly-recap episodes ship with NO Closing chapter (orphan-closing) — SHIPPED FIX
+`digests/spacex/chapters_ep003.json` (the **committed** chapters the podcast
+app shows) is `['Introduction', 'The Engineering Angle', 'Tomorrow Teaser',
+'Market Watch']` — **no Closing**. Ep3's sign-off is
+`"…And that's a wrap on today's SpaceX developments. S P C X closed at one
+hundred sixty dollars… See you next time."` The code-supplied closing block
+(`shows/hooks/spacex.py:_price_sentence`) appends the SPCX price into the
+sign-off, and the **Market Watch** marker
+(`S ?P ?C ?X (closed|is at|is trading|opened)`) matches that price phrase.
+Market Watch was listed **before** Closing, so under first-marker-per-line the
+sign-off was titled **Market Watch** and the real Closing was orphaned.
+
+Daily episodes escaped it only because their *real* Market Watch segment
+consumes that marker first (once-per-title) — but weekly recaps have no
+separate Market Watch segment, so the price-only sign-off was the marker's
+sole match. This is the exact orphan-closing class fixed on EI/OV/MAB/FP/UC,
+and precisely the risk the 2026-06-13 review flagged as the blocker on the
+price-twice item.
+
+**Fix:** reorder the `Closing` marker **before** `Market Watch` in
+`shows/spacex.yaml` so Closing (pinned `where: end`) wins the sign-off line.
+Verified across all 7 committed scripts: Ep3 gains its Closing chapter; every
+daily keeps **both** Market Watch and Closing — zero regression. Metadata-only
+(chapters.json), **no audio change**. Drift guards:
+`TestClosingBeforeMarketWatch` (3 tests).
+
+## P1 — quality ceiling (documented; not shipped this pass)
+
+### Engineering Deep Dive under-delivers its own spec → chronic under-length
+4 of the last 5 normal episodes ship under the 1300-word floor (Ep3 956,
+Ep4 851, Ep5 999, Ep6 1117; Ep7 1364). Root cause is the digest ceiling — the
+podcast tracks the digest, and digests run 736–1243w. The lever is the
+**Engineering Deep Dive**, the prompt's own "flagship section" and stated
+"length lever," explicitly licensed to use the model's own engineering
+knowledge (so it is NOT digest-source-capped). But it under-delivers its own
+spec: the digest prompt asks for "3 paragraphs of 4–6 sentences each"
+(~250–360w), while the actual deep dives run **Ep4 181w, Ep5 147w, Ep6 140w,
+Ep7 276w** — roughly half, on 3 of 4.
+
+**Deferred, not shipped:** expanding the deep dive is the network-wide
+length lever that `CLAUDE.md` keeps deferred **pending the operator's
+four-show length A/B** (FF June-16 note). That reason still holds, so per the
+playbook it stays deferred — but the new evidence (the deep dive is short
+against its *own* per-section spec, not just the global target) makes this the
+single highest-value lever the moment the A/B settles. Recommended attack:
+give the deep-dive section an explicit word floor (~280–340w) in both the
+digest and podcast prompts; A/B-listen.
+
+### SPCX price number spoken twice every episode — chapter blocker now cleared
+Still 7/7 (Ep7: "a quick market note: SPCX is at $191.82" in Market Watch
+**and** "SPCX is trading at $191.82" in the closing). The 2026-06-13 review
+deferred the fix because dropping the Market Watch price risked the
+orphan-closing regression. **This pass's P0 reorder removes that blocker** —
+with Closing now ahead of Market Watch, the sign-off keeps its Closing chapter
+regardless of the price phrase. So a future pass can safely make the Market
+Watch note **qualitative** (direction + why, no repeated number), leaving the
+single precise quote to the closing. Not shipped here: the reorder just
+landed; observe Ep8+ to confirm chapters stay clean before touching the
+audio prompt. Audio-affecting when done → A/B.
+
+## P2 / monitor
+
+- **Tomorrow-teaser frame "Watch for the [first/next] <test> to <purpose>"**
+  is now 5/7 (refueling test, hot-fire, earnings, static-fire ×2). Content
+  varies, but the frame is hardening into a template. Monitor; if it becomes
+  a dead rotation, rotate the teaser opener in the podcast prompt (low-risk,
+  no chapter dependency).
+
+## Resolved / not findings (verified)
+
+- **Hook jargon (Idiot Index unglossed)** did **not** recur — Ep4–7 hooks
+  lead with concrete engineering claims (Raptor 3 shutdowns, Shotwell's
+  target, orbital refueling).
+- **"from an engineering standpoint" (6/7) and "on the AI front" (5/7)** are
+  **REQUIRED chapter-marker anchors** by design (podcast prompt lines 88, 91,
+  "vary everything after it") — not tics. Left unchanged (cf. MAB "pop the
+  hood").
+- **"i'm patrick and vancouver" (5/7)** is a Whisper mishear — the `_tts.txt`
+  correctly says "I'm Patrick **in** Vancouver". No bug.
+- **AI & Compute chapter lumping** (2026-06-13 deferred) did **not** recur —
+  chapters are clean Ep4–7.
+
+## Hard guardrails honored
+No R2/RSS-enclosure changes, no MP3s, no `min_articles_skip` default change,
+no TTS-coupled-field flips, no voice/provider changes, no phonetic
+respellings, no posting/sending/uploading/paid APIs. The shipped fix is
+metadata-only (chapter marker order) — no audio change, no A/B required.
+
+## Tests
+`tests/test_spacex_show.py` (49, incl. 3 new), `test_network_quality_pass.py`,
+`test_chapters.py`, `test_prompt_fidelity.py`, `test_episode_validity.py` —
+all pass (208).

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -196,6 +196,18 @@ chapters:
     - pattern: "Space ?X Daily|welcome to Space ?X"
       title: "Introduction"
       where: start
+    # Closing is listed BEFORE Market Watch so it wins the sign-off line.
+    # The code-supplied closing block appends the SPCX price ("…that's a
+    # wrap. S P C X closed at $X…"), which the Market Watch pattern below
+    # also matches. On weekly-recap episodes there's no separate Market
+    # Watch SEGMENT to consume that marker first, so the sign-off was being
+    # mis-titled "Market Watch" and the episode shipped with NO Closing
+    # chapter (Ep3 2026-06-14). `where: end` keeps Closing pinned to the
+    # sign-off; daily episodes still get a Market Watch chapter from their
+    # real segment. Orphan-closing class (cf. EI/OV/MAB/FP/UC).
+    - pattern: "that.?s.*for today|that.?s a wrap|that covers|see you (tomorrow|next time)"
+      title: "Closing"
+      where: end
     - pattern: "on the market side|market watch|S ?P ?C ?X (closed|is at|is trading|opened)"
       title: "Market Watch"
     - pattern: "one thing worth watching|worth keeping an eye on|the counterpoint"
@@ -210,9 +222,6 @@ chapters:
       title: "AI & Compute"
     - pattern: "Before we go|before we wrap"
       title: "Tomorrow Teaser"
-      where: end
-    - pattern: "that.?s.*for today|that.?s a wrap|that covers|see you (tomorrow|next time)"
-      title: "Closing"
       where: end
 
 newsletter:

--- a/tests/test_spacex_show.py
+++ b/tests/test_spacex_show.py
@@ -80,6 +80,53 @@ class TestChapterPositionalAnchors:
         assert by_title["Tomorrow Teaser"].get("where") == "end"
 
 
+class TestClosingBeforeMarketWatch:
+    """The code-supplied closing block appends the SPCX price, which the
+    Market Watch pattern also matches. Closing MUST be listed before Market
+    Watch so it wins the sign-off line — otherwise weekly-recap episodes
+    (no separate Market Watch segment) ship with the sign-off mis-titled
+    'Market Watch' and NO Closing chapter (Ep3 2026-06-14 orphan-closing)."""
+
+    def test_closing_listed_before_market_watch(self):
+        titles = [m["title"] for m in _spacex_markers()]
+        assert titles.index("Closing") < titles.index("Market Watch"), (
+            "Closing must precede Market Watch so the price-carrying sign-off "
+            "line is titled Closing, not Market Watch"
+        )
+
+    def test_recap_signoff_with_price_gets_closing_chapter(self):
+        # Weekly-recap shape: no separate Market Watch segment; the closing
+        # carries the SPCX price (the exact Ep3 failure).
+        script = (
+            "Welcome to SpaceX Daily, episode 3. Let's get into it.\n\n"
+            "From an engineering standpoint, the booster catch geometry is "
+            "the whole game this week.\n\n"
+            "Before we go, the static-fire attempt is the item to watch next week.\n\n"
+            "And that's a wrap on today's SpaceX developments. S P C X closed "
+            "at one hundred sixty dollars and ninety-five cents. See you next time."
+        )
+        titles = [c.title for c in parse_chapters(
+            script, _spacex_markers(), show_name="SpaceX Daily")]
+        assert "Closing" in titles, titles
+        assert "Market Watch" not in titles, (
+            "no Market Watch segment in a recap — the price-only sign-off must "
+            f"not create a spurious Market Watch chapter: {titles}")
+
+    def test_daily_keeps_both_market_watch_and_closing(self):
+        # Daily shape: a real Market Watch segment AND a price-carrying close.
+        script = (
+            "Welcome to SpaceX Daily. Let's get into today's developments.\n\n"
+            "From an engineering standpoint, Raptor 3's plumbing is the story.\n\n"
+            "And a quick market note: S P C X is at two hundred one dollars, "
+            "down two percent.\n\n"
+            "That's a wrap on today's SpaceX developments. S P C X is trading "
+            "at two hundred one dollars, down two percent. See you tomorrow."
+        )
+        titles = [c.title for c in parse_chapters(
+            script, _spacex_markers(), show_name="SpaceX Daily")]
+        assert "Market Watch" in titles and "Closing" in titles, titles
+
+
 class TestClosingPoolMatchesChapterPattern:
     def test_every_closing_variant_matched(self):
         regex = re.compile(_closing_pattern(), re.IGNORECASE)


### PR DESCRIPTION
## TLDR
Second SpaceX Daily review (5 episodes since the 2026-06-13 pass). **Both prior predictions HIT** (theme history clean; no `tf`/`T F` letter-spellings). Found and fixed a **P0** the snapshot's "clean chapters" heuristic missed, and strengthened the evidence on the deferred under-length lever. OP3 now shows a first audience signal (31 downloads/7d).

## What shipped (P0 — metadata-only, no audio)
**Weekly-recap episodes shipped with NO Closing chapter.** `digests/spacex/chapters_ep003.json` (the committed chapters the podcast app shows) ends at a mis-titled **"Market Watch"** with no Closing. The code-supplied closing block (`shows/hooks/spacex.py:_price_sentence`) appends the SPCX price into the sign-off ("…that's a wrap. **S P C X closed at** $160.95…"), the **Market Watch** marker matches that price phrase, and Market Watch was listed **before** Closing — so under first-marker-per-line the sign-off was titled Market Watch and Closing was orphaned. Daily episodes escape it because their *real* Market Watch segment consumes the marker first (once-per-title); weekly recaps have no such segment. Orphan-closing class (cf. EI/OV/MAB/FP/UC).

**Fix:** reordered the `Closing` marker **ahead of** `Market Watch` in `shows/spacex.yaml` (`where: end` keeps it pinned to the sign-off). Verified across **all 7 committed scripts**: Ep3 gains its Closing chapter; every daily keeps **both** Market Watch and Closing — zero regression. Also fixed a pre-existing YAML malformation in the ledger so it parses.

Drift guards: `tests/test_spacex_show.py::TestClosingBeforeMarketWatch` (3 tests — marker order, recap sign-off → Closing, daily keeps both).

## ⚠️ A/B-listen required (landmine #17)
**None.** The shipped fix is chapter-marker order only — it changes `chapters.json` metadata, not the audio.

## Test results
`test_spacex_show.py` (49, +3 new), `test_network_quality_pass.py`, `test_chapters.py`, `test_prompt_fidelity.py`, `test_episode_validity.py` — **208 pass**.

## Deferred (documented, not shipped)
- **Chronic under-length** (4 of last 5 < 1300w floor). Root cause: the **Engineering Deep Dive under-delivers its own spec** — the digest prompt asks "3 paragraphs of 4–6 sentences" (~250–360w) but it ships 140–276w (Ep6 140, Ep5 147, Ep4 181). It's the one section licensed to use the model's own knowledge, so it's not source-capped. Stays deferred **pending the network four-show length A/B** (per CLAUDE.md), but the evidence is stronger now (short vs its *own* per-section spec). Attack when the A/B settles: explicit ~280–340w deep-dive floor in digest + podcast prompts (A/B).
- **SPCX price spoken twice/episode** (7/7). This pass's reorder **clears the chapter blocker** the 2026-06-13 review cited — a future pass can make the Market Watch note qualitative (drop the repeated number, keep the single precise quote in the closing). Observe Ep8+ first; audio-affecting → A/B.
- **Tomorrow-teaser "Watch for the [first/next] <test>" frame** now 5/7 — monitor for dead rotation (P2).

## Verified non-findings
Hook-jargon and AI-&-Compute-lumping (both 2026-06-13 deferrals) did **not** recur. "from an engineering standpoint" / "on the AI front" are intentional REQUIRED chapter anchors, not tics. "i'm patrick and vancouver" is a Whisper mishear (script says "in Vancouver").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_