### PR TITLE
Russian-dubbed YouTube videos on @NerraRU for the top 4 English shows

### DIFF
--- a/.github/workflows/multilingual.yml
+++ b/.github/workflows/multilingual.yml
@@ -158,6 +158,23 @@ jobs:
           # `</dev/null`: keep ffmpeg/ffprobe from consuming the step's stdin.
           python scripts/generate_translations.py "${{ matrix.show }}" --latest "$LATEST" --zh-approved $FORCE </dev/null
 
+      - name: Publish ${{ matrix.show }} Russian dubs to @NerraRU
+        if: always()
+        # Builds a Russian-dubbed video from the just-generated `ru` audio
+        # track (reusing the episode's gallery scene images) and uploads to
+        # the @NerraRU channel — only for shows with youtube.ru_dub_enabled.
+        # Clean no-op for every other show and when YOUTUBE_REFRESH_TOKEN_RU
+        # is unset. Off the episode critical path → no timeout risk.
+        env:
+          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+          YOUTUBE_REFRESH_TOKEN_RU: ${{ secrets.YOUTUBE_REFRESH_TOKEN_RU }}
+        run: |
+          LATEST="${{ github.event.inputs.latest }}"
+          [ -z "$LATEST" ] && LATEST=3
+          python scripts/publish_ru_dubs.py "${{ matrix.show }}" --latest "$LATEST" </dev/null || \
+            echo "::warning::RU dub publish failed for ${{ matrix.show }} (non-fatal)"
+
       - name: Build ${{ matrix.show }} language feeds
         if: always()
         env:

