### PR TITLE
Enable ru multilingual track for Modern Investing (fixes its @NerraRU dub)

### DIFF
--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -105,7 +105,12 @@ keywords:
 - interest rate decision
 - dollar cost averaging
 multilingual:
-  enabled: false
+  # Enabled June 2026 for the Russian YouTube dub (@NerraRU) — MIT was the
+  # one ru_dub show without a Russian audio track. Scoped to `ru` only (MIT
+  # never carried FR/ZH); this generates the RU track engine.ru_dub needs.
+  enabled: true
+  auto: true
+  languages: [ru]
 llm:
   provider: xai
   fallback_model: grok-4.20-non-reasoning

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -47,10 +47,18 @@ class TestMultilingualConfig:
         assert load_config("shows/tesla.yaml").multilingual.cloned_voice_env == "GROK_CLONED_VOICE_ID"
 
     def test_english_only_shows_disabled(self):
+        # modern_investing was enabled June 2026 (ru-only) for the @NerraRU
+        # YouTube dub — it's the one ru_dub show that needs a Russian track.
         from engine.config import load_config
-        for slug in ("modern_investing", "planetterrian", "omni_view",
+        for slug in ("planetterrian", "omni_view",
                      "models_agents_beginners", "unintended_consequences"):
             assert load_config(f"shows/{slug}.yaml").multilingual.enabled is False, slug
+
+    def test_modern_investing_ru_only(self):
+        from engine.config import load_config
+        ml = load_config("shows/modern_investing.yaml").multilingual
+        assert ml.enabled is True
+        assert ml.languages == ["ru"]  # ru-only; MIT never carried fr/zh
 
     def test_russian_shows_opt_out(self):
         from engine.config import load_config

--- a/tests/test_ru_dub.py
+++ b/tests/test_ru_dub.py
@@ -109,3 +109,19 @@ class TestRealShowConfigs:
         for slug in ("omni_view", "env_intel", "planetterrian"):
             c = load_config(f"shows/{slug}.yaml")
             assert c.youtube.ru_dub_enabled is False, slug
+
+    def test_ru_dub_requires_ru_audio_track(self):
+        """A ru_dub-enabled show MUST also generate a Russian audio track
+        (multilingual.enabled + 'ru' in languages) — otherwise the dub has
+        no audio to build from. This guards the MIT-class misconfig where
+        ru_dub was on but multilingual was off (the dub silently no-ops and
+        the translate step errors)."""
+        from engine.config import discover_show_slugs
+        for slug in discover_show_slugs():
+            c = load_config(f"shows/{slug}.yaml")
+            if getattr(c.youtube, "ru_dub_enabled", False):
+                ml = c.multilingual
+                assert ml.enabled and "ru" in (ml.languages or []), (
+                    f"{slug}: ru_dub_enabled but no RU audio track "
+                    f"(multilingual.enabled={ml.enabled}, languages={ml.languages})"
+                )


### PR DESCRIPTION
## Summary

Follow-up from the RU-dub smoke test (#736). I dispatched all four shows; **Tesla published its Russian long-form + Short to @NerraRU successfully** (validating the whole new render→upload path). **Modern Investing failed** — and the cause was a config gap, not the dub code:

- MIT had `youtube.ru_dub_enabled: true` but **`multilingual.enabled: false`**, so it never generates a Russian audio track.
- Its *translate* step errored (`Multilingual audio is not enabled for 'modern_investing'`), and the RU-dub step then correctly self-guarded (`no_ru_lang`) — it just had no audio to build from.
- (SpaceX + Fascinating Frontiers were merely cancelled-as-pending by the workflow's serialized concurrency group; they're correctly configured and I've re-dispatched them.)

## Fix
- `shows/modern_investing.yaml`: enable `multilingual` scoped to **`ru` only** (MIT never carried fr/zh), so it produces the Russian track `engine.ru_dub` needs. ~$0.18/episode (the RU translation), exactly what the RU YouTube dub requires.
- `tests/test_ru_dub.py`: new drift guard — every `ru_dub_enabled` show must also have `multilingual.enabled` + `'ru'` in `languages`, so this MIT-class misconfig can't recur.
- `tests/test_multilingual.py`: updated the "English-only disabled" list (MIT moved out) + pins MIT as ru-only.

## Testing
146 related guards pass (`test_ru_dub`, `test_multilingual`, `test_config`, `test_schedule`).

Once merged, MIT's next episode generates its `ru` track and the dub publishes to @NerraRU like the other three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3

---
_Generated by [Claude Code](https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3)_