### PR TITLE
Fix push regression (clean tree) + recovery/newsletter failure alerting

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -593,7 +593,18 @@ jobs:
           # them, and both fell back to recovery branches). Per-show feeds /
           # pages (podcast.rss, blog_<show>.rss, <show>.html, blog/<show>/*)
           # are NOT aggregates and still commit normally.
-          git reset HEAD -- blog.rss network.rss blog/index.html 2>/dev/null || true
+          #
+          # IMPORTANT: use `git checkout HEAD --`, NOT `git reset HEAD --`.
+          # The per-show steps above (Regenerate network RSS / show HTML) have
+          # already MODIFIED these files in the working tree. `git reset` only
+          # unstages — it leaves them dirty, which then makes the push-retry
+          # `git pull --rebase` abort with "cannot pull with rebase: you have
+          # unstaged changes" and the merge fallback abort with "local changes
+          # would be overwritten by network.rss". That regression (June 27)
+          # sent ~7/8 shows to recovery branches on June 28. `git checkout
+          # HEAD --` reverts index AND working tree to HEAD, leaving a clean
+          # tree so the rebase can replay onto the latest main.
+          git checkout HEAD -- blog.rss network.rss blog/index.html 2>/dev/null || true
 
           # Check if there are changes to commit
           if git diff --cached --quiet; then

--- a/run_show.py
+++ b/run_show.py
@@ -118,6 +118,23 @@ logging.basicConfig(
 logger = logging.getLogger("run_show")
 
 
+def _alert_webhook(text: str) -> None:
+    """Best-effort operator alert via NOTIFICATION_WEBHOOK_URL.
+
+    Used for operator-actionable failures that would otherwise only surface
+    as a buried log line (e.g. a newsletter send failure). No-op when the
+    webhook is unset; never raises.
+    """
+    webhook = (os.getenv("NOTIFICATION_WEBHOOK_URL") or "").strip()
+    if not webhook:
+        return
+    try:
+        import requests
+        requests.post(webhook, json={"text": text}, timeout=15)
+    except Exception as exc:  # noqa: BLE001 — alerting must never break a run
+        logger.warning("Alert webhook failed: %s", exc)
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -3100,6 +3117,19 @@ def run(args: argparse.Namespace) -> None:
                     "engine.newsletter log line for the specific "
                     "reason (contrast block, scaffold leak, send "
                     "guardrail, or Buttondown response).",
+                )
+                # Loud alert: a configured-and-enabled newsletter that fails
+                # to send is an operator-actionable problem, not routine. The
+                # Buttondown account-disabled outage (June 19-28 2026) ran 9
+                # days unnoticed because this only logged a WARNING. Fire the
+                # notification webhook so a real send failure pages the
+                # operator immediately. Best-effort, never blocks the run.
+                _alert_webhook(
+                    f"⚠️ Newsletter NOT sent for {config.name} "
+                    f"ep{episode_num}. The Buttondown send failed (see the "
+                    f"run log for the API response — e.g. account disabled, "
+                    f"tag/recipient, or contrast/scaffold block). Newsletters "
+                    f"stay down until resolved."
                 )
 
     # 13. Post to X

--- a/scripts/create_recovery_pr.sh
+++ b/scripts/create_recovery_pr.sh
@@ -87,6 +87,9 @@ BODYEOF
 
 echo "Opening draft recovery PR..."
 
+echo "Opening draft recovery PR..."
+
+PR_OPENED=false
 if gh pr create \
   --title "Recovery: ${SHOW} episode outputs (run ${RUN_ID})" \
   --body-file "${BODY_FILE}" \
@@ -94,13 +97,40 @@ if gh pr create \
   --head "${RECOVERY_BRANCH}" \
   --draft; then
   echo "Recovery PR opened successfully."
+  PR_OPENED=true
 else
-  echo "Warning: gh pr create returned non-zero (may already exist or other transient)."
+  # The common failure here is the org/repo setting "Allow GitHub Actions to
+  # create and approve pull requests" being OFF, which returns:
+  #   GraphQL: GitHub Actions is not permitted to create or approve pull requests
+  # In that case the recovery BRANCH is still safely pushed (data preserved);
+  # only the convenience PR is missing. Do not treat this as fatal — but make
+  # it LOUD via the notification webhook so the operator actually sees it
+  # (the branch alone is easy to miss; June 2026 had branches pile up unnoticed).
+  echo "::warning::gh pr create failed for ${SHOW} — likely the repo setting"
+  echo "  'Allow GitHub Actions to create and approve pull requests' is OFF"
+  echo "  (Settings -> Actions -> General -> Workflow permissions). The recovery"
+  echo "  branch '${RECOVERY_BRANCH}' is pushed and safe; open a PR from it manually,"
+  echo "  or enable that setting so future recoveries auto-PR."
 fi
 
 rm -f "${BODY_FILE}"
 
