### PR TITLE
RU Shorts parity: Russian captions + smart start + end-card CTA

### DIFF
--- a/.github/workflows/multilingual.yml
+++ b/.github/workflows/multilingual.yml
@@ -139,6 +139,16 @@ jobs:
           system-packages: 'ffmpeg'
           skip-checkout: 'true'
 
+      - name: Cache Whisper transcription model
+        # The RU-dub step transcribes the Russian audio (faster-whisper
+        # "base") for smart-start + Russian captions on the Shorts. Same
+        # pinned model + cache key as run-show.yml so the ~150 MB HF
+        # download is a one-time cost, not per-run.
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/huggingface
+          key: whisper-faster-base-v1
+
       - name: Translate ${{ matrix.show }}
         env:
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}

--- a/docs/ru_youtube_dubs.md
+++ b/docs/ru_youtube_dubs.md
@@ -81,13 +81,31 @@ python scripts/publish_ru_dubs.py tesla --episode <N>
 Idempotent: an episode already in `youtube_videos.ru.json` is skipped unless
 `--force`.
 
+## Shorts parity with the EN channel (July 2026)
+
+The RU Shorts now match the EN Shorts' polish. The RU dub audio is
+transcribed with faster-whisper (`language="ru"`, word timestamps), then:
+
+- **Russian burned-in captions** — per-word ASS captions via
+  `transcript_to_ass_window` (the caption font, DejaVu Sans, covers Cyrillic).
+- **Smart engaging-beat start** — `pick_engaging_window` on the RU transcript
+  picks where the Short begins (falls back to the configured offset when no
+  beat scores above threshold; the scorer's cue phrases are English, so RU
+  falls back more often — the captions are the bigger win).
+- **End-card CTA** — a Russian "СМОТРЕТЬ ВЫПУСК / Подпишись ↗" card on the last
+  3 s, same as the EN "WATCH FULL EPISODE" card.
+
+Every piece is best-effort — the Short still ships if transcription or a caption
+step fails. The multilingual workflow caches the Whisper model
+(`whisper-faster-base-v1`, same key as `run-show.yml`) so the download is
+one-time. The EN Shorts already carried crossfades (PR #733), per-word
+captions, smart-start, end cards, and entity hashtags — this brings RU up to
+that bar.
+
 ## Deliberately left for later
 
-- **Russian chapters / burned-in captions** — the English chapter markers don't
-  match the Russian script, so v1 ships without chapters on the RU long-form.
-  A Russian-aware chapter pass (or a Whisper transcript of the RU audio) is the
-  follow-up.
-- **Smart Shorts window** — without a Russian transcript the Short starts at the
-  configured offset rather than the most-engaging beat.
+- **Russian chapters** on the RU long-form — the English chapter markers don't
+  match the Russian script; a Russian-aware chapter pass (reusing the same RU
+  Whisper transcript) is the next follow-up.
 
 Drift guards: `tests/test_ru_dub.py`.

--- a/engine/ru_dub.py
+++ b/engine/ru_dub.py
@@ -39,6 +39,11 @@ _AI_DISCLOSURE_RU = (
     "а озвучка создаётся с помощью ИИ-синтеза голоса."
 )
 
+# Russian end-card call-to-action for the Shorts (parity with the EN
+# "WATCH FULL EPISODE" / "Tap Subscribe ↗" card).
+_RU_END_CARD_MAIN = "СМОТРЕТЬ ВЫПУСК"
+_RU_END_CARD_SUB = "Подпишись ↗"
+
 
 def _episode_id(episode_num: int) -> str:
     return f"ep{episode_num:03d}"
@@ -289,13 +294,72 @@ def publish_ru_dub(
                     config.slug, episode_num, intended_use="social")
                 short_scenes = _download_images(short_urls, tmp) if short_urls else []
                 short_mp4 = tmp / f"ru_short_ep{episode_num:03d}.mp4"
+                short_dur = float(getattr(yt, "short_duration_seconds", 55.0))
+
+                # Parity with the EN shorts: transcribe the RU dub audio
+                # (Russian Whisper, word timestamps) → smart engaging-beat
+                # start + Russian burned-in per-word captions. DejaVu Sans
+                # (the caption font) covers Cyrillic. Every piece is
+                # best-effort — the short still ships without them.
+                start_offset = float(getattr(yt, "shorts_start_offset", 0.0) or 0.0)
+                ass_path = None
+                try:
+                    from engine.transcripts import generate_transcript
+                    from engine.captions import transcript_to_ass_window
+                    from engine.shorts_selector import pick_engaging_window
+                    from engine.audio import get_audio_duration
+                    tr = generate_transcript(
+                        audio, tmp, f"ru_ep{episode_num:03d}", language="ru")
+                    if tr and tr.json_path.exists():
+                        total_dur = get_audio_duration(audio) or 0.0
+                        win = pick_engaging_window(
+                            tr.json_path, audio_offset=start_offset,
+                            audio_duration=total_dur, window_duration=short_dur,
+                            min_start_final=start_offset)
+                        if win is not None:
+                            start_offset = win.start_seconds
+                        ass_candidate = tmp / f"ru_short_ep{episode_num:03d}.ass"
+                        transcript_to_ass_window(
+                            tr.json_path, ass_candidate,
+                            window_start_seconds=start_offset,
+                            window_duration_seconds=short_dur,
+                            audio_offset_seconds=0.0)
+                        if (ass_candidate.exists()
+                                and ass_candidate.stat().st_size > 0
+                                and "Dialogue:" in ass_candidate.read_text(
+                                    encoding="utf-8", errors="replace")):
+                            ass_path = ass_candidate
+                            result["ru_short_captions"] = "ass"
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("ru_dub: RU transcript/captions failed (%s) — "
+                                   "short without captions", exc)
+
+                # End-card CTA (Russian) — reuse the RU long-form thumbnail.
+                end_card_png = None
+                try:
+                    from engine.publisher import generate_shorts_end_card
+                    if thumb_path is not None:
+                        ec = tmp / f"ru_short_ep{episode_num:03d}_endcard.png"
+                        generate_shorts_end_card(
+                            thumb_path, ec, show_name=config.name,
+                            main_text=_RU_END_CARD_MAIN, sub_text=_RU_END_CARD_SUB)
+                        if ec.exists():
+                            end_card_png = ec
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("ru_dub: end-card render failed (%s)", exc)
+
                 build_short_video(
                     audio, cover, short_mp4,
-                    start_offset=float(getattr(yt, "shorts_start_offset", 0.0) or 0.0),
-                    duration=float(getattr(yt, "short_duration_seconds", 55.0)),
+                    start_offset=start_offset,
+                    duration=short_dur,
                     hook=ru_title,
                     scene_paths=short_scenes if len(short_scenes) >= 2 else None,
-                    show_name=config.name)
+                    show_name=config.name,
+                    subtitles_path=ass_path,
+                    end_card=True,
+                    end_card_main_text=_RU_END_CARD_MAIN,
+                    end_card_sub_text=_RU_END_CARD_SUB,
+                    end_card_image_path=end_card_png)
                 sup = upload_video(
                     short_mp4, credentials=creds,
                     title=_cap_title(ru_title, 90) + " #Shorts",

--- a/tests/test_ru_dub.py
+++ b/tests/test_ru_dub.py
@@ -81,6 +81,29 @@ class TestTextHelpers:
         assert "#Tesla" in out  # keyword hashtag
 
 
+class TestShortParity:
+    """RU shorts reach EN parity: Russian captions (transcribe the RU audio) +
+    smart engaging-beat start + end-card CTA. Full render needs ffmpeg+creds,
+    so pin the wiring structurally so it can't silently regress."""
+
+    def test_russian_end_card_text_is_cyrillic(self):
+        assert ru_dub._RU_END_CARD_MAIN and ru_dub._RU_END_CARD_SUB
+        # Contains Cyrillic (not the English EN defaults).
+        assert any("Ѐ" <= ch <= "ӿ" for ch in ru_dub._RU_END_CARD_MAIN)
+
+    def test_short_path_wires_transcript_captions_and_endcard(self):
+        src = (Path(ru_dub.__file__)).read_text(encoding="utf-8")
+        # Transcribe the RU audio in Russian.
+        assert "generate_transcript(" in src and 'language="ru"' in src
+        # Smart engaging-beat start + per-word ASS captions.
+        assert "pick_engaging_window(" in src
+        assert "transcript_to_ass_window(" in src
+        assert "subtitles_path=ass_path" in src
+        # End-card CTA on the short.
+        assert "generate_shorts_end_card(" in src
+        assert "end_card=True" in src
+
+
 class TestGuards:
     def test_skip_when_not_enabled(self):
         cfg = _cfg()


### PR DESCRIPTION
## Summary

Brings the @NerraRU dub Shorts up to the polish level of the EN Shorts. Previously the RU Shorts reused the EN 9:16 images and audio but had **no captions**, a **fixed start offset**, and **no end-card** — so they looked barer than the EN Shorts even though the imagery matched.

Now the RU dub audio is transcribed with faster-whisper (`language="ru"`, word timestamps), and the Short gets:

- **Per-word burned-in Russian captions** — `transcript_to_ass_window` (the caption font is DejaVu Sans, which covers Cyrillic).
- **Smart engaging-beat start** — `pick_engaging_window` on the RU transcript (falls back to the configured offset when no beat scores above threshold; the scorer's cue phrases are English, so RU falls back more often — captions are the bigger win).
- **Russian end-card CTA** — "СМОТРЕТЬ ВЫПУСК / Подпишись ↗", same treatment as the EN "WATCH FULL EPISODE" card.

All best-effort: the Short still ships if any step fails. The multilingual workflow now caches the Whisper model (same `whisper-faster-base-v1` key as `run-show.yml`) so the ~150 MB download is one-time, not per-run.

## On "improvements to all shorts"
The **EN Shorts were already fully polished** — rotating crossfades (added in #733, and Shorts share the `_render_slideshow` path so they already got them), per-word ASS captions, smart-window start, end cards, and entity hashtags. Rather than pile risky changes onto that tuned output, this PR closes the one real gap (RU parity). If you want to push EN Shorts further (e.g. longer-form Shorts, different caption styling), that's a separate, deliberately-A/B'd change.

## Testing
`tests/test_ru_dub.py` (13, incl. new `TestShortParity` pinning the transcript/caption/smart-start/end-card wiring + Cyrillic end-card text) + 202 related tests (multilingual, captions, shorts-selector, video-commands) pass. Full render needs ffmpeg + @NerraRU creds and validates on a real multilingual run.

## Deferred
Russian **chapters** on the RU long-form (reuse the same RU transcript) — the next follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3

---
_Generated by [Claude Code](https://claude.ai/code/session_017ifFBUzWY4cbZdiW5Zwyc3)_