### PR TITLE
Align pronunciation layer with the Grok voice: drop legacy respellings

### DIFF
--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -397,7 +397,11 @@ WORD_PRONUNCIATIONS: Dict[str, str] = {
     "IF Metall": "I F Metall",
 
     # --- Company / brand names ---
-    "Teslarati": "Tesla-rah-tee",
+    # ``Teslarati`` respelling removed 2026-06-25: the garble-repair layer
+    # (engine.utils.fix_phonetic_garbles, run_show.py:2284) reverts
+    # "Tesla-rah-tee" → "Teslarati" immediately after this map runs, so the
+    # entry was a dead round-trip (no effect on audio OR transcript). The
+    # garble map still protects against an LLM that writes "Tesla-rah-tee".
     "CleanTechnica": "Clean Technica",
     "BrewDog": "Brew Dog",
     "AstraZeneca": "Astra-Zeneca",
@@ -407,7 +411,11 @@ WORD_PRONUNCIATIONS: Dict[str, str] = {
     "LangChain": "Lang Chain",
     "PyTorch": "Pie Torch",
     "Mistral": "Mee-stral",
-    "Anthropic": "An-thropic",
+    # ``Anthropic`` respelling removed 2026-06-25 (garble layer reverts
+    # "An-thropic" → "Anthropic" — dead round-trip). ``NVIDIA`` is kept: its
+    # garble revert lands on "Nvidia" (a DIFFERENT token), so dropping it could
+    # let an all-caps "NVIDIA" reach Grok and letter-split — deferred to the
+    # A/B-listen batch.
     "NVIDIA": "En-vidia",
     "DeepSeek": "Deep Seek",
     "MiniMax": "Mini Max",
@@ -425,7 +433,10 @@ WORD_PRONUNCIATIONS: Dict[str, str] = {
     "Afeela": "ah-FEE-lah",
 
     # --- Scientific names ---
-    "Enceladus": "En-sell-uh-dus",
+    # ``Enceladus`` respelling removed 2026-06-25 (garble layer reverts
+    # "En-sell-uh-dus" → "Enceladus" — dead round-trip). The remaining
+    # science-name respellings below are NOT garble-covered and are deferred
+    # to the A/B-listen batch.
     "Cassini": "Kah-see-nee",
     "Oberth": "Oh-bairt",
     "xenotransplantation": "zeno-transplantation",
@@ -444,19 +455,23 @@ WORD_PRONUNCIATIONS: Dict[str, str] = {
     # untouched, only the audio reflects the override.
 
     # --- AI model names ---
-    "Qwen": "Chwen",
-    "Llama": "Lah-mah",
+    # ``Qwen`` ("Chwen") and ``Llama`` ("Lah-mah") respellings removed
+    # 2026-06-25 — both are reverted by the garble-repair layer immediately
+    # after this map runs (dead round-trips).
 
     # --- People ---
+    # ``Starmer`` ("Star-mer"), ``Tianwen`` ("Tee-en-wen") and ``Hassabis``
+    # ("Hah-sah-biss") respellings removed 2026-06-25 — each is reverted by the
+    # garble-repair layer right after this map runs (dead round-trips). The
+    # foreign-name respellings kept below are NOT garble-covered (they reach
+    # both the audio and the transcript) and are deferred to the A/B-listen
+    # batch.
     "Karpathy": "Kar-pathy",
     "Milei": "Mee-lay",
-    "Starmer": "Star-mer",
     "Zelenskyy": "Zeh-len-skee",
     "Zelenskyj": "Zeh-len-skee",
     "Zelensky": "Zeh-len-skee",
-    "Tianwen": "Tee-en-wen",
     "Altman": "Awlt-man",
-    "Hassabis": "Hah-sah-biss",
     "Amodei": "Ah-mo-day",
 
     # Note: Common words like "who", "ice", "us", "led", "dot" are now

--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -367,26 +367,16 @@ WORD_PRONUNCIATIONS: Dict[str, str] = {
     # into reader-facing text.
 
     # --- Tesla product names ---
-    "Robotaxis": "Robo-taxis",
-    "Robotaxi": "Robo-taxi",
-    "robotaxis": "robo-taxis",
-    "robotaxi": "robo-taxi",
-    "Cybertruck": "Cyber-truck",
-    "Cybercab": "Cyber-cab",
-    "Megapack": "Mega-pack",
-    "Megapacks": "Mega-packs",
-    "Powerwall": "Power-wall",
-    "Powerwalls": "Power-walls",
-    "Supercharger": "Super-charger",
-    "Superchargers": "Super-chargers",
-    "Gigafactory": "Giga-factory",
-    "Gigafactories": "Giga-factories",
-    "Autopilot": "Auto-pilot",
-    "Megacharger": "Mega-charger",
-    "Megachargers": "Mega-chargers",
-    "Megafactory": "Mega-factory",
-    "gigacasting": "giga-casting",
-    "Gigacasting": "Giga-casting",
+    # Hyphenated respellings (Cybertruck → "Cyber-truck", Robotaxi →
+    # "Robo-taxi", Gigafactory → "Giga-factory", Supercharger, Autopilot,
+    # Megapack, Powerwall, gigacasting, …) removed 2026-06-25. They are common
+    # English compounds the Grok custom voice says natively, and because this
+    # layer leaks into the saved _tts.txt → blog/RSS, the hyphenated forms were
+    # shipping verbatim in published transcripts ("Cyber-truck", "Robo-taxi").
+    # Per landmine #17 this changes shipped audio → A/B-listened before merge.
+    # If a specific compound ever regresses on the voice, re-add it to
+    # shows/pronunciation_map.yaml (audio-only) — NOT here — so the respelling
+    # never re-enters the transcript.
 
     # --- Tesla model names ---
     "Model 3": "Model Three",

--- a/tests/test_pronunciation.py
+++ b/tests/test_pronunciation.py
@@ -585,8 +585,12 @@ class TestApplyPronunciationFixes:
         assert "plan it TAIR ee uhn" not in result
 
     def test_teslarati(self):
+        # Respelling removed 2026-06-25 — the garble-repair layer reverted
+        # "Tesla-rah-tee" → "Teslarati" right after this map, so the canonical
+        # word is what reaches TTS + transcript. The map now leaves it alone.
         result = apply_pronunciation_fixes("According to Teslarati")
-        assert "Tesla-rah-tee" in result
+        assert "Teslarati" in result
+        assert "Tesla-rah-tee" not in result
 
 
 # ===================== Full Pipeline (prepare_text_for_tts) =====================
@@ -697,7 +701,7 @@ class TestPrepareTextForTts:
         assert "thirty-nine" in result        # Episode number
         assert "slash" in result               # Comet designation
         assert "Kah-see-nee" in result         # Cassini pronunciation
-        assert "En-sell-uh-dus" in result      # Enceladus pronunciation
+        assert "Enceladus" in result           # respelling removed 2026-06-25 (garble-redundant)
         assert "Phase three" in result         # Roman numeral
         assert "five hundred thousand" in result  # Large number
         assert "kilometers" in result          # Unit expansion

--- a/tests/test_pronunciation.py
+++ b/tests/test_pronunciation.py
@@ -535,25 +535,33 @@ class TestApplyPronunciationFixes:
         result = apply_pronunciation_fixes("The DOT approved it")
         assert "D O T" in result
 
-    def test_megacharger(self):
+    # Tesla product-name hyphen respellings removed 2026-06-25 — the Grok
+    # custom voice says these common compounds natively, and the respelling
+    # had been leaking into the published transcript. The raw word must now
+    # pass through unchanged (and the old hyphenated form must NOT appear).
+    def test_megacharger_unrespelled(self):
         result = apply_pronunciation_fixes("Tesla Megacharger network")
-        assert "Mega-charger" in result
+        assert "Megacharger" in result
+        assert "Mega-charger" not in result
 
-    def test_gigacasting(self):
+    def test_gigacasting_unrespelled(self):
         result = apply_pronunciation_fixes("Tesla's gigacasting technology")
-        assert "giga-casting" in result
+        assert "gigacasting" in result
+        assert "giga-casting" not in result
 
     def test_ig_metall(self):
         result = apply_pronunciation_fixes("IG Metall union conflict")
         assert "I G Metall" in result
 
-    def test_robotaxi(self):
+    def test_robotaxi_unrespelled(self):
         result = apply_pronunciation_fixes("Tesla Robotaxi service")
-        assert "Robo-taxi" in result
+        assert "Robotaxi" in result
+        assert "Robo-taxi" not in result
 
-    def test_cybertruck(self):
+    def test_cybertruck_unrespelled(self):
         result = apply_pronunciation_fixes("The Cybertruck is here")
-        assert "Cyber-truck" in result
+        assert "Cybertruck" in result
+        assert "Cyber-truck" not in result
 
     def test_planetterrian_passes_through_unchanged(self):
         """Operator caught (PT Ep060, May 11 2026 daily review) the

--- a/tests/test_pronunciation_calibration.py
+++ b/tests/test_pronunciation_calibration.py
@@ -225,10 +225,12 @@ class TestLoadPipelineCandidates:
 
     def test_includes_word_pronunciations_entries(self):
         """At least one entry that lives only in WORD_PRONUNCIATIONS
-        (e.g. Cybertruck, Gigafactory) must appear."""
+        (e.g. Cassini, DeepSeek) must appear. (The Tesla product compounds
+        Cybertruck/Gigafactory were dropped 2026-06-25 — Grok says them
+        natively.)"""
         candidates = tp._load_pipeline_candidates()
         targets = {c.target.lower() for c in candidates}
-        assert "cybertruck" in targets or "gigafactory" in targets
+        assert "cassini" in targets or "deepseek" in targets
 
     def test_case_variants_dedup_by_lowercase(self):
         """``tissue`` + ``Tissue`` + ``tissues`` + ``Tissues`` collapse

--- a/tests/test_pronunciation_grok_alignment.py
+++ b/tests/test_pronunciation_grok_alignment.py
@@ -1,0 +1,56 @@
+"""Guards that the script-save pronunciation layer stays aligned with the Grok
+voice and the garble-repair layer.
+
+Background
+----------
+``assets.pronunciation.WORD_PRONUNCIATIONS`` runs at script-save time
+(``run_show.py:_apply_pronunciation``) and its output is then passed through
+``engine.utils.fix_phonetic_garbles`` *before* TTS / blog / RSS see the script
+(``run_show.py:2284``). Any respelling whose VALUE is a key in the garble map is
+a **dead round-trip**: it is produced and then immediately reverted, so it
+changes neither the audio nor the published transcript. Those entries are pure
+confusion (and they contradict the operator's "no phonetic respellings on the
+Grok custom voice" policy — landmine #17). This guard blocks new dead
+round-trips from creeping back in and documents the one tolerated exception.
+"""
+
+from assets.pronunciation import WORD_PRONUNCIATIONS
+from engine.utils import _PHONETIC_GARBLES, fix_phonetic_garbles
+
+
+# ``NVIDIA`` -> "En-vidia" is reverted by the garble layer to "Nvidia" (a
+# DIFFERENT token than the "NVIDIA" key), so removing it could let an all-caps
+# "NVIDIA" reach Grok and letter-split. Kept until the A/B-listen batch settles
+# it; every other garble-reverted respelling has been dropped.
+_TOLERATED_ROUND_TRIPS = {"NVIDIA"}
+
+
+def test_no_new_garble_redundant_respellings():
+    garble_keys = {k.lower() for k in _PHONETIC_GARBLES}
+    overlaps = {
+        k: v for k, v in WORD_PRONUNCIATIONS.items() if v.lower() in garble_keys
+    }
+    assert set(overlaps) <= _TOLERATED_ROUND_TRIPS, (
+        "These WORD_PRONUNCIATIONS entries are reverted by fix_phonetic_garbles "
+        f"immediately after they run (dead round-trips) — drop them: {overlaps}"
+    )
+
+
+def test_removed_garble_redundant_entries_stay_removed():
+    for word in (
+        "Teslarati", "Anthropic", "Enceladus", "Qwen",
+        "Llama", "Starmer", "Tianwen", "Hassabis",
+    ):
+        assert word not in WORD_PRONUNCIATIONS, (
+            f"{word} respelling was removed as a dead round-trip — re-adding it "
+            "here only leaks the respelling into the transcript before the "
+            "garble layer reverts it."
+        )
+
+
+def test_garble_layer_still_protects_against_llm_garbles():
+    # The respelling entries were redundant, but the garble map must stay —
+    # it's what catches the LLM itself writing the phonetic form in the script.
+    assert fix_phonetic_garbles("An-thropic and Lah-mah") == "Anthropic and Llama"
+    assert "Teslarati" in fix_phonetic_garbles("per Tesla-rah-tee")
+    assert "Enceladus" in fix_phonetic_garbles("the moon En-sell-uh-dus")


### PR DESCRIPTION
## Why

Follow-up to the pronunciation-pipeline audit. The Grok **engine** config is already optimal (`text_normalization: true`, WAV @ 48 kHz, custom voice; letter-by-letter acronyms are the blessed class). The **dictionaries** still carried ElevenLabs-era *phonetic respellings* in `assets/pronunciation.py:WORD_PRONUNCIATIONS` — the exact class the operator's **May 11 2026 A/B test removed** ("every respelling sounded *worse* than the original word" on voice `kdif6sqjcyiq`). That layer runs at script-save time and **leaks into the published `_tts.txt` → blog/RSS transcript** (same mechanism as the CUDA landmine), so the respellings were both feeding Grok hyphenated tokens and shipping verbatim in transcripts.

This PR removes the clearly-actionable subset in two separate commits so the safe change ships immediately and the audio-affecting change can be A/B-listened.

## Commit 1 — garble-redundant removals (no-op, no A/B needed)

8 entries (`Teslarati, Anthropic, Enceladus, Qwen, Llama, Starmer, Tianwen, Hassabis`) were respelled at `run_show.py:2232` and then **reverted to canonical** by `fix_phonetic_garbles` at `run_show.py:2284` — dead round-trips with zero effect on audio or transcript. Verified the net pipeline output is unchanged:

```
full pipeline (apply → garble), AFTER this PR:
"According to Teslarati, Anthropic and Llama trail Qwen; Hassabis and Starmer weighed in."
```

The garble map is **untouched** — it still catches the LLM writing the phonetic form directly. New drift guard `tests/test_pronunciation_grok_alignment.py` blocks re-introduction. `NVIDIA→En-vidia` is intentionally kept (its revert lands on the different token `Nvidia`; dropping it risks an all-caps letter-split) and documented as the one tolerated exception.

## Commit 2 — Tesla product-name compounds ⚠️ A/B-listen required

`Cybertruck→"Cyber-truck"`, `Robotaxi→"Robo-taxi"`, `Gigafactory→"Giga-factory"`, `Supercharger`, `Autopilot`, `Megapack`, `Powerwall`, `Megacharger`, `Megafactory`, `gigacasting` (+ plurals/case-variants). These are common English compounds Grok says natively, and the hyphenated forms were shipping in transcripts. Removing them cleans both surfaces:

```
apply_pronunciation_fixes(...) on the same Tesla sentence
BEFORE: "The Cyber-truck and Robo-taxi rely on Auto-pilot, built at the Giga-factory."
AFTER:  "The Cybertruck and Robotaxi rely on Autopilot, built at the Gigafactory."
```

Per **landmine #17** this changes shipped audio on the network's largest show. Please A/B-listen one rendered Tesla episode's audio before merge; if any single compound regresses, re-add it to `shows/pronunciation_map.yaml` (audio-only), not back into this layer. `Model 3`/`Model Y` expansions are kept (different class).

## Tests

`pytest tests/test_pronunciation*.py tests/test_*quality_pass.py` → all green (305 passed). The one unrelated red in the broader suite is the pre-existing `first_principles` queue-runway test (operator-owned restock), not touched here.

## Deferred to a follow-up A/B batch (documented in code)

Not in this PR — each needs its own per-item listen and some have subtle garble interactions:
- **Foreign-name / science respellings** still live & leaking: `Mistral, Karpathy, Milei, Zelensky, Altman, Amodei, AstraZeneca, Alnylam, Roscosmos, Afeela, Hachette, Oberth, Cassini, xenotransplantation, inflammaging, epigenetic`. (These are genuinely hard for TTS raw — higher regression risk, so held back.)
- **`COMMON_ACRONYMS` phonetic word-guides** not covered by the garble layer (`JAXA→jacksa, PSYCHE→Sy-key, OPEC→oh-peck, EBITDA→ee-bit-dah, LoRA→Laura, GAAP, SPAC`) — also leak to transcripts.
- **`NVIDIA→En-vidia`** (the tolerated round-trip above).
- **MAB hook respellings** (`shows/hooks/models_agents_beginners.py`: `LoRA→laura, CUDA→kooda, SOTA→so-tah, Karpathy`) — note its `tts: {}` inherits the **Grok** custom voice (the CLAUDE.md table calling MAB/PR "ElevenLabs" is stale; PR's YAML is `provider: grok`/Olya), so these land on Grok too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MijFStKrJvtf9JxQvKQUDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MijFStKrJvtf9JxQvKQUDx)_