### PR TITLE
Schedule + language overhaul, cheaper images, translation cost tracking

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -24,22 +24,22 @@ on:
     # Saturday with a weekend-focus angle (international markets, crypto,
     # lessons learned). Cron times shifted +1h from the prior schedule.
     #
-    # Привет, Русский!: Even days at 6:00 UTC
-    - cron: '7 6 2-31/2 * *'
+    # Привет, Русский!: Weekly on Monday at 6:00 UTC
+    - cron: '7 6 * * 1'
     # Omni View: Daily at 6:30 UTC (Sunday = weekly recap)
     - cron: '37 6 * * *'
     # Planetterrian Daily: Daily at 7:00 UTC (Sunday = weekly recap)
     - cron: '7 7 * * *'
     # Fascinating Frontiers: Daily at 7:30 UTC (Sunday = weekly recap)
     - cron: '37 7 * * *'
-    # Environmental Intelligence: Odd weekdays at 8:00 UTC
-    - cron: '7 8 1-31/2 * 1-5'
+    # Environmental Intelligence: Weekly on Monday at 8:00 UTC
+    - cron: '7 8 * * 1'
     # Models & Agents: Daily at 8:30 UTC (Sunday = weekly recap)
     - cron: '37 8 * * *'
     # Models & Agents for Beginners: Daily at 9:00 UTC (Sunday = weekly recap)
     - cron: '7 9 * * *'
-    # Финансы Просто: Even days at 9:30 UTC
-    - cron: '37 9 2-31/2 * *'
+    # Финансы Просто: Weekly on Monday at 9:30 UTC
+    - cron: '37 9 * * 1'
     # Modern Investing Techniques: Daily at 10:00 UTC.
     # Mon-Fri = US market preview; Sat = weekend angle (international
     # markets, crypto, lessons learned, what to prepare for, long-term
@@ -51,9 +51,9 @@ on:
     - cron: '37 10 * * *'
     # Tesla Shorts Time: Daily at 11:00 UTC (Sunday = weekly recap)
     - cron: '7 11 * * *'
-    # Unintended Consequences: Weekdays at 11:30 UTC. Narrative show —
-    # topic-queue-driven, no daily news fetch. Mon-Fri only (5x/week).
-    - cron: '37 11 * * 1-5'
+    # Unintended Consequences: Daily at 11:30 UTC. Narrative show —
+    # topic-queue-driven, no daily news fetch. Runs all 7 days.
+    - cron: '37 11 * * *'
     # SpaceX Daily: Daily at 12:07 UTC (Sunday = weekly recap)
     - cron: '7 12 * * *'
 
@@ -134,18 +134,18 @@ jobs:
               # so some crons fire more often than intended.  The day_filter
               # applies the intended restriction.
               CRON_MAP = {
-                  "7 6 2-31/2 * *":   ("privet_russian",          "even"),
+                  "7 6 * * 1":        ("privet_russian",          "monday"),
                   "37 6 * * *":       ("omni_view",                None),
                   "7 7 * * *":        ("planetterrian",            None),
                   "37 7 * * *":       ("fascinating_frontiers",    None),
-                  "7 8 1-31/2 * 1-5": ("env_intel",               "odd_weekday"),
+                  "7 8 * * 1":        ("env_intel",               "monday"),
                   "37 8 * * *":       ("models_agents",            None),
                   "7 9 * * *":        ("models_agents_beginners",  None),
-                  "37 9 2-31/2 * *":  ("finansy_prosto",          "even"),
+                  "37 9 * * 1":       ("finansy_prosto",          "monday"),
                   "7 10 * * *":       ("modern_investing",         None),
                   "37 10 * * *":      ("first_principles",         None),
                   "7 11 * * *":       ("tesla",                    None),
-                  "37 11 * * 1-5":    ("unintended_consequences", "weekday"),
+                  "37 11 * * *":      ("unintended_consequences", None),
                   "7 12 * * *":       ("spacex",                   None),
               }
 
@@ -177,6 +177,13 @@ jobs:
                       run_today = False
                       known_noop = True
                       print(f"Weekend no-op: {show_slug} only runs on weekdays.")
