### PR TITLE
Images-only pipeline: crossfades, faster render, headline chapter titles + YouTube feedback loop

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -75,6 +75,23 @@ jobs:
         # api/op3_stats.json is missing or has no entry for a show.
         run: python scripts/update_performance_trackers.py
 
+      - name: Fetch YouTube analytics + refresh title performance hints
+        # Recursive YouTube-feedback loop: reads per-video retention back
+        # from the Analytics API into api/youtube_stats.json, then distils
+        # per-show 'what's working' title hints into
+        # digests/<slug>/youtube_performance.json (title-only, no audio →
+        # outside landmine #17). Clean no-op until the stored token is
+        # re-authorised with yt-analytics.readonly AND data accrues
+        # (docs/youtube_feedback_loop.md).
+        env:
+          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+          YOUTUBE_REFRESH_TOKEN_EN: ${{ secrets.YOUTUBE_REFRESH_TOKEN_EN }}
+          YOUTUBE_REFRESH_TOKEN_RU: ${{ secrets.YOUTUBE_REFRESH_TOKEN_RU }}
+        run: |
+          python scripts/fetch_youtube_analytics.py --out api/youtube_stats.json --days 90 || true
+          python scripts/update_youtube_performance.py || true
+
       - name: Refresh SpaceX launch dashboard data
         # Next/previous launch, 12-month cadence, and stats for
         # spacex-dashboard.html (The Space Devs Launch Library 2). Keeps

