### PR TITLE
Disable Grok Video network-wide (too expensive) — revert to image slideshows

### DIFF
--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -274,9 +274,10 @@ youtube:
   # floor from the 5.0 default so good-but-not-perfect beats still win over the
   # boilerplate voice-intro start. See engine/shorts_selector.py.
   shorts_min_score_threshold: 3.5
-  # TEMPORARY (2026-06-21): Test Grok Video pipeline for quality comparison
-  # vs image slideshow. Remove this flag after the next run to revert to images.
-  video_provider: grok
+  # Grok Video pipeline DISABLED 2026-06-23 — too expensive
+  # ($0.07/sec 720p ≈ $40-50/episode). Reverted to the image slideshow
+  # (image_provider below). Do NOT re-enable without a cost decision.
+  video_provider: null
   video_resolution: "720p"
   video_aspect_ratio: "16:9"
 

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -305,12 +305,11 @@ youtube:
   category_id: 28               # Science & Tech (algorithm performs better than 2/Autos here)
   default_language: en
   privacy_status: public        # Phase-1 validated; uploads are public
-  # June 2026 — Grok video generation experiment. When enabled, generates
-  # full-length videos from the podcast script instead of still-image
-  # slideshows. Set to null/false to revert to image-based pipeline.
-  # Pricing: $0.07/second for 720p, so a 12-min episode ≈ $50.40.
-  # Test against still-image approach to measure engagement delta.
-  video_provider: grok          # "grok" enables video, null/false reverts to images
+  # June 2026 — Grok video generation experiment. DISABLED 2026-06-23:
+  # full-length video is too expensive ($0.07/sec 720p ≈ $50/episode). The
+  # show reverts to the still-image slideshow (image_provider below). Do NOT
+  # set this back to "grok" without an explicit cost decision.
+  video_provider: null          # null/false = image slideshow (cheap); "grok" = video ($$$)
   video_resolution: "720p"
   video_aspect_ratio: "16:9"    # Full-format episodes
 

--- a/tests/test_grok_video.py
+++ b/tests/test_grok_video.py
@@ -300,6 +300,36 @@ class TestVideoBudget:
             assert mock_status.called  # we did poll at least once
 
 
+class TestVideoDisabledNetworkWide:
+    """Grok Video is DISABLED network-wide (2026-06-23, cost: ~$50/episode).
+
+    Every show must fall back to the image slideshow. Re-enabling video is a
+    deliberate cost decision — this guard blocks a silent regression.
+    """
+
+    def test_no_show_enables_grok_video(self):
+        import glob
+        import os
+
+        offenders = []
+        for path in sorted(glob.glob("shows/*.yaml")):
+            if os.path.basename(path).startswith("_"):
+                continue
+            cfg = load_config(path)
+            vp = (getattr(cfg.youtube, "video_provider", None) or "").lower()
+            if vp == "grok":
+                offenders.append(os.path.basename(path))
+        assert not offenders, (
+            f"Grok Video is disabled network-wide (too expensive); these shows "
+            f"re-enabled it: {offenders}. Set video_provider: null."
+        )
+
+    def test_config_default_video_provider_is_not_grok(self):
+        from engine.config import YouTubeConfig
+
+        assert (YouTubeConfig.video_provider or "").lower() != "grok"
+
+
 class TestStatusVocabulary:
     """Drift guards: the xAI API reports finished clips as 'done', not
     'completed'. The original code only accepted 'completed', so every clip


### PR DESCRIPTION
## What

Disable the Grok **Video** pipeline network-wide — it's too expensive (full-length 720p ≈ **$0.07/sec ≈ $40–50/episode**) — and revert every show to the still-image slideshow.

- `shows/tesla.yaml`, `shows/spacex.yaml`: `video_provider: grok` → **`null`**. These were the only two shows that enabled it. Both already set `image_provider: grok` (Grok Imagine), so they fall back to the still-image slideshow (`run_show` treats anything but `"grok"` as image mode). The image pipeline (and gallery) is unchanged.
- Drift guard `tests/test_grok_video.py::TestVideoDisabledNetworkWide`: asserts no show YAML — and the dataclass default — re-enables `video_provider: grok`, so it can't silently come back.

## Verified
- All shows resolve to `video_provider=None`; tesla/spacex keep `image_provider='grok'`.
- `tests/test_grok_video.py` 21/21 pass (incl. the 2 new guards).

No prompt/audio changes. The `done`-status + budget fixes from #707/#708 stay in place (harmless now that video is off, and ready if you ever re-enable with an explicit cost decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f1zpWenyiRrLscKfFiETA

---
_Generated by [Claude Code](https://claude.ai/code/session_016f1zpWenyiRrLscKfFiETA)_