### PR TITLE
YouTube visual reuse: chapter-aligned scenes, gallery blending, scene thumbnails, recap reuse, B-roll

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -132,6 +132,13 @@ jobs:
           python scripts/build_gallery_manifest.py --out site/data/gallery-manifest.json
           python scripts/build_search_index.py --out site/data/search-index.json
 
+      - name: Join gallery images with YouTube retention
+        # Imagery data flywheel: joins the fresh gallery manifest with the
+        # per-video retention fetched above (api/youtube_stats.json) into
+        # api/gallery_retention.json — which imagery styles keep viewers
+        # watching. Clean no-op (empty JSON) until analytics data accrues.
+        run: python scripts/build_gallery_retention.py --out api/gallery_retention.json || echo "::warning::Gallery retention join failed (non-fatal)"
+
       - name: Generate MIT Performance Page + Tesla Narrative Page + Main Site
         # Ensures dedicated transparency pages (MIT performance + TST narrative tracker)
         # and other pages that depend on fresh data stay up to date.
@@ -171,6 +178,7 @@ jobs:
             api/dashboard.json
             api/daily-show-health.json
             api/youtube_stats.json
+            api/gallery_retention.json
             digests/**/youtube_performance.json
             api/op3_stats.json
             api/buttondown_stats.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -930,6 +930,56 @@ for Russian-language shows when they migrate to YouTube). Drift
 guards in `tests/test_video_commands.py` under the "Shorts end-
 screen CTA card" header.
 