--- a/docs/youtube_feedback_loop.md
+++ b/docs/youtube_feedback_loop.md
@@ -1,0 +1,104 @@
+# YouTube → workflow recursive feedback loop (June 2026)
+
+**Goal:** stop improving YouTube packaging by hand. Read each video's
+*performance* (especially retention) back into the pipeline and let it steer
+future titles automatically — the same closed loop the audio side already has
+via OP3 download stats.
+
+This mirrors the proven OP3 pattern
+(`fetch_op3_stats.py` → `update_performance_trackers.py` →
+`engine/show_memory.py` → prompt injection), built to ship **dormant**: every
+piece is a clean no-op until (a) the operator re-authorises the OAuth token
+with the analytics scope and (b) a few weeks of data accrue. You collect
+first, then the loop turns itself on.
+
+## Data flow
+
+```
+publish (run_show.py _publish_youtube)
+   └─ engine/youtube_index.record_video
+        → digests/<slug>/youtube_videos.json   (per-show video→episode map)
+
+nightly-maintenance.yml
+   ├─ scripts/fetch_youtube_analytics.py
+   │     reads every digests/<slug>/youtube_videos.json,
+   │     queries YouTube Analytics API (views / watch-time / avg view %),
+   │     → api/youtube_stats.json
+   └─ scripts/update_youtube_performance.py
+         distils per-show "what's working" from the best-retention videos
+         → digests/<slug>/youtube_performance.json  ({ "title_hint": "..." })
+
+next episode (run_show.py → engine/youtube_titles.generate_youtube_titles)
+   └─ _performance_hint(slug) injects the hint into the title prompt
+        → titles lean toward the angles/keywords that retained best
+```
+
+### Why per-show index files (not one shared file)
+
+Up to a dozen show jobs run concurrently in the daily matrix. A single shared
+`api/youtube_videos.json` would have every job racing to commit/push the same
+file — exactly the cross-show push-contention fixed in June 2026 (the
+`blog.rss` / `network.rss` exclusion; landmine #23). Each show writes only its
+own `digests/<slug>/youtube_videos.json`, written by that show's serialised
+job alone.
+
+### Why retention, not CTR
+
+`averageViewPercentage` is the strongest content-quality signal the **public**
+YouTube Analytics API exposes. Impressions and click-through rate are
+Studio-only (no reliable public-API metric), so they are intentionally
+omitted. Retention is also the better lever: the 2026 algorithm gates "Quality
+CTR" on whether the title's promise is actually kept.
+
+### Why this is safe to run automatically (no landmine #17 gate)
+
+The only thing the loop changes is the **YouTube title** — visual metadata,
+generated separately from the spoken hook (`engine/youtube_titles.py`). It
+never touches the audio script or TTS, so it sits outside the A/B-listen gate.
+If the hint is empty (no data yet) the title prompt renders exactly as before.
+
+## Operator one-time setup
+
+1. **Re-authorise the OAuth token** with the analytics scope. The June 2026
+   change added `https://www.googleapis.com/auth/yt-analytics.readonly` to
+   `engine.youtube.YOUTUBE_SCOPES`. Google rejects a stored refresh token that
+   lacks a requested scope, so re-run:
+
+   ```
+   python scripts/youtube_oauth_bootstrap.py        # @NerraNetwork (EN)
+   ```
+
+   and re-consent, then update the `YOUTUBE_REFRESH_TOKEN_EN` secret (and
+   `YOUTUBE_REFRESH_TOKEN_RU` for @NerraRU if RU shows are publishing). **Until
+   this is done, uploads keep working on the old token; only the analytics
+   read no-ops** (it logs "Analytics query rejected … re-auth needed").
+
+2. That's it. The nightly job already passes the YouTube secrets to the fetch
+   step; `api/youtube_stats.json` and the per-show `youtube_performance.json`
+   files start populating once the scope is live and videos have a few weeks of
+   watch data. The title hint switches on the moment a show has ≥4 videos with
+   retention numbers.
+
+## Verifying
+
+```
+# After re-auth, dry-run the fetch (prints what it would write):
+python scripts/fetch_youtube_analytics.py --dry-run --days 90
+
+# Then build the hints and inspect one:
+python scripts/update_youtube_performance.py
+cat digests/tesla/youtube_performance.json
+```
+
+Drift guards: `tests/test_youtube_feedback_loop.py`.
+
+## Deliberately staged for later
+
+- **Topic steering from retention** (feeding the signal into the *digest*
+  prompt so the show covers more of what retains) is a bigger lever but
+  changes generated **audio** → it must go through the landmine #17 A/B-listen
+  gate. Left out of v1 on purpose; revisit once a few weeks of retention data
+  show a clear, trustworthy signal.
+- **Dashboard surfacing** of `api/youtube_stats.json` (an "Audience: YouTube"
+  card next to the OP3 card) is a straightforward follow-up once real data
+  exists to display.

--- a/engine/chapters.py
+++ b/engine/chapters.py
@@ -77,6 +77,68 @@ def _first_sentence_as_title(text: str, max_chars: int = 60) -> str:
     return candidate
 
 
+# Words that carry no topical signal when matching a script segment to a
+# clean digest headline (auto-segment titling). Kept small + lowercase.
+_TITLE_MATCH_STOPWORDS = frozenset({
+    "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "for",
+    "with", "at", "by", "from", "as", "is", "are", "was", "were", "be",
+    "been", "it", "its", "this", "that", "these", "those", "into", "over",
+    "after", "before", "about", "than", "then", "so", "we", "you", "they",
+    "their", "our", "his", "her", "new", "now", "up", "out", "has", "have",
+})
+
+
+def _tokenize_for_match(text: str) -> set:
+    """Lowercase content-word token set for overlap scoring."""
+    toks = re.findall(r"[a-z0-9]{3,}", (text or "").lower())
+    return {t for t in toks if t not in _TITLE_MATCH_STOPWORDS}
+
+
+def _best_headline_for_segment(
+    seg_text: str, headlines: List[str], used: set,
+    max_chars: int = 60,
+) -> str:
+    """Pick the unused digest *headline* that best overlaps *seg_text*.
+
+    Auto-segment titles drawn from the segment's raw first sentence are
+    often mid-thought fragments ("Knowing this, when you hear claims…").
+    The episode digest already carries clean, capitalised per-story
+    headlines (``extract_story_headlines``); matching each spoken segment
+    to its originating headline by content-word overlap yields a proper
+    title ("Tesla unveils robotaxi service in Texas"). Returns "" when no
+    headline overlaps the segment meaningfully (caller falls back to the
+    first-sentence title, then ``Segment N``).
+    """
+    if not headlines:
+        return ""
+    seg_tokens = _tokenize_for_match(seg_text)
+    if not seg_tokens:
+        return ""
+    best_title = ""
+    best_score = 0
+    for h in headlines:
+        if h in used:
+            continue
+        h_tokens = _tokenize_for_match(h)
+        if not h_tokens:
+            continue
+        overlap = len(seg_tokens & h_tokens)
+        # Require ≥2 shared content words (or ≥half a short headline) so an
+        # incidental single-word match doesn't mis-title a segment.
+        if overlap > best_score and (
+            overlap >= 2 or overlap >= max(1, len(h_tokens) // 2)
+        ):
+            best_score = overlap
+            best_title = h
+    if not best_title:
+        return ""
+    used.add(best_title)  # claim the headline so the next segment can't reuse it
+    title = re.sub(r"[*_`]+", "", best_title).strip()
+    if len(title) > max_chars:
+        title = title[: max_chars - 1].rsplit(" ", 1)[0].rstrip(",;:") + "…"
+    return title
+
+
 def parse_chapters(
     script: str,
     section_markers: list,
@@ -85,6 +147,7 @@ def parse_chapters(
     min_chapters: int = 4,
     auto_segment_target_seconds: float = 90.0,
     estimated_words_per_minute: float = 165.0,
+    story_headlines: Optional[List[str]] = None,
 ) -> List[Chapter]:
     """Parse a podcast script to identify section boundaries.
 
@@ -242,6 +305,7 @@ def parse_chapters(
                     last_w = w
 
             if insertions:
+                _used_headlines: set[str] = set()
                 rebuilt: list[Chapter] = [Chapter(
                     title=head.title,
                     word_start=head.word_start,
@@ -252,11 +316,16 @@ def parse_chapters(
                 for n, (w, c) in enumerate(insertions, start=2):
                     next_w = insertions[n - 1][0] if n - 1 < len(insertions) else head_w_end
                     next_c = insertions[n - 1][1] if n - 1 < len(insertions) else head_c_end
-                    # Title from the first sentence of the segment text.
-                    # Falls back to "Segment N" if extraction fails (very
-                    # short text, no sentence-ending punctuation, etc).
+                    # Title preference: (1) matching clean digest headline
+                    # (avoids mid-sentence spoken fragments), (2) the
+                    # segment's first sentence, (3) "Segment N" placeholder.
                     seg_text = script[c:next_c]
-                    title = _first_sentence_as_title(seg_text) or f"Segment {n}"
+                    title = (
+                        _best_headline_for_segment(
+                            seg_text, story_headlines or [], _used_headlines)
+                        or _first_sentence_as_title(seg_text)
+                        or f"Segment {n}"
+                    )
                     rebuilt.append(Chapter(
                         title=title,
                         word_start=w,

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -364,10 +364,16 @@ def run_generation_phase(
             and getattr(config.chapters, "enabled", False)
             and getattr(config.chapters, "section_markers", None)):
         from engine.chapters import parse_chapters
+        try:
+            from engine.grok_imagine import extract_story_headlines as _ch_heads
+            _chapter_headlines = _ch_heads(x_thread or "", max_count=12)
+        except Exception:
+            _chapter_headlines = []
         episode_chapters = parse_chapters(
             podcast_script,
             config.chapters.section_markers,
             show_name=config.name,
+            story_headlines=_chapter_headlines,
         )
 
     return x_thread, podcast_script, episode_chapters, effective_hook

--- a/engine/video.py
+++ b/engine/video.py
@@ -70,6 +70,19 @@ _VIDEO_ENCODE: List[str] = [
     "-force_key_frames", "expr:gte(t,n_forced*2)",
 ]
 
+# Fast profile for the STAGE-1 slideshow, which is an *intermediate* file —
+# stage 2 (the composite) re-encodes it with the full _VIDEO_ENCODE profile, so
+# stage-1 quality barely reaches the final pixels. Using a fast preset here cut
+# the slideshow render from ~10 min toward ~2-3 min on Tesla/SpaceX, which is
+# the main reason those clip-era runs crept toward the 40-min pipeline timeout.
+# No keyframe args needed (it's not the delivered file). June 2026 render pass.
+_VIDEO_ENCODE_FAST: List[str] = [
+    "-c:v", "libx264",
+    "-pix_fmt", "yuv420p",
+    "-preset", "veryfast",
+    "-crf", "20",          # slightly higher quality to offset the re-encode loss
+]
+
 _AUDIO_ENCODE: List[str] = [
     "-c:a", "aac",
     "-b:a", "192k",
@@ -421,20 +434,39 @@ _SHORT_SCENE_DURATION_SECONDS = 7.0
 _MAX_SCENE_HOLD_S = 15.0
 
 
+# Crossfade between scenes for a more dynamic, modern slideshow (June 2026
+# visual pass — replaces hard cuts). Rotating tasteful transition types add
+# variety at zero cost. Set to 0.0 to disable (plain hard cuts). The render
+# path falls back to hard-cut concat if the xfade chain ever fails, so this
+# can never make a render fail outright.
+_SLIDESHOW_XFADE_S = 0.6
+_XFADE_TRANSITIONS = [
+    "fade", "dissolve", "smoothleft", "fadeblack", "smoothright", "fade",
+]
+
+
 def _slideshow_filter_graph(scene_count: int, *,
                             scene_duration: float = _SCENE_DURATION_SECONDS,
                             width: int = 1920, height: int = 1080,
-                            fps: int = 30) -> str:
-    """Build the filter_complex for a Ken Burns slideshow with hard cuts.
+                            fps: int = 30,
+                            crossfade: float = _SLIDESHOW_XFADE_S) -> str:
+    """Build the filter_complex for a Ken Burns slideshow.
 
-    Each scene gets a 1.00 → 1.12 zoom over its window. Hard cuts
-    between scenes (no crossfade) — the spectrum + brand pill + caption
-    motion in stage 2 hides any visual jump.
+    Each scene gets a 1.00 → 1.12 zoom over its window. When *crossfade* > 0
+    and there are ≥2 scenes, consecutive scenes are joined with a rotating
+    ``xfade`` transition (more dynamic than the old hard cut); otherwise scenes
+    are hard-cut via ``concat``. Each scene clip is rendered ``scene_duration +
+    crossfade`` long so the xfade overlap doesn't shorten the per-scene visible
+    time, and the xfade offset for scene k is ``k * scene_duration`` — keeping
+    total runtime ≈ ``scene_count * scene_duration`` (slightly longer, never
+    shorter, than the audio it backs).
     """
     pre_w = int(width * 1.15)
     pre_h = int(height * 1.15)
     zoom_expr = "min(zoom+0.0006,1.12)"
-    frames_per_scene = int(scene_duration * fps)
+    use_xfade = crossfade and crossfade > 0 and scene_count >= 2
+    clip_len = scene_duration + (crossfade if use_xfade else 0.0)
+    frames_per_scene = int(clip_len * fps)
 
     chains: List[str] = []
     for i in range(scene_count):
@@ -444,29 +476,48 @@ def _slideshow_filter_graph(scene_count: int, *,
             f"crop={pre_w}:{pre_h},setsar=1,"
             f"zoompan=z='{zoom_expr}':d={frames_per_scene}"
             f":s={width}x{height}:fps={fps},"
-            f"trim=duration={scene_duration:.2f},setpts=PTS-STARTPTS"
+            f"trim=duration={clip_len:.2f},setpts=PTS-STARTPTS"
             f"[s{i}]"
         )
-    concat_in = "".join(f"[s{i}]" for i in range(scene_count))
-    chains.append(f"{concat_in}concat=n={scene_count}:v=1:a=0[v]")
+
+    if not use_xfade:
+        concat_in = "".join(f"[s{i}]" for i in range(scene_count))
+        chains.append(f"{concat_in}concat=n={scene_count}:v=1:a=0[v]")
+        return ";".join(chains)
+
+    # Chain xfades: [s0][s1]->[x1], [x1][s2]->[x2], ... last -> [v].
+    prev = "[s0]"
+    for k in range(1, scene_count):
+        trans = _XFADE_TRANSITIONS[(k - 1) % len(_XFADE_TRANSITIONS)]
+        offset = k * scene_duration
+        out = "[v]" if k == scene_count - 1 else f"[x{k}]"
+        chains.append(
+            f"{prev}[s{k}]xfade=transition={trans}"
+            f":duration={crossfade:.2f}:offset={offset:.2f}{out}"
+        )
+        prev = out
     return ";".join(chains)
 
 
 def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
                    *, scene_duration: float = _SCENE_DURATION_SECONDS,
                    width: int = 1920, height: int = 1080,
-                   fps: int = 30) -> List[str]:
+                   fps: int = 30,
+                   crossfade: float = _SLIDESHOW_XFADE_S) -> List[str]:
     """ffmpeg command for stage 1 (slideshow render).
 
     *width* and *height* default to 1920x1080 for the long-form path;
-    pass 1080x1920 for the vertical Shorts variant.
+    pass 1080x1920 for the vertical Shorts variant. Uses the fast encode
+    profile (this is an intermediate re-encoded by stage 2).
     """
