### PR TITLE
Bootstrap OAuth from canonical YOUTUBE_SCOPES (include analytics scope)

### DIFF
--- a/scripts/youtube_oauth_bootstrap.py
+++ b/scripts/youtube_oauth_bootstrap.py
@@ -16,9 +16,14 @@ Usage::
 
     python scripts/youtube_oauth_bootstrap.py path/to/client_secrets.json
 
-The token is granted ``youtube.upload`` + ``youtube`` scopes (the second
-is needed for ``thumbnails.set`` and channel reads). Run once per
-channel, signing into the matching Google account each time.
+The token is granted the full ``engine.youtube.YOUTUBE_SCOPES`` set —
+``youtube.upload`` + ``youtube`` (thumbnails.set / channel reads) +
+``youtube.force-ssl`` (caption upload) + ``yt-analytics.readonly`` (the
+recursive feedback loop, ``docs/youtube_feedback_loop.md``). Run once per
+channel, signing into the matching Google account each time. If you are
+re-authorising an existing token to pick up a newly-added scope, revoke
+the old grant first at https://myaccount.google.com/permissions so Google
+re-shows the consent screen and returns a fresh refresh token.
 """
 
 from __future__ import annotations
@@ -27,13 +32,26 @@ import argparse
 import sys
 from pathlib import Path
 
-
-SCOPES = [
-    "https://www.googleapis.com/auth/youtube.upload",
-    "https://www.googleapis.com/auth/youtube",
-    # Required for captions.insert (CC track upload after long-form).
-    "https://www.googleapis.com/auth/youtube.force-ssl",
-]
+# Source the scope list from the single canonical place so this one-time
+# bootstrap can never drift from what the pipeline actually uses (it did:
+# the June 2026 yt-analytics.readonly addition for the feedback loop landed
+# in engine.youtube.YOUTUBE_SCOPES but not here, so re-auth'd tokens lacked
+# analytics). Falls back to a literal list — kept in sync — if the import
+# fails for any reason.
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+try:
+    from engine.youtube import YOUTUBE_SCOPES as SCOPES
+except Exception:
+    SCOPES = [
+        "https://www.googleapis.com/auth/youtube.upload",
+        "https://www.googleapis.com/auth/youtube",
+        # Required for captions.insert (CC track upload after long-form).
+        "https://www.googleapis.com/auth/youtube.force-ssl",
+        # Required for the YouTube-analytics feedback loop (June 2026).
+        "https://www.googleapis.com/auth/yt-analytics.readonly",
+    ]
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

Follow-up to #733. While the operator was running `scripts/youtube_oauth_bootstrap.py` to re-authorise for the new YouTube feedback loop, I caught that the bootstrap script carries its **own hardcoded `SCOPES` list** — so the `yt-analytics.readonly` scope #733 added to `engine.youtube.YOUTUBE_SCOPES` was **not** in the bootstrap. A token minted by the bootstrap would still lack analytics, and the feedback loop would stay dormant even after a full re-auth.

## Fix
- `scripts/youtube_oauth_bootstrap.py` now imports `YOUTUBE_SCOPES` from `engine.youtube` (single source of truth → the two can never drift again). Keeps a literal fallback, kept in sync, if the import fails.
- Verified the resolved scope set includes all four: `youtube.upload`, `youtube`, `youtube.force-ssl`, `yt-analytics.readonly`.
- Docstring updated to note the revoke-first step (`myaccount.google.com/permissions`) when re-authorising an existing grant for a newly-added scope, since Google only returns a fresh refresh token when it re-shows consent.

## Testing
- Script imports and resolves scopes correctly (analytics present); ruff clean. Pure scope-list sourcing change — no behavior change to the OAuth flow itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3

---
_Generated by [Claude Code](https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3)_