+### YouTube visual reuse + chapter-aligned scenes (June 2026)
+
+Renders now reuse the imagery the network already paid for and time scene
+changes editorially — full doc:
+[`docs/youtube_visual_reuse.md`](docs/youtube_visual_reuse.md). **Everything
+here is render/metadata-only (no audio → outside the landmine-#17 A/B
+gate)**, config-gated with defaults **on** (`youtube:` knobs in
+`shows/_defaults.yaml`: `gallery_blend_enabled` + per-aspect caps,
+`chapter_aligned_scenes`, `long_form_thumbnail_from_scene` /
+`thumbnail_variants`, `recap_reuse_scenes`, `gallery_fallback_enabled`,
+`shorts_sentence_cuts`, `evergreen_broll`), and best-effort by contract —
+any failure logs a warning and ships the exact legacy render.
+
+- **Layers:** [`engine/gallery_library.py`](engine/gallery_library.py)
+  (pull relevant historical scenes/b-roll from the `nerra-gallery` R2
+  bucket via the committed manifest; cached, never raises) →
+  [`engine/scene_scheduler.py`](engine/scene_scheduler.py) (pure planning:
+  chapter-aligned scene schedules + sentence-snapped Shorts cuts) →
+  `engine/video.py` render hooks (`scene_schedule` / `broll_clips` /
+  `scene_change_times`; `None` = legacy byte-identical) →
+  [`engine/visual_reuse.py`](engine/visual_reuse.py) (the thin composition
+  layer run_show calls: `long_form_visual_plan`, `short_visual_extras`,
+  `recap_scene_pool`, `fallback_scene_pool`).
+- **Per episode:** long-form blends ≤8 library 16:9 scenes into the 4 fresh
+  ones (ranked by hook/chapter-title overlap) and switches scenes on
+  chapter boundaries; Shorts blend ≤4 library 9:16 scenes and snap scene
+  cuts to sentence ends from the existing Whisper word transcript.
+- **Sunday recaps** skip Grok Imagine entirely and reuse the week's gallery
+  scenes when both aspects have ≥2 pooled images (below that: generate as
+  usual). **Degraded days** (<2 fresh scenes) fall back to gallery-library
+  scenes BEFORE the static cover; the degraded `::warning::` says which
+  fallback shipped.
+- **Thumbnails:** long-form thumbnail composites over the first fresh 16:9
+  scene (cover fallback) + up to 2 variant composites from other scenes
+  (`engine.publisher.generate_thumbnail_variants`), uploaded to the gallery
+  bucket (`intended_use: thumbnail_variant` — invisible to the scene
+  selector) for Studio "Test & Compare".
+- **Evergreen b-roll:** ≤3 curated clips interleaved into the long-form
+  slideshow; a clean no-op until the operator publishes
+  `digests/<dir>/broll.json` via `scripts/build_broll_pool.py`.
+- **Flywheel:** `scripts/build_gallery_retention.py` (nightly, after the
+  analytics fetch + manifest rebuild) joins gallery images with per-video
+  `averageViewPercentage` → `api/gallery_retention.json` (top/bottom image
+  tags by mean retention, min 3 videos). Clean no-op until analytics data
+  accrues.
+- **Metrics:** `visual_mode` (chapter_schedule|uniform|cover|
+  library_fallback|recap_pool), `scene_fresh_count`, `scene_library_count`,
+  `broll_clips_used`, `thumbnail_base`, `thumbnail_variant_urls`. Drift
+  guards: `tests/test_visual_reuse.py`.
+
 ### Testing
 
 ```bash

--- a/docs/youtube_visual_reuse.md
+++ b/docs/youtube_visual_reuse.md
@@ -1,0 +1,121 @@
+# YouTube visual reuse + chapter-aligned scenes (June 2026)
+
+Everything on this page is **render/metadata-only — no audio is touched, so
+the whole system sits outside the landmine-#17 A/B gate.** Every path is
+best-effort and config-gated (defaults **on**): any failure logs a warning
+and degrades to the exact legacy render; a publish is never blocked.
+
+## What / why
+
+The network has paid Grok Imagine credits for every scene image it has ever
+generated — they all live in the public `nerra-gallery` R2 bucket, indexed
+by the committed `site/data/gallery-manifest.json`. Until this pass the
+pipeline treated that archive as write-only: every render used only the 4
+fresh images per aspect, scene changes ran on a uniform timer (long-form) or
+a flat 7 s grid (Shorts), Sunday recaps regenerated imagery for stories
+already illustrated during the week, a Grok Imagine outage degraded straight
+to the static cover, and every long-form thumbnail was the same show cover.
+
+Layers (bottom-up):
+
+| Layer | Module | Role |
+|---|---|---|
+| Selection | `engine/gallery_library.py` | Pull relevant historical scenes/b-roll down from R2 (manifest-driven, cached, never raises) |
+| Planning | `engine/scene_scheduler.py` | Chapter-aligned `[(scene, hold_s), …]` schedules + sentence-snapped Shorts cut times (pure logic) |
+| Rendering | `engine/video.py` | `build_long_form_video(scene_schedule=, broll_clips=)`, `build_short_video(scene_change_times=)` — `None` = legacy byte-identical |
+| Composition | `engine/visual_reuse.py` | The thin layer run_show calls: honors the config gates, assembles pools/plans, returns legacy shapes on any failure |
+| Wiring | `run_show.py:_publish_youtube` | One call per surface + metrics |
+
+## Behaviours (all defaults on)
+
+- **Gallery blending** — each long-form render blends up to
+  `gallery_blend_max_long` (8) historical 16:9 scenes into the 4 fresh ones,
+  ranked by token overlap with the episode hook + chapter titles; each Short
+  blends up to `gallery_blend_max_short` (4) 9:16 scenes ranked against its
+  hook. Zero new image-generation cost.
+- **Chapter-aligned scene schedule** — scene switches land on
+  `chapters_ep<NNN>.json` boundaries (subdivided into 6–15 s holds), with
+  per-chapter scene choice scored by title↔prompt overlap (fresh scenes win
+  ties; reuse penalised for variety). `<2` usable chapters → uniform plan
+  identical to legacy.
+- **Sentence-snapped Shorts cuts** — scene changes snap to sentence-ending
+  words from the faster-whisper word-level transcript (already generated for
+  captions — no new transcription cost) instead of the flat 7 s grid.
+- **Sunday recap reuse** — recap episodes pull the week's gallery scenes
+  (both aspects, `collect_week_scenes`) and **skip Grok Imagine generation
+  entirely** when both aspects have ≥2 pooled images; below that they
+  generate as on any other day. The recap re-tells the week's stories, so
+  its imagery already exists.
+- **Degraded fallback** — when scene generation yields <2 usable images
+  (previously: straight to the static cover), the show's historical gallery
+  scenes ship instead; the cover remains the last resort (and the degraded
+  `::warning::` annotation now says which fallback was used). Shows with no
+  gallery history (Pexels-only) degrade to the cover exactly as before.
+- **Scene-based thumbnails + variants** — the long-form thumbnail composites
+  over the episode's first fresh 16:9 scene (cover fallback), and up to
+  `thumbnail_variants` (2) additional composites are rendered from OTHER
+  scenes (same hook text/autofit) and uploaded to the gallery R2 bucket
+  (`intended_use: thumbnail_variant`, ignored by the scene selector) for the
+  operator's Studio "Test & Compare" A/B. URLs land in the episode metrics.
+- **Evergreen b-roll** — up to 3 curated silent clips interleave into the
+  long-form slideshow. A clean no-op until the operator publishes a
+  `digests/<dir>/broll.json` pool (below).
+
+## Config knobs (`youtube:` block; network defaults in `shows/_defaults.yaml`)
+
+```yaml
+youtube:
+  gallery_blend_enabled: true      # blend historical gallery scenes
+  gallery_blend_max_long: 8        # 16:9 library scenes per long-form
+  gallery_blend_max_short: 4       # 9:16 library scenes per Short
+  chapter_aligned_scenes: true     # scene switches on chapter boundaries
+  long_form_thumbnail_from_scene: true
+  thumbnail_variants: 2            # extra Test & Compare composites
+  recap_reuse_scenes: true         # Sunday recap skips generation
+  gallery_fallback_enabled: true   # library before static cover
+  shorts_sentence_cuts: true       # sentence-snapped Shorts scene cuts
+  evergreen_broll: true            # no-op until broll.json exists
+```
+
+Disable per show by flipping any flag to `false` in the show YAML — each
+gate is independent and `false` restores that surface's legacy behaviour
+byte-for-byte. All fields are declared on `YouTubeConfig`
+(`engine/config.py`) — remember the silent-config-drop landmine: never add a
+`youtube:` YAML key without a matching dataclass field.
+
+## Operator b-roll workflow
+
+1. Recover Grok Video clips soon after a run (result URLs are temporary):
+   `GROK_API_KEY=... python scripts/recover_grok_video.py --out-dir recovered/`
+2. Curate locally — keep only evergreen footage (generic factory shots,
+   rockets on the pad; nothing dated like a headline overlay).
+3. Publish: `python scripts/build_broll_pool.py --show tesla clip1.mp4 clip2.mp4`
+   — uploads to the gallery R2 bucket under `broll/<slug>/` and commits ONLY
+   the small `digests/<dir>/broll.json` index (media in git is landmine #1).
+
+Renders pick the pool up automatically (`evergreen_broll: true`), capped at
+3 clips per episode so accents stay accents.
+
+## Data flywheel: image ↔ retention join
+
+`scripts/build_gallery_retention.py` (nightly, after the analytics fetch +
+manifest rebuild) joins gallery images with per-video
+`averageViewPercentage` from `api/youtube_stats.json` into
+`api/gallery_retention.json`: per show, per image `{video_id, retention,
+episode_id, tags}` plus top/bottom tags by mean retention (min 3 videos per
+tag). Join key: the sidecar's `youtube_video_id` when set, else
+`(show_slug, episode, kind)` — `segment_card`→long, `social`→short. Clean
+no-op (empty `shows` map) until analytics data accrues (the token re-auth in
+`docs/youtube_feedback_loop.md`).
+
+## Observability (per-episode metrics)
+
+- `visual_mode` — `chapter_schedule | uniform | cover | library_fallback | recap_pool`
+- `scene_fresh_count` / `scene_library_count` — fresh vs recycled imagery
+- `broll_clips_used`
+- `thumbnail_base` (`scene | cover`), `thumbnail_variant_urls`
+- `visual_fallback` (`library | cover`, only on degraded episodes)
+
+Drift guards: `tests/test_visual_reuse.py` (plus `tests/test_gallery_library.py`,
+`tests/test_scene_scheduler.py`, and the schedule/cut paths in
+`tests/test_video_commands.py`).

--- a/engine/config.py
+++ b/engine/config.py
@@ -558,6 +558,46 @@ class YouTubeConfig:
     video_clip_seconds: int = 5
     video_clips_resolution: str = "720p"
 
+    # ---- Visual reuse + chapter-aligned scenes (June 2026) ----
+    # These gate engine/visual_reuse.py, the composition layer over
+    # engine.gallery_library + engine.scene_scheduler. All default ON and
+    # all are render/metadata-only (no audio → outside landmine #17);
+    # every path is best-effort and degrades to the legacy render.
+    #
+    # Blend already-generated gallery scenes (pulled from the nerra-gallery
+    # R2 bucket via the committed manifest) into the fresh per-episode
+    # Grok Imagine sets, ranked by hook/chapter-title relevance. Zero new
+    # image-generation cost; caps below bound the download volume.
+    gallery_blend_enabled: bool = True
+    gallery_blend_max_long: int = 8    # 16:9 library scenes per long-form
+    gallery_blend_max_short: int = 4   # 9:16 library scenes per Short
+    # Align long-form scene switches with the episode's chapters.json
+    # boundaries (engine.scene_scheduler.plan_chapter_schedule) instead of
+    # the uniform timer. <2 usable chapters falls back to uniform.
+    chapter_aligned_scenes: bool = True
+    # Use the episode's first fresh 16:9 scene as the long-form thumbnail
+    # base (cover fallback), and render up to `thumbnail_variants` extra
+    # composites from OTHER scenes for the operator's Studio
+    # "Test & Compare" A/B (uploaded to the gallery R2 bucket, tiny files).
+    long_form_thumbnail_from_scene: bool = True
+    thumbnail_variants: int = 2
+    # Sunday weekly recaps reuse the past week's gallery scenes (both
+    # aspects) instead of generating new imagery — the recap summarises
+    # stories whose imagery the network already paid for. Requires ≥2
+    # pooled images per aspect; below that, generates as usual.
+    recap_reuse_scenes: bool = True
+    # When Grok Imagine produces <2 usable scenes, fall back to the show's
+    # historical gallery scenes before degrading to the static cover.
+    gallery_fallback_enabled: bool = True
+    # Snap Shorts scene changes to sentence boundaries from the Whisper
+    # word-level transcript (engine.scene_scheduler.sentence_cut_times)
+    # instead of the flat 7 s grid.
+    shorts_sentence_cuts: bool = True
+    # Interleave curated evergreen b-roll clips (digests/<dir>/broll.json,
+    # published by scripts/build_broll_pool.py) into the long-form
+    # slideshow. A clean no-op until the operator publishes a pool.
+    evergreen_broll: bool = True
+
     # Optional path (relative to repo root) to a text template for the
     # long-form description body. Placeholders: {hook}, {episode_num},
     # {show_name}, {today_str}. When empty, uses digest paragraphs.

--- a/engine/gallery_library.py
+++ b/engine/gallery_library.py
@@ -1,0 +1,367 @@
+"""Render-time reuse of already-generated gallery images + evergreen b-roll.
+
+The network has paid (Grok Imagine credits) for every scene image it has ever
+generated — they all live in the public ``nerra-gallery`` R2 bucket and are
+indexed by the committed ``site/data/gallery-manifest.json``. This module
+lets render-time consumers (Sunday weekly recaps, RU dubs, any show whose
+fresh scenes failed to generate) pull *relevant* historical scenes back down
+instead of falling back to a static cover — zero new image-generation cost.
+
+Selection is deterministic: candidates are filtered (show / aspect / episode
+window / current-episode exclusion), scored by token overlap between the
+caller's context text (episode hook, chapter titles) and the image's
+``prompt`` + ``caption`` + ``tags``, and tie-broken by recency then
+``image_id``. Winners are downloaded into a local cache keyed on
+``image_id`` so repeated renders (and the weekly recap re-using a daily's
+scenes) never re-fetch bytes.
+
+Everything network-facing is best-effort by contract: a missing manifest, a
+dead URL, or a full R2 outage yields fewer (or zero) results — the public
+API never raises, matching the gallery-uploader's soft-fail design
+(``engine/gallery_uploader.py``).
+
+The evergreen b-roll pool (``select_broll_clips``) is the companion for
+*video* clips: a small committed ``broll.json`` per show (written by
+``scripts/build_broll_pool.py``) points at curated clips on R2 — e.g. the
+recovered Grok Video clips from ``scripts/recover_grok_video.py``. Only the
+JSON is committed; the media stays on R2 (landmine #1).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import tempfile
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = PROJECT_ROOT / "site" / "data" / "gallery-manifest.json"
+
+DOWNLOAD_TIMEOUT_SECONDS = 20
+
+# Aspect → the manifest's ``intended_use`` value (see gallery_uploader):
+# ``segment_card`` is the 16:9 long-form scene, ``social`` the 9:16 Short.
+_ASPECT_TO_USE = {"16:9": "segment_card", "9:16": "social"}
+
+# Words too common in Grok Imagine prompts / hooks to signal relevance —
+# without this every "photo, dramatic lighting" boilerplate token matches.
+_STOPWORDS = frozenset(
+    "a an and are as at be by for from has have in is it its of on or that "
+    "the this to was were will with photo image style lighting composition "
+    "detailed ultra framing depicting no text words rendered".split()
+)
+
+# Local-cache path → manifest entry, populated at download time so
+# ``scene_context_map`` can resolve paths even without the manifest.
+_PATH_REGISTRY: Dict[Path, dict] = {}
+
+
+# ---------------------------------------------------------------------------
+# Manifest loading + selection
+# ---------------------------------------------------------------------------
+
+
+def load_manifest(path: Optional[Path] = None) -> dict:
+    """Load the gallery manifest; ``{}`` on any failure (missing/corrupt)."""
+    p = Path(path) if path else DEFAULT_MANIFEST
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 — missing/corrupt = empty library
+        logger.info("gallery_library: manifest unreadable at %s (%s)", p, exc)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _tokenize(text: str) -> frozenset:
+    return frozenset(
+        t for t in re.findall(r"[a-z0-9]+", (text or "").lower())
+        if len(t) > 2 and t not in _STOPWORDS
+    )
+
+
+def _entry_tokens(entry: dict) -> frozenset:
+    parts = [entry.get("prompt", ""), entry.get("caption", ""),
+             entry.get("episode_title", "")]
+    parts.extend(entry.get("tags") or [])
+    return _tokenize(" ".join(str(p) for p in parts))
+
+
+def _candidate_entries(
+    manifest: dict,
+    show_slug: str,
+    *,
+    intended_use: str,
+    exclude_episode_id: Optional[str],
+    min_episode_date: Optional[str],
+    max_episode_date: Optional[str],
+) -> List[dict]:
+    out = []
+    for entry in manifest.get("images", []) or []:
+        if entry.get("show_slug") != show_slug:
+            continue
+        if entry.get("intended_use") != intended_use:
+            continue
+        if not entry.get("original_url"):
+            continue
+        eid = (entry.get("episode_id") or "").lower()
+        if exclude_episode_id and eid == exclude_episode_id.lower():
+            continue
+        # ISO date strings compare correctly lexicographically.
+        date = entry.get("episode_date") or ""
+        if min_episode_date and date < min_episode_date:
+            continue
+        if max_episode_date and date > max_episode_date:
+            continue
+        out.append(entry)
+    return out
+
+
+def _rank(entries: List[dict], context_text: str) -> List[dict]:
+    """Deterministic best-first ordering.
+
+    Primary: token overlap with the context. Ties: newer ``episode_date``
+    first, then ``image_id`` — so identical inputs always yield identical
+    output regardless of manifest document order. Implemented as three
+    stable sorts (least- to most-significant key); Python's sort is stable
+    even with ``reverse=True``.
+    """
+    ctx = _tokenize(context_text)
+    ranked = sorted(entries, key=lambda e: e.get("image_id") or "")
+    ranked.sort(key=lambda e: e.get("episode_date") or "", reverse=True)
+    if ctx:
+        ranked.sort(key=lambda e: len(ctx & _entry_tokens(e)), reverse=True)
+    return ranked
+
+
+def _default_cache_dir() -> Path:
+    return Path(tempfile.gettempdir()) / "gallery_cache"
+
+
+def _cache_filename(entry: dict) -> str:
+    url = entry["original_url"]
+    basename = url.rstrip("/").rsplit("/", 1)[-1]
+    ext = Path(basename).suffix or ".jpg"
+    stem = entry.get("image_id") or Path(basename).stem
+    return f"{stem}{ext}"
+
+
+def _download_entry(entry: dict, cache_dir: Path) -> Optional[Path]:
+    """Fetch one image into the cache (or reuse); None on failure."""
+    dest = cache_dir / _cache_filename(entry)
+    if dest.exists() and dest.stat().st_size > 0:
+        _PATH_REGISTRY[dest] = entry
+        return dest
+    try:
+        resp = requests.get(entry["original_url"],
+                            timeout=DOWNLOAD_TIMEOUT_SECONDS)
+        resp.raise_for_status()
+        if not resp.content:
+            raise ValueError("empty response body")
+        dest.write_bytes(resp.content)
+    except Exception as exc:  # noqa: BLE001 — skip the image, keep going
+        logger.warning("gallery_library: failed to fetch %s: %s",
+                       entry.get("original_url"), exc)
+        return None
+    _PATH_REGISTRY[dest] = entry
+    return dest
+
+
+def select_library_scenes(
+    show_slug: str,
+    *,
+    aspect: str,
+    exclude_episode_id: Optional[str] = None,
+    context_text: str = "",
+    limit: int = 8,
+    manifest: Optional[dict] = None,
+    cache_dir: Optional[Path] = None,
+    min_episode_date: Optional[str] = None,
+    max_episode_date: Optional[str] = None,
+) -> List[Path]:
+    """Pick + download the show's most relevant already-generated scenes.
+
+    ``aspect`` is ``"16:9"`` (long-form ``segment_card`` images) or
+    ``"9:16"`` (Shorts ``social`` images). Candidates from the current
+    episode (``exclude_episode_id``) and outside the optional
+    ``[min_episode_date, max_episode_date]`` ISO-date window are dropped;
+    the rest are ranked by ``context_text`` token overlap against each
+    image's prompt/caption/tags with recency as the tiebreak.
+
+    Downloads are cached by ``image_id`` under ``cache_dir`` (default:
+    ``gallery_cache/`` in the system temp dir). Failed downloads are
+    skipped and the next-best candidate backfills, so the return is
+    best-first local Paths, up to ``limit``. Never raises.
+    """
+    try:
+        use = _ASPECT_TO_USE.get(aspect)
+        if use is None:
+            logger.warning("gallery_library: unknown aspect %r "
+                           "(want 16:9 or 9:16)", aspect)
+            return []
+        data = manifest if manifest is not None else load_manifest()
+        entries = _candidate_entries(
+            data, show_slug, intended_use=use,
+            exclude_episode_id=exclude_episode_id,
+            min_episode_date=min_episode_date,
+            max_episode_date=max_episode_date)
+        if not entries or limit <= 0:
+            return []
+        cdir = Path(cache_dir) if cache_dir else _default_cache_dir()
+        cdir.mkdir(parents=True, exist_ok=True)
+        paths: List[Path] = []
+        for entry in _rank(entries, context_text):
+            if len(paths) >= limit:
+                break
+            p = _download_entry(entry, cdir)
+            if p is not None:
+                paths.append(p)
+        return paths
+    except Exception as exc:  # noqa: BLE001 — library reuse is optional
+        logger.warning("gallery_library: scene selection failed for %s: %s",
+                       show_slug, exc)
+        return []
+
+
+def collect_week_scenes(
+    show_slug: str,
+    *,
+    aspect: str,
+    end_date: str,
+    days: int = 7,
+    exclude_episode_id: Optional[str] = None,
+    manifest: Optional[dict] = None,
+    cache_dir: Optional[Path] = None,
+    limit: int = 24,
+) -> List[Path]:
+    """Scenes from the ``days`` ending at ``end_date`` (ISO), newest first.
+
+    The weekly-recap variant of :func:`select_library_scenes`: no context
+    scoring — with an empty context the ranking degrades to pure recency,
+    which is exactly the "this week's imagery in order" a recap wants.
+    """
+    try:
+        import datetime as _dt
+        end = _dt.date.fromisoformat(str(end_date)[:10])
+        start = end - _dt.timedelta(days=max(0, days - 1))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("gallery_library: bad end_date %r: %s", end_date, exc)
+        return []
+    return select_library_scenes(
+        show_slug,
+        aspect=aspect,
+        exclude_episode_id=exclude_episode_id,
+        context_text="",
+        limit=limit,
+        manifest=manifest,
+        cache_dir=cache_dir,
+        min_episode_date=start.isoformat(),
+        max_episode_date=end.isoformat(),
+    )
+
+
+def scene_context_map(manifest: dict, paths: Iterable[Path]) -> Dict[Path, str]:
+    """Map each local scene Path back to its ``prompt`` + ``caption`` text.
+
+    This is the shape the scene scheduler consumes (``scene_context:
+    dict[Path, str]``). Resolution is two-layer: the in-process registry
+    written at download time (exact), then a manifest lookup by the
+    filename stem (cache files are named by ``image_id``, so a warm cache
+    from an earlier process still resolves). Unknown paths map to ``""``.
+    """
+    by_id: Dict[str, dict] = {}
+    try:
+        for entry in (manifest or {}).get("images", []) or []:
+            iid = entry.get("image_id")
+            if iid:
+                by_id.setdefault(iid, entry)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("gallery_library: bad manifest in scene_context_map: %s",
+                       exc)
+    out: Dict[Path, str] = {}
+    for p in paths:
+        p = Path(p)
+        entry = _PATH_REGISTRY.get(p) or by_id.get(p.stem) or {}
+        parts = [str(entry.get("prompt") or "").strip(),
+                 str(entry.get("caption") or "").strip()]
+        out[p] = "\n".join(part for part in parts if part)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Evergreen b-roll clips
+# ---------------------------------------------------------------------------
+
+
+def load_broll_entries(digests_dir: Path) -> List[dict]:
+    """Entries from ``<digests_dir>/broll.json`` in committed order.
+
+    Accepts both the builder's wrapped form (``{"clips": [...]}``) and a
+    bare list. Missing/corrupt file → ``[]``.
+    """
+    path = Path(digests_dir) / "broll.json"
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("gallery_library: broll.json unreadable at %s: %s",
+                       path, exc)
+        return []
+    clips = data.get("clips") if isinstance(data, dict) else data
+    if not isinstance(clips, list):
+        return []
+    return [c for c in clips if isinstance(c, dict) and c.get("url")]
+
+
+def select_broll_clips(
+    show_slug: str,
+    *,
+    digests_dir: Path,
+    limit: int = 3,
+    cache_dir: Optional[Path] = None,
+) -> List[Path]:
+    """Download up to ``limit`` curated evergreen clips for a show.
+
+    Reads the committed ``broll.json`` pool (see
+    ``scripts/build_broll_pool.py``) and returns local Paths in the pool's
+    stable committed order — no scoring, the operator curated the order.
+    Best-effort: a failed download is skipped (the next entry backfills);
+    a missing pool file is a clean ``[]``. Never raises.
+    """
+    try:
+        entries = load_broll_entries(Path(digests_dir))
+        if not entries or limit <= 0:
+            return []
+        cdir = (Path(cache_dir) if cache_dir
+                else _default_cache_dir() / "broll" / show_slug)
+        cdir.mkdir(parents=True, exist_ok=True)
+        paths: List[Path] = []
+        for entry in entries:
+            if len(paths) >= limit:
+                break
+            url = str(entry["url"])
+            dest = cdir / (url.rstrip("/").rsplit("/", 1)[-1] or "clip.mp4")
+            if dest.exists() and dest.stat().st_size > 0:
+                paths.append(dest)
+                continue
+            try:
+                resp = requests.get(url, timeout=DOWNLOAD_TIMEOUT_SECONDS)
+                resp.raise_for_status()
+                if not resp.content:
+                    raise ValueError("empty response body")
+                dest.write_bytes(resp.content)
+                paths.append(dest)
+            except Exception as exc:  # noqa: BLE001 — skip, keep going
+                logger.warning("gallery_library: failed to fetch b-roll %s: %s",
+                               url, exc)
+        return paths
+    except Exception as exc:  # noqa: BLE001 — b-roll is optional garnish
+        logger.warning("gallery_library: b-roll selection failed for %s: %s",
+                       show_slug, exc)
+        return []

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -108,6 +108,23 @@ def record_youtube_outcomes(
         metrics.record("shorts_end_card_enabled", bool(youtube_urls.get("shorts_end_card_enabled", True)))
         if youtube_urls.get("shorts_end_card_generated") is not None:
             metrics.record("shorts_end_card_generated", bool(youtube_urls["shorts_end_card_generated"]))
+
+        # Visual reuse + chapter-aligned scenes (June 2026 — engine/visual_reuse).
+        # visual_mode ∈ chapter_schedule | uniform | cover | library_fallback |
+        # recap_pool; the counts let the dashboard plot how much of each
+        # episode's imagery was fresh vs recycled from the gallery.
+        if youtube_urls.get("visual_mode"):
+            metrics.record("visual_mode", str(youtube_urls["visual_mode"]))
+        if "scene_fresh_count" in youtube_urls:
+            metrics.record("scene_fresh_count", int(youtube_urls.get("scene_fresh_count", 0) or 0))
+        if "scene_library_count" in youtube_urls:
+            metrics.record("scene_library_count", int(youtube_urls.get("scene_library_count", 0) or 0))
+        if "broll_clips_used" in youtube_urls:
+            metrics.record("broll_clips_used", int(youtube_urls.get("broll_clips_used", 0) or 0))
+        if youtube_urls.get("thumbnail_base"):
+            metrics.record("thumbnail_base", str(youtube_urls["thumbnail_base"]))
+        if youtube_urls.get("thumbnail_variant_urls"):
+            metrics.record("thumbnail_variant_urls", list(youtube_urls["thumbnail_variant_urls"]))
     except Exception:
         # Never let metrics recording break a publish
         logger = __import__("logging").getLogger(__name__)

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -18,7 +18,7 @@ import re
 import xml.etree.ElementTree as ET
 from email.utils import parsedate_to_datetime
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -1467,6 +1467,52 @@ def generate_episode_thumbnail(
     # the decision for observability of the May 2026 thumbnail improvements.
     final_hook_font = font_size if 'font_size' in locals() else None
     return output_path, final_hook_font
+
+
+def generate_thumbnail_variants(
+    scene_paths: "Sequence[Path]",
+    *,
+    episode_num: int,
+    date_str: str,
+    output_dir: Path,
+    base_name: str,
+    hook: str = "",
+    show_name: str = "",
+    count: int = 2,
+) -> "list[Path]":
+    """Render extra long-form thumbnail composites from alternate scenes.
+
+    WHY: YouTube Studio's "Test & Compare" A/B needs up to three thumbnail
+    candidates, but the pipeline historically produced exactly one (always
+    over the static show cover). Each variant here reuses the exact
+    :func:`generate_episode_thumbnail` composition (same hook text, same
+    autofit) over a DIFFERENT episode scene, so the only variable the A/B
+    measures is the background imagery — the signal the gallery-retention
+    join (scripts/build_gallery_retention.py) wants to learn from.
+
+    Variant files are named ``<base_name>_thumb_v2.jpg``, ``_v3.jpg``, …
+    (``v1`` is the primary thumbnail). Best-effort per scene: a failed
+    render is logged and skipped, never raised — variants are optional
+    garnish on the publish path.
+    """
+    out: "list[Path]" = []
+    for idx, scene in enumerate(scene_paths):
+        if len(out) >= max(0, int(count)):
+            break
+        try:
+            dest = Path(output_dir) / f"{base_name}_thumb_v{idx + 2}.jpg"
+            path, _font = generate_episode_thumbnail(
+                Path(scene),
+                episode_num,
+                date_str,
+                dest,
+                hook=hook,
+                show_name=show_name,
+            )
+            out.append(path)
+        except Exception as exc:  # noqa: BLE001 — variants are optional
+            logger.warning("Thumbnail variant v%d failed: %s", idx + 2, exc)
+    return out
 
 
 def generate_shorts_thumbnail(

--- a/engine/ru_dub.py
+++ b/engine/ru_dub.py
@@ -22,7 +22,9 @@ See ``docs/ru_youtube_dubs.md``.
 
 from __future__ import annotations
 
+import datetime
 import logging
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -49,6 +51,62 @@ def _episode_id(episode_num: int) -> str:
     return f"ep{episode_num:03d}"
 
 
+def _is_fresh_episode(date_str: str, *, today: Optional[datetime.date] = None) -> bool:
+    """True when the episode aired today or yesterday (UTC).
+
+    Used to decide whether a scene-less episode should be DEFERRED (fresh —
+    the gallery-manifest rebuild simply hasn't caught up yet) or published
+    with the cover anyway (old — no scenes are ever coming, and deferring
+    forever would silently drop the episode). Unparsable/empty dates count
+    as old so a malformed record still publishes rather than stalls.
+    """
+    try:
+        ep_date = datetime.date.fromisoformat((date_str or "")[:10])
+    except ValueError:
+        return False
+    now = today or datetime.datetime.now(datetime.timezone.utc).date()
+    return datetime.timedelta(0) <= (now - ep_date) <= datetime.timedelta(days=1)
+
+
+def _fresh_manifest_path(dest_dir: Path, *,
+                         manifest_path: Path = _MANIFEST) -> Path:
+    """Best-effort refresh of the gallery manifest from ``origin/main``.
+
+    The RU-dub sweep runs from a checkout whose manifest can LAG the newest
+    episode (the manifest is rebuilt by a separate workflow that commits to
+    main after the episode publishes) — so a fresh episode's scenes exist on
+    R2 + origin/main but not in this working tree. ``git fetch`` + ``git
+    show origin/main:<manifest>`` pulls the newest committed copy into
+    *dest_dir* without touching the working tree. Any failure (offline,
+    shallow clone without the ref, corrupt blob) falls back to the
+    checked-out file — never raises.
+    """
+    try:
+        rel = manifest_path.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return manifest_path  # non-repo path (tests) — nothing to refresh
+    try:
+        subprocess.run(["git", "fetch", "origin", "main"],
+                       cwd=PROJECT_ROOT, capture_output=True,
+                       timeout=60, check=False)
+        show = subprocess.run(["git", "show", f"origin/main:{rel}"],
+                              cwd=PROJECT_ROOT, capture_output=True,
+                              timeout=30, check=False)
+        if show.returncode == 0 and show.stdout:
+            import json
+            json.loads(show.stdout)  # validate before trusting the blob
+            fresh = Path(dest_dir) / "gallery-manifest.origin.json"
+            fresh.write_bytes(show.stdout)
+            logger.info("ru_dub: using origin/main gallery manifest")
+            return fresh
+        logger.info("ru_dub: origin/main manifest unavailable (rc=%s) — "
+                    "using checked-out copy", show.returncode)
+    except Exception as exc:  # noqa: BLE001 — refresh is best-effort
+        logger.info("ru_dub: manifest refresh failed (%s) — "
+                    "using checked-out copy", exc)
+    return manifest_path
+
+
 def gallery_images_for_episode(
     show_slug: str, episode_num: int, *,
     intended_use: str = "segment_card",
@@ -59,8 +117,10 @@ def gallery_images_for_episode(
     Filters the committed gallery manifest by ``show_slug`` + ``episode_id``
     + ``intended_use`` (``segment_card`` = the 16:9 long-form scenes;
     ``social`` = the 9:16 Shorts scenes). Empty list when the manifest has no
-    entry yet (the manifest rebuild can lag the newest episode — caller falls
-    back to the cover image, and a later sweep picks up the real scenes).
+    entry yet (the manifest rebuild can lag the newest episode —
+    ``publish_ru_dub`` defers a FRESH scene-less episode as ``no_scenes_yet``
+    so a later sweep retries with the real scenes; genuinely old episodes
+    fall back to the cover image).
     """
     import json
     try:
@@ -209,6 +269,30 @@ def publish_ru_dub(
         result["status"] = "no_cover"
         return result
 
+    # Scene availability gate. The checked-out manifest lags the newest
+    # episode (rebuilt by a separate workflow), so refresh from origin/main
+    # first; if a FRESH episode still has <2 long-form scenes, defer instead
+    # of shipping a cover-only dub — the recording sweep (publish_ru_dubs)
+    # marks it not-done so the next sweep retries once the manifest catches
+    # up. Old scene-less episodes still publish with the cover (no scenes
+    # are ever coming for them).
+    date_str = (rec.get("date") or "")[:10]
+    with tempfile.TemporaryDirectory() as mtd:
+        manifest_path = _fresh_manifest_path(Path(mtd))
+        long_urls = gallery_images_for_episode(
+            config.slug, episode_num, intended_use="segment_card",
+            manifest_path=manifest_path)
+        short_urls = gallery_images_for_episode(
+            config.slug, episode_num, intended_use="social",
+            manifest_path=manifest_path)
+    if len(long_urls) < 2 and _is_fresh_episode(date_str):
+        logger.info("ru_dub: %s Ep%s has %d gallery scene(s) and is fresh — "
+                    "deferring until the manifest rebuild catches up",
+                    config.slug, episode_num, len(long_urls))
+        result["status"] = "no_scenes_yet"
+        result["scene_count"] = len(long_urls)
+        return result
+
     from engine.video import build_long_form_video, build_short_video
     from engine.youtube import upload_video, add_video_to_playlist
     from engine.youtube_index import record_video
@@ -220,11 +304,9 @@ def publish_ru_dub(
             result["status"] = "no_ru_audio"
             return result
 
-        # Reuse the episode's already-generated 16:9 scene images (zero cost).
-        long_urls = gallery_images_for_episode(
-            config.slug, episode_num, intended_use="segment_card")
+        # Reuse the episode's already-generated 16:9 scene images (zero
+        # cost; URLs resolved above from the refreshed manifest).
         long_scenes = _download_images(long_urls, tmp) if long_urls else []
-        date_str = (rec.get("date") or "")[:10]
 
         # --- Long-form ---
         try:
@@ -290,8 +372,6 @@ def publish_ru_dub(
         # --- Short (best-effort; failure never blocks the long-form result) ---
         if build_short and getattr(yt, "publish_shorts", True):
             try:
-                short_urls = gallery_images_for_episode(
-                    config.slug, episode_num, intended_use="social")
                 short_scenes = _download_images(short_urls, tmp) if short_urls else []
                 short_mp4 = tmp / f"ru_short_ep{episode_num:03d}.mp4"
                 short_dur = float(getattr(yt, "short_duration_seconds", 55.0))

--- a/engine/scene_scheduler.py
+++ b/engine/scene_scheduler.py
@@ -1,0 +1,345 @@
+"""Chapter-aware scene scheduling for the YouTube slideshow renderers.
+
+WHY: the long-form slideshow historically cycled its Grok-Imagine scenes
+on a uniform timer (``audio_duration / scene_count``, capped at the
+15 s max hold), so scene changes landed at arbitrary moments — often
+mid-sentence, and never aligned with the episode's actual structure.
+Shorts were even blunter: a flat 7 s grid. The episode already ships a
+``chapters_ep<NNN>.json`` (Podcasting 2.0 JSON Chapters — ``startTime``
+seconds + ``title`` per entry) and a faster-whisper word-level
+transcript, so the planning inputs for *editorial* scene timing exist
+at zero extra cost.
+
+This module is PURE PLANNING — no ffmpeg, no network, no filesystem
+writes. It converts (scenes, chapters, audio length) into an explicit
+``[(scene_path, hold_seconds), …]`` schedule and (words, window) into
+sentence-snapped Shorts cut times. :mod:`engine.video` consumes the
+plans (``build_long_form_video(scene_schedule=…)`` /
+``build_short_video(scene_change_times=…)``); the gallery library
+supplies the scene pools + per-scene context text. Keeping the logic
+here makes it deterministic and unit-testable without rendering a
+single frame.
+
+Scheduling rules:
+
+* Scene switches land ON chapter boundaries; a chapter longer than
+  the max hold is subdivided into equal slots within
+  ``[min_hold_s, max_hold_s]``.
+* Scene choice per chapter scores case-insensitive token overlap
+  between the chapter title and each scene's context text (prompt /
+  caption). Fresh (this-episode) scenes win ties over library scenes;
+  scenes already used in the plan take a reuse penalty so a big pool
+  yields variety. Fully deterministic — stable index tie-break, no
+  randomness.
+* No chapters (or fewer than 2) falls back to the uniform plan that
+  mirrors today's ``engine.video`` behaviour byte-for-byte in spirit:
+  even split of the audio across the pool, capped at ``max_hold_s``,
+  rotating through the pool.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Legacy floor from engine.video.build_long_form_video — a very short
+# episode doesn't whip through scenes faster than this.
+_UNIFORM_MIN_HOLD_S = 8.0
+
+# Flat Shorts pacing (engine.video._SHORT_SCENE_DURATION_SECONDS) used
+# when a cadence gap contains no sentence-ending word to snap to.
+_FLAT_FALLBACK_GAP_S = 7.0
+
+# Scoring weights for scene selection. The fresh bonus is deliberately
+# smaller than one token of title overlap (topical match beats
+# freshness); the reuse penalty is larger than the fresh bonus so an
+# unused library scene beats a reused fresh one (variety wins when the
+# pool is big); the repeat penalty discourages the same image on two
+# consecutive slots when any alternative exists.
+_FRESH_BONUS = 0.25
+_REUSE_PENALTY = 0.5
+_REPEAT_PENALTY = 0.75
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_SENTENCE_END_CHARS = (".", "!", "?")
+
+# Chapter starts closer together than this collapse into one window —
+# sub-second "chapters" would produce unwatchable flicker.
+_MIN_CHAPTER_GAP_S = 1.0
+
+
+def _tokenize(text: Optional[str]) -> frozenset:
+    """Lower-cased alphanumeric token set for overlap scoring."""
+    if not text:
+        return frozenset()
+    return frozenset(_TOKEN_RE.findall(text.lower()))
+
+
+def _chapter_windows(
+    chapters, audio_duration_s: float,
+) -> Optional[List[Tuple[float, float, str]]]:
+    """Normalize a parsed chapters.json list into ``(start, end, title)``
+    windows partitioning ``[0, audio_duration_s]``.
+
+    Accepts either the raw ``chapters`` list or the whole file dict
+    (``{"version": …, "chapters": […]}``). Returns ``None`` when fewer
+    than 2 usable chapters exist — the caller falls back to the uniform
+    plan.
+    """
+    if isinstance(chapters, dict):
+        chapters = chapters.get("chapters")
+    entries: List[Tuple[float, str]] = []
+    for ch in chapters or []:
+        try:
+            start = float(ch.get("startTime"))
+        except (AttributeError, TypeError, ValueError):
+            continue
+        if not (0 <= start < audio_duration_s):
+            continue
+        entries.append((start, str(ch.get("title") or "")))
+    entries.sort(key=lambda e: e[0])
+
+    deduped: List[Tuple[float, str]] = []
+    for start, title in entries:
+        if deduped and start - deduped[-1][0] < _MIN_CHAPTER_GAP_S:
+            continue
+        deduped.append((start, title))
+    if len(deduped) < 2:
+        return None
+
+    # The plan must cover the full audio: clamp the first chapter to 0,
+    # or prepend an untitled window for any pre-chapter lead-in.
+    if deduped[0][0] > 0.5:
+        deduped.insert(0, (0.0, ""))
+    else:
+        deduped[0] = (0.0, deduped[0][1])
+
+    windows: List[Tuple[float, float, str]] = []
+    for i, (start, title) in enumerate(deduped):
+        end = deduped[i + 1][0] if i + 1 < len(deduped) else audio_duration_s
+        if end - start > 1e-6:
+            windows.append((start, end, title))
+    return windows or None
+
+
+def _subdivide(length: float, max_hold_s: float, min_hold_s: float) -> List[float]:
+    """Split a chapter into equal slots within ``[min_hold_s, max_hold_s]``.
+
+    A chapter shorter than ``min_hold_s`` is one slot of its full length
+    (the boundary alignment matters more than the floor). When the two
+    bounds conflict (pathological ``min > max/2`` configs), the min
+    hold wins — a slightly-long hold beats a flickering one.
+    """
+    n = max(1, math.ceil(length / max_hold_s))
+    while n > 1 and length / n < min_hold_s:
+        n -= 1
+    return [length / n] * n
+
+
+def _pick_scene(
+    pool: Sequence[Path],
+    fresh: frozenset,
+    context: Dict[Path, frozenset],
+    title_tokens: frozenset,
+    use_counts: Dict[Path, int],
+    last_pick: Optional[Path],
+) -> Path:
+    """Deterministically pick the best scene for one slot."""
+    best_path = pool[0]
+    best_key: Optional[Tuple[float, int]] = None
+    for idx, path in enumerate(pool):
+        score = float(len(title_tokens & context.get(path, frozenset())))
+        if path in fresh:
+            score += _FRESH_BONUS
+        score -= _REUSE_PENALTY * use_counts[path]
+        if path == last_pick:
+            score -= _REPEAT_PENALTY
+        key = (-score, idx)  # stable: index breaks exact ties
+        if best_key is None or key < best_key:
+            best_key = key
+            best_path = path
+    return best_path
+
+
+def _uniform_plan(
+    pool: Sequence[Path], audio_duration_s: float, max_hold_s: float,
+) -> List[Tuple[Path, float]]:
+    """The no-chapters fallback — mirrors today's uniform rotation in
+    ``engine.video.build_long_form_video``: even split of the audio
+    across the pool (floor 8 s), cycling the pool so no image holds
+    longer than ``max_hold_s``.
+    """
+    hold = max(_UNIFORM_MIN_HOLD_S, audio_duration_s / len(pool))
+    slots: List[Path] = list(pool)
+    if hold > max_hold_s and len(pool) > 1:
+        target = math.ceil(audio_duration_s / max_hold_s)
+        slots = [pool[i % len(pool)] for i in range(target)]
+        hold = max(_UNIFORM_MIN_HOLD_S, audio_duration_s / len(slots))
+    plan = [(path, hold) for path in slots]
+    # Last slot absorbs float rounding so the cumulative plan sums to
+    # the audio length. When the 8 s floor made the plan overshoot
+    # (very short audio), leave it — the composite's -shortest trims,
+    # exactly as the legacy renderer behaves.
+    diff = audio_duration_s - math.fsum(d for _, d in plan)
+    if plan and plan[-1][1] + diff >= 1.0:
+        plan[-1] = (plan[-1][0], plan[-1][1] + diff)
+    return plan
+
+
+def plan_chapter_schedule(
+    fresh_scenes: Optional[Sequence[Path]],
+    library_scenes: Optional[Sequence[Path]],
+    chapters,
+    audio_duration_s: float,
+    *,
+    max_hold_s: float = 15.0,
+    min_hold_s: float = 6.0,
+    scene_context: Optional[Dict[Path, str]] = None,
+) -> List[Tuple[Path, float]]:
+    """Plan the long-form slideshow as ``[(scene_path, hold_seconds), …]``.
+
+    Parameters
+    ----------
+    fresh_scenes:
+        This episode's Grok-Imagine scenes (preferred on score ties).
+    library_scenes:
+        Evergreen scenes from the gallery library (tie-break losers).
+    chapters:
+        The parsed ``chapters_ep<NNN>.json`` list (each entry carries
+        ``startTime`` seconds + ``title``; the whole file dict is also
+        accepted). ``None`` / empty / fewer than 2 chapters falls back
+        to the uniform rotation plan.
+    audio_duration_s:
+        Final mixed episode length; the plan's cumulative durations sum
+        to ~this (last slot absorbs rounding).
+    max_hold_s, min_hold_s:
+        Subdivision bounds — chapters longer than ``max_hold_s`` split
+        into equal slots no shorter than ``min_hold_s``.
+    scene_context:
+        Optional ``{path: prompt/caption text}`` used for the
+        title-overlap scoring; scenes without context score 0 overlap.
+    """
+    seen = set()
+    pool: List[Path] = []
+    fresh_list: List[Path] = []
+    for raw in list(fresh_scenes or []):
+        path = Path(raw)
+        if path not in seen:
+            seen.add(path)
+            pool.append(path)
+            fresh_list.append(path)
+    for raw in list(library_scenes or []):
+        path = Path(raw)
+        if path not in seen:
+            seen.add(path)
+            pool.append(path)
+
+    if not pool or not audio_duration_s or audio_duration_s <= 0:
+        return []
+    audio_duration_s = float(audio_duration_s)
+    fresh = frozenset(fresh_list)
+
+    context: Dict[Path, frozenset] = {}
+    for key, value in (scene_context or {}).items():
+        context[Path(key)] = _tokenize(value)
+
+    windows = _chapter_windows(chapters, audio_duration_s)
+    if windows is None:
+        logger.debug(
+            "scene_scheduler: no usable chapters — uniform fallback "
+            "(%d scenes, %.1fs)", len(pool), audio_duration_s,
+        )
+        return _uniform_plan(pool, audio_duration_s, max_hold_s)
+
+    plan: List[Tuple[Path, float]] = []
+    use_counts: Dict[Path, int] = {path: 0 for path in pool}
+    last_pick: Optional[Path] = None
+    for start, end, title in windows:
+        title_tokens = _tokenize(title)
+        for slot_duration in _subdivide(end - start, max_hold_s, min_hold_s):
+            pick = _pick_scene(
+                pool, fresh, context, title_tokens, use_counts, last_pick,
+            )
+            plan.append((pick, slot_duration))
+            use_counts[pick] += 1
+            last_pick = pick
+
+    diff = audio_duration_s - math.fsum(d for _, d in plan)
+    if plan and plan[-1][1] + diff >= 1.0:
+        plan[-1] = (plan[-1][0], plan[-1][1] + diff)
+    logger.debug(
+        "scene_scheduler: %d chapter windows → %d slots over %.1fs",
+        len(windows), len(plan), audio_duration_s,
+    )
+    return plan
+
+
+def sentence_cut_times(
+    words: Optional[Sequence[dict]],
+    window_start_s: float,
+    duration_s: float,
+    *,
+    min_gap_s: float = 5.0,
+    max_gap_s: float = 9.0,
+) -> List[float]:
+    """Sentence-snapped Shorts scene-change times, RELATIVE to clip start.
+
+    ``words`` is the faster-whisper per-word list already used by
+    :func:`engine.captions.transcript_to_ass_window` — dicts carrying
+    ``word`` (token, may include leading space + trailing punctuation),
+    ``start`` and ``end`` (seconds on the same timeline as
+    ``window_start_s``; the caller applies any music-intro audio offset
+    before handing the words over, same contract as the captions path).
+
+    Walks the clip in ``[min_gap_s, max_gap_s]`` steps; each cut snaps
+    to the sentence-ending word (``.``/``!``/``?`` suffix) nearest the
+    middle of the allowed band, so scene changes land between sentences
+    instead of mid-word. A band with no sentence end falls back to the
+    legacy flat 7 s pace for that step. No cut is ever placed within
+    ``min_gap_s`` of the clip end — the last scene always gets a full
+    hold before the end-card takes over.
+    """
+    if not duration_s or duration_s <= 0:
+        return []
+    duration_s = float(duration_s)
+    window_start_s = float(window_start_s)
+
+    ends: List[float] = []
+    for w in words or []:
+        token = (w.get("word") or "").strip()
+        if not token or not token.endswith(_SENTENCE_END_CHARS):
+            continue
+        try:
+            rel = float(w["end"]) - window_start_s
+        except (KeyError, TypeError, ValueError):
+            continue
+        if 0.0 < rel < duration_s:
+            ends.append(rel)
+    ends.sort()
+
+    flat_gap = min(max(_FLAT_FALLBACK_GAP_S, min_gap_s), max_gap_s)
+    limit = duration_s - min_gap_s  # end guard: no cut beyond this
+    cuts: List[float] = []
+    last = 0.0
+    while True:
+        lo = last + min_gap_s
+        hi = last + max_gap_s
+        if lo > limit:
+            break
+        band_hi = min(hi, limit)
+        candidates = [e for e in ends if lo <= e <= band_hi]
+        if candidates:
+            mid = (lo + hi) / 2.0
+            cut = min(candidates, key=lambda e: (abs(e - mid), e))
+        else:
+            cut = last + flat_gap
+            if cut > limit:
+                break
+        cuts.append(round(cut, 3))
+        last = cut
+    return cuts

--- a/engine/video.py
+++ b/engine/video.py
@@ -33,9 +33,10 @@ the rendition with "video can't play".
 from __future__ import annotations
 
 import logging
+import math
 import subprocess
 from pathlib import Path
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -448,6 +449,7 @@ _XFADE_TRANSITIONS = [
 
 def _slideshow_filter_graph(scene_count: int, *,
                             scene_duration: float = _SCENE_DURATION_SECONDS,
+                            scene_durations: Optional[Sequence[float]] = None,
                             width: int = 1920, height: int = 1080,
                             fps: int = 30,
                             crossfade: float = _SLIDESHOW_XFADE_S) -> str:
@@ -461,16 +463,39 @@ def _slideshow_filter_graph(scene_count: int, *,
     time, and the xfade offset for scene k is ``k * scene_duration`` — keeping
     total runtime ≈ ``scene_count * scene_duration`` (slightly longer, never
     shorter, than the audio it backs).
+
+    ``scene_durations`` (June 2026 chapter-aware pass) gives each scene its
+    OWN visible duration — the vehicle for chapter-aligned scene switches
+    planned by :mod:`engine.scene_scheduler`. Scene ``i`` is rendered
+    ``scene_durations[i] + crossfade`` long, and the xfade offset for join
+    ``k`` generalizes to the cumulative visible time ``sum(durations[:k])``
+    (with per-clip length ``d_k + crossfade`` this IS the standard xfade
+    chaining formula ``sum(clip_lens[:k]) - k*crossfade``). A uniform
+    durations list reproduces the legacy graph exactly (``math.fsum`` of
+    ``k`` equal floats rounds identically to ``k * scene_duration``); the
+    hard-cut ``concat`` fallback likewise honours per-scene durations via
+    each clip's own ``trim``.
     """
+    if scene_durations is not None and len(scene_durations) != scene_count:
+        raise ValueError(
+            f"scene_durations length {len(scene_durations)} != "
+            f"scene_count {scene_count}"
+        )
     pre_w = int(width * 1.15)
     pre_h = int(height * 1.15)
     zoom_expr = "min(zoom+0.0006,1.12)"
     use_xfade = crossfade and crossfade > 0 and scene_count >= 2
-    clip_len = scene_duration + (crossfade if use_xfade else 0.0)
-    frames_per_scene = int(clip_len * fps)
+    xfade_pad = crossfade if use_xfade else 0.0
+    durs: List[float] = (
+        [float(d) for d in scene_durations]
+        if scene_durations is not None
+        else [scene_duration] * scene_count
+    )
 
     chains: List[str] = []
     for i in range(scene_count):
+        clip_len = durs[i] + xfade_pad
+        frames_per_scene = int(clip_len * fps)
         chains.append(
             f"[{i}:v]"
             f"scale={pre_w}:{pre_h}:force_original_aspect_ratio=increase,"
@@ -490,7 +515,10 @@ def _slideshow_filter_graph(scene_count: int, *,
     prev = "[s0]"
     for k in range(1, scene_count):
         trans = _XFADE_TRANSITIONS[(k - 1) % len(_XFADE_TRANSITIONS)]
-        offset = k * scene_duration
+        offset = (
+            k * scene_duration if scene_durations is None
+            else math.fsum(durs[:k])
+        )
         out = "[v]" if k == scene_count - 1 else f"[x{k}]"
         chains.append(
             f"{prev}[s{k}]xfade=transition={trans}"
@@ -502,6 +530,7 @@ def _slideshow_filter_graph(scene_count: int, *,
 
 def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
                    *, scene_duration: float = _SCENE_DURATION_SECONDS,
+                   scene_durations: Optional[Sequence[float]] = None,
                    width: int = 1920, height: int = 1080,
                    fps: int = 30,
                    crossfade: float = _SLIDESHOW_XFADE_S) -> List[str]:
@@ -510,15 +539,25 @@ def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
     *width* and *height* default to 1920x1080 for the long-form path;
     pass 1080x1920 for the vertical Shorts variant. Uses the fast encode
     profile (this is an intermediate re-encoded by stage 2).
+
+    ``scene_durations`` gives each scene its own visible duration (the
+    chapter-aware schedule path); each looped image input's ``-t`` then
+    covers its OWN clip length instead of the shared uniform one. A
+    uniform list reproduces the legacy command exactly.
     """
     use_xfade = crossfade and crossfade > 0 and len(scene_paths) >= 2
-    per_input_t = scene_duration + (crossfade if use_xfade else 0.0) + 0.5
+    input_pad = (crossfade if use_xfade else 0.0) + 0.5
+    durs: List[float] = (
+        [float(d) for d in scene_durations]
+        if scene_durations is not None
+        else [scene_duration] * len(scene_paths)
+    )
     inputs: List[str] = []
-    for path in scene_paths:
+    for i, path in enumerate(scene_paths):
         inputs.extend([
             "-loop", "1",
             "-framerate", str(fps),
-            "-t", f"{per_input_t:.2f}",
+            "-t", f"{durs[i] + input_pad:.2f}",
             "-i", str(path),
         ])
     return [
@@ -527,6 +566,7 @@ def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
         "-filter_complex",
         _slideshow_filter_graph(len(scene_paths),
                                 scene_duration=scene_duration,
+                                scene_durations=scene_durations,
                                 width=width, height=height, fps=fps,
                                 crossfade=crossfade),
         "-map", "[v]",
@@ -540,13 +580,18 @@ def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
 
 def _render_slideshow(scene_paths: Sequence[Path], output: Path,
                       *, scene_duration: float = _SCENE_DURATION_SECONDS,
+                      scene_durations: Optional[Sequence[float]] = None,
                       width: int = 1920, height: int = 1080,
                       fps: int = 30) -> Path:
     """Render the stage-1 slideshow MP4. Idempotent (skips if output exists).
 
     Tries the crossfade graph first; if ffmpeg rejects it for any reason,
     retries once with plain hard-cut concat so a transition bug can never
-    block a render (worst case = the pre-June-2026 hard-cut look).
+    block a render (worst case = the pre-June-2026 hard-cut look). The
+    retry also catches the ``RuntimeError`` that :func:`_run_ffmpeg` wraps
+    around ffmpeg failures (June 2026 fix — the original
+    ``CalledProcessError``-only clause never matched the wrapped error,
+    so the documented hard-cut fallback couldn't actually fire).
     """
     if output.exists():
         return output
@@ -555,9 +600,10 @@ def _render_slideshow(scene_paths: Sequence[Path], output: Path,
     try:
         cmd = _slideshow_cmd(scene_paths, output,
                              scene_duration=scene_duration,
+                             scene_durations=scene_durations,
                              width=width, height=height, fps=fps)
         _run_ffmpeg(cmd, label="slideshow render (crossfade)")
-    except subprocess.CalledProcessError as exc:
+    except (subprocess.CalledProcessError, RuntimeError) as exc:
         logger.warning(
             "Crossfade slideshow render failed (%s) — retrying with hard cuts.",
             exc,
@@ -565,6 +611,7 @@ def _render_slideshow(scene_paths: Sequence[Path], output: Path,
         output.unlink(missing_ok=True)
         cmd = _slideshow_cmd(scene_paths, output,
                              scene_duration=scene_duration,
+                             scene_durations=scene_durations,
                              width=width, height=height, fps=fps,
                              crossfade=0.0)
         _run_ffmpeg(cmd, label="slideshow render (hard cut fallback)")
@@ -704,6 +751,81 @@ def _build_hybrid_sequence(scene_paths: Sequence[Path],
         visuals.append((clip_paths[ci], True, float(clip_durations[ci])))
         ci += 1
     return visuals
+
+
+# Evergreen-B-roll cap: more than ~3 clips per episode stops feeling like
+# accent motion and starts fighting the chapter-aligned still rhythm.
+_MAX_BROLL_CLIPS = 3
+
+
+def _interleave_broll_into_schedule(
+    schedule: Sequence[Tuple[Path, float]],
+    clip_paths: Sequence[Path],
+    clip_durations: Sequence[float],
+) -> List[tuple]:
+    """Interleave B-roll clips among the SCHEDULED stills.
+
+    Counterpart of :func:`_build_hybrid_sequence` for the chapter-aware
+    path: the stills keep their planned ORDER (so scene topicality still
+    tracks the chapters) but their holds shrink proportionally to make
+    room for the clips, keeping total runtime ≈ the scheduled total
+    (which the scheduler pinned to the audio length). Clips are spread
+    at roughly even positions, first clip at the open — same placement
+    rhythm as the uniform hybrid path.
+    """
+    total = math.fsum(d for _, d in schedule)
+    clip_total = math.fsum(float(d) for d in clip_durations)
+    factor = (max(0.0, total - clip_total) / total) if total > 0 else 1.0
+    stills = [(path, max(1.0, dur * factor)) for path, dur in schedule]
+
+    n_clips = len(clip_paths)
+    if n_clips == 0:
+        return [(path, False, dur) for path, dur in stills]
+    visuals: List[tuple] = []
+    step = max(1, len(stills) // n_clips)
+    ci = 0
+    for j, (path, dur) in enumerate(stills):
+        if ci < n_clips and j % step == 0:
+            visuals.append((clip_paths[ci], True, float(clip_durations[ci])))
+            ci += 1
+        visuals.append((path, False, dur))
+    while ci < n_clips:
+        visuals.append((clip_paths[ci], True, float(clip_durations[ci])))
+        ci += 1
+    return visuals
+
+
+def _short_segment_durations(cut_times: Sequence[float],
+                             duration: float,
+                             *, min_segment_s: float = 0.5) -> List[float]:
+    """Turn Shorts scene-change times into per-segment durations.
+
+    ``cut_times`` are seconds relative to the clip start (the
+    :func:`engine.scene_scheduler.sentence_cut_times` contract). Cuts
+    are sorted, deduped, and dropped when they'd create a segment
+    shorter than *min_segment_s* or land within *min_segment_s* of the
+    clip end. The last segment runs to the clip end, so the durations
+    always sum to *duration* exactly. Returns ``[]`` when no usable cut
+    survives — the caller keeps the legacy flat-pace path.
+    """
+    cuts: List[float] = []
+    last = 0.0
+    for t in sorted(float(t) for t in cut_times or []):
+        if t - last < min_segment_s:
+            continue
+        if t > duration - min_segment_s:
+            break
+        cuts.append(t)
+        last = t
+    if not cuts:
+        return []
+    durations: List[float] = []
+    prev = 0.0
+    for t in cuts:
+        durations.append(t - prev)
+        prev = t
+    durations.append(duration - prev)
+    return durations
 
 
 # ---------------------------------------------------------------------------
@@ -1165,13 +1287,17 @@ def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
                     end_card_sub_text: str = "Tap Subscribe ↗",
                     end_card_duration: float = 3.0,
                     end_card_image_in: Optional[str] = None,
-                    caption_margin_v: Optional[int] = None) -> List[str]:
+                    caption_margin_v: Optional[int] = None,
+                    bg_loop: bool = True) -> List[str]:
     """ffmpeg command for the 1080x1920 Shorts build.
 
     When *bg_is_video* is True, *bg_in* is a pre-rendered vertical
     slideshow MP4; we ``-stream_loop -1`` it so it loops to match the
     Shorts clip length, and we drop the ``-loop 1 -framerate``
-    image-input flags.
+    image-input flags. ``bg_loop=False`` (June 2026 sentence-cut pass)
+    drops the ``-stream_loop`` too — used when the slideshow was built
+    to the clip's FULL length from explicit scene-change times, so
+    looping it would restart the visuals mid-clip.
 
     When *url_pill_in* is provided, a 4th input is added (the
     ``nerranetwork.com`` URL pill PNG) and overlaid at bottom-center.
@@ -1185,7 +1311,10 @@ def _short_form_cmd(audio_in: str, bg_in: str, brand_in: str,
     (y≈1820).
     """
     if bg_is_video:
-        bg_input = ["-stream_loop", "-1", "-i", bg_in]
+        if bg_loop:
+            bg_input = ["-stream_loop", "-1", "-i", bg_in]
+        else:
+            bg_input = ["-i", bg_in]
     else:
         bg_input = ["-loop", "1", "-framerate", str(fps), "-i", bg_in]
 
@@ -1252,6 +1381,8 @@ def build_long_form_video(
     clip_paths: Optional[Sequence[Path]] = None,
     subtitles_path: Optional[Path] = None,
     show_name: Optional[str] = None,
+    scene_schedule: Optional[Sequence[Tuple[Path, float]]] = None,
+    broll_clips: Optional[Sequence[Path]] = None,
 ) -> Path:
     """Render a 1920x1080 long-form podcast video.
 
@@ -1282,6 +1413,20 @@ def build_long_form_video(
         top-right. When ``None``: legacy single "Nerra Network" pill
         in the top-left only. Tests + back-compat callers omit this
         kwarg and keep the legacy behaviour.
+    scene_schedule:
+        Optional explicit ``[(scene_path, hold_seconds), …]`` plan
+        (June 2026 — produced by
+        ``engine.scene_scheduler.plan_chapter_schedule`` so scene
+        switches land on chapter boundaries). With ≥2 entries the
+        slideshow uses these per-scene durations (cumulative xfade
+        offsets) instead of the uniform timer; ``None`` (or <2
+        entries) keeps the legacy uniform behaviour byte-for-byte.
+    broll_clips:
+        Optional already-local evergreen 16:9 silent MP4s. Up to
+        ``_MAX_BROLL_CLIPS`` (3) are interleaved at roughly even
+        positions between the stills via the hybrid renderer;
+        any failure degrades to the pure slideshow. Purely a
+        consumer of existing files — this never generates clips.
 
     Returns
     -------
@@ -1312,9 +1457,16 @@ def build_long_form_video(
         _make_brand_pill(brand_path)
         url_pill_path = None
 
+    # Chapter-aware schedule (June 2026): an explicit per-scene plan wins
+    # over the uniform timer. Normalized once so every branch below sees
+    # clean (Path, float) pairs; <2 entries keeps legacy behaviour.
+    schedule: Optional[List[Tuple[Path, float]]] = None
+    if scene_schedule and len(scene_schedule) >= 2:
+        schedule = [(Path(p), float(d)) for p, d in scene_schedule]
+
     bg_path: Path = cover_path
     bg_is_video = False
-    if scene_paths and len(scene_paths) >= 2:
+    if schedule or (scene_paths and len(scene_paths) >= 2):
         slideshow_path = work_dir / f"{output_path.stem}_slides.mp4"
         # Stretch each scene so the slideshow naturally spans the full
         # audio duration. Operator caught (May 8 2026) the previous
@@ -1332,10 +1484,16 @@ def build_long_form_video(
 
         # Hybrid path: interleave short video clips among the stills for
         # motion (Phase-4). Best-effort — any failure falls through to the
-        # pure-stills slideshow below.
+        # pure-stills slideshow below. ``broll_clips`` (June 2026) feeds
+        # the same renderer with already-local evergreen clips, capped at
+        # _MAX_BROLL_CLIPS so accents stay accents.
         usable_clips: List[Path] = [
             Path(c) for c in (clip_paths or []) if Path(c).exists()
         ]
+        usable_clips.extend(
+            Path(c) for c in list(broll_clips or [])[:_MAX_BROLL_CLIPS]
+            if Path(c).exists()
+        )
         if usable_clips and audio_duration_s > 0:
             try:
                 clip_durs: List[float] = []
@@ -1344,10 +1502,15 @@ def build_long_form_video(
                         clip_durs.append(float(_get_duration(str(c)) or 5.0))
                     except Exception:
                         clip_durs.append(5.0)
-                visuals = _build_hybrid_sequence(
-                    list(scene_paths), usable_clips, clip_durs,
-                    audio_duration_s=audio_duration_s,
-                )
+                if schedule:
+                    visuals = _interleave_broll_into_schedule(
+                        schedule, usable_clips, clip_durs,
+                    )
+                else:
+                    visuals = _build_hybrid_sequence(
+                        list(scene_paths), usable_clips, clip_durs,
+                        audio_duration_s=audio_duration_s,
+                    )
                 hybrid_path = work_dir / f"{output_path.stem}_hybrid.mp4"
                 _render_hybrid_slideshow(visuals, hybrid_path, fps=fps)
                 bg_path = hybrid_path
@@ -1376,40 +1539,60 @@ def build_long_form_video(
             _run_ffmpeg(cmd, label="long-form video")
             return output_path
 
-        slideshow_scenes = list(scene_paths)
-        if audio_duration_s > 0:
-            scene_duration_s = max(8.0, audio_duration_s / len(slideshow_scenes))
-            # Cycle the scene list so no single image holds longer than
-            # _MAX_SCENE_HOLD_S (module constant; June 2026 motion pass lowered
-            # it 25 → 15 s). The May 12 retune halved Grok spend to 4
-            # images/aspect, which left each scene on screen ~2-3 minutes on a
-            # full-length episode (Ep505: 4 scenes over 673 s = 168 s/image) —
-            # visually static. Reusing the SAME images in rotation restores
-            # visual rhythm at zero additional image cost.
-            if scene_duration_s > _MAX_SCENE_HOLD_S and len(slideshow_scenes) > 1:
-                import math
-                target = math.ceil(audio_duration_s / _MAX_SCENE_HOLD_S)
-                slideshow_scenes = [
-                    slideshow_scenes[i % len(slideshow_scenes)]
-                    for i in range(target)
-                ]
-                scene_duration_s = max(
-                    8.0, audio_duration_s / len(slideshow_scenes),
+        if schedule:
+            # Chapter-aware plan: the scheduler already decided both the
+            # scene ORDER and each scene's hold, so we render the
+            # slideshow with per-scene durations (cumulative xfade
+            # offsets) instead of the uniform timer. Distinct filename —
+            # a persistent work dir may hold a stale uniform render
+            # under the legacy name.
+            slideshow_path = work_dir / f"{output_path.stem}_slides_sched.mp4"
+            try:
+                _render_slideshow(
+                    [p for p, _ in schedule], slideshow_path,
+                    scene_durations=[d for _, d in schedule], fps=fps,
+                )
+                bg_path = slideshow_path
+                bg_is_video = True
+            except (subprocess.CalledProcessError, RuntimeError) as exc:
+                logger.warning(
+                    "Scheduled slideshow render failed (%s) — falling back "
+                    "to single cover", exc,
                 )
         else:
-            scene_duration_s = _SCENE_DURATION_SECONDS  # legacy 12 s
-        try:
-            _render_slideshow(
-                slideshow_scenes, slideshow_path,
-                scene_duration=scene_duration_s, fps=fps,
-            )
-            bg_path = slideshow_path
-            bg_is_video = True
-        except subprocess.CalledProcessError as exc:
-            logger.warning(
-                "Slideshow render failed (%s) — falling back to single cover",
-                exc,
-            )
+            slideshow_scenes = list(scene_paths)
+            if audio_duration_s > 0:
+                scene_duration_s = max(8.0, audio_duration_s / len(slideshow_scenes))
+                # Cycle the scene list so no single image holds longer than
+                # _MAX_SCENE_HOLD_S (module constant; June 2026 motion pass lowered
+                # it 25 → 15 s). The May 12 retune halved Grok spend to 4
+                # images/aspect, which left each scene on screen ~2-3 minutes on a
+                # full-length episode (Ep505: 4 scenes over 673 s = 168 s/image) —
+                # visually static. Reusing the SAME images in rotation restores
+                # visual rhythm at zero additional image cost.
+                if scene_duration_s > _MAX_SCENE_HOLD_S and len(slideshow_scenes) > 1:
+                    target = math.ceil(audio_duration_s / _MAX_SCENE_HOLD_S)
+                    slideshow_scenes = [
+                        slideshow_scenes[i % len(slideshow_scenes)]
+                        for i in range(target)
+                    ]
+                    scene_duration_s = max(
+                        8.0, audio_duration_s / len(slideshow_scenes),
+                    )
+            else:
+                scene_duration_s = _SCENE_DURATION_SECONDS  # legacy 12 s
+            try:
+                _render_slideshow(
+                    slideshow_scenes, slideshow_path,
+                    scene_duration=scene_duration_s, fps=fps,
+                )
+                bg_path = slideshow_path
+                bg_is_video = True
+            except subprocess.CalledProcessError as exc:
+                logger.warning(
+                    "Slideshow render failed (%s) — falling back to single cover",
+                    exc,
+                )
 
     cmd = _long_form_cmd(
         str(audio_path), str(bg_path), str(brand_path),
@@ -1440,7 +1623,8 @@ def build_short_video(audio_path: Path, cover_path: Path,
                       end_card_duration: float = 3.0,
                       end_card_image_path: Optional[Path] = None,
                       drop_url_pill: bool = False,
-                      caption_margin_v: Optional[int] = None) -> Path:
+                      caption_margin_v: Optional[int] = None,
+                      scene_change_times: Optional[Sequence[float]] = None) -> Path:
     """Render a 1080x1920 vertical YouTube Shorts video.
 
     ``drop_url_pill`` / ``caption_margin_v`` support the multi-platform
@@ -1480,6 +1664,17 @@ def build_short_video(audio_path: Path, cover_path: Path,
         ``_SHORTS_SUBTITLES_FORCE_STYLE``. The cues sit between the
         static hook (above) and the URL pill (below) so all three
         overlays are visible together without overlap.
+    scene_change_times:
+        Optional scene-cut times in seconds RELATIVE to the clip start
+        (June 2026 — produced by
+        ``engine.scene_scheduler.sentence_cut_times`` so background
+        changes land between sentences instead of on the flat 7 s
+        grid). When provided with ≥2 scene images, the vertical
+        slideshow is built to the clip's FULL length with those
+        per-segment durations and the composite drops the
+        ``-stream_loop`` (looping a full-length background would
+        restart the visuals mid-clip). ``None`` keeps the legacy
+        flat-pace loop path unchanged.
     """
     if duration >= 60:
         raise ValueError(
@@ -1509,21 +1704,56 @@ def build_short_video(audio_path: Path, cover_path: Path,
 
     bg_path: Path = cover_path
     bg_is_video = False
+    bg_full_length = False
     if scene_paths and len(scene_paths) >= 2:
-        slideshow_path = work_dir / f"{output_path.stem}_short_slides.mp4"
-        try:
-            _render_slideshow(
-                scene_paths, slideshow_path,
-                scene_duration=_SHORT_SCENE_DURATION_SECONDS,
-                width=1080, height=1920, fps=fps,
+        if scene_change_times:
+            # Sentence-snapped cuts (June 2026): build the vertical
+            # slideshow to the clip's FULL length with per-segment
+            # durations — no -stream_loop needed downstream. Scenes
+            # rotate through the pool per segment, mirroring the flat
+            # path's cycling. Any failure falls through to the legacy
+            # flat-pace loop below.
+            seg_durations = _short_segment_durations(
+                scene_change_times, duration,
             )
-            bg_path = slideshow_path
-            bg_is_video = True
-        except subprocess.CalledProcessError as exc:
-            logger.warning(
-                "Shorts slideshow render failed (%s) — falling back to cover",
-                exc,
-            )
+            if seg_durations:
+                seg_scenes = [
+                    scene_paths[i % len(scene_paths)]
+                    for i in range(len(seg_durations))
+                ]
+                slideshow_path = (
+                    work_dir / f"{output_path.stem}_short_slides_sched.mp4"
+                )
+                try:
+                    _render_slideshow(
+                        seg_scenes, slideshow_path,
+                        scene_durations=seg_durations,
+                        width=1080, height=1920, fps=fps,
+                    )
+                    bg_path = slideshow_path
+                    bg_is_video = True
+                    bg_full_length = True
+                except (subprocess.CalledProcessError, RuntimeError) as exc:
+                    logger.warning(
+                        "Scheduled Shorts slideshow render failed (%s) — "
+                        "falling back to the flat %.0fs pace",
+                        exc, _SHORT_SCENE_DURATION_SECONDS,
+                    )
+        if not bg_is_video:
+            slideshow_path = work_dir / f"{output_path.stem}_short_slides.mp4"
+            try:
+                _render_slideshow(
+                    scene_paths, slideshow_path,
+                    scene_duration=_SHORT_SCENE_DURATION_SECONDS,
+                    width=1080, height=1920, fps=fps,
+                )
+                bg_path = slideshow_path
+                bg_is_video = True
+            except subprocess.CalledProcessError as exc:
+                logger.warning(
+                    "Shorts slideshow render failed (%s) — falling back to cover",
+                    exc,
+                )
 
     cmd = _short_form_cmd(
         str(audio_path), str(bg_path), str(brand_path),
@@ -1543,6 +1773,7 @@ def build_short_video(audio_path: Path, cover_path: Path,
             else None
         ),
         caption_margin_v=caption_margin_v,
+        bg_loop=not bg_full_length,
     )
     logger.info(
         "Building Shorts video (%.1fs from %.1fs) → %s "

--- a/engine/visual_reuse.py
+++ b/engine/visual_reuse.py
@@ -1,0 +1,412 @@
+"""Composition layer wiring gallery reuse + chapter-aware scenes into run_show.
+
+WHY this module exists: the June 2026 visual-reuse engine layer
+(:mod:`engine.gallery_library` for pulling already-paid-for Grok Imagine
+scenes back down from R2, :mod:`engine.scene_scheduler` for chapter-aligned
+scene timing, and the ``scene_schedule`` / ``broll_clips`` /
+``scene_change_times`` render hooks on :mod:`engine.video`) is deliberately
+made of small orthogonal pieces. Composing them inline in
+``run_show.py:_publish_youtube`` would add ~150 lines to a function that is
+already the monolith's worst offender — so the composition lives here, where
+it is unit-testable without rendering a frame, and run_show only makes one
+call per surface (long-form plan / per-Short extras / recap pool / degraded
+fallback).
+
+Contract (identical to the gallery library's): every public function is
+best-effort and NEVER raises. Any internal failure logs a warning and
+returns the "legacy" shape — ``scene_schedule=None`` / ``scene_paths=None``
+/ empty lists — so the caller's byte-for-byte legacy render path takes over
+and a publish is never blocked by an optional visual upgrade.
+
+All behaviour is config-gated on the ``youtube:`` knobs added in the same
+pass (``gallery_blend_enabled``, ``chapter_aligned_scenes``,
+``recap_reuse_scenes``, ``gallery_fallback_enabled``,
+``shorts_sentence_cuts``, ``evergreen_broll`` — defaults on). None of this
+touches audio, so the whole system sits outside the landmine-#17 A/B gate.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# Matches engine.video._MAX_BROLL_CLIPS — requesting more would just be
+# truncated by the renderer, and the download cost is per-clip.
+_BROLL_LIMIT = 3
+
+# Weekly recaps pull a bigger pool than the daily blend: a ~15-min recap at
+# the 15 s max hold has ~60 slots, so more distinct images = less repetition.
+_RECAP_POOL_LIMIT = 24
+
+
+def _yt(config) -> Any:
+    return getattr(config, "youtube", None)
+
+
+def _flag(config, name: str, default: bool = True) -> bool:
+    return bool(getattr(_yt(config), name, default))
+
+
+def _paths(items: Optional[Sequence]) -> List[Path]:
+    return [Path(p) for p in (items or [])]
+
+
+def _dedup(*lists: Sequence[Path]) -> List[Path]:
+    seen: set = set()
+    out: List[Path] = []
+    for lst in lists:
+        for p in lst:
+            p = Path(p)
+            if p not in seen:
+                seen.add(p)
+                out.append(p)
+    return out
+
+
+def _load_chapters(chapters_path) -> Optional[list]:
+    """Parsed chapters list from a Podcasting-2.0 chapters.json; None if
+    missing/corrupt. Accepts the whole-file dict or a bare list."""
+    if not chapters_path:
+        return None
+    try:
+        p = Path(chapters_path)
+        if not p.exists():
+            return None
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 — chapters are optional input
+        logger.warning("visual_reuse: unreadable chapters at %s: %s",
+                       chapters_path, exc)
+        return None
+    chapters = data.get("chapters") if isinstance(data, dict) else data
+    return chapters if isinstance(chapters, list) else None
+
+
+def _usable_chapter_count(chapters: Optional[list],
+                          audio_duration_s: float) -> int:
+    """How many chapter entries the scheduler could actually anchor on.
+
+    Mirrors the scheduler's own filter (numeric ``startTime`` inside the
+    audio) so we can decide UP FRONT whether a chapter-aligned schedule is
+    meaningful — with <2 anchors the scheduler degrades to the uniform plan
+    anyway, and we'd rather report ``mode="uniform"`` honestly than ship a
+    schedule that is uniform in disguise.
+    """
+    starts = []
+    for ch in chapters or []:
+        try:
+            start = float(ch.get("startTime"))
+        except (AttributeError, TypeError, ValueError):
+            continue
+        if 0 <= start < audio_duration_s:
+            starts.append(start)
+    return len(set(starts))
+
+
+def load_transcript_words(transcript_path) -> List[dict]:
+    """Flatten a faster-whisper transcript JSON into one word list.
+
+    The per-word dicts (``word`` / ``start`` / ``end``) are exactly what
+    :func:`engine.scene_scheduler.sentence_cut_times` consumes. Older
+    episodes transcribed without ``word_timestamps=True`` have no ``words``
+    arrays — those (and any parse failure) return ``[]`` so the caller
+    simply skips sentence cuts. Never raises.
+    """
+    try:
+        p = Path(transcript_path)
+        data = json.loads(p.read_text(encoding="utf-8"))
+        words: List[dict] = []
+        for seg in (data.get("segments") or []) if isinstance(data, dict) else []:
+            for w in seg.get("words") or []:
+                if isinstance(w, dict):
+                    words.append(w)
+        return words
+    except Exception as exc:  # noqa: BLE001 — cuts are optional garnish
+        logger.warning("visual_reuse: could not load transcript words from "
+                       "%s: %s", transcript_path, exc)
+        return []
+
+
+def long_form_visual_plan(
+    config,
+    *,
+    show_slug: str,
+    episode_id: str,
+    hook: str,
+    fresh_scenes: Optional[Sequence[Path]],
+    chapters_path,
+    audio_duration_s: float,
+    digests_dir,
+    cache_dir: Optional[Path] = None,
+    fresh_scene_context: Optional[Dict[Path, str]] = None,
+    blend_library: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Plan the long-form slideshow visuals for one episode.
+
+    Returns a dict the caller can pass straight through to
+    ``engine.video.build_long_form_video``:
+
+    * ``scene_schedule`` — explicit ``[(path, hold_s), …]`` plan when
+      ``chapter_aligned_scenes`` is on AND the episode has ≥2 usable
+      chapters; ``None`` otherwise (legacy uniform rendering).
+    * ``scene_paths`` — the blended fresh + library pool (best-first),
+      or ``None`` when the pool has <2 images (legacy cover path).
+    * ``broll_clips`` — local evergreen clips (``evergreen_broll``; a
+      no-op until the operator publishes ``broll.json``), or ``None``.
+    * ``fresh_count`` / ``library_count`` / ``mode`` — observability
+      (``mode`` ∈ chapter_schedule | uniform | library_fallback | cover).
+
+    ``fresh_scene_context`` maps this episode's scene paths to their Grok
+    Imagine prompts so chapter-title scoring can pick topical images;
+    library context comes from the manifest. ``blend_library`` overrides
+    the ``gallery_blend_enabled`` config gate (the recap path passes
+    ``False`` because its pool IS library imagery already).
+
+    Best-effort: any failure returns the legacy shape (no schedule, no
+    extra scenes) with a logged warning. Never raises.
+    """
+    fresh = _paths(fresh_scenes)
+    legacy = {
+        "scene_schedule": None,
+        "broll_clips": None,
+        "scene_paths": None,
+        "fresh_count": len(fresh),
+        "library_count": 0,
+        "mode": "uniform" if len(fresh) >= 2 else "cover",
+    }
+    try:
+        out = dict(legacy)
+        chapters = _load_chapters(chapters_path)
+        context_text = " ".join(
+            [hook or ""] + [str(c.get("title") or "") for c in chapters or []]
+        ).strip()
+
+        manifest: Optional[dict] = None
+        library: List[Path] = []
+        do_blend = (_flag(config, "gallery_blend_enabled")
+                    if blend_library is None else bool(blend_library))
+        if do_blend:
+            from engine.gallery_library import load_manifest, select_library_scenes
+            manifest = load_manifest()
+            limit = int(getattr(_yt(config), "gallery_blend_max_long", 8) or 0)
+            library = select_library_scenes(
+                show_slug,
+                aspect="16:9",
+                exclude_episode_id=episode_id,
+                context_text=context_text,
+                limit=limit,
+                manifest=manifest,
+                cache_dir=cache_dir,
+            )
+        out["library_count"] = len(library)
+
+        if _flag(config, "evergreen_broll"):
+            from engine.gallery_library import select_broll_clips
+            broll = select_broll_clips(
+                show_slug, digests_dir=Path(digests_dir),
+                limit=_BROLL_LIMIT, cache_dir=cache_dir,
+            )
+            out["broll_clips"] = broll or None
+
+        pool = _dedup(fresh, library)
+        if len(pool) < 2:
+            out["mode"] = "cover"
+            return out
+        out["scene_paths"] = pool
+        out["mode"] = "uniform" if len(fresh) >= 2 else "library_fallback"
+
+        if (
+            _flag(config, "chapter_aligned_scenes")
+            and audio_duration_s and audio_duration_s > 0
+            and _usable_chapter_count(chapters, float(audio_duration_s)) >= 2
+        ):
+            scene_context: Dict[Path, str] = {
+                Path(k): str(v) for k, v in (fresh_scene_context or {}).items()
+            }
+            if library:
+                from engine.gallery_library import scene_context_map
+                scene_context.update(scene_context_map(manifest or {}, library))
+            from engine.scene_scheduler import plan_chapter_schedule
+            schedule = plan_chapter_schedule(
+                fresh, library, chapters, float(audio_duration_s),
+                scene_context=scene_context,
+            )
+            if len(schedule) >= 2:
+                out["scene_schedule"] = schedule
+                if len(fresh) >= 2:
+                    out["mode"] = "chapter_schedule"
+        logger.info(
+            "visual_reuse: long-form plan for %s %s — mode=%s fresh=%d "
+            "library=%d broll=%d slots=%s",
+            show_slug, episode_id, out["mode"], len(fresh), len(library),
+            len(out["broll_clips"] or []),
+            len(out["scene_schedule"]) if out["scene_schedule"] else "-",
+        )
+        return out
+    except Exception as exc:  # noqa: BLE001 — never block a publish
+        logger.warning(
+            "visual_reuse: long-form visual plan failed for %s %s: %s — "
+            "falling back to legacy visuals", show_slug, episode_id, exc,
+        )
+        return legacy
+
+
+def short_visual_extras(
+    config,
+    *,
+    show_slug: str,
+    episode_id: str,
+    fresh_short_scenes: Optional[Sequence[Path]],
+    transcript_words: Optional[Sequence[dict]],
+    window_start_s: float,
+    clip_duration_s: float,
+    cache_dir: Optional[Path] = None,
+    context_text: str = "",
+    blend_library: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Per-Short visual upgrades: blended 9:16 pool + sentence-snapped cuts.
+
+    * ``scene_paths`` — fresh vertical scenes + up to
+      ``gallery_blend_max_short`` library 9:16 scenes ranked against the
+      Short's hook; ``None`` when the blended pool has <2 images (the
+      caller keeps its legacy scene handling).
+    * ``scene_change_times`` — cut times relative to the clip start, from
+      :func:`engine.scene_scheduler.sentence_cut_times`
+      (``shorts_sentence_cuts`` gate); ``None`` when disabled or no word
+      data exists (legacy flat 7 s grid).
+
+    ``window_start_s`` must be on the SAME timeline as the transcript
+    words (the caller subtracts the music-intro offset, exactly as the
+    captions path does). Best-effort; never raises.
+    """
+    fresh = _paths(fresh_short_scenes)
+    legacy = {
+        "scene_paths": None,
+        "scene_change_times": None,
+        "fresh_count": len(fresh),
+        "library_count": 0,
+    }
+    try:
+        out = dict(legacy)
+        library: List[Path] = []
+        do_blend = (_flag(config, "gallery_blend_enabled")
+                    if blend_library is None else bool(blend_library))
+        if do_blend:
+            from engine.gallery_library import select_library_scenes
+            limit = int(getattr(_yt(config), "gallery_blend_max_short", 4) or 0)
+            library = select_library_scenes(
+                show_slug,
+                aspect="9:16",
+                exclude_episode_id=episode_id,
+                context_text=context_text,
+                limit=limit,
+                cache_dir=cache_dir,
+            )
+        out["library_count"] = len(library)
+        pool = _dedup(fresh, library)
+        if len(pool) >= 2:
+            out["scene_paths"] = pool
+
+        if _flag(config, "shorts_sentence_cuts") and transcript_words:
+            from engine.scene_scheduler import sentence_cut_times
+            cuts = sentence_cut_times(
+                list(transcript_words), float(window_start_s),
+                float(clip_duration_s),
+            )
+            out["scene_change_times"] = cuts or None
+        return out
+    except Exception as exc:  # noqa: BLE001 — never block a publish
+        logger.warning(
+            "visual_reuse: Shorts visual extras failed for %s %s: %s — "
+            "falling back to legacy visuals", show_slug, episode_id, exc,
+        )
+        return legacy
+
+
+def recap_scene_pool(
+    config,
+    *,
+    show_slug: str,
+    episode_id: str,
+    end_date: str,
+    cache_dir: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """The Sunday-recap scene pool: this week's imagery in both aspects.
+
+    A weekly recap synthesises its digest from the past 7 days of episodes
+    — the matching imagery already exists in the gallery, so regenerating
+    with Grok Imagine would pay twice for pictures of the same stories.
+    Returns ``{"long": [16:9 paths], "short": [9:16 paths], "enabled": bool}``;
+    the caller only skips generation when BOTH aspects have ≥2 images
+    (below that, generating fresh scenes as today is the better episode).
+    Gated on ``recap_reuse_scenes``. Best-effort; never raises.
+    """
+    out: Dict[str, Any] = {"long": [], "short": [], "enabled": False}
+    try:
+        if not _flag(config, "recap_reuse_scenes"):
+            return out
+        out["enabled"] = True
+        from engine.gallery_library import collect_week_scenes
+        for key, aspect in (("long", "16:9"), ("short", "9:16")):
+            out[key] = collect_week_scenes(
+                show_slug,
+                aspect=aspect,
+                end_date=end_date,
+                exclude_episode_id=episode_id,
+                cache_dir=cache_dir,
+                limit=_RECAP_POOL_LIMIT,
+            )
+        logger.info(
+            "visual_reuse: recap pool for %s %s — %d long / %d short scenes",
+            show_slug, episode_id, len(out["long"]), len(out["short"]),
+        )
+        return out
+    except Exception as exc:  # noqa: BLE001 — never block a publish
+        logger.warning(
+            "visual_reuse: recap scene pool failed for %s %s: %s — "
+            "generating scenes as usual", show_slug, episode_id, exc,
+        )
+        return {"long": [], "short": [], "enabled": False}
+
+
+def fallback_scene_pool(
+    config,
+    *,
+    show_slug: str,
+    episode_id: str,
+    cache_dir: Optional[Path] = None,
+    limit: int = 6,
+    aspect: str = "16:9",
+    context_text: str = "",
+) -> List[Path]:
+    """Library scenes for the degraded (<2 fresh scenes) case.
+
+    When Grok Imagine has a bad day (bad key / rate limit / model outage)
+    the slideshow used to degrade straight to the static cover. The show's
+    own historical imagery is strictly better than a static cover, so this
+    pulls the most relevant library scenes instead. Gated on
+    ``gallery_fallback_enabled``. Returns ``[]`` when disabled, when the
+    gallery has nothing for the show (e.g. Pexels-only shows), or on any
+    failure — the caller then degrades to the cover exactly as before.
+    """
+    try:
+        if not _flag(config, "gallery_fallback_enabled"):
+            return []
+        from engine.gallery_library import select_library_scenes
+        return select_library_scenes(
+            show_slug,
+            aspect=aspect,
+            exclude_episode_id=episode_id,
+            context_text=context_text,
+            limit=limit,
+            cache_dir=cache_dir,
+        )
+    except Exception as exc:  # noqa: BLE001 — never block a publish
+        logger.warning(
+            "visual_reuse: fallback scene pool failed for %s %s: %s",
+            show_slug, episode_id, exc,
+        )
+        return []

--- a/run_show.py
+++ b/run_show.py
@@ -613,6 +613,11 @@ def run(args: argparse.Namespace) -> None:
     digest_md = None
     extra_context: dict = {}
     articles: list = []
+    # Default for the resume-publish path (which skips the generation
+    # branch where the Sunday flag is resolved). Resumed runs generate
+    # imagery as usual — the recap-reuse optimisation only applies to
+    # first-pass Sunday runs where the flag is known.
+    is_weekly_recap = False
 
     if resume_publish:
         args = apply_resume_args(args)
@@ -2727,6 +2732,7 @@ def run(args: argparse.Namespace) -> None:
         chapters_path=chapters_path_for_yt,
         digests_dir=digests_dir,
         args=args,
+        is_weekly_recap=is_weekly_recap,
     )
     youtube_long_url = youtube_urls.get("long_url", "")
     youtube_short_url = youtube_urls.get("short_url", "")
@@ -2823,15 +2829,23 @@ def run(args: argparse.Namespace) -> None:
             if _imgs < 2:
                 _why = "; ".join(youtube_urls.get("grok_image_failures") or []) \
                     or "no failure detail captured"
+                # Which degraded path actually shipped (June 2026): the
+                # gallery-library fallback rescues most degraded days now;
+                # the static cover is the last resort.
+                _fb = (
+                    "the show's gallery-library scenes"
+                    if youtube_urls.get("visual_fallback") == "library"
+                    else "the static cover"
+                )
                 print(
                     f"::warning::Grok Imagine produced only {_imgs} image(s) "
-                    f"for {args.show} — the video shipped with the static cover "
+                    f"for {args.show} — the video shipped with {_fb} "
                     f"as a fallback. Cause: {_why}",
                     flush=True,
                 )
                 logger.warning(
                     "Grok slideshow degraded for %s: %d images (fell back to "
-                    "cover). Cause: %s", args.show, _imgs, _why,
+                    "%s). Cause: %s", args.show, _imgs, _fb, _why,
                 )
     except Exception:
         logger.warning("post-publish step failed (non-fatal)", exc_info=True)
@@ -3748,6 +3762,7 @@ def _publish_youtube(
     chapters_path: "Path",
     digests_dir: "Path",
     args,
+    is_weekly_recap: bool = False,
 ) -> dict:
     """Render long-form + Shorts video assets and upload them to YouTube.
 
@@ -4023,6 +4038,12 @@ def _publish_youtube(
     gallery_uploaded = 0
     gallery_attempted = 0
     gallery_skipped_reason = ""
+    # Path → Grok Imagine prompt for THIS episode's fresh scenes, so the
+    # chapter-aware scene scheduler can score fresh images against chapter
+    # titles the same way library images are scored via the manifest.
+    # Populated by _run_grok_path (filenames are grok_<NN>.<ext> where NN is
+    # the prompt index — same pairing the gallery uploader relies on).
+    fresh_scene_prompts: dict = {}
 
     def _run_pexels_path(into_long: bool, into_short: bool):
         nonlocal pexels_attribution, pexels_filtered
@@ -4139,6 +4160,13 @@ def _publish_youtube(
                     prompts=prompts,
                     aspect=aspect,
                 )
+                # Pair each scene back with its prompt (grok_NN filename ↔
+                # prompt index) for the chapter-aware scene scheduler.
+                import re as _re_ctx
+                for _sp in result.scene_set.paths():
+                    _m = _re_ctx.match(r"grok_(\d+)\.", Path(_sp).name)
+                    if _m and 0 <= int(_m.group(1)) < len(prompts):
+                        fresh_scene_prompts[Path(_sp)] = prompts[int(_m.group(1))]
                 return result.scene_set.paths()
         except Exception as exc:  # pragma: no cover — best-effort
             logger.warning("Grok Imagine scene fetch failed: %s", exc)
@@ -4257,8 +4285,44 @@ def _publish_youtube(
             first_failure or None,
         )
 
-    # Skip image provider logic if video_provider is enabled (videos replace slides)
-    if video_provider != "grok":
+    # ---- Sunday recap: reuse the week's gallery scenes (June 2026) ----
+    # A weekly recap re-tells this week's stories, whose imagery already
+    # exists in the gallery R2 bucket — regenerating with Grok Imagine
+    # would pay twice for pictures of the same stories. When BOTH aspects
+    # have ≥2 pooled scenes, skip scene generation entirely; below that,
+    # generate as on any other day. Best-effort + gated on
+    # youtube.recap_reuse_scenes (visual_reuse returns empty pools when
+    # disabled or on any failure).
+    recap_pool_used = False
+    if is_weekly_recap and video_provider != "grok":
+        try:
+            from engine.visual_reuse import recap_scene_pool
+            _recap_pool = recap_scene_pool(
+                config,
+                show_slug=config.slug,
+                episode_id=f"ep{episode_num:03d}",
+                end_date=f"{today:%Y-%m-%d}",
+            )
+            if (len(_recap_pool.get("long") or []) >= 2
+                    and len(_recap_pool.get("short") or []) >= 2):
+                long_scene_paths = list(_recap_pool["long"])
+                short_scene_paths = list(_recap_pool["short"])
+                recap_pool_used = True
+                pexels_attribution.append(
+                    "Imagery generated by Grok Imagine (xAI)."
+                )
+                logger.info(
+                    "Recap scene reuse: %d long / %d short gallery scenes — "
+                    "skipping scene generation.",
+                    len(long_scene_paths), len(short_scene_paths),
+                )
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.warning("Recap scene reuse failed: %s — generating "
+                           "scenes as usual", exc)
+
+    # Skip image provider logic if video_provider is enabled (videos replace
+    # slides) or the recap pool already supplied both scene sets.
+    if video_provider != "grok" and not recap_pool_used:
         if image_provider == "grok":
             long_scene_paths = _run_grok_path(aspect="16:9", label_suffix="")
             short_scene_paths = _run_grok_path(aspect="9:16", label_suffix="_short")
@@ -4267,6 +4331,142 @@ def _publish_youtube(
             short_scene_paths = _run_grok_path(aspect="9:16", label_suffix="_short")
         else:  # pexels (default)
             _run_pexels_path(into_long=True, into_short=True)
+
+    # ---- Fresh-scene bookkeeping + degraded gallery fallback (June 2026) ----
+    # "Fresh" = generated for THIS episode (recap-pool scenes are recycled,
+    # so they don't count). When generation degraded (<2 usable scenes —
+    # previously a straight fall-back to the static cover), pull the show's
+    # historical gallery scenes first and only degrade to the cover when
+    # the gallery is also empty (e.g. Pexels-only shows have no gallery).
+    if recap_pool_used:
+        fresh_long_scenes: "list[Path]" = []
+        fresh_short_scenes: "list[Path]" = []
+    else:
+        fresh_long_scenes = (
+            [Path(p) for p in long_scene_paths if Path(p) != Path(cover_path)]
+            if len(long_scene_paths) >= 2 else []
+        )
+        fresh_short_scenes = (
+            [Path(p) for p in short_scene_paths if Path(p) != Path(cover_path)]
+            if len(short_scene_paths) >= 2 else []
+        )
+    visual_fallback = ""
+    scene_library_count = 0
+    if not recap_pool_used and video_provider != "grok":
+        try:
+            from engine.visual_reuse import fallback_scene_pool
+            if len(long_scene_paths) < 2:
+                _fb_long = fallback_scene_pool(
+                    config, show_slug=config.slug,
+                    episode_id=f"ep{episode_num:03d}",
+                    aspect="16:9", context_text=hook or "",
+                )
+                if len(_fb_long) >= 2:
+                    long_scene_paths = list(_fb_long)
+                    scene_library_count += len(_fb_long)
+                    visual_fallback = "library"
+                elif image_provider in ("grok", "hybrid"):
+                    visual_fallback = "cover"
+            if len(short_scene_paths) < 2:
+                _fb_short = fallback_scene_pool(
+                    config, show_slug=config.slug,
+                    episode_id=f"ep{episode_num:03d}",
+                    aspect="9:16", context_text=hook or "",
+                )
+                if len(_fb_short) >= 2:
+                    short_scene_paths = list(_fb_short)
+                    scene_library_count += len(_fb_short)
+                    visual_fallback = visual_fallback or "library"
+                elif image_provider in ("grok", "hybrid"):
+                    visual_fallback = visual_fallback or "cover"
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.warning("Gallery fallback pool failed: %s", exc)
+        if visual_fallback:
+            result["visual_fallback"] = visual_fallback
+            logger.warning(
+                "Scene generation degraded for %s ep%s — fell back to the "
+                "%s.", config.slug, episode_num,
+                "gallery library" if visual_fallback == "library"
+                else "static cover",
+            )
+
+    # ---- Long-form thumbnail from a fresh scene + A/B variants ----
+    # The static cover made every episode's thumbnail identical; a fresh
+    # 16:9 scene gives each upload a distinct, episode-specific preview.
+    # The cover-based render above stays as the fallback when this fails.
+    result["thumbnail_base"] = "cover"
+    if getattr(yt, "long_form_thumbnail_from_scene", True) and fresh_long_scenes:
+        try:
+            _scene_thumb_out = work_dir / f"{base_name}_thumb.jpg"
+            _t_path, _t_font = generate_episode_thumbnail(
+                fresh_long_scenes[0],
+                episode_num=episode_num,
+                date_str=today_str,
+                output_path=_scene_thumb_out,
+                hook=hook,
+                show_name=show_label,
+            )
+            thumbnail_path = _scene_thumb_out
+            result["thumbnail_base"] = "scene"
+            if _t_font is not None:
+                result["thumbnail_autofit_font_size"] = int(_t_font)
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.warning(
+                "Scene-based thumbnail failed: %s — keeping the cover-based "
+                "thumbnail.", exc,
+            )
+    # Extra thumbnail composites from OTHER scenes (same hook/autofit) for
+    # the operator's Studio "Test & Compare" A/B. Uploaded to the gallery
+    # R2 bucket (tiny files; clean no-op when unconfigured) so their URLs
+    # survive past the ephemeral work dir.
+    _n_thumb_variants = int(getattr(yt, "thumbnail_variants", 2) or 0)
+    if (result["thumbnail_base"] == "scene" and _n_thumb_variants > 0
+            and len(fresh_long_scenes) > 1):
+        try:
+            from engine.publisher import generate_thumbnail_variants
+            _variant_paths = generate_thumbnail_variants(
+                fresh_long_scenes[1:],
+                episode_num=episode_num,
+                date_str=today_str,
+                output_dir=work_dir,
+                base_name=base_name,
+                hook=hook,
+                show_name=show_label,
+                count=_n_thumb_variants,
+            )
+            _variant_urls: "list[str]" = []
+            if _variant_paths:
+                from engine.gallery_uploader import (
+                    ImageMetadata as _VariantMeta,
+                    gallery_config_from_env as _variant_gconfig,
+                    upload_image as _variant_upload,
+                )
+                _vg = _variant_gconfig()
+                if _vg.is_configured:
+                    for _vp in _variant_paths:
+                        _vres = _variant_upload(
+                            Path(_vp).read_bytes(),
+                            _VariantMeta(
+                                image_id="",
+                                show_slug=config.slug,
+                                show_name=config.name,
+                                episode_id=f"ep{episode_num:03d}",
+                                episode_title=(
+                                    f"Ep {episode_num}: {hook}".strip(": ")
+                                    if hook else f"Ep {episode_num}"
+                                ),
+                                episode_date=today.strftime("%Y-%m-%d"),
+                                intended_use="thumbnail_variant",
+                                tags=[config.slug, "thumbnail_variant"],
+                            ),
+                            gallery_config=_vg,
+                        )
+                        if _vres is not None:
+                            _variant_urls.append(_vres.original_url)
+            if _variant_urls:
+                result["thumbnail_variant_urls"] = _variant_urls
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.warning("Thumbnail variants skipped: %s", exc)
 
     # Shorts thumbnail: vertical crop from cover or first vertical scene.
     shorts_thumb_base = cover_path
@@ -4290,6 +4490,42 @@ def _publish_youtube(
         _ep_duration = _audio_dur(str(final_mp3)) or 0.0
     except Exception:
         _ep_duration = 0.0
+
+    # ---- Long-form visual plan (June 2026 — engine/visual_reuse) ----
+    # Chapter-aligned scene schedule + gallery blending + evergreen b-roll.
+    # Best-effort: the planner never raises, and a legacy-shaped plan
+    # (scene_schedule=None) keeps build_long_form_video byte-for-byte on
+    # today's uniform path. Skipped entirely under the Grok Video path
+    # (videos replace slides).
+    _visual_plan: dict = {
+        "scene_schedule": None, "broll_clips": None, "scene_paths": None,
+        "fresh_count": len(fresh_long_scenes), "library_count": 0,
+        "mode": "uniform" if len(long_scene_paths) >= 2 else "cover",
+    }
+    if config.youtube.publish_long_form and video_provider != "grok":
+        try:
+            from engine.visual_reuse import long_form_visual_plan
+            _visual_plan = long_form_visual_plan(
+                config,
+                show_slug=config.slug,
+                episode_id=f"ep{episode_num:03d}",
+                hook=hook or "",
+                # On recap days the pooled week scenes take the fresh slot
+                # (they ARE the episode's imagery) and re-blending is off —
+                # the pool already came from the library.
+                fresh_scenes=(
+                    long_scene_paths if recap_pool_used else fresh_long_scenes
+                ),
+                chapters_path=chapters_path if chapters_path.exists() else None,
+                audio_duration_s=_ep_duration,
+                digests_dir=digests_dir,
+                fresh_scene_context=fresh_scene_prompts,
+                blend_library=False if recap_pool_used else None,
+            )
+            scene_library_count += int(_visual_plan.get("library_count") or 0)
+        except Exception as exc:  # pragma: no cover — never block a publish
+            logger.warning("Long-form visual plan failed: %s — legacy "
+                           "visuals", exc)
 
     # ---- Hybrid short video clips (Phase 4) — motion to complement stills ----
     # Best-effort, gated on youtube.video_clips_enabled (pilot: Tesla + SpaceX).
@@ -4326,10 +4562,15 @@ def _publish_youtube(
         try:
             build_long_form_video(
                 final_mp3, cover_path, long_video_path,
-                scene_paths=long_scene_paths if len(long_scene_paths) >= 2 else None,
+                scene_paths=(
+                    _visual_plan.get("scene_paths")
+                    or (long_scene_paths if len(long_scene_paths) >= 2 else None)
+                ),
                 clip_paths=long_clip_paths or None,
                 subtitles_path=srt_path,
                 show_name=config.name,
+                scene_schedule=_visual_plan.get("scene_schedule"),
+                broll_clips=_visual_plan.get("broll_clips"),
             )
             meta = build_long_form_metadata(
                 config,
@@ -4548,6 +4789,20 @@ def _publish_youtube(
                 getattr(config.audio, "voice_intro_delay", 0.0) or 0.0
             )
 
+            # Whisper word-level timings for sentence-snapped scene cuts
+            # (June 2026 — engine/visual_reuse). Loaded once per episode;
+            # [] (older transcripts without word data, or any failure)
+            # keeps the legacy flat 7 s scene grid.
+            _transcript_words: "list[dict]" = []
+            if transcript_path is not None and getattr(
+                _yt, "shorts_sentence_cuts", True
+            ):
+                try:
+                    from engine.visual_reuse import load_transcript_words
+                    _transcript_words = load_transcript_words(transcript_path)
+                except Exception as exc:  # pragma: no cover — best-effort
+                    logger.debug("Transcript word load skipped: %s", exc)
+
             # ---- Per-Short loop ----
             short_urls_out: "list[str]" = []
             short_video_ids_out: "list[str]" = []
@@ -4644,14 +4899,57 @@ def _publish_youtube(
                                 short_idx + 1, exc,
                             )
 
+                    # Per-Short visual extras (June 2026): 9:16 gallery
+                    # blending + sentence-snapped scene cuts. The legacy
+                    # scene list / flat grid takes over whenever the
+                    # extras come back empty (disabled flags, no library,
+                    # no word data, or any internal failure).
+                    _short_visuals: dict = {
+                        "scene_paths": None, "scene_change_times": None,
+                    }
+                    try:
+                        from engine.visual_reuse import short_visual_extras
+                        _short_visuals = short_visual_extras(
+                            config,
+                            show_slug=config.slug,
+                            episode_id=f"ep{episode_num:03d}",
+                            fresh_short_scenes=(
+                                short_scene_paths if recap_pool_used
+                                else fresh_short_scenes
+                            ),
+                            transcript_words=_transcript_words,
+                            # Words live on the voice-only Whisper
+                            # timeline; the final mix prepends the music
+                            # intro — same offset the captions apply.
+                            window_start_s=this_offset - _caption_offset,
+                            clip_duration_s=duration,
+                            context_text=(this_hook or hook or ""),
+                            blend_library=(
+                                False if recap_pool_used else None
+                            ),
+                        )
+                        if short_idx == 0:
+                            scene_library_count += int(
+                                _short_visuals.get("library_count") or 0
+                            )
+                    except Exception as exc:  # pragma: no cover
+                        logger.warning(
+                            "Shorts visual extras #%d failed: %s — legacy "
+                            "visuals", short_idx + 1, exc,
+                        )
+
                     build_short_video(
                         final_mp3, cover_path, this_short_video_path,
                         start_offset=this_offset,
                         duration=duration,
                         hook=this_hook or None,
                         scene_paths=(
-                            short_scene_paths
-                            if len(short_scene_paths) >= 2 else None
+                            _short_visuals.get("scene_paths")
+                            or (short_scene_paths
+                                if len(short_scene_paths) >= 2 else None)
+                        ),
+                        scene_change_times=_short_visuals.get(
+                            "scene_change_times"
                         ),
                         show_name=config.name,
                         subtitles_path=this_srt_path,
@@ -4817,6 +5115,23 @@ def _publish_youtube(
     except OSError:
         pass
 
+    # Visual reuse observability (June 2026). visual_mode is the single
+    # dashboard signal for how the episode's imagery was assembled:
+    # recap_pool (Sunday reuse) > library_fallback (degraded generation
+    # rescued by the gallery) > chapter_schedule / uniform / cover from
+    # the long-form plan.
+    if recap_pool_used:
+        result["visual_mode"] = "recap_pool"
+    elif visual_fallback == "library":
+        result["visual_mode"] = "library_fallback"
+    else:
+        result["visual_mode"] = str(_visual_plan.get("mode") or "cover")
+    result["scene_fresh_count"] = len(fresh_long_scenes) + len(fresh_short_scenes)
+    result["scene_library_count"] = (
+        scene_library_count + (len(long_scene_paths) + len(short_scene_paths)
+                               if recap_pool_used else 0)
+    )
+    result["broll_clips_used"] = len(_visual_plan.get("broll_clips") or [])
     # Surface the Pexels safety-filter count so the caller can record
     # it as a metric. A spike here is the operator's signal that the
     # show's image_queries / safe_skip_terms need tightening.

--- a/scripts/build_broll_pool.py
+++ b/scripts/build_broll_pool.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Populate a show's evergreen b-roll pool from curated local clips.
+
+The pool lets renders reuse video clips the network already paid for —
+primarily the recovered Grok Video clips (46 Tesla Ep519 + 12 SpaceX Ep12,
+16:9, silent) — instead of regenerating imagery. Consumers pull clips via
+``engine.gallery_library.select_broll_clips``.
+
+Operator workflow (end to end):
+
+  1. Recover clips that still exist server-side (result URLs are temporary,
+     so do this soon after a run)::
+
+         GROK_API_KEY=... python scripts/recover_grok_video.py \\
+             --out-dir recovered_ep519/
+
+  2. Curate locally: watch the clips, delete the duds, keep only evergreen
+     footage (generic Tesla factory shots, rockets on the pad — nothing
+     dated like a specific headline overlay).
+
+  3. Run this script to upload the keepers to R2 and index them::
+
+         python scripts/build_broll_pool.py --show tesla \\
+             recovered_ep519/ep519_clip02.mp4 recovered_ep519/ep519_clip05.mp4
+
+Uploads go to the gallery R2 bucket (``R2_GALLERY_BUCKET``, same env vars as
+``engine/gallery_uploader.py`` — ``R2_ENDPOINT_URL`` / ``R2_ACCESS_KEY_ID``
+/ ``R2_SECRET_ACCESS_KEY`` / ``R2_GALLERY_PUBLIC_BASE_URL``) under a
+``broll/<slug>/`` prefix, keyed by content hash so re-runs are idempotent.
+Duration is probed via ffprobe (``engine.audio.get_audio_duration`` — the
+format-level probe works for video files too).
+
+The ONLY thing committed to git is the small ``digests/<dir>/broll.json``
+index (entries: ``{"url", "duration_s", "label", "key"}``, merged by url,
+stable order). Never ``git add`` the clips themselves — media in git is
+landmine #1.
+
+Usage::
+
+    python scripts/build_broll_pool.py --show tesla clip1.mp4 clip2.mp4
+    python scripts/build_broll_pool.py --show spacex --label "pad b-roll" clip.mp4
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import List
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(PROJECT_ROOT / ".env")
+
+from engine.audio import get_audio_duration  # noqa: E402
+from engine.config import load_config  # noqa: E402
+from engine.gallery_uploader import (  # noqa: E402
+    compute_image_id,
+    gallery_config_from_env,
+)
+from engine.storage import upload_to_r2  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("build_broll_pool")
+
+_VIDEO_CONTENT_TYPES = {
+    ".mp4": "video/mp4",
+    ".mov": "video/quicktime",
+    ".webm": "video/webm",
+    ".mkv": "video/x-matroska",
+}
+
+
+def _load_pool(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Existing %s unreadable (%s) — starting fresh", path, exc)
+        return {}
+    if isinstance(data, list):  # tolerate a hand-written bare list
+        return {"clips": data}
+    return data if isinstance(data, dict) else {}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--show", required=True, help="Show slug (e.g. tesla)")
+    ap.add_argument("clips", nargs="+", type=Path,
+                    help="Curated local clip files (.mp4/.mov/.webm)")
+    ap.add_argument("--label", default=None,
+                    help="Label for the uploaded clips (default: file stem)")
+    args = ap.parse_args()
+
+    try:
+        config = load_config(f"shows/{args.show}.yaml")
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Cannot load shows/%s.yaml: %s", args.show, exc)
+        return 1
+    pool_path = PROJECT_ROOT / config.episode.output_dir / "broll.json"
+
+    gcfg = gallery_config_from_env()
+    if not gcfg.is_configured:
+        logger.error("Gallery R2 not configured — set R2_ENDPOINT_URL / "
+                     "R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY "
+                     "(+ optional R2_GALLERY_BUCKET / "
+                     "R2_GALLERY_PUBLIC_BASE_URL).")
+        return 1
+
+    data = _load_pool(pool_path)
+    clips: List[dict] = [c for c in data.get("clips", [])
+                         if isinstance(c, dict) and c.get("url")]
+    by_url = {c["url"]: c for c in clips}
+
+    uploaded = 0
+    for clip in args.clips:
+        if not clip.exists():
+            logger.error("%s: not found — skipped", clip)
+            continue
+        ext = clip.suffix.lower()
+        content_type = _VIDEO_CONTENT_TYPES.get(ext)
+        if content_type is None:
+            logger.error("%s: unsupported extension %s — skipped", clip, ext)
+            continue
+        duration = get_audio_duration(clip)  # ffprobe format probe; video OK
+        if not duration:
+            logger.error("%s: ffprobe could not read a duration — skipped "
+                         "(is it a valid video file?)", clip)
+            continue
+        # Content-hash key (same idempotency convention as gallery images):
+        # re-running on the same bytes re-uploads to the same object.
+        stem = compute_image_id(clip.read_bytes())
+        key = f"broll/{args.show}/{stem}{ext}"
+        try:
+            url = upload_to_r2(
+                clip, key,
+                bucket=gcfg.bucket,
+                endpoint_url=gcfg.endpoint_url,
+                access_key=gcfg.access_key,
+                secret_key=gcfg.secret_key,
+                public_base_url=gcfg.public_base_url,
+                content_type=content_type,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("%s: R2 upload failed (%s): %s — skipped",
+                         clip, type(exc).__name__, exc)
+            continue
+        entry = {
+            "url": url,
+            "duration_s": round(float(duration), 2),
+            "label": args.label or clip.stem,
+            "key": key,
+        }
+        if url in by_url:
+            by_url[url].update(entry)  # refresh label/duration in place
+        else:
+            clips.append(entry)
+            by_url[url] = entry
+        uploaded += 1
+        logger.info("%s → %s (%.1fs)", clip.name, url, duration)
+
+    if not uploaded:
+        logger.error("No clips uploaded — broll.json unchanged.")
+        return 1
+
+    data["show_slug"] = args.show
+    data["updated"] = datetime.datetime.now(
+        datetime.timezone.utc).isoformat(timespec="seconds")
+    data["clips"] = clips
+    pool_path.parent.mkdir(parents=True, exist_ok=True)
+    pool_path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+                         encoding="utf-8")
+    logger.info("Pool updated: %s (%d clip(s) total). Commit ONLY this JSON — "
+                "never the media files.", pool_path, len(clips))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_gallery_retention.py
+++ b/scripts/build_gallery_retention.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Join gallery images with YouTube retention — the imagery data flywheel.
+
+The gallery manifest (``site/data/gallery-manifest.json``) knows which Grok
+Imagine images went into which episode's video; the YouTube analytics
+fetcher (``scripts/fetch_youtube_analytics.py`` → ``api/youtube_stats.json``)
+knows each video's ``averageViewPercentage`` (retention — the strongest
+public content-quality signal). Neither side alone can answer "which imagery
+styles keep viewers watching?" — this script joins them into
+``api/gallery_retention.json`` so the dashboard (and a future
+image-prompt feedback loop, mirroring the title-hint loop in
+``scripts/update_youtube_performance.py``) can rank image tags by the mean
+retention of the videos they appeared in.
+
+Join strategy: an image's ``youtube_video_id`` wins when present (the
+sidecar field exists but uploads happen before the video id is known, so it
+is usually empty); otherwise the image joins on
+``(show_slug, episode number, kind)`` — ``segment_card`` (16:9) images pair
+with the ``long`` upload, ``social`` (9:16) with the ``short``.
+
+Per-show summary: top/bottom tags by mean retention, only for tags backed by
+at least ``--min-videos`` (default 3) distinct videos — below that the mean
+is noise.
+
+Clean no-op by convention: when the manifest or the analytics file is
+missing/empty, the output is written with an empty ``shows`` map (never an
+error), so the nightly workflow can run this unconditionally.
+
+Usage::
+
+    python scripts/build_gallery_retention.py                    # write api/gallery_retention.json
+    python scripts/build_gallery_retention.py --dry-run          # print, no write
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_ROOT = _SCRIPT_DIR.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("build_gallery_retention")
+
+# Manifest intended_use → youtube_videos kind. Only these two uses appear in
+# rendered videos; thumbnails/variants/other are skipped (no watch-time to
+# attribute).
+_USE_TO_KIND = {"segment_card": "long", "social": "short"}
+
+# Tags that appear on virtually every image (slug, provider, use) carry no
+# imagery-style signal and would dominate every summary.
+_GENERIC_TAGS = frozenset({"grok-imagine", "segment_card", "social",
+                           "thumbnail_variant"})
+
+
+def _load_json(path: Path) -> Optional[dict]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 — absent data = clean no-op
+        logger.info("Unreadable %s (%s) — treating as absent", path, exc)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _episode_number(episode_id: str) -> Optional[int]:
+    """``ep051`` → 51 (the manifest form); bare digits also accepted."""
+    m = re.search(r"(\d+)", str(episode_id or ""))
+    return int(m.group(1)) if m else None
+
+
+def _index_videos(stats: dict) -> tuple:
+    """Index analytics rows by video_id and by (slug, episode, kind)."""
+    by_id: Dict[str, dict] = {}
+    by_key: Dict[tuple, dict] = {}
+    for show in (stats.get("shows") or {}).values():
+        for v in (show or {}).get("videos") or []:
+            vid = v.get("video_id")
+            if not vid:
+                continue
+            by_id[vid] = v
+            slug = v.get("show_slug") or ""
+            episode = v.get("episode")
+            kind = v.get("kind") or ""
+            if slug and episode is not None and kind:
+                # First writer wins — multi-Shorts episodes upload several
+                # ``short`` rows; attributing the 9:16 set to the first is
+                # the stable, deterministic choice.
+                by_key.setdefault((slug, int(episode), kind), v)
+    return by_id, by_key
+
+
+def build(manifest: Optional[dict], stats: Optional[dict],
+          *, min_videos: int = 3) -> dict:
+    """Compose the retention join. Empty ``shows`` when either side is absent."""
+    payload = {
+        "schema_version": 1,
+        "generated": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "shows": {},
+    }
+    if not manifest or not stats:
+        return payload
+
+    by_id, by_key = _index_videos(stats)
+    if not by_id:
+        return payload
+
+    shows: Dict[str, dict] = {}
+    # tag → list of (video_id, retention) per show, deduped by video so a
+    # 4-image episode doesn't count its one video 4 times per tag.
+    tag_videos: Dict[str, Dict[str, Dict[str, float]]] = defaultdict(
+        lambda: defaultdict(dict))
+
+    for entry in manifest.get("images") or []:
+        slug = entry.get("show_slug") or ""
+        image_id = entry.get("image_id") or ""
+        if not slug or not image_id:
+            continue
+        kind = _USE_TO_KIND.get(entry.get("intended_use") or "")
+        video = by_id.get(entry.get("youtube_video_id") or "")
+        if video is None and kind:
+            episode = _episode_number(entry.get("episode_id") or "")
+            if episode is not None:
+                video = by_key.get((slug, episode, kind))
+        if video is None:
+            continue
+        retention = float(video.get("average_view_percentage") or 0.0)
+        tags = [t for t in (entry.get("tags") or [])
+                if t and t != slug and t not in _GENERIC_TAGS]
+        shows.setdefault(slug, {"images": {}, "summary": {}})
+        shows[slug]["images"][image_id] = {
+            "video_id": video.get("video_id"),
+            "averageViewPercentage": retention,
+            "episode_id": entry.get("episode_id") or "",
+            "tags": tags,
+        }
+        for tag in tags:
+            tag_videos[slug][tag][video["video_id"]] = retention
+
+    for slug, per_tag in tag_videos.items():
+        ranked: List[dict] = []
+        for tag, vids in per_tag.items():
+            if len(vids) < max(1, int(min_videos)):
+                continue
+            ranked.append({
+                "tag": tag,
+                "videos": len(vids),
+                "mean_retention": round(sum(vids.values()) / len(vids), 2),
+            })
+        ranked.sort(key=lambda r: (-r["mean_retention"], r["tag"]))
+        shows[slug]["summary"] = {
+            "min_videos": int(min_videos),
+            "top_tags": ranked[:5],
+            "bottom_tags": sorted(
+                ranked, key=lambda r: (r["mean_retention"], r["tag"])
+            )[:5],
+        }
+
+    payload["shows"] = shows
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", default="site/data/gallery-manifest.json")
+    parser.add_argument("--stats", default="api/youtube_stats.json")
+    parser.add_argument("--out", default="api/gallery_retention.json")
+    parser.add_argument("--min-videos", type=int, default=3,
+                        help="Minimum distinct videos behind a tag before "
+                             "its mean retention enters the summary")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    payload = build(
+        _load_json(_ROOT / args.manifest),
+        _load_json(_ROOT / args.stats),
+        min_videos=args.min_videos,
+    )
+    n_images = sum(len(s["images"]) for s in payload["shows"].values())
+    logger.info("Joined %d gallery images with retention across %d shows",
+                n_images, len(payload["shows"]))
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, ensure_ascii=False)[:4000])
+        return 0
+
+    out_path = _ROOT / args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    logger.info("Wrote %s", out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publish_ru_dubs.py
+++ b/scripts/publish_ru_dubs.py
@@ -8,7 +8,10 @@ images) and uploads it to the @NerraRU channel. See ``engine.ru_dub`` /
 ``docs/ru_youtube_dubs.md``.
 
 Idempotent: skips episodes whose RU video is already recorded in the per-show
-``youtube_videos.ru.json`` index unless ``--force``.
+``youtube_videos.ru.json`` index unless ``--force``. A ``no_scenes_yet``
+deferral (fresh episode whose gallery scenes haven't reached the committed
+manifest yet) is recorded as a status-only row and does NOT count as done —
+the next sweep retries it with the real scenes.
 
 Usage::
 
@@ -67,6 +70,12 @@ def _already_done(config, episode_num: int) -> bool:
     # public long-form video. A failed Short is therefore NOT retried; it is
     # recorded durably in the index by _record_short_failure so the gap is
     # visible (re-publish with --force after fixing the cause).
+    #
+    # The row must carry a video_id: status-only rows (a short-failure row
+    # or a no_scenes_yet deferral row) mean nothing was uploaded, so the
+    # episode is NOT done and the next sweep retries it — that's the whole
+    # point of the deferral (the gallery-manifest rebuild lags the newest
+    # episode; retrying later picks up the real scenes).
     idx = _index_path(config)
     if not idx.exists():
         return False
@@ -75,6 +84,7 @@ def _already_done(config, episode_num: int) -> bool:
     except Exception:  # noqa: BLE001
         return False
     return any(v.get("episode") == episode_num and v.get("kind") == "long"
+               and v.get("video_id")
                for v in data.get("videos", []))
 
 
@@ -110,6 +120,64 @@ def _record_short_failure(config, episode_num: int, error: str) -> None:
                        encoding="utf-8")
     except OSError as exc:
         logger.warning("Could not record short failure in %s: %s", idx, exc)
+
+
+def _record_scenes_deferral(config, episode_num: int) -> None:
+    """Durably note a ``no_scenes_yet`` deferral in the per-show RU index.
+
+    Same conventions as ``_record_short_failure``: no ``video_id`` (nothing
+    was uploaded — so ``_already_done`` treats the episode as NOT done and
+    the next sweep retries once the gallery-manifest rebuild catches up),
+    one row per episode (latest wins), and the row exists so the operator
+    can see WHY an episode's RU dub hasn't shipped yet instead of the
+    deferral living only in a runner log."""
+    import datetime as _dt
+    idx = _index_path(config)
+    try:
+        data = json.loads(idx.read_text(encoding="utf-8")) if idx.exists() else {}
+    except Exception:  # noqa: BLE001
+        data = {}
+    videos = data.setdefault("videos", [])
+    videos[:] = [v for v in videos
+                 if not (v.get("episode") == episode_num
+                         and v.get("kind") == "long"
+                         and v.get("status") == "deferred")]
+    videos.append({
+        "episode": episode_num,
+        "kind": "long",
+        "status": "deferred",
+        "reason": "no_scenes_yet",
+        "recorded": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+    })
+    try:
+        idx.parent.mkdir(parents=True, exist_ok=True)
+        idx.write_text(json.dumps(data, ensure_ascii=False, indent=2),
+                       encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Could not record scenes deferral in %s: %s", idx, exc)
+
+
+def _clear_scenes_deferral(config, episode_num: int) -> None:
+    """Drop a stale deferral row once the episode's long-form ships."""
+    idx = _index_path(config)
+    if not idx.exists():
+        return
+    try:
+        data = json.loads(idx.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return
+    videos = data.get("videos", [])
+    kept = [v for v in videos
+            if not (v.get("episode") == episode_num
+                    and v.get("kind") == "long"
+                    and v.get("status") == "deferred")]
+    if len(kept) != len(videos):
+        data["videos"] = kept
+        try:
+            idx.write_text(json.dumps(data, ensure_ascii=False, indent=2),
+                           encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Could not clear scenes deferral in %s: %s", idx, exc)
 
 
 def _clear_short_failure(config, episode_num: int) -> None:
@@ -182,6 +250,16 @@ def main() -> int:
             res = ru_dub.publish_ru_dub(
                 config, ep, build_short=not args.no_short, dry_run=args.dry_run)
             logger.info("%s Ep%s: %s", slug, ep, res.get("status"))
+            if res.get("status") == "no_scenes_yet" and not args.dry_run:
+                # Fresh episode whose gallery scenes aren't in the manifest
+                # yet — record the deferral (visible + NOT done) so the next
+                # sweep retries with the real scenes instead of the first
+                # scene-less cover upload becoming final.
+                logger.info("%s Ep%s: scenes not in gallery manifest yet — "
+                            "deferred for the next sweep", slug, ep)
+                _record_scenes_deferral(config, ep)
+            elif res.get("status") == "done":
+                _clear_scenes_deferral(config, ep)
             if res.get("short_error") and not args.dry_run:
                 logger.warning("%s Ep%s: Short failed (long uploaded): %s",
                                slug, ep, res["short_error"])

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -315,3 +315,34 @@ youtube:
   video_mood: ""
   video_keywords: []
   video_visual_style: ""
+
+  # ---- Visual reuse + chapter-aligned scenes (June 2026) ----
+  # Gates for engine/visual_reuse.py (gallery reuse + scene scheduling).
+  # All render/metadata-only (no audio → outside landmine #17); every path
+  # is best-effort and degrades to the legacy render on any failure.
+  # Blend already-generated gallery scenes (nerra-gallery R2, via the
+  # committed manifest) into the fresh Grok Imagine sets — zero new
+  # image-generation cost; the caps bound the per-episode downloads.
+  gallery_blend_enabled: true
+  gallery_blend_max_long: 8     # 16:9 library scenes per long-form video
+  gallery_blend_max_short: 4    # 9:16 library scenes per Short
+  # Scene switches land on chapters.json boundaries instead of the
+  # uniform timer (<2 usable chapters falls back to uniform).
+  chapter_aligned_scenes: true
+  # Long-form thumbnail uses the episode's first fresh 16:9 scene as its
+  # base (cover fallback); `thumbnail_variants` extra composites from
+  # other scenes feed the operator's Studio "Test & Compare" A/B.
+  long_form_thumbnail_from_scene: true
+  thumbnail_variants: 2
+  # Sunday recaps reuse the week's gallery scenes (both aspects) instead
+  # of regenerating imagery for stories already illustrated this week.
+  recap_reuse_scenes: true
+  # <2 usable fresh scenes → historical gallery scenes before the static
+  # cover (the old degraded path).
+  gallery_fallback_enabled: true
+  # Shorts scene changes snap to sentence ends from the Whisper word
+  # transcript instead of the flat 7 s grid.
+  shorts_sentence_cuts: true
+  # Interleave curated evergreen b-roll (digests/<dir>/broll.json via
+  # scripts/build_broll_pool.py). Clean no-op until a pool is published.
+  evergreen_broll: true

--- a/tests/test_gallery_library.py
+++ b/tests/test_gallery_library.py
@@ -1,0 +1,339 @@
+"""Drift guards for engine.gallery_library (render-time gallery reuse).
+
+All network access is stubbed (a fake ``requests`` module injected on the
+module) — these tests pin the pure selection contract: filtering, the
+deterministic score-then-recency ordering, cache reuse, the best-effort
+skip-on-failure download path, the b-roll pool reader, and the
+Path → prompt/caption context map the scene scheduler consumes.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from engine import gallery_library as gl  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / stubs
+# ---------------------------------------------------------------------------
+
+
+def _entry(image_id, *, show="tesla", episode="ep520", date="2026-06-24",
+           use="segment_card", prompt="", caption="", tags=(), url=None):
+    return {
+        "image_id": image_id,
+        "show_slug": show,
+        "episode_id": episode,
+        "episode_date": date,
+        "intended_use": use,
+        "prompt": prompt,
+        "caption": caption,
+        "tags": list(tags),
+        "original_url": (url if url is not None
+                         else f"https://gallery.test/{show}/{image_id}.jpeg"),
+        "episode_title": "",
+    }
+
+
+def _manifest():
+    return {"images": [
+        _entry("aaa111", episode="ep520", date="2026-06-24",
+               prompt="Cybercab factory robots assembling vehicles",
+               caption="Cybercab line"),
+        _entry("bbb222", episode="ep521", date="2026-06-25",
+               prompt="battery pack assembly closeup"),
+        _entry("ccc333", episode="ep522", date="2026-06-26",
+               prompt="solar roof installation crew"),
+        _entry("ddd444", episode="ep522", date="2026-06-26", use="social",
+               prompt="vertical cybercab teaser"),
+        _entry("eee555", show="spacex", episode="ep012", date="2026-06-26",
+               prompt="rocket on the pad"),
+        # No original_url → never a candidate.
+        {**_entry("fff000", episode="ep519", date="2026-06-23"),
+         "original_url": ""},
+        _entry("ggg777", episode="ep400", date="2026-02-01",
+               prompt="old winter delivery event"),
+    ]}
+
+
+class _FakeResp:
+    def __init__(self, content):
+        self.content = content
+
+    def raise_for_status(self):
+        pass
+
+
+def _stub_requests(monkeypatch, fail_urls=()):
+    """Inject a fake requests module; returns the list of fetched URLs."""
+    calls = []
+
+    def get(url, timeout=None):
+        assert timeout, "downloads must carry a timeout"
+        calls.append(url)
+        if url in fail_urls:
+            raise RuntimeError("stub network failure")
+        return _FakeResp(b"bytes:" + url.encode())
+
+    monkeypatch.setattr(gl, "requests", SimpleNamespace(get=get))
+    return calls
+
+
+def _stems(paths):
+    return [p.stem for p in paths]
+
+
+# ---------------------------------------------------------------------------
+# load_manifest
+# ---------------------------------------------------------------------------
+
+
+class TestLoadManifest:
+    def test_missing_file_is_empty(self, tmp_path):
+        assert gl.load_manifest(tmp_path / "nope.json") == {}
+
+    def test_corrupt_file_is_empty(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("{not json", encoding="utf-8")
+        assert gl.load_manifest(p) == {}
+
+    def test_non_dict_json_is_empty(self, tmp_path):
+        p = tmp_path / "list.json"
+        p.write_text("[1, 2]", encoding="utf-8")
+        assert gl.load_manifest(p) == {}
+
+    def test_default_path_is_committed_manifest(self):
+        assert gl.DEFAULT_MANIFEST.name == "gallery-manifest.json"
+
+
+# ---------------------------------------------------------------------------
+# select_library_scenes
+# ---------------------------------------------------------------------------
+
+
+class TestSelection:
+    def test_filters_show_and_aspect(self, tmp_path, monkeypatch):
+        _stub_requests(monkeypatch)
+        got = gl.select_library_scenes(
+            "tesla", aspect="16:9", manifest=_manifest(), cache_dir=tmp_path)
+        # No social (ddd444), no spacex (eee555), no url-less (fff000).
+        assert set(_stems(got)) == {"aaa111", "bbb222", "ccc333", "ggg777"}
+
+        got = gl.select_library_scenes(
+            "tesla", aspect="9:16", manifest=_manifest(), cache_dir=tmp_path)
+        assert _stems(got) == ["ddd444"]
+
+    def test_unknown_aspect_is_empty(self, tmp_path):
+        assert gl.select_library_scenes(
+            "tesla", aspect="4:3", manifest=_manifest(),
+            cache_dir=tmp_path) == []
+
+    def test_excludes_current_episode(self, tmp_path, monkeypatch):
+        _stub_requests(monkeypatch)
+        got = gl.select_library_scenes(
+            "tesla", aspect="16:9", exclude_episode_id="ep522",
+            manifest=_manifest(), cache_dir=tmp_path)
+        assert "ccc333" not in _stems(got)
+
+    def test_date_window(self, tmp_path, monkeypatch):
+        _stub_requests(monkeypatch)
+        got = gl.select_library_scenes(
+            "tesla", aspect="16:9", manifest=_manifest(), cache_dir=tmp_path,
+            min_episode_date="2026-06-25", max_episode_date="2026-06-26")
+        assert set(_stems(got)) == {"bbb222", "ccc333"}
+
+    def test_recency_order_without_context(self, tmp_path, monkeypatch):
+        _stub_requests(monkeypatch)
+        got = gl.select_library_scenes(
+            "tesla", aspect="16:9", context_text="",
+            manifest=_manifest(), cache_dir=tmp_path)
+        assert _stems(got) == ["ccc333", "bbb222", "aaa111", "ggg777"]
+
+    def test_context_overlap_outranks_recency(self, tmp_path, monkeypatch):
+        _stub_requests(monkeypatch)
+        got = gl.select_library_scenes(
+            "tesla", aspect="16:9",
+            context_text="Cybercab robots hit the factory floor",
+            manifest=_manifest(), cache_dir=tmp_path)
+        # aaa111 is the OLDEST candidate but matches 3 context tokens.
+        assert _stems(got)[0] == "aaa111"
+
+    def test_deterministic_across_manifest_order(self, tmp_path, monkeypatch):
+        _stub_requests(monkeypatch)
+        m1, m2 = _manifest(), _manifest()
+        m2["images"] = list(reversed(m2["images"]))
+        kw = dict(aspect="16:9", context_text="battery assembly news",
+                  cache_dir=tmp_path)
+        assert (_stems(gl.select_library_scenes("tesla", manifest=m1, **kw))
+                == _stems(gl.select_library_scenes("tesla", manifest=m2, **kw)))
+
+    def test_limit_applies_best_first(self, tmp_path, monkeypatch):
+        _stub_requests(monkeypatch)
+        got = gl.select_library_scenes(
+            "tesla", aspect="16:9", limit=2,
+            manifest=_manifest(), cache_dir=tmp_path)
+        assert _stems(got) == ["ccc333", "bbb222"]
+
+    def test_cache_reuse_skips_downloads(self, tmp_path, monkeypatch):
+        calls = _stub_requests(monkeypatch)
+        gl.select_library_scenes(
+            "tesla", aspect="16:9", manifest=_manifest(), cache_dir=tmp_path)
+        first = len(calls)
+        assert first == 4
+        got = gl.select_library_scenes(
+            "tesla", aspect="16:9", manifest=_manifest(), cache_dir=tmp_path)
+        assert len(calls) == first  # warm cache — zero new fetches
+        assert all(p.exists() and p.read_bytes() for p in got)
+
+    def test_failed_download_skipped_and_backfilled(self, tmp_path, monkeypatch):
+        fail = "https://gallery.test/tesla/ccc333.jpeg"
+        _stub_requests(monkeypatch, fail_urls={fail})
+        got = gl.select_library_scenes(
+            "tesla", aspect="16:9", limit=2,
+            manifest=_manifest(), cache_dir=tmp_path)
+        # Best candidate failed → next two backfill, still limit results.
+        assert _stems(got) == ["bbb222", "aaa111"]
+
+    def test_never_raises_on_garbage_manifest(self, tmp_path):
+        assert gl.select_library_scenes(
+            "tesla", aspect="16:9", manifest={"images": "not-a-list"},
+            cache_dir=tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# collect_week_scenes
+# ---------------------------------------------------------------------------
+
+
+class TestWeekScenes:
+    def test_window_and_recency_order(self, tmp_path, monkeypatch):
+        _stub_requests(monkeypatch)
+        got = gl.collect_week_scenes(
+            "tesla", aspect="16:9", end_date="2026-06-26", days=3,
+            manifest=_manifest(), cache_dir=tmp_path)
+        # 06-24..06-26 window: ggg777 (Feb) excluded; newest first.
+        assert _stems(got) == ["ccc333", "bbb222", "aaa111"]
+
+    def test_exclude_current_episode(self, tmp_path, monkeypatch):
+        _stub_requests(monkeypatch)
+        got = gl.collect_week_scenes(
+            "tesla", aspect="16:9", end_date="2026-06-26", days=7,
+            exclude_episode_id="ep522",
+            manifest=_manifest(), cache_dir=tmp_path)
+        assert "ccc333" not in _stems(got)
+
+    def test_bad_end_date_is_empty(self, tmp_path):
+        assert gl.collect_week_scenes(
+            "tesla", aspect="16:9", end_date="soonish",
+            manifest=_manifest(), cache_dir=tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# scene_context_map
+# ---------------------------------------------------------------------------
+
+
+class TestContextMap:
+    def test_maps_paths_to_prompt_and_caption(self, tmp_path, monkeypatch):
+        _stub_requests(monkeypatch)
+        m = _manifest()
+        got = gl.select_library_scenes(
+            "tesla", aspect="16:9", limit=1, manifest=m, cache_dir=tmp_path)
+        ctx = gl.scene_context_map(m, got)
+        assert ctx[got[0]] == "solar roof installation crew"
+
+    def test_caption_joined_after_prompt(self, tmp_path, monkeypatch):
+        _stub_requests(monkeypatch)
+        m = _manifest()
+        got = gl.select_library_scenes(
+            "tesla", aspect="16:9", context_text="cybercab robots factory",
+            limit=1, manifest=m, cache_dir=tmp_path)
+        text = gl.scene_context_map(m, got)[got[0]]
+        assert "Cybercab factory robots" in text
+        assert text.endswith("Cybercab line")
+
+    def test_manifest_stem_lookup_survives_cold_registry(self, tmp_path,
+                                                         monkeypatch):
+        # A warm on-disk cache from an EARLIER process: registry empty, but
+        # files are named by image_id so the manifest lookup still resolves.
+        monkeypatch.setattr(gl, "_PATH_REGISTRY", {})
+        p = tmp_path / "bbb222.jpeg"
+        p.write_bytes(b"cached")
+        ctx = gl.scene_context_map(_manifest(), [p])
+        assert ctx[p] == "battery pack assembly closeup"
+
+    def test_unknown_path_maps_to_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gl, "_PATH_REGISTRY", {})
+        p = tmp_path / "zzz999.jpeg"
+        assert gl.scene_context_map(_manifest(), [p])[p] == ""
+
+
+# ---------------------------------------------------------------------------
+# b-roll pool
+# ---------------------------------------------------------------------------
+
+
+class TestBroll:
+    def _pool(self, tmp_path, clips):
+        d = tmp_path / "digests_show"
+        d.mkdir()
+        (d / "broll.json").write_text(
+            json.dumps({"show_slug": "tesla", "clips": clips}),
+            encoding="utf-8")
+        return d
+
+    def _clips(self, n=3):
+        return [{"url": f"https://gallery.test/broll/tesla/clip{i}.mp4",
+                 "duration_s": 5.0 + i, "label": f"clip {i}"}
+                for i in range(n)]
+
+    def test_missing_pool_is_empty(self, tmp_path):
+        assert gl.select_broll_clips(
+            "tesla", digests_dir=tmp_path, cache_dir=tmp_path) == []
+
+    def test_downloads_in_stable_order_up_to_limit(self, tmp_path, monkeypatch):
+        calls = _stub_requests(monkeypatch)
+        d = self._pool(tmp_path, self._clips(3))
+        cache = tmp_path / "cache"
+        got = gl.select_broll_clips("tesla", digests_dir=d, limit=2,
+                                    cache_dir=cache)
+        assert [p.name for p in got] == ["clip0.mp4", "clip1.mp4"]
+        assert len(calls) == 2
+        # Cache reuse: second call fetches nothing new.
+        again = gl.select_broll_clips("tesla", digests_dir=d, limit=2,
+                                      cache_dir=cache)
+        assert again == got and len(calls) == 2
+
+    def test_failed_clip_skipped(self, tmp_path, monkeypatch):
+        _stub_requests(
+            monkeypatch,
+            fail_urls={"https://gallery.test/broll/tesla/clip0.mp4"})
+        d = self._pool(tmp_path, self._clips(3))
+        got = gl.select_broll_clips("tesla", digests_dir=d, limit=2,
+                                    cache_dir=tmp_path / "cache")
+        assert [p.name for p in got] == ["clip1.mp4", "clip2.mp4"]
+
+    def test_bare_list_form_accepted(self, tmp_path, monkeypatch):
+        _stub_requests(monkeypatch)
+        d = tmp_path / "digests_show"
+        d.mkdir()
+        (d / "broll.json").write_text(json.dumps(self._clips(1)),
+                                      encoding="utf-8")
+        got = gl.select_broll_clips("tesla", digests_dir=d,
+                                    cache_dir=tmp_path / "cache")
+        assert [p.name for p in got] == ["clip0.mp4"]
+
+    def test_corrupt_pool_is_empty(self, tmp_path):
+        d = tmp_path / "digests_show"
+        d.mkdir()
+        (d / "broll.json").write_text("{oops", encoding="utf-8")
+        assert gl.select_broll_clips("tesla", digests_dir=d,
+                                     cache_dir=tmp_path / "cache") == []

--- a/tests/test_ru_dub.py
+++ b/tests/test_ru_dub.py
@@ -15,8 +15,8 @@ _ROOT = Path(__file__).resolve().parent.parent
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-from engine import ru_dub
-from engine.config import load_config
+from engine import ru_dub  # noqa: E402
+from engine.config import load_config  # noqa: E402
 
 
 def _cfg(**yt):
@@ -181,6 +181,245 @@ class TestShortFailureIndex:
         drv._clear_short_failure(cfg, 7)
         data = json.loads((tmp_path / "youtube_videos.ru.json").read_text())
         assert [v for v in data["videos"] if v.get("status") == "failed"] == []
+
+
+class TestFreshEpisode:
+    """_is_fresh_episode decides defer-vs-cover for scene-less episodes."""
+
+    def test_today_and_yesterday_are_fresh(self):
+        import datetime
+        today = datetime.date(2026, 7, 1)
+        assert ru_dub._is_fresh_episode("2026-07-01", today=today) is True
+        assert ru_dub._is_fresh_episode("2026-06-30", today=today) is True
+
+    def test_older_episodes_are_not_fresh(self):
+        import datetime
+        today = datetime.date(2026, 7, 1)
+        assert ru_dub._is_fresh_episode("2026-06-29", today=today) is False
+        assert ru_dub._is_fresh_episode("2026-01-01", today=today) is False
+
+    def test_unparsable_dates_count_as_old(self):
+        # Malformed record must PUBLISH (with cover), never stall forever.
+        assert ru_dub._is_fresh_episode("") is False
+        assert ru_dub._is_fresh_episode("soonish") is False
+
+    def test_datetime_prefix_accepted(self):
+        import datetime
+        today = datetime.date(2026, 7, 1)
+        assert ru_dub._is_fresh_episode("2026-07-01T09:00:00+00:00",
+                                        today=today) is True
+
+
+class TestManifestRefresh:
+    """_fresh_manifest_path: best-effort origin/main refresh, checked-out
+    fallback on ANY failure — the sweep's checkout can lag the manifest
+    rebuild workflow, so fresh episodes' scenes only exist on origin/main."""
+
+    def _fake_run(self, show_rc=0, show_stdout=b'{"images": []}'):
+        calls = []
+
+        def run(cmd, **kwargs):
+            calls.append(cmd)
+            assert kwargs.get("timeout"), "git calls must carry a timeout"
+            if cmd[:2] == ["git", "fetch"]:
+                return SimpleNamespace(returncode=0, stdout=b"")
+            if cmd[:2] == ["git", "show"]:
+                return SimpleNamespace(returncode=show_rc, stdout=show_stdout)
+            raise AssertionError(f"unexpected command {cmd}")
+
+        return run, calls
+
+    def test_refresh_writes_origin_copy(self, tmp_path, monkeypatch):
+        run, calls = self._fake_run(
+            show_stdout=b'{"images": [{"image_id": "x"}]}')
+        monkeypatch.setattr(ru_dub.subprocess, "run", run)
+        p = ru_dub._fresh_manifest_path(tmp_path)
+        assert p.parent == tmp_path
+        assert json.loads(p.read_text(encoding="utf-8"))["images"]
+        assert [c[:2] for c in calls] == [["git", "fetch"], ["git", "show"]]
+
+    def test_git_failure_falls_back_to_checkout(self, tmp_path, monkeypatch):
+        run, _ = self._fake_run(show_rc=128, show_stdout=b"")
+        monkeypatch.setattr(ru_dub.subprocess, "run", run)
+        assert ru_dub._fresh_manifest_path(tmp_path) == ru_dub._MANIFEST
+
+    def test_corrupt_origin_blob_falls_back(self, tmp_path, monkeypatch):
+        run, _ = self._fake_run(show_stdout=b"{truncated")
+        monkeypatch.setattr(ru_dub.subprocess, "run", run)
+        assert ru_dub._fresh_manifest_path(tmp_path) == ru_dub._MANIFEST
+
+    def test_subprocess_exception_falls_back(self, tmp_path, monkeypatch):
+        def boom(*a, **k):
+            raise OSError("no git binary")
+        monkeypatch.setattr(ru_dub.subprocess, "run", boom)
+        assert ru_dub._fresh_manifest_path(tmp_path) == ru_dub._MANIFEST
+
+    def test_non_repo_manifest_skips_git(self, tmp_path, monkeypatch):
+        def never(*a, **k):
+            raise AssertionError("git must not run for a non-repo manifest")
+        monkeypatch.setattr(ru_dub.subprocess, "run", never)
+        outside = tmp_path / "m.json"
+        assert ru_dub._fresh_manifest_path(
+            tmp_path, manifest_path=outside) == outside
+
+
+class TestNoScenesYetGate:
+    """A FRESH scene-less episode defers (no_scenes_yet) instead of shipping
+    a cover-only dub; an OLD scene-less episode still publishes with the
+    cover (no scenes are ever coming for it)."""
+
+    def _cfg_with_summaries(self, tmp_path, date_str):
+        summaries = tmp_path / "summaries.json"
+        summaries.write_text(json.dumps({"podcast": "TST", "summaries": [{
+            "episode_num": 5,
+            "date": date_str,
+            "episode_title": "Ep 5",
+            "translations": {"ru": {"title": "Заголовок", "description": "Оп",
+                                    "audio_url": ""}},
+        }]}), encoding="utf-8")
+        cfg = _cfg()
+        cfg.publishing.summaries_json = str(summaries)
+        cfg.episode.output_dir = str(tmp_path / "out")
+        return cfg
+
+    def _arm(self, monkeypatch, tmp_path, scene_urls):
+        import engine.youtube as yt_mod
+        monkeypatch.setattr(yt_mod, "get_channel_credentials_from_env",
+                            lambda channel="en": object())
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"jpg")
+        monkeypatch.setattr(ru_dub, "_cover_path", lambda config: cover)
+        # No real git: the "refreshed" manifest is the checked-in stub.
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(json.dumps({"images": [
+            {"show_slug": "tesla", "episode_id": "ep005",
+             "intended_use": "segment_card", "original_url": u}
+            for u in scene_urls
+        ]}), encoding="utf-8")
+        monkeypatch.setattr(ru_dub, "_fresh_manifest_path",
+                            lambda dest_dir, **kw: manifest)
+        # Stop the proceed-path before any render/network work.
+        monkeypatch.setattr(ru_dub, "_resolve_ru_audio",
+                            lambda *a, **k: None)
+
+    def test_fresh_episode_without_scenes_defers(self, tmp_path, monkeypatch):
+        import datetime
+        today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+        cfg = self._cfg_with_summaries(tmp_path, today)
+        self._arm(monkeypatch, tmp_path, scene_urls=[])
+        res = ru_dub.publish_ru_dub(cfg, 5)
+        assert res["status"] == "no_scenes_yet"
+        assert res["scene_count"] == 0
+
+    def test_fresh_episode_with_one_scene_defers(self, tmp_path, monkeypatch):
+        import datetime
+        today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+        cfg = self._cfg_with_summaries(tmp_path, today)
+        self._arm(monkeypatch, tmp_path, scene_urls=["https://r2/a.jpg"])
+        res = ru_dub.publish_ru_dub(cfg, 5)
+        assert res["status"] == "no_scenes_yet"
+        assert res["scene_count"] == 1
+
+    def test_old_episode_without_scenes_proceeds_with_cover(
+            self, tmp_path, monkeypatch):
+        cfg = self._cfg_with_summaries(tmp_path, "2026-01-01")
+        self._arm(monkeypatch, tmp_path, scene_urls=[])
+        res = ru_dub.publish_ru_dub(cfg, 5)
+        # Past the scene gate — stopped by the armed no-audio stub instead.
+        assert res["status"] == "no_ru_audio"
+
+    def test_fresh_episode_with_scenes_proceeds(self, tmp_path, monkeypatch):
+        import datetime
+        today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+        cfg = self._cfg_with_summaries(tmp_path, today)
+        self._arm(monkeypatch, tmp_path,
+                  scene_urls=["https://r2/a.jpg", "https://r2/b.jpg"])
+        res = ru_dub.publish_ru_dub(cfg, 5)
+        assert res["status"] == "no_ru_audio"
+
+
+class TestScenesDeferralIndex:
+    """publish_ru_dubs.py retry semantics: a no_scenes_yet deferral is
+    recorded like the short-failure rows (status row, no video_id) and the
+    episode stays NOT done so the next sweep retries it."""
+
+    def _driver(self):
+        import importlib.util
+        path = _ROOT / "scripts" / "publish_ru_dubs.py"
+        spec = importlib.util.spec_from_file_location("publish_ru_dubs", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def _cfg(self, tmp_path):
+        return SimpleNamespace(
+            episode=SimpleNamespace(output_dir=str(tmp_path)),
+        )
+
+    def test_deferral_row_matches_index_conventions(self, tmp_path):
+        drv = self._driver()
+        cfg = self._cfg(tmp_path)
+        drv._record_scenes_deferral(cfg, 5)
+        data = json.loads((tmp_path / "youtube_videos.ru.json").read_text())
+        rows = [v for v in data["videos"]
+                if v.get("episode") == 5 and v.get("status") == "deferred"]
+        assert len(rows) == 1
+        assert rows[0]["kind"] == "long"
+        assert rows[0]["reason"] == "no_scenes_yet"
+        assert "video_id" not in rows[0]
+        assert rows[0]["recorded"]
+
+    def test_deferred_episode_is_not_done(self, tmp_path):
+        drv = self._driver()
+        cfg = self._cfg(tmp_path)
+        drv._record_scenes_deferral(cfg, 5)
+        assert drv._already_done(cfg, 5) is False  # next sweep retries
+
+    def test_absent_entry_is_not_done(self, tmp_path):
+        drv = self._driver()
+        assert drv._already_done(self._cfg(tmp_path), 5) is False
+
+    def test_repeat_deferral_keeps_single_row(self, tmp_path):
+        drv = self._driver()
+        cfg = self._cfg(tmp_path)
+        drv._record_scenes_deferral(cfg, 5)
+        drv._record_scenes_deferral(cfg, 5)
+        data = json.loads((tmp_path / "youtube_videos.ru.json").read_text())
+        assert len([v for v in data["videos"]
+                    if v.get("status") == "deferred"]) == 1
+
+    def test_real_long_row_is_done_and_clear_drops_deferral(self, tmp_path):
+        drv = self._driver()
+        cfg = self._cfg(tmp_path)
+        drv._record_scenes_deferral(cfg, 5)
+        idx = tmp_path / "youtube_videos.ru.json"
+        data = json.loads(idx.read_text())
+        data["videos"].append({"video_id": "v1", "episode": 5, "kind": "long"})
+        idx.write_text(json.dumps(data), encoding="utf-8")
+        assert drv._already_done(cfg, 5) is True
+        drv._clear_scenes_deferral(cfg, 5)
+        data = json.loads(idx.read_text())
+        assert [v for v in data["videos"]
+                if v.get("status") == "deferred"] == []
+        assert drv._already_done(cfg, 5) is True  # real row survives
+
+    def test_status_only_long_row_never_counts_as_done(self, tmp_path):
+        # Defensive: a long row WITHOUT video_id (nothing uploaded) must not
+        # gate the retry, whatever its status says.
+        drv = self._driver()
+        cfg = self._cfg(tmp_path)
+        idx = tmp_path / "youtube_videos.ru.json"
+        idx.write_text(json.dumps({"videos": [
+            {"episode": 5, "kind": "long", "status": "whatever"}]}),
+            encoding="utf-8")
+        assert drv._already_done(cfg, 5) is False
+
+    def test_main_loop_wires_deferral_recording(self):
+        src = (_ROOT / "scripts" / "publish_ru_dubs.py").read_text(
+            encoding="utf-8")
+        assert '== "no_scenes_yet"' in src
+        assert "_record_scenes_deferral(config, ep)" in src
+        assert "_clear_scenes_deferral(config, ep)" in src
 
 
 class TestRealShowConfigs:

--- a/tests/test_scene_scheduler.py
+++ b/tests/test_scene_scheduler.py
@@ -1,0 +1,272 @@
+"""Tests for :mod:`engine.scene_scheduler` — chapter-aware scene planning.
+
+Pure-logic tests (no ffmpeg, no filesystem): the scheduler converts
+(scene pools, chapters.json entries, audio length) into an explicit
+``[(path, hold_seconds), …]`` plan, and (whisper words, Shorts window)
+into sentence-snapped cut times. The uniform fallback must mirror the
+legacy ``engine.video`` rotation math so shipping the scheduler with no
+chapters available changes nothing.
+"""
+
+import math
+from pathlib import Path
+
+from engine.scene_scheduler import plan_chapter_schedule, sentence_cut_times
+
+
+def _scenes(prefix: str, n: int):
+    return [Path(f"/scenes/{prefix}{i}.png") for i in range(n)]
+
+
+def _chapters(*starts_titles):
+    return [{"startTime": s, "title": t} for s, t in starts_titles]
+
+
+# ---------------------------------------------------------------------------
+# Uniform fallback — must mirror the legacy engine.video rotation
+# ---------------------------------------------------------------------------
+
+class TestUniformFallback:
+    def test_no_chapters_mirrors_legacy_rotation(self):
+        """4 scenes over 360 s: legacy math says 90 s/scene > 15 s max
+        hold → cycle to ceil(360/15) = 24 slots of 15 s, rotating
+        through the pool in order."""
+        pool = _scenes("fresh", 4)
+        plan = plan_chapter_schedule(pool, [], None, 360.0)
+        assert len(plan) == 24
+        assert all(abs(d - 15.0) < 1e-9 for _, d in plan)
+        assert [p for p, _ in plan] == [pool[i % 4] for i in range(24)]
+        assert abs(math.fsum(d for _, d in plan) - 360.0) < 1e-6
+
+    def test_no_cycling_when_even_split_fits(self):
+        """10 scenes over 100 s → 10 s/scene ≤ 15 s: one slot per scene,
+        no cycling — exactly the legacy behaviour."""
+        pool = _scenes("fresh", 10)
+        plan = plan_chapter_schedule(pool, [], [], 100.0)
+        assert len(plan) == 10
+        assert [p for p, _ in plan] == pool
+        assert abs(math.fsum(d for _, d in plan) - 100.0) < 1e-6
+
+    def test_single_chapter_falls_back_to_uniform(self):
+        pool = _scenes("fresh", 4)
+        chapters = _chapters((0.0, "Introduction"))
+        plan = plan_chapter_schedule(pool, [], chapters, 360.0)
+        uniform = plan_chapter_schedule(pool, [], None, 360.0)
+        assert plan == uniform
+
+    def test_whole_file_dict_accepted(self):
+        """The scheduler accepts either the parsed ``chapters`` list or
+        the whole chapters.json dict."""
+        pool = _scenes("fresh", 3)
+        wrapped = {"version": "1.2.0", "chapters": _chapters(
+            (0.0, "Intro"), (30.0, "Body"), (60.0, "Closing"),
+        )}
+        bare = _chapters((0.0, "Intro"), (30.0, "Body"), (60.0, "Closing"))
+        assert (plan_chapter_schedule(pool, [], wrapped, 90.0)
+                == plan_chapter_schedule(pool, [], bare, 90.0))
+
+    def test_empty_pool_returns_empty(self):
+        assert plan_chapter_schedule([], [], None, 300.0) == []
+        assert plan_chapter_schedule(None, None, None, 300.0) == []
+
+    def test_zero_audio_returns_empty(self):
+        assert plan_chapter_schedule(_scenes("f", 3), [], None, 0.0) == []
+
+
+# ---------------------------------------------------------------------------
+# Chapter-boundary alignment + subdivision bounds
+# ---------------------------------------------------------------------------
+
+class TestChapterAlignment:
+    def test_scene_switches_land_on_chapter_boundaries(self):
+        """Chapters at 0/30/60 over 90 s of audio: the cumulative plan
+        must pass EXACTLY through 30 and 60 — that's the whole point of
+        the scheduler."""
+        pool = _scenes("fresh", 5)
+        chapters = _chapters((0.0, "Intro"), (30.0, "Deep Dive"),
+                             (60.0, "Closing"))
+        plan = plan_chapter_schedule(pool, [], chapters, 90.0)
+        cumulative = set()
+        acc = 0.0
+        for _, dur in plan:
+            acc += dur
+            cumulative.add(round(acc, 6))
+        assert 30.0 in cumulative
+        assert 60.0 in cumulative
+        assert abs(math.fsum(d for _, d in plan) - 90.0) < 1e-6
+
+    def test_long_chapter_subdivides_within_bounds(self):
+        """A 40 s chapter with max_hold=15 splits into 3 equal ~13.3 s
+        slots — every slot within [min_hold, max_hold]."""
+        pool = _scenes("fresh", 6)
+        chapters = _chapters((0.0, "Intro"), (40.0, "Closing"))
+        plan = plan_chapter_schedule(pool, [], chapters, 55.0,
+                                     max_hold_s=15.0, min_hold_s=6.0)
+        # First chapter (40 s) contributes 3 slots of 40/3 s.
+        first_three = [d for _, d in plan[:3]]
+        assert all(abs(d - 40.0 / 3) < 1e-9 for d in first_three)
+        for _, dur in plan:
+            assert dur <= 15.0 + 1e-9
+            assert dur >= 6.0 - 1e-9
+
+    def test_sixteen_second_chapter_splits_into_two_eights(self):
+        pool = _scenes("fresh", 4)
+        chapters = _chapters((0.0, "Intro"), (16.0, "Closing"))
+        plan = plan_chapter_schedule(pool, [], chapters, 32.0)
+        assert abs(plan[0][1] - 8.0) < 1e-9
+        assert abs(plan[1][1] - 8.0) < 1e-9
+
+    def test_chapter_shorter_than_min_hold_gets_single_full_slot(self):
+        """Boundary alignment beats the floor: a 4 s teaser chapter is
+        one 4 s slot, not merged into a neighbour."""
+        pool = _scenes("fresh", 4)
+        chapters = _chapters((0.0, "Intro"), (20.0, "Teaser"),
+                             (24.0, "Closing"))
+        plan = plan_chapter_schedule(pool, [], chapters, 36.0,
+                                     max_hold_s=15.0, min_hold_s=6.0)
+        assert any(abs(d - 4.0) < 1e-9 for _, d in plan)
+
+    def test_leading_gap_before_first_chapter_is_covered(self):
+        """chapters.json occasionally starts a few seconds in; the plan
+        must still cover from t=0."""
+        pool = _scenes("fresh", 4)
+        chapters = _chapters((5.0, "Intro"), (25.0, "Closing"))
+        plan = plan_chapter_schedule(pool, [], chapters, 40.0)
+        assert abs(math.fsum(d for _, d in plan) - 40.0) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Scene selection — token overlap, fresh tie-break, reuse variety
+# ---------------------------------------------------------------------------
+
+class TestSceneSelection:
+    def test_token_overlap_picks_topical_scene_per_chapter(self):
+        cyber = Path("/scenes/cybercab.png")
+        star = Path("/scenes/starship.png")
+        context = {
+            cyber: "Cybercab robotaxi rolling off the factory line",
+            star: "Starship stacked on the launch pad at Boca Chica",
+        }
+        chapters = _chapters(
+            (0.0, "Tesla Cybercab factory update"),
+            (20.0, "SpaceX Starship launch window"),
+        )
+        plan = plan_chapter_schedule([cyber, star], [], chapters, 40.0,
+                                     scene_context=context)
+        # 2 chapters × 20 s → 2 slots each of 10 s.
+        assert [p for p, _ in plan] == [cyber, cyber, star, star]
+
+    def test_fresh_scene_wins_tie_over_library(self):
+        fresh = _scenes("fresh", 1)
+        library = _scenes("lib", 2)
+        chapters = _chapters((0.0, "Intro"), (12.0, "Closing"))
+        plan = plan_chapter_schedule(fresh, library, chapters, 24.0)
+        assert plan[0][0] == fresh[0]
+
+    def test_reuse_penalty_yields_rotation_variety(self):
+        """With a context-less pool of 3, the plan should rotate
+        through all three scenes with no back-to-back repeat."""
+        pool = _scenes("fresh", 3)
+        chapters = _chapters((0.0, "Intro"), (45.0, "Closing"))
+        plan = plan_chapter_schedule(pool, [], chapters, 90.0)
+        picks = [p for p, _ in plan]
+        assert len(picks) == 6
+        assert set(picks) == set(pool)
+        for a, b in zip(picks, picks[1:]):
+            assert a != b, f"back-to-back repeat of {a}"
+
+    def test_deterministic(self):
+        pool = _scenes("fresh", 4)
+        library = _scenes("lib", 3)
+        context = {pool[1]: "battery pack close-up",
+                   library[0]: "gigafactory aerial view"}
+        chapters = _chapters((0.0, "Battery day recap"),
+                             (30.0, "Gigafactory expansion"),
+                             (60.0, "Closing"))
+        first = plan_chapter_schedule(pool, library, chapters, 90.0,
+                                      scene_context=context)
+        second = plan_chapter_schedule(pool, library, chapters, 90.0,
+                                       scene_context=context)
+        assert first == second
+
+    def test_string_paths_accepted(self):
+        """The gallery library may hand over str paths; they normalize
+        to Path in the plan."""
+        plan = plan_chapter_schedule(["/scenes/a.png", "/scenes/b.png"],
+                                     [], None, 30.0)
+        assert all(isinstance(p, Path) for p, _ in plan)
+
+
+# ---------------------------------------------------------------------------
+# sentence_cut_times — snap Shorts cuts to sentence ends
+# ---------------------------------------------------------------------------
+
+def _word(token, start, end):
+    return {"word": token, "start": start, "end": end}
+
+
+class TestSentenceCutTimes:
+    def test_snaps_to_sentence_ends_within_cadence(self):
+        """Absolute word times, window at 10 s: sentence ends at rel
+        6.8 / 14.0 / 21.5 each fall inside the rolling [5, 9] band and
+        become the cuts."""
+        words = [
+            _word(" Tesla", 12.0, 12.4),          # no punctuation — ignored
+            _word(" ahead.", 16.4, 16.8),          # rel 6.8
+            _word(" then", 20.0, 20.3),
+            _word(" done.", 23.5, 24.0),           # rel 14.0
+            _word(" wow!", 31.0, 31.5),            # rel 21.5
+            _word(" tail?", 38.0, 38.6),           # rel 28.6 — beyond end guard
+        ]
+        cuts = sentence_cut_times(words, 10.0, 30.0)
+        assert cuts == [6.8, 14.0, 21.5]
+
+    def test_prefers_sentence_end_nearest_band_middle(self):
+        """Two sentence ends inside one band: pick the one closest to
+        the band midpoint (7 s into the gap), not simply the first."""
+        words = [
+            _word(" early.", 4.9, 5.2),
+            _word(" late.", 6.5, 6.9),
+        ]
+        cuts = sentence_cut_times(words, 0.0, 20.0)
+        assert cuts[0] == 6.9
+
+    def test_flat_grid_fallback_when_no_sentence_ends(self):
+        """No sentence-ending words at all → the legacy flat 7 s grid."""
+        words = [_word(" and", i * 1.0, i * 1.0 + 0.4) for i in range(30)]
+        assert sentence_cut_times(words, 0.0, 30.0) == [7.0, 14.0, 21.0]
+        assert sentence_cut_times(None, 0.0, 30.0) == [7.0, 14.0, 21.0]
+
+    def test_gap_without_sentence_end_uses_flat_step(self):
+        """First band snaps to a sentence; the next band has no
+        sentence end so it advances by the flat 7 s step."""
+        words = [_word(" go.", 6.5, 6.9)]
+        cuts = sentence_cut_times(words, 0.0, 20.0)
+        assert cuts == [6.9, 13.9]
+
+    def test_never_cuts_within_min_gap_of_clip_end(self):
+        cuts = sentence_cut_times([], 0.0, 20.0, min_gap_s=5.0)
+        assert cuts, "expected at least one flat-grid cut"
+        assert all(c <= 20.0 - 5.0 for c in cuts)
+        # A sentence end just before the clip end must not become a cut.
+        words = [_word(" end.", 16.0, 16.5)]
+        cuts = sentence_cut_times(words, 0.0, 20.0, min_gap_s=5.0)
+        assert 16.5 not in cuts
+        assert all(c <= 15.0 for c in cuts)
+
+    def test_times_are_relative_to_clip_start(self):
+        words = [_word(" mark.", 106.2, 106.5)]
+        cuts = sentence_cut_times(words, 100.0, 30.0)
+        assert cuts[0] == 6.5
+
+    def test_zero_duration_returns_empty(self):
+        assert sentence_cut_times([], 0.0, 0.0) == []
+
+    def test_malformed_words_are_skipped(self):
+        words = [
+            {"word": " ok."},                       # no timestamps
+            {"word": None, "start": 1, "end": 2},   # no token
+            _word(" fine.", 6.6, 6.9),
+        ]
+        cuts = sentence_cut_times(words, 0.0, 20.0)
+        assert cuts[0] == 6.9

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1437,3 +1437,534 @@ def test_generate_shorts_end_card_custom_text(tmp_path):
         sub_text="Подписывайтесь ↗",
     )
     assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# Chapter-aware scene schedule (June 2026) — per-scene slideshow durations
+# ---------------------------------------------------------------------------
+#
+# engine.scene_scheduler plans [(scene, hold_seconds), …] so scene
+# switches land on chapter boundaries. The renderer consumes the plan
+# via scene_durations= (graph/cmd level) and scene_schedule= (public
+# API). The invariant that matters most: a UNIFORM schedule reproduces
+# the legacy graph/command byte-for-byte, and None keeps every legacy
+# path untouched.
+
+def test_slideshow_filter_graph_schedule_uses_cumulative_offsets():
+    """Variable durations → xfade offsets are the CUMULATIVE visible
+    time (sum(durations[:k])), not k * uniform_duration."""
+    graph = _slideshow_filter_graph(
+        scene_count=3, scene_durations=[10.0, 14.0, 8.0],
+    )
+    # Join 1 starts after scene 0's 10 s; join 2 after 10 + 14 = 24 s.
+    assert "offset=10.00" in graph
+    assert "offset=24.00" in graph
+    # Each clip renders its OWN duration + the 0.6 s crossfade pad.
+    assert "trim=duration=10.60" in graph
+    assert "trim=duration=14.60" in graph
+    assert "trim=duration=8.60" in graph
+    assert graph.endswith("[v]")
+
+
+def test_slideshow_filter_graph_uniform_schedule_matches_legacy():
+    """A uniform durations list must reproduce the legacy graph EXACTLY
+    (math.fsum of k equal floats rounds identically to k * duration) —
+    the drift fence that says the schedule path is a strict superset."""
+    for dur in (10.0, 13.85, 12.0):
+        legacy = _slideshow_filter_graph(scene_count=4, scene_duration=dur)
+        sched = _slideshow_filter_graph(
+            scene_count=4, scene_durations=[dur] * 4,
+        )
+        assert sched == legacy
+
+
+def test_slideshow_filter_graph_schedule_hard_cut_uses_per_scene_trims():
+    """The crossfade=0 fallback (ffmpeg-failure retry) must keep the
+    per-scene durations via each clip's own trim in the concat chain."""
+    graph = _slideshow_filter_graph(
+        scene_count=3, scene_durations=[10.0, 14.0, 8.0], crossfade=0.0,
+    )
+    assert "concat=n=3:v=1:a=0[v]" in graph
+    assert "xfade" not in graph
+    assert "trim=duration=10.00" in graph
+    assert "trim=duration=14.00" in graph
+    assert "trim=duration=8.00" in graph
+
+
+def test_slideshow_filter_graph_schedule_length_mismatch_raises():
+    with pytest.raises(ValueError, match="scene_durations length"):
+        _slideshow_filter_graph(scene_count=3, scene_durations=[10.0, 14.0])
+
+
+def test_slideshow_cmd_schedule_sets_per_input_duration(tmp_path):
+    paths = [tmp_path / f"scene{i}.jpg" for i in range(3)]
+    out = tmp_path / "slides.mp4"
+    cmd = _slideshow_cmd(paths, out, scene_durations=[10.0, 14.0, 8.0])
+    # Each looped image input's -t covers its own clip: dur + 0.6 + 0.5.
+    t_indices = [i for i, x in enumerate(cmd) if x == "-t"]
+    t_values = [cmd[i + 1] for i in t_indices]
+    assert t_values == ["11.10", "15.10", "9.10"]
+
+
+def test_slideshow_cmd_uniform_schedule_matches_legacy(tmp_path):
+    paths = [tmp_path / f"scene{i}.jpg" for i in range(3)]
+    out = tmp_path / "slides.mp4"
+    legacy = _slideshow_cmd(paths, out, scene_duration=13.85)
+    sched = _slideshow_cmd(paths, out, scene_durations=[13.85] * 3)
+    assert sched == legacy
+
+
+def test_render_slideshow_schedule_hard_cut_fallback(tmp_path, monkeypatch):
+    """When the crossfade render fails, the hard-cut retry must carry
+    the SAME per-scene durations (concat with per-scene trims)."""
+    import subprocess as _subprocess
+
+    from engine.video import _render_slideshow
+
+    scenes = []
+    for i in range(3):
+        s = tmp_path / f"scene{i}.jpg"
+        s.write_bytes(b"\xFF\xD8")
+        scenes.append(s)
+    out = tmp_path / "slides.mp4"
+
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(list(cmd))
+        if len(calls) == 1:
+            raise _subprocess.CalledProcessError(1, cmd, stderr="xfade broke")
+        Path(cmd[-1]).write_bytes(b"\x00")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    _render_slideshow(scenes, out, scene_durations=[10.0, 14.0, 8.0])
+    assert len(calls) == 2
+    retry_graph = calls[1][calls[1].index("-filter_complex") + 1]
+    assert "concat=n=3" in retry_graph
+    assert "xfade" not in retry_graph
+    assert "trim=duration=10.00" in retry_graph
+    assert "trim=duration=14.00" in retry_graph
+    assert "trim=duration=8.00" in retry_graph
+
+
+def test_build_long_form_video_uses_scene_schedule(tmp_path, monkeypatch):
+    """scene_schedule= drives the stage-1 slideshow: scheduled scene
+    order, per-scene -t inputs, cumulative xfade offsets."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    scenes = []
+    for i in range(3):
+        s = tmp_path / f"scene{i}.jpg"
+        s.write_bytes(b"\xFF\xD8")
+        scenes.append(s)
+    out = tmp_path / "out.mp4"
+
+    captured_cmds = []
+
+    def fake_run(cmd, **kw):
+        captured_cmds.append(list(cmd))
+        if "-an" in cmd:
+            Path(cmd[-1]).write_bytes(b"\x00")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    monkeypatch.setattr("engine.audio.get_audio_duration", lambda _p: 32.0)
+    schedule = [(scenes[0], 10.0), (scenes[2], 14.0), (scenes[1], 8.0)]
+    build_long_form_video(audio, cover, out, scene_schedule=schedule)
+
+    assert len(captured_cmds) == 2
+    stage1 = captured_cmds[0]
+    assert stage1[-1].endswith("_slides_sched.mp4")
+    # Scheduled ORDER (scene2 before scene1), not the input list order.
+    i_indices = [i for i, x in enumerate(stage1) if x == "-i"]
+    input_paths = [stage1[i + 1] for i in i_indices]
+    assert input_paths == [str(scenes[0]), str(scenes[2]), str(scenes[1])]
+    graph = stage1[stage1.index("-filter_complex") + 1]
+    assert "offset=10.00" in graph
+    assert "offset=24.00" in graph
+    # Stage 2 still loops the slideshow background.
+    assert "-stream_loop" in captured_cmds[1]
+
+
+def test_build_long_form_video_short_schedule_keeps_legacy_path(tmp_path,
+                                                                monkeypatch):
+    """A degenerate 1-entry schedule must NOT flip the pipeline — the
+    legacy uniform slideshow (from scene_paths) still runs."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    scenes = []
+    for i in range(3):
+        s = tmp_path / f"scene{i}.jpg"
+        s.write_bytes(b"\xFF\xD8")
+        scenes.append(s)
+    out = tmp_path / "out.mp4"
+
+    captured_cmds = []
+
+    def fake_run(cmd, **kw):
+        captured_cmds.append(list(cmd))
+        if "-an" in cmd:
+            Path(cmd[-1]).write_bytes(b"\x00")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    monkeypatch.setattr("engine.audio.get_audio_duration", lambda _p: 36.0)
+    build_long_form_video(audio, cover, out, scene_paths=scenes,
+                          scene_schedule=[(scenes[0], 36.0)])
+    assert len(captured_cmds) == 2
+    assert captured_cmds[0][-1].endswith("_slides.mp4")
+    assert not captured_cmds[0][-1].endswith("_slides_sched.mp4")
+
+
+def test_build_long_form_video_none_schedule_is_byte_identical(tmp_path,
+                                                               monkeypatch):
+    """scene_schedule=None / broll_clips=None must produce EXACTLY the
+    same ffmpeg command as omitting the kwargs (legacy fence)."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    out = tmp_path / "out.mp4"
+
+    captured_cmds = []
+    monkeypatch.setattr(
+        "engine.video.subprocess.run",
+        lambda cmd, **kw: (captured_cmds.append(list(cmd)),
+                           type("R", (), {"returncode": 0})())[1],
+    )
+    build_long_form_video(audio, cover, out)
+    build_long_form_video(audio, cover, out,
+                          scene_schedule=None, broll_clips=None)
+    assert len(captured_cmds) == 2
+    assert captured_cmds[0] == captured_cmds[1]
+
+
+# ---------------------------------------------------------------------------
+# Shorts sentence-cut background (June 2026) — full-length, no loop
+# ---------------------------------------------------------------------------
+
+def test_short_segment_durations_sum_to_clip_length():
+    from engine.video import _short_segment_durations
+    durs = _short_segment_durations([6.5, 13.9, 21.0], 30.0)
+    assert durs == pytest.approx([6.5, 7.4, 7.1, 9.0])
+    assert sum(durs) == pytest.approx(30.0)
+
+
+def test_short_segment_durations_drops_end_hugging_and_bunched_cuts():
+    from engine.video import _short_segment_durations
+    # 29.9 hugs the 30 s end; 6.6 is within 0.5 s of 6.5.
+    durs = _short_segment_durations([6.5, 6.6, 29.9], 30.0)
+    assert durs == [6.5, 23.5]
+    # Nothing usable → empty (caller keeps the legacy flat path).
+    assert _short_segment_durations([29.9], 30.0) == []
+    assert _short_segment_durations([], 30.0) == []
+
+
+def test_build_short_video_scene_change_times_drops_stream_loop(tmp_path,
+                                                                monkeypatch):
+    """Explicit cut times cover the whole clip → the slideshow is built
+    full-length and the composite must NOT -stream_loop it."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    scenes = []
+    for i in range(3):
+        s = tmp_path / f"scene{i}.jpg"
+        s.write_bytes(b"\xFF\xD8")
+        scenes.append(s)
+    out = tmp_path / "short.mp4"
+
+    captured_cmds = []
+
+    def fake_run(cmd, **kw):
+        captured_cmds.append(list(cmd))
+        if "-an" in cmd:
+            Path(cmd[-1]).write_bytes(b"\x00")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    build_short_video(audio, cover, out, duration=55.0,
+                      scene_paths=scenes,
+                      scene_change_times=[6.8, 14.0, 21.5, 29.0, 36.5, 44.0])
+    assert len(captured_cmds) == 2
+    stage1, stage2 = captured_cmds
+    # Stage 1: full-length scheduled slideshow (7 segments summing 55 s),
+    # cumulative xfade offsets at the requested cut times.
+    assert stage1[-1].endswith("_short_slides_sched.mp4")
+    graph1 = stage1[stage1.index("-filter_complex") + 1]
+    assert "offset=6.80" in graph1
+    assert "offset=14.00" in graph1
+    assert "offset=44.00" in graph1
+    # Stage 2: bg is the slideshow, WITHOUT the loop.
+    assert "-stream_loop" not in stage2
+    assert stage1[-1] in stage2
+    # Only the brand pill remains a looped image input.
+    assert stage2.count("-loop") == 1
+
+
+def test_build_short_video_cut_times_scenes_rotate_across_segments(tmp_path,
+                                                                   monkeypatch):
+    """6 segments from a 3-scene pool → the pool cycles in order."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    scenes = []
+    for i in range(3):
+        s = tmp_path / f"scene{i}.jpg"
+        s.write_bytes(b"\xFF\xD8")
+        scenes.append(s)
+    out = tmp_path / "short.mp4"
+
+    captured_cmds = []
+
+    def fake_run(cmd, **kw):
+        captured_cmds.append(list(cmd))
+        if "-an" in cmd:
+            Path(cmd[-1]).write_bytes(b"\x00")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    build_short_video(audio, cover, out, duration=55.0,
+                      scene_paths=scenes,
+                      scene_change_times=[8.0, 16.0, 24.0, 32.0, 40.0])
+    stage1 = captured_cmds[0]
+    i_indices = [i for i, x in enumerate(stage1) if x == "-i"]
+    input_paths = [stage1[i + 1] for i in i_indices]
+    assert input_paths == [str(scenes[i % 3]) for i in range(6)]
+
+
+def test_build_short_video_none_cut_times_is_byte_identical(tmp_path,
+                                                            monkeypatch):
+    """scene_change_times=None must produce EXACTLY the legacy command."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    out = tmp_path / "short.mp4"
+
+    captured_cmds = []
+    monkeypatch.setattr(
+        "engine.video.subprocess.run",
+        lambda cmd, **kw: (captured_cmds.append(list(cmd)),
+                           type("R", (), {"returncode": 0})())[1],
+    )
+    build_short_video(audio, cover, out, duration=55.0)
+    build_short_video(audio, cover, out, duration=55.0,
+                      scene_change_times=None)
+    assert len(captured_cmds) == 2
+    assert captured_cmds[0] == captured_cmds[1]
+
+
+def test_build_short_video_unusable_cut_times_keep_flat_loop_path(tmp_path,
+                                                                  monkeypatch):
+    """Cut times that all fall inside the end guard produce no usable
+    segments → the legacy flat-pace loop path still ships."""
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    scenes = []
+    for i in range(2):
+        s = tmp_path / f"scene{i}.jpg"
+        s.write_bytes(b"\xFF\xD8")
+        scenes.append(s)
+    out = tmp_path / "short.mp4"
+
+    captured_cmds = []
+
+    def fake_run(cmd, **kw):
+        captured_cmds.append(list(cmd))
+        if "-an" in cmd:
+            Path(cmd[-1]).write_bytes(b"\x00")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    build_short_video(audio, cover, out, duration=55.0,
+                      scene_paths=scenes, scene_change_times=[54.9])
+    assert len(captured_cmds) == 2
+    assert captured_cmds[0][-1].endswith("_short_slides.mp4")
+    assert "-stream_loop" in captured_cmds[1]
+
+
+# ---------------------------------------------------------------------------
+# Evergreen B-roll interleave (June 2026) — local clips only, soft-fail
+# ---------------------------------------------------------------------------
+
+def _make_broll(tmp_path, n):
+    clips = []
+    for i in range(n):
+        c = tmp_path / f"broll{i}.mp4"
+        c.write_bytes(b"\x00\x00\x00\x18ftypmp42")
+        clips.append(c)
+    return clips
+
+
+def _make_long_form_fixtures(tmp_path):
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"\x00")
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xFF\xD8")
+    scenes = []
+    for i in range(4):
+        s = tmp_path / f"scene{i}.jpg"
+        s.write_bytes(b"\xFF\xD8")
+        scenes.append(s)
+    return audio, cover, scenes
+
+
+def test_build_long_form_video_broll_uses_hybrid_renderer(tmp_path,
+                                                          monkeypatch):
+    audio, cover, scenes = _make_long_form_fixtures(tmp_path)
+    clips = _make_broll(tmp_path, 2)
+    out = tmp_path / "out.mp4"
+
+    captured_cmds = []
+
+    def fake_run(cmd, **kw):
+        captured_cmds.append(list(cmd))
+        if "-an" in cmd:
+            Path(cmd[-1]).write_bytes(b"\x00")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "engine.audio.get_audio_duration",
+        lambda p: 5.0 if str(p).endswith(".mp4") else 120.0,
+    )
+    build_long_form_video(audio, cover, out, scene_paths=scenes,
+                          broll_clips=clips)
+    # Stage 1 = hybrid render (stills + clips), stage 2 = composite.
+    assert len(captured_cmds) == 2
+    hybrid = captured_cmds[0]
+    assert hybrid[-1].endswith("_hybrid.mp4")
+    # Both clips appear as plain (non-looped) inputs.
+    for clip in clips:
+        assert str(clip) in hybrid
+    graph = hybrid[hybrid.index("-filter_complex") + 1]
+    assert "concat=" in graph
+    assert "-stream_loop" in captured_cmds[1]
+
+
+def test_build_long_form_video_broll_caps_at_three(tmp_path, monkeypatch):
+    audio, cover, scenes = _make_long_form_fixtures(tmp_path)
+    clips = _make_broll(tmp_path, 5)
+    out = tmp_path / "out.mp4"
+
+    captured_cmds = []
+
+    def fake_run(cmd, **kw):
+        captured_cmds.append(list(cmd))
+        if "-an" in cmd:
+            Path(cmd[-1]).write_bytes(b"\x00")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "engine.audio.get_audio_duration",
+        lambda p: 5.0 if str(p).endswith(".mp4") else 120.0,
+    )
+    build_long_form_video(audio, cover, out, scene_paths=scenes,
+                          broll_clips=clips)
+    hybrid = captured_cmds[0]
+    used = [c for c in clips if str(c) in hybrid]
+    assert len(used) == 3
+    assert used == clips[:3]
+
+
+def test_build_long_form_video_broll_failure_degrades_to_slideshow(tmp_path,
+                                                                   monkeypatch):
+    """Any ffmpeg failure on the hybrid render must degrade to the pure
+    slideshow — same soft-fallback philosophy as the crossfade retry."""
+    import subprocess as _subprocess
+
+    audio, cover, scenes = _make_long_form_fixtures(tmp_path)
+    clips = _make_broll(tmp_path, 2)
+    out = tmp_path / "out.mp4"
+
+    captured_cmds = []
+
+    def fake_run(cmd, **kw):
+        captured_cmds.append(list(cmd))
+        if cmd[-1].endswith("_hybrid.mp4"):
+            raise _subprocess.CalledProcessError(1, cmd, stderr="boom")
+        if "-an" in cmd:
+            Path(cmd[-1]).write_bytes(b"\x00")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "engine.audio.get_audio_duration",
+        lambda p: 5.0 if str(p).endswith(".mp4") else 120.0,
+    )
+    build_long_form_video(audio, cover, out, scene_paths=scenes,
+                          broll_clips=clips)
+    # hybrid (failed) → pure slideshow → composite.
+    assert len(captured_cmds) == 3
+    assert captured_cmds[0][-1].endswith("_hybrid.mp4")
+    assert captured_cmds[1][-1].endswith("_slides.mp4")
+    assert "-stream_loop" in captured_cmds[2]
+    # No clip reaches the fallback slideshow.
+    for clip in clips:
+        assert str(clip) not in captured_cmds[1]
+
+
+def test_build_long_form_video_broll_with_schedule_keeps_scene_order(
+    tmp_path, monkeypatch,
+):
+    """B-roll + chapter schedule: scheduled stills keep their planned
+    order in the hybrid sequence, with clips interleaved among them."""
+    audio, cover, scenes = _make_long_form_fixtures(tmp_path)
+    clips = _make_broll(tmp_path, 1)
+    out = tmp_path / "out.mp4"
+
+    captured_cmds = []
+
+    def fake_run(cmd, **kw):
+        captured_cmds.append(list(cmd))
+        if "-an" in cmd:
+            Path(cmd[-1]).write_bytes(b"\x00")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "engine.audio.get_audio_duration",
+        lambda p: 5.0 if str(p).endswith(".mp4") else 40.0,
+    )
+    schedule = [(scenes[2], 10.0), (scenes[0], 15.0), (scenes[1], 15.0)]
+    build_long_form_video(audio, cover, out, scene_schedule=schedule,
+                          broll_clips=clips)
+    hybrid = captured_cmds[0]
+    assert hybrid[-1].endswith("_hybrid.mp4")
+    i_indices = [i for i, x in enumerate(hybrid) if x == "-i"]
+    input_paths = [hybrid[i + 1] for i in i_indices]
+    # Clip opens the sequence; scheduled still order preserved after it.
+    assert input_paths[0] == str(clips[0])
+    assert [p for p in input_paths if p != str(clips[0])] == [
+        str(scenes[2]), str(scenes[0]), str(scenes[1]),
+    ]
+
+
+def test_interleave_broll_into_schedule_scales_holds():
+    """Unit-level: still order preserved, holds scaled so total stays
+    ≈ the scheduled total after the clips take their share."""
+    from engine.video import _interleave_broll_into_schedule
+
+    schedule = [(Path("/s/a.png"), 20.0), (Path("/s/b.png"), 20.0),
+                (Path("/s/c.png"), 20.0)]
+    visuals = _interleave_broll_into_schedule(
+        schedule, [Path("/c/x.mp4")], [6.0],
+    )
+    stills = [(path, dur) for path, is_video, dur in visuals if not is_video]
+    clips = [(path, dur) for path, is_video, dur in visuals if is_video]
+    assert [p for p, _ in stills] == [Path("/s/a.png"), Path("/s/b.png"),
+                                      Path("/s/c.png")]
+    assert clips == [(Path("/c/x.mp4"), 6.0)]
+    total = sum(d for _, d in stills) + sum(d for _, d in clips)
+    assert abs(total - 60.0) < 1e-6

--- a/tests/test_visual_reuse.py
+++ b/tests/test_visual_reuse.py
@@ -1,0 +1,520 @@
+"""Drift guards for the June 2026 YouTube visual-reuse composition layer.
+
+Pins: the new ``youtube:`` config knobs exist on the dataclass AND in
+``shows/_defaults.yaml`` (the silent-config-drop landmine), the
+``engine.visual_reuse`` flag gating + never-raise contract, the recap /
+fallback pools, the new observability keys in ``record_youtube_outcomes``,
+the gallery↔retention join script, and the nightly-workflow wiring. All
+gallery/network access is stubbed via monkeypatch — no R2, no manifest.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from engine.config import YouTubeConfig  # noqa: E402
+from engine import visual_reuse as vr  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_NEW_KNOBS = {
+    "gallery_blend_enabled": True,
+    "gallery_blend_max_long": 8,
+    "gallery_blend_max_short": 4,
+    "chapter_aligned_scenes": True,
+    "long_form_thumbnail_from_scene": True,
+    "thumbnail_variants": 2,
+    "recap_reuse_scenes": True,
+    "gallery_fallback_enabled": True,
+    "shorts_sentence_cuts": True,
+    "evergreen_broll": True,
+}
+
+
+def _config(**overrides):
+    return SimpleNamespace(youtube=YouTubeConfig(**overrides))
+
+
+def _chapters_file(tmp_path, n=3):
+    chapters = [
+        {"startTime": float(i * 60), "title": f"Chapter {i}"} for i in range(n)
+    ]
+    p = tmp_path / "chapters_ep001.json"
+    p.write_text(json.dumps({"version": "1.2.0", "chapters": chapters}),
+                 encoding="utf-8")
+    return p
+
+
+def _scenes(prefix, n):
+    return [Path(f"/scenes/{prefix}{i}.jpeg") for i in range(n)]
+
+
+def _stub_library(monkeypatch, *, scenes=(), broll=(), raise_on=None):
+    """Stub every gallery_library entry point visual_reuse touches."""
+    import engine.gallery_library as gl
+
+    def _select(*a, **k):
+        if raise_on == "select":
+            raise RuntimeError("boom")
+        return list(scenes)
+
+    def _week(*a, **k):
+        if raise_on == "week":
+            raise RuntimeError("boom")
+        return list(scenes)
+
+    def _broll(*a, **k):
+        return list(broll)
+
+    def _manifest(*a, **k):
+        if raise_on == "manifest":
+            raise RuntimeError("boom")
+        return {"images": []}
+
+    monkeypatch.setattr(gl, "select_library_scenes", _select)
+    monkeypatch.setattr(gl, "collect_week_scenes", _week)
+    monkeypatch.setattr(gl, "select_broll_clips", _broll)
+    monkeypatch.setattr(gl, "load_manifest", _manifest)
+    monkeypatch.setattr(gl, "scene_context_map",
+                        lambda manifest, paths: {p: "" for p in paths})
+
+
+# ---------------------------------------------------------------------------
+# Config knobs — dataclass + _defaults.yaml (silent-config-drop landmine)
+# ---------------------------------------------------------------------------
+
+class TestConfigKnobs:
+    def test_dataclass_declares_all_knobs_with_defaults(self):
+        fields = YouTubeConfig.__dataclass_fields__
+        cfg = YouTubeConfig()
+        for name, expected in _NEW_KNOBS.items():
+            assert name in fields, f"YouTubeConfig missing {name}"
+            assert getattr(cfg, name) == expected, (
+                f"{name} default is {getattr(cfg, name)!r}, want {expected!r}"
+            )
+
+    def test_defaults_yaml_documents_all_knobs(self):
+        data = yaml.safe_load(
+            (_ROOT / "shows" / "_defaults.yaml").read_text(encoding="utf-8")
+        )
+        yt = data.get("youtube") or {}
+        for name, expected in _NEW_KNOBS.items():
+            assert name in yt, f"_defaults.yaml youtube: missing {name}"
+            assert yt[name] == expected
+
+
+# ---------------------------------------------------------------------------
+# long_form_visual_plan
+# ---------------------------------------------------------------------------
+
+class TestLongFormVisualPlan:
+    def _plan(self, config, tmp_path, *, fresh=4, chapters=3, **kwargs):
+        return vr.long_form_visual_plan(
+            config,
+            show_slug="tesla",
+            episode_id="ep001",
+            hook="Cybercab production begins",
+            fresh_scenes=_scenes("fresh", fresh),
+            chapters_path=_chapters_file(tmp_path, chapters) if chapters else None,
+            audio_duration_s=600.0,
+            digests_dir=tmp_path,
+            **kwargs,
+        )
+
+    def test_happy_path_chapter_schedule(self, monkeypatch, tmp_path):
+        _stub_library(monkeypatch, scenes=_scenes("lib", 3))
+        out = self._plan(_config(), tmp_path)
+        assert out["mode"] == "chapter_schedule"
+        assert out["scene_schedule"] and len(out["scene_schedule"]) >= 2
+        assert out["fresh_count"] == 4
+        assert out["library_count"] == 3
+        # Blended pool = fresh + library, fresh first.
+        assert out["scene_paths"][:4] == _scenes("fresh", 4)
+        assert abs(sum(d for _, d in out["scene_schedule"]) - 600.0) < 1.0
+
+    def test_chapter_alignment_disabled_gives_no_schedule(
+        self, monkeypatch, tmp_path,
+    ):
+        _stub_library(monkeypatch, scenes=_scenes("lib", 3))
+        out = self._plan(_config(chapter_aligned_scenes=False), tmp_path)
+        assert out["scene_schedule"] is None
+        assert out["mode"] == "uniform"
+        assert out["scene_paths"]  # blending still applies
+
+    def test_blend_disabled_uses_only_fresh(self, monkeypatch, tmp_path):
+        _stub_library(monkeypatch, scenes=_scenes("lib", 3))
+        out = self._plan(_config(gallery_blend_enabled=False), tmp_path)
+        assert out["library_count"] == 0
+        assert out["scene_paths"] == _scenes("fresh", 4)
+
+    def test_fewer_than_two_chapters_falls_back_to_uniform_mode(
+        self, monkeypatch, tmp_path,
+    ):
+        _stub_library(monkeypatch, scenes=[])
+        out = self._plan(_config(), tmp_path, chapters=1)
+        assert out["scene_schedule"] is None
+        assert out["mode"] == "uniform"
+
+    def test_no_fresh_scenes_is_library_fallback_mode(
+        self, monkeypatch, tmp_path,
+    ):
+        _stub_library(monkeypatch, scenes=_scenes("lib", 4))
+        out = self._plan(_config(), tmp_path, fresh=0)
+        assert out["mode"] == "library_fallback"
+        assert out["scene_paths"] == _scenes("lib", 4)
+
+    def test_empty_pool_is_cover_mode(self, monkeypatch, tmp_path):
+        _stub_library(monkeypatch, scenes=[])
+        out = self._plan(_config(), tmp_path, fresh=0)
+        assert out["mode"] == "cover"
+        assert out["scene_paths"] is None
+        assert out["scene_schedule"] is None
+
+    def test_broll_gating(self, monkeypatch, tmp_path):
+        clips = [Path("/broll/clip1.mp4")]
+        _stub_library(monkeypatch, scenes=[], broll=clips)
+        assert self._plan(_config(), tmp_path)["broll_clips"] == clips
+        assert self._plan(
+            _config(evergreen_broll=False), tmp_path,
+        )["broll_clips"] is None
+
+    def test_internal_failure_never_raises_and_returns_legacy(
+        self, monkeypatch, tmp_path,
+    ):
+        _stub_library(monkeypatch, raise_on="manifest")
+        out = self._plan(_config(), tmp_path)
+        assert out["scene_schedule"] is None
+        assert out["scene_paths"] is None
+        assert out["broll_clips"] is None
+        assert out["mode"] == "uniform"  # ≥2 fresh scenes → legacy uniform
+
+    def test_scheduler_failure_never_raises(self, monkeypatch, tmp_path):
+        _stub_library(monkeypatch, scenes=_scenes("lib", 2))
+        import engine.scene_scheduler as ss
+
+        def _boom(*a, **k):
+            raise RuntimeError("scheduler exploded")
+
+        monkeypatch.setattr(ss, "plan_chapter_schedule", _boom)
+        out = self._plan(_config(), tmp_path)
+        assert out["scene_schedule"] is None
+        assert out["mode"] == "uniform"
+
+
+# ---------------------------------------------------------------------------
+# short_visual_extras
+# ---------------------------------------------------------------------------
+
+_WORDS = [
+    {"word": " Hello", "start": 10.0, "end": 10.4},
+    {"word": " world.", "start": 10.5, "end": 11.0},
+    {"word": " Next", "start": 16.0, "end": 16.3},
+    {"word": " sentence.", "start": 16.4, "end": 17.0},
+    {"word": " More.", "start": 24.0, "end": 24.5},
+]
+
+
+class TestShortVisualExtras:
+    def _extras(self, config, **kwargs):
+        defaults = dict(
+            show_slug="tesla",
+            episode_id="ep001",
+            fresh_short_scenes=_scenes("vert", 4),
+            transcript_words=_WORDS,
+            window_start_s=5.0,
+            clip_duration_s=55.0,
+            context_text="cybercab",
+        )
+        defaults.update(kwargs)
+        return vr.short_visual_extras(config, **defaults)
+
+    def test_blends_library_and_produces_cuts(self, monkeypatch):
+        _stub_library(monkeypatch, scenes=_scenes("libv", 2))
+        out = self._extras(_config())
+        assert out["scene_paths"][:4] == _scenes("vert", 4)
+        assert out["library_count"] == 2
+        assert out["scene_change_times"], "expected sentence cuts"
+
+    def test_sentence_cuts_disabled(self, monkeypatch):
+        _stub_library(monkeypatch, scenes=[])
+        out = self._extras(_config(shorts_sentence_cuts=False))
+        assert out["scene_change_times"] is None
+
+    def test_no_word_data_means_no_cuts(self, monkeypatch):
+        _stub_library(monkeypatch, scenes=[])
+        out = self._extras(_config(), transcript_words=[])
+        assert out["scene_change_times"] is None
+
+    def test_blend_disabled_and_thin_fresh_gives_no_scene_paths(
+        self, monkeypatch,
+    ):
+        _stub_library(monkeypatch, scenes=_scenes("libv", 4))
+        out = self._extras(
+            _config(gallery_blend_enabled=False),
+            fresh_short_scenes=_scenes("vert", 1),
+        )
+        assert out["scene_paths"] is None  # legacy handling takes over
+
+    def test_failure_never_raises(self, monkeypatch):
+        _stub_library(monkeypatch, raise_on="select")
+        out = self._extras(_config())
+        assert out["scene_paths"] is None
+        assert out["scene_change_times"] is None
+
+
+# ---------------------------------------------------------------------------
+# recap_scene_pool / fallback_scene_pool
+# ---------------------------------------------------------------------------
+
+class TestRecapAndFallbackPools:
+    def test_recap_pool_returns_both_aspects(self, monkeypatch):
+        _stub_library(monkeypatch, scenes=_scenes("wk", 5))
+        out = vr.recap_scene_pool(
+            _config(), show_slug="tesla", episode_id="ep001",
+            end_date="2026-06-28",
+        )
+        assert out["enabled"] is True
+        assert len(out["long"]) == 5 and len(out["short"]) == 5
+
+    def test_recap_pool_disabled_flag(self, monkeypatch):
+        _stub_library(monkeypatch, scenes=_scenes("wk", 5))
+        out = vr.recap_scene_pool(
+            _config(recap_reuse_scenes=False), show_slug="tesla",
+            episode_id="ep001", end_date="2026-06-28",
+        )
+        assert out == {"long": [], "short": [], "enabled": False}
+
+    def test_recap_pool_failure_never_raises(self, monkeypatch):
+        _stub_library(monkeypatch, raise_on="week")
+        out = vr.recap_scene_pool(
+            _config(), show_slug="tesla", episode_id="ep001",
+            end_date="2026-06-28",
+        )
+        assert out["long"] == [] and out["short"] == []
+
+    def test_run_show_gates_recap_on_two_per_aspect(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert 'len(_recap_pool.get("long") or []) >= 2' in src
+        assert 'len(_recap_pool.get("short") or []) >= 2' in src
+
+    def test_fallback_pool(self, monkeypatch):
+        _stub_library(monkeypatch, scenes=_scenes("fb", 3))
+        got = vr.fallback_scene_pool(
+            _config(), show_slug="tesla", episode_id="ep001",
+        )
+        assert got == _scenes("fb", 3)
+
+    def test_fallback_pool_disabled_flag(self, monkeypatch):
+        _stub_library(monkeypatch, scenes=_scenes("fb", 3))
+        assert vr.fallback_scene_pool(
+            _config(gallery_fallback_enabled=False),
+            show_slug="tesla", episode_id="ep001",
+        ) == []
+
+    def test_fallback_pool_failure_never_raises(self, monkeypatch):
+        _stub_library(monkeypatch, raise_on="select")
+        assert vr.fallback_scene_pool(
+            _config(), show_slug="tesla", episode_id="ep001",
+        ) == []
+
+
+class TestLoadTranscriptWords:
+    def test_flattens_segments(self, tmp_path):
+        p = tmp_path / "t.json"
+        p.write_text(json.dumps({"segments": [
+            {"start": 0, "end": 1, "text": "a", "words": _WORDS[:2]},
+            {"start": 1, "end": 2, "text": "b", "words": _WORDS[2:]},
+        ]}), encoding="utf-8")
+        assert vr.load_transcript_words(p) == _WORDS
+
+    def test_missing_or_wordless_is_empty(self, tmp_path):
+        assert vr.load_transcript_words(tmp_path / "nope.json") == []
+        p = tmp_path / "old.json"
+        p.write_text(json.dumps({"segments": [{"start": 0, "end": 1,
+                                               "text": "a"}]}),
+                     encoding="utf-8")
+        assert vr.load_transcript_words(p) == []
+
+
+# ---------------------------------------------------------------------------
+# Metrics — record_youtube_outcomes carries the new observability keys
+# ---------------------------------------------------------------------------
+
+class _FakeMetrics:
+    def __init__(self):
+        self.data = {}
+
+    def record(self, key, value):
+        self.data[key] = value
+
+
+class TestVisualMetricsRecorded:
+    def test_new_keys_recorded(self):
+        from engine.pipeline import record_youtube_outcomes
+        metrics = _FakeMetrics()
+        record_youtube_outcomes(
+            metrics,
+            {
+                "visual_mode": "chapter_schedule",
+                "scene_fresh_count": 4,
+                "scene_library_count": 6,
+                "broll_clips_used": 2,
+                "thumbnail_base": "scene",
+                "thumbnail_variant_urls": ["https://g/x.jpg"],
+            },
+            1.0,
+            config=_config(),
+        )
+        assert metrics.data["visual_mode"] == "chapter_schedule"
+        assert metrics.data["scene_fresh_count"] == 4
+        assert metrics.data["scene_library_count"] == 6
+        assert metrics.data["broll_clips_used"] == 2
+        assert metrics.data["thumbnail_base"] == "scene"
+        assert metrics.data["thumbnail_variant_urls"] == ["https://g/x.jpg"]
+
+    def test_absent_keys_not_recorded(self):
+        from engine.pipeline import record_youtube_outcomes
+        metrics = _FakeMetrics()
+        record_youtube_outcomes(metrics, {}, 1.0, config=_config())
+        for key in ("visual_mode", "scene_fresh_count", "scene_library_count",
+                    "broll_clips_used", "thumbnail_base",
+                    "thumbnail_variant_urls"):
+            assert key not in metrics.data
+
+
+# ---------------------------------------------------------------------------
+# run_show wiring drift guards (source-level, matching repo convention)
+# ---------------------------------------------------------------------------
+
+class TestRunShowWiring:
+    def test_wiring_present(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        # Long-form: plan feeds the renderer.
+        assert 'scene_schedule=_visual_plan.get("scene_schedule")' in src
+        assert 'broll_clips=_visual_plan.get("broll_clips")' in src
+        # Shorts: extras feed the renderer.
+        assert "scene_change_times=_short_visuals.get(" in src
+        # Recap flag threaded from run() into _publish_youtube.
+        assert "is_weekly_recap=is_weekly_recap" in src
+        # Recap + degraded fallback pools wired.
+        assert "recap_scene_pool" in src
+        assert "fallback_scene_pool" in src
+        # Scene-based thumbnail + variants.
+        assert "long_form_thumbnail_from_scene" in src
+        assert "generate_thumbnail_variants" in src
+
+    def test_publisher_variant_helper_exists(self):
+        from engine.publisher import generate_thumbnail_variants
+        assert callable(generate_thumbnail_variants)
+
+
+# ---------------------------------------------------------------------------
+# Gallery ↔ retention join script
+# ---------------------------------------------------------------------------
+
+def _load_retention_module():
+    spec = importlib.util.spec_from_file_location(
+        "build_gallery_retention",
+        _ROOT / "scripts" / "build_gallery_retention.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _stats_fixture():
+    return {"schema_version": 1, "shows": {"tesla_shorts_time": {"videos": [
+        {"video_id": "vidLONG", "show_slug": "tesla", "episode": 520,
+         "kind": "long", "channel": "en", "average_view_percentage": 41.5},
+        {"video_id": "vidSHORT", "show_slug": "tesla", "episode": 520,
+         "kind": "short", "channel": "en", "average_view_percentage": 62.0},
+        {"video_id": "vidOTHER", "show_slug": "tesla", "episode": 521,
+         "kind": "long", "channel": "en", "average_view_percentage": 30.0},
+    ]}}}
+
+
+def _manifest_fixture():
+    def img(image_id, ep, use, tags, video_id=""):
+        return {"image_id": image_id, "show_slug": "tesla",
+                "episode_id": ep, "intended_use": use,
+                "tags": ["tesla"] + tags, "youtube_video_id": video_id}
+    return {"images": [
+        img("aaa", "ep520", "segment_card", ["factory"]),
+        img("bbb", "ep520", "social", ["factory"]),
+        img("ccc", "ep521", "segment_card", ["factory"], video_id="vidOTHER"),
+        img("ddd", "ep999", "segment_card", ["orphan"]),  # no video → dropped
+        img("eee", "ep520", "thumbnail_variant", ["x"]),  # not rendered use
+    ]}
+
+
+class TestGalleryRetentionJoin:
+    def test_join_by_episode_and_video_id(self):
+        mod = _load_retention_module()
+        out = mod.build(_manifest_fixture(), _stats_fixture(), min_videos=1)
+        tesla = out["shows"]["tesla"]
+        assert tesla["images"]["aaa"]["video_id"] == "vidLONG"
+        assert tesla["images"]["aaa"]["averageViewPercentage"] == 41.5
+        assert tesla["images"]["bbb"]["video_id"] == "vidSHORT"
+        assert tesla["images"]["ccc"]["video_id"] == "vidOTHER"
+        assert "ddd" not in tesla["images"]
+        assert "eee" not in tesla["images"]
+        # Summary: 'factory' spans 3 distinct videos → mean of 41.5/62/30.
+        factory = [t for t in tesla["summary"]["top_tags"]
+                   if t["tag"] == "factory"][0]
+        assert factory["videos"] == 3
+        assert abs(factory["mean_retention"] - 44.5) < 0.01
+
+    def test_min_videos_threshold_prunes_summary(self):
+        mod = _load_retention_module()
+        out = mod.build(_manifest_fixture(), _stats_fixture(), min_videos=4)
+        assert out["shows"]["tesla"]["summary"]["top_tags"] == []
+
+    def test_absent_data_is_clean_empty_payload(self):
+        mod = _load_retention_module()
+        for manifest, stats in ((None, _stats_fixture()),
+                                (_manifest_fixture(), None), (None, None)):
+            out = mod.build(manifest, stats)
+            assert out["shows"] == {}
+            assert out["schema_version"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Nightly workflow wiring
+# ---------------------------------------------------------------------------
+
+class TestNightlyWiring:
+    def test_retention_step_and_commit_path(self):
+        text = (_ROOT / ".github" / "workflows"
+                / "nightly-maintenance.yml").read_text(encoding="utf-8")
+        data = yaml.safe_load(text)
+        steps = data["jobs"]["generate-artifacts"]["steps"]
+        runs = " ".join(s.get("run", "") or "" for s in steps)
+        assert "scripts/build_gallery_retention.py" in runs
+        commit = [s for s in steps
+                  if (s.get("uses") or "").endswith("safe-commit-push")]
+        assert commit, "safe-commit-push step missing"
+        assert "api/gallery_retention.json" in commit[0]["with"]["add-paths"]
+        # Ordering: the join must run AFTER the analytics fetch and AFTER
+        # the manifest rebuild (it joins both files fresh).
+        names = [s.get("name", "") for s in steps]
+        join_idx = next(i for i, s in enumerate(steps)
+                        if "build_gallery_retention" in (s.get("run") or ""))
+        analytics_idx = next(i for i, n in enumerate(names)
+                             if "YouTube analytics" in n)
+        manifest_idx = next(i for i, s in enumerate(steps)
+                            if "build_gallery_manifest" in (s.get("run") or ""))
+        assert join_idx > analytics_idx
+        assert join_idx > manifest_idx


### PR DESCRIPTION
Implements the full set of YouTube pipeline improvements built on the assets the network has already generated — the ~1,540-image Grok Imagine gallery and the recovered video clips — so every video gets richer visuals at essentially zero new generation cost. Docs: `docs/youtube_visual_reuse.md`. Everything is video/metadata-only (outside the landmine #17 audio gate), config-gated with defaults on, and strictly best-effort — any failure falls back to today's exact behavior and never blocks a publish.

## What changes on screen

- **Long-form**: instead of 4 images cycling on a flat timer, episodes get a chapter-aligned schedule — scene switches land on chapter boundaries, each chapter shows the image whose prompt best matches its title, and up to 8 on-topic images from the show's gallery library blend in for variety (Tesla has 344 banked).
- **Shorts**: the 9:16 pool blends up to 4 library images (~8 distinct scenes instead of 4 looped twice) and scene changes snap to sentence boundaries using the caption word timestamps.
- **Thumbnails**: long-form thumbnails composite the hook on the episode's best scene instead of the identical flat cover every episode; up to 2 variants from other scenes are uploaded to R2 and their URLs recorded per episode for Studio Test &amp; Compare.
- **Sunday recaps** reuse the week's own ~24 scenes (both aspects) and skip Grok Imagine generation entirely — the most repetitive episode of the week becomes the richest, at negative cost.
- **Degraded episodes** (&lt;2 fresh scenes) fall back to recent gallery images before the static cover.
- **Evergreen B-roll**: `build_long_form_video` can interleave up to 3 curated local clips via the previously dead hybrid renderer. New operator CLI `scripts/build_broll_pool.py` uploads recovered clips (46 Tesla + 12 SpaceX exist server-side) to R2 and writes a small committed `broll.json` — no per-episode Grok video generation returns, and no media touches git.

## Fixes riding along

- **RU dubs no longer ship static-cover videos**: the dub step refreshes the gallery manifest from origin/main and defers a fresh episode with no scenes (`no_scenes_yet`, retried next sweep); old scene-less episodes still publish with cover rather than stalling.
- Latent bug: the slideshow hard-cut retry caught `CalledProcessError` but ffmpeg failures raise `RuntimeError` — the documented fallback could never fire. Now it can.

## Data flywheel

`scripts/build_gallery_retention.py` (nightly) joins gallery images with per-video retention into `api/gallery_retention.json`, so once analytics accrue you can see which visual styles hold viewers. New per-episode metrics: `visual_mode`, `scene_fresh_count`, `scene_library_count`, `broll_clips_used`, `thumbnail_base`, `thumbnail_variant_urls`.

## Knobs (all in `shows/_defaults.yaml`, per-show overridable)

`gallery_blend_enabled` / `gallery_blend_max_long: 8` / `gallery_blend_max_short: 4` / `chapter_aligned_scenes` / `long_form_thumbnail_from_scene` / `thumbnail_variants: 2` / `recap_reuse_scenes` / `gallery_fallback_enabled` / `shorts_sentence_cuts` / `evergreen_broll` (no-op until a show has a curated `broll.json`).

## Verification

Full suite: **3,489 passed, 0 failed** (131 new tests across `test_scene_scheduler`, `test_gallery_library`, `test_visual_reuse`, plus extensions to `test_video_commands` / `test_ru_dub`). A uniform schedule reproduces the legacy ffmpeg graph byte-for-byte (pinned); `None` args keep the literal legacy code paths.

## Operator follow-ups (optional)

- Run `scripts/recover_grok_video.py` + `scripts/build_broll_pool.py` once to activate B-roll for Tesla/SpaceX.
- Watch the first day's episodes for `visual_mode: chapter_schedule` in metrics and eyeball one video per show — if anything looks off, each behavior is one YAML flag to disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX

---
_Generated by [Claude Code](https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX)_