### PR TITLE
Bound Grok Video step to a wall-clock budget so it can't time out the pipeline

### DIFF
--- a/engine/grok_video.py
+++ b/engine/grok_video.py
@@ -45,7 +45,23 @@ GROK_VIDEO_ENDPOINT = "https://api.x.ai/v1/videos/generations"
 GROK_VIDEO_STATUS_ENDPOINT = "https://api.x.ai/v1/videos"
 DEFAULT_TIMEOUT_S = 60
 DEFAULT_POLL_INTERVAL_S = 3
-MAX_POLL_ATTEMPTS = 300  # 15 minutes at 3s intervals
+MAX_POLL_ATTEMPTS = 300  # 15 minutes at 3s intervals (legacy per-clip cap)
+
+# Overall wall-clock budget for the entire video step (submit + poll +
+# download + stitch). A single stuck clip must NEVER starve the others or
+# push the per-episode pipeline past its SIGALRM timeout — that fires a
+# SystemExit mid-render and skips the episode's git commit, leaving a
+# partial publish (audio on R2, nothing committed). Env-overridable; the
+# caller (run_show) additionally clamps this to the time actually left in
+# the pipeline budget. See run_show._timeout_handler + landmine notes on
+# the multilingual decoupling (same timeout class).
+DEFAULT_VIDEO_BUDGET_S = float(os.getenv("GROK_VIDEO_BUDGET_SECONDS", "1200"))
+
+# Minimum fraction of clips that must render before we use the stitched
+# full-length video. Below this we fall back to the image slideshow rather
+# than ship a truncated episode (the audio composite uses -shortest, so a
+# partial clip set would clip the episode to the stitched length).
+MIN_CLIP_COMPLETION_RATIO = 0.85
 
 # Pricing per second of video output
 VIDEO_COST_USD = {
@@ -445,6 +461,35 @@ def _poll_video_status(
     )
 
 
+def _check_video_status_once(
+    request_id: str,
+    *,
+    api_key: str,
+    timeout_s: int = DEFAULT_TIMEOUT_S,
+) -> dict:
+    """Single status GET — no internal sleep loop.
+
+    Returns the response body. ``body["status"]`` is "completed" / "pending"
+    / etc. Raises GrokVideoError on an HTTP/transport error or an API
+    "failed" status. Used by the round-robin poller in generate_grok_videos
+    so one slow clip can't block the others.
+    """
+    headers = {"Authorization": f"Bearer {api_key}"}
+    url = f"{GROK_VIDEO_STATUS_ENDPOINT}/{request_id}"
+    resp = requests.get(url, headers=headers, timeout=timeout_s)
+    if resp.status_code >= 400:
+        raise GrokVideoError(
+            f"Grok Video status HTTP {resp.status_code}: {resp.text[:300]}"
+        )
+    body = resp.json()
+    if body.get("status") == "failed":
+        error = body.get("error", {})
+        raise GrokVideoError(
+            f"Grok Video generation failed: {error.get('message', 'Unknown error')}"
+        )
+    return body
+
+
 def _download_video(url: str, output_path: Path, timeout_s: int = 120) -> bool:
     """Download a video from the temporary URL and save locally."""
     try:
@@ -553,6 +598,7 @@ def generate_grok_videos(
     short_duration_seconds: int = 40,
     final_mp3_path: Optional[Path] = None,
     show_config=None,
+    max_total_seconds: Optional[float] = None,
 ) -> GrokVideoResult:
     """Generate full-length and short videos from a podcast script.
 
@@ -578,11 +624,26 @@ def generate_grok_videos(
         short_duration_seconds: Duration in seconds for the short
         final_mp3_path: Path to pre-mixed episode audio (for composite)
         show_config: Show configuration object (has video_genre, video_mood, etc.)
+        max_total_seconds: Wall-clock budget for the whole step. Clamps the
+            module default (DEFAULT_VIDEO_BUDGET_S) — the caller passes the
+            time actually left in the pipeline so video can never trip the
+            episode SIGALRM and skip the git commit. None → module default.
 
     Returns:
         GrokVideoResult with paths to generated videos and cost tracking.
     """
     start_time = time.time()
+
+    # Resolve the wall-clock budget and deadline. The caller's value clamps
+    # the module default downward (never up) so the env knob stays a ceiling.
+    budget_s = DEFAULT_VIDEO_BUDGET_S
+    if max_total_seconds is not None and max_total_seconds > 0:
+        budget_s = (
+            min(budget_s, float(max_total_seconds))
+            if budget_s > 0
+            else float(max_total_seconds)
+        )
+    deadline = (start_time + budget_s) if budget_s > 0 else None
 
     if api_key is None:
         api_key = (
@@ -641,6 +702,17 @@ def generate_grok_videos(
     SUBMISSION_DELAY_S = 1.5
 
     for idx, clip in enumerate(clips):
+        # Stop submitting if we're already out of budget (defensive — the
+        # submission phase is short, but a tiny caller budget could exhaust
+        # here). Unsubmitted clips stay "queued" and are dropped below.
+        if deadline is not None and time.time() >= deadline:
+            logger.warning(
+                "Grok Video budget (%.0fs) exhausted during submission — "
+                "submitted %d/%d clips before stopping",
+                budget_s, idx, len(clips),
+            )
+            break
+
         # Rate limit: wait between submissions (but not before the first)
         if idx > 0:
             logger.info(
@@ -669,29 +741,57 @@ def generate_grok_videos(
             result.failures.append(f"{clip.clip_id}: {exc}")
             logger.warning("Failed to submit %s: %s", clip.clip_id, exc)
 
-    # Poll for completion and download
+    # Poll for completion and download — ROUND-ROBIN with a global deadline.
+    # Each pass checks every still-pending clip ONCE (no per-clip blocking
+    # loop), so a single stuck clip can't starve the others, and the whole
+    # phase is bounded by `deadline`. When the budget runs out we mark the
+    # stragglers failed and proceed with whatever finished so the episode
+    # pipeline can still commit.
     video_dir = work_dir / f"videos_ep{episode_num:03d}"
     video_dir.mkdir(parents=True, exist_ok=True)
 
-    completed_clips = []
-    for clip in clips:
-        if clip.status == "failed":
-            continue
-
-        try:
-            status_response = _poll_video_status(
-                clip.request_id,
-                api_key=api_key,
-            )
-
-            # Extract video URL from response
-            url = status_response.get("url")
-            if not url:
-                raise GrokVideoError(
-                    f"Response missing video URL: {status_response}"
+    pending = [c for c in clips if c.status == "pending"]
+    while pending:
+        if deadline is not None and time.time() >= deadline:
+            for clip in pending:
+                clip.status = "failed"
+                clip.error_message = "Video budget exceeded before completion"
+                result.failures.append(
+                    f"{clip.clip_id}: budget exceeded ({budget_s:.0f}s)"
                 )
+            logger.warning(
+                "Grok Video budget (%.0fs) exhausted — %d clip(s) still pending; "
+                "proceeding with completed clips so the pipeline can commit",
+                budget_s, len(pending),
+            )
+            break
 
-            # Download the video
+        still_pending = []
+        for clip in pending:
+            if deadline is not None and time.time() >= deadline:
+                still_pending.append(clip)
+                continue
+
+            try:
+                body = _check_video_status_once(clip.request_id, api_key=api_key)
+            except GrokVideoError as exc:
+                clip.status = "failed"
+                clip.error_message = str(exc)
+                result.failures.append(f"{clip.clip_id}: {exc}")
+                logger.warning("Failed to complete %s: %s", clip.clip_id, exc)
+                continue
+
+            if body.get("status") != "completed":
+                still_pending.append(clip)
+                continue
+
+            url = body.get("url")
+            if not url:
+                clip.status = "failed"
+                clip.error_message = f"Response missing video URL: {body}"
+                result.failures.append(f"{clip.clip_id}: missing video URL")
+                continue
+
             local_path = video_dir / f"{clip.clip_id}.mp4"
             if _download_video(url, local_path):
                 clip.url = url
@@ -703,8 +803,6 @@ def generate_grok_videos(
                 cost_per_sec = VIDEO_COST_USD.get(resolution, 0.07)
                 clip.cost_usd = round(duration_sec * cost_per_sec, 4)
                 result.total_cost_usd += clip.cost_usd
-
-                completed_clips.append(clip)
                 logger.info(
                     "Completed %s (duration=%ds, cost=$%.4f)",
                     clip.clip_id, duration_sec, clip.cost_usd,
@@ -714,13 +812,35 @@ def generate_grok_videos(
                 clip.error_message = "Download failed"
                 result.failures.append(f"{clip.clip_id}: Download failed")
 
-        except GrokVideoError as exc:
-            clip.status = "failed"
-            clip.error_message = str(exc)
-            result.failures.append(f"{clip.clip_id}: {exc}")
-            logger.warning("Failed to complete %s: %s", clip.clip_id, exc)
+        pending = still_pending
+        if pending:
+            time.sleep(DEFAULT_POLL_INTERVAL_S)
 
     result.clips = clips
+
+    # Recompute in script order (round-robin completes clips out of order;
+    # the stitch needs them sequential).
+    completed_clips = [c for c in clips if c.status == "completed"]
+
+    # Don't ship a truncated episode: if too few clips rendered, skip the
+    # stitch and let the caller fall back to the image slideshow. The audio
+    # composite uses -shortest, so a partial clip set would clip the episode
+    # to the (shorter) stitched length.
+    total_clips = len(clips)
+    if total_clips and len(completed_clips) < MIN_CLIP_COMPLETION_RATIO * total_clips:
+        logger.warning(
+            "Only %d/%d (%.0f%%) video clips completed (< %.0f%% required) — "
+            "skipping stitch; caller falls back to image slideshow",
+            len(completed_clips), total_clips,
+            100.0 * len(completed_clips) / total_clips,
+            100.0 * MIN_CLIP_COMPLETION_RATIO,
+        )
+        result.is_fallback = True
+        result.failures.append(
+            f"insufficient clips: {len(completed_clips)}/{total_clips}"
+        )
+        result.generation_time_s = round(time.time() - start_time, 2)
+        return result
 
     # Stitch completed clips together
     if completed_clips:

--- a/generate_html.py
+++ b/generate_html.py
@@ -3382,7 +3382,7 @@ def generate_player_page(*, dry_run=False):
     context = {
         "path_prefix": "",
         "page_title": "Player | Nerra Network",
-        "meta_description": "Listen to all Nerra Network shows in one player. Build your queue, reorder episodes, and discover new content.",
+        "meta_description": f"Listen to all {len(NETWORK_SHOWS)} Nerra Network shows in one player. Build your queue, reorder episodes, and discover new content.",
         "meta_keywords": "podcast player, Nerra Network, queue, playlist",
         "theme_color": "#6B47FF",
         "og_image": None,

--- a/run_show.py
+++ b/run_show.py
@@ -37,10 +37,27 @@ from dotenv import load_dotenv
 # Default 15 minutes; override with PIPELINE_TIMEOUT_SECONDS env var.
 # ---------------------------------------------------------------------------
 _PIPELINE_TIMEOUT = int(os.environ.get("PIPELINE_TIMEOUT_SECONDS", 900))
+_PIPELINE_STARTED_AT = time.monotonic()
+
+# Headroom reserved at the tail of the pipeline (commit + finalize). Optional
+# slow stages (notably Grok Video) are budgeted against the time LEFT minus
+# this reserve, so they can never trip the SIGALRM and skip the episode's git
+# commit — the partial-publish failure class that decoupled the multilingual
+# step (see the comment near the translation stage below).
+_PIPELINE_COMMIT_RESERVE_S = int(os.environ.get("PIPELINE_COMMIT_RESERVE_SECONDS", 420))
 
 
 def _timeout_handler(signum, frame):
     raise SystemExit(f"PIPELINE TIMEOUT: exceeded {_PIPELINE_TIMEOUT}s — aborting to prevent hung CI job")
+
+
+def _pipeline_budget_remaining() -> float:
+    """Seconds left before the pipeline SIGALRM fires (>= 0)."""
+    return max(0.0, _PIPELINE_TIMEOUT - (time.monotonic() - _PIPELINE_STARTED_AT))
+
+
+class _SkipVideo(Exception):
+    """Internal sentinel: bail out of the video stage to the image fallback."""
 
 
 # Only set alarm on platforms that support it (not Windows)
@@ -3831,9 +3848,23 @@ def _publish_youtube(
             resolution = getattr(yt, "video_resolution", "720p")
             aspect_ratio = getattr(yt, "video_aspect_ratio", "16:9")
 
+            # Budget the (slow, optional) video step against the time LEFT in
+            # the pipeline, holding back the commit/finalize reserve. If too
+            # little is left, skip video entirely and fall back to the image
+            # slideshow rather than risk the SIGALRM skipping the git commit.
+            _video_budget = _pipeline_budget_remaining() - _PIPELINE_COMMIT_RESERVE_S
+            if _video_budget < 60:
+                logger.warning(
+                    "Skipping Grok Video — only %.0fs left after the commit "
+                    "reserve; falling back to image slideshow",
+                    _video_budget,
+                )
+                video_provider = None  # Fall through to image provider logic
+                raise _SkipVideo()
+
             logger.info(
-                "Generating Grok Video for episode %d (%s @ %s)",
-                episode_num, resolution, aspect_ratio,
+                "Generating Grok Video for episode %d (%s @ %s, budget %.0fs)",
+                episode_num, resolution, aspect_ratio, _video_budget,
             )
 
             # Read the podcast script to use as video generation input
@@ -3858,6 +3889,7 @@ def _publish_youtube(
                 short_duration_seconds=getattr(yt, "short_duration_seconds", 40),
                 final_mp3_path=final_mp3,  # Pre-mixed audio with intro/outro/EQ
                 show_config=config,  # For show-specific video prompts
+                max_total_seconds=_video_budget,
             )
 
             if grok_video_result.full_video_path and grok_video_result.full_video_path.exists():
@@ -3875,6 +3907,8 @@ def _publish_youtube(
                     "Grok Video failed or produced no output; falling back to image slideshow"
                 )
                 video_provider = None  # Fall through to image provider logic
+        except _SkipVideo:
+            pass  # Budget guard already logged + set video_provider=None
         except Exception as exc:
             logger.warning(
                 "Grok Video generation failed: %s; falling back to image slideshow",

--- a/scripts/grok_show_check.py
+++ b/scripts/grok_show_check.py
@@ -25,15 +25,15 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 import argparse
-from datetime import datetime, timedelta
+from datetime import datetime
 
 # Add repo root to path
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from engine.config import load_config
-from generate_html import NETWORK_SHOWS
+from engine.config import load_config  # noqa: E402 (after sys.path bootstrap)
+from generate_html import NETWORK_SHOWS  # noqa: E402 (after sys.path bootstrap)
 
 
 # ========================== TIER 1 CHECKS ==========================
@@ -213,7 +213,7 @@ def check_metadata_sanity(tts_txt: str, show_slug: str) -> Dict[str, Any]:
                 "type": "possible_refusal",
                 "pattern": pattern,
                 "confidence": 0.60,  # Lower confidence (could be false positive)
-                "description": f"Transcript may contain a refusal pattern"
+                "description": "Transcript may contain a refusal pattern"
             })
             break
 
@@ -234,7 +234,6 @@ def discover_episodes(date_str: Optional[str] = None, show_slug: Optional[str] =
         date_str = datetime.now().strftime("%Y%m%d")
 
     episodes = []
-    digests_dir = ROOT / "digests"
 
     # Search all show subdirectories for matching _tts.txt files
     # (output dirs may not match slug names, e.g. slug "tesla" → output_dir "digests/tesla_shorts_time")

--- a/scripts/recover_grok_video.py
+++ b/scripts/recover_grok_video.py
@@ -1,38 +1,59 @@
 #!/usr/bin/env python3
-"""Recover a Grok Video episode from already-submitted clip request IDs.
+"""Recover Grok Video clips that were generated but not (fully) used.
 
 When the per-episode pipeline submits its Grok Video clips but dies before
 downloading them (e.g. the 2026-06-23 Tesla Ep519 pipeline timeout), the
-clips may still be retrievable server-side: each was submitted and has a
-``request_id`` logged, and the status endpoint
-``GET https://api.x.ai/v1/videos/{request_id}`` returns the finished clip's
-(temporary) URL once it has rendered.
+clips may still be retrievable server-side. Each clip was submitted and has a
+``request_id``; the status endpoint ``GET https://api.x.ai/v1/videos/{id}``
+returns the finished clip's (temporary) URL once it has rendered.
 
-This script takes a list of ``clip_id request_id`` pairs, polls each status
-endpoint, downloads whatever has completed, stitches them in order, and (if
-given the episode audio) composites the audio onto the video — producing the
-full-length MP4 the pipeline would have made.
+Three modes:
 
-IMPORTANT — the clip result URLs are temporary. If too much time has passed
-the clips may no longer be retrievable; the script reports per-clip status so
-you can see how many survived. Nothing here is destructive.
+  1. --list-all       Enumerate EVERY video on the account via the xAI list
+                      endpoint (best-effort) and download each into --out-dir.
+                      This is the "get all clips that ran so far, across all
+                      shows" path — it doesn't need any request IDs.
 
-Usage:
-    # Use the embedded Tesla Ep519 (2026-06-23) request IDs:
+  2. --requests FILE  Retrieve a specific set of clips. FILE has one
+                      "clip_id request_id" (or bare "request_id") per line;
+                      "#" comments allowed. Harvest these from a run's logs —
+                      see HARVESTING below.
+
+  3. (default)        Retrieve the embedded Tesla Ep519 (2026-06-23) clips.
+
+By default every retrieved clip is KEPT as an individual .mp4 in the output
+dir. Pass --stitch (+ optional --audio) to also concatenate an ordered set
+into one episode video.
+
+IMPORTANT — clip result URLs are TEMPORARY. Clips from runs more than a day
+or so old are likely already gone; the script reports per-clip status so you
+can see how many survived. Nothing here is destructive.
+
+HARVESTING request IDs from a run's logs (you have `gh`; this sandbox agent
+does not have an xAI key, so run this yourself):
+
+    gh run view <RUN_ID> --repo Planetterrian/nerranetwork --log \
+      | grep -oE 'ep[0-9]+_clip[0-9]+ \(request_id=[0-9a-f-]+' \
+      | sed -E 's/ \(request_id=/ /' > ep_requests.txt
     GROK_API_KEY=... python scripts/recover_grok_video.py \
-        --audio https://audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep519_20260623.mp3 \
-        --out Tesla_Shorts_Time_Pod_Ep519_20260623_video.mp4
+      --requests ep_requests.txt --out-dir recovered/
 
-    # Or supply your own list (one "clip_id request_id" per line, "#" comments ok):
+Usage examples:
+    # Everything the account still has:
+    GROK_API_KEY=... python scripts/recover_grok_video.py --list-all --out-dir recovered/
+
+    # The embedded Ep519 set, stitched with the published audio:
     GROK_API_KEY=... python scripts/recover_grok_video.py \
-        --requests my_request_ids.txt --audio episode.mp3 --out out.mp4
+        --stitch --audio https://audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep519_20260623.mp3 \
+        --out Ep519_video.mp4 --out-dir recovered_ep519/
 
-Requires: GROK_API_KEY (or XAI_API_KEY) in the environment, and ffmpeg on PATH.
+Requires: GROK_API_KEY (or XAI_API_KEY) in the environment. --stitch needs ffmpeg.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 import tempfile
@@ -40,11 +61,14 @@ import time
 from pathlib import Path
 from urllib.request import urlretrieve
 
+import requests
+
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from engine.grok_video import (  # noqa: E402 (after sys.path bootstrap)
+    GROK_VIDEO_STATUS_ENDPOINT,
     GrokVideoError,
     _check_video_status_once,
     _composite_video_with_audio,
@@ -53,8 +77,7 @@ from engine.grok_video import (  # noqa: E402 (after sys.path bootstrap)
 )
 
 # Tesla Shorts Time Ep519 (2026-06-23) — the 46 clips submitted before the
-# pipeline timed out, in script order (clip_id, request_id). Recovered from
-# the failed run's logs.
+# pipeline timed out, in script order (clip_id, request_id). From the run log.
 EP519_REQUESTS = [
     ("ep519_clip00", "f7c995bc-ff2e-93c1-a402-dd6b29f81cf0"),
     ("ep519_clip01", "7b47df6a-a5b0-9781-affe-11212b12019d"),
@@ -106,7 +129,7 @@ EP519_REQUESTS = [
 
 
 def _load_requests(path: Path) -> list[tuple[str, str]]:
-    """Parse a 'clip_id request_id' per-line file ('#' comments allowed)."""
+    """Parse a 'clip_id request_id' (or bare 'request_id') per-line file."""
     out: list[tuple[str, str]] = []
     for raw in path.read_text(encoding="utf-8").splitlines():
         line = raw.split("#", 1)[0].strip()
@@ -114,14 +137,13 @@ def _load_requests(path: Path) -> list[tuple[str, str]]:
             continue
         parts = line.split()
         if len(parts) == 1:
-            out.append((f"clip{len(out):02d}", parts[0]))
+            out.append((f"clip{len(out):03d}", parts[0]))
         else:
             out.append((parts[0], parts[1]))
     return out
 
 
 def _resolve_audio(audio: str, work_dir: Path) -> Path | None:
-    """Return a local path to the audio, downloading it if a URL was given."""
     if not audio:
         return None
     if audio.startswith(("http://", "https://")):
@@ -133,12 +155,151 @@ def _resolve_audio(audio: str, work_dir: Path) -> Path | None:
     return p if p.exists() else None
 
 
+def _list_all_videos(api_key: str) -> list[dict]:
+    """Best-effort enumerate every video on the account.
+
+    The xAI video API is documented only for POST .../generations and
+    GET .../{id}; a list endpoint is not guaranteed. We try GET on the
+    collection with simple pagination and accept the common response shapes
+    ({"data": [...]}, {"videos": [...]}, or a bare list). Returns [] (with a
+    clear message) if the endpoint isn't available.
+    """
+    headers = {"Authorization": f"Bearer {api_key}"}
+    items: list[dict] = []
+    url: str | None = GROK_VIDEO_STATUS_ENDPOINT
+    params = {"limit": 100}
+    seen_pages = 0
+    while url and seen_pages < 100:
+        try:
+            resp = requests.get(url, headers=headers, params=params, timeout=60)
+        except requests.RequestException as exc:
+            print(f"List endpoint unreachable: {exc}", file=sys.stderr)
+            break
+        if resp.status_code == 404:
+            print(
+                "The account-level list endpoint (GET /v1/videos) is not "
+                "available on this API. Use --requests with IDs harvested from "
+                "the run logs instead (see the script header).",
+                file=sys.stderr,
+            )
+            break
+        if resp.status_code >= 400:
+            print(f"List endpoint HTTP {resp.status_code}: {resp.text[:200]}", file=sys.stderr)
+            break
+        try:
+            body = resp.json()
+        except ValueError:
+            print("List endpoint returned non-JSON; cannot enumerate.", file=sys.stderr)
+            break
+
+        page = body.get("data") or body.get("videos") if isinstance(body, dict) else body
+        if not page:
+            break
+        items.extend(page)
+        seen_pages += 1
+
+        # Cursor pagination, if present.
+        nxt = body.get("next_cursor") or body.get("next") if isinstance(body, dict) else None
+        if not nxt:
+            break
+        params = {"limit": 100, "cursor": nxt}
+        url = GROK_VIDEO_STATUS_ENDPOINT
+
+    return items
+
+
+def _run_list_all(api_key: str, out_dir: Path) -> int:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    items = _list_all_videos(api_key)
+    if not items:
+        print("No videos enumerated (endpoint unavailable or account empty).")
+        return 1
+
+    manifest = []
+    got = 0
+    for i, item in enumerate(items):
+        vid = str(item.get("id") or item.get("request_id") or f"video{i:04d}")
+        url = item.get("url")
+        status = item.get("status", "unknown")
+        if not url and status != "completed":
+            # Re-poll by id to get a fresh temporary URL.
+            try:
+                body = _check_video_status_once(vid, api_key=api_key)
+                url, status = body.get("url"), body.get("status", status)
+            except GrokVideoError as exc:
+                print(f"  {vid}: {exc}")
+        if url:
+            dest = out_dir / f"{vid}.mp4"
+            if _download_video(url, dest):
+                got += 1
+                manifest.append({"id": vid, "status": status, "file": dest.name})
+                print(f"  {vid}: downloaded ✓")
+                continue
+        print(f"  {vid}: not downloadable (status={status})")
+        manifest.append({"id": vid, "status": status, "file": None})
+
+    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(f"\nDownloaded {got}/{len(items)} videos → {out_dir} (manifest.json written)")
+    return 0 if got else 1
+
+
+def _retrieve(requests_list, api_key, out_dir, retries, retry_wait):
+    """Poll + download a list of (clip_id, request_id). Returns ordered paths."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    downloaded: list[Path] = []
+    pending = failed = 0
+    for clip_id, request_id in requests_list:
+        body = None
+        for attempt in range(max(1, retries)):
+            try:
+                body = _check_video_status_once(request_id, api_key=api_key)
+            except GrokVideoError as exc:
+                print(f"  {clip_id} [{request_id}]: status error — {exc}")
+                body = None
+                break
+            if body.get("status") == "completed":
+                break
+            if attempt < retries - 1:
+                print(f"  {clip_id}: status={body.get('status')} — retry in {retry_wait:.0f}s")
+                time.sleep(retry_wait)
+
+        if not body or body.get("status") != "completed":
+            status = (body or {}).get("status", "unreachable")
+            print(f"  {clip_id} [{request_id}]: NOT available (status={status})")
+            if status in ("failed", "unreachable"):
+                failed += 1
+            else:
+                pending += 1
+            continue
+
+        url = body.get("url")
+        if not url:
+            print(f"  {clip_id}: completed but no URL")
+            failed += 1
+            continue
+        dest = out_dir / f"{clip_id}.mp4"
+        if _download_video(url, dest):
+            downloaded.append(dest)
+            print(f"  {clip_id}: downloaded ✓")
+        else:
+            failed += 1
+            print(f"  {clip_id}: download failed")
+
+    print(
+        f"\nRecovered {len(downloaded)}/{len(requests_list)} clips "
+        f"({pending} still pending, {failed} failed) → {out_dir}"
+    )
+    return downloaded
+
+
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__)
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--list-all", action="store_true", help="Enumerate + download every video on the account")
     ap.add_argument("--requests", type=Path, help="File of 'clip_id request_id' lines (default: embedded Ep519)")
-    ap.add_argument("--audio", default="", help="Episode audio (local path or URL) to composite onto the video")
-    ap.add_argument("--out", type=Path, required=True, help="Output MP4 path")
-    ap.add_argument("--workdir", type=Path, default=None, help="Scratch dir for clips (default: a temp dir)")
+    ap.add_argument("--out-dir", type=Path, default=None, help="Directory to keep the individual clips")
+    ap.add_argument("--stitch", action="store_true", help="Also concatenate the clips into one episode video")
+    ap.add_argument("--audio", default="", help="Episode audio (path or URL) to composite when --stitch")
+    ap.add_argument("--out", type=Path, help="Stitched output MP4 (required with --stitch)")
     ap.add_argument("--retries", type=int, default=3, help="Status-poll retries per clip if still pending")
     ap.add_argument("--retry-wait", type=float, default=10.0, help="Seconds between status retries")
     args = ap.parse_args()
@@ -148,69 +309,37 @@ def main() -> int:
         print("ERROR: set GROK_API_KEY (or XAI_API_KEY) in the environment.", file=sys.stderr)
         return 2
 
-    requests = _load_requests(args.requests) if args.requests else list(EP519_REQUESTS)
-    if not requests:
+    if args.list_all:
+        out_dir = args.out_dir or Path("recovered_videos")
+        return _run_list_all(api_key, out_dir)
+
+    requests_list = _load_requests(args.requests) if args.requests else list(EP519_REQUESTS)
+    if not requests_list:
         print("ERROR: no request IDs to recover.", file=sys.stderr)
         return 2
 
-    work_dir = args.workdir or Path(tempfile.mkdtemp(prefix="grok_video_recover_"))
-    work_dir.mkdir(parents=True, exist_ok=True)
-    print(f"Recovering {len(requests)} clip(s) into {work_dir}")
+    out_dir = args.out_dir or Path(tempfile.mkdtemp(prefix="grok_video_recover_"))
+    print(f"Recovering {len(requests_list)} clip(s) into {out_dir}")
+    downloaded = _retrieve(requests_list, api_key, out_dir, args.retries, args.retry_wait)
 
-    downloaded: list[Path] = []
-    pending: list[str] = []
-    failed: list[str] = []
-
-    for clip_id, request_id in requests:
-        body = None
-        for attempt in range(max(1, args.retries)):
-            try:
-                body = _check_video_status_once(request_id, api_key=api_key)
-            except GrokVideoError as exc:
-                print(f"  {clip_id} [{request_id}]: status error — {exc}")
-                body = None
-                break
-            if body.get("status") == "completed":
-                break
-            if attempt < args.retries - 1:
-                print(f"  {clip_id}: status={body.get('status')} — retrying in {args.retry_wait:.0f}s")
-                time.sleep(args.retry_wait)
-
-        if not body or body.get("status") != "completed":
-            status = (body or {}).get("status", "unreachable")
-            print(f"  {clip_id} [{request_id}]: NOT available (status={status})")
-            (pending if status not in ("failed", "unreachable") else failed).append(clip_id)
-            continue
-
-        url = body.get("url")
-        if not url:
-            print(f"  {clip_id}: completed but no URL in response")
-            failed.append(clip_id)
-            continue
-
-        local = work_dir / f"{clip_id}.mp4"
-        if _download_video(url, local):
-            downloaded.append(local)
-            print(f"  {clip_id}: downloaded ✓")
-        else:
-            failed.append(clip_id)
-            print(f"  {clip_id}: download failed")
-
-    print(
-        f"\nRecovered {len(downloaded)}/{len(requests)} clips "
-        f"({len(pending)} still pending, {len(failed)} failed)."
-    )
     if not downloaded:
-        print("Nothing to stitch — the clips are no longer retrievable.", file=sys.stderr)
+        print("Nothing downloaded — the clips are no longer retrievable.", file=sys.stderr)
         return 1
 
-    # Stitch in submission order (downloaded preserves the request order).
-    stitched = work_dir / "stitched.mp4"
+    if not args.stitch:
+        print(f"Individual clips kept in {out_dir}. Pass --stitch to assemble a video.")
+        return 0
+
+    if not args.out:
+        print("ERROR: --stitch requires --out <file.mp4>.", file=sys.stderr)
+        return 2
+
+    stitched = out_dir / "stitched.mp4"
     if not _stitch_videos_ffmpeg(downloaded, stitched, cleanup=True):
         print("ERROR: stitching failed (is ffmpeg installed?).", file=sys.stderr)
         return 1
 
-    audio_path = _resolve_audio(args.audio, work_dir)
+    audio_path = _resolve_audio(args.audio, out_dir)
     args.out.parent.mkdir(parents=True, exist_ok=True)
     if audio_path and audio_path.exists():
         if _composite_video_with_audio(stitched, audio_path, args.out):
@@ -224,9 +353,9 @@ def main() -> int:
         stitched.replace(args.out)
         print(f"\nDONE → {args.out} (video only — pass --audio to add sound)")
 
-    if len(downloaded) < len(requests):
+    if len(downloaded) < len(requests_list):
         print(
-            "NOTE: this is a PARTIAL recovery — some clips were missing, so the "
+            "NOTE: PARTIAL recovery — some clips were missing, so the stitched "
             "video is shorter than the audio (the composite uses -shortest)."
         )
     return 0

--- a/scripts/recover_grok_video.py
+++ b/scripts/recover_grok_video.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Recover a Grok Video episode from already-submitted clip request IDs.
+
+When the per-episode pipeline submits its Grok Video clips but dies before
+downloading them (e.g. the 2026-06-23 Tesla Ep519 pipeline timeout), the
+clips may still be retrievable server-side: each was submitted and has a
+``request_id`` logged, and the status endpoint
+``GET https://api.x.ai/v1/videos/{request_id}`` returns the finished clip's
+(temporary) URL once it has rendered.
+
+This script takes a list of ``clip_id request_id`` pairs, polls each status
+endpoint, downloads whatever has completed, stitches them in order, and (if
+given the episode audio) composites the audio onto the video — producing the
+full-length MP4 the pipeline would have made.
+
+IMPORTANT — the clip result URLs are temporary. If too much time has passed
+the clips may no longer be retrievable; the script reports per-clip status so
+you can see how many survived. Nothing here is destructive.
+
+Usage:
+    # Use the embedded Tesla Ep519 (2026-06-23) request IDs:
+    GROK_API_KEY=... python scripts/recover_grok_video.py \
+        --audio https://audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep519_20260623.mp3 \
+        --out Tesla_Shorts_Time_Pod_Ep519_20260623_video.mp4
+
+    # Or supply your own list (one "clip_id request_id" per line, "#" comments ok):
+    GROK_API_KEY=... python scripts/recover_grok_video.py \
+        --requests my_request_ids.txt --audio episode.mp3 --out out.mp4
+
+Requires: GROK_API_KEY (or XAI_API_KEY) in the environment, and ffmpeg on PATH.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+from urllib.request import urlretrieve
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from engine.grok_video import (  # noqa: E402 (after sys.path bootstrap)
+    GrokVideoError,
+    _check_video_status_once,
+    _composite_video_with_audio,
+    _download_video,
+    _stitch_videos_ffmpeg,
+)
+
+# Tesla Shorts Time Ep519 (2026-06-23) — the 46 clips submitted before the
+# pipeline timed out, in script order (clip_id, request_id). Recovered from
+# the failed run's logs.
+EP519_REQUESTS = [
+    ("ep519_clip00", "f7c995bc-ff2e-93c1-a402-dd6b29f81cf0"),
+    ("ep519_clip01", "7b47df6a-a5b0-9781-affe-11212b12019d"),
+    ("ep519_clip02", "e277dcef-1f14-9370-a90b-67cd14c17a08"),
+    ("ep519_clip03", "0b5e3610-763f-96a9-b31e-2c1de5a44944"),
+    ("ep519_clip04", "a39b9d1e-701a-928f-9e8d-798144abe48a"),
+    ("ep519_clip05", "da43ccae-7cd4-9e51-82c4-f46dbd429980"),
+    ("ep519_clip06", "096b6b08-c20d-950d-afaa-7a4f5f0c6c2b"),
+    ("ep519_clip07", "098e05cf-9ccf-99bd-9b6e-cef8b4efb645"),
+    ("ep519_clip08", "6e5e6438-50c1-9ef9-9764-598c2e641985"),
+    ("ep519_clip09", "6a051bc0-5ce0-9f1f-bb83-5e2a885492f3"),
+    ("ep519_clip10", "7678d0f6-59cd-94ff-84b7-c1730c591f1a"),
+    ("ep519_clip11", "fd8ca420-ddf4-9e47-bdfb-393c7ab3683b"),
+    ("ep519_clip12", "d66e6016-e41a-9faf-8185-1b96392c78b0"),
+    ("ep519_clip13", "163ab06f-2e58-991f-a0be-5587a0069f74"),
+    ("ep519_clip14", "b7efd621-309c-9da3-8deb-00f2645327bd"),
+    ("ep519_clip15", "e02934c5-8b52-9dd8-ad71-6aa032369841"),
+    ("ep519_clip16", "0eb1e7a4-d8e9-9639-b6af-4420d348534d"),
+    ("ep519_clip17", "be7e2652-3d5a-9f6a-9f61-5684a51a4d56"),
+    ("ep519_clip18", "56bc2fe9-eaa7-9961-a36f-cb6666fb4b10"),
+    ("ep519_clip19", "84f67d7e-8622-9a54-a2a9-56bd3d18d668"),
+    ("ep519_clip20", "f50c89f6-d3ab-983f-acf9-e5c1e868aa5d"),
+    ("ep519_clip21", "a5945ebd-29ac-9c50-b364-92b28b9497ff"),
+    ("ep519_clip22", "958a814e-fe44-97b7-a79e-0f029bd7b5e7"),
+    ("ep519_clip23", "1920effa-326d-9eb8-b1ce-03fafad84281"),
+    ("ep519_clip24", "bad1e95e-1928-973a-b581-6f1d61506a89"),
+    ("ep519_clip25", "c0432406-1d97-9166-b6e5-68a44c3aaaed"),
+    ("ep519_clip26", "78c991ab-56c9-9384-b8d3-be7cf20497b5"),
+    ("ep519_clip27", "ce467d1e-8296-91ec-9ba8-bf96f84d54f2"),
+    ("ep519_clip28", "afbcd9fd-f8d6-9e3e-84e1-37db8c4a5f20"),
+    ("ep519_clip29", "4ff0c50a-d905-92f9-9a8e-9a6240a2e8ad"),
+    ("ep519_clip30", "d09ffe5f-35b5-96ed-8740-1e07992a4561"),
+    ("ep519_clip31", "ffa73f0c-3067-9d0a-8511-7c92f0428aeb"),
+    ("ep519_clip32", "8c5d5558-aad1-97a1-a835-b04fef8e74fa"),
+    ("ep519_clip33", "4ab93e72-ecf2-9498-96f7-8e15927bd907"),
+    ("ep519_clip34", "c3520bfa-2dd0-92c6-9995-3c2d1a6569ea"),
+    ("ep519_clip35", "8b183210-912d-984b-92d4-8b8ee26ef818"),
+    ("ep519_clip36", "932bdcf4-1de1-94b8-9e75-42c1766dec3b"),
+    ("ep519_clip37", "ec8fe772-02f8-9006-aed0-6f200cb6c860"),
+    ("ep519_clip38", "05b98857-761c-9406-9f08-cebd6a52140c"),
+    ("ep519_clip39", "0fda3cb2-3b7a-90be-9c4f-a66e659f3bee"),
+    ("ep519_clip40", "5487b491-20fa-96d9-83ed-c8fd21add4c2"),
+    ("ep519_clip41", "dad8bb29-b809-9890-bc21-0e57f4b768c6"),
+    ("ep519_clip42", "376bf67a-2f65-9d2f-8d65-8a47dd5f52fa"),
+    ("ep519_clip43", "c7032afb-dc88-9122-9704-cdec6fdec20a"),
+    ("ep519_clip44", "6b7c8d3d-c4c0-94d4-a220-d9a14c31cc3b"),
+    ("ep519_clip45", "03625e1c-c097-95d7-9bb9-e472eacb7715"),
+]
+
+
+def _load_requests(path: Path) -> list[tuple[str, str]]:
+    """Parse a 'clip_id request_id' per-line file ('#' comments allowed)."""
+    out: list[tuple[str, str]] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) == 1:
+            out.append((f"clip{len(out):02d}", parts[0]))
+        else:
+            out.append((parts[0], parts[1]))
+    return out
+
+
+def _resolve_audio(audio: str, work_dir: Path) -> Path | None:
+    """Return a local path to the audio, downloading it if a URL was given."""
+    if not audio:
+        return None
+    if audio.startswith(("http://", "https://")):
+        dest = work_dir / "episode_audio.mp3"
+        print(f"Downloading episode audio: {audio}")
+        urlretrieve(audio, dest)  # noqa: S310 — operator-supplied URL
+        return dest
+    p = Path(audio)
+    return p if p.exists() else None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--requests", type=Path, help="File of 'clip_id request_id' lines (default: embedded Ep519)")
+    ap.add_argument("--audio", default="", help="Episode audio (local path or URL) to composite onto the video")
+    ap.add_argument("--out", type=Path, required=True, help="Output MP4 path")
+    ap.add_argument("--workdir", type=Path, default=None, help="Scratch dir for clips (default: a temp dir)")
+    ap.add_argument("--retries", type=int, default=3, help="Status-poll retries per clip if still pending")
+    ap.add_argument("--retry-wait", type=float, default=10.0, help="Seconds between status retries")
+    args = ap.parse_args()
+
+    api_key = os.getenv("GROK_API_KEY", "").strip() or os.getenv("XAI_API_KEY", "").strip()
+    if not api_key:
+        print("ERROR: set GROK_API_KEY (or XAI_API_KEY) in the environment.", file=sys.stderr)
+        return 2
+
+    requests = _load_requests(args.requests) if args.requests else list(EP519_REQUESTS)
+    if not requests:
+        print("ERROR: no request IDs to recover.", file=sys.stderr)
+        return 2
+
+    work_dir = args.workdir or Path(tempfile.mkdtemp(prefix="grok_video_recover_"))
+    work_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Recovering {len(requests)} clip(s) into {work_dir}")
+
+    downloaded: list[Path] = []
+    pending: list[str] = []
+    failed: list[str] = []
+
+    for clip_id, request_id in requests:
+        body = None
+        for attempt in range(max(1, args.retries)):
+            try:
+                body = _check_video_status_once(request_id, api_key=api_key)
+            except GrokVideoError as exc:
+                print(f"  {clip_id} [{request_id}]: status error — {exc}")
+                body = None
+                break
+            if body.get("status") == "completed":
+                break
+            if attempt < args.retries - 1:
+                print(f"  {clip_id}: status={body.get('status')} — retrying in {args.retry_wait:.0f}s")
+                time.sleep(args.retry_wait)
+
+        if not body or body.get("status") != "completed":
+            status = (body or {}).get("status", "unreachable")
+            print(f"  {clip_id} [{request_id}]: NOT available (status={status})")
+            (pending if status not in ("failed", "unreachable") else failed).append(clip_id)
+            continue
+
+        url = body.get("url")
+        if not url:
+            print(f"  {clip_id}: completed but no URL in response")
+            failed.append(clip_id)
+            continue
+
+        local = work_dir / f"{clip_id}.mp4"
+        if _download_video(url, local):
+            downloaded.append(local)
+            print(f"  {clip_id}: downloaded ✓")
+        else:
+            failed.append(clip_id)
+            print(f"  {clip_id}: download failed")
+
+    print(
+        f"\nRecovered {len(downloaded)}/{len(requests)} clips "
+        f"({len(pending)} still pending, {len(failed)} failed)."
+    )
+    if not downloaded:
+        print("Nothing to stitch — the clips are no longer retrievable.", file=sys.stderr)
+        return 1
+
+    # Stitch in submission order (downloaded preserves the request order).
+    stitched = work_dir / "stitched.mp4"
+    if not _stitch_videos_ffmpeg(downloaded, stitched, cleanup=True):
+        print("ERROR: stitching failed (is ffmpeg installed?).", file=sys.stderr)
+        return 1
+
+    audio_path = _resolve_audio(args.audio, work_dir)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    if audio_path and audio_path.exists():
+        if _composite_video_with_audio(stitched, audio_path, args.out):
+            print(f"\nDONE → {args.out} (video + episode audio)")
+        else:
+            stitched.replace(args.out)
+            print(f"\nAudio composite failed; wrote video-only → {args.out}")
+    else:
+        if args.audio:
+            print("WARNING: could not resolve --audio; writing video-only.", file=sys.stderr)
+        stitched.replace(args.out)
+        print(f"\nDONE → {args.out} (video only — pass --audio to add sound)")
+
+    if len(downloaded) < len(requests):
+        print(
+            "NOTE: this is a PARTIAL recovery — some clips were missing, so the "
+            "video is shorter than the audio (the composite uses -shortest)."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -174,6 +174,16 @@ keywords:
 min_articles: 5
 min_articles_skip: 2
 
+# Per-show translation set (June 2026 "Spanish dropped network-wide" decision).
+# Env Intel is a lighter daily show like Models & Agents / First Principles —
+# French only, NOT the inherited _defaults [fr, ru, es, zh]. Without this
+# override it silently inherited the stale default (incl. the dropped Spanish).
+multilingual:
+  enabled: true
+  auto: true
+  languages:
+  - fr
+
 llm:
   provider: xai
   system_prompt_file: shows/prompts/env_intel_system.txt

--- a/tests/test_grok_video.py
+++ b/tests/test_grok_video.py
@@ -252,5 +252,53 @@ class TestGrokVideoResult:
             assert result.short_video_path == short_path
 
 
+class TestVideoBudget:
+    """Drift guards: a stuck clip must never blow the pipeline budget.
+
+    Regression: Tesla Ep519 (2026-06-23) timed out because the video step
+    polled 46 clips sequentially at 15 min/clip with no overall budget; the
+    pipeline SIGALRM fired mid-render and skipped the episode's git commit.
+    """
+
+    def test_signature_has_budget_param_defaulting_none(self):
+        from engine.grok_video import generate_grok_videos
+        import inspect
+
+        sig = inspect.signature(generate_grok_videos)
+        assert "max_total_seconds" in sig.parameters
+        assert sig.parameters["max_total_seconds"].default is None
+
+    def test_module_defines_budget_and_ratio(self):
+        import engine.grok_video as g
+
+        assert g.DEFAULT_VIDEO_BUDGET_S > 0
+        assert 0 < g.MIN_CLIP_COMPLETION_RATIO <= 1.0
+
+    def test_stuck_clips_respect_budget_and_fall_back(self):
+        """Clips that never complete must not hang past the budget; with too
+        few completed the result is a fallback (no full video path)."""
+        import engine.grok_video as g
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(g, "_request_one_video", side_effect=lambda *a, **k: "req-123"), \
+                 patch.object(g, "_check_video_status_once", return_value={"status": "pending"}) as mock_status, \
+                 patch.object(g, "DEFAULT_POLL_INTERVAL_S", 0):
+
+                result = g.generate_grok_videos(
+                    work_dir=Path(tmpdir),
+                    episode_num=1,
+                    podcast_script="One short sentence here.",  # 1 clip
+                    hook="hook",
+                    api_key="test-key",
+                    max_total_seconds=0.5,  # clip never completes within budget
+                )
+
+            # Never produced a full video; flagged fallback so the caller
+            # uses the image slideshow instead of a truncated episode.
+            assert result.full_video_path is None
+            assert result.is_fallback is True
+            assert mock_status.called  # we did poll at least once
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

Tesla **Ep519 (2026-06-23)** failed CI with `PIPELINE TIMEOUT: exceeded 2400s — aborting`. The episode itself generated fine (audio synthesized, mixed, uploaded to R2, transcript + chapters done) — the failure was entirely in the **Grok Video** stage.

The synchronous video step had **no overall time budget**:
1. It submitted 46 clips (1.5s apart), then **polled them sequentially**, each allowed `MAX_POLL_ATTEMPTS = 300 × 3s = 15 min`.
2. `clip00` got stuck and blocked for the full 15 min while clips 1–45 (already rendering in parallel on the server) waited their turn.
3. The pipeline-wide `SIGALRM` (2400s) then fired **mid-render** and raised `SystemExit` — which is `BaseException`, so the `except Exception` around the video call did **not** catch it.
4. `run_show` died non-zero → the episode's **git commit step was skipped** → partial publish (audio on R2, nothing committed).

This is the same timeout class that previously got the multilingual translation step decoupled (see the comment near the translation stage in `run_show.py`).

## Fix (durability-first — always falls back to the existing image slideshow)

**`engine/grok_video.py`**
- New wall-clock budget `DEFAULT_VIDEO_BUDGET_S` (env `GROK_VIDEO_BUDGET_SECONDS`, default 1200) + a deadline for the whole submit/poll/download/stitch phase.
- New `_check_video_status_once()` helper; the poll loop is now **round-robin** — each pass checks every still-pending clip once, so one stuck clip can't starve the others. On budget exhaustion, stragglers are marked failed and we proceed with whatever finished.
- Require `MIN_CLIP_COMPLETION_RATIO` (85%) of clips before stitching; below that we skip the stitch and return `is_fallback=True` so the caller uses the slideshow instead of a `-shortest`-truncated episode.

**`run_show.py`**
- Track pipeline start; reserve commit/finalize headroom (`PIPELINE_COMMIT_RESERVE_SECONDS`, default 420s) and pass the **time actually left** as `max_total_seconds`. Skip video entirely (slideshow fallback) when <60s remain. Result: the video stage can no longer trip the SIGALRM or skip the commit.

**`tests/test_grok_video.py`**
- Drift guards: the budget param + its `None` default, the module constants, and that stuck clips respect the budget and fall back rather than hang. All 17 tests pass.

## Notes
- No prompt/audio changes — this is pipeline plumbing, so landmine #17 doesn't apply.
- Effect on the video experiment: on slow-API days, episodes now reliably fall back to the image slideshow and **commit** rather than losing the episode. Operator can raise `GROK_VIDEO_BUDGET_SECONDS` if the API speeds up.
- A larger follow-up (decoupling video to an out-of-band workflow like multilingual) remains the cleaner long-term architecture, but is out of scope here since it changes when/how YouTube long-form publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1zpWenyiRrLscKfFiETA

---
_Generated by [Claude Code](https://claude.ai/code/session_016f1zpWenyiRrLscKfFiETA)_