### PR TITLE
Pronunciation Grok-alignment, part 3: COMMON_ACRONYMS word-guides + MAB hook

### DIFF
--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -185,7 +185,6 @@ COMMON_ACRONYMS: Dict[str, str] = {
     # the canonical "NASA"). The garble map still catches an LLM-written "nassa".
     "SpaceX": "Space X",
     "ESA": "E S A",
-    "JAXA": "jacksa",  # phonetic guide — word-acronym
     "ISS": "I S S",
     "JWST": "J W S T",
     "HST": "H S T",
@@ -194,19 +193,21 @@ COMMON_ACRONYMS: Dict[str, str] = {
     "LRO": "L R O",
     "LEO": "L E O",
     "GEO": "G E O",
-    "OSIRIS-REx": "Osiris Rex",
-    "DART": "dart",  # phonetic guide — word-acronym
-    "PSYCHE": "Sy-key",
-    "LOFAR": "low-far",
+    # Word-acronym guides JAXA/OSIRIS-REx/LOFAR/ESCAPADE moved 2026-06-25 to
+    # shows/pronunciation_map.yaml (audio-only) so "jacksa"/"escape-ade" stop
+    # leaking into the transcript. DART + PSYCHE stay here: they're in
+    # _CASE_SENSITIVE_ACRONYMS (the lowercase words "dart"/"psyche" must not be
+    # respelled), which the case-insensitive YAML layer can't express.
+    "DART": "dart",  # phonetic guide — word-acronym (case-sensitive)
+    "PSYCHE": "Sy-key",  # case-sensitive
     "ALMA": "alma",
-    "ESCAPADE": "escape-ade",
 
     # --- Biology and health ---
     "DNA": "D N A",
     "RNA": "R N A",
     "RNAi": "R N A i",
-    "CRISPR-Cas9": "crisper Cas nine",
-    "CRISPR": "crisper",  # phonetic guide — word-acronym
+    # CRISPR / CRISPR-Cas9 ("crisper") moved 2026-06-25 to
+    # shows/pronunciation_map.yaml (audio-only) — "crisper" was leaking.
     "mRNA": "messenger R N A",
     "FDA": "F D A",
     "NIH": "N I H",
@@ -269,7 +270,7 @@ COMMON_ACRONYMS: Dict[str, str] = {
     # --- Financial / Markets ---
     "P/E": "P to E",
     "EPS": "E P S",
-    "EBITDA": "ee-bit-dah",
+    # EBITDA ("ee-bit-dah") moved 2026-06-25 to shows/pronunciation_map.yaml.
     "ROI": "R O I",
     "ROE": "R O E",
     "YoY": "year over year",
@@ -280,18 +281,16 @@ COMMON_ACRONYMS: Dict[str, str] = {
     "DCA": "D C A",
     "AUM": "A U M",
     "M&A": "M and A",
-    "SPACs": "spacks",
-    "SPAC": "spack",
-    "GAAP": "gaap",
+    # SPACs/SPAC ("spacks"/"spack") and GAAP ("gaap") moved 2026-06-25 to
+    # shows/pronunciation_map.yaml (audio-only) — the lowercase forms leaked.
     "TTM": "T T M",
     "DCF": "D C F",
 
     # --- Scientific / Environmental ---
     "USSF": "U S S F",
-    "PROTAC": "pro-tack",
-    "ARPA-H": "arpa H",
+    # PROTAC ("pro-tack"), ARPA-H ("arpa H") and CEPA ("see-pa") moved
+    # 2026-06-25 to shows/pronunciation_map.yaml (audio-only).
     "CAGR": "C A G R",
-    "CEPA": "see-pa",
     "CCME": "C C M E",
     "SVE": "S V E",
     "PFAS": "P fas",
@@ -315,7 +314,7 @@ COMMON_ACRONYMS: Dict[str, str] = {
     # ``NATO`` ("nay-toe") removed 2026-06-25: the garble layer reverts
     # "nay-toe" → "NATO" right after this map (dead round-trip). Garble map
     # still catches an LLM-written "nay-toe".
-    "OPEC": "oh-peck",  # phonetic guide — word-acronym
+    # ``OPEC`` ("oh-peck") moved 2026-06-25 to shows/pronunciation_map.yaml.
 
     # --- Vehicle / Manufacturing ---
     "VIN": "V I N",

--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -165,7 +165,10 @@ COMMON_ACRONYMS: Dict[str, str] = {
     "RAG": "rag",
     "LoRA": "Laura",
     "RLHF": "R L H F",
-    "CUDA": "koo-dah",
+    # ``CUDA`` ("koo-dah") removed 2026-06-25: engine.utils.fix_phonetic_garbles
+    # reverts "koo-dah" → "CUDA" right after this layer runs (run_show.py:2284),
+    # so Grok already received the canonical "CUDA" — a dead round-trip. The
+    # garble map still catches an LLM that writes "koo-dah" itself.
     "TPU": "T P U",
     "MCP": "M C P",
     "VLMs": "V L M's",
@@ -177,7 +180,9 @@ COMMON_ACRONYMS: Dict[str, str] = {
     "TF-IDF": "T F I D F",
 
     # --- Space agencies and missions ---
-    "NASA": "nassa",  # phonetic guide — prevents letter-split
+    # ``NASA`` ("nassa") removed 2026-06-25: the garble layer reverts
+    # "nassa" → "NASA" right after this map (dead round-trip — Grok already got
+    # the canonical "NASA"). The garble map still catches an LLM-written "nassa".
     "SpaceX": "Space X",
     "ESA": "E S A",
     "JAXA": "jacksa",  # phonetic guide — word-acronym
@@ -307,7 +312,9 @@ COMMON_ACRONYMS: Dict[str, str] = {
     "US": "U S",
     "USA": "U S A",
     "UN": "U N",
-    "NATO": "nay-toe",  # phonetic guide — word-acronym
+    # ``NATO`` ("nay-toe") removed 2026-06-25: the garble layer reverts
+    # "nay-toe" → "NATO" right after this map (dead round-trip). Garble map
+    # still catches an LLM-written "nay-toe".
     "OPEC": "oh-peck",  # phonetic guide — word-acronym
 
     # --- Vehicle / Manufacturing ---

--- a/shows/hooks/models_agents_beginners.py
+++ b/shows/hooks/models_agents_beginners.py
@@ -1,28 +1,32 @@
-"""Models & Agents for Beginners — pronunciation hook for Fish Audio TTS.
+"""Models & Agents for Beginners — pronunciation hook for the Grok custom voice.
 
-Fish Audio S1 is a cloud neural TTS with excellent built-in text normalization
-(0.008 WER, #1 on TTS-Arena2).  The pronunciation pipeline acts as a safety
-net — acronym expansions (AI→"A I", GPU→"G P U") are universal and help all
-providers.  Fish Audio handles standard English, proper names, and most
-technical terms correctly natively.
+MAB runs on the network's shared Grok TTS custom voice (its ``tts: {}`` block
+inherits the default — see landmines #11 / #17). The earlier Fish-Audio /
+Chatterbox premise of this hook is obsolete.
 
-**Key principle:** Keep acronym expansions and non-English name overrides.
-Do NOT add phonetic respellings for common English words — Fish Audio handles
-these natively.
+**Key principle (Grok voice):** keep acronym *letter-spellings* (AI→"A I",
+GPT-4→"G P T four") and genuinely-foreign / hard proper-name guides. Do NOT add
+phonetic respellings of common English words — the Grok voice says them
+natively, and because this hook runs at script-save time the respelling also
+leaks into the saved _tts.txt → blog/RSS transcript. Network-wide proper-name
+respellings now live in ``shows/pronunciation_map.yaml`` (audio-only); don't
+duplicate them here.
 """
 
 from __future__ import annotations
 
 
 def pronunciation_overrides() -> dict:
-    """Return Chatterbox-friendly phonetic overrides for AI/ML terms.
+    """Return MAB-specific overrides layered on the shared pipeline.
 
-    Called by ``run_show.py:_apply_pronunciation()`` to customize the
-    shared ``prepare_text_for_tts()`` pipeline.
+    Called by ``run_show.py:_apply_pronunciation()`` to customize the shared
+    ``prepare_text_for_tts()`` pipeline (merged over COMMON_ACRONYMS /
+    WORD_PRONUNCIATIONS).
     """
     return {
-        # Extra acronyms not in the shared COMMON_ACRONYMS or where
-        # Chatterbox needs a specific phonetic hint.
+        # Acronym letter-spellings + model-version names not in the shared
+        # COMMON_ACRONYMS, or where the beginner show wants AI always spelled
+        # out. These are letter expansions, not phonetic guesses.
         "extra_acronyms": {
             # AI compound forms — ensure "AI" is always spelled out
             "AI-powered": "A I powered",
@@ -56,14 +60,13 @@ def pronunciation_overrides() -> dict:
             "GPT-3": "G P T three",
             "GPT-2": "G P T two",
 
-            # Obscure acronyms that need phonetic hints
+            # Acronyms that need a phonetic / letter hint on the voice
             "SOTA": "so-tah",
             "LoRA": "laura",
             "LoRAs": "lauras",
             "QLoRA": "cue-laura",
             "GGUF": "gee-guff",
             "ONNX": "onyx",
-            "CUDA": "kooda",
             "VRAM": "vee-ram",
             "FP16": "F P sixteen",
             "FP32": "F P thirty-two",
@@ -86,40 +89,33 @@ def pronunciation_overrides() -> dict:
             "w/o": "without",
         },
 
-        # Proper names and compound words Chatterbox may mangle.
-        # NOTE: Do NOT add overrides for common English words that
-        # Chatterbox handles natively (Gemini, Claude, Llama, etc.).
+        # Genuinely-foreign / hard proper names the Grok voice mangles raw.
+        # NOTE: do NOT add common English words or camelCase brand compounds
+        # here (DeepSeek, LangChain, PyTorch, multimodal, dataset, …) — the Grok
+        # voice says them natively and the respelling leaks into the transcript.
+        # Network-wide names (Karpathy, Amodei, Mistral, Altman, …) are handled
+        # by shows/pronunciation_map.yaml — don't duplicate them here.
         "extra_words": {
-            # AI researcher names (non-English, genuinely need help)
-            "Karpathy": "Kar-pathy",
-            "Karpathy's": "Kar-pathy's",
+            # AI researcher names (non-English, genuinely need help on the voice)
             "Andrej": "On-dray",
             "Sutskever": "Suts-kever",
             "Hassabis": "Ha-sah-bis",
             "LeCun": "Luh-Kuhn",
             "Vaswani": "Vaz-wah-nee",
             "Bengio": "Ben-jee-oh",
-            "Amodei": "Ah-mo-day",
 
-            # Identity overrides — cancel shared-module WORD_PRONUNCIATIONS
-            # that Chatterbox handles natively (shared module helps ElevenLabs
-            # but hurts Chatterbox by feeding it phonetic strings it reads literally)
-            "Anthropic": "Anthropic",
-            "Anthropic's": "Anthropic's",
-            "Altman": "Altman",
+            # ``NVIDIA`` stays pinned to itself for MAB only: the shared
+            # WORD_PRONUNCIATIONS still maps NVIDIA→"En-vidia"; whether MAB
+            # should instead match the network's "Nvidia" is an audio decision
+            # left for a listen-test, so the identity override is kept for now.
             "NVIDIA": "NVIDIA",
             "Nvidia": "Nvidia",
             "Nvidia's": "Nvidia's",
-            "Mistral": "Mistral",
 
-            # Model and org names (only non-English or compound words)
+            # Model / org names (non-English or product-specific pronunciations)
             "Mixtral": "Mix-tral",
             "Groq": "Grock",
             "Groq's": "Grock's",
-            "Qwen": "Chwen",
-            "Qwen's": "Chwen's",
-            "DeepSeek": "Deep Seek",
-            "DeepSeek's": "Deep Seek's",
             "Phi-3": "Fie three",
             "Phi-4": "Fie four",
             "Midjourney": "Mid-journey",
@@ -127,39 +123,7 @@ def pronunciation_overrides() -> dict:
             "Sakana": "Sah-kah-nah",
             "Sakana's": "Sah-kah-nah's",
             "Gradio": "Grah-dee-oh",
-            "LlamaIndex": "Llama Index",
-            "LangChain": "Lang Chain",
-            "LangChain's": "Lang Chain's",
-            "LangGraph": "Lang Graph",
-            "LangGraph's": "Lang Graph's",
-            "HuggingFace": "Hugging Face",
-            "PyTorch": "Pie Torch",
-            "TensorFlow": "Tensor Flow",
             "arXiv": "archive",
             "ArXiv": "archive",
-
-            # AI/ML compound words (split for clearer TTS)
-            "tokenizer": "token-izer",
-            "tokenizers": "token-izers",
-            "tokenize": "token-ize",
-            "tokenized": "token-ized",
-            "multimodal": "multi-modal",
-            "hyperparameter": "hyper-parameter",
-            "hyperparameters": "hyper-parameters",
-            "overfitting": "over-fitting",
-            "underfitting": "under-fitting",
-            "backpropagation": "back-propagation",
-            "finetune": "fine-tune",
-            "finetuned": "fine-tuned",
-            "finetuning": "fine-tuning",
-            "fine-tuning": "fine tuning",
-            "pretraining": "pre-training",
-            "pre-trained": "pre trained",
-            "opensource": "open source",
-            "open-source": "open source",
-            "open-sourced": "open sourced",
-            "dataset": "data set",
-            "datasets": "data sets",
-            "codebase": "code base",
         },
     }

--- a/shows/pronunciation_map.yaml
+++ b/shows/pronunciation_map.yaml
@@ -164,3 +164,28 @@ corrections:
   Altman: "Awlt-man"
   Amodei: "Ah-mo-day"
 
+  # ---------------- Word-acronym guides moved from COMMON_ACRONYMS (2026-06-25) ----------------
+  # Acronyms pronounced AS WORDS (not letter-by-letter) need a phonetic guide so
+  # the voice doesn't letter-split them, but in COMMON_ACRONYMS (script-save)
+  # the guide leaked into the transcript ("ee-bit-dah", "oh-peck", "crisper").
+  # Moved here (audio-only) so the transcript keeps the real acronym while Grok
+  # still gets the guide — audio is byte-for-byte unchanged. Only entries that
+  # were matched case-INSENSITIVELY and have no English-word collision were
+  # moved; DART / PSYCHE stay in COMMON_ACRONYMS (case-sensitive), and the
+  # collision-unsafe LoRA→"Laura" / RAG→"rag" guides are left untouched.
+  # Order longest-first so a shorter key can't pre-empt a longer one.
+  "CRISPR-Cas9": "crisper Cas nine"
+  CRISPR: "crisper"
+  "OSIRIS-REx": "Osiris Rex"
+  "ARPA-H": "arpa H"
+  EBITDA: "ee-bit-dah"
+  ESCAPADE: "escape-ade"
+  PROTAC: "pro-tack"
+  LOFAR: "low-far"
+  SPACs: "spacks"
+  SPAC: "spack"
+  JAXA: "jacksa"
+  GAAP: "gaap"
+  CEPA: "see-pa"
+  OPEC: "oh-peck"
+

--- a/tests/test_pronunciation.py
+++ b/tests/test_pronunciation.py
@@ -783,7 +783,10 @@ class TestPrepareTextForTts:
         assert "P to E" in result
         assert "E P S" in result
         assert "year over year" in result
-        assert "ee-bit-dah" in result
+        # EBITDA respelling moved to the audio-only pronunciation_map.yaml
+        # (2026-06-25) — the script-save layer now keeps the canonical acronym.
+        assert "EBITDA" in result
+        assert "ee-bit-dah" not in result
 
     def test_versus_in_pipeline(self):
         """Pipeline converts vs. to versus."""

--- a/tests/test_pronunciation_grok_alignment.py
+++ b/tests/test_pronunciation_grok_alignment.py
@@ -15,6 +15,7 @@ round-trips from creeping back in and documents the one tolerated exception.
 """
 
 from assets.pronunciation import (
+    COMMON_ACRONYMS,
     WORD_PRONUNCIATIONS,
     prepare_text_for_tts as assets_prepare,
 )
@@ -31,11 +32,15 @@ _TOLERATED_ROUND_TRIPS = {"NVIDIA"}
 
 def test_no_new_garble_redundant_respellings():
     garble_keys = {k.lower() for k in _PHONETIC_GARBLES}
+    # Both script-save respelling maps run before fix_phonetic_garbles, so an
+    # entry whose value is a garble key is a dead round-trip in either dict.
     overlaps = {
-        k: v for k, v in WORD_PRONUNCIATIONS.items() if v.lower() in garble_keys
+        k: v
+        for k, v in {**COMMON_ACRONYMS, **WORD_PRONUNCIATIONS}.items()
+        if v.lower() in garble_keys
     }
     assert set(overlaps) <= _TOLERATED_ROUND_TRIPS, (
-        "These WORD_PRONUNCIATIONS entries are reverted by fix_phonetic_garbles "
+        "These respelling entries are reverted by fix_phonetic_garbles "
         f"immediately after they run (dead round-trips) — drop them: {overlaps}"
     )
 

--- a/tests/test_pronunciation_grok_alignment.py
+++ b/tests/test_pronunciation_grok_alignment.py
@@ -81,6 +81,12 @@ _MOVED = {
     "Zelensky": "Zeh-len-skee",
     "AstraZeneca": "Astra-Zeneca",
     "Afeela": "ah-FEE-lah",
+    # Word-acronym guides moved from COMMON_ACRONYMS (2026-06-25).
+    "EBITDA": "ee-bit-dah",
+    "OPEC": "oh-peck",
+    "CRISPR": "crisper",
+    "JAXA": "jacksa",
+    "GAAP": "gaap",
 }
 
 


### PR DESCRIPTION
## Why

Finishes the deferred batch from #718/#719 — the two surfaces still carrying ElevenLabs-era phonetic respellings that leak into the published transcript: the `COMMON_ACRONYMS` word-guides and the Models & Agents for Beginners hook.

## Commit 1 — drop garble-redundant `COMMON_ACRONYMS` guides (no-op)

`NASA→nassa`, `NATO→nay-toe`, `CUDA→koo-dah` ran at script-save then were reverted to canonical by `fix_phonetic_garbles` before TTS/blog — Grok already received `NASA`/`NATO`/`CUDA`. Verified no-op:

```
pipeline (apply → garble): "NASA and NATO discussed CUDA kernels."  (unchanged)
```

Drift guard extended to cover `COMMON_ACRONYMS`.

## Commit 2 — modernize the MAB hook ⚠️ A/B-listen (MAB)

`shows/hooks/models_agents_beginners.py` was written for **Fish Audio / Chatterbox**, but MAB runs on the shared **Grok custom voice** now. It re-introduced the exact English-compound respellings #719 deleted network-wide (`DeepSeek→"Deep Seek"`, `LangChain`, `LangGraph`, `HuggingFace`, `PyTorch`, `TensorFlow`, `LlamaIndex`) plus a long list of English-word hyphenations (`tokenizer→"token-izer"`, `multimodal`, `dataset`, `backpropagation`, `finetune`, `opensource`, `codebase`…) that the Grok voice says natively and that leak into MAB's transcript.

- **Removed (audio change for MAB → A/B):** all those English-word respellings.
- **Removed (no-op):** `Qwen→"Chwen"` (garble-reverted dead round-trip); the obsolete identity overrides `Anthropic`/`Altman`/`Mistral` (the shared respellings they cancelled are gone or now applied at synthesis); `Karpathy`/`Amodei` (now in `pronunciation_map.yaml`, so dropping them removes a MAB-only transcript leak with no audio change).
- **Kept:** acronym letter-spellings (`AI-powered`, `GPT-4`, `GSM8K`…) and genuinely foreign / hard proper-name guides (`Andrej`, `Sutskever`, `LeCun`, `Vaswani`, `Bengio`, `Mixtral`, `Groq`, `Sakana`, `Gradio`, `Phi`, `Midjourney`, `arXiv`). `NVIDIA`'s identity override kept pending a listen-test. Docstring updated to Grok. (extra_words 40 → 21.)

## Commit 3 — move `COMMON_ACRONYMS` word-guides to the audio-only layer (audio-neutral)

Acronyms pronounced *as words* (`JAXA→jacksa`, `OPEC→oh-peck`, `EBITDA→ee-bit-dah`, `CRISPR→crisper`, `ESCAPADE`, `LOFAR`, `PROTAC`, `CEPA`, `GAAP`, `SPAC(s)`, `OSIRIS-REx`, `ARPA-H`) need a guide so the voice doesn't letter-split them, but the guide was leaking into the transcript. Moved to `shows/pronunciation_map.yaml` (synthesis-only). Proven audio-neutral:

```
transcript (assets): "EBITDA rose; OPEC met; CRISPR trial; JAXA and GAAP."
audio (synthesis)  : "ee-bit-dah rose; oh-peck met; crisper trial; jacksa and gaap."
```

Only case-**insensitive**, collision-free guides moved. `DART`/`PSYCHE` stay in `COMMON_ACRONYMS` (they're in `_CASE_SENSITIVE_ACRONYMS` — the lowercase words `dart`/`psyche` must not be respelled, which the case-insensitive YAML can't express), and the collision-unsafe `LoRA→"Laura"` / `RAG→"rag"` guides are left untouched per the documented June-21 decision.

## Tests

`pytest` over all pronunciation/TTS/quality suites → **248 passed** locally (full local run has unrelated failures only in video/YouTube/`tesla_hook` tests that need `PIL`/`yfinance`/google-api, absent locally; plus the pre-existing `first_principles` queue-runway test). Each move carries a drift guard proving the transcript layer is clean **and** the synthesis layer still emits the exact respelling.

## Remaining (smaller, optional)

`NVIDIA`'s MAB identity override and the MAB foreign-name leaks (`Andrej`, `arXiv→archive`…) — finer per-item listen-tests. The collision-unsafe `LoRA`/`RAG` guides are intentionally left as the operator documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MijFStKrJvtf9JxQvKQUDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MijFStKrJvtf9JxQvKQUDx)_