--- a/docs/ru_youtube_dubs.md
+++ b/docs/ru_youtube_dubs.md
@@ -1,0 +1,93 @@
+# Russian-dubbed YouTube videos (@NerraRU) — June 2026
+
+Publishes Russian-language videos of the English shows to the **@NerraRU**
+channel, built from the Russian **audio** track the multilingual pipeline
+already generates for every English show. No new audio, no new images — it
+reuses both.
+
+## What it does
+
+For a show with `youtube.ru_dub_enabled: true`, the decoupled multilingual
+workflow, after generating the episode's `ru` audio track, also:
+
+1. Pulls the episode's **already-generated Grok scene images** from the gallery
+   manifest's public R2 URLs (`segment_card` = 16:9 long-form, `social` = 9:16
+   Short) — **zero extra image-generation cost**.
+2. Renders a long-form video (RU audio + those scenes) and a 1 Short.
+3. Uploads both to **@NerraRU** (`channel: ru` token) with the Russian
+   title/description from the translation record + the Russian AI-voice
+   disclosure, and adds them to the show's @NerraRU playlist.
+4. Records each upload in a **per-show** `digests/<slug>/youtube_videos.ru.json`
+   index (per-show → no cross-show push contention; also feeds the analytics
+   loop).
+
+```
+multilingual.yml (decoupled — off the episode critical path)
+  generate_translations.py  → digests/<slug>/…​.ru.mp3 + summaries `ru` track
+  publish_ru_dubs.py        → engine.ru_dub.publish_ru_dub
+        gallery images (R2)  +  ru.mp3  →  long-form + Short  →  @NerraRU
+```
+
+### Why the decoupled workflow, not the episode pipeline
+
+The English episode pipeline is timeout-bounded; adding RU TTS + a second
+render there is exactly what caused the partial-publish landmine that pushed
+multilingual into its own workflow. The RU dub lives in that same off-critical
+workflow, so it can never delay or break an English publish.
+
+### Why reuse gallery images instead of regenerating
+
+Every Grok scene is already uploaded to the `nerra-gallery` R2 bucket with a
+committed manifest keyed by `show_slug` + `episode_id`. Fetching those public
+URLs costs nothing and keeps the RU video visually identical to the English
+one. If the manifest hasn't been rebuilt for the newest episode yet, the dub
+falls back to the cover-only slideshow and a later idempotent sweep picks up
+the real scenes.
+
+## Enabled shows (June 2026)
+
+`tesla`, `spacex`, `fascinating_frontiers`, `modern_investing` —
+long-form + 1 Short each. Every other show is `ru_dub_enabled: false`
+(byte-for-byte no-op).
+
+## Operator one-time setup
+
+1. **@NerraRU OAuth token** — `YOUTUBE_REFRESH_TOKEN_RU` must be set (run
+   `scripts/youtube_oauth_bootstrap.py` signed into the @NerraRU account; the
+   token now includes `yt-analytics.readonly` too). Until it's set, the dub
+   step logs `no_ru_credentials` and no-ops.
+2. **Playlists** (optional but recommended, landmine #15) — create one playlist
+   per show on @NerraRU in Studio, flag it as a podcast, and put its ID in the
+   show YAML's `youtube.ru_podcast_playlist_id`. Uploads still publish without
+   it (a warning is logged); they just aren't added to a playlist.
+
+## Cost & cadence
+
+- Incremental cost per episode ≈ the RU translation+TTS that **already runs**
+  today (~$0.18) + a cheap slideshow render. Image cost is **$0** (reused).
+- @NerraRU gains 4 long-form + 4 Shorts/day on top of the 2 native RU shows —
+  well under the channel's 200k quota and the ~30/day authenticity soft-cap.
+
+## Verifying
+
+```bash
+# Dry-run (resolves the RU track + title, renders/uploads nothing):
+python scripts/publish_ru_dubs.py all --dry-run
+
+# One episode for real (needs YOUTUBE_REFRESH_TOKEN_RU + ffmpeg):
+python scripts/publish_ru_dubs.py tesla --episode <N>
+```
+
+Idempotent: an episode already in `youtube_videos.ru.json` is skipped unless
+`--force`.
+
+## Deliberately left for later
+
+- **Russian chapters / burned-in captions** — the English chapter markers don't
+  match the Russian script, so v1 ships without chapters on the RU long-form.
+  A Russian-aware chapter pass (or a Whisper transcript of the RU audio) is the
+  follow-up.
+- **Smart Shorts window** — without a Russian transcript the Short starts at the
+  configured offset rather than the most-engaging beat.
+
+Drift guards: `tests/test_ru_dub.py`.

--- a/engine/config.py
+++ b/engine/config.py
@@ -453,6 +453,16 @@ class YouTubeConfig:
     tags: List[str] = field(default_factory=list)
     synthetic_disclosure: str = ""
     podcast_playlist_id: Optional[str] = None
+    # ---- Russian-dub YouTube (June 2026) ----
+    # When true, the decoupled multilingual flow also builds a Russian-dubbed
+    # video from the show's auto-generated `ru` audio track (reusing the same
+    # gallery scene images) and uploads it to the @NerraRU channel
+    # (channel=ru token). English upload is unaffected. Off by default →
+    # byte-for-byte no-op. See engine.ru_dub / docs/ru_youtube_dubs.md.
+    ru_dub_enabled: bool = False
+    # @NerraRU playlist for this show's RU dubs (operator creates + flags it
+    # in Studio per landmine #15; uploads still publish without it, warned).
+    ru_podcast_playlist_id: Optional[str] = None
     # ---- Slideshow imagery (Pexels search) ----
     # Curated, disambiguated search phrases. When non-empty, these are
     # used verbatim and the show's ``keywords:`` list is ignored. This

--- a/engine/ru_dub.py
+++ b/engine/ru_dub.py
@@ -1,0 +1,327 @@
+"""Russian-dubbed YouTube videos for the English shows (@NerraRU).
+
+The English shows already auto-generate a Russian *audio* track per episode
+(``engine.multilingual`` → ``languages: [ru, …]``) which today only becomes an
+R2 file + a per-language podcast RSS feed. This module turns that existing
+Russian track into a **video** and uploads it to the @NerraRU YouTube channel,
+reusing the episode's already-generated Grok scene images (pulled from the
+gallery manifest's public R2 URLs — zero extra image-generation cost).
+
+Design contract (mirrors every optional integration here):
+  - Runs in the **decoupled multilingual workflow**, never the episode's
+    critical path — so it cannot re-introduce the timeout/partial-publish
+    landmine that decoupling exists to prevent.
+  - Fully best-effort + self-guarding: returns a status dict, never raises.
+    No-ops cleanly when the show hasn't opted in (``youtube.ru_dub_enabled``),
+    the RU track doesn't exist yet, the @NerraRU credentials
+    (``YOUTUBE_REFRESH_TOKEN_RU``) aren't set, or anything fails.
+  - English upload + the RU podcast feed are completely unaffected.
+
+See ``docs/ru_youtube_dubs.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_MANIFEST = PROJECT_ROOT / "site" / "data" / "gallery-manifest.json"
+
+# Russian AI-voice disclosure appended to every RU description (same text the
+# native RU shows speak; kept in sync with run_show._AI_DISCLOSURE_RU).
+_AI_DISCLOSURE_RU = (
+    "Дисклеймер об ИИ: подкаст курирует Патрик, "
+    "а озвучка создаётся с помощью ИИ-синтеза голоса."
+)
+
+
+def _episode_id(episode_num: int) -> str:
+    return f"ep{episode_num:03d}"
+
+
+def gallery_images_for_episode(
+    show_slug: str, episode_num: int, *,
+    intended_use: str = "segment_card",
+    manifest_path: Path = _MANIFEST,
+) -> List[str]:
+    """Public R2 URLs of this episode's scene images, in document order.
+
+    Filters the committed gallery manifest by ``show_slug`` + ``episode_id``
+    + ``intended_use`` (``segment_card`` = the 16:9 long-form scenes;
+    ``social`` = the 9:16 Shorts scenes). Empty list when the manifest has no
+    entry yet (the manifest rebuild can lag the newest episode — caller falls
+    back to the cover image, and a later sweep picks up the real scenes).
+    """
+    import json
+    try:
+        data = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.info("ru_dub: gallery manifest unreadable (%s) — no scenes", exc)
+        return []
+    eid = _episode_id(episode_num)
+    urls: List[str] = []
+    for img in data.get("images", []):
+        if (img.get("show_slug") == show_slug
+                and (img.get("episode_id") or "").lower() == eid
+                and img.get("intended_use") == intended_use
+                and img.get("original_url")):
+            urls.append(img["original_url"])
+    return urls
+
+
+def _download_images(urls: List[str], dest_dir: Path) -> List[Path]:
+    """Best-effort download of *urls* → dest_dir. Skips any that fail."""
+    import requests
+    paths: List[Path] = []
+    for i, url in enumerate(urls):
+        try:
+            resp = requests.get(url, timeout=60)
+            resp.raise_for_status()
+            ext = ".jpg" if ".jpg" in url.lower() or ".jpeg" in url.lower() else ".png"
+            p = dest_dir / f"scene_{i:02d}{ext}"
+            p.write_bytes(resp.content)
+            paths.append(p)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("ru_dub: failed to fetch scene %s: %s", url, exc)
+    return paths
+
+
+def _resolve_ru_audio(config, episode_num: int, rec: dict,
+                      ru_track: dict, dest_dir: Path) -> Optional[Path]:
+    """Local path to the RU mp3 — the freshly-rendered local file if present,
+    else downloaded from the track's R2 ``audio_url``."""
+    output_dir = PROJECT_ROOT / config.episode.output_dir
+    local = sorted(output_dir.glob(f"*_Ep{episode_num:03d}_*.ru.mp3"))
+    if local:
+        return local[-1]
+    url = ru_track.get("audio_url", "")
+    if not url:
+        return None
+    try:
+        import requests
+        resp = requests.get(url, timeout=120)
+        resp.raise_for_status()
+        p = dest_dir / f"ru_audio_ep{episode_num:03d}.mp3"
+        p.write_bytes(resp.content)
+        return p
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("ru_dub: could not fetch RU audio %s: %s", url, exc)
+        return None
+
+
+def _cover_path(config) -> Optional[Path]:
+    cands = [
+        PROJECT_ROOT / "assets" / "covers" / f"{config.slug.replace('_', '-')}.jpg",
+        PROJECT_ROOT / "assets" / "covers" / f"{config.slug}.jpg",
+    ]
+    rss_image = getattr(config.publishing, "rss_image", "") or ""
+    base = rss_image.rstrip("/").rsplit("/", 1)[-1]
+    if base:
+        cands.append(PROJECT_ROOT / "assets" / "covers" / base)
+    return next((c for c in cands if c.exists()), None)
+
+
+def _hashtags(config) -> str:
+    tags = [t for t in (getattr(config, "keywords", []) or [])][:3]
+    parts = []
+    for t in tags:
+        cleaned = "".join(ch for ch in t.title() if ch.isalnum())
+        if cleaned:
+            parts.append("#" + cleaned)
+    return " ".join(parts)
+
+
+def _ru_long_description(config, ru_desc: str) -> str:
+    base_url = getattr(config.publishing, "base_url", "https://nerranetwork.com")
+    lines = [ru_desc.strip(), "", f"🎧 {base_url}", "", _AI_DISCLOSURE_RU]
+    tags = _hashtags(config)
+    if tags:
+        lines += ["", tags]
+    return "\n".join(lines).strip()
+
+
+def _cap_title(title: str, limit: int = 95) -> str:
+    title = (title or "").strip()
+    return title if len(title) <= limit else title[: limit - 1].rstrip() + "…"
+
+
+def publish_ru_dub(
+    config, episode_num: int, *,
+    build_short: bool = True,
+    dry_run: bool = False,
+) -> Dict[str, object]:
+    """Build + upload the Russian-dubbed long-form (and optional Short) for
+    one episode of an English show. Returns a status dict; never raises."""
+    result: Dict[str, object] = {"status": "skip"}
+    yt = getattr(config, "youtube", None)
+    if not (yt and getattr(yt, "ru_dub_enabled", False)):
+        return result
+    ml = getattr(config, "multilingual", None)
+    if not (ml and ml.enabled and "ru" in (ml.languages or [])):
+        result["status"] = "no_ru_lang"
+        return result
+
+    # The RU audio track must already exist (the multilingual sweep makes it).
+    from engine.summaries_io import load_summaries
+    summaries_path = PROJECT_ROOT / config.publishing.summaries_json
+    try:
+        _w, records = load_summaries(summaries_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("ru_dub: cannot read summaries: %s", exc)
+        return result
+    rec = next((r for r in records if r.get("episode_num") == episode_num), None)
+    if not rec:
+        result["status"] = "no_record"
+        return result
+    ru_track = (rec.get("translations", {}) or {}).get("ru")
+    if not ru_track:
+        result["status"] = "no_ru_track"  # translation hasn't run yet
+        return result
+
+    ru_title = _cap_title(ru_track.get("title") or rec.get("episode_title") or "")
+    ru_desc = ru_track.get("description") or ru_title
+
+    # Dry-run is creds-independent so the operator can preview the resolved
+    # RU title before doing the @NerraRU OAuth.
+    if dry_run:
+        result.update(status="dryrun", title=ru_title)
+        return result
+
+    from engine.youtube import get_channel_credentials_from_env
+    creds = get_channel_credentials_from_env("ru")
+    if creds is None:
+        result["status"] = "no_ru_credentials"  # YOUTUBE_REFRESH_TOKEN_RU unset
+        return result
+
+    cover = _cover_path(config)
+    if cover is None:
+        logger.warning("ru_dub: no cover art for %s — skip", config.slug)
+        result["status"] = "no_cover"
+        return result
+
+    from engine.video import build_long_form_video, build_short_video
+    from engine.youtube import upload_video, add_video_to_playlist
+    from engine.youtube_index import record_video
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        audio = _resolve_ru_audio(config, episode_num, rec, ru_track, tmp)
+        if audio is None:
+            result["status"] = "no_ru_audio"
+            return result
+
+        # Reuse the episode's already-generated 16:9 scene images (zero cost).
+        long_urls = gallery_images_for_episode(
+            config.slug, episode_num, intended_use="segment_card")
+        long_scenes = _download_images(long_urls, tmp) if long_urls else []
+        date_str = (rec.get("date") or "")[:10]
+
+        # --- Long-form ---
+        try:
+            from engine.publisher import generate_episode_thumbnail
+            thumb = tmp / "ru_thumb.jpg"
+            generate_episode_thumbnail(
+                cover, episode_num, date_str, thumb,
+                hook=ru_title, show_name=config.name)
+            thumb_path = thumb if thumb.exists() else None
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("ru_dub: thumbnail failed (%s) — uploading without", exc)
+            thumb_path = None
+
+        long_mp4 = tmp / f"ru_long_ep{episode_num:03d}.mp4"
+        try:
+            build_long_form_video(
+                audio, cover, long_mp4,
+                scene_paths=long_scenes if len(long_scenes) >= 2 else None,
+                show_name=config.name)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("ru_dub: long-form render failed for Ep%s: %s",
+                         episode_num, exc)
+            result["status"] = "render_failed"
+            return result
+
+        long_url = ""
+        try:
+            up = upload_video(
+                long_mp4, credentials=creds,
+                title=ru_title,
+                description=_ru_long_description(config, ru_desc),
+                tags=list(getattr(config, "keywords", []) or []),
+                category_id=int(getattr(yt, "category_id", 28)),
+                default_language="ru",
+                privacy_status=getattr(yt, "privacy_status", "public"),
+                thumbnail_path=thumb_path,
+            )
+            long_url = up.watch_url
+            result["long_url"] = long_url
+            record_video(
+                video_id=up.video_id, show_slug=config.slug, episode=episode_num,
+                kind="long", title=ru_title, hook=ru_title, published=date_str,
+                watch_url=long_url, channel="ru",
+                index_path=PROJECT_ROOT / config.episode.output_dir
+                / "youtube_videos.ru.json")
+            pl = (getattr(yt, "ru_podcast_playlist_id", None) or "").strip()
+            if pl:
+                try:
+                    add_video_to_playlist(credentials=creds,
+                                          video_id=up.video_id, playlist_id=pl)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("ru_dub: playlist add failed: %s", exc)
+            else:
+                logger.info("ru_dub: no ru_podcast_playlist_id — skipped playlist")
+        except Exception as exc:  # noqa: BLE001
+            logger.error("ru_dub: long-form upload failed for Ep%s: %s",
+                         episode_num, exc)
+            result["status"] = "upload_failed"
+            return result
+
+        result["status"] = "done"
+
+        # --- Short (best-effort; failure never blocks the long-form result) ---
+        if build_short and getattr(yt, "publish_shorts", True):
+            try:
+                short_urls = gallery_images_for_episode(
+                    config.slug, episode_num, intended_use="social")
+                short_scenes = _download_images(short_urls, tmp) if short_urls else []
+                short_mp4 = tmp / f"ru_short_ep{episode_num:03d}.mp4"
+                build_short_video(
+                    audio, cover, short_mp4,
+                    start_offset=float(getattr(yt, "shorts_start_offset", 0.0) or 0.0),
+                    duration=float(getattr(yt, "short_duration_seconds", 55.0)),
+                    hook=ru_title,
+                    scene_paths=short_scenes if len(short_scenes) >= 2 else None,
+                    show_name=config.name)
+                sup = upload_video(
+                    short_mp4, credentials=creds,
+                    title=_cap_title(ru_title, 90) + " #Shorts",
+                    description=_ru_long_description(config, ru_desc),
+                    tags=list(getattr(config, "keywords", []) or []),
+                    category_id=int(getattr(yt, "category_id", 28)),
+                    default_language="ru",
+                    privacy_status=getattr(yt, "privacy_status", "public"))
+                result["short_url"] = sup.watch_url
+                record_video(
+                    video_id=sup.video_id, show_slug=config.slug,
+                    episode=episode_num, kind="short", title=ru_title,
+                    hook=ru_title, published=date_str, watch_url=sup.watch_url,
+                    channel="ru",
+                    index_path=PROJECT_ROOT / config.episode.output_dir
+                    / "youtube_videos.ru.json")
+                pl = (getattr(yt, "ru_podcast_playlist_id", None) or "").strip()
+                if pl:
+                    try:
+                        add_video_to_playlist(credentials=creds,
+                                              video_id=sup.video_id, playlist_id=pl)
+                    except Exception:  # noqa: BLE001
+                        pass
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("ru_dub: Short failed for Ep%s (non-fatal): %s",
+                               episode_num, exc)
+                result["short_error"] = str(exc)
+
+    return result

--- a/scripts/publish_ru_dubs.py
+++ b/scripts/publish_ru_dubs.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Publish Russian-dubbed videos to @NerraRU for the opted-in English shows.
+
+Runs AFTER ``scripts/generate_translations.py`` in the decoupled multilingual
+workflow: for each show with ``youtube.ru_dub_enabled`` it builds a video from
+the episode's already-generated Russian audio track (reusing the gallery scene
+images) and uploads it to the @NerraRU channel. See ``engine.ru_dub`` /
+``docs/ru_youtube_dubs.md``.
+
+Idempotent: skips episodes whose RU video is already recorded in the per-show
+``youtube_videos.ru.json`` index unless ``--force``.
+
+Usage::
+
+    python scripts/publish_ru_dubs.py all --latest 2
+    python scripts/publish_ru_dubs.py tesla --episode 526
+    python scripts/publish_ru_dubs.py all --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(PROJECT_ROOT / ".env")
+
+from engine import ru_dub  # noqa: E402
+from engine.config import discover_show_slugs, load_config  # noqa: E402
+from engine.summaries_io import load_summaries  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("publish_ru_dubs")
+
+
+def _ru_dub_shows() -> List[str]:
+    out = []
+    for slug in discover_show_slugs():
+        try:
+            cfg = load_config(f"shows/{slug}.yaml")
+        except Exception:  # noqa: BLE001
+            continue
+        yt = getattr(cfg, "youtube", None)
+        if yt and getattr(yt, "ru_dub_enabled", False):
+            out.append(slug)
+    return out
+
+
+def _already_done(config, episode_num: int) -> bool:
+    idx = PROJECT_ROOT / config.episode.output_dir / "youtube_videos.ru.json"
+    if not idx.exists():
+        return False
+    try:
+        data = json.loads(idx.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return False
+    return any(v.get("episode") == episode_num and v.get("kind") == "long"
+               for v in data.get("videos", []))
+
+
+def _select_episodes(config, latest: int, episode: Optional[int]) -> List[int]:
+    summaries_path = PROJECT_ROOT / config.publishing.summaries_json
+    try:
+        _w, records = load_summaries(summaries_path)
+    except Exception:  # noqa: BLE001
+        return []
+    nums = sorted((r["episode_num"] for r in records
+                   if isinstance(r.get("episode_num"), int)), reverse=True)
+    if episode is not None:
+        return [episode] if episode in nums else []
+    return nums[:latest]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("show", help='Show slug, or "all" for every ru_dub-enabled show')
+    ap.add_argument("--latest", type=int, default=2, help="Most recent N episodes")
+    ap.add_argument("--episode", type=int, default=None, help="One specific episode")
+    ap.add_argument("--force", action="store_true", help="Re-publish even if recorded")
+    ap.add_argument("--no-short", action="store_true", help="Long-form only")
+    ap.add_argument("--dry-run", action="store_true", help="Resolve only; no render/upload")
+    args = ap.parse_args()
+
+    slugs = _ru_dub_shows() if args.show == "all" else [args.show]
+    if not slugs:
+        logger.info("No ru_dub-enabled shows — nothing to do (clean no-op).")
+        return 0
+
+    total = 0
+    for slug in slugs:
+        try:
+            config = load_config(f"shows/{slug}.yaml")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("%s: cannot load config (%s) — skip", slug, exc)
+            continue
+        yt = getattr(config, "youtube", None)
+        if not (yt and getattr(yt, "ru_dub_enabled", False)):
+            logger.info("%s: ru_dub not enabled — skip", slug)
+            continue
+        for ep in _select_episodes(config, args.latest, args.episode):
+            if not args.force and not args.dry_run and _already_done(config, ep):
+                logger.info("%s Ep%s: RU dub already recorded — skip", slug, ep)
+                continue
+            res = ru_dub.publish_ru_dub(
+                config, ep, build_short=not args.no_short, dry_run=args.dry_run)
+            logger.info("%s Ep%s: %s", slug, ep, res.get("status"))
+            if res.get("status") in ("done", "dryrun"):
+                total += 1
+    logger.info("RU dubs processed: %d", total)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -290,6 +290,12 @@ youtube:
   shorts_start_mode: smart
   short_duration_seconds: 40
   channel: en
+  # Russian-dubbed video to @NerraRU from the auto-generated `ru` audio
+  # track (engine.ru_dub, decoupled multilingual flow). Operator must
+  # create + flag the @NerraRU playlist in Studio (landmine #15) and set
+  # ru_podcast_playlist_id; uploads still publish without it (warned).
+  ru_dub_enabled: true
+  ru_podcast_playlist_id: null
   category_id: 28
   default_language: en
   privacy_status: public

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -222,6 +222,12 @@ youtube:
   shorts_start_mode: smart
   short_duration_seconds: 40
   channel: en
+  # Russian-dubbed video to @NerraRU from the auto-generated `ru` audio
+  # track (engine.ru_dub, decoupled multilingual flow). Operator must
+  # create + flag the @NerraRU playlist in Studio (landmine #15) and set
+  # ru_podcast_playlist_id; uploads still publish without it (warned).
+  ru_dub_enabled: true
+  ru_podcast_playlist_id: null
   category_id: 25
   default_language: en
   image_queries:

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -261,6 +261,12 @@ youtube:
   # channel quota math (landmine #20) is unchanged by the swap.
   enabled: true
   channel: en
+  # Russian-dubbed video to @NerraRU from the auto-generated `ru` audio
+  # track (engine.ru_dub, decoupled multilingual flow). Operator must
+  # create + flag the @NerraRU playlist in Studio (landmine #15) and set
+  # ru_podcast_playlist_id; uploads still publish without it (warned).
+  ru_dub_enabled: true
+  ru_podcast_playlist_id: null
   category_id: 28               # Science & Technology
   default_language: en
   privacy_status: public

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -302,6 +302,12 @@ youtube:
   podcast_playlist_id: PLRHMnzNNXPYCRrcYpPwAzjaRXqzKRUl23
   enabled: true                 # Phase-1 rollout show
   channel: en
+  # Russian-dubbed video to @NerraRU from the auto-generated `ru` audio
+  # track (engine.ru_dub, decoupled multilingual flow). Operator must
+  # create + flag the @NerraRU playlist in Studio (landmine #15) and set
+  # ru_podcast_playlist_id; uploads still publish without it (warned).
+  ru_dub_enabled: true
+  ru_podcast_playlist_id: null
   category_id: 28               # Science & Tech (algorithm performs better than 2/Autos here)
   default_language: en
   privacy_status: public        # Phase-1 validated; uploads are public

--- a/tests/test_ru_dub.py
+++ b/tests/test_ru_dub.py
@@ -1,0 +1,111 @@
+"""Drift guards for the Russian-dubbed YouTube pipeline (engine.ru_dub).
+
+Covers the pure logic + the self-guarding no-op contract. Render/upload
+need ffmpeg + @NerraRU credentials and are validated by a real workflow run.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from engine import ru_dub
+from engine.config import load_config
+
+
+def _cfg(**yt):
+    return SimpleNamespace(
+        slug="tesla", name="Tesla Shorts Time",
+        youtube=SimpleNamespace(ru_dub_enabled=True, **yt),
+        multilingual=SimpleNamespace(enabled=True, languages=["ru"]),
+        publishing=SimpleNamespace(summaries_json="nope.json",
+                                   base_url="https://nerranetwork.com"),
+        episode=SimpleNamespace(output_dir="digests/tesla_shorts_time"),
+        keywords=["Tesla", "Cybercab"],
+    )
+
+
+class TestGalleryImageSelection:
+    def _manifest(self, tmp_path):
+        m = tmp_path / "gallery-manifest.json"
+        m.write_text(json.dumps({"images": [
+            {"show_slug": "tesla", "episode_id": "ep526",
+             "intended_use": "segment_card", "original_url": "https://r2/a.jpg"},
+            {"show_slug": "tesla", "episode_id": "ep526",
+             "intended_use": "social", "original_url": "https://r2/b.jpg"},
+            {"show_slug": "tesla", "episode_id": "ep525",
+             "intended_use": "segment_card", "original_url": "https://r2/c.jpg"},
+            {"show_slug": "spacex", "episode_id": "ep526",
+             "intended_use": "segment_card", "original_url": "https://r2/d.jpg"},
+            {"show_slug": "tesla", "episode_id": "ep526",
+             "intended_use": "segment_card"},  # no url → skipped
+        ]}), encoding="utf-8")
+        return m
+
+    def test_filters_by_show_episode_and_use(self, tmp_path):
+        m = self._manifest(tmp_path)
+        seg = ru_dub.gallery_images_for_episode(
+            "tesla", 526, intended_use="segment_card", manifest_path=m)
+        assert seg == ["https://r2/a.jpg"]  # not the social, ep525, spacex, or url-less
+        soc = ru_dub.gallery_images_for_episode(
+            "tesla", 526, intended_use="social", manifest_path=m)
+        assert soc == ["https://r2/b.jpg"]
+
+    def test_zero_padded_episode_id(self):
+        assert ru_dub._episode_id(7) == "ep007"
+        assert ru_dub._episode_id(526) == "ep526"
+
+    def test_missing_manifest_returns_empty(self, tmp_path):
+        assert ru_dub.gallery_images_for_episode(
+            "tesla", 1, manifest_path=tmp_path / "nope.json") == []
+
+
+class TestTextHelpers:
+    def test_cap_title(self):
+        assert ru_dub._cap_title("short") == "short"
+        long = "я" * 200
+        assert len(ru_dub._cap_title(long, 95)) <= 95
+        assert ru_dub._cap_title(long, 95).endswith("…")
+
+    def test_ru_description_has_disclosure_and_links(self):
+        out = ru_dub._ru_long_description(_cfg(), "Описание выпуска")
+        assert "Описание выпуска" in out
+        assert ru_dub._AI_DISCLOSURE_RU in out
+        assert "nerranetwork.com" in out
+        assert "#Tesla" in out  # keyword hashtag
+
+
+class TestGuards:
+    def test_skip_when_not_enabled(self):
+        cfg = _cfg()
+        cfg.youtube.ru_dub_enabled = False
+        assert ru_dub.publish_ru_dub(cfg, 1)["status"] == "skip"
+
+    def test_skip_when_ru_not_a_language(self):
+        cfg = _cfg()
+        cfg.multilingual.languages = ["fr", "es"]
+        assert ru_dub.publish_ru_dub(cfg, 1)["status"] == "no_ru_lang"
+
+    def test_no_record_when_summaries_missing(self):
+        # summaries_json points at a nonexistent file → no record → skip.
+        cfg = _cfg()
+        assert ru_dub.publish_ru_dub(cfg, 999)["status"] in ("skip", "no_record")
+
+
+class TestRealShowConfigs:
+    def test_four_shows_enabled(self):
+        for slug in ("tesla", "spacex", "fascinating_frontiers", "modern_investing"):
+            c = load_config(f"shows/{slug}.yaml")
+            assert c.youtube.ru_dub_enabled is True, slug
+            assert "ru" in (c.multilingual.languages or []), slug
+
+    def test_other_shows_not_enabled(self):
+        for slug in ("omni_view", "env_intel", "planetterrian"):
+            c = load_config(f"shows/{slug}.yaml")
+            assert c.youtube.ru_dub_enabled is False, slug


### PR DESCRIPTION
## Summary

Adds Russian-language videos of the English shows to **@NerraRU**, built from the Russian **audio track the multilingual pipeline already generates** for every English show (today that track only becomes an R2 file + a per-language podcast RSS feed). Enabled for **Tesla, SpaceX, Fascinating Frontiers, Modern Investing** — long-form + 1 Short each (the scope you picked).

No new audio and no new images: the RU video reuses the episode's existing Grok scene images, pulled from the gallery manifest's public R2 URLs (**$0 image cost**). The only incremental spend is the RU translation/TTS that already runs today (~$0.18/ep).

## How it works

```
multilingual.yml  (decoupled — off the episode critical path)
  generate_translations.py → digests/<slug>/….ru.mp3 + summaries `ru` track
  publish_ru_dubs.py       → engine.ru_dub.publish_ru_dub
       gallery images (R2)  +  ru.mp3  →  long-form + Short  →  @NerraRU
```

- **`engine/ru_dub.py`** — builds the long-form (RU audio + 16:9 `segment_card` scenes) and one Short (9:16 `social` scenes), Russian title/description from the translation record + the Russian AI-voice disclosure, uploads to the `channel: ru` token, adds to the RU playlist, and records each in a **per-show** `digests/<slug>/youtube_videos.ru.json` index (per-show → no cross-show push contention; also feeds the analytics loop). Fully best-effort/self-guarding — never raises, never touches the English publish.
- **`scripts/publish_ru_dubs.py`** — idempotent driver (skips episodes already in the RU index unless `--force`); `--dry-run` is credentials-independent.
- Runs in the **decoupled multilingual workflow**, so it cannot re-introduce the timeout/partial-publish landmine that decoupling exists to prevent.
- `engine/config.py`: `youtube.ru_dub_enabled` (default false → byte-for-byte no-op) + `ru_podcast_playlist_id`.

## ⚠️ Operator setup (one-time)
1. **`YOUTUBE_REFRESH_TOKEN_RU`** — run `scripts/youtube_oauth_bootstrap.py` signed into the **@NerraRU** account (the token now includes `yt-analytics.readonly` too). Until set, the dub step logs `no_ru_credentials` and no-ops; English uploads + the RU podcast feed are unaffected.
2. **Playlists (optional, landmine #15)** — create one @NerraRU playlist per show, flag it as a podcast, set `youtube.ru_podcast_playlist_id` in the show YAML. Uploads still publish without it (warned).

## Testing
- `tests/test_ru_dub.py` (10): gallery image filtering by show/episode/use, zero-padded `episode_id`, title cap, RU description (disclosure + links + hashtags), the no-op guards, and the 4-shows-enabled / others-disabled config assertions.
- 178 related guards pass (config/schedule/multilingual/quota/visual). End-to-end `--dry-run` resolves Tesla Ep526's RU dub. Render/upload need ffmpeg + @NerraRU creds and validate on a real workflow run.

## Deliberately deferred
- Russian chapters / burned-in captions (English markers don't match the RU script — needs a RU transcript). v1 long-form ships without chapters.
- Smart Shorts window (no RU transcript → Short starts at the configured offset).

Full writeup: `docs/ru_youtube_dubs.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3

---
_Generated by [Claude Code](https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3)_