+                  elif day_filter == "monday" and weekday != 0:
+                      # Weekly shows run only on Monday (weekday()==0). The cron
+                      # already pins Monday; this guard also drops a GitHub cron
+                      # that fires late on a different day.
+                      run_today = False
+                      known_noop = True
+                      print(f"Weekly no-op: {show_slug} only runs on Mondays.")
 
                   if run_today:
                       shows.append(show_slug)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,13 @@ and (where enabled) post to X/Twitter via `engine/publisher.post_to_x()`.
 | Omni View | — (deleted) | `shows/omni_view.yaml` | Daily | `@omniviewnews` | Grok TTS (custom) |
 | Fascinating Frontiers | — (deleted) | `shows/fascinating_frontiers.yaml` | Daily | `@planetterrian` | Grok TTS (custom) |
 | Planetterrian Daily | — (deleted) | `shows/planetterrian.yaml` | Daily | `@planetterrian` | Grok TTS (custom) |
-| Env Intel | — | `shows/env_intel.yaml` | Odd weekdays | `@teslashortstime` | Grok TTS (custom) |
+| Env Intel | — | `shows/env_intel.yaml` | Monday | `@teslashortstime` | Grok TTS (custom) |
 | Models & Agents | — | `shows/models_agents.yaml` | Daily | — (X disabled) | Grok TTS (custom) |
 | Models & Agents for Beginners | — | `shows/models_agents_beginners.yaml` | Daily | — (X disabled) | Grok TTS (custom) |
-| Финансы Просто | — | `shows/finansy_prosto.yaml` | Even days | — (X disabled) | Grok TTS (Olya) |
+| Финансы Просто | — | `shows/finansy_prosto.yaml` | Monday | — (X disabled) | Grok TTS (Olya) |
 | Modern Investing Techniques | — | `shows/modern_investing.yaml` | Daily | — (X disabled) | Grok TTS (custom) |
-| Привет, Русский! | — | `shows/privet_russian.yaml` | Even days | — (X disabled) | Grok TTS (Olya) |
-| Unintended Consequences | — | `shows/unintended_consequences.yaml` | Weekdays | — (X disabled) | Grok TTS (custom) |
+| Привет, Русский! | — | `shows/privet_russian.yaml` | Monday | — (X disabled) | Grok TTS (Olya) |
+| Unintended Consequences | — | `shows/unintended_consequences.yaml` | Daily | — (X disabled) | Grok TTS (custom) |
 | First Principles Daily | — | `shows/first_principles.yaml` | Daily | — (X disabled) | Grok TTS (custom) |
 | SpaceX Daily | — | `shows/spacex.yaml` | Daily | — (X disabled) | Grok TTS (custom) |
 

--- a/engine/multilingual.py
+++ b/engine/multilingual.py
@@ -151,6 +151,12 @@ def generate_for_episode(
     existing = rec.get("translations", {}) or {}
 
     results: Dict[str, str] = {}
+    # Cost accounting — written to a per-episode multilingual credit_usage file
+    # so the dashboard's multilingual spend stops reading $0 (the untracked
+    # blind spot; June 2026). Charged: Grok TTS chars + the translation LLM.
+    ml_cost = 0.0
+    ml_chars = 0
+    ml_langs_done: list[str] = []
     for lang in languages:
         if lang in existing and not force:
             results[lang] = "skip"
@@ -229,9 +235,51 @@ def generate_for_episode(
             "generated_at": datetime.now(timezone.utc).isoformat(),
         })
         results[lang] = "done"
+        ml_cost += _estimate_track_cost(len(english_script), len(translated))
+        ml_chars += len(translated)
+        ml_langs_done.append(lang)
         logger.info("Ep%s [%s]: done → %s", episode_num, lang, public_url)
 
+    if ml_langs_done and not dry_run:
+        _write_ml_usage(output_dir, config, episode_num, rec.get("date", ""),
+                        ml_cost, ml_chars, ml_langs_done)
     return results
