### PR TITLE
Unblock CI: restock UC queue + fix July-rollover SpaceX cadence test

### DIFF
--- a/shows/topic_queues/unintended_consequences.yaml
+++ b/shows/topic_queues/unintended_consequences.yaml
@@ -447,3 +447,24 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
+- id: asbestos-miracle-mineral
+  title: The Fireproof Miracle That Killed
+  brief: 'For most of the twentieth century asbestos was sold as a safety miracle — a cheap, abundant mineral that fireproofed schools, ships, homes, and firefighters'' suits, and by insulating pipes and boilers it genuinely saved energy and prevented fires. The same indestructible fibres that made it wonderful made it lethal: inhaled, they lodge in the lungs for decades and cause asbestosis and mesothelioma, a cancer with a 20-to-50-year latency that hid the harm long past the point of mass installation. Trace how a material adopted expressly to protect people seeded a slow-motion epidemic still killing tens of thousands a year, why the latency defeated early warnings, and the lesson: when a product''s virtue is that it never breaks down, ask what never breaking down does inside a human body. Treat all figures as approximate.'
+  category: medicine
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: nile-perch-lake-victoria
+  title: The Fish That Ate a Lake
+  brief: 'In the mid-twentieth century the Nile perch was deliberately introduced into Lake Victoria to boost fisheries — a big, marketable fish to feed and employ the region, and for a while it worked, spawning a lucrative export trade in perch fillets. Then the predator did what predators do: it helped drive hundreds of endemic cichlid species toward extinction in one of the fastest vertebrate collapses ever recorded, and processing the oily perch (unlike the old sun-dried catch) demanded firewood, accelerating shoreline deforestation and, with nutrient runoff, algal blooms and dead zones. Cover the boom that was real, the ecological and social bill that came due, and the lesson: adding one profitable piece to an ecosystem is not addition — it is rewriting the whole web. Figures are approximate.'
+  category: classic
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: africanized-killer-bees
+  title: The Bees That Escaped the Lab
+  brief: 'In 1950s Brazil, researchers crossbred European honeybees with an African subspecies hoping to build a bee better suited to the tropics and more productive for local beekeepers — a sensible agricultural improvement. In 1957 a couple dozen swarms escaped, and the hybrids proved not just hardy but intensely defensive, spreading across South and Central America and into the southern United States over the following decades, displacing gentler bees and causing rare but real human and livestock deaths that earned the "killer bee" headlines. Be honest in both directions — the bees are also vigorous foragers and pollinators — and land the lesson: when you breed for one trait in a living thing that can reproduce and travel on its own, containment, not just the trait, is the hard problem. Treat figures as approximate.'
+  category: classic
+  produced: false
+  episode_number: null
+  produced_date: null

--- a/tests/test_spacex_show.py
+++ b/tests/test_spacex_show.py
@@ -414,7 +414,12 @@ class TestLaunchDashboard:
                 {"net": "2026-05-02T00:00:00Z"}]
         cad = mod._monthly_cadence(prev)
         assert len(cad) == 12
-        assert cad[-1] == {"month": "2026-06", "count": 2}
+        # _monthly_cadence buckets against the real current month, so assert
+        # by month key (not position) — cad[-1] shifts on every rollover and
+        # made this test a time bomb that broke on the 1st of each month.
+        by_month = {b["month"]: b["count"] for b in cad}
+        assert by_month.get("2026-06") == 2
+        assert by_month.get("2026-05") == 1
         # stats
         st = mod._stats(prev, now)
         assert st["launches_ytd"] == 3


### PR DESCRIPTION
## Summary

Two independent, pre-existing CI blockers (both fail on `main`; the suite runs `-x` so either blocks every PR). Found while shipping #745.

**1. Unintended Consequences queue runway.** UC dropped to 3.8 weeks (19 unproduced × 5/wk) after this week's episodes, below the 4.0-week floor (`test_network_quality_pass.py::TestNarrativeQueueRunway`). Added 3 on-brand "backfire" topics → 22 unproduced ≈ 4.4 weeks:
- The Fireproof Miracle That Killed — asbestos → mesothelioma
- The Fish That Ate a Lake — Nile perch in Lake Victoria
- The Bees That Escaped the Lab — Africanized honeybees

**2. Time-bomb SpaceX cadence test.** `test_spacex_show.py::test_fetcher_pure_helpers` asserted the *last* bucket of the trailing 12-month cadence window was `2026-06` — true only during June. On **2026-07-01** the window rolled to end at `2026-07` (count 0) and the test failed. `_monthly_cadence` buckets against the real current month with no injectable `now`, so the fix asserts the June/May buckets **by month key** instead of by position (robust to every month rollover).

## Testing
`TestNarrativeQueueRunway`, `test_unintended_consequences_quality_pass`, and the fixed `test_fetcher_pure_helpers` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3