### PR TITLE
Pronunciation Grok-alignment, part 2: move foreign names to audio-only, drop English respellings

### DIFF
--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -400,29 +400,25 @@ WORD_PRONUNCIATIONS: Dict[str, str] = {
     # ``NVIDIA`` stays (its garble revert lands on the different token "Nvidia";
     # moving it would change the audio). ``Lifespan.io`` stays (strip_urls
     # rewrites the .io domain before this map runs, so it needs the script-save
-    # layer). The English-compound brand names that REMAIN below are removed in
-    # the companion A/B commit — the Grok voice says them natively.
-    "CleanTechnica": "Clean Technica",
-    "BrewDog": "Brew Dog",
+    # layer).
+    #
+    # English-compound brand names (CleanTechnica, BrewDog, LangChain, PyTorch,
+    # DeepSeek, MiniMax, TradingView, JailbreakBench, GeoChallenge) had their
+    # space-insertion respellings removed 2026-06-25: the Grok custom voice
+    # reads the camelCase compounds natively, and the split forms ("Deep Seek",
+    # "Lang Chain") were leaking into the transcript. Per landmine #17 this
+    # changes shipped audio → A/B-listened. If one regresses, re-add it to
+    # shows/pronunciation_map.yaml (audio-only), not here.
     "Lifespan.io": "Life-span dot i o",
-    "LangChain": "Lang Chain",
-    "PyTorch": "Pie Torch",
     "NVIDIA": "En-vidia",
-    "DeepSeek": "Deep Seek",
-    "MiniMax": "Mini Max",
-    "TradingView": "Trading View",
-    "JailbreakBench": "Jailbreak Bench",
-    "GeoChallenge": "Geo Challenge",
 
     # --- Scientific names ---
     # ``Cassini`` / ``Oberth`` MOVED to shows/pronunciation_map.yaml on
-    # 2026-06-25 (audio-only). The plain-English science words that REMAIN
-    # below are removed in the companion A/B commit — the Grok voice says them
-    # natively.
-    "xenotransplantation": "zeno-transplantation",
-    "inflammaging": "inflamma-aging",
-    "epigenetic": "epi-genetic",
-    "epigenetics": "epi-genetics",
+    # 2026-06-25 (audio-only). The plain-English science words that used to be
+    # here (xenotransplantation, inflammaging, epigenetic[s]) had their hyphen
+    # respellings removed 2026-06-25 — the Grok voice says them natively and the
+    # respellings ("epi-genetic", "zeno-transplantation") were leaking into the
+    # transcript. A/B-listened (landmine #17).
 
     # ``tissue`` / ``neurodegenerative`` and related respellings used to
     # live here (PR #355). Operator caught (May 11 2026 daily review)

--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -383,52 +383,42 @@ WORD_PRONUNCIATIONS: Dict[str, str] = {
     "Model Y": "Model Why",
 
     # --- Organizations / unions ---
-    "IG Metall": "I G Metall",
-    "IF Metall": "I F Metall",
+    # ``IG Metall`` / ``IF Metall`` letter-prefix respellings MOVED to
+    # shows/pronunciation_map.yaml on 2026-06-25 (audio-only) so "I G Metall"
+    # stops leaking into the saved transcript; the audio is unchanged.
 
     # --- Company / brand names ---
-    # ``Teslarati`` respelling removed 2026-06-25: the garble-repair layer
-    # (engine.utils.fix_phonetic_garbles, run_show.py:2284) reverts
-    # "Tesla-rah-tee" → "Teslarati" immediately after this map runs, so the
-    # entry was a dead round-trip (no effect on audio OR transcript). The
-    # garble map still protects against an LLM that writes "Tesla-rah-tee".
+    # Foreign / hard-to-say brand, mission and person names that used to live
+    # here were MOVED to shows/pronunciation_map.yaml on 2026-06-25. That layer
+    # is applied at synthesis time only, so the audio is byte-for-byte identical
+    # (Grok still receives the respelling) while the saved _tts.txt / blog / RSS
+    # now read the canonical spelling instead of "Mee-stral" / "Kah-see-nee" /
+    # "Mee-lay" etc. Moved: Mistral, AstraZeneca, Alnylam, Roscosmos, Hachette,
+    # SoFi, NOIRLab, Afeela, DSPy, HarmfulQA, TheoremQA, VideoQA, MedQuAD,
+    # Cassini, Oberth, Karpathy, Milei, Zelensky(+yy/yj), Altman, Amodei.
+    #
+    # ``NVIDIA`` stays (its garble revert lands on the different token "Nvidia";
+    # moving it would change the audio). ``Lifespan.io`` stays (strip_urls
+    # rewrites the .io domain before this map runs, so it needs the script-save
+    # layer). The English-compound brand names that REMAIN below are removed in
+    # the companion A/B commit — the Grok voice says them natively.
     "CleanTechnica": "Clean Technica",
     "BrewDog": "Brew Dog",
-    "AstraZeneca": "Astra-Zeneca",
-    "Alnylam": "Al-nye-lam",
-    "Roscosmos": "Ross-cosmos",
     "Lifespan.io": "Life-span dot i o",
     "LangChain": "Lang Chain",
     "PyTorch": "Pie Torch",
-    "Mistral": "Mee-stral",
-    # ``Anthropic`` respelling removed 2026-06-25 (garble layer reverts
-    # "An-thropic" → "Anthropic" — dead round-trip). ``NVIDIA`` is kept: its
-    # garble revert lands on "Nvidia" (a DIFFERENT token), so dropping it could
-    # let an all-caps "NVIDIA" reach Grok and letter-split — deferred to the
-    # A/B-listen batch.
     "NVIDIA": "En-vidia",
     "DeepSeek": "Deep Seek",
     "MiniMax": "Mini Max",
-    "Hachette": "hah-SHET",
-    "SoFi": "So-Fi",
     "TradingView": "Trading View",
-    "NOIRLab": "Noir Lab",
-    "DSPy": "D S Pie",
-    "HarmfulQA": "Harmful Q A",
     "JailbreakBench": "Jailbreak Bench",
     "GeoChallenge": "Geo Challenge",
-    "TheoremQA": "Theorem Q A",
-    "VideoQA": "Video Q A",
-    "MedQuAD": "Med Quad",
-    "Afeela": "ah-FEE-lah",
 
     # --- Scientific names ---
-    # ``Enceladus`` respelling removed 2026-06-25 (garble layer reverts
-    # "En-sell-uh-dus" → "Enceladus" — dead round-trip). The remaining
-    # science-name respellings below are NOT garble-covered and are deferred
-    # to the A/B-listen batch.
-    "Cassini": "Kah-see-nee",
-    "Oberth": "Oh-bairt",
+    # ``Cassini`` / ``Oberth`` MOVED to shows/pronunciation_map.yaml on
+    # 2026-06-25 (audio-only). The plain-English science words that REMAIN
+    # below are removed in the companion A/B commit — the Grok voice says them
+    # natively.
     "xenotransplantation": "zeno-transplantation",
     "inflammaging": "inflamma-aging",
     "epigenetic": "epi-genetic",
@@ -450,19 +440,9 @@ WORD_PRONUNCIATIONS: Dict[str, str] = {
     # after this map runs (dead round-trips).
 
     # --- People ---
-    # ``Starmer`` ("Star-mer"), ``Tianwen`` ("Tee-en-wen") and ``Hassabis``
-    # ("Hah-sah-biss") respellings removed 2026-06-25 — each is reverted by the
-    # garble-repair layer right after this map runs (dead round-trips). The
-    # foreign-name respellings kept below are NOT garble-covered (they reach
-    # both the audio and the transcript) and are deferred to the A/B-listen
-    # batch.
-    "Karpathy": "Kar-pathy",
-    "Milei": "Mee-lay",
-    "Zelenskyy": "Zeh-len-skee",
-    "Zelenskyj": "Zeh-len-skee",
-    "Zelensky": "Zeh-len-skee",
-    "Altman": "Awlt-man",
-    "Amodei": "Ah-mo-day",
+    # All person-name respellings (Karpathy, Milei, Zelensky(+yy/yj), Altman,
+    # Amodei) MOVED to shows/pronunciation_map.yaml on 2026-06-25 (audio-only)
+    # — same audio, clean transcript.
 
     # Note: Common words like "who", "ice", "us", "led", "dot" are now
     # protected by case-sensitive acronym matching (_CASE_SENSITIVE_ACRONYMS)

--- a/shows/pronunciation_map.yaml
+++ b/shows/pronunciation_map.yaml
@@ -122,3 +122,45 @@ corrections:
   nerranetwork: "NEH-ruh Network"
   Nerra: "NEH-ruh"
 
+  # ---------------- Proper nouns moved from WORD_PRONUNCIATIONS (2026-06-25) ----------------
+  # These foreign / hard-to-say names were respelled in
+  # assets/pronunciation.py:WORD_PRONUNCIATIONS, which runs at SCRIPT-SAVE time
+  # and leaks the respelling into the saved _tts.txt -> blog/RSS transcript
+  # (the same class as the historical "nassa" / "koo-dah" / "An-thropic"
+  # leaks). Moved here (audio-only, applied at synthesis) so the transcript
+  # keeps the canonical spelling while Grok still receives the pronunciation
+  # guide. The audio is byte-for-byte unchanged from the WORD_PRONUNCIATIONS
+  # version, and none of these values overlap engine.utils._PHONETIC_GARBLES,
+  # so there is no double-processing. NOT phonetic respellings of common
+  # English words (those are deleted, not moved) — these are genuinely foreign
+  # / hard tokens where the guide is load-bearing on the voice.
+  # Organizations / unions
+  "IG Metall": "I G Metall"
+  "IF Metall": "I F Metall"
+  # Companies / brands / missions
+  Mistral: "Mee-stral"
+  AstraZeneca: "Astra-Zeneca"
+  Alnylam: "Al-nye-lam"
+  Roscosmos: "Ross-cosmos"
+  Hachette: "hah-SHET"
+  SoFi: "So-Fi"
+  NOIRLab: "Noir Lab"
+  Afeela: "ah-FEE-lah"
+  # Benchmark / library names with embedded letters
+  DSPy: "D S Pie"
+  HarmfulQA: "Harmful Q A"
+  TheoremQA: "Theorem Q A"
+  VideoQA: "Video Q A"
+  MedQuAD: "Med Quad"
+  # Space-mission / scientist names
+  Cassini: "Kah-see-nee"
+  Oberth: "Oh-bairt"
+  # People (longest variants first so the bare "Zelensky" can't pre-empt them)
+  Zelenskyy: "Zeh-len-skee"
+  Zelenskyj: "Zeh-len-skee"
+  Zelensky: "Zeh-len-skee"
+  Karpathy: "Kar-pathy"
+  Milei: "Mee-lay"
+  Altman: "Awlt-man"
+  Amodei: "Ah-mo-day"
+

--- a/tests/test_pronunciation.py
+++ b/tests/test_pronunciation.py
@@ -549,9 +549,14 @@ class TestApplyPronunciationFixes:
         assert "gigacasting" in result
         assert "giga-casting" not in result
 
-    def test_ig_metall(self):
+    def test_ig_metall_moved_to_yaml(self):
+        # Letter-prefix respelling moved to shows/pronunciation_map.yaml
+        # (audio-only) 2026-06-25 — the script-save layer now leaves it alone,
+        # so "I G Metall" no longer leaks into the transcript. The audio guide
+        # is applied at synthesis instead (see test_pronunciation_grok_alignment).
         result = apply_pronunciation_fixes("IG Metall union conflict")
-        assert "I G Metall" in result
+        assert "IG Metall" in result
+        assert "I G Metall" not in result
 
     def test_robotaxi_unrespelled(self):
         result = apply_pronunciation_fixes("Tesla Robotaxi service")
@@ -708,7 +713,7 @@ class TestPrepareTextForTts:
         result = prepare_text_for_tts(text)
         assert "thirty-nine" in result        # Episode number
         assert "slash" in result               # Comet designation
-        assert "Kah-see-nee" in result         # Cassini pronunciation
+        assert "Cassini" in result             # respelling moved to pronunciation_map.yaml (audio-only) 2026-06-25
         assert "Enceladus" in result           # respelling removed 2026-06-25 (garble-redundant)
         assert "Phase three" in result         # Roman numeral
         assert "five hundred thousand" in result  # Large number

--- a/tests/test_pronunciation_grok_alignment.py
+++ b/tests/test_pronunciation_grok_alignment.py
@@ -14,7 +14,11 @@ Grok custom voice" policy — landmine #17). This guard blocks new dead
 round-trips from creeping back in and documents the one tolerated exception.
 """
 
-from assets.pronunciation import WORD_PRONUNCIATIONS
+from assets.pronunciation import (
+    WORD_PRONUNCIATIONS,
+    prepare_text_for_tts as assets_prepare,
+)
+from engine.tts import prepare_text_for_tts as tts_prepare
 from engine.utils import _PHONETIC_GARBLES, fix_phonetic_garbles
 
 
@@ -54,3 +58,49 @@ def test_garble_layer_still_protects_against_llm_garbles():
     assert fix_phonetic_garbles("An-thropic and Lah-mah") == "Anthropic and Llama"
     assert "Teslarati" in fix_phonetic_garbles("per Tesla-rah-tee")
     assert "Enceladus" in fix_phonetic_garbles("the moon En-sell-uh-dus")
+
+
+# --- Foreign / hard-name respellings MOVED to the audio-only YAML layer ---
+# (2026-06-25) so they stop leaking the respelling into the published
+# transcript while keeping the SAME audio. Each is verified two ways below:
+#   1. the script-save layer (assets) now leaves the canonical spelling alone
+#      -> transcript is clean,
+#   2. the synthesis layer (engine.tts, shows/pronunciation_map.yaml) still
+#      emits the respelling -> audio is unchanged.
+_MOVED = {
+    "Milei": "Mee-lay",
+    "Mistral": "Mee-stral",
+    "Cassini": "Kah-see-nee",
+    "Karpathy": "Kar-pathy",
+    "Amodei": "Ah-mo-day",
+    "Zelensky": "Zeh-len-skee",
+    "AstraZeneca": "Astra-Zeneca",
+    "Afeela": "ah-FEE-lah",
+}
+
+
+def test_moved_names_not_in_word_pronunciations():
+    for word in _MOVED:
+        assert word not in WORD_PRONUNCIATIONS, (
+            f"{word} was moved to the audio-only pronunciation_map.yaml — it "
+            "must not be back in the transcript-leaking WORD_PRONUNCIATIONS."
+        )
+
+
+def test_moved_names_clean_in_transcript_layer():
+    # assets.prepare_text_for_tts feeds the saved _tts.txt / blog / RSS.
+    for word, respelling in _MOVED.items():
+        out = assets_prepare(f"Today {word} made news.")
+        assert word in out, f"{word} should pass through the script-save layer"
+        assert respelling not in out, f"{respelling} must not leak into the transcript"
+
+
+def test_moved_names_still_respelled_for_audio():
+    # engine.tts.prepare_text_for_tts applies shows/pronunciation_map.yaml at
+    # synthesis — the Grok-bound audio must still get the pronunciation guide.
+    for word, respelling in _MOVED.items():
+        out = tts_prepare(f"Today {word} made news.")
+        assert respelling in out, (
+            f"{word} lost its audio respelling — the move to the YAML layer "
+            "must preserve the exact pronunciation Grok hears."
+        )


### PR DESCRIPTION
## Why

Continues the Grok-voice pronunciation cleanup (after #718). The leftover phonetic respellings in `assets/pronunciation.py:WORD_PRONUNCIATIONS` run at **script-save time** and leak into the saved `_tts.txt → blog/RSS transcript` (the historical `nassa`/`koo-dah`/`An-thropic` leak class). This PR clears the rest, splitting by risk so the safe half needs no listening.

After this PR, `WORD_PRONUNCIATIONS` holds just **4 entries** (`Model 3`, `Model Y`, `Lifespan.io`, `NVIDIA`) and `shows/pronunciation_map.yaml` is the single home for pronunciation overrides — exactly the architecture the May-11 note in the code recommends.

## Commit 1 — move foreign/hard names to the audio-only layer (no audio change, no A/B)

For names where the respelling is genuinely load-bearing on the voice (foreign people, companies, missions, embedded-letter benchmark names), the fix isn't to delete the guide — it's to **move it to `shows/pronunciation_map.yaml`**, which applies at **synthesis time only**. Net effect:
- **Audio: byte-for-byte identical** — Grok still receives the respelling.
- **Transcript: now clean** — the blog/RSS reads `Milei`/`Cassini`/`Mistral`, not `Mee-lay`/`Kah-see-nee`/`Mee-stral`.

Moved: `Mistral, AstraZeneca, Alnylam, Roscosmos, Hachette, SoFi, NOIRLab, Afeela, DSPy, HarmfulQA, TheoremQA, VideoQA, MedQuAD, Cassini, Oberth, Karpathy, Milei, Zelensky(+yy/yj), Altman, Amodei, IG/IF Metall`. New drift guards prove, per name, that the transcript layer is clean **and** the synthesis layer still emits the exact respelling. (None overlap the garble map → no double-processing.)

## Commit 2 — delete English-compound respellings ⚠️ A/B-listen

The Grok voice reads these common compounds natively, so the respellings were pure transcript pollution:

```
apply_pronunciation_fixes(...) — same sentence
BEFORE: "Deep Seek and Lang Chain shipped; Pie Torch too. … epi-genetic … zeno-transplantation."
AFTER:  "DeepSeek and LangChain shipped; PyTorch too. … epigenetic … xenotransplantation."
```

Deleted: `CleanTechnica, BrewDog, LangChain, PyTorch, DeepSeek, MiniMax, TradingView, JailbreakBench, GeoChallenge, xenotransplantation, inflammaging, epigenetic, epigenetics`. Per **landmine #17** this changes shipped audio — please spot-listen one M&A / Tesla episode. If any single term regresses, re-add it to `shows/pronunciation_map.yaml` (audio-only), not back to the leaking layer.

## Kept deliberately

`NVIDIA` (garble-token interaction — moving it would change audio), `Lifespan.io` (`.io` URL rewrite needs the script-save layer), `Model 3`/`Model Y` (number/letter expansion that interacts with the number passes).

## Still deferred (separate, needs per-item ears)

The `COMMON_ACRONYMS` phonetic word-guides (`JAXA→jacksa`, `PSYCHE→Sy-key`, `OPEC→oh-peck`, `EBITDA→ee-bit-dah`, `LoRA→Laura`, `GAAP`, `SPAC`) and the MAB hook respellings (`LoRA→laura`, `CUDA→kooda`, `SOTA→so-tah`, `Karpathy`) — these touch the 150-entry shared acronym dict / per-show hook and have subtle garble interactions, so they want their own focused pass.

## Tests

`pytest tests/test_pronunciation*.py tests/test_tts_grok.py tests/test_*quality_pass.py tests/test_spacex_show.py` → **359 passed**. The only unrelated red in the full suite is the pre-existing `first_principles` queue-runway test (operator-owned restock), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MijFStKrJvtf9JxQvKQUDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MijFStKrJvtf9JxQvKQUDx)_