+
+
+def _estimate_track_cost(english_chars: int, translated_chars: int) -> float:
+    """Per-track translation cost: Grok TTS on the translated script + the
+    translation LLM call (grok-latest, priced like grok-4.3; tokens ≈ chars/4)."""
+    from engine.tracking import GROK_PRICING, GROK_TTS_COST_PER_1K_CHARS
+    tts_cost = (translated_chars / 1000.0) * GROK_TTS_COST_PER_1K_CHARS
+    pr = GROK_PRICING.get("grok-4.3", {"input_per_1m": 1.25, "output_per_1m": 2.50})
+    llm_cost = ((english_chars / 4.0) / 1e6) * pr["input_per_1m"] \
+        + ((translated_chars / 4.0) / 1e6) * pr["output_per_1m"]
+    return tts_cost + llm_cost
+
+
+def _write_ml_usage(output_dir, config, episode_num: int, date_str: str,
+                    cost: float, chars: int, langs: list) -> None:
+    """Write a per-episode multilingual credit_usage file. The dashboard's
+    aggregate_multilingual reads services.multilingual.estimated_cost_usd; the
+    network episode-cost aggregator reads only grok_api/tts_api, so this file
+    (multilingual-only) never double-counts."""
+    import json
+    ds = (date_str or datetime.now(timezone.utc).strftime("%Y-%m-%d"))[:10]
+    path = output_dir / f"credit_usage_{ds}_ep{episode_num:03d}_multilingual.json"
+    try:
+        path.write_text(json.dumps({
+            "date": ds,
+            "show": getattr(config, "name", None) or getattr(config, "slug", ""),
+            "episode_number": episode_num,
+            "services": {"multilingual": {
+                "estimated_cost_usd": round(cost, 6),
+                "languages": langs,
+                "tracks": len(langs),
+                "tts_chars": chars,
+            }},
+        }, ensure_ascii=False, indent=2), encoding="utf-8")
+    except OSError as exc:  # noqa: BLE001 — cost record must never block a run
+        logger.warning("Ep%s: could not write multilingual usage: %s", episode_num, exc)
 
 
 def auto_generate_after_publish(config, episode_num: int) -> Dict[str, str]:

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -174,6 +174,11 @@ keywords:
 min_articles: 5
 min_articles_skip: 2
 
+multilingual:
+  enabled: true
+  auto: true
+  languages: [fr]
+
 llm:
   provider: xai
   system_prompt_file: shows/prompts/env_intel_system.txt

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -189,6 +189,11 @@ keywords:
   - universe
   - cosmos
 
+multilingual:
+  enabled: true
+  auto: true
+  languages: [fr, ru, zh]
+
 llm:
   provider: xai
   system_prompt_file: shows/prompts/fascinating_frontiers_system.txt
@@ -356,7 +361,7 @@ youtube:
   # pexels default, so Shorts shipped stock photos). Unique, narrative-tied
   # space/science visuals + feeds the gallery pipeline.
   image_provider: grok
-  grok_image_model: grok-imagine-image-quality
+  grok_image_model: grok-imagine-image
   grok_image_descriptor: "cinematic, awe-inspiring space and science photo, dramatic lighting, ultra-detailed"
   tags:
     - space

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -313,7 +313,7 @@ youtube:
   # June 14 2026 — Grok Imagine for all imagery (was inheriting the pexels
   # default). Unique, narrative-tied finance visuals on @NerraRU.
   image_provider: grok
-  grok_image_model: grok-imagine-image-quality
+  grok_image_model: grok-imagine-image
   grok_image_descriptor: "cinematic, polished personal-finance lifestyle photo, dramatic lighting, ultra-detailed"
   tags:
     - финансы

--- a/shows/first_principles.yaml
+++ b/shows/first_principles.yaml
@@ -19,6 +19,11 @@ weekly_recap_on_sunday: false
 
 min_articles_skip: 0       # Narrative show — articles aren't the input.
 
+multilingual:
+  enabled: true
+  auto: true
+  languages: [fr]
+
 llm:
   provider: xai
   system_prompt_file: shows/prompts/first_principles_system.txt
@@ -190,7 +195,7 @@ youtube:
   # Grok Imagine for podcast-format imagery (long-form slideshow only since
   # Shorts are off). Required by test_all_youtube_shows_use_grok_imagine.
   image_provider: grok
-  grok_image_model: grok-imagine-image-quality
+  grok_image_model: grok-imagine-image
   grok_image_descriptor: "documentary-style engineering photo, dramatic lighting, technical, ultra-detailed"
   tags:
     - first principles

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -161,6 +161,11 @@ keywords:
   - alignment
   - guardrails
 
+multilingual:
+  enabled: true
+  auto: true
+  languages: [fr]
+
 llm:
   provider: xai
   system_prompt_file: shows/prompts/models_agents_system.txt

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -144,6 +144,10 @@ keywords:
 
 min_articles_skip: 2
 
