### PR TITLE
Commit the YouTube feedback-loop outputs in nightly maintenance

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -167,6 +167,8 @@ jobs:
             *_podcast.*.rss
             digests/**/channel_i18n.json
             api/dashboard.json
+            api/youtube_stats.json
+            digests/**/youtube_performance.json
             api/op3_stats.json
             api/buttondown_stats.json
             digests/tesla_shorts_time/tesla_performance_tracker.json

--- a/tests/test_youtube_feedback_loop.py
+++ b/tests/test_youtube_feedback_loop.py
@@ -35,6 +35,20 @@ def _load_script(name: str):
     return mod
 
 
+class TestNightlyPersistsLoopOutputs:
+    """The nightly job PRODUCES api/youtube_stats.json + per-show
+    youtube_performance.json but commits via an explicit add-paths allowlist.
+    If the loop outputs aren't in that list they're generated then discarded —
+    the loop can never persist (the bug found 2026-07-01)."""
+
+    def test_add_paths_includes_loop_outputs(self):
+        wf = (_ROOT / ".github" / "workflows" / "nightly-maintenance.yml").read_text(
+            encoding="utf-8")
+        # Both must appear in the workflow's commit allowlist.
+        assert "api/youtube_stats.json" in wf
+        assert "digests/**/youtube_performance.json" in wf
+
+
 class TestScope:
     def test_analytics_scope_present(self):
         assert any("yt-analytics.readonly" in s for s in YOUTUBE_SCOPES), (


### PR DESCRIPTION
## Summary

Found while checking the state of the recursive YouTube feedback loop (#733). The nightly job runs the two loop scripts:

- `fetch_youtube_analytics.py` → `api/youtube_stats.json`
- `update_youtube_performance.py` → `digests/<slug>/youtube_performance.json`

…but the nightly `safe-commit-push` **add-paths allowlist did not include either output**. So even once YouTube has retention data, the files are generated in the runner and then **discarded** — the loop could never persist its analytics or feed the per-show title hints back into title generation.

The intake half works fine (each show's `youtube_videos.json` index is committed by the run-show/multilingual jobs and is accumulating). Only the nightly-produced outputs were being dropped.

## Fix
- Add `api/youtube_stats.json` and `digests/**/youtube_performance.json` to the nightly commit allowlist.
- Drift guard (`test_youtube_feedback_loop.py::TestNightlyPersistsLoopOutputs`) so a future allowlist edit can't silently drop them again.

## Note on data availability (separate from this bug)
Even with this fix, `youtube_stats.json`/hints only appear once YouTube actually has retention data: `averageViewPercentage` needs a few days of watch data to populate, and a show's title hint only activates at ≥4 rated videos. The videos are 1–3 days old, so expect the first real output within a few days of nightly runs after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3

---
_Generated by [Claude Code](https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3)_