### PR TITLE
Reschedule daily shows to 7:01-10:01 UTC window

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -3,8 +3,8 @@ name: Run Podcast Show
 on:
   schedule:
     # Network ships ~10 episodes/day. All shows scheduled to finish before
-    # 8 AM Eastern (~12 UTC EDT / 13 UTC EST). Pipeline takes up to 45 min,
-    # so triggers must be staggered by at least that much.
+    # 10:01 UTC. Pipeline takes up to 45 min, so triggers must be staggered
+    # accordingly (15-minute intervals for 10 daily shows across 7:01-10:01 UTC).
     #
     # June 2026 punctuality pass: GitHub delivers `schedule` events
     # best-effort and 1-6 h late in practice (Tesla's 11:00 cron observed
@@ -24,38 +24,38 @@ on:
     # Saturday with a weekend-focus angle (international markets, crypto,
     # lessons learned). Cron times shifted +1h from the prior schedule.
     #
-    # Привет, Русский!: Weekly on Monday at 6:00 UTC
+    # Привет, Русский!: Weekly on Monday at 6:07 UTC
     - cron: '7 6 * * 1'
-    # Omni View: Daily at 6:30 UTC (Sunday = weekly recap)
-    - cron: '37 6 * * *'
-    # Planetterrian Daily: Daily at 7:00 UTC (Sunday = weekly recap)
-    - cron: '7 7 * * *'
-    # Fascinating Frontiers: Daily at 7:30 UTC (Sunday = weekly recap)
-    - cron: '37 7 * * *'
-    # Environmental Intelligence: Weekly on Monday at 8:00 UTC
+    # Omni View: Daily at 7:01 UTC (Sunday = weekly recap)
+    - cron: '1 7 * * *'
+    # Planetterrian Daily: Daily at 7:16 UTC (Sunday = weekly recap)
+    - cron: '16 7 * * *'
+    # Fascinating Frontiers: Daily at 7:31 UTC (Sunday = weekly recap)
+    - cron: '31 7 * * *'
+    # Models & Agents: Daily at 7:46 UTC (Sunday = weekly recap)
+    - cron: '46 7 * * *'
+    # Environmental Intelligence: Weekly on Monday at 8:07 UTC
     - cron: '7 8 * * 1'
-    # Models & Agents: Daily at 8:30 UTC (Sunday = weekly recap)
-    - cron: '37 8 * * *'
-    # Models & Agents for Beginners: Daily at 9:00 UTC (Sunday = weekly recap)
-    - cron: '7 9 * * *'
-    # Финансы Просто: Weekly on Monday at 9:30 UTC
-    - cron: '37 9 * * 1'
-    # Modern Investing Techniques: Daily at 10:00 UTC.
+    # Models & Agents for Beginners: Daily at 8:01 UTC (Sunday = weekly recap)
+    - cron: '1 8 * * *'
+    # Modern Investing Techniques: Daily at 8:16 UTC.
     # Mon-Fri = US market preview; Sat = weekend angle (international
     # markets, crypto, lessons learned, what to prepare for, long-term
     # insights); Sun = weekly recap.
-    - cron: '7 10 * * *'
-    # First Principles Daily: Daily at 10:30 UTC. Narrative show —
+    - cron: '16 8 * * *'
+    # First Principles Daily: Daily at 8:31 UTC. Narrative show —
     # topic-queue-driven, no daily news fetch. Alternates concrete
     # example / opportunity area per episode. Runs all 7 days.
-    - cron: '37 10 * * *'
-    # Tesla Shorts Time: Daily at 11:00 UTC (Sunday = weekly recap)
-    - cron: '7 11 * * *'
-    # Unintended Consequences: Daily at 11:30 UTC. Narrative show —
+    - cron: '31 8 * * *'
+    # Tesla Shorts Time: Daily at 8:46 UTC (Sunday = weekly recap)
+    - cron: '46 8 * * *'
+    # Unintended Consequences: Daily at 9:01 UTC. Narrative show —
     # topic-queue-driven, no daily news fetch. Runs all 7 days.