+    use_xfade = crossfade and crossfade > 0 and len(scene_paths) >= 2
+    per_input_t = scene_duration + (crossfade if use_xfade else 0.0) + 0.5
     inputs: List[str] = []
     for path in scene_paths:
         inputs.extend([
             "-loop", "1",
             "-framerate", str(fps),
-            "-t", f"{scene_duration + 0.5:.2f}",
+            "-t", f"{per_input_t:.2f}",
             "-i", str(path),
         ])
     return [
@@ -475,10 +526,11 @@ def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
         "-filter_complex",
         _slideshow_filter_graph(len(scene_paths),
                                 scene_duration=scene_duration,
-                                width=width, height=height, fps=fps),
+                                width=width, height=height, fps=fps,
+                                crossfade=crossfade),
         "-map", "[v]",
         "-r", str(fps),
-        *_VIDEO_ENCODE,
+        *_VIDEO_ENCODE_FAST,
         "-an",
         "-movflags", "+faststart",
         str(output),
@@ -489,15 +541,32 @@ def _render_slideshow(scene_paths: Sequence[Path], output: Path,
                       *, scene_duration: float = _SCENE_DURATION_SECONDS,
                       width: int = 1920, height: int = 1080,
                       fps: int = 30) -> Path:
-    """Render the stage-1 slideshow MP4. Idempotent (skips if output exists)."""
+    """Render the stage-1 slideshow MP4. Idempotent (skips if output exists).
+
+    Tries the crossfade graph first; if ffmpeg rejects it for any reason,
+    retries once with plain hard-cut concat so a transition bug can never
+    block a render (worst case = the pre-June-2026 hard-cut look).
+    """
     if output.exists():
         return output
-    cmd = _slideshow_cmd(scene_paths, output,
-                         scene_duration=scene_duration,
-                         width=width, height=height, fps=fps)
-    logger.info("Rendering slideshow (%d scenes, %dx%d) → %s",
-                len(scene_paths), width, height, output.name)
-    _run_ffmpeg(cmd, label="slideshow render")
+    logger.info("Rendering slideshow (%d scenes, %dx%d, crossfade=%.1fs) → %s",
+                len(scene_paths), width, height, _SLIDESHOW_XFADE_S, output.name)
+    try:
+        cmd = _slideshow_cmd(scene_paths, output,
+                             scene_duration=scene_duration,
+                             width=width, height=height, fps=fps)
+        _run_ffmpeg(cmd, label="slideshow render (crossfade)")
+    except subprocess.CalledProcessError as exc:
+        logger.warning(
+            "Crossfade slideshow render failed (%s) — retrying with hard cuts.",
+            exc,
+        )
+        output.unlink(missing_ok=True)
+        cmd = _slideshow_cmd(scene_paths, output,
+                             scene_duration=scene_duration,
+                             width=width, height=height, fps=fps,
+                             crossfade=0.0)
+        _run_ffmpeg(cmd, label="slideshow render (hard cut fallback)")
     return output
 
 

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -46,11 +46,22 @@ logger = logging.getLogger(__name__)
 
 
 # OAuth scopes required for upload + thumbnail set + channel read +
-# caption track upload (``captions.insert`` needs force-ssl).
+# caption track upload (``captions.insert`` needs force-ssl) + reading
+# back YouTube Analytics (the recursive-feedback loop —
+# ``scripts/fetch_youtube_analytics.py``).
+#
+# NOTE: adding ``yt-analytics.readonly`` here means the stored refresh
+# token must be re-authorised once (the operator re-runs
+# ``scripts/youtube_oauth_bootstrap.py`` and re-consents) before the
+# analytics fetch can read data — Google rejects a token that lacks a
+# requested scope. Upload/publish keeps working on the old token; only
+# the analytics read no-ops until the re-auth lands. See
+# ``docs/youtube_feedback_loop.md``.
 YOUTUBE_SCOPES = [
     "https://www.googleapis.com/auth/youtube.upload",
     "https://www.googleapis.com/auth/youtube",
     "https://www.googleapis.com/auth/youtube.force-ssl",
+    "https://www.googleapis.com/auth/yt-analytics.readonly",
 ]
 
 # Google's OAuth token endpoint. Held as a constant rather than an env

--- a/engine/youtube_index.py
+++ b/engine/youtube_index.py
@@ -1,0 +1,141 @@
+"""Per-show index of published YouTube videos → episode metadata.
+
+The recursive YouTube-feedback loop (``scripts/fetch_youtube_analytics.py``
+→ ``scripts/update_youtube_performance.py``) needs to map a bare YouTube
+``video_id`` back to *which show, episode, and topic* produced it, so the
+analytics it reads (views / retention) can be attributed to content
+choices. The Analytics API returns metrics keyed by ``video_id`` only — it
+knows nothing about Nerra's shows.
+
+This module maintains ``digests/<slug>/youtube_videos.json`` (one file per
+show) as that mapping. Each successful upload appends one record to its own
+show's file; the analytics fetcher reads every show's file. It is small (one
+row per upload), text-only, and committed with the episode — no media, so it
+does not touch landmine #1.
+
+**Per-show, not network-wide, on purpose:** up to a dozen show jobs run
+concurrently in the daily matrix. A single shared index would have every job
+racing to commit/push the same file — exactly the cross-show push-contention
+class fixed in June 2026 (landmine #23 / the blog.rss/network.rss exclusion).
+A per-show file is only ever written by that show's own (serialised) job.
+
+Schema (``schema_version`` 1)::
+
+    {
+      "schema_version": 1,
+      "videos": [
+        {
+          "video_id": "abc123",
+          "show_slug": "tesla",
+          "episode": 526,
+          "kind": "long" | "short",
+          "title": "<the published YouTube title>",
+          "hook": "<episode hook / spoken lead>",
+          "published": "2026-06-29",
+          "watch_url": "https://www.youtube.com/watch?v=abc123",
+          "channel": "en" | "ru"
+        },
+        ...
+      ]
+    }
+
+Idempotent: re-recording the same ``video_id`` updates the existing row
+rather than duplicating it (a re-run of the same episode keeps one entry).
+All writes are best-effort — a failure here must never break a publish, so
+callers wrap the call defensively (the recorder also swallows its own IO
+errors and logs).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA_VERSION = 1
+# Per-show index lives in the show's own output dir.
+_INDEX_FILENAME = "youtube_videos.json"
+
+
+def index_path_for(show_slug: str) -> Path:
+    """``digests/<slug>/youtube_videos.json`` for *show_slug*."""
+    return Path("digests") / (show_slug or "_unknown") / _INDEX_FILENAME
+
+
+# Keep each show's index from growing without bound — newest-first cap. A
+# show ships ≤3 videos/day, so 1000 rows ≈ ~10 months of history, plenty for
+# a 30-90 day performance window while staying a small text file.
+_MAX_ROWS = 1000
+
+
+def _load(path: Path) -> dict:
+    if not path.exists():
+        return {"schema_version": _SCHEMA_VERSION, "videos": []}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or not isinstance(data.get("videos"), list):
+            raise ValueError("malformed index")
+        return data
+    except Exception as exc:  # corrupt file shouldn't lose new data
+        logger.warning("youtube_videos.json unreadable (%s) — starting fresh", exc)
+        return {"schema_version": _SCHEMA_VERSION, "videos": []}
+
+
+def record_video(
+    *,
+    video_id: str,
+    show_slug: str,
+    episode: int,
+    kind: str,
+    title: str = "",
+    hook: str = "",
+    published: str = "",
+    watch_url: str = "",
+    channel: str = "en",
+    index_path: Optional[Path] = None,
+) -> bool:
+    """Append (or update) one published-video record. Best-effort.
+
+    Returns True when the index was written, False on any no-op/error
+    (missing ``video_id``, IO failure). Never raises — callers publish
+    regardless of the feedback bookkeeping.
+    """
+    if not video_id:
+        return False
+    path = Path(index_path) if index_path else index_path_for(show_slug)
+    try:
+        data = _load(path)
+        videos = data["videos"]
+        row = {
+            "video_id": video_id,
+            "show_slug": show_slug,
+            "episode": int(episode) if episode is not None else None,
+            "kind": kind,
+            "title": (title or "")[:300],
+            "hook": (hook or "")[:300],
+            "published": published,
+            "watch_url": watch_url,
+            "channel": channel,
+        }
+        # Idempotent upsert keyed on video_id.
+        for i, existing in enumerate(videos):
+            if existing.get("video_id") == video_id:
+                videos[i] = row
+                break
+        else:
+            videos.append(row)
+        # Newest-first cap (keep the tail = most recent appends).
+        if len(videos) > _MAX_ROWS:
+            data["videos"] = videos[-_MAX_ROWS:]
+        data["schema_version"] = _SCHEMA_VERSION
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        return True
+    except Exception as exc:
+        logger.warning("Could not record video %s in index: %s", video_id, exc)
+        return False

--- a/engine/youtube_titles.py
+++ b/engine/youtube_titles.py
@@ -51,6 +51,33 @@ def _clean_title(line: str) -> str:
     return t.strip()
 
 
+def _performance_hint(perf_dir: Optional[Path]) -> str:
+    """A one-paragraph 'what's been working' steer from past YouTube
+    retention, or "" when there's no data yet (the loop is dormant until
+    the operator re-auths the analytics scope and a few weeks accrue).
+
+    Read from ``<perf_dir>/youtube_performance.json`` — *perf_dir* is the
+    show's own output dir (slug != dir for some shows, e.g. tesla →
+    digests/tesla_shorts_time), written by
+    ``scripts/update_youtube_performance.py``. Pure best-effort — title
+    generation must never depend on it. Title-only signal, no audio impact.
+    """
+    if not perf_dir:
+        return ""
+    try:
+        import json
+        path = Path(perf_dir) / "youtube_performance.json"
+        if not path.exists():
+            return ""
+        data = json.loads(path.read_text(encoding="utf-8"))
+        hint = (data.get("title_hint") or "").strip()
+        return ("\nWHAT'S WORKING (from this show's recent YouTube retention — "
+                "lean toward these angles/keywords if they fit honestly):\n"
+                f"{hint}\n") if hint else ""
+    except Exception:
+        return ""
+
+
 def generate_youtube_titles(
     *,
     hook: str,
@@ -60,6 +87,7 @@ def generate_youtube_titles(
     keywords: Optional[List[str]] = None,
     n: int = 3,
     model: str = "grok-4.3",
+    perf_dir: Optional[Path] = None,
 ) -> List[str]:
     """Return up to *n* click-optimized title candidates, best first.
 
