### PR TITLE
Fix Nerra brand pronunciation: stop respelling (fixes "N-E-H dash ruh")

### DIFF
--- a/shows/pronunciation_map.yaml
+++ b/shows/pronunciation_map.yaml
@@ -105,22 +105,24 @@ corrections:
   LLM: "L L M"
   MCP: "M C P"
 
-  # ---------------- Brand names ----------------
-  # Added 2026-06-24. The rotating closing promo says the network brand three
-  # ways in one segment — the spaced "Nerra Network", the URL "nerranetwork.com"
-  # (which strip_urls turns into "nerranetwork dot com"), and the YouTube handle
-  # — and Grok was guessing a different pronunciation for each, so listeners
-  # heard "Nerra" said 2-3 ways back to back. These entries are audio-only
-  # (applied at synthesis, after strip_urls) so the blog/RSS transcript keeps
-  # the clean brand while every spoken form normalizes to one pronunciation.
-  # Operator-chosen pronunciation: "NEH-ruh" (short e, like "Nera"). This is an
-  # explicit operator override of the "no phonetic respellings" pause above for
-  # the network's own name — A/B-listen before merge (landmine #17).
-  # Order matters (longest-first): "Nerra Network" before the "nerranetwork"
-  # URL compound before the bare "Nerra".
-  "Nerra Network": "NEH-ruh Network"
-  nerranetwork: "NEH-ruh Network"
-  Nerra: "NEH-ruh"
+  # ---------------- Brand name ----------------
+  # The rotating closing promo says the network brand three ways in one segment
+  # — the spaced "Nerra Network", the URL "nerranetwork.com" (strip_urls turns
+  # it into "nerranetwork dot com"), and the (handle-split) YouTube form — and
+  # Grok was guessing a different pronunciation for each.
+  #
+  # FIX HISTORY: a phonetic respelling was tried twice ("NAIR-uh" then
+  # "NEH-ruh") and REGRESSED badly on the Grok voice — the all-caps stressed
+  # syllable was read as an INITIALISM ("N. E. H.") and the hyphen voiced
+  # ALOUD, so the brand shipped as "N-E-H dash ruh". Per landmine #17 (no
+  # phonetic respellings on this voice — they reliably sound worse than the raw
+  # word), we do NOT respell. We only normalize the SPELLING: split the
+  # URL / handle compound "nerranetwork" into the two real words "Nerra
+  # Network" so every spoken form is identical and Grok says the natural word
+  # the same way each time. No caps, no hyphen — nothing for the voice to
+  # letter-spell or voice as "dash". The bare spaced "Nerra Network" and "Nerra"
+  # are already real words and need no entry.
+  nerranetwork: "Nerra Network"
 
   # ---------------- Proper nouns moved from WORD_PRONUNCIATIONS (2026-06-25) ----------------
   # These foreign / hard-to-say names were respelled in

--- a/tests/test_nerra_pronunciation.py
+++ b/tests/test_nerra_pronunciation.py
@@ -6,63 +6,95 @@ the spaced "Nerra Network" (promo), the "nerranetwork.com" URL, and the
 "NerraNetwork" YouTube handle — and only the spaced form was normalized, so
 Grok guessed a drifting pronunciation for the other two.
 
-Fix (2026-06-24):
+Fix (2026-06-24, revised 2026-06-25):
   * the EN YouTube handle is split to the spaced brand in
     ``engine.intros._maybe_append_youtube_cta`` (RU "NerraRU" left intact);
-  * the brand respelling moved OUT of ``assets.pronunciation`` (which leaks
-    into the published transcript) and INTO ``shows/pronunciation_map.yaml``
-    (audio-only), with compound coverage so all three spoken forms normalize
-    to one pronunciation ("NEH-ruh Network").
+  * every spoken form is normalized to the SAME two real words "Nerra
+    Network" in ``shows/pronunciation_map.yaml`` (audio-only) — the URL /
+    handle compound "nerranetwork" is split into "Nerra Network".
 
-These guards pin that behavior.
+A phonetic respelling was tried twice ("NAIR-uh", then "NEH-ruh") and regressed
+badly on the Grok voice: the all-caps stressed syllable was read as an
+initialism and the hyphen voiced aloud ("N-E-H dash ruh"). Per landmine #17 we
+do NOT respell the brand — we only normalize the spelling so Grok says the
+natural word identically each time. These guards pin that no respelling (old or
+new) survives and that every form reduces to the spaced "Nerra Network".
 """
+
+import re
 
 import engine.tts as tts
 from engine.intros import _maybe_append_youtube_cta
 from assets.pronunciation import WORD_PRONUNCIATIONS
 from assets.pronunciation import prepare_text_for_tts as assets_prepare
 
+# Both failed phonetic respellings (and the "spelling-out" / dash artifacts they
+# produced) must never reappear in any spoken form.
+_BANNED_RESPELLINGS = ("NEH-ruh", "NAIR-uh", "Neh-ruh", "Nair-uh")
+
 
 class TestAudioFormsNormalizeIdentically:
-    """Every spoken form of the brand must reduce to the SAME pronunciation
+    """Every spoken form of the brand must reduce to the SAME natural words
     in the TTS (audio-only) layer."""
 
-    def test_all_three_forms_become_neh_ruh_network(self):
+    def test_all_three_forms_become_spaced_brand(self):
         # In production the assets layer runs strip_urls first, turning
         # "nerranetwork.com" into "nerranetwork dot com"; either way the
-        # whole-word "nerranetwork" entry catches the compound.
+        # whole-word "nerranetwork" entry catches the compound and splits it.
         sample = (
             "part of the Nerra Network. Find every show at nerranetwork.com. "
             "Watch on YouTube at NerraNetwork."
         )
         out = tts.prepare_text_for_tts(sample)