-echo "::warning::Recovery PR created for ${SHOW} (run ${RUN_ID}). Merge it to permanently save the episode artifacts that would otherwise have been lost."
+# Operator alert (best-effort) — fire regardless of whether the PR opened, so a
+# stranded episode is never silent. NOTIFICATION_WEBHOOK_URL is the same hook
+# the post-run summary uses; no-op when unset.
+WEBHOOK="${NOTIFICATION_WEBHOOK_URL:-}"
+if [ -n "${WEBHOOK}" ]; then
+  if [ "${PR_OPENED}" = "true" ]; then
+    MSG="⚠️ ${SHOW}: episode push to main failed; recovered to draft PR from branch ${RECOVERY_BRANCH}. Merge it to publish."
+  else
+    MSG="⚠️ ${SHOW}: episode push to main failed AND recovery PR could not be opened (Actions PR creation likely disabled). Episode is safe on branch ${RECOVERY_BRANCH} — open a PR from it manually to publish."
+  fi
+  curl -sS -m 15 -X POST -H 'Content-Type: application/json' \
+    -d "{\"text\": $(printf '%s' "${MSG}" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')}" \
+    "${WEBHOOK}" >/dev/null 2>&1 || echo "(recovery alert webhook failed — non-fatal)"
+fi
+
+echo "::warning::Recovery branch ${RECOVERY_BRANCH} created for ${SHOW} (run ${RUN_ID}). Merge its PR (or open one from the branch) to permanently save the episode artifacts."
 
 # Success from the perspective of "data is preserved".
 exit 0

--- a/tests/test_workflow_efficiency.py
+++ b/tests/test_workflow_efficiency.py
@@ -26,6 +26,18 @@ class TestRunShowWorkflow:
         assert "~/.cache/huggingface" in wf
         assert "whisper-faster-base" in wf
 
+    def test_aggregate_exclusion_leaves_clean_tree(self):
+        """Per-show commits exclude the cross-show aggregates, but must use
+        `git checkout HEAD --` (reverts index + working tree), NOT `git reset
+        HEAD --` (unstages only). `reset` leaves the regenerated aggregates
+        dirty, which makes the push-retry `git pull --rebase` abort with
+        'cannot pull with rebase: you have unstaged changes' and sends shows
+        to recovery branches (the June 28 2026 regression)."""
+        wf = _read("run-show.yml")
+        assert "git checkout HEAD -- blog.rss network.rss blog/index.html" in wf
+        # The buggy reset form must not be what excludes the aggregates.
+        assert "git reset HEAD -- blog.rss network.rss blog/index.html" not in wf
+
     def test_secrets_as_env_not_dotenv_file(self):
         """Secrets go to the pipeline step's env block — no .env heredoc
         on disk, no indentation-sensitive sed hack."""


### PR DESCRIPTION
## Context
Follow-up to the June 27 push-contention work, after the June 28 incident review.

### #11 — Push regression (the big one)
My #728 aggregate-exclusion used `git reset HEAD -- blog.rss network.rss blog/index.html`, which only **unstages** — it left those regenerated files **dirty in the working tree**. The push-retry `git pull --rebase` then aborted with *"cannot pull with rebase: you have unstaged changes"* and the merge fallback with *"local changes would be overwritten by network.rss"*, sending **~7 of 8 shows to recovery branches on June 28** (worse than before the fix). Switched to `git checkout HEAD --` (reverts index **and** working tree → clean). Drift guard added in `tests/test_workflow_efficiency.py`.

### #12 — Recovery PR path
`gh pr create` is blocked org-side (*"GitHub Actions is not permitted to create or approve pull requests"*), so recovery PRs never opened and stranded episodes were silent. PR-failure is now explicitly non-fatal with a clear message (enable *Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"*), and the script fires `NOTIFICATION_WEBHOOK_URL` so the operator is paged that an episode is on a recovery branch.

### #15 — Newsletter failure alerting
Newsletters broke network-wide on **~June 19**: the Buttondown account returned `400 {"code":"email_invalid","detail":"Your account has been disabled!..."}`. It ran **9 days unnoticed** because the failure only logged a WARNING. Added `_alert_webhook` in `run_show.py`, fired when an enabled show's newsletter send fails. **The disabled-account state itself is an operator action with Buttondown — no code fixes that.**

## Tests
`test_workflow_efficiency.py`, `test_pipeline_safety.py`, `test_newsletter_sender.py` pass; workflow YAML + recovery bash validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3)_