+multilingual:
+  # English-only show (operator decision June 2026) — no translations.
+  enabled: false
+
 llm:
   provider: xai
   system_prompt_file: shows/prompts/mab_system.txt

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -130,6 +130,10 @@ keywords:
   - interest rate decision
   - dollar cost averaging
 
+multilingual:
+  # English-only show (operator decision June 2026) — no translations.
+  enabled: false
+
 llm:
   provider: xai
   # Inherits grok-4.3 from _defaults.yaml. Modern Investing previously
@@ -315,7 +319,7 @@ youtube:
   # pexels default, so Shorts shipped stock photos). Unique, narrative-tied
   # markets/finance visuals + feeds the gallery pipeline.
   image_provider: grok
-  grok_image_model: grok-imagine-image-quality
+  grok_image_model: grok-imagine-image
   grok_image_descriptor: "cinematic, polished financial-news photo, dramatic lighting, ultra-detailed"
   tags:
     - investing

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -144,6 +144,10 @@ keywords:
   - space
   - breaking
 
+multilingual:
+  # English-only show (operator decision June 2026) — no translations.
+  enabled: false
+
 llm:
   provider: xai
   system_prompt_file: shows/prompts/omni_view_system.txt

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -182,6 +182,10 @@ keywords:
   - yeast aging
   - mouse lifespan
 
+multilingual:
+  # English-only show (operator decision June 2026) — no translations.
+  enabled: false
+
 llm:
   provider: xai
   system_prompt_file: shows/prompts/planetterrian_system.txt

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -262,7 +262,7 @@ youtube:
   # June 14 2026 — Grok Imagine for all imagery (was inheriting the pexels
   # default). Unique, narrative-tied language-learning visuals on @NerraRU.
   image_provider: grok
-  grok_image_model: grok-imagine-image-quality
+  grok_image_model: grok-imagine-image
   grok_image_descriptor: "cinematic, warm language-learning lifestyle photo, dramatic lighting, ultra-detailed"
   tags:
     - learn russian

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -108,6 +108,11 @@ x_accounts:
 min_articles: 8
 min_articles_skip: 5
 
+multilingual:
+  enabled: true
+  auto: true
+  languages: [fr, ru, zh]
+
 llm:
   provider: xai
   system_prompt_file: shows/prompts/spacex_system.txt
@@ -264,7 +269,7 @@ youtube:
   # narrative-tied spaceflight visuals and feeds the gallery pipeline. ~$0.32/
   # episode (8 imgs × 2 formats × $0.02 standard model).
   image_provider: grok
-  grok_image_model: grok-imagine-image-quality
+  grok_image_model: grok-imagine-image
   grok_image_descriptor: "cinematic, high-energy spaceflight photo, dramatic lighting, ultra-detailed"
   # Curated, disambiguated subjects spanning the whole SpaceX business so the
   # slideshow matches the day's narrative (rockets, Starship, Raptor, launch

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -111,6 +111,11 @@ keywords:
   - solar roof
   - tesla charging
 
+multilingual:
+  enabled: true
+  auto: true
+  languages: [fr, ru, zh]
+
 llm:
   provider: xai
   # Inherits grok-4.3 from _defaults.yaml. Tesla previously pinned
@@ -326,7 +331,7 @@ youtube:
   # ``grok-imagine-image`` rate (8 imgs × 2 formats × $0.02). Flip
   # back to ``pexels`` if engagement metrics don't justify the spend.
   image_provider: grok
-  grok_image_model: grok-imagine-image-quality
+  grok_image_model: grok-imagine-image
   grok_image_descriptor: "high-energy Tesla news photo"
   tags:
     - tesla

--- a/shows/unintended_consequences.yaml
+++ b/shows/unintended_consequences.yaml
@@ -15,6 +15,10 @@ weekly_recap_on_sunday: false
 
 min_articles_skip: 0       # Narrative show — articles aren't the input
 
+multilingual:
+  # English-only show (operator decision June 2026) — no translations.
+  enabled: false
+
 llm:
   provider: xai
   system_prompt_file: shows/prompts/unintended_consequences_system.txt

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -27,18 +27,58 @@ TESLA_DIGESTS = PROJECT_ROOT / "digests" / "tesla_shorts_time"
 # ---------------------------------------------------------------------------
 
 class TestMultilingualConfig:
