### PR TITLE
Include @NerraRU dubs in the YouTube analytics loop (was EN-only)

### DIFF
--- a/scripts/fetch_youtube_analytics.py
+++ b/scripts/fetch_youtube_analytics.py
@@ -72,8 +72,13 @@ _BATCH = 200
 
 
 def _load_index(digests_dir: Path) -> List[dict]:
-    """Collect rows from every ``digests/<slug>/youtube_videos.json``."""
+    """Collect rows from every per-show video index — the EN channel
+    (``youtube_videos.json``) AND the @NerraRU dubs
+    (``youtube_videos.ru.json``). Each row carries its own ``channel`` field,
+    so the fetch groups them onto the right channel token; without the RU
+    files the analytics loop was EN-only and never read the RU channel."""
     files = sorted(digests_dir.glob("*/youtube_videos.json"))
+    files += sorted(digests_dir.glob("*/youtube_videos.ru.json"))
     if not files:
         logger.info("No per-show video indexes under %s — nothing to fetch "
                     "(clean no-op)", digests_dir)

--- a/tests/test_youtube_feedback_loop.py
+++ b/tests/test_youtube_feedback_loop.py
@@ -146,6 +146,25 @@ class TestUpdaterHint:
         assert "Median retention" in hint
 
 
+class TestBothChannelsCovered:
+    """The analytics loop must read BOTH the EN index (youtube_videos.json)
+    and the @NerraRU dubs (youtube_videos.ru.json) — otherwise the RU channel
+    is invisible to the loop (the gap found 2026-07-01)."""
+
+    def test_load_index_includes_ru_dubs(self, tmp_path):
+        fya = _load_script("fetch_youtube_analytics.py")
+        show = tmp_path / "tesla_shorts_time"
+        show.mkdir()
+        (show / "youtube_videos.json").write_text(json.dumps({"videos": [
+            {"video_id": "en1", "channel": "en"}]}), encoding="utf-8")
+        (show / "youtube_videos.ru.json").write_text(json.dumps({"videos": [
+            {"video_id": "ru1", "channel": "ru"}]}), encoding="utf-8")
+        rows = fya._load_index(tmp_path)
+        channels = {r.get("channel") for r in rows}
+        assert channels == {"en", "ru"}, channels
+        assert {r["video_id"] for r in rows} == {"en1", "ru1"}
+
+
 class TestScriptsAreCleanNoOps:
     def test_fetch_no_data(self, tmp_path):
         fya = _load_script("fetch_youtube_analytics.py")


### PR DESCRIPTION
## Summary

Answering "is the feedback loop set up for both EN and RU channels?" — it **wasn't**. `fetch_youtube_analytics._load_index` only globbed `digests/<slug>/youtube_videos.json`, which excludes the RU-dub index `youtube_videos.ru.json`. So the recursive loop read only the EN channel; the @NerraRU videos were never pulled into analytics.

The fetch already groups rows by each row's `channel` field and resolves per-channel credentials (`get_channel_credentials_from_env("ru")`), so the only gap was reading the RU index files.

## Fix
- `_load_index` now globs both `youtube_videos.json` and `youtube_videos.ru.json`. RU rows (channel `ru`) group onto the RU token automatically.
- Drift guard (`test_youtube_feedback_loop.py::TestBothChannelsCovered`) asserts both channels are read.

## Note
Both channels' analytics still depend on the @NerraRU OAuth token (`YOUTUBE_REFRESH_TOKEN_RU`, already set) having the `yt-analytics.readonly` scope — which it does if the RU token was minted with the updated `youtube_oauth_bootstrap.py` (#734). Data still needs a few days of watch time to populate, same as EN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3

---
_Generated by [Claude Code](https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3)_