-    - cron: '37 11 * * *'
-    # SpaceX Daily: Daily at 12:07 UTC (Sunday = weekly recap)
-    - cron: '7 12 * * *'
+    - cron: '1 9 * * *'
+    # SpaceX Daily: Daily at 9:16 UTC (Sunday = weekly recap)
+    - cron: '16 9 * * *'
+    # Финансы Просто: Weekly on Monday at 9:37 UTC
+    - cron: '37 9 * * 1'
 
   workflow_dispatch:
     inputs:
@@ -135,18 +135,18 @@ jobs:
               # applies the intended restriction.
               CRON_MAP = {
                   "7 6 * * 1":        ("privet_russian",          "monday"),
-                  "37 6 * * *":       ("omni_view",                None),
-                  "7 7 * * *":        ("planetterrian",            None),
-                  "37 7 * * *":       ("fascinating_frontiers",    None),
+                  "1 7 * * *":        ("omni_view",                None),
+                  "16 7 * * *":       ("planetterrian",            None),
+                  "31 7 * * *":       ("fascinating_frontiers",    None),
+                  "46 7 * * *":       ("models_agents",            None),
                   "7 8 * * 1":        ("env_intel",               "monday"),
-                  "37 8 * * *":       ("models_agents",            None),
-                  "7 9 * * *":        ("models_agents_beginners",  None),
+                  "1 8 * * *":        ("models_agents_beginners",  None),
+                  "16 8 * * *":       ("modern_investing",         None),
+                  "31 8 * * *":       ("first_principles",         None),
+                  "46 8 * * *":       ("tesla",                    None),
+                  "1 9 * * *":        ("unintended_consequences", None),
+                  "16 9 * * *":       ("spacex",                   None),
                   "37 9 * * 1":       ("finansy_prosto",          "monday"),
-                  "7 10 * * *":       ("modern_investing",         None),
-                  "37 10 * * *":      ("first_principles",         None),
-                  "7 11 * * *":       ("tesla",                    None),
-                  "37 11 * * *":      ("unintended_consequences", None),
-                  "7 12 * * *":       ("spacex",                   None),
               }
 
               shows = []

--- a/tests/test_scheduling_punctuality.py
+++ b/tests/test_scheduling_punctuality.py
@@ -40,11 +40,17 @@ def _worker_slots() -> dict:
 
 
 def test_cron_minutes_off_peak():
-    """Top-of-hour and half-hour marks are the most contended schedule
-    slots; every show cron must sit at :07/:37."""
+    """Crons are staggered to avoid bunching on the same minute. The
+    original :07/:37 design avoided top-of-hour contention but capped at
+    2 slots/hour (13 shows, 12 hours min). For 10 daily shows in 3 hours,
+    :01/:16/:31/:46 spacing is used instead (same anti-bunch principle,
+    tighter packing). GitHub fallback crons are no longer on the
+    historically-off-peak :07/:37 marks, but the Cloudflare Worker (primary,
+    minute-accurate dispatch) is unaffected and the duplicate guard still
+    prevents double-publishing."""
     crons = re.findall(r"- cron: '(\d+) ", _WF)
     assert crons, "no crons parsed"
-    assert set(crons) <= {"7", "37"}, f"on-peak cron minutes present: {crons}"
+    assert set(crons) <= {"1", "7", "16", "31", "37", "46"}, f"unexpected cron minutes: {crons}"
 
 
 def test_worker_slots_match_cron_map():
@@ -60,7 +66,7 @@ def test_worker_slots_match_cron_map():
 
 def test_worker_trigger_covers_all_slots():
     toml = (_ROOT / "workers" / "scheduler" / "wrangler.toml").read_text(encoding="utf-8")
-    assert '"7,37 6-12 * * *"' in toml
+    assert '"1,7,16,31,37,46 6-12 * * *"' in toml
 
 
 def test_gate_has_duplicate_guard():

--- a/tests/test_unintended_consequences.py
+++ b/tests/test_unintended_consequences.py
@@ -348,12 +348,12 @@ class TestUCPodcastPromptRules:
 def test_cron_entry_exists_for_unintended_consequences():
     workflow = (REPO_ROOT / ".github" / "workflows" / "run-show.yml"
                 ).read_text(encoding="utf-8")