-    def test_english_show_inherits_enabled_default(self):
+    def test_per_show_languages(self):
+        # June 2026 per-show language sets (Spanish dropped network-wide):
+        # flagships get fr/ru/zh, lighter shows fr-only, the rest English-only.
         from engine.config import load_config
-        cfg = load_config("shows/tesla.yaml")
-        assert cfg.multilingual.enabled is True
-        assert cfg.multilingual.languages == ["fr", "ru", "es", "zh"]
-        assert cfg.multilingual.cloned_voice_env == "GROK_CLONED_VOICE_ID"
+        expected = {
+            "tesla": ["fr", "ru", "zh"],
+            "spacex": ["fr", "ru", "zh"],
+            "fascinating_frontiers": ["fr", "ru", "zh"],
+            "first_principles": ["fr"],
+            "models_agents": ["fr"],
+            "env_intel": ["fr"],
+        }
+        for slug, langs in expected.items():
+            cfg = load_config(f"shows/{slug}.yaml")
+            assert cfg.multilingual.enabled is True, slug
+            assert cfg.multilingual.languages == langs, slug
+            assert "es" not in cfg.multilingual.languages, slug
+        assert load_config("shows/tesla.yaml").multilingual.cloned_voice_env == "GROK_CLONED_VOICE_ID"
+
+    def test_english_only_shows_disabled(self):
+        from engine.config import load_config
+        for slug in ("modern_investing", "planetterrian", "omni_view",
+                     "models_agents_beginners", "unintended_consequences"):
+            assert load_config(f"shows/{slug}.yaml").multilingual.enabled is False, slug
 
     def test_russian_shows_opt_out(self):
         from engine.config import load_config
         for slug in ("finansy_prosto", "privet_russian"):
             cfg = load_config(f"shows/{slug}.yaml")
             assert cfg.multilingual.enabled is False, slug
+
+
+class TestMultilingualCostTracking:
+    """Translation spend is recorded so the dashboard stops reading $0."""
+
+    def test_track_cost_is_positive_and_tts_dominant(self):
+        from engine.multilingual import _estimate_track_cost
+        c = _estimate_track_cost(6500, 7000)
+        assert c > 0
+        # A full track is mostly TTS; sanity-bound it well under a dollar.
+        assert 0.005 < c < 0.5
+
+    def test_writes_multilingual_usage_file(self, tmp_path):
+        import json, types
+        from engine.multilingual import _write_ml_usage
+        cfg = types.SimpleNamespace(name="Demo", slug="demo")
+        _write_ml_usage(tmp_path, cfg, 7, "2026-06-18", 0.12, 21000, ["fr", "ru", "zh"])
+        f = tmp_path / "credit_usage_2026-06-18_ep007_multilingual.json"
+        assert f.exists()
+        d = json.loads(f.read_text())
+        ml = d["services"]["multilingual"]
+        assert ml["estimated_cost_usd"] == 0.12 and ml["tracks"] == 3
 
     def test_auto_enabled_for_english_shows(self):
         from engine.config import load_config

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -127,8 +127,9 @@ DAILY_SHOWS = [
     "models_agents", "models_agents_beginners", "modern_investing",
 ]
 ALT_CADENCE_SHOWS = [
+    # Weekly on Monday (June 2026): privet_russian + finansy_prosto moved off
+    # even-days, env_intel off odd-weekdays. None carry the recap flag.
     "privet_russian", "finansy_prosto", "env_intel",
-    "unintended_consequences",  # weekday-only narrative show
 ]
 
 
@@ -163,7 +164,7 @@ def test_alt_cadence_show_does_not_recap(slug):
 # Daily narrative shows (run every day, topic-queue-driven, no recap)
 # ---------------------------------------------------------------------------
 
-DAILY_NARRATIVE_SHOWS = ["first_principles"]
+DAILY_NARRATIVE_SHOWS = ["first_principles", "unintended_consequences"]
 
 
 @pytest.mark.parametrize("slug", DAILY_NARRATIVE_SHOWS)