@@ -76,6 +104,7 @@ def generate_youtube_titles(
                 "hook": (hook or "").strip(),
                 "keywords": ", ".join(keywords or []),
                 "digest_excerpt": (digest_text or "")[:2000],
+                "performance_hint": _performance_hint(perf_dir),
                 "n": n,
             },
         )
@@ -113,6 +142,7 @@ def best_youtube_title(
     episode_num: int,
     keywords: Optional[List[str]] = None,
     model: str = "grok-4.3",
+    perf_dir: Optional[Path] = None,
 ) -> Optional[str]:
     """Convenience: the single best candidate, or ``None`` on failure."""
     cands = generate_youtube_titles(
@@ -123,5 +153,6 @@ def best_youtube_title(
         keywords=keywords,
         n=1,
         model=model,
+        perf_dir=perf_dir,
     )
     return cands[0] if cands else None

--- a/run_show.py
+++ b/run_show.py
@@ -3786,6 +3786,7 @@ def _publish_youtube(
                 episode_num=episode_num,
                 keywords=list(getattr(config, "keywords", []) or []),
                 n=3,
+                perf_dir=digests_dir,
             )
             if yt_title_variants:
                 yt_title = yt_title_variants[0]
@@ -4351,6 +4352,25 @@ def _publish_youtube(
             )
             long_url = upload.watch_url
             result["long_url"] = long_url
+            # Record in the network video→episode index so the YouTube
+            # analytics-feedback loop can attribute retention/CTR back to
+            # this show + episode (best-effort; never blocks publish).
+            try:
+                from engine.youtube_index import record_video as _yt_record
+                _yt_record(
+                    video_id=upload.video_id,
+                    show_slug=getattr(config, "slug", ""),
+                    episode=episode_num,
+                    kind="long",
+                    title=meta.get("title", ""),
+                    hook=hook,
+                    published=f"{today:%Y-%m-%d}",
+                    watch_url=long_url,
+                    channel=(getattr(config.youtube, "channel", "en") or "en"),
+                    index_path=digests_dir / "youtube_videos.json",
+                )
+            except Exception as _exc:
+                logger.debug("video index (long) skipped: %s", _exc)
             playlist_id = (
                 getattr(config.youtube, "podcast_playlist_id", None) or ""
             ).strip()
@@ -4663,6 +4683,22 @@ def _publish_youtube(
                     )
                     short_urls_out.append(this_upload.watch_url)
                     short_video_ids_out.append(this_upload.video_id)
+                    try:
+                        from engine.youtube_index import record_video as _yt_record
+                        _yt_record(
+                            video_id=this_upload.video_id,
+                            show_slug=getattr(config, "slug", ""),
+                            episode=episode_num,
+                            kind="short",
+                            title=meta.get("title", ""),
+                            hook=(this_hook or hook),
+                            published=f"{today:%Y-%m-%d}",
+                            watch_url=this_upload.watch_url,
+                            channel=(getattr(config.youtube, "channel", "en") or "en"),
+                            index_path=digests_dir / "youtube_videos.json",
+                        )
+                    except Exception as _exc:
+                        logger.debug("video index (short) skipped: %s", _exc)
                     playlist_id = (
                         getattr(config.youtube, "podcast_playlist_id", None) or ""
                     ).strip()

--- a/run_show.py
+++ b/run_show.py
@@ -2318,12 +2318,21 @@ def run(args: argparse.Namespace) -> None:
             )
             podcast_script = podcast_script.rstrip() + "\n\n" + _disclosure
 
-            # Parse chapter markers from the cleaned script (before TTS)
+            # Parse chapter markers from the cleaned script (before TTS).
+            # Pass the digest's clean per-story headlines so the
+            # auto-segment fallback titles chapters with real headlines
+            # instead of mid-sentence spoken fragments.
             from engine.chapters import parse_chapters
+            try:
+                from engine.grok_imagine import extract_story_headlines as _ch_heads
+                _chapter_headlines = _ch_heads(x_thread or "", max_count=12)
+            except Exception:
+                _chapter_headlines = []
             episode_chapters = parse_chapters(
                 podcast_script,
                 config.chapters.section_markers,
                 show_name=config.name,
+                story_headlines=_chapter_headlines,
             ) if config.chapters.enabled and config.chapters.section_markers else []
 
             # Final defense-in-depth: strip any speaker prefixes that survived