-    # June 2026 punctuality pass: crons moved off-peak to :37.
-    assert "37 11 * * 1-5" in workflow, (
-        "Cron line for Unintended Consequences (11:37 UTC weekdays) "
+    # June 2026 schedule compression: UC moved to 9:01 UTC daily.
+    assert "1 9 * * *" in workflow, (
+        "Cron line for Unintended Consequences (9:01 UTC daily) "
         "missing from run-show.yml"
     )
-    assert '"37 11 * * 1-5":' in workflow, (
+    assert '"1 9 * * *":' in workflow, (
         "CRON_MAP entry for Unintended Consequences missing — show "
         "would fire but never run"
     )

--- a/workers/scheduler/src/index.ts
+++ b/workers/scheduler/src/index.ts
@@ -17,18 +17,18 @@ const WORKFLOW = "run-show.yml";
 // [utcHour, utcMinute, show, dayFilter]
 const SLOTS: Array<[number, number, string, string | null]> = [
   [6, 7,  "privet_russian",          "monday"],
-  [6, 37, "omni_view",                null],
-  [7, 7,  "planetterrian",            null],
-  [7, 37, "fascinating_frontiers",    null],
+  [7, 1,  "omni_view",                null],
+  [7, 16, "planetterrian",            null],
+  [7, 31, "fascinating_frontiers",    null],
+  [7, 46, "models_agents",            null],
   [8, 7,  "env_intel",               "monday"],
-  [8, 37, "models_agents",            null],
-  [9, 7,  "models_agents_beginners",  null],
+  [8, 1,  "models_agents_beginners",  null],
+  [8, 16, "modern_investing",         null],
+  [8, 31, "first_principles",         null],
+  [8, 46, "tesla",                    null],
+  [9, 1,  "unintended_consequences",  null],
+  [9, 16, "spacex",                   null],
   [9, 37, "finansy_prosto",          "monday"],
-  [10, 7, "modern_investing",         null],
-  [10, 37, "first_principles",        null],
-  [11, 7, "tesla",                    null],
-  [11, 37, "unintended_consequences", null],
-  [12, 7, "spacex",                   null],
 ];
 
 function dayFilterPasses(filter: string | null, now: Date): boolean {

--- a/workers/scheduler/wrangler.toml
+++ b/workers/scheduler/wrangler.toml
@@ -16,7 +16,7 @@ main = "src/index.ts"
 compatibility_date = "2026-05-01"
 
 [triggers]
-# One trigger covering every slot (:07/:37 from 06:00-11:59 UTC); the
-# Worker maps the firing time to the show, mirroring run-show.yml's
+# One trigger covering every slot (:01/:07/:16/:31/:37/:46 from 06:00-12:00 UTC);
+# the Worker maps the firing time to the show, mirroring run-show.yml's
 # CRON_MAP (drift guard: tests/test_scheduling_punctuality.py).
-crons = ["7,37 6-12 * * *"]
+crons = ["1,7,16,31,37,46 6-12 * * *"]


### PR DESCRIPTION
## Summary

Compressed the daily show schedule to finish all 10 episodes by 10:01 UTC (previously 12:07 UTC).

- **Omni View** moved from 6:37 to 7:01 UTC (start of new window)
- All daily shows staggered at 15-minute intervals
- Total window: 7:01–10:01 UTC (3 hours for ~10 episodes at ~45 min each)
- Weekly shows (Привет, Env Intel, Финансы Просто) unchanged
- Updated CRON_MAP in gate job to match

## Schedule Changes

| Show | Old Time | New Time |
|------|----------|----------|
| Omni View | 6:37 UTC | 7:01 UTC |
| Planetterrian | 7:07 UTC | 7:16 UTC |
| Fascinating Frontiers | 7:37 UTC | 7:31 UTC |
| Models & Agents | 8:37 UTC | 7:46 UTC |
| Models & Agents for Beginners | 9:07 UTC | 8:01 UTC |
| Modern Investing | 10:07 UTC | 8:16 UTC |
| First Principles | 10:37 UTC | 8:31 UTC |
| Tesla Shorts Time | 11:07 UTC | 8:46 UTC |
| Unintended Consequences | 11:37 UTC | 9:01 UTC |
| SpaceX Daily | 12:07 UTC | 9:16 UTC |

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKG2UVbqiEcRt5ugJorj12)_