--- a/workers/scheduler/src/index.ts
+++ b/workers/scheduler/src/index.ts
@@ -16,18 +16,18 @@ const WORKFLOW = "run-show.yml";
 
 // [utcHour, utcMinute, show, dayFilter]
 const SLOTS: Array<[number, number, string, string | null]> = [
-  [6, 7,  "privet_russian",          "even"],
+  [6, 7,  "privet_russian",          "monday"],
   [6, 37, "omni_view",                null],
   [7, 7,  "planetterrian",            null],
   [7, 37, "fascinating_frontiers",    null],
-  [8, 7,  "env_intel",               "odd_weekday"],
+  [8, 7,  "env_intel",               "monday"],
   [8, 37, "models_agents",            null],
   [9, 7,  "models_agents_beginners",  null],
-  [9, 37, "finansy_prosto",          "even"],
+  [9, 37, "finansy_prosto",          "monday"],
   [10, 7, "modern_investing",         null],
   [10, 37, "first_principles",        null],
   [11, 7, "tesla",                    null],
-  [11, 37, "unintended_consequences", "weekday"],
+  [11, 37, "unintended_consequences", null],
   [12, 7, "spacex",                   null],
 ];
 
@@ -44,6 +44,8 @@ function dayFilterPasses(filter: string | null, now: Date): boolean {
       return isWeekday;
     case "odd_weekday":
       return day % 2 === 1 && isWeekday;
+    case "monday":
+      return weekday === 1;
     default:
       return true;
   }


### PR DESCRIPTION
## What
Implements the requested scheduling + language changes, switches to the cheaper Grok Imagine model, and wires translation cost into the dashboard (it was reading $0).

### Languages (Spanish dropped network-wide; explicit per-show blocks)
| Show | Languages |
|---|---|
| Tesla, SpaceX, Fascinating Frontiers | EN + FR + RU + ZH |
| First Principles, Models & Agents, Env Intel | EN + FR |
| Modern Investing, Planetterrian, Omni View, Models & Agents for Beginners, Unintended Consequences | **English-only** (`multilingual.enabled: false`) |
| Финансы Просто, Привет Русский | unchanged (RU-only) |

### Schedule
- **Unintended Consequences:** weekdays → **daily** (now a daily narrative show, like First Principles).
- **Env Intel, Финансы Просто, Привет Русский:** → **weekly on Monday** (new `monday` day_filter; crons pinned `* * 1`). `run-show.yml` CRON_MAP, `workers/scheduler` SLOTS, and `test_schedule.py` all kept in sync (guarded by `test_scheduling_punctuality`).

### Cheaper images
Reverted `grok-imagine-image-quality` → `grok-imagine-image` ($0.05 → $0.02) on all 7 image-generating shows.

### Cost tracking ("wire in all charges")
`engine/multilingual.py` now writes a per-episode `credit_usage_*_multilingual.json` (`services.multilingual.estimated_cost_usd` = Grok TTS chars + the translation LLM). The dashboard's `aggregate_multilingual` already reads that field — it was just never written, so multilingual spend showed **$0**. Multilingual-only file → never double-counts the episode aggregator.

## 💰 Resulting monthly charges (all-in)
| Item | $/mo |
|---|---|
| English LLM + TTS (~317 episodes) | ~$21 |
| Translations (~339 tracks: Tesla/SpaceX/FF ×3 langs, First Principles/M&A ×1, Env Intel ×1) | ~$15 |
| Grok Imagine (standard $0.02) | ~$12 |
| R2 / Buttondown / domain / workers (external est.) | ~$15 |
| **TOTAL** | **≈ $63 / month** |

**Savings vs the prior trajectory:** translations drop from ~$55→~$15/mo (**~$40 saved** — fewer shows, fewer languages, Spanish gone, 3 shows now weekly), and images from ~$29 (at the quality tier)→~$12 (**~$17 saved**). Net **≈ $55/mo less** than where it was heading, landing the network around **$60–65/mo**. The biggest remaining cost (translations) is now visible on the dashboard instead of hidden.

## Tests
`test_multilingual` (per-show langs + en-only disabled + cost tracking), `test_schedule` (UC daily-narrative; weekly-Monday alt-cadence), `test_scheduling_punctuality`, `test_config`, `test_grok_imagine`, `test_visual_assets`, `test_network_quality_pass`, `test_episode_validity`, `test_prompt_fidelity` — **all pass (310)**.

> Note: episodes already translated into Spanish keep their existing `es` tracks/feeds; no new Spanish tracks will be generated. Existing `*_podcast.es.rss` feeds simply stop gaining episodes (I can prune them in a follow-up if you want them removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7jwG7cKw5hAELkBRXnqK)_