--- a/scripts/fetch_youtube_analytics.py
+++ b/scripts/fetch_youtube_analytics.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Read YouTube Analytics back into the network — the recursive-feedback loop.
+
+The pipeline uploads long-form + Shorts every day and records each in
+``api/youtube_videos.json`` (``engine.youtube_index``) but never read the
+*performance* back. This closes that loop, mirroring ``fetch_op3_stats.py``
+for the audio side:
+
+* ``api/youtube_stats.json`` — per-show + per-video views, watch-time, and
+  **average view percentage** (the retention signal — the strongest
+  content-quality lever YouTube exposes via the public API). The operator
+  dashboard reads it; ``scripts/update_youtube_performance.py`` turns it
+  into the per-show "what's working" guidance injected into prompts.
+
+The video→episode map is read from every show's own
+``digests/<slug>/youtube_videos.json`` (per-show to avoid the concurrent
+push-contention a shared index would cause — see ``engine.youtube_index``).
+
+Clean no-op when YouTube credentials are unset OR the stored token lacks
+the ``yt-analytics.readonly`` scope (logs one line, exits 0, leaves any
+previously committed output untouched) — same convention as every optional
+integration here.
+
+**Operator one-time setup:** the analytics scope was added to
+``engine.youtube.YOUTUBE_SCOPES`` in June 2026, so the refresh token must be
+re-authorised once (re-run ``scripts/youtube_oauth_bootstrap.py`` and
+re-consent) before this returns data. Uploads keep working on the old token;
+only this read no-ops until then. See ``docs/youtube_feedback_loop.md``.
+
+YouTube Analytics API v2 (https://developers.google.com/youtube/analytics):
+``reports.query`` with ``ids=channel==MINE``, ``dimensions=video``,
+``filters=video==<id1>,<id2>,...`` (≤500 ids/query), metrics
+``views,estimatedMinutesWatched,averageViewDuration,averageViewPercentage``.
+Impressions / click-through are Studio-only and intentionally omitted.
+
+Usage::
+
+    python scripts/fetch_youtube_analytics.py                  # write the file
+    python scripts/fetch_youtube_analytics.py --dry-run        # print, no write
+    python scripts/fetch_youtube_analytics.py --days 30        # window (default 90)
+    python scripts/fetch_youtube_analytics.py --index api/youtube_videos.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_ROOT = _SCRIPT_DIR.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("fetch_youtube_analytics")
+
+_METRICS = [
+    "views",
+    "estimatedMinutesWatched",
+    "averageViewDuration",
+    "averageViewPercentage",
+]
+# Analytics API allows up to 500 ids in a single video== filter.
+_BATCH = 200
+
+
+def _load_index(digests_dir: Path) -> List[dict]:
+    """Collect rows from every ``digests/<slug>/youtube_videos.json``."""
+    files = sorted(digests_dir.glob("*/youtube_videos.json"))
+    if not files:
+        logger.info("No per-show video indexes under %s — nothing to fetch "
+                    "(clean no-op)", digests_dir)
+        return []
+    rows: List[dict] = []
+    for f in files:
+        # The output dir name is the canonical key (slug != dir for some
+        # shows, e.g. tesla → digests/tesla_shorts_time); the updater writes
+        # the perf file back into this same dir.
+        dir_name = f.parent.name
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+            for v in data.get("videos", []):
+                if v.get("video_id"):
+                    v = dict(v)
+                    v["_dir"] = dir_name
+                    rows.append(v)
+        except Exception as exc:
+            logger.warning("Could not parse %s: %s — skipping", f, exc)
+    return rows
+
+
+def _analytics_service(credentials):
+    """Build the youtubeAnalytics v2 client; None if libs/creds unusable."""
+    try:
+        from googleapiclient.discovery import build
+    except Exception as exc:  # pragma: no cover - import guard
+        logger.info("googleapiclient unavailable (%s) — skipping", exc)
+        return None
+    try:
+        return build("youtubeAnalytics", "v2", credentials=credentials,
+                     cache_discovery=False)
+    except Exception as exc:
+        logger.warning("Could not build analytics service: %s", exc)
+        return None
+
+
+def _query_batch(service, video_ids: List[str], start: str, end: str) -> Dict[str, dict]:
+    """Return {video_id: {metric: value}} for a batch of ids. {} on error."""
+    try:
+        resp = service.reports().query(
+            ids="channel==MINE",
+            startDate=start,
+            endDate=end,
+            metrics=",".join(_METRICS),
+            dimensions="video",
+            filters="video==" + ",".join(video_ids),
+            maxResults=len(video_ids),
+        ).execute()
+    except Exception as exc:
+        msg = str(exc)
+        if "insufficient" in msg.lower() or "scope" in msg.lower() or "403" in msg:
+            logger.warning(
+                "Analytics query rejected (likely missing yt-analytics.readonly "
+                "scope — re-auth needed): %s", msg[:200],
+            )
+        else:
+            logger.warning("Analytics query failed: %s", msg[:200])
+        return {}
+    out: Dict[str, dict] = {}
+    headers = [h["name"] for h in resp.get("columnHeaders", [])]
+    for row in resp.get("rows", []) or []:
+        record = dict(zip(headers, row))
+        vid = record.pop("video", None)
+        if vid:
+            out[vid] = record
+    return out
+
+
+def fetch(digests_dir: Path, days: int) -> Optional[dict]:
+    """Build the stats payload, or None if there is nothing to do."""
+    videos = _load_index(digests_dir)
+    if not videos:
+        return None
+
+    try:
+        from engine.youtube import get_channel_credentials_from_env
+    except Exception as exc:
+        logger.info("engine.youtube unavailable (%s) — skipping", exc)
+        return None
+
+    today = _dt.date.today()
+    start = (today - _dt.timedelta(days=days)).isoformat()
+    end = today.isoformat()
+
+    # Group video ids by channel (each channel needs its own token).
+    by_channel: Dict[str, List[dict]] = defaultdict(list)
+    for v in videos:
+        by_channel[(v.get("channel") or "en").lower()].append(v)
+
+    metrics_by_video: Dict[str, dict] = {}
+    any_data = False
+    for channel, rows in by_channel.items():
+        creds = get_channel_credentials_from_env(channel)
+        if creds is None:
+            logger.info("No credentials for channel=%s — skipped", channel)
+            continue
+        service = _analytics_service(creds)
+        if service is None:
+            continue
+        ids = [r["video_id"] for r in rows]
+        for i in range(0, len(ids), _BATCH):
+            batch = ids[i:i + _BATCH]
+            got = _query_batch(service, batch, start, end)
+            if got:
+                any_data = True
+            metrics_by_video.update(got)
+
+    if not any_data:
+        logger.info("No analytics returned (no scope / no data yet) — no-op")
+        return None
+
+    # Assemble per-show structure for the updater + dashboard. Keyed by the
+    # show's output-dir name (where the updater writes the perf file back).
+    shows: Dict[str, dict] = defaultdict(lambda: {"videos": []})
+    for v in videos:
+        m = metrics_by_video.get(v["video_id"])
+        if not m:
+            continue
+        shows[v["_dir"]]["videos"].append({
+            "video_id": v["video_id"],
+            "show_slug": v.get("show_slug", ""),
+            "episode": v.get("episode"),
+            "kind": v.get("kind"),
+            "title": v.get("title", ""),
+            "hook": v.get("hook", ""),
+            "published": v.get("published", ""),
+            "views": int(float(m.get("views", 0) or 0)),
+            "estimated_minutes_watched": float(m.get("estimatedMinutesWatched", 0) or 0),
+            "average_view_duration_s": float(m.get("averageViewDuration", 0) or 0),
+            "average_view_percentage": float(m.get("averageViewPercentage", 0) or 0),
+        })
+
+    return {
+        "schema_version": 1,
+        "generated": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "window_days": days,
+        "shows": shows,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--digests", default="digests",
+                        help="Directory holding per-show output dirs")
+    parser.add_argument("--out", default="api/youtube_stats.json")
+    parser.add_argument("--days", type=int, default=90)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    payload = fetch(_ROOT / args.digests, args.days)
+    if payload is None:
+        return 0
+
+    n_videos = sum(len(s["videos"]) for s in payload["shows"].values())
+    logger.info("Fetched analytics for %d videos across %d shows",
+                n_videos, len(payload["shows"]))
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, ensure_ascii=False)[:4000])
+        return 0
+
+    out_path = _ROOT / args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    logger.info("Wrote %s", out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fetch_youtube_analytics.py
+++ b/scripts/fetch_youtube_analytics.py
@@ -50,7 +50,7 @@ import logging
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _ROOT = _SCRIPT_DIR.parent

--- a/scripts/update_youtube_performance.py
+++ b/scripts/update_youtube_performance.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Turn YouTube analytics into per-show 'what's working' guidance.
+
+Second half of the recursive YouTube-feedback loop: reads the analytics
+``scripts/fetch_youtube_analytics.py`` wrote to ``api/youtube_stats.json``
+and distils, per show, the angles/keywords that earned the best *retention*
+(average view percentage — the strongest content-quality signal YouTube
+exposes) into ``digests/<slug>/youtube_performance.json``.
+
+The title generator (``engine.youtube_titles._performance_hint``) reads that
+file and steers future titles toward what's landing. The signal is
+TITLE-ONLY (visual metadata, no audio) so it sits outside the landmine #17
+A/B-listen gate — the recursive improvement is safe to run automatically.
+
+Clean no-op when ``api/youtube_stats.json`` is missing or empty (the loop is
+dormant until the operator re-auths the analytics scope and data accrues).
+
+Usage::
+
+    python scripts/update_youtube_performance.py [--stats api/youtube_stats.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Dict, List
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("update_youtube_performance")
+
+# Need a few videos before retention numbers mean anything.
+_MIN_VIDEOS = 4
+# Content words to ignore when mining recurring keywords from titles.
+_STOP = frozenset({
+    "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "for",
+    "with", "at", "by", "from", "as", "is", "are", "was", "this", "that",
+    "how", "why", "what", "new", "now", "you", "your", "ep", "episode",
+    "daily", "show", "could", "will", "can", "vs", "its",
+})
+
+
+def _keywords(text: str) -> List[str]:
+    toks = re.findall(r"[A-Za-z0-9][A-Za-z0-9'-]{2,}", (text or ""))
+    return [t for t in toks if t.lower() not in _STOP]
+
+
+def _build_hint(videos: List[dict]) -> str:
+    """Compose a short natural-language steer from the best performers."""
+    rated = [v for v in videos if v.get("average_view_percentage")]
+    if len(rated) < _MIN_VIDEOS:
+        return ""
+    rated.sort(key=lambda v: v.get("average_view_percentage", 0), reverse=True)
+    top = rated[: max(3, len(rated) // 4)]  # top quartile (min 3)
+    median_pct = sorted(v["average_view_percentage"] for v in rated)[len(rated) // 2]
+
+    # Recurring keywords across the high-retention titles + hooks.
+    counter: Counter = Counter()
+    for v in top:
+        for kw in _keywords(v.get("title", "")) + _keywords(v.get("hook", "")):
+            counter[kw.lower()] += 1
+    common = [w for w, c in counter.most_common(8) if c >= 2]
+
+    parts: List[str] = []
+    if common:
+        parts.append(
+            "Topics/keywords that retained best recently: "
+            + ", ".join(common[:8]) + "."
+        )
+    # Show the operator/LLM 2-3 concrete high-retention titles as exemplars.
+    examples = [v["title"] for v in top[:3] if v.get("title")]
+    if examples:
+        parts.append("Highest-retention titles so far: "
+                     + " | ".join(f'"{t}"' for t in examples) + ".")
+    parts.append(
+        f"Median retention is {median_pct:.0f}% — beat it: keep the promise "
+        "concrete and front-load the strongest entity."
+    )
+    return " ".join(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stats", default="api/youtube_stats.json")
+    args = parser.parse_args()
+
+    stats_path = ROOT / args.stats
+    if not stats_path.exists():
+        logger.info("No YouTube stats at %s — nothing to do (clean no-op)",
+                    stats_path)
+        return 0
+    try:
+        shows: Dict[str, dict] = (
+            json.loads(stats_path.read_text(encoding="utf-8")).get("shows") or {}
+        )
+    except Exception as exc:
+        logger.warning("Could not parse %s: %s — skipping", stats_path, exc)
+        return 0
+
+    written = 0
+    # Keys are the show output-dir names (e.g. "tesla_shorts_time"), so the
+    # perf file lands next to that show's index file.
+    for dir_name, payload in shows.items():
+        videos = payload.get("videos") or []
+        hint = _build_hint(videos)
+        if not hint:
+            logger.info("%s: too few rated videos (%d) — skipped",
+                        dir_name, len(videos))
+            continue
+        out_dir = ROOT / "digests" / dir_name
+        if not out_dir.exists():
+            logger.info("%s: no output dir — skipped", dir_name)
+            continue
+        out = {
+            "schema_version": 1,
+            "generated": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+            "video_count": len(videos),
+            "title_hint": hint,
+        }
+        (out_dir / "youtube_performance.json").write_text(
+            json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        written += 1
+        logger.info("%s: wrote youtube_performance.json", dir_name)
+
+    logger.info("Updated YouTube performance for %d show(s)", written)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shows/prompts/_shared/youtube_title.txt
+++ b/shows/prompts/_shared/youtube_title.txt
@@ -8,7 +8,7 @@ SPOKEN HOOK (the on-air opener — for context, do NOT just copy it): {hook}
 TOPIC KEYWORDS: {keywords}
 EPISODE CONTENT (excerpt):
 {digest_excerpt}
-
+{performance_hint}
 Write {n} distinct YouTube title candidates, best first, one per line.
 
 RULES (2025-2026 YouTube best practice):

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -281,14 +281,11 @@ youtube:
   video_resolution: "720p"
   video_aspect_ratio: "16:9"
 
-  # ---- Hybrid short video clips (Phase 4, June 2026 pilot) ----
-  # A few SHORT Grok clips interleaved with the still slideshow for motion
-  # (NOT full-episode video). ~3 × 5 s × $0.07 ≈ $1.05/episode. Best-effort:
-  # falls back to all-stills on any failure. Tesla + SpaceX pilot.
-  video_clips_enabled: true
-  video_clips_count: 3
-  video_clip_seconds: 5
-  video_clips_resolution: "720p"
+  # ---- Hybrid short video clips — RETIRED June 2026 ----
+  # Removed network-wide (see shows/tesla.yaml): ~33% clip success, ~$0.35/ep
+  # for one clip, and the extra render risked the 40-min timeout. Visual appeal
+  # now comes from free slideshow motion (crossfades + varied Ken Burns).
+  video_clips_enabled: false
 
   # Grok Imagine for all imagery (long-form slideshow + Shorts) — unique,
   # narrative-tied spaceflight visuals and feeds the gallery pipeline. ~$0.32/

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -313,15 +313,14 @@ youtube:
   video_resolution: "720p"
   video_aspect_ratio: "16:9"    # Full-format episodes
 
-  # ---- Hybrid short video clips (Phase 4, June 2026 pilot) ----
-  # A few SHORT Grok clips interleaved with the still slideshow for motion
-  # (NOT full-episode video). ~3 × 5 s × $0.07 ≈ $1.05/episode. Best-effort:
-  # falls back to all-stills on any failure. Tesla + SpaceX pilot; review
-  # retention before expanding network-wide.
-  video_clips_enabled: true
-  video_clips_count: 3
-  video_clip_seconds: 5
-  video_clips_resolution: "720p"
+  # ---- Hybrid short video clips — RETIRED June 2026 ----
+  # The Grok text-to-video clip pilot was removed network-wide: ~33% clip
+  # success rate (1/3 per episode), ~$0.35/ep for a single 5 s clip among ~48
+  # slideshow segments (the most expensive component for the weakest payoff),
+  # and the extra render pushed Tesla near the 40-min pipeline timeout. Visual
+  # appeal is now driven by free slideshow motion (crossfades + varied Ken
+  # Burns) over Grok Imagine stills. Leave disabled.
+  video_clips_enabled: false
 
   # ---- Show-specific video prompt customization ----
   # Genre/mood guide the visual generation. Keywords are shown to Grok

--- a/shows/topic_queues/first_principles.yaml
+++ b/shows/topic_queues/first_principles.yaml
@@ -300,3 +300,31 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
+- id: lithium-battery-cost-curve
+  title: 'The Battery Pack: Cost Per Kilowatt-Hour From First Principles'
+  brief: Concrete example (modern). For decades a battery was treated as an expensive black box, but the magic-wand floor is the raw cost of the active materials and the energy to assemble cells, not the assembled pack price. Reasoning from the materials up, engineers and manufacturers attacked where the Idiot Index actually lived - cell chemistry, manufacturing scale, pack engineering, and yield - and the cost per kilowatt-hour fell along a steep, sustained curve over a couple of decades. Trace how that decline moved batteries from a rounding-error novelty to the enabler of electric vehicles and grid storage, the chemistry and factory-scale breakthroughs behind it, and the honest catch that some input metals carry their own supply and price floors. Treat every figure as approximate.
+  category: concrete_example
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: modular-housing-construction
+  title: 'Modular Housing: The Building Cost That Is Not the Materials'
+  brief: Opportunity area. A house is mostly cheap, abundant materials - lumber, gypsum, concrete, glass - yet the delivered price per square foot stays stubbornly high, so the magic-wand insight is that the floor is not the materials but the way we build. Reason about where the Idiot Index actually sits - on-site labor done in the weather, permitting and inspection cycles, financing carry, and the one-off custom nature of each build - rather than the bill of materials. Examine first-principles levers like factory-built modules, standardized designs, automated framing, and permitting reform that could push delivered housing cost toward its material floor. Cover the honest constraints of transport limits, local code fragmentation, and site preparation, and treat all figures as approximate.
+  category: opportunity_area
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: mechanical-refrigeration
+  title: 'Refrigeration: From Harvested Ice to Manufactured Cold'
+  brief: Concrete example (historical). Before mechanical refrigeration, cold was a harvested commodity - ice cut from frozen lakes, shipped in sawdust, and sold by the block - so the magic-wand floor was never the ice itself but the energy and machinery needed to move heat out of a box on demand. Reasoning from thermodynamics, inventors built vapor-compression cycles that could make cold anywhere, and the price of refrigeration collapsed as the equipment improved and scaled. Trace the first-principles reasoning, how cheap reliable cold then reshaped food supply, medicine, and entire cities, and the honest catch that the early refrigerants carried serious safety and environmental costs that took generations to address. Treat every figure as approximate.
+  category: concrete_example
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: precision-fermentation-protein
+  title: 'Protein Without the Animal: Reasoning Down the Cost'
+  brief: Opportunity area. Producing protein by raising an animal spends most of its input energy on the animal living its life, so the magic-wand insight is that the molecule you actually want - a specific protein - can in principle be brewed directly by microbes for a fraction of the thermodynamic input. Reason about where the delivered cost truly lives - bioreactor capacity, feedstock sugars, purification, and regulatory approval - rather than the protein itself, which is cheap once the process works. Examine first-principles levers like cheaper feedstocks, larger and continuous fermentation, strain engineering, and downstream-processing improvements that could drive cost toward the input-energy floor. Cover the honest constraints of scale-up economics, taste and texture, and consumer acceptance, and treat all figures as approximate.
+  category: opportunity_area
+  produced: false
+  episode_number: null
+  produced_date: null

--- a/tests/test_chapter_auto_titles.py
+++ b/tests/test_chapter_auto_titles.py
@@ -21,6 +21,7 @@ from engine.chapters import (
     Chapter,
     parse_chapters,
     _first_sentence_as_title,
+    _best_headline_for_segment,
 )
 
 
@@ -150,6 +151,76 @@ def test_auto_segment_titles_derive_from_content():
         f"At least one auto-segment should have a content-derived title; "
         f"got {auto_titles!r}"
     )
+
+
+def test_auto_segment_prefers_clean_digest_headlines():
+    """When the digest's clean per-story headlines are supplied, the
+    auto-segment fallback titles chapters with the matching headline
+    (not the spoken first-sentence fragment)."""
+    # Each story paragraph is padded past the ~120-word segment floor so
+    # the splitter lands one break per story (mirrors a real episode).
+    robotaxi = (
+        "Knowing this context, the big news is that Tesla just launched its "
+        "robotaxi service across three Texas cities this morning. " +
+        "The pilot fleet operates in Austin, Houston, and Dallas with riders "
+        "hailing autonomous trips through the existing mobile application. " * 6
+    )
+    semi = (
+        "Shifting gears to the trucking side of the business now. "
+        "California regulators disclosed the Tesla Semi battery pack sizes in "
+        "a routine safety filing today. " +
+        "The larger pack supports long-haul routes while the smaller pack "
+        "targets regional fleet operators running shorter distances. " * 6
+    )
+    script = (
+        "Welcome back to the show, everybody.\n\n"
+        f"{robotaxi}\n\n"
+        f"{semi}\n\n"
+        "That wraps up today's show. Thanks for listening, see you tomorrow."
+    )
+    headlines = [
+        "Tesla unveils robotaxi service in Texas",
+        "California discloses Tesla Semi battery sizes",
+    ]
+    chapters = parse_chapters(
+        script,
+        section_markers=[
+            {"pattern": r"\bWelcome back\b", "title": "Introduction"},
+        ],
+        show_name="TestShow",
+        min_chapters=4,
+        auto_segment_target_seconds=40.0,
+        estimated_words_per_minute=165.0,
+        story_headlines=headlines,
+    )
+    titles = [c.title for c in chapters]
+    # At least one auto-segment chapter should carry a verbatim headline.
+    assert any(t in headlines for t in titles[1:]), (
+        f"Expected a clean headline title; got {titles!r}"
+    )
+    # And no clean-headline chapter should reuse the same headline twice.
+    headline_hits = [t for t in titles if t in headlines]
+    assert len(headline_hits) == len(set(headline_hits))
+
+
+def test_best_headline_for_segment_requires_real_overlap():
+    """A segment that shares no topical words with any headline yields ""
+    so the caller can fall back to the first-sentence title."""
+    used: set = set()
+    seg = "The weather today is mild and pleasant across the region."
+    headlines = ["Tesla unveils robotaxi service in Texas"]
+    assert _best_headline_for_segment(seg, headlines, used) == ""
+    assert not used  # nothing claimed when no match
+
+
+def test_best_headline_for_segment_claims_match_once():
+    used: set = set()
+    headlines = ["Tesla unveils robotaxi service in Texas"]
+    seg = "Tesla just launched its robotaxi service across Texas cities."
+    title = _best_headline_for_segment(seg, headlines, used)
+    assert title == "Tesla unveils robotaxi service in Texas"
+    # Second segment can't reuse the claimed headline.
+    assert _best_headline_for_segment(seg, headlines, used) == ""
 
 
 def test_auto_segment_falls_back_to_segment_n_when_text_unusable():

--- a/tests/test_planetterrian_quality_pass.py
+++ b/tests/test_planetterrian_quality_pass.py
@@ -146,7 +146,7 @@ class TestMissingClosingGuard:
         def fake_generate(template_vars, config, tracker=None):
             return script
 
-        def fake_parse(podcast_script, markers, show_name=""):
+        def fake_parse(podcast_script, markers, show_name="", **kwargs):
             captured["script"] = podcast_script
             return []
 

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -19,6 +19,7 @@ from engine.video import (
     _AUDIO_ENCODE,
     _SUBTITLES_FORCE_STYLE,
     _VIDEO_ENCODE,
+    _VIDEO_ENCODE_FAST,
     _drawtext_escape,
     _long_form_cmd,
     _long_form_filter_graph,
@@ -561,11 +562,28 @@ def test_wrap_caption_default_budget_fits_realistic_hook():
 
 def test_slideshow_filter_graph_has_per_scene_chains():
     graph = _slideshow_filter_graph(scene_count=4)
-    # One zoompan chain per scene, then a final concat.
+    # One zoompan chain per scene, then a rotating xfade chain (≥2 scenes).
     assert graph.count("zoompan") == 4
     assert graph.count("[s0]") >= 1
     assert graph.count("[s3]") >= 1
+    # Crossfade transitions replace the old hard-cut concat for ≥2 scenes.
+    assert "concat=" not in graph
+    assert graph.count("xfade=transition=") == 3  # N-1 joins for 4 scenes
+    assert graph.endswith("[v]")
+
+
+def test_slideshow_filter_graph_hard_cut_fallback():
+    """crossfade=0 (the ffmpeg-failure retry path) hard-cuts via concat."""
+    graph = _slideshow_filter_graph(scene_count=4, crossfade=0.0)
     assert "concat=n=4:v=1:a=0[v]" in graph
+    assert "xfade" not in graph
+    assert graph.endswith("[v]")
+
+
+def test_slideshow_filter_graph_single_scene_uses_concat():
+    """A lone scene can't xfade — it must still terminate at [v]."""
+    graph = _slideshow_filter_graph(scene_count=1)
+    assert "xfade" not in graph
     assert graph.endswith("[v]")
 
 
@@ -586,9 +604,11 @@ def test_slideshow_cmd_has_one_input_per_scene(tmp_path):
     assert cmd.count("-loop") == 3
     # No audio in slideshow output.
     assert "-an" in cmd
-    # Encoding profile applies (keyframe args present).
-    for token in _VIDEO_ENCODE:
+    # Stage-1 slideshow is an intermediate → fast encode profile (re-encoded
+    # by the stage-2 composite, which carries the full keyframe profile).
+    for token in _VIDEO_ENCODE_FAST:
         assert token in cmd
+    assert "veryfast" in cmd
     assert cmd[-1] == str(out)
 
 
@@ -810,7 +830,9 @@ def test_slideshow_filter_graph_supports_vertical_dimensions():
     assert "1080:1920" in graph or "s=1080x1920" in graph
     # Per-scene zoompan still drives motion.
     assert graph.count("zoompan") == 3
-    assert "concat=n=3:v=1:a=0[v]" in graph
+    # ≥2 scenes → rotating xfade transitions (concat is the crossfade=0 fallback).
+    assert graph.count("xfade=transition=") == 2
+    assert graph.endswith("[v]")
 
 
 def test_slideshow_cmd_accepts_width_height(tmp_path):

--- a/tests/test_youtube_feedback_loop.py
+++ b/tests/test_youtube_feedback_loop.py
@@ -1,0 +1,139 @@
+"""Drift guards for the recursive YouTube-feedback loop (June 2026).
+
+Pieces under test:
+  * engine.youtube_index.record_video — per-show video→episode index
+    (per-show, NOT a shared file, to avoid concurrent push-contention).
+  * engine.youtube.YOUTUBE_SCOPES carries yt-analytics.readonly.
+  * engine.youtube_titles._performance_hint reads the per-show signal
+    file and is a clean no-op when absent.
+  * scripts/fetch_youtube_analytics.py + update_youtube_performance.py
+    are clean no-ops with no data (the loop ships dormant).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from engine import youtube_index
+from engine.youtube import YOUTUBE_SCOPES
+
+
+def _load_script(name: str):
+    path = _ROOT / "scripts" / name
+    spec = importlib.util.spec_from_file_location(name.replace(".py", ""), path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestScope:
+    def test_analytics_scope_present(self):
+        assert any("yt-analytics.readonly" in s for s in YOUTUBE_SCOPES), (
+            "the feedback loop needs the analytics read scope"
+        )
+
+    def test_upload_scopes_still_present(self):
+        # Re-auth must not drop the upload/publish scopes.
+        joined = " ".join(YOUTUBE_SCOPES)
+        assert "youtube.upload" in joined
+        assert "youtube.force-ssl" in joined
+
+
+class TestVideoIndex:
+    def test_per_show_path_not_shared(self):
+        p = youtube_index.index_path_for("tesla")
+        assert p == Path("digests/tesla/youtube_videos.json")
+        # Two shows must resolve to different files (no shared aggregate).
+        assert youtube_index.index_path_for("spacex") != p
+
+    def test_record_and_upsert(self, tmp_path):
+        idx = tmp_path / "tesla" / "youtube_videos.json"
+        assert youtube_index.record_video(
+            video_id="v1", show_slug="tesla", episode=526, kind="long",
+            title="A", index_path=idx)
+        assert youtube_index.record_video(
+            video_id="v1", show_slug="tesla", episode=526, kind="long",
+            title="B", index_path=idx)  # upsert, no dup
+        assert youtube_index.record_video(
+            video_id="v2", show_slug="tesla", episode=526, kind="short",
+            index_path=idx)
+        data = json.loads(idx.read_text())
+        ids = [v["video_id"] for v in data["videos"]]
+        assert ids == ["v1", "v2"]
+        assert data["videos"][0]["title"] == "B"  # upserted in place
+
+    def test_empty_video_id_is_noop(self, tmp_path):
+        idx = tmp_path / "x" / "youtube_videos.json"
+        assert youtube_index.record_video(
+            video_id="", show_slug="x", episode=1, kind="long",
+            index_path=idx) is False
+        assert not idx.exists()
+
+    def test_corrupt_index_does_not_lose_new_row(self, tmp_path):
+        idx = tmp_path / "x" / "youtube_videos.json"
+        idx.parent.mkdir(parents=True)
+        idx.write_text("{not json", encoding="utf-8")
+        assert youtube_index.record_video(
+            video_id="v9", show_slug="x", episode=1, kind="long", index_path=idx)
+        data = json.loads(idx.read_text())
+        assert [v["video_id"] for v in data["videos"]] == ["v9"]
+
+
+class TestPerformanceHint:
+    def test_no_file_is_empty(self, tmp_path):
+        from engine.youtube_titles import _performance_hint
+        assert _performance_hint(tmp_path) == ""  # dir exists, no perf file
+
+    def test_none_dir_is_empty(self):
+        from engine.youtube_titles import _performance_hint
+        assert _performance_hint(None) == ""
+
+    def test_reads_title_hint(self, tmp_path):
+        import json
+        from engine.youtube_titles import _performance_hint
+        (tmp_path / "youtube_performance.json").write_text(
+            json.dumps({"title_hint": "robotaxi retains best"}), encoding="utf-8")
+        out = _performance_hint(tmp_path)
+        assert "robotaxi retains best" in out
+        assert "WHAT'S WORKING" in out
+
+
+class TestUpdaterHint:
+    def test_build_hint_needs_minimum_videos(self):
+        uyp = _load_script("update_youtube_performance.py")
+        vids = [{"title": "t", "hook": "h", "average_view_percentage": 50}] * 2
+        assert uyp._build_hint(vids) == ""
+
+    def test_build_hint_surfaces_keywords_and_median(self):
+        uyp = _load_script("update_youtube_performance.py")
+        vids = [
+            {"title": "Tesla Robotaxi Launch Texas", "hook": "robotaxi",
+             "average_view_percentage": 62},
+            {"title": "Tesla Robotaxi Expands Cities", "hook": "robotaxi",
+             "average_view_percentage": 58},
+            {"title": "Tesla Semi Battery", "hook": "semi",
+             "average_view_percentage": 40},
+            {"title": "Tesla Earnings", "hook": "earnings",
+             "average_view_percentage": 30},
+            {"title": "Tesla FSD", "hook": "fsd",
+             "average_view_percentage": 25},
+        ]
+        hint = uyp._build_hint(vids)
+        assert "robotaxi" in hint.lower()
+        assert "Median retention" in hint
+
+
+class TestScriptsAreCleanNoOps:
+    def test_fetch_no_data(self, tmp_path):
+        fya = _load_script("fetch_youtube_analytics.py")
+        # No per-show indexes under an empty digests dir → None (no-op).
+        assert fya.fetch(tmp_path, days=90) is None


### PR DESCRIPTION
## Summary

Addresses the full request: remove Grok video clips network-wide (images only), make the videos more visually appealing **cheaply** without causing problems, speed up the render, fix YouTube chapter titles, and wire a recursive YouTube → workflow feedback loop. **No audio changes** anywhere in this PR — all of it is video/metadata/infra, so it sits outside the landmine #17 A/B-listen gate.

### 1. Clips removed — images only (`shows/{tesla,spacex}.yaml`)
The only two shows with `video_clips_enabled: true` are flipped to `false` (config block replaced with a "RETIRED" note). `engine/grok_video_clips.py` stays in-tree but is now dead/harmless.

### 2. Cheap visual appeal — crossfades + varied Ken Burns (`engine/video.py`)
- Rotating `xfade` transitions (fade / dissolve / smoothleft / fadeblack / smoothright) between Ken Burns scenes, replacing the hard-cut `concat`. Per-scene clip-length + offset compensation keeps total runtime unchanged. This is the real fix for YouTube's 2025-26 "static slideshow" penalty — at zero added cost.
- **Safety net:** hard-cut `concat` remains for `<2` scenes and as an automatic ffmpeg-failure retry, so a transition bug can never block a render (worst case = the pre-existing hard-cut look).
- **Gallery image reuse was evaluated and deliberately deferred:** injecting past images into a story-specific slideshow risks topic mismatch (a "don't cause problems" violation) for marginal gain now that crossfades solve the motion problem. Easy to revisit.

### 3. Faster render — `_VIDEO_ENCODE_FAST` (`engine/video.py`)
The stage-1 slideshow is an *intermediate* re-encoded by the stage-2 composite, so it now uses a `veryfast`/`crf 20` profile. Cuts the long-form render by several minutes — the main creep toward the 40-min pipeline timeout that stranded clip-era episodes. Delivered pixels are unchanged (stage 2 still carries the full keyframe profile).

### 4. Headline-based chapter titles (`engine/chapters.py`)
The auto-segment fallback titled chapters from raw mid-sentence spoken text ("Knowing this, when you hear claims…"). It now matches each segment to the digest's clean per-story headlines (`extract_story_headlines`) by content-word overlap, falling back to the first sentence then `Segment N`. Each headline is claimed once. Threaded through both `parse_chapters` call sites (`run_show.py`, `engine/pipeline.py`).

### 5. Recursive YouTube → workflow feedback loop (ships dormant)
Mirrors the proven OP3 download-stats loop, for YouTube performance:
- `engine/youtube_index.record_video` → `digests/<output_dir>/youtube_videos.json` (**per-show, not shared** — a network-wide index would re-introduce the concurrent push-contention fixed in #731).
- `scripts/fetch_youtube_analytics.py` → `api/youtube_stats.json` (views / watch-time / **average view %**; impressions/CTR are Studio-only and omitted).
- `scripts/update_youtube_performance.py` → `digests/<dir>/youtube_performance.json` (per-show "what's working").
- `engine/youtube_titles` injects that hint into the title prompt → future titles lean toward what retained.
- Added `yt-analytics.readonly` to `YOUTUBE_SCOPES`; wired fetch+update into nightly maintenance after the OP3 step.

Keyed off the show's **output dir** so slug≠dir shows (tesla → `tesla_shorts_time`) map correctly. Clean no-op until the operator re-auths + data accrues. Topic steering from retention (digest prompt = audio) is deliberately staged behind the A/B gate. Full writeup: `docs/youtube_feedback_loop.md`.

## ⚠️ Operator action required
**One-time YouTube OAuth re-auth.** The analytics scope was added to `YOUTUBE_SCOPES`, so the stored refresh token must be re-authorised (`scripts/youtube_oauth_bootstrap.py`, re-consent, update `YOUTUBE_REFRESH_TOKEN_EN`/`_RU`). Uploads keep working on the old token; only the analytics read no-ops until then. See `docs/youtube_feedback_loop.md`.

## Testing
- New/updated drift guards: `tests/test_youtube_feedback_loop.py` (11), `tests/test_chapter_auto_titles.py` (headline matching), `tests/test_video_commands.py` (xfade + fast-encode), `tests/test_planetterrian_quality_pass.py` (fake-parse kwarg).
- 226 focused tests pass; end-to-end loop verified with a stubbed analytics service including the slug≠dir case.
- Pre-existing/environmental failures unrelated to this PR: `test_youtube.py` + `test_tesla_hook.py` errors are a broken `cryptography`/`_cffi_backend` sandbox install; the `first_principles` queue-runway failure is a topic-queue restock reminder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3

---
_Generated by [Claude Code](https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3)_