### PR TITLE
Fix Grok Video status handling ('done' ≠ 'completed') + add SpaceX clip recovery

### DIFF
--- a/engine/grok_video.py
+++ b/engine/grok_video.py
@@ -63,6 +63,49 @@ DEFAULT_VIDEO_BUDGET_S = float(os.getenv("GROK_VIDEO_BUDGET_SECONDS", "1200"))
 # partial clip set would clip the episode to the stitched length).
 MIN_CLIP_COMPLETION_RATIO = 0.85
 
+# Status vocabulary. The xAI video API reports a finished clip as "done"
+# (NOT "completed" — the value the original code checked for, so every clip
+# was treated as still-pending and polled until timeout; confirmed against
+# live responses 2026-06-23). Accept the documented + observed spellings.
+_TERMINAL_SUCCESS = frozenset({"completed", "done", "succeeded", "success", "ready"})
+_TERMINAL_FAILURE = frozenset({"failed", "error", "errored", "cancelled", "canceled"})
+
+# Where the result URL can live across response shapes.
+_URL_FIELDS = ("url", "video_url", "download_url", "output_url", "result_url", "asset_url")
+_URL_CONTAINERS = ("result", "output", "video", "data", "asset", "assets")
+
+
+def _is_terminal_success(status) -> bool:
+    return str(status).lower() in _TERMINAL_SUCCESS
+
+
+def _is_terminal_failure(status) -> bool:
+    return str(status).lower() in _TERMINAL_FAILURE
+
+
+def _extract_video_url(body) -> Optional[str]:
+    """Find the downloadable video URL across known response shapes."""
+    if isinstance(body, str):
+        return body if body.startswith("http") else None
+    if not isinstance(body, dict):
+        return None
+    for key in _URL_FIELDS:
+        val = body.get(key)
+        if isinstance(val, str) and val.startswith("http"):
+            return val
+    for container in _URL_CONTAINERS:
+        child = body.get(container)
+        if isinstance(child, dict):
+            found = _extract_video_url(child)
+            if found:
+                return found
+        elif isinstance(child, list):
+            for item in child:
+                found = _extract_video_url(item)
+                if found:
+                    return found
+    return None
+
 # Pricing per second of video output
 VIDEO_COST_USD = {
     "480p": 0.05,
@@ -431,13 +474,13 @@ def _poll_video_status(
                 request_id, attempt + 1, max_attempts, status,
             )
 
-            if status == "completed":
-                logger.info("Grok Video %s completed", request_id)
+            if _is_terminal_success(status):
+                logger.info("Grok Video %s completed (status=%s)", request_id, status)
                 return body
 
-            if status == "failed":
-                error = body.get("error", {})
-                msg = error.get("message", "Unknown error")
+            if _is_terminal_failure(status):
+                error = body.get("error", {}) if isinstance(body.get("error"), dict) else {}
+                msg = error.get("message", status)
                 raise GrokVideoError(f"Grok Video generation failed: {msg}")
 
             # Still pending — wait and retry
@@ -482,10 +525,10 @@ def _check_video_status_once(
             f"Grok Video status HTTP {resp.status_code}: {resp.text[:300]}"
         )
     body = resp.json()
-    if body.get("status") == "failed":
-        error = body.get("error", {})
+    if _is_terminal_failure(body.get("status")):
+        error = body.get("error", {}) if isinstance(body.get("error"), dict) else {}
         raise GrokVideoError(
-            f"Grok Video generation failed: {error.get('message', 'Unknown error')}"
+            f"Grok Video generation failed: {error.get('message', body.get('status', 'Unknown error'))}"
         )
     return body
 
@@ -781,11 +824,11 @@ def generate_grok_videos(
                 logger.warning("Failed to complete %s: %s", clip.clip_id, exc)
                 continue
 
-            if body.get("status") != "completed":
+            if not _is_terminal_success(body.get("status")):
                 still_pending.append(clip)
                 continue
 
-            url = body.get("url")
+            url = _extract_video_url(body)
             if not url:
                 clip.status = "failed"
                 clip.error_message = f"Response missing video URL: {body}"

--- a/scripts/recover_grok_video.py
+++ b/scripts/recover_grok_video.py
@@ -73,6 +73,9 @@ from engine.grok_video import (  # noqa: E402 (after sys.path bootstrap)
     _check_video_status_once,
     _composite_video_with_audio,
     _download_video,
+    _extract_video_url,
+    _is_terminal_failure,
+    _is_terminal_success,
     _stitch_videos_ffmpeg,
 )
 
@@ -126,6 +129,35 @@ EP519_REQUESTS = [
     ("ep519_clip44", "6b7c8d3d-c4c0-94d4-a220-d9a14c31cc3b"),
     ("ep519_clip45", "03625e1c-c097-95d7-9bb9-e472eacb7715"),
 ]
+
+# SpaceX Daily Ep12 (2026-06-23) — the 12 clips submitted before that
+# pipeline timed out, in script order. From the run log.
+SPACEX_EP12_REQUESTS = [
+    ("ep012_clip00", "6b2e91d5-07e0-9133-97a2-e6f8c631f4eb"),
+    ("ep012_clip01", "e99f058c-781d-9b64-95fa-3390d9d9f307"),
+    ("ep012_clip02", "4feefd20-2a7a-9b45-933e-a176c09512c6"),
+    ("ep012_clip03", "b62a5624-e3c4-9d12-809d-5a5860a4c44b"),
+    ("ep012_clip04", "0050ff95-a20e-9508-86f9-b7623f471966"),
+    ("ep012_clip05", "53ba2b36-8d4c-9dd6-b56d-5732f239eebb"),
+    ("ep012_clip06", "bfa19b55-03c7-9e0b-8edc-9e240bd0a2a8"),
+    ("ep012_clip07", "6c552b94-f917-9217-8bf7-92a09a0db864"),
+    ("ep012_clip08", "645d6892-8e9c-9293-9204-e9236764a545"),
+    ("ep012_clip09", "757a0c39-1c31-91d6-a0ed-84196b3c490e"),
+    ("ep012_clip10", "def29b63-bdb3-93bf-b09e-ca38ab121812"),
+    ("ep012_clip11", "468520d4-b54c-9aa2-9f75-e24b52c259b6"),
+]
+
+# Episode audio (R2) for the embedded sets, for --stitch convenience.
+EMBEDDED_SETS = {
+    "tesla_ep519": (
+        EP519_REQUESTS,
+        "https://audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep519_20260623.mp3",
+    ),
+    "spacex_ep12": (
+        SPACEX_EP12_REQUESTS,
+        "https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep012_20260623.mp3",
+    ),
+}
 
 
 def _load_requests(path: Path) -> list[tuple[str, str]]:
@@ -219,13 +251,13 @@ def _run_list_all(api_key: str, out_dir: Path) -> int:
     got = 0
     for i, item in enumerate(items):
         vid = str(item.get("id") or item.get("request_id") or f"video{i:04d}")
-        url = item.get("url")
+        url = _extract_video_url(item)
         status = item.get("status", "unknown")
-        if not url and status != "completed":
+        if not url and not _is_terminal_success(status):
             # Re-poll by id to get a fresh temporary URL.
             try:
                 body = _check_video_status_once(vid, api_key=api_key)
-                url, status = body.get("url"), body.get("status", status)
+                url, status = _extract_video_url(body), body.get("status", status)
             except GrokVideoError as exc:
                 print(f"  {vid}: {exc}")
         if url:
@@ -248,6 +280,7 @@ def _retrieve(requests_list, api_key, out_dir, retries, retry_wait):
     out_dir.mkdir(parents=True, exist_ok=True)
     downloaded: list[Path] = []
     pending = failed = 0
+    dumped = False
     for clip_id, request_id in requests_list:
         body = None
         for attempt in range(max(1, retries)):
@@ -257,25 +290,34 @@ def _retrieve(requests_list, api_key, out_dir, retries, retry_wait):
                 print(f"  {clip_id} [{request_id}]: status error — {exc}")
                 body = None
                 break
-            if body.get("status") == "completed":
+            if _is_terminal_success(body.get("status")):
+                break
+            if _is_terminal_failure(body.get("status")):
                 break
             if attempt < retries - 1:
                 print(f"  {clip_id}: status={body.get('status')} — retry in {retry_wait:.0f}s")
                 time.sleep(retry_wait)
 
-        if not body or body.get("status") != "completed":
-            status = (body or {}).get("status", "unreachable")
+        status = (body or {}).get("status", "unreachable")
+        if not body or not _is_terminal_success(status):
             print(f"  {clip_id} [{request_id}]: NOT available (status={status})")
-            if status in ("failed", "unreachable"):
+            if _is_terminal_failure(status) or status == "unreachable":
                 failed += 1
             else:
                 pending += 1
             continue
 
-        url = body.get("url")
+        url = _extract_video_url(body)
         if not url:
-            print(f"  {clip_id}: completed but no URL")
             failed += 1
+            print(f"  {clip_id}: finished (status={status}) but no URL field found")
+            if not dumped:
+                # Dump one raw response so the URL field can be pinned if the
+                # shape is unexpected.
+                print("  --- raw response (for diagnosis) ---")
+                print(json.dumps(body, indent=2)[:2000])
+                print("  --- end raw response ---")
+                dumped = True
             continue
         dest = out_dir / f"{clip_id}.mp4"
         if _download_video(url, dest):
@@ -295,7 +337,9 @@ def _retrieve(requests_list, api_key, out_dir, retries, retry_wait):
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--list-all", action="store_true", help="Enumerate + download every video on the account")
-    ap.add_argument("--requests", type=Path, help="File of 'clip_id request_id' lines (default: embedded Ep519)")
+    ap.add_argument("--set", dest="embedded_set", choices=sorted(EMBEDDED_SETS),
+                    default="tesla_ep519", help="Which embedded clip set to recover (default: tesla_ep519)")
+    ap.add_argument("--requests", type=Path, help="File of 'clip_id request_id' lines (overrides --set)")
     ap.add_argument("--out-dir", type=Path, default=None, help="Directory to keep the individual clips")
     ap.add_argument("--stitch", action="store_true", help="Also concatenate the clips into one episode video")
     ap.add_argument("--audio", default="", help="Episode audio (path or URL) to composite when --stitch")
@@ -313,7 +357,12 @@ def main() -> int:
         out_dir = args.out_dir or Path("recovered_videos")
         return _run_list_all(api_key, out_dir)
 
-    requests_list = _load_requests(args.requests) if args.requests else list(EP519_REQUESTS)
+    if args.requests:
+        requests_list = _load_requests(args.requests)
+        default_audio = ""
+    else:
+        requests_list, default_audio = EMBEDDED_SETS[args.embedded_set]
+        requests_list = list(requests_list)
     if not requests_list:
         print("ERROR: no request IDs to recover.", file=sys.stderr)
         return 2
@@ -339,7 +388,7 @@ def main() -> int:
         print("ERROR: stitching failed (is ffmpeg installed?).", file=sys.stderr)
         return 1
 
-    audio_path = _resolve_audio(args.audio, out_dir)
+    audio_path = _resolve_audio(args.audio or default_audio, out_dir)
     args.out.parent.mkdir(parents=True, exist_ok=True)
     if audio_path and audio_path.exists():
         if _composite_video_with_audio(stitched, audio_path, args.out):

--- a/tests/test_grok_video.py
+++ b/tests/test_grok_video.py
@@ -300,5 +300,32 @@ class TestVideoBudget:
             assert mock_status.called  # we did poll at least once
 
 
+class TestStatusVocabulary:
+    """Drift guards: the xAI API reports finished clips as 'done', not
+    'completed'. The original code only accepted 'completed', so every clip
+    polled until timeout (the real root cause of the Ep519/Ep12 timeouts)."""
+
+    def test_done_is_terminal_success(self):
+        from engine.grok_video import _is_terminal_success, _is_terminal_failure
+
+        for ok in ("done", "completed", "DONE", "Succeeded", "ready"):
+            assert _is_terminal_success(ok), ok
+        for not_ok in ("pending", "processing", "queued", "running"):
+            assert not _is_terminal_success(not_ok), not_ok
+        for bad in ("failed", "error", "cancelled"):
+            assert _is_terminal_failure(bad), bad
+        assert not _is_terminal_failure("done")
+
+    def test_extract_url_across_shapes(self):
+        from engine.grok_video import _extract_video_url
+
+        assert _extract_video_url({"url": "https://a/v.mp4"}) == "https://a/v.mp4"
+        assert _extract_video_url({"video_url": "https://b/v.mp4"}) == "https://b/v.mp4"
+        assert _extract_video_url({"result": {"url": "https://c/v.mp4"}}) == "https://c/v.mp4"
+        assert _extract_video_url({"data": [{"download_url": "https://d/v.mp4"}]}) == "https://d/v.mp4"
+        assert _extract_video_url({"status": "done"}) is None
+        assert _extract_video_url({"url": "not-a-url"}) is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Root cause (found while recovering Ep519's clips)

Recovering the Tesla Ep519 clips revealed why the video step kept timing out: the xAI video API reports a finished clip as **`status: "done"`**, but the code only ever treated **`"completed"`** as terminal. So every clip was polled as "still pending" until the 300-attempt timeout — and then the pipeline budget blew. **Grok Video generation never actually succeeded; it always fell back to the image slideshow.** (The budget fix in #707 prevented the *episode loss*; this fixes the *underlying feature*.)

Live confirmation from the account: clips report `status=done`, not `completed`.

## Changes

**`engine/grok_video.py`** (makes the real pipeline path work, not just recovery)
- `_is_terminal_success` / `_is_terminal_failure` — accept `done`/`completed`/`succeeded`/`success`/`ready` and `failed`/`error`/`cancelled`/…
- `_extract_video_url` — find the URL across `url`/`video_url`/`download_url`/… and nested `result`/`output`/`data`/… shapes.
- Wired into `_check_video_status_once`, the round-robin poller, and the legacy `_poll_video_status`.

**`scripts/recover_grok_video.py`**
- Recognise `done`, extract the URL robustly, and **dump one raw response** if a finished clip has no URL field (so an unexpected shape can be pinned).
- Add the **SpaceX Daily Ep12 (2026-06-23)** clip set (12 IDs) + a `--set {tesla_ep519,spacex_ep12}` selector, each wired to its episode audio for `--stitch`.

**`tests/test_grok_video.py`** — drift guards for the status vocabulary + URL extraction (19 pass).

## Recover the clips

```bash
# SpaceX Ep12 (12 clips)
GROK_API_KEY='…' python3 scripts/recover_grok_video.py --set spacex_ep12 --out-dir recovered_spacex_ep12/
# Tesla Ep519 (46 clips)
GROK_API_KEY='…' python3 scripts/recover_grok_video.py --set tesla_ep519 --out-dir recovered_ep519/
```
Add `--stitch --out <file>.mp4` (needs ffmpeg) to assemble the episode video with its audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1zpWenyiRrLscKfFiETA

---
_Generated by [Claude Code](https://claude.ai/code/session_016f1zpWenyiRrLscKfFiETA)_