-        # One canonical pronunciation, applied to every occurrence.
-        assert out.count("NEH-ruh Network") == 3
-        # No un-normalized compound and no stale respelling survive.
+        # One canonical spoken form, applied to every occurrence.
+        assert out.count("Nerra Network") == 3
+        # No un-normalized compound and no phonetic respelling survive.
         assert "NerraNetwork" not in out
-        assert "NAIR-uh" not in out
+        for bad in _BANNED_RESPELLINGS:
+            assert bad not in out
 
-    def test_bare_nerra_normalized(self):
+    def test_bare_nerra_left_as_word(self):
+        # The bare brand is already a real word — Grok says it natively, never
+        # respelled (which is what produced the "N-E-H dash ruh" garble).
         out = tts.prepare_text_for_tts("The Nerra family of shows.")
-        assert "NEH-ruh" in out
-        assert "NAIR-uh" not in out
+        assert "Nerra" in out
+        for bad in _BANNED_RESPELLINGS:
+            assert bad not in out
 
 
-class TestTranscriptStaysClean:
-    """The transcript-facing layer (assets.pronunciation, which leaks into the
-    saved _tts.txt / blog / RSS) must keep the CLEAN brand — no respelling."""
+class TestNoBrandRespellingAnywhere:
+    """No phonetic respelling of the brand may live in EITHER pronunciation
+    layer — the audio-only YAML map or the transcript-leaking assets dict."""
 
     def test_assets_layer_does_not_respell_brand(self):
         out = assets_prepare("This show is part of the Nerra Network.")
         assert "Nerra Network" in out
-        assert "NEH-ruh" not in out
-        assert "NAIR-uh" not in out
+        for bad in _BANNED_RESPELLINGS:
+            assert bad not in out
 
     def test_no_nerra_respelling_in_word_pronunciations(self):
-        # Moved to shows/pronunciation_map.yaml (audio-only) so it can't leak
-        # into the published transcript again.
         for key in WORD_PRONUNCIATIONS:
             assert "nerra" not in key.lower()
+
+    def test_yaml_map_has_no_phonetic_brand_respelling(self):
+        # The synthesis map may normalize spelling (split the compound) but must
+        # never reintroduce an all-caps/hyphen phonetic guess for the brand.
+        import yaml
+        from pathlib import Path
+
+        corrections = yaml.safe_load(
+            Path("shows/pronunciation_map.yaml").read_text()
+        )["corrections"]
+        for key, val in corrections.items():
+            if "nerra" in str(key).lower():
+                # Allowed: a plain spelling normalization to the real words.
+                assert val == "Nerra Network", (
+                    f"{key!r} -> {val!r}: brand entries must normalize spelling "
+                    "only, never a phonetic respelling (landmine #17)."
+                )
+                # Defensively reject the failure-mode shapes.
+                assert not re.search(r"[A-Z]{2,}", val), "no all-caps initialism"
+                assert "-" not in val, "no hyphen (Grok voices it as 'dash')"
 
 
 class TestYouTubeHandleSplit:


### PR DESCRIPTION
## The bug

The closing-promo brand pronunciation shipped as **"N-E-H dash ruh"** — Grok spelled out the letters `N E H` and voiced the hyphen as the word "dash."

**Root cause:** the audio-only respelling `Nerra → "NEH-ruh"` used an all-caps stressed syllable plus a hyphen. Grok's text normalization reads an all-caps token as an **initialism** (`N. E. H.`) and voices the hyphen between an initialism and a lowercase tail as **"dash."** This was the *second* failed phonetic attempt — the first, `"NAIR-uh"`, failed the same way (the drift-guard test still banned it).

## The fix

Per **landmine #17** (no phonetic respellings on the Grok custom voice — they reliably sound worse than the raw word), stop respelling the brand. Instead, **normalize only the spelling** so every spoken form is the same two real words and Grok says the natural word identically each time:

```
- "Nerra Network": "NEH-ruh Network"
- nerranetwork:     "NEH-ruh Network"
- Nerra:            "NEH-ruh"
+ nerranetwork:     "Nerra Network"      # split the URL/handle compound only
```

The three-different-spellings drift (spaced brand / `nerranetwork.com` URL / `NerraNetwork` handle) was the actual cause of "Nerra said 2-3 ways." Combined with the existing YouTube-handle split, all three forms now reduce to the spaced **"Nerra Network"** — no caps, no hyphen, nothing for the voice to letter-spell or "dash." The bare `Nerra Network` / `Nerra` are already real words and need no entry.

**Verified** (`engine.tts.prepare_text_for_tts`):
```
IN : "...the Nerra Network. ...at nerranetwork.com. ...YouTube at NerraNetwork."
OUT: "...the Nerra Network. ...at Nerra Network[.com]. ...YouTube at Nerra Network."
```
(In production `strip_urls` turns the `.com` into " dot com" upstream.)

## Tests

`tests/test_nerra_pronunciation.py` updated: now asserts every form reduces to the spaced brand and that **no** phonetic respelling (`NEH-ruh`/`NAIR-uh` and the mixed-case variants) survives in **either** pronunciation layer. 219 passed across the pronunciation/TTS suites.

## Note on the spoken sound

This guarantees the awful letter-spelling/dash is gone and the brand is said consistently as the word "Nerra Network." If the *raw* way Grok says "Nerra" still isn't the exact short-e you want, the next step is a **mixed-case, no-hyphen** guide (e.g. `Nehra`) — but that needs a listen-test, since the all-caps+hyphen pattern has now regressed twice. I did not ship a third blind respelling guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MijFStKrJvtf9JxQvKQUDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MijFStKrJvtf9JxQvKQUDx)_