### PR TITLE
[show-review] Network editorial pass (2026-07-02)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1138,6 +1138,36 @@ same review ran across the other ten shows. Drift guards:
   (review recommends waiting to ~Ep15); confirm X handles for the
   X-enabled shows so the follow CTA can be set.
 
+### Network editorial review (July 2026)
+
+Full editorial pass over every transcript in the 2026-06-18 → 07-02 window
+(~150 episodes, all 13 shows — fit, interest, content quality, positioning).
+Canonical writeup:
+[`docs/reviews/network_review_2026_07_02.md`](docs/reviews/network_review_2026_07_02.md);
+prediction verdicts + new entries in every per-show ledger
+([`docs/reviews/ledger/`](docs/reviews/ledger/) — new ledgers for
+privet_russian, modern_investing, network). Four cross-cutting classes:
+(1) **number/name garbles in flagship positions** — the comma-blind
+currency/ordinal formatter shipped "fifty-nine dollars,990"-class hooks on
+Tesla/SpaceX (fixed, `assets/pronunciation.py`); (2) **guard/retry mechanisms
+degrading the audio they protect** — the missing-closing guard's literal
+signature match double-spoke MAB's closing 5/15 (fixed: fuzzy match in
+`engine/pipeline.py`) and the expand-below-target retry pads by
+paraphrase-duplication (fixed: near-duplicate sentence stripping);
+(3) **third-generation seeded-template convergence** (OV "Both sides
+agree…" 12/12, EI "There's a nuance here…" 6/6, MAB/FP/MIT/SpaceX tics) —
+ALL prompt de-seeds are PROPOSED-not-applied pending operator A/B (landmine
+#17); meta-lesson: de-seed by shape, never with a quotable example;
+(4) **same-day sibling overlap** — PT astronomy fetch filter (the pass's
+highest-leverage fix), FF lookback 2→7 + ephemeris filter, SpaceX junk-title
+filter. Also shipped: EI Closing/Teaser-before-body chapter reorder, MIT
+voided phantom trades (honest 37-trade record + review-once), PR vocab
+no-reteach 8 + WOTD never-repeat + theme gap, network-wide Source-line scrub
+(FP scaffold leak), UC/FPD queue hygiene, Tesla second-brand-normalizer
+completion, and `review_snapshot.py` Unicode + missing-final-Closing fixes.
+Operator items: three same-day double-publishes + SpaceX's silently missed
+June-28 recap (scheduler forensics).
+
 ### Website review (June 10, 2026)
 
 Full public-site review — canonical writeup:

--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -870,9 +870,12 @@ def _year_to_words(year: int) -> str:
 def replace_currency(text: str) -> str:
     """Convert currency values to spoken form."""
     # Large currency first: "$3 Trillion", "$2.5 Billion", etc.
+    # Comma-grouped amounts ("$1,200 million") are accepted \u2014 commas are
+    # stripped before conversion. See the July 2026 comma-blindness fix on
+    # _currency_whole below for the shipped-audio bugs this class caused.
     def _large_currency(m: re.Match) -> str:
         symbol = m.group(1)
-        num_str = m.group(2)
+        num_str = m.group(2).replace(",", "")
         unit = m.group(3).lower()
         currency = {"$": "dollars", "\u20ac": "euros", "\u00a3": "pounds"}.get(symbol, "dollars")
         try:
@@ -882,7 +885,7 @@ def replace_currency(text: str) -> str:
             return m.group(0)
 
     text = re.sub(
-        r"([$\u20ac\u00a3])(\d+\.?\d*)\s*(trillion|billion|million)\b",
+        r"([$\u20ac\u00a3])(\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d+\.?\d*)\s*(trillion|billion|million)\b",
         _large_currency,
         text,
         flags=re.IGNORECASE,
@@ -891,7 +894,7 @@ def replace_currency(text: str) -> str:
     # Regular currency with cents: "$417.44" -> "four hundred seventeen dollars and forty-four cents"
     def _currency_with_cents(m: re.Match) -> str:
         symbol = m.group(1)
-        whole = m.group(2)
+        whole = m.group(2).replace(",", "")
         frac = m.group(3)
         currency = {"$": "dollars", "\u20ac": "euros", "\u00a3": "pounds"}.get(symbol, "dollars")
         sub_unit = {"$": "cents", "\u20ac": "cents", "\u00a3": "pence"}.get(symbol, "cents")
@@ -906,19 +909,29 @@ def replace_currency(text: str) -> str:
         except ValueError:
             return m.group(0)
 
-    text = re.sub(r"([$\u20ac\u00a3])(\d+)\.(\d{1,2})\b", _currency_with_cents, text)
+    text = re.sub(
+        r"([$\u20ac\u00a3])(\d{1,3}(?:,\d{3})+|\d+)\.(\d{1,2})\b",
+        _currency_with_cents,
+        text,
+    )
 
     # Whole currency: "$500" -> "five hundred dollars"
+    # Comma-grouped amounts are accepted (July 2026): the old ``(\d+)\b``
+    # matched only the digits before the comma, so "$59,990" shipped as
+    # "fifty-nine dollars,990" (Tesla Ep515 hook), "$20,000" as
+    # "twenty dollars,000" (Ep523 \u2014 Whisper: "under $20 in $1000"), and
+    # "$80,000" the same way (Ep521). Same comma tolerance the Canadian-
+    # dollar path (replace_canadian_currency) has carried since May 2026.
     def _currency_whole(m: re.Match) -> str:
         symbol = m.group(1)
-        num_str = m.group(2)
+        num_str = m.group(2).replace(",", "")
         currency = {"$": "dollars", "\u20ac": "euros", "\u00a3": "pounds"}.get(symbol, "dollars")
         try:
             return f"{number_to_words(int(num_str))} {currency}"
         except ValueError:
             return m.group(0)
 
-    text = re.sub(r"([$\u20ac\u00a3])(\d+)\b", _currency_whole, text)
+    text = re.sub(r"([$\u20ac\u00a3])(\d{1,3}(?:,\d{3})+|\d+)\b", _currency_whole, text)
     return text
 
 
@@ -1121,7 +1134,25 @@ def replace_episode_numbers(text: str) -> str:
 
 
 def replace_ordinal_numbers(text: str) -> str:
-    """Convert '7th' to 'seventh', '10th' to 'tenth', etc."""
+    """Convert '7th' to 'seventh', '10th' to 'tenth', etc.
+
+    Comma-grouped ordinals are handled first (July 2026): the plain
+    ``\\b(\\d+)…`` pattern used to match only the digits after the comma,
+    so "1,000th" shipped as "1,zeroth" (Tesla Ep518/524) and "1,500th" as
+    "1,five hundredth" (SpaceX Ep10). The grouped handler strips commas
+    before conversion so "1,000th" → "one thousandth".
+    """
+    def _ordinal_grouped(m: re.Match) -> str:
+        num_str = m.group(1).replace(",", "")
+        try:
+            return _number_to_ordinal(int(num_str))
+        except ValueError:
+            return m.group(0)
+
+    text = re.sub(
+        r"\b(\d{1,3}(?:,\d{3})+)(?:st|nd|rd|th)\b", _ordinal_grouped, text
+    )
+
     def _ordinal(m: re.Match) -> str:
         num_str = m.group(1)
         try:

--- a/digests/modern_investing/investment_tracker.json
+++ b/digests/modern_investing/investment_tracker.json
@@ -14,15 +14,15 @@
     "nasdaq_ytd_year": 2026
   },
   "summary": {
-    "total_trades": 41,
+    "total_trades": 37,
     "wins": 21,
     "losses": 13,
-    "breakeven": 7,
-    "win_rate_pct": 51.2,
+    "breakeven": 3,
+    "win_rate_pct": 56.8,
     "cumulative_pnl": 263.15,
     "best_trade_pct": 20.11,
     "worst_trade_pct": -11.8,
-    "average_return_pct": 0.64,
+    "average_return_pct": 0.71,
     "cumulative_alpha_vs_nasdaq": 10.96,
     "trades_with_alpha": 30,
     "current_streak": -1,
@@ -754,14 +754,15 @@
       "confidence": "Medium",
       "target_range": "+2% to +5% over the five-day hold as IPO-related volatility lifts bank desks",
       "trade_type": "weekly",
-      "status": "closed",
+      "status": "voided",
       "entry_price": null,
       "exit_price": null,
-      "pnl_pct": 0.0,
-      "pnl_dollars": 0.0,
-      "lesson": "Market data was unavailable for evaluation.",
+      "pnl_pct": null,
+      "pnl_dollars": null,
+      "lesson": "Trade voided — market data was unavailable for evaluation.",
       "sector": "other",
-      "current_price": 54.05
+      "current_price": 54.05,
+      "void_reason": "market_data_unavailable"
     },
     {
       "episode_num": 75,
@@ -772,14 +773,15 @@
       "confidence": "Medium",
       "target_range": "+2% to +4% over the five-day hold window.",
       "trade_type": "weekly",
-      "status": "closed",
+      "status": "voided",
       "entry_price": null,
       "exit_price": null,
-      "pnl_pct": 0.0,
-      "pnl_dollars": 0.0,
-      "lesson": "Market data was unavailable for evaluation.",
+      "pnl_pct": null,
+      "pnl_dollars": null,
+      "lesson": "Trade voided — market data was unavailable for evaluation.",
       "sector": "other",
-      "current_price": 79.93
+      "current_price": 79.93,
+      "void_reason": "market_data_unavailable"
     },
     {
       "episode_num": 77,
@@ -790,14 +792,15 @@
       "confidence": "Medium",
       "target_range": "+3% to +6% over the five-day window as the spread narrows toward closing certainty.",
       "trade_type": "weekly",
-      "status": "closed",
+      "status": "voided",
       "entry_price": null,
       "exit_price": null,
-      "pnl_pct": 0.0,
-      "pnl_dollars": 0.0,
-      "lesson": "Market data was unavailable for evaluation.",
+      "pnl_pct": null,
+      "pnl_dollars": null,
+      "lesson": "Trade voided — market data was unavailable for evaluation.",
       "sector": "other",
-      "current_price": 137.29
+      "current_price": 137.29,
+      "void_reason": "market_data_unavailable"
     },
     {
       "episode_num": 79,
@@ -808,14 +811,15 @@
       "confidence": "Medium",
       "target_range": "+4% to +8% over the week if momentum holds.",
       "trade_type": "weekly",
-      "status": "closed",
+      "status": "voided",
       "entry_price": null,
       "exit_price": null,
-      "pnl_pct": 0.0,
-      "pnl_dollars": 0.0,
-      "lesson": "Market data was unavailable for evaluation.",
+      "pnl_pct": null,
+      "pnl_dollars": null,
+      "lesson": "Trade voided — market data was unavailable for evaluation.",
       "sector": "other",
-      "current_price": 57.64
+      "current_price": 57.64,
+      "void_reason": "market_data_unavailable"
     },
     {
       "episode_num": 81,
@@ -979,25 +983,25 @@
     "last_updated": "2026-07-01"
   },
   "alpha": {
-    "inception_to_date_pct": -16.52,
-    "ytd_pct": -12.18,
+    "inception_to_date_pct": -16.45,
+    "ytd_pct": -12.11,
     "monthly": {}
   },
   "sectors": {
     "other": {
-      "trade_count": 6,
-      "exposure_pct": 60.0,
-      "cumulative_pnl": -117.96
+      "trade_count": 5,
+      "exposure_pct": 50.0,
+      "cumulative_pnl": -154.09
+    },
+    "healthcare": {
+      "trade_count": 2,
+      "exposure_pct": 20.0,
+      "cumulative_pnl": 1.68
     },
     "tech": {
       "trade_count": 3,
       "exposure_pct": 30.0,
       "cumulative_pnl": -15.57
-    },
-    "healthcare": {
-      "trade_count": 1,
-      "exposure_pct": 10.0,
-      "cumulative_pnl": 0.0
     }
   },
   "monthly_snapshots": [

--- a/docs/reviews/ledger/env_intel.yaml
+++ b/docs/reviews/ledger/env_intel.yaml
@@ -129,11 +129,52 @@ reviews:
       - metric: episodes shipping with no Introduction chapter, last 10
         baseline: "4/10 (Ep037/038/042/046 — the 'Welcome to' greeting variant)"
         expected: "0/10 post-merge — all three greeting shapes now title an Introduction chapter"
-        verdict: pending
-        evidence: "Drift guards pass: test_introduction_pattern_matches_every_greeting_variant + test_welcome_to_opener_yields_introduction_chapter. Re-score on next 2-3 'Welcome to' episodes."
+        verdict: hit
+        evidence: "2026-07-02 network pass: every window episode (incl. the
+          'Welcome to' greeting variant) has an Introduction chapter."
       - metric: deep-dive opener "There's a nuance here worth understanding" (potential new tic)
         baseline: "1/1 post-merge episode (Ep046)"
         expected: "openers rotate; this lead-in does not become a 5+/10 template echo"
+        verdict: miss
+        evidence: "2026-07-02 network pass: exactly as feared — 'There's a
+          nuance here worth understanding' opened the deep dive in 6/6 window
+          episodes; the replacement became the template (third-generation
+          tic). Reopened; menu removal + rotation memory proposed under A/B."
+    agent_cost_usd: null
+
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >
+      Network editorial pass. Scored June-17: Introduction HIT; nuance-tic
+      MISS (6/6 — the ledger predicted exactly this; reopened, menu removal
+      proposed). P0: orphan-Closing chapters RETURNED (variant 3) — 3/5
+      window episodes ended on a promo-collision body chapter. Also: thin
+      days triple-tell one story (Ep047/049 told one story 4x); "federal
+      register" spoken instead of "Canada Gazette" (Ep051 x4); "Tomorrow,
+      watch for…" on an every-other-day show. The Practitioner Deep Dive
+      remains the network's best B2B content.
+    shipped:
+      - chapter reorder — Closing/Tomorrow Teaser ordered before ALL body
+        markers; bare "deep dive" dropped; science|technical marker
+        promo-proofed; re-parsed all five real window episodes to verify
+        (metadata-only, no audio)
+    deferred:
+      - "A/B proposals (NOT applied): thin-day rule (a 1-2-story day tells
+        the story ONCE; Regulatory Watch/Industry from the forward
+        calendar); remove 'There's a nuance here worth understanding' from
+        the menu (prefer rotation memory over another menu); 'Next briefing,
+        watch for…'; always 'Canada Gazette'; spoken script carries cited
+        instrument references"
+      - chronic under-length (carried; digest ceiling, four-show length A/B)
+      - "operator: verify Ep050's 'coordinated federal-provincial
+        permitting' claim; QC/SK/Atlantic got ZERO mentions despite the
+        Phase-4 queries — French-language sources or soften the RSS promise"
+    predictions:
+      - metric: episodes whose LAST chapter is Closing (chapters_ep*.json)
+        baseline: "2 of 5 in the window (3/5 ended on a promo-collision body chapter)"
+        expected: "all of the next 5 episodes end with a Closing chapter"
         verdict: pending
         evidence: null
     agent_cost_usd: null

--- a/docs/reviews/ledger/fascinating_frontiers.yaml
+++ b/docs/reviews/ledger/fascinating_frontiers.yaml
@@ -215,8 +215,54 @@ reviews:
           0 stock/market-action items in Ep115 — the content lake no longer
           accumulates stock content (dailies filter at fetch) and the recap window
           (June 22-28) excludes pre-filter Ep103. If it leaks, attack the recap path.
+        verdict: hit
+        evidence: >-
+          2026-07-02 network pass: Ep115 recap (2026-06-28) clean — 0
+          stock/market-action items; pre-filter Ep103 content aged out of the
+          lake window as predicted (resolved-HIT). No recap-side guard needed.
+
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >-
+      Network editorial pass. Scored June-24/16/12 predictions: launch
+      false-drop HIT, recap stock-leak resolved-HIT (Ep115 recap clean),
+      June-12 garbles HIT. Findings: slow-day self-recycling (Ep116 re-ran 4
+      of its own week's stories); ephemeris / sky-tonight filler diluting
+      digests; led with the same SiriusXM launch as SpaceX Daily the same
+      day; the Swift reboost story ran 4x with no new development. Cosmic
+      Deep Dive still earns the subscription.
+    shipped:
+      - >-
+        content_freshness.lookback_days 2 -> 7 (stops same-week
+        self-recycling; deterministic, no A/B).
+      - >-
+        Ephemeris title filter at fetch — verified zero false drops against
+        the window's titles.
+    deferred:
+      - >-
+        A/B proposals (NOT applied): de-prioritize routine comsat/cadence
+        launches (SpaceX Daily's beat); developing-story discipline (no
+        re-run without a new development).
+      - >-
+        Cosmic Deep Dive length lever (carried; four-show length A/B).
+      - >-
+        Mid-section digest-driven chapter titles (carried, network lever);
+        theme residual "science nasa" + curated narrative-tracker status
+        pass (carried).
+    predictions:
+      - metric: own-week story re-runs without a new development, per episode
+        baseline: "Ep116 re-ran 4 of its own week's stories"
+        expected: "0 post-merge (7-day freshness lookback)"
         verdict: pending
         evidence: null
+      - metric: ephemeris / sky-tonight filler items in digests
+        baseline: "recurring across the window"
+        expected: "0 post-merge; no false drops of real astronomy news"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
 
 do_not_retry:
   - idea: Phonetic respellings or programmatic speech-tag injection.

--- a/docs/reviews/ledger/finansy_prosto.yaml
+++ b/docs/reviews/ledger/finansy_prosto.yaml
@@ -17,7 +17,7 @@ reviews:
       is (69-129 articles/day).
     shipped:
       - Russian YouTube call-out for FP (engine/intros._RUSSIAN_SPOKEN_SHOWS)
-      - "@" stripped from spoken handle network-wide (fixes "at at" stutter)
+      - '"@" stripped from spoken handle network-wide (fixes "at at" stutter)'
       - cadence-neutral FP closings ("до встречи" replaces "до завтра")
       - _extract_hook matches "HOOK|ЗАГОЛОВОК"
       - structural-retry suffix de-Tesla'd (generic section language)
@@ -30,31 +30,70 @@ reviews:
       - metric: transcripts ending with an English YouTube call-out (FP)
         baseline: "5/5 recent FP episodes (English on the Olya voice)"
         expected: "0 post-merge; the call-out is Russian ('Ссылка в описании выпуска')"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: window FP episodes end with the
+          Russian call-out; no English CTA on the Olya voice."
       - metric: episodes voicing "at at Nerra …" (network-wide)
         baseline: "75+ across 6 shows (49 'at at Nerra Network', 8+10 'Nerra RU')"
         expected: "0 post-merge; handle spoken without the '@' sigil"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: no 'at at' stutter in any window
+          transcript, network-wide."
       - metric: FP transcripts saying "до завтра" in the closing
         baseline: "present in both closing-pool variants (even-days show)"
         expected: "0 post-merge; closings cadence-neutral ('до встречи')"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: closings cadence-neutral; no
+          'до завтра' in the window."
       - metric: FP episodes with digest_structural_regen=true
         baseline: "10/10 (Ep45-54, every episode — ЗАГОЛОВОК hook unrecognized)"
         expected: "0 (or near 0) post-merge — ЗАГОЛОВОК now recognized"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: digest_structural_regen no longer
+          fires every episode; the Russian hook label is recognized."
       - metric: median FP _tts.txt words / audio minutes, last ~5 post-merge eps
         baseline: "~700w / ~5.0 min (Ep50-54)"
         expected: ">= 950w / >= 7 min on normal-news even-days; not lower than baseline"
-        verdict: pending
-        evidence: "Clean --test A/B not possible Jun 16 (news pool drained by real Ep54 + dedup). Score on Jun 18/20."
+        verdict: miss
+        evidence: "2026-07-02 network pass: episodes still ~700w / ~5 min —
+          the digest-depth prompt did not lift shipped length. Chronic
+          under-length stays deferred (digest ceiling; four-show length A/B)."
       - metric: FP practical-tips count per episode (digest)
         baseline: "2-3 (digest) vs podcast's required minimum of 3"
         expected: ">= 3 tips every episode"
+        verdict: hit
+        evidence: "2026-07-02 network pass: window episodes carry >= 3
+          practical tips."
+    agent_cost_usd: null
+
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >
+      Network editorial pass. Scored June-16: five HITs (Russian CTA, at-at,
+      до-завтра, ЗАГОЛОВОК regen, tips), length MISS (deferred). P0: Ep059
+      spoke a raw digest scaffold line on air («Сорс MoneySense…»). Also:
+      one fabricated tip; a template echo the Cyrillic-blind snapshot missed
+      — «не так уж и сложно, правда?» 7/8 and «Подруга спросила меня вчера»
+      6/8. Real niche, real localization otherwise. Cadence is stated three
+      contradictory ways across YAML / CLAUDE.md / ledger (operator item).
+    shipped:
+      - Source-line scrub in the script-save path (network-wide; kills the
+        spoken «Сорс …» scaffold class)
+    deferred:
+      - "A/B proposals (NOT applied): de-seed «не так уж и сложно, правда?»
+        and «Подруга спросила меня вчера» (keep the method, fresh phrasing);
+        cap «Коротко и ясно» at 2-3 sentences + finance-relevance rule;
+        disclaimer line in all closing variants; deep-dive may not
+        re-explain the episode's own main topic"
+      - chronic under-length (carried; digest ceiling, four-show length A/B)
+      - "operator: align the cadence (YAML daily vs CLAUDE.md-table Monday
+        vs ledger even-days; actual mixed)"
+    predictions:
+      - metric: spoken source-scaffold lines («Сорс …» / «Source …») in _tts.txt
+        baseline: "Ep059 spoke «Сорс MoneySense…» on air"
+        expected: "0 post-merge (script-save scrub)"
         verdict: pending
         evidence: null
     agent_cost_usd: null

--- a/docs/reviews/ledger/first_principles.yaml
+++ b/docs/reviews/ledger/first_principles.yaml
@@ -88,21 +88,66 @@ reviews:
           keyword, e.g. concrete_example days)
         baseline: "7 of 18 episodes (Ep001/004/007/009/011/015/017) had NO Closing"
         expected: "Closing present on 100% of new episodes after the marker reorder"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: >-
+          2026-07-02 network pass: Closing chapter present on all new
+          episodes; the marker-reorder fix verified.
       - metric: >-
           recurrence of the verbatim lesson formula "whose price greatly
           exceeds its [materials/atoms] is announcing a design problem" as the
           lesson opener in _tts.txt
         baseline: "12 of ~16 episodes opened the lesson with the formula"
         expected: "<= 2 of the next 10 episodes use the verbatim formula"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: >-
+          2026-07-02 network pass: the verbatim lesson formula is absent from
+          the window's episodes.
       - metric: "FP brief (.md) word count"
         baseline: "848-1116 words (no digest expansion path)"
         expected: ">= 1300 words median after the digest expansion retry fires"
+        verdict: hit
+        evidence: >-
+          2026-07-02 network pass (~hit): the digest-stage retry fires and
+          lifts briefs toward the 1400 floor; a minority still land below
+          1300 — bounded by the grok-4.3 plateau (do_not_retry), not a fix
+          target.
+
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >-
+      Network editorial pass. Scored June-23: Closing-chapter fix verified
+      (HIT), lesson-template de-seed HIT, digest expansion retry ~HIT
+      (briefs lifted; a few still capped by the model plateau). Best content
+      accuracy in the network. Findings: topic-queue duplicates; Ep020/021
+      shipped back-to-back concrete_example episodes (the
+      concrete/opportunity alternation broken); Ep024 spoke its digest's
+      creative sub-headings mid-paragraph (header leak).
+    shipped:
+      - >-
+        Queue hygiene — duplicate topic pruning + concrete/opportunity
+        alternation restored in shows/topic_queues/first_principles.yaml.
+    deferred:
+      - >-
+        A/B proposals (NOT applied): FPD podcast stage must not emit
+        markdown-style headers (a code-side header-strip is worth
+        considering); forbid absolute cost-effectiveness claims without
+        units sanity (shared with UC — the $50/life-saved class).
+      - >-
+        Garbage auto-segment chapter titles (carried; shared network lever).
+    predictions:
+      - metric: consecutive same-category episodes (concrete vs opportunity)
+        baseline: "Ep020/021 shipped back-to-back concrete_example"
+        expected: "strict alternation over the next 10 episodes"
         verdict: pending
         evidence: null
+      - metric: spoken markdown-style sub-headings in _tts.txt
+        baseline: "Ep024 spoke its digest's creative sub-headings mid-paragraph"
+        expected: "0 once the header rule/strip ships; monitored until then"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
 
 do_not_retry:
   - idea: >-

--- a/docs/reviews/ledger/models_agents.yaml
+++ b/docs/reviews/ledger/models_agents.yaml
@@ -16,7 +16,9 @@ reviews:
     deferred:
       - digest-driven / position-aware mid-section chapter titles (medium effort, shared; Ep078 residual)
       - expand Under the Hood section for length, after the four-show length A/B settles
-      - "let's pop the hood on" opener tic — not changed (signature phrase, audio-change risk); revisit only with A/B evidence
+      - >-
+        "let's pop the hood on" opener tic — not changed (signature phrase,
+        audio-change risk); revisit only with A/B evidence
     predictions:
       - metric: '"An-thropic" occurrences in last-10 _tts.txt (sum)'
         baseline: "94 (snapshot 2026-06-14; 6 in Ep080)"
@@ -67,8 +69,9 @@ reviews:
       - metric: '"koo-dah" occurrences in published blog transcripts of post-merge CUDA episodes'
         baseline: "shipped in 12 episodes since Ep040 (23 total occurrences); live in Ep086 (2), Ep088 (2)"
         expected: "0 in any episode generated post-merge that mentions CUDA (CUDA appears instead)"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: 'koo-dah' absent from all post-merge
+          transcripts; CUDA appears instead."
       - metric: 'custom voice still reads CUDA cleanly (Whisper of next post-merge CUDA episode)'
         baseline: 'current "koo-dah" audio reads as ~CUDA (Whisper Ep088: "a CUDA kernel")'
         expected: 'Whisper transcript shows "CUDA"; no "C U D A" letter-split (matches NASA/Anthropic precedent)'
@@ -77,6 +80,41 @@ reviews:
       - metric: median _tts.txt words, last 10 eps
         baseline: "~1300 (range 1067-1582; 9/10 below 1500 floor)"
         expected: "no regression; chronic under-length stays deferred to the four-show length A/B"
+        verdict: hit
+        evidence: "2026-07-02 network pass: median steady ~1300, no regression.
+          Under-length stays deferred (digest ceiling)."
+    agent_cost_usd: null
+
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >
+      Network editorial pass. Scored June-21 (koo-dah HIT; length
+      no-regression HIT). Findings: arXiv cs.CL was subscribed TWICE — the
+      preprint flood crowded out the fortnight's two biggest builder stories
+      (Codex Record Replay + Gemini Computer Use aired on the BEGINNER show,
+      never here); the expand-below-target retry pads by
+      paraphrase-duplication (Ep087 shipped verbatim doubled sentences);
+      continuity-callback tic ("...tracked since episode eighty six" — the
+      banned phrase reborn).
+    shipped:
+      - duplicate arXiv cs.CL feed removed + network-wide no-duplicate-feeds
+        guard
+      - expansion-retry near-duplicate sentence stripping with
+        fallback-to-original (network-wide, engine-side)
+    deferred:
+      - "A/B proposals (NOT applied): selection rebalance (lab
+        product/feature announcements outrank preprints; arXiv items <= 40%);
+        continuity-callback cap (<= 1 spoken callback/episode, never episode
+        numbers); recap must synthesize, not splice (Ep095 reused dailies'
+        sentences verbatim; Ep088 proves the model can)"
+      - digest-driven / position-aware chapter titles (carried)
+      - chronic under-length = digest ceiling (carried; four-show length A/B)
+    predictions:
+      - metric: verbatim-doubled sentence pairs in shipped _tts.txt scripts
+        baseline: "Ep087 shipped verbatim doubled sentences (retry padding)"
+        expected: "0 post-merge (near-duplicate stripping in the retry)"
         verdict: pending
         evidence: null
     agent_cost_usd: null

--- a/docs/reviews/ledger/models_agents_beginners.yaml
+++ b/docs/reviews/ledger/models_agents_beginners.yaml
@@ -27,13 +27,19 @@ reviews:
       - metric: '"not so scary, right?" occurrences in last-10 transcripts'
         baseline: "9/10 episodes (Ep080/081/082 verbatim three-sentence formula)"
         expected: "<= 3/10 episodes generated post-merge; no verbatim 'so next time someone says X, you can tell them' formula"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: verbatim formula gone post-merge.
+          Caveat: successor template '...stops feeling like magic...' emerged
+          in 5/6 post-fix episodes (third-generation tic; de-seed-by-shape
+          proposed under A/B)."
       - metric: 'Big Story openers using "Something [adj] just happened", last 10'
         baseline: "5/10 (Ep073/074/075/078/080)"
         expected: "0/10 post-merge"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: 0/10 post-merge. Caveat: the model
+          converged on 'Here's something that's going to change...' — straight
+          from the prompt's own example menu; opener-menu rewrite with zero
+          quotable strings proposed under A/B."
       - metric: median _tts.txt words, last 10 eps
         baseline: "~1085 (range 820-1470; 9/10 below 1200 floor)"
         expected: "no regression; chronic under-length stays deferred to the four-show length A/B"
@@ -45,6 +51,40 @@ reviews:
         verdict: pending
         evidence: null
     agent_cost_usd: 0.02
+
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >
+      Network editorial pass. Scored June-25 (both de-seeds HIT, each with a
+      successor-template caveat — the meta-lesson is de-seed by SHAPE, never
+      with a quotable example). P0 found + fixed: the missing-closing
+      guard's literal signature match double-spoke the ENTIRE closing on
+      5/15 episodes (the LLM de-contracts "that's" -> "that is", the guard
+      thinks the closing is absent and appends it again). Also: Quick Bits
+      balloon with expansion-retry restatements; "try this" experiments name
+      no tool. Genuinely distinct and beginner-followable otherwise (caught
+      the two builder stories the sister show missed).
+    shipped:
+      - closing-guard fuzzy signature match (engine/pipeline.py; still fires
+        on genuinely missing closings)
+      - expansion-retry near-duplicate sentence stripping (network-wide)
+    deferred:
+      - "A/B proposals (NOT applied): rewrite the opener menu with zero
+        quotable strings; ban '...stops feeling like magic...' verbatim
+        alongside 'not so scary'; 'try this' items ineligible unless the
+        tool is NAMED in the source; Quick Bits <= 3 sentences, every
+        sentence a new fact"
+      - chronic under-length (carried; digest ceiling, four-show length A/B)
+      - '"The Big Story" chapter missing (carried; digest-driven titles lever)'
+    predictions:
+      - metric: episodes with a double-spoken closing (guard false-fire)
+        baseline: "5 of 15 in the window"
+        expected: "0 of next 15 (fuzzy signature match)"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
 
 do_not_retry:
   - idea: phonetic respellings / programmatic speech-tag injection on the custom voice

--- a/docs/reviews/ledger/modern_investing.yaml
+++ b/docs/reviews/ledger/modern_investing.yaml
@@ -1,0 +1,48 @@
+# Review ledger for modern_investing. Schema: docs/reviews/ledger/README.md
+# Created by the 2026-07-02 network editorial pass (first scored MIT entry;
+# the June 2026 flagship pass predates the ledger system for this show).
+reviews:
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >
+      Network editorial pass — first ledger entry. Most actionable show in
+      the network, but its worst-possible error class shipped: PHANTOM
+      (data-failure) trades narrated as market outcomes ("ROKU closed
+      flat…", "KO closed flat today" — no price was ever fetched; 4 of the
+      spoken "7 breakeven outcomes" were data failures). The MU trade was
+      reviewed as "yesterday's flash trade" three times. Also: the seeded
+      callback sentence colonized 9/10 episodes; two irreconciled alphas
+      spoken (+11% daily vs -13.1% Sunday — the Sunday honesty is a strength
+      to keep); Ep093 amplified an investing.com promo headline ("Qualys
+      surged 65%") with invented same-day framing (operator item).
+    shipped:
+      - voided-trade status for data-failure closes — excluded from every
+        aggregate / review / lookback (deterministic)
+      - one-time tracker migration to the honest 37-trade record (was 41
+        with 4 phantoms)
+      - review-once guard (each closed trade reviewed exactly once)
+    deferred:
+      - "A/B proposals (NOT applied): de-seed the 'This is the exact
+        scenario where our earlier rule…' callback; retire 'closing-price
+        confirmation' as a teachable lesson (it describes the pipeline's own
+        former price-fetch bug); label the two alpha metrics whenever
+        spoken; Saturday scripts say 'Friday's close'"
+      - "operator: demote the investing.com promo tier / require a second
+        source for >20% single-day move claims"
+    predictions:
+      - metric: spoken closed-trade record vs tracker after migration
+        baseline: "41 spoken incl. 4 phantom data-failure 'breakeven' trades"
+        expected: "spoken record excludes voided trades (37 honest trades);
+          no data-failure close ever narrated as a market outcome"
+        verdict: pending
+        evidence: null
+      - metric: times a single closed trade is reviewed on air
+        baseline: "MU reviewed as 'yesterday's flash trade' 3x"
+        expected: "exactly once per closed trade (review-once guard)"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
+do_not_retry: []

--- a/docs/reviews/ledger/network.yaml
+++ b/docs/reviews/ledger/network.yaml
@@ -1,0 +1,73 @@
+# Review ledger for the cross-cutting `network` target.
+# Schema: docs/reviews/ledger/README.md. Feeds the meta-review (verdict
+# rates by finding category) per the README.
+reviews:
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >
+      Full network editorial review — every transcript in the
+      2026-06-18..07-02 window (~150 episodes, all 13 shows) scored for
+      fit / interest / content / positioning. Four cross-cutting classes:
+      (1) number/name normalization garbles in flagship positions
+      (Tesla/SpaceX comma-number hooks — fixed); (2) guard/retry mechanisms
+      degrading the audio they protect (MAB double-spoken closing;
+      M&A/MAB/UC expansion-retry paraphrase padding — both fixed);
+      (3) third-generation seeded-template convergence (OV/EI/MAB/FP/MIT/
+      SpaceX — all prompt de-seeds PROPOSED under A/B, not applied);
+      (4) same-day sibling overlap / beat encroachment (PT astronomy filter
+      shipped — the review's highest-leverage fix; FF lookback + ephemeris;
+      Tesla/SpaceX beat rules proposed). Plus scheduler anomalies: three
+      same-day double-publishes + one silently missed SpaceX recap
+      (operator forensics).
+    shipped:
+      - comma-number normalization (assets/pronunciation.py; all five
+        shipped garble forms regression-tested)
+      - closing-guard fuzzy signature match (engine/pipeline.py)
+      - expansion-retry near-duplicate sentence stripping with
+        fallback-to-original
+      - Source-line scrub in the script-save path (spoken scaffold class)
+      - EI Closing/Teaser-before-body chapter reorder; PT astronomy + FF
+        ephemeris/lookback-7 + SpaceX junk-title fetch filters; M&A
+        duplicate-feed removal + network no-duplicate-feeds guard
+      - MIT voided-trade status + 37-trade migration + review-once guard
+      - PR vocab no-reteach 8 / WOTD never-repeat / theme-gap enforcement
+      - UC + FPD topic-queue hygiene (interleave, dedup, alternation)
+      - review_snapshot.py Unicode-aware tic detector +
+        missing-final-Closing chapter check (two tooling blind spots that
+        let shipped defects pass three snapshots)
+    deferred:
+      - "all seeded-template de-seeds (the 12-show A/B list in the review
+        doc) — PROPOSED, NOT applied (landmine #17; no GROK_API_KEY here to
+        render before/after)"
+      - "playbook meta-lesson (recorded, not yet applied to
+        .claude/commands/review-show.md): never put a quotable example
+        phrase in a rotation menu — three shows elected the first menu item
+        as their next tic; de-seed by shape"
+      - "operator: double-publish forensics (Tesla 6/23, PR 6/22, OV 6/19);
+        SpaceX 6/28 missed recap; FP cadence alignment; M&A x_enabled
+        mismatch vs CLAUDE.md"
+    predictions:
+      - metric: guard/retry-inflicted audio defects network-wide
+          (double-spoken closings, verbatim-doubled sentences)
+        baseline: "MAB 5/15 double closings; M&A Ep087 doubled sentences"
+        expected: "0 across the next 2 weeks of episodes"
+        verdict: pending
+        evidence: null
+      - metric: snapshot visibility of Cyrillic tics + missing-final-Closing
+          chapter shapes
+        baseline: "snapshot cleared FP while a template ran 7/8, and cleared
+          EI while 3/5 shipped orphaned Closings"
+        expected: "the next FP/EI snapshots surface these classes
+          mechanically (no hand-reading required)"
+        verdict: pending
+        evidence: null
+      - metric: same-day sibling story duplication (PT vs FF lead stories)
+        baseline: "6 consecutive days of verbatim astronomy duplication"
+        expected: "0 after the PT fetch filter"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
+do_not_retry: []

--- a/docs/reviews/ledger/omni_view.yaml
+++ b/docs/reviews/ledger/omni_view.yaml
@@ -23,26 +23,70 @@ reviews:
       - metric: episodes (last 10) with a Closing chapter in chapters_ep*.json
         baseline: "3 of 10"
         expected: "10 of 10 within 2 weeks"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: Closing chapter present on window
+          episodes; where-anchors holding."
       - metric: chapters with sentence-fragment / ellipsis titles (last 10 eps)
         baseline: ">=2 (ep061, ep068)"
         expected: "0"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: 0 fragment/ellipsis chapter titles
+          in the window."
       - metric: max "the strongest case" count in any single episode (last 10)
         baseline: 20
         expected: "<= 1"
-        verdict: pending
-        evidence: null
+        verdict: partial
+        evidence: "2026-07-02 network pass: SCRIPT clean — 0 uses in 15 window
+          episodes (the podcast-side ban held). But the DIGEST regressed:
+          Ep085 shipped 'the strongest case' x24, 8 days after the ban.
+          Mechanical digest lint on template saturation proposed."
       - metric: episodes opening stories with anonymous "one side frames / the other side frames" (last 10)
         baseline: ">=1 (ep077, 6x)"
         expected: "0"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: 0 anonymous 'one side frames'
+          openers in the window; advocates named."
       - metric: median _tts.txt words (last 10 eps)
         baseline: 1150
         expected: ">= 1600 within 2 weeks"
+        verdict: miss
+        evidence: "2026-07-02 network pass: median still well under 1600 —
+          digest ceiling class; stays deferred behind the four-show length
+          A/B (not re-litigated)."
+    agent_cost_usd: null
+
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >
+      Network editorial pass. Scored June-10: Closing HIT, fragments HIT,
+      anonymity HIT, strongest-case PARTIAL (script 0/15 — the podcast ban
+      held — but digest Ep085 shipped it x24, 8 days after the ban), length
+      MISS (deferred). The neutrality promise HOLDS (3-story audit clean),
+      but steel-manning is now simulated by formula: "Both sides agree X;
+      they differ on whether Y" at saturation — 12/12 stories in Ep099,
+      including manufactured "sides" on a shark attack, an earthquake, and a
+      celebrity outfit. Depth vs breadth conflict: prompt demands 6-7
+      stories x 6-8 sentences; window ships 12-13 x ~5. June-19
+      double-publish Ep086+Ep087 (operator item).
+    shipped:
+      - none show-specific (network-wide expansion-retry dedup + Source-line
+        scrub apply to OV)
+    deferred:
+      - "A/B proposals (NOT applied): remove the literal 'Both sides agree
+        on [X]; they differ on [Y]' seed from omni_view_digest.txt; cap the
+        construction <= 2/episode; disasters/tragedies/obituaries/celebrity
+        items get facts + coverage framing, never manufactured sides; select
+        6-8 stories and deepen"
+      - mechanical digest lint on template saturation (tooling proposal)
+      - chronic under-length (carried; digest ceiling, four-show length A/B)
+      - "operator: June-19 double-publish forensics"
+    predictions:
+      - metric: '"Both sides agree" constructions per episode digest'
+        baseline: "12/12 stories in Ep099 (saturation)"
+        expected: "<= 2/episode once the proposed de-seed ships; unchanged
+          until then (scores the proposal's urgency)"
         verdict: pending
         evidence: null
     agent_cost_usd: null

--- a/docs/reviews/ledger/planetterrian.yaml
+++ b/docs/reviews/ledger/planetterrian.yaml
@@ -25,21 +25,60 @@ reviews:
       - metric: episodes with an Introduction chapter at word 0, last 10
         baseline: "6/10 (Ep085/086/088/093 missed — non-Welcome greetings)"
         expected: "10/10 within 2 weeks of post-merge episodes"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: chapter shape holds — Introduction
+          present on post-merge episodes across all greeting variants."
       - metric: episodes shipping with no Closing chapter, last 10
         baseline: "Ep086 + Ep090 (teaser stole the sign-off line)"
         expected: "0/10 post-merge (Closing precedes teaser; real teaser line now matches)"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: no missing-Closing episodes
+          post-merge; ordering fix holding."
       - metric: episodes with a real Science Deep Dive chapter (when a deep dive aired)
         baseline: "0/10 (literal-label marker never matched; section fell to auto-segment)"
         expected: ">= 1 per episode that contains a deep-dive opener"
-        verdict: pending
-        evidence: "Re-parse of Ep090-093 with the new marker yields a Science Deep Dive chapter."
+        verdict: hit
+        evidence: "Re-parse of Ep090-093 yielded the chapter at fix time;
+          2026-07-02 network pass confirms deep-dive chapters on post-merge
+          episodes (chapter shape holds)."
       - metric: median _tts.txt words, last 10 eps
         baseline: "~1272 (snapshot 2026-06-18); floor 1600, target 1,800-2,100"
         expected: "no regression below baseline; length stays deferred (digest ceiling)"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >
+      Network editorial pass. Scored June-18: chapter shape holds (all three
+      chapter predictions HIT). Headline finding — the biggest positioning
+      problem in the network: a longevity/health brand shipping a
+      general-science firehose, duplicating Fascinating Frontiers' astronomy
+      stories verbatim on 6 consecutive days. Health-claim hedging is
+      exemplary and must be preserved.
+    shipped:
+      - astronomy fetch filter (exclude_title_patterns; verified against the
+        window's titles — kills the 6-day FF duplication; the single
+        highest-leverage fix of this review)
+    deferred:
+      - "A/B proposals (NOT applied): digest-prompt scope guard + >= 8/15
+        life-science floor; trim bare science/research/study/discovery
+        keywords (monitor volume vs min_articles_skip 2); explicit prompt
+        rule preserving the exemplary health-claim hedging"
+      - chronic under-length (carried; digest ceiling, four-show length A/B)
+      - garbage mid-body auto-segment chapter titles (carried, shared lever)
+    predictions:
+      - metric: pure-astronomy items per PT episode digest
+        baseline: "~2-3/day (6 consecutive days duplicating FF verbatim)"
+        expected: "0 post-merge (fetch filter)"
+        verdict: pending
+        evidence: null
+      - metric: article volume vs min_articles_skip (2) after the filter
+        baseline: "no skip days in the window"
+        expected: "no filter-induced skip days (monitor)"
         verdict: pending
         evidence: null
     agent_cost_usd: null

--- a/docs/reviews/ledger/privet_russian.yaml
+++ b/docs/reviews/ledger/privet_russian.yaml
@@ -1,0 +1,45 @@
+# Review ledger for privet_russian. Schema: docs/reviews/ledger/README.md
+# Created by the 2026-07-02 network editorial pass (first scored PR entry).
+reviews:
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >
+      Network editorial pass — first dedicated ledger entry. Great pedagogy
+      architecture, but two content P0s: Ep043 taught ungrammatical Russian
+      as model sentences («Я есть хлеб», «Моя яблоко») and Ep050 fabricated
+      an etymology as fact (чемодан/valise). Curriculum loop was stuck:
+      «хлеб» was Word-of-the-Day 3x in 12 days, only 27 of 87 taught
+      word-slots were new, and 3 themes looped for two weeks. June-22
+      double-publish (Ep046+Ep047) + skipped June 26/28 (operator item).
+    shipped:
+      - vocab no-reteach window 3 -> 8 episodes
+      - Word-of-the-Day never-repeat rule
+      - theme-gap enforcement (no theme re-run inside the rotation window)
+    deferred:
+      - "A/B proposals (NOT applied): grammar-correctness rule (model
+        sentences fully conjugated/agreeing; never 'Я + infinitive');
+        etymologies must be standard/verifiable or hedged; stop narrating
+        plan-field labels ('The memory hook notes that…'); English AI
+        disclosure for the English-speaking audience"
+      - "operator: June-22 double-publish + June 26/28 skip forensics"
+    predictions:
+      - metric: distinct themes across the next 8 episodes
+        baseline: "4 themes looped over the two-week window"
+        expected: ">= 6 distinct themes (theme-gap enforcement)"
+        verdict: pending
+        evidence: null
+      - metric: repeated Word-of-the-Day within any 12-day span
+        baseline: "«хлеб» was WOTD 3x in 12 days"
+        expected: "0 repeats (never-repeat rule)"
+        verdict: pending
+        evidence: null
+      - metric: share of taught word-slots that are NEW words
+        baseline: "27 of 87 in the window"
+        expected: "majority new per episode (no-reteach window 8)"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
+do_not_retry: []

--- a/docs/reviews/ledger/spacex.yaml
+++ b/docs/reviews/ledger/spacex.yaml
@@ -103,17 +103,54 @@ reviews:
       - Tomorrow-teaser "Watch for the [first/next] <test>" frame now 6/8
         (Ep1,2,4,6,7,8); hardening across two reviews. Rotate teaser opener in
         podcast prompt if it goes fully dead (low risk, P2).
-      - Weekly-recap Closing chapter: dailies confirmed; score the next recap
-        (Sun 2026-06-21) for the recap half of the June-18 prediction.
+      - "Weekly-recap Closing chapter: dailies confirmed; score the next recap
+        (Sun 2026-06-21) for the recap half of the June-18 prediction."
     predictions:
       - metric: stranded time fragments in spacex _tts.txt (regex "[A-Z] M:[0-9]" or "\\d{3,4}:\\d{2}")
         baseline: "2 (Ep8: 'one fifty A M:45' + '0850:45 U T C')"
         expected: "0 — launch times render clean (seconds dropped; compact UTC spoken) from Ep9 on"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: no stranded time fragments in any
+          window _tts.txt / Whisper transcript (Ep9+)."
       - metric: Closing chapter on the 2026-06-21 weekly recap (chapters_ep*.json)
         baseline: "Ep3 (prior recap) shipped with NO Closing; June-18 reorder applied"
         expected: "the 2026-06-21 recap has a Closing chapter (closes the carried-forward June-18 prediction)"
+        verdict: hit
+        evidence: "2026-07-02 network pass: the 2026-06-21 recap shipped WITH a
+          Closing chapter — closes the carried June-18 half. (Separate issue:
+          the June-28 recap never ran at all — scheduler, operator item.)"
+    agent_cost_usd: null
+
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >
+      Network editorial pass. Scored June-19 (time-garbles HIT; recap-Closing
+      HIT). Findings: laundered SEO spam reached the digest ("Fiorentina
+      versus Genoa" video-ID titles); xAI<->SpaceX entity conflation
+      ("SpaceXAI"; Memphis/Colossus attributed to SpaceX); memory-echo
+      "...remain the key open questions" x5 in one episode; Ep17's hook
+      promised a static fire the episode never covered; the June-28 Sunday
+      recap silently never ran (operator item); SPCX price still spoken
+      twice per episode (8/8 — strongest evidence yet for the deferred
+      price-once fix).
+    shipped:
+      - junk-title fetch filter (video-ID / sports-fixture titles;
+        13F/stock-filter class, deterministic, no A/B)
+    deferred:
+      - "A/B proposals (NOT applied): entity discipline (Memphis/Colossus is
+        xAI's; ban 'SpaceXAI'); every hook clause must correspond to a
+        covered story; Tesla-style deep-dive topic-history injection
+        (Ep15/Ep19 ran the same deep dive); decide the deferred price-once
+        fix"
+      - Engineering Deep Dive length floor (carried; four-show length A/B)
+      - "operator: June-28 silently missed Sunday recap — scheduler
+        forensics"
+    predictions:
+      - metric: laundered SEO / sports-fixture / video-ID junk titles in digests
+        baseline: "Fiorentina-vs-Genoa class present in the window"
+        expected: "0 post-merge (fetch filter)"
         verdict: pending
         evidence: null
     agent_cost_usd: null

--- a/docs/reviews/ledger/tesla.yaml
+++ b/docs/reviews/ledger/tesla.yaml
@@ -61,16 +61,67 @@ reviews:
       - metric: '"Tesla-rah-tee" occurrences in last-10 _tts.txt scripts'
         baseline: "5 of last 10 episodes (Ep500/505/512/516 + more)"
         expected: "0 of 10 — every instance restored to 'Teslarati'"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: zero 'Tesla-rah-tee' in any
+          window _tts.txt (2026-06-18..07-02)."
       - metric: episodes whose spoken intro says "Tesla Shorts Time Daily"
         baseline: "10 of 10 (Ep506-516)"
         expected: "0 of 10 — normalizer drops the stray 'Daily'"
-        verdict: pending
-        evidence: null
+        verdict: miss
+        evidence: "Still spoken in 14/14 window episodes. Root-caused
+          2026-07-02: a SECOND normalizer in run_show.py
+          (_normalize_tst_opening) kept rewriting TOWARD the old brand,
+          undoing the June-20 generator fix. Fixed in the network pass."
       - metric: 13F institutional-filing items in the digest
         baseline: "up to 3/episode on thin days (Ep516)"
         expected: "0 — filtered at fetch via exclude_title_patterns"
+        verdict: hit
+        evidence: "2026-07-02 network pass: no 13F institutional-filing items
+          in any window digest; fetch filter holding."
+    agent_cost_usd: null
+
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >
+      Network editorial pass (all 13 shows). Scored June-20 (Teslarati HIT,
+      13F HIT, brand-"Daily" MISS — root-caused to a SECOND normalizer).
+      Findings: comma-blind number formatting shipped hook garbles
+      ("fifty-nine dollars,990", "1,zeroth") in 4 episodes, twice in the
+      HOOK; spoken brand still "Tesla Shorts Time Daily" 14/14; SpaceX
+      corporate-finance drift (Ep518's first two minutes were "a worse
+      SpaceX Daily"); weak recaps (Ep517 covered the Dojo patent 3x, read
+      raw headlines + "EtherType 0x9AC6" hex on air); June-23 double-publish
+      Ep519+Ep520 (operator item).
+    shipped:
+      - "comma-number normalization fix (assets/pronunciation.py) — kills the
+        'dollars,990' / '1,zeroth' hook-garble class; regression tests for
+        all five shipped forms"
+      - "second brand normalizer in run_show.py (_normalize_tst_opening)
+        fixed — it kept rewriting TOWARD 'Tesla Shorts Time Daily', undoing
+        the June-20 generator fix; completes the approved June-10 decision
+        (quick A/B-listen advised)"
+    deferred:
+      - "chronic under-length: digest ceiling (carried; four-show length A/B)"
+      - digest-driven chapter titles (carried, shared network lever)
+      - "A/B proposals (NOT applied): recap hardening (one story once, no
+        Title-Case headlines or patent/hex minutiae, transition variety);
+        ban standalone dateline-filler sentences; require named entities;
+        counterpoint-section enforcement (5/14 misses); SpaceX/xAI corporate
+        items are SpaceX Daily's beat — never Tesla's hook/lead"
+      - "operator: June-23 double-publish forensics; narrative-tracker
+        curated status texts lag the show's own reporting by months
+        (scripts/update_tesla_narrative.py)"
+    predictions:
+      - metric: episodes whose spoken intro says "Tesla Shorts Time Daily"
+        baseline: "14 of 14 (window 2026-06-18..07-02)"
+        expected: "0 of next 10 — the second normalizer no longer re-adds it"
+        verdict: pending
+        evidence: null
+      - metric: comma-number hook garbles ("dollars,990"-class) in new _tts.txt
+        baseline: "4 episodes in the window, twice in the HOOK"
+        expected: "0 post-merge (deterministic formatter fix)"
         verdict: pending
         evidence: null
     agent_cost_usd: null

--- a/docs/reviews/ledger/unintended_consequences.yaml
+++ b/docs/reviews/ledger/unintended_consequences.yaml
@@ -27,8 +27,9 @@ reviews:
       - metric: "fraction of last-10 episodes shipping 'That wraps today's case' as the sign-off"
         baseline: "5/10"
         expected: "0/10 (phrase removed from pool)"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-02 network pass: 'That wraps today's case' absent
+          in 13/13 window episodes."
       - metric: "distinct closing variants across the last 10 episodes"
         baseline: "2"
         expected: ">= 3"
@@ -37,6 +38,41 @@ reviews:
       - metric: "median _tts.txt words, last 10 episodes (under-length; NOT fixed this pass)"
         baseline: "~903"
         expected: "still < 1300 — re-confirms the digest lever is the open problem"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
+  - date: 2026-07-02
+    pr: null
+    doc: docs/reviews/network_review_2026_07_02.md
+    reviewer: claude-code (network editorial pass)
+    summary: >-
+      Network editorial pass. Scored June-12: "That wraps today's case"
+      absent 13/13 (HIT). Empathy discipline + mechanism depth intact
+      (content 8.5). Findings: topic-queue category-clustering (8 straight
+      medicine episodes); expansion-retry arithmetic filler ("one hundred
+      vehicles… eighty-five vehicles" restate-percentage-as-count); a
+      likely-wrong $50/life-saved stat (Ep038, operator item); June-23/24
+      episodes shipped the since-reverted brand garble in audio
+      (regenerate-or-accept, operator).
+    shipped:
+      - >-
+        Queue hygiene — category interleave + one miscategorized entry fixed
+        in shows/topic_queues/unintended_consequences.yaml.
+      - >-
+        Expansion-retry near-duplicate sentence stripping (network-wide)
+        curbs the restatement-padding class.
+    deferred:
+      - >-
+        A/B proposals (NOT applied): cap the restate-percentage-as-count
+        device and "One might ask/object" at <= 1/episode; forbid absolute
+        cost-effectiveness claims without units sanity.
+      - >-
+        Chronic under-length (carried; digest lever, grok plateau accepted).
+    predictions:
+      - metric: consecutive same-category episodes in produced queue order
+        baseline: "8 straight medicine episodes in the window"
+        expected: "no 3+ consecutive same-category episodes after interleave"
         verdict: pending
         evidence: null
     agent_cost_usd: null

--- a/docs/reviews/network_review_2026_07_02.md
+++ b/docs/reviews/network_review_2026_07_02.md
@@ -1,0 +1,288 @@
+# Network Editorial Review — All 13 Shows, Transcripts 2026-06-18 → 2026-07-02
+
+**Target:** `network` (editorial: fit, interest, content quality, positioning vs
+each show's target audience). **Method:** every episode transcript in the
+two-week window read in full (~150 episodes: `_tts.txt` scripts + Whisper
+transcripts as ears + digests), against each show's YAML/prompts/RSS
+positioning, both prior-review ledgers, and `review_snapshot.py` mechanical
+numbers. Prior passes' deferred items honored (chronic under-length / digest
+ceiling is NOT re-litigated anywhere below); `do_not_retry` respected.
+Prediction verdicts from every scoreable ledger are recorded in the per-show
+ledger files alongside this review.
+
+## Network verdict
+
+The network's **formats are working**: every show has at least one segment
+that genuinely delivers its brand promise (Tesla's First Principles essays,
+SpaceX's Engineering Deep Dive, EI's Practitioner Deep Dive, OV's
+Understanding the Issue, MAB's analogy craft, MIT's no-trade discipline,
+UC's empathy arc, FPD's load-bearing arithmetic, FP's «как подруге» deep
+dives, PR's lesson architecture). The problems are concentrated in four
+cross-cutting classes, three of which are mechanical and fixed in this PR:
+
+1. **Number/name normalization garbles in flagship positions** — the
+   currency/ordinal formatter was comma-blind, so hooks shipped as spoken
+   gibberish ("fifty-nine dollars,990", "1,zeroth") on Tesla (4 episodes,
+   twice in the HOOK) and SpaceX. Fixed deterministically (June-19
+   seconds-fix class).
+2. **Guard/retry mechanisms degrading the audio they protect** — the
+   missing-closing guard's literal signature match double-spoke the entire
+   closing on 5 of 15 MAB episodes (LLM de-contracted "that's"→"that is");
+   the expand-below-target retry pads by paraphrase-duplication (M&A Ep087
+   shipped verbatim doubled sentences; MAB Quick Bits balloon with
+   restatements; UC's "one hundred vehicles… eighty-five vehicles"
+   arithmetic filler). Both fixed (fuzzy signature match; near-duplicate
+   sentence stripping with fallback-to-original).
+3. **Seeded-template convergence, third generation.** The single most
+   persistent editorial failure mode network-wide: any literal example
+   sentence in a prompt becomes the show's next tic. This window's crop:
+   OV's *"Both sides agree X; they differ on whether Y"* at saturation
+   (12/12 stories in Ep099 — including manufactured "sides" on a shark
+   attack, an earthquake, and Naomi Osaka's outfit); EI's *"There's a
+   nuance here worth understanding"* 6/6 (the ledger predicted exactly
+   this — MISS scored); MAB's replacement templates ("…stops feeling like
+   magic…" 5/6 post-fix; "Here's something that's going to change…" from
+   the prompt's own example menu); FP's «не так уж и сложно, правда?» 7/8
+   and «Подруга спросила меня вчера» 6/8; MIT's seeded callback sentence
+   colonizing 9/10 episodes; SpaceX's memory-echo "…remain the key open
+   questions" ×5 in one episode. **These are prompt edits → all listed
+   under the A/B gate below, NOT auto-applied.** The meta-lesson is
+   recorded for the playbook: de-seed by *shape*, never by quotable
+   example; menus of literal phrases just elect the next template.
+4. **Same-day sibling overlap / beat encroachment** — Planetterrian
+   (life-science show) duplicated Fascinating Frontiers' astronomy stories
+   verbatim on 6 consecutive days; Tesla led with SpaceX corporate-finance
+   stories (Ep518's first two minutes were "a worse SpaceX Daily");
+   FF led with the same SiriusXM launch as SpaceX the same day. Fixed
+   deterministically where possible (PT astronomy fetch filter — the
+   single highest-leverage fix in this review; FF ephemeris filter +
+   lookback), prompt-level beat rules proposed under A/B.
+
+Also in this window: **two same-day double-publishes** (Tesla Ep519+Ep520
+June 23; Привет Русский Ep046+Ep047 June 22 — plus OV June 19) that the
+landmine-#24 duplicate guard did not stop, and **one silently missed
+episode** (SpaceX's June-28 Sunday recap never ran). These are scheduler
+forensics → operator items.
+
+## Per-show scorecards (fit / interest / content / positioning, 1-10)
+
+| Show | Fit | Int | Cont | Pos | One-line editorial verdict |
+|---|---|---|---|---|---|
+| Tesla Shorts Time | 6 | 5 | 4 | 5 | Right breadth, real analysis in First Principles; undermined by hook garbles, "Daily" brand bug, dateline filler, weak recaps, SpaceX drift |
+| SpaceX Daily | 7 | 6 | 5 | 7 | Engineering-first identity is real; entity conflation (xAI↔SpaceX) and story re-leads are the quality gap |
+| Models & Agents | 7 | 5 | 4 | 7 | Practitioner depth is real; arXiv flood crowded out the fortnight's two biggest builder stories (the *beginner* show caught them) |
+| M&A for Beginners | 7 | 7 | 5 | 8 | Genuinely distinct and beginner-followable; double-closing P0 + unnamed "try this" tools |
+| Fascinating Frontiers | 7 | 6.5 | 7.5 | 6.5 | Cosmic Deep Dive earns the subscription; slow-day self-recycling and ephemeris filler dilute |
+| Planetterrian | 5.5 | 6 | 7.5 | 5 | **Biggest positioning problem in the network**: a longevity/health brand shipping a general-science firehose; health-claim hedging is exemplary though |
+| Omni View | 6.5 | 6 | 5.5 | 6 | The neutrality promise HOLDS (3-story audit clean) — but steel-manning is now simulated by formula, applied to stories with no sides |
+| Env Intel | 5.5 | 5 | 5 | 6 | Deep-dive substance is the network's best B2B content; orphan-Closing chapters returned (variant 3), thin days triple-tell one story |
+| Финансы Просто | 7 | 5 | 5 | 8 | Real niche, real localization; scaffold leak on air, one fabricated tip, template echo |
+| Привет, Русский! | 7 | 4 | 4 | 8 | Great pedagogy architecture — but taught ungrammatical Russian as model sentences and looped 3 themes for two weeks |
+| Modern Investing | 8 | 6 | 6 | 7 | Most actionable show; **phantom (data-failure) trades narrated as market outcomes** is its worst-possible error class |
+| Unintended Consequences | 8 | 6.5 | 8.5 | 6.5 | Empathy discipline + mechanism depth intact; queue category-clustering (8 straight medicine episodes) |
+| First Principles Daily | 8.5 | 7.5 | 9 | 7 | Best content accuracy in the network; queue duplicates + one header-leak episode |
+
+## P0s found (and their dispositions)
+
+1. **Tesla/SpaceX comma-number garbles in hooks** — FIXED (deterministic,
+   `assets/pronunciation.py`; regression tests for all five shipped forms).
+2. **MAB double-spoken closing, 5/15 episodes** — FIXED (fuzzy closing-guard
+   signature, `engine/pipeline.py`; the guard still fires on genuinely
+   missing closings).
+3. **MIT phantom trades spoken as market outcomes** ("ROKU closed flat…",
+   "KO closed flat today" — no price was ever fetched; 4 of the spoken "7
+   breakeven outcomes" are data failures) — FIXED (voided-trade status,
+   excluded from every aggregate/review/lookback; one-time tracker
+   migration via the module's own recompute: 41 → 37 trades, breakeven
+   7 → 3, win rate 51.2% → 56.8%, avg return 0.64% → 0.71%, cumulative
+   P&L and alpha unchanged; each closed trade now reviewed exactly once —
+   the MU trade had been "yesterday's flash trade" three times).
+4. **PR taught ungrammatical Russian as model sentences** (Ep043: «Я есть
+   хлеб», «Моя яблоко») and **fabricated an etymology as fact** (Ep050
+   чемодан/valise) — prompt-rule proposals (A/B); the *curriculum loop*
+   half is FIXED in code (no-reteach window 3→8, Word-of-the-Day
+   never-repeat, theme-gap enforcement — «хлеб» was WOTD 3× in 12 days,
+   only 27 of 87 taught word-slots were new).
+5. **EI orphan-Closing chapters returned (variant 3)** — 3/5 episodes ended
+   on a promo-collision body chapter — FIXED (Closing/Teaser ordered before
+   all body markers; bare `deep dive` dropped; `science|technical`
+   promo-proofed; re-parsed all five real episodes — all now start
+   Introduction / end Closing). Deeper root cause found during
+   verification: the June-11 `where: end` window (last 15%) itself
+   EXCLUDED the closing on short EI episodes (the ~130-word outro stack
+   lands the sign-off at ~82-84% of a 650-870-word episode), so Closing
+   now relies on its brand-anchored pattern without the positional window.
+6. **SpaceX "Fiorentina versus Genoa" laundered SEO spam + xAI↔SpaceX
+   entity conflation** — spam class FIXED at fetch (video-ID/fixture title
+   filter, 13F/stock-filter class); entity discipline is a prompt proposal
+   (A/B) — not safely mechanical.
+7. **FP spoke raw digest scaffold** («Сорс MoneySense…», Ep059) — FIXED
+   network-wide (Source-line scrub in the script-save path).
+8. **Tesla spoken brand "Tesla Shorts Time Daily" 14/14** — root cause
+   found (a second normalizer in `run_show.py` rewriting TOWARD the old
+   brand, undoing the June-20 generator fix) — FIXED (completes the
+   operator-approved June-10 decision; quick A/B-listen advised).
+9. **Double-publishes + missed SpaceX recap** — NOT fixed here (scheduler
+   forensics needed) — operator item with dates/evidence below.
+
+## Selected P1s (full details in the six per-show analyses)
+
+- **M&A sourcing drift:** arXiv cs.CL was subscribed TWICE (fixed — duplicate
+  feed removed + network-wide no-duplicate-feeds guard); selection-rule
+  rebalance (lab releases outrank preprints) proposed under A/B. Evidence:
+  Codex Record Replay and Gemini Computer Use (OSWorld 78.4) never aired on
+  the builder show but both aired on the beginner show.
+- **FF slow-day self-recycling** (Ep116 re-ran 4 of its own week's stories):
+  `content_freshness.lookback_days` 2→7 (fixed) + ephemeris title filter
+  (fixed, verified zero false drops against the window's titles).
+- **PT scope backstop:** astronomy fetch filter (fixed, verified against the
+  window's titles — kills the 6-day FF duplication) — the prompt-side scope
+  guard + life-science floor and the keywords trim are proposals.
+- **OV Ep085 digest regression:** "the strongest case" ×24 in a shipped
+  digest 8 days after the ban (script clean — the ban held there). Proposal:
+  mechanical digest lint (warn/regen on template saturation), plus the
+  "Both sides agree" de-seed + no-manufactured-sides escape hatch (A/B).
+- **OV depth vs breadth:** prompt demands 6-7 stories × 6-8 sentences;
+  window ships 12-13 × ~5 — steel-manning compressed to one sentence per
+  side (A/B proposal to select-and-deepen).
+- **Tesla recap quality:** Ep517 covered the Dojo patent three times and
+  read raw headlines + "EtherType 0x9AC6" hex on air; Ep525 used nine
+  consecutive "From X, Y comes next" transitions (A/B proposals).
+- **EI thin-day triple-telling** (Ep047/049 tell one story 4×) + "federal
+  register" spoken instead of "Canada Gazette" (Ep051 ×4) + "Tomorrow,
+  watch for…" on an every-other-day show — A/B proposals.
+- **UC/FPD:** likely-wrong $50/life-saved stat (Ep038); FPD Ep024 spoke its
+  digest's creative sub-headings mid-paragraph (header-strip proposal);
+  queue hygiene FIXED (UC category interleave + miscategorized entry; FPD
+  duplicate pruning + concrete/opportunity alternation restored — Ep020/021
+  had shipped back-to-back concrete).
+- **MIT two irreconciled alphas** (+11% daily vs −13.1% Sunday) — labeling
+  proposal (A/B); the Sunday honesty is a strength to keep.
+- **Snapshot tooling blind spots:** the repeated-phrase detector was
+  Cyrillic-blind (cleared FP while a template ran 7/8) and the chapter check
+  missed missing-final-Closing (cleared EI while 3/5 shipped orphaned) —
+  both FIXED so future reviews see what this one had to find by hand.
+
+## ⚠️ A/B-listen required (landmine #17) — proposed, NOT applied
+
+No prompt file was edited in this PR (no GROK_API_KEY in this environment to
+render before/after excerpts, and the seeded-template class deserves the
+operator's ear). Proposed edits, per show, in priority order:
+
+1. **OV** `omni_view_digest.txt:51` — remove the literal "Both sides agree
+   on [X]; they differ on [Y]" seed; cap the construction ≤2/episode; add:
+   disasters/tragedies/obituaries/celebrity items get facts + coverage
+   framing, never manufactured "sides". Also: select 6-8 stories and deepen
+   (resolves the 12-slot digest vs 6-7-story podcast conflict).
+2. **EI** — thin-day rule (a 1-2-story day tells the story ONCE; Regulatory
+   Watch/Industry come from the forward calendar per the existing
+   low-content-day format); remove "There's a nuance here worth
+   understanding" from the menu (third-generation tic — prefer rotation
+   memory over another menu); "Next briefing, watch for…"; always "Canada
+   Gazette", never "federal register"; spoken script must carry cited
+   instrument references.
+3. **MAB** — rewrite the opener menu with zero quotable strings; ban "…stops
+   feeling like magic…" verbatim alongside "not so scary"; "try this" items
+   ineligible unless the tool is NAMED in the source; Quick Bits ≤3
+   sentences, every sentence a new fact.
+4. **FP** — de-seed «не так уж и сложно, правда?» and «Подруга спросила
+   меня вчера» (keep the method, fresh phrasing); cap «Коротко и ясно» at
+   2-3 sentences + finance-relevance rule; disclaimer line in all closing
+   variants; deep-dive may not re-explain the episode's own main topic.
+5. **PR** — grammar-correctness rule (model sentences fully
+   conjugated/agreeing; never "Я + infinitive"); etymologies must be
+   standard/verifiable or hedged; stop narrating plan-field labels ("The
+   memory hook notes that…"); English AI disclosure for the
+   English-speaking audience.
+6. **MIT** — de-seed the "This is the exact scenario where our earlier
+   rule…" callback example; retire "closing-price confirmation" as a
+   teachable lesson (it's the pipeline describing its own former price-fetch
+   bug); label the two alpha metrics whenever spoken; Saturday scripts say
+   "Friday's close".
+7. **Tesla** — recap hardening (one story once; never speak Title-Case
+   headlines or patent/hex minutiae; transition variety); ban standalone
+   dateline-filler sentences; require named entities ("One city…" is not a
+   story); counterpoint-section enforcement (5/14 misses); SpaceX/xAI
+   corporate items are SpaceX Daily's beat — never Tesla's hook/lead.
+8. **SpaceX** — entity discipline (Memphis/Colossus is xAI's; ban
+   "SpaceXAI"); every hook clause must correspond to a covered story
+   (Ep17's hook promised a static fire the episode never covered); Tesla-
+   style deep-dive topic history injection (Ep15/Ep19 ran the same deep
+   dive); decide the deferred price-once fix (Ep17 spoke "lowest close
+   since IPO" and "up 0.3%" 30 seconds apart — the strongest evidence yet).
+9. **PT** — the real fix behind the deterministic filter: scope guard +
+   ≥8/15 life-science floor in the digest prompt; trim bare
+   "science/research/study/discovery" keywords (monitor volume vs
+   `min_articles_skip: 2`); preserve the exemplary health-claim hedging
+   with an explicit prompt rule so it can't regress.
+10. **FF** — de-prioritize routine comsat/cadence launches (SpaceX Daily's
+    beat); developing-story discipline (no re-run without a new
+    development — Swift reboost ran 4×).
+11. **UC/FPD** — cap the restate-percentage-as-count device and "One might
+    ask/object" ≤1/episode (UC); forbid absolute cost-effectiveness claims
+    without units sanity (the $50/life-saved class); FPD podcast stage must
+    not emit markdown headers (plus a code-side header-strip is worth
+    considering).
+12. **M&A** — continuity-callback cap (≤1 spoken callback/episode, never
+    episode numbers — "sits in the ongoing maturation of agent tool use
+    tracked since episode eighty six" is the banned phrase reborn);
+    selection rule: lab product/feature announcements outrank preprints,
+    arXiv items ≤40%; recap must synthesize, not splice (Ep095 reused
+    dailies' sentences verbatim; Ep088 proves the model can do it).
+
+## Operator items
+
+1. **Double-publish forensics:** Tesla June 23 (Ep519+Ep520 both in RSS —
+   decide whether to pull one), PR June 22 (Ep046+Ep047), OV June 19
+   (Ep086+Ep087). The landmine-#24 duplicate guard + Cloudflare dispatcher
+   interplay needs a look; PR also skipped June 26/28.
+2. **SpaceX June-28 Sunday recap never ran** — no commit, no episode,
+   silent.
+3. **Verify EI Ep050's "coordinated federal-provincial permitting" claim**
+   against its source; if unsupported, it's the strongest argument for a
+   grounding rule on Lead-Story regulatory-mechanics claims.
+4. **MIT Ep093 "Qualys surged 65%"** — investing.com promo headline
+   amplified with invented same-day framing; consider demoting that source
+   tier and requiring a second source for >20% single-day move claims.
+5. **FP cadence** is stated three contradictory ways (YAML "daily",
+   CLAUDE.md table "Monday", ledger "even days"); actual: mixed. Decide and
+   align.
+6. **Tesla narrative tracker curated `status` texts lag the show's own
+   reporting by months** (cybercab still "unveiled at We, Robot") — refresh
+   via `scripts/update_tesla_narrative.py`.
+7. **EI "all-province" promise vs reality:** QC/SK/Atlantic got ZERO
+   mentions in the window despite the Phase-4 queries — try French-language
+   sources or soften the RSS promise.
+8. **CLAUDE.md says M&A X posting is disabled but the YAML has
+   `x_enabled: true`** with the @teslashortstime app prefix — confirm intent.
+   Also: the new no-duplicate-feeds guard surfaced a pre-existing BBC
+   http/https duplicate in `omni_view.yaml` (allowlisted with a comment —
+   collapse it when convenient).
+9. Regenerate-or-accept: UC Ep038/039 and other June-23/24 episodes shipped
+   the since-reverted "NAIR-uh NET-work" brand garble in audio.
+
+## Ledger prediction verdicts recorded this pass
+
+Tesla June-20: Teslarati **HIT**, 13F **HIT**, brand-"Daily" **MISS**
+(root-caused + fixed here). SpaceX June-19: time-garbles **HIT**, recap
+Closing **HIT**. M&A June-21: koo-dah **HIT**, length no-regression **HIT**.
+MAB June-25: both de-seeds **HIT** (with successor-template caveat recorded).
+FF June-24: launch false-drop **HIT**, recap stock-leak **resolved-HIT**,
+June-12 garbles **HIT**. OV June-10: strongest-case **PARTIAL** (script 0/15;
+digest 24× Ep085), anonymity **HIT**, Closing **HIT**, fragments **HIT**,
+length **MISS** (deferred). EI June-17: Introduction **HIT**, nuance-tic
+**MISS** (reopened + menu fix proposed), orphan-Closing **reopened as
+variant 3** (fixed). FP June-16: five **HITs**, length **MISS** (deferred).
+FPD June-23: retry **~HIT**, lesson-template **HIT**, Closing-chapter fix
+verified. PT June-18: chapter shape holds. New ledgers created for
+privet_russian and modern_investing (previously unscored shows).
+
+## What this pass changes about the review process itself
+
+- `review_snapshot.py` is now Unicode-aware (Cyrillic tics visible) and
+  flags missing-final-Closing chapter shapes — two blind spots that let
+  shipped defects pass three snapshots in a row.
+- Meta-lesson for the playbook (recorded, not yet applied to
+  `.claude/commands/review-show.md`): **never put a quotable example phrase
+  in a rotation menu** — three separate shows elected the first menu item
+  as their next tic. De-seed by describing the shape.

--- a/docs/reviews/review_state.yaml
+++ b/docs/reviews/review_state.yaml
@@ -14,7 +14,7 @@
 # network-scope passes on June 10).
 targets:
   tesla: 2026-06-10
-  network: 2026-06-10
+  network: 2026-07-02
   modern_investing: 2026-06-10
   fascinating_frontiers: 2026-06-24
   models_agents: 2026-06-21

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -931,6 +931,62 @@ def _build_expansion_retry_prompt(
     )
 
 
+_EXPANSION_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+def _dedup_expansion_sentences(
+    script: str,
+    *,
+    threshold: float = 0.85,
+    min_words: int = 6,
+) -> tuple:
+    """Strip near-duplicate sentences from an expansion-retry script.
+
+    July 2026 (network editorial pass): the ``podcast_expand_below_target``
+    retry sometimes "expands" by RE-STATING sentences it already wrote —
+    M&A Ep087 shipped verbatim doubled sentences in audio ("Sui deployed
+    Seal MPC on mainnet…" twice), and MAB Quick Bits ballooned with
+    restatements. This intra-script dedup drops any sentence that is a
+    near-duplicate (``calculate_similarity`` >= *threshold*) of an EARLIER
+    kept sentence in the same script, preserving order and paragraph
+    structure. Sentences shorter than *min_words* words are never dropped
+    (and never used as dedup anchors) — short rhetorical beats ("Right?",
+    "Let's dig in.") are legitimate repeats.
+
+    Returns ``(deduped_script, removed_count)``.
+    """
+    from engine.utils import calculate_similarity
+
+    if not script:
+        return script, 0
+
+    kept_anchors: list = []
+    out_lines: list = []
+    removed = 0
+    for line in script.split("\n"):
+        if not line.strip():
+            out_lines.append(line)
+            continue
+        kept_sentences = []
+        for sentence in _EXPANSION_SENTENCE_SPLIT_RE.split(line):
+            stripped = sentence.strip()
+            if len(stripped.split()) >= min_words:
+                if any(
+                    calculate_similarity(stripped, prev) >= threshold
+                    for prev in kept_anchors
+                ):
+                    removed += 1
+                    continue
+                kept_anchors.append(stripped)
+            kept_sentences.append(sentence)
+        if kept_sentences:
+            out_lines.append(" ".join(kept_sentences))
+        # A line whose every sentence was a duplicate is dropped entirely.
+    deduped = "\n".join(out_lines)
+    deduped = re.sub(r"\n{3,}", "\n\n", deduped).strip("\n")
+    return deduped, removed
+
+
 def _build_digest_expansion_retry_prompt(
     word_count: int,
     min_words: int,
@@ -2002,11 +2058,28 @@ def generate_podcast_script(
             except Exception as e:
                 logger.warning("Failed to record retry LLM usage: %s", e)
 
+        # July 2026 (network editorial pass): the retry sometimes pads by
+        # re-stating sentences it already wrote (M&A Ep087 shipped verbatim
+        # doubled sentences in audio; MAB Quick Bits ballooned with
+        # restatements). Strip intra-script near-duplicates from the
+        # expanded script BEFORE deciding whether to accept it, and only
+        # accept when the deduped expansion is meaningfully (>=5%) longer
+        # than the original \u2014 paraphrase padding stripped back to the
+        # original length is not an expansion.
+        text2, _dup_removed = _dedup_expansion_sentences(text2)
+        if _dup_removed:
+            logger.warning(
+                "Expansion retry for '%s' repeated itself \u2014 stripped %d "
+                "near-duplicate sentence(s) from the expanded script",
+                config.name, _dup_removed,
+            )
         word_count2 = len(text2.split())
-        if word_count2 > word_count:
+        if word_count2 >= int(word_count * 1.05) and word_count2 > word_count:
             logger.info(
-                "Retry produced longer script for '%s' (%d \u2192 %d words)",
+                "Retry produced longer script for '%s' (%d \u2192 %d words%s)",
                 config.name, word_count, word_count2,
+                f", {_dup_removed} duplicate sentence(s) stripped"
+                if _dup_removed else "",
             )
             text = text2
             _rep_count = _validate_llm_output(text, stage="podcast_script",
@@ -2014,8 +2087,8 @@ def generate_podcast_script(
                                               min_podcast_words=min_words)
         else:
             logger.warning(
-                "Retry did not improve script length for '%s' (%d \u2192 %d words), "
-                "keeping original",
+                "Retry did not meaningfully improve script length for '%s' "
+                "(%d \u2192 %d words after dedup, <5%% gain), keeping original",
                 config.name, word_count, word_count2,
             )
 

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 import datetime
 import logging
+import re
+from collections import Counter
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -32,6 +34,106 @@ logger = logging.getLogger(__name__)
 
 # Placeholder for future phase result types
 PublishResult = Dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Missing-closing guard helpers (June 10 2026; hardened July 2026)
+# ---------------------------------------------------------------------------
+
+# Common contractions the LLM expands/collapses when it lightly rewrites the
+# supplied closing block. The July 2026 network editorial pass found the
+# June-10 missing-closing guard comparing the closing's first-5-words
+# signature LITERALLY ("and that's a wrap! if"): the LLM de-contracts to
+# "And that is a wrap!", the literal check misses, and the guard appends the
+# ENTIRE closing again — 5 of 15 MAB episodes shipped the closing spoken
+# twice (Ep075/076/077/079/084, Whisper-confirmed).
+_CLOSING_CONTRACTIONS = {
+    "that's": "that is",
+    "it's": "it is",
+    "we're": "we are",
+    "you're": "you are",
+    "they're": "they are",
+    "i'm": "i am",
+    "we've": "we have",
+    "you've": "you have",
+    "i've": "i have",
+    "we'll": "we will",
+    "you'll": "you will",
+    "i'll": "i will",
+    "here's": "here is",
+    "there's": "there is",
+    "what's": "what is",
+    "let's": "let us",
+    "don't": "do not",
+    "doesn't": "does not",
+    "didn't": "did not",
+    "isn't": "is not",
+    "aren't": "are not",
+    "wasn't": "was not",
+    "won't": "will not",
+    "can't": "cannot",
+}
+
+
+def _normalize_closing_text(text: str) -> str:
+    """Normalize text for closing-signature comparison.
+
+    Lowercases, expands common contractions (so "that's" == "that is"),
+    strips punctuation, and collapses whitespace — the three drift classes
+    (contraction, punctuation, casing) the LLM applies when it "quotes"
+    the supplied closing block.
+    """
+    text = text.lower().replace("’", "'")
+    for contraction, expanded in _CLOSING_CONTRACTIONS.items():
+        text = re.sub(r"\b" + re.escape(contraction) + r"\b", expanded, text)
+    text = re.sub(r"[^\w\s]", " ", text)
+    return " ".join(text.split())
+
+
+def closing_block_present(
+    podcast_script: str,
+    closing_block: str,
+    *,
+    sig_words: int = 10,
+    threshold: float = 0.8,
+) -> bool:
+    """True when the supplied closing block already appears in the script tail.
+
+    Fuzzy by design: both sides are normalized (lowercase, contractions
+    expanded, punctuation stripped) and the closing's first *sig_words*
+    tokens must reach *threshold* token-overlap with some same-length
+    window of the script's tail. A genuinely absent closing (PT Ep081/084
+    class) stays below the threshold and the caller appends the block;
+    a lightly rewritten closing ("And that is a wrap!" for "And that's a
+    wrap!") counts as present so the guard never double-appends (MAB
+    Ep075-084 class).
+    """
+    if not closing_block or not podcast_script:
+        return False
+    # Drop a leading "Host:"-style speaker prefix from the closing.
+    closing = re.sub(r"^\s*\w+:\s*", "", closing_block.strip())
+    sig_tokens = _normalize_closing_text(closing).split()[:sig_words]
+    if not sig_tokens:
+        return True  # nothing meaningful to check — treat as present
+    tail = podcast_script[-max(len(podcast_script) // 4, 600):]
+    tail_tokens = _normalize_closing_text(tail).split()
+    if not tail_tokens:
+        return False
+    # Fast path: exact normalized containment.
+    if " ".join(sig_tokens) in " ".join(tail_tokens):
+        return True
+    n = len(sig_tokens)
+    sig_counts = Counter(sig_tokens)
+    windows = (
+        [tail_tokens]
+        if len(tail_tokens) < n
+        else [tail_tokens[i:i + n] for i in range(len(tail_tokens) - n + 1)]
+    )
+    for window in windows:
+        overlap = sum((sig_counts & Counter(window)).values())
+        if overlap / n >= threshold:
+            return True
+    return False
 
 
 def record_youtube_outcomes(
@@ -368,14 +470,14 @@ def run_generation_phase(
     # the LLM occasionally omits it. If the resolved closing's opening
     # signature isn't in the script's tail, append the block verbatim so
     # every episode ends properly (and the Closing chapter always parses).
+    # July 2026 hardening: the presence check is FUZZY (contractions,
+    # punctuation, casing normalized) — the old literal first-5-words
+    # check missed the LLM's de-contracted "And that is a wrap!" and
+    # double-appended the closing on 5 of 15 MAB episodes. See
+    # closing_block_present().
     _closing = str(pod_vars.get("closing_block", "")).strip()
     if _closing and podcast_script:
-        import re as _re_close
-        _sig = " ".join(
-            _re_close.sub(r"^\s*\w+:\s*", "", _closing).split()[:5]
-        ).lower()
-        _tail = podcast_script[-max(len(podcast_script) // 4, 600):].lower()
-        if _sig and _sig not in _tail:
+        if not closing_block_present(podcast_script, _closing):
             logger.warning(
                 "Podcast script is missing the supplied closing block — "
                 "appending it verbatim (script ended: %r)",

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -693,6 +693,18 @@ _PHONETIC_GARBLES = {
     # has no legitimate English use, so no collision (unlike RAG→"rag" /
     # LoRA→"Laura", which are left alone).
     "koo-dah": "CUDA",
+    # July 2026 network editorial pass — all Whisper/transcript-evidenced,
+    # collision-safe (the hyphenated respellings have no legitimate English
+    # use; the correct spellings never match):
+    # "Mee-stral" → Mistral (M&A Ep089), "Kar-pathy" → Karpathy (M&A Ep091
+    # ×2), "Mid-journey" → Midjourney (MAB Ep075 ×3 / Ep079 — the product
+    # name is one word; the hyphen forces an audible break), and
+    # "Notpower" → NatPower, the UK-Italian energy developer the Tesla show
+    # covers (Tesla Ep519 audio + Ep525 recap; "notpower" is not a word).
+    "mee-stral": "Mistral",
+    "kar-pathy": "Karpathy",
+    "mid-journey": "Midjourney",
+    "notpower": "NatPower",
 }
 
 _PHONETIC_GARBLE_RE = re.compile(

--- a/engine/vocab_tracker.py
+++ b/engine/vocab_tracker.py
@@ -53,7 +53,14 @@ _RU_STOPWORDS = {
 # inside the forgetting window without crowding new material.
 _REVIEW_GAP_EPISODES = 2
 _REVIEW_WORDS_PER_EPISODE = 4
-_RECENT_EPISODES_NO_RETEACH = 3
+# July 2 2026 review: 3 -> 8. Three episodes was ONE theme-cycle short —
+# the show looped Food -> Animals -> Weather 2.3× in 8 episodes and only 27
+# of 87 taught word-slots were new, because a theme three episodes back was
+# neither in the no-reteach window NOR remembered as a used theme. Eight
+# episodes (~16 days on the even-day cadence) clears a full rotation.
+_RECENT_EPISODES_NO_RETEACH = 8
+# Recent themes surfaced to the prompt as an explicit "do not reuse" list.
+_RECENT_THEMES_WINDOW = 6
 _WORDS_PER_EPISODE_CAP = 12
 
 
@@ -61,15 +68,29 @@ def _path(output_dir: Path) -> Path:
     return Path(output_dir) / VOCAB_FILENAME
 
 
+def _fresh() -> Dict[str, Any]:
+    return {
+        "version": 1, "last_updated": "", "words": {}, "episodes": {},
+        # July 2 2026: permanent Word-of-the-Day ledger (a word here is
+        # never picked as Word of the Day again — «хлеб» was WotD 3× in 12
+        # days) + per-episode theme record for the recent-theme rotation.
+        "word_of_day_history": [], "themes": {},
+    }
+
+
 def load_vocab(output_dir: Path) -> Dict[str, Any]:
     p = _path(output_dir)
     if not p.exists():
-        return {"version": 1, "last_updated": "", "words": {}, "episodes": {}}
+        return _fresh()
     try:
-        return json.loads(p.read_text(encoding="utf-8"))
+        data = json.loads(p.read_text(encoding="utf-8"))
     except Exception as exc:  # noqa: BLE001
         logger.warning("Failed to load %s (%s) — starting fresh", p.name, exc)
-        return {"version": 1, "last_updated": "", "words": {}, "episodes": {}}
+        return _fresh()
+    # Back-compat: older files predate the WotD ledger + theme record.
+    data.setdefault("word_of_day_history", [])
+    data.setdefault("themes", {})
+    return data
 
 
 def save_vocab(data: Dict[str, Any], output_dir: Path) -> None:
@@ -95,8 +116,60 @@ def mine_vocabulary(text: str, cap: int = _WORDS_PER_EPISODE_CAP) -> List[str]:
     return [w for w, c in counts.most_common(cap) if c >= 2]
 
 
+def extract_word_of_day(text: str) -> str:
+    """Return the episode's Word of the Day (lowercased Cyrillic), or ''.
+
+    Handles both the digest's "### Word of the Day" section (the first
+    Cyrillic token after the header, tolerating a bold marker or a
+    "Russian (Cyrillic):" label) and the inline "word of the day is X"
+    phrasing used in lesson prose.
+    """
+    if not text:
+        return ""
+    # Section form: "### Word of the Day\n**хлеб**" / "…**Russian (Cyrillic):** Солнце".
+    m = re.search(r"word of the day\s*[:\-]?\s*(.*)", text, re.IGNORECASE)
+    if m:
+        # Search the header match's tail plus the following ~2 lines.
+        tail_start = m.start()
+        window = text[tail_start:tail_start + 200]
+        # Drop a "Russian (Cyrillic):" label so it doesn't shadow the word.
+        window = re.sub(r"russian\s*\(cyrillic\)\s*:?", " ", window, flags=re.IGNORECASE)
+        cyr = re.search(r"[а-яё]{2,}", window, re.IGNORECASE)
+        if cyr:
+            return cyr.group(0).lower()
+    return ""
+
+
+def extract_theme(text: str) -> str:
+    """Return a short theme label for the episode (from the hook), or ''.
+
+    The hook is the digest's leading blockquote ("> **…**") or a "HOOK:"
+    line. The full hook sentence is a good enough "domain" signal for the
+    LLM's do-not-reuse list; truncated so the block stays scannable.
+    """
+    if not text:
+        return ""
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith(">") or re.match(r"^\**\s*hook\s*:", line, re.IGNORECASE):
+            cleaned = line.lstrip(">").strip()
+            cleaned = re.sub(r"[*_`]+", "", cleaned).strip()
+            cleaned = re.sub(r"^hook\s*:\s*", "", cleaned, flags=re.IGNORECASE).strip()
+            if cleaned:
+                return cleaned[:90].rstrip()
+        # Only inspect the first non-empty line for a hook.
+        break
+    return ""
+
+
 def record_episode_vocab(output_dir: Path, episode_num: int, text: str) -> List[str]:
     """Mine + persist the episode's vocabulary. Idempotent per episode.
+
+    Also records the episode's Word of the Day (into the permanent
+    ``word_of_day_history`` ledger) and its theme (into ``themes``) so the
+    review block can enforce no-repeat WotD selection and theme rotation.
 
     Returns the recorded word list.
     """
@@ -117,9 +190,22 @@ def record_episode_vocab(output_dir: Path, episode_num: int, text: str) -> List[
     for w in taught:
         entry = words.setdefault(w, {"first_taught": episode_num, "last_heard": episode_num})
         entry["last_heard"] = episode_num
+
+    # Permanent Word-of-the-Day ledger (dedup, order-preserving).
+    wotd = extract_word_of_day(text)
+    if wotd:
+        history = data.setdefault("word_of_day_history", [])
+        if wotd not in history:
+            history.append(wotd)
+
+    # Per-episode theme record for the recent-theme rotation list.
+    theme = extract_theme(text)
+    if theme:
+        data.setdefault("themes", {})[key] = theme
+
     save_vocab(data, output_dir)
-    logger.info("Vocab tracker: recorded %d words for Ep%s (%s…)",
-                len(taught), episode_num, ", ".join(taught[:5]))
+    logger.info("Vocab tracker: recorded %d words for Ep%s (%s…); WotD=%s theme=%r",
+                len(taught), episode_num, ", ".join(taught[:5]), wotd or "—", theme[:40])
     return taught
 
 
@@ -145,6 +231,19 @@ def build_review_section(output_dir: Path, current_episode: int) -> str:
     for ep in recent_eps[:_RECENT_EPISODES_NO_RETEACH]:
         recent_words.extend(episodes[str(ep)])
 
+    # Never repeat a Word of the Day (permanent).
+    wotd_history = data.get("word_of_day_history", []) or []
+
+    # Recent themes (most-recent first) to rotate away from.
+    themes = data.get("themes", {}) or {}
+    recent_themes: List[str] = []
+    for ep in recent_eps:
+        t = themes.get(str(ep))
+        if t:
+            recent_themes.append(t)
+        if len(recent_themes) >= _RECENT_THEMES_WINDOW:
+            break
+
     lines = ["### VOCABULARY MEMORY (from previous episodes — use, do not read this section aloud)"]
     if review_words:
         lines.append(
@@ -157,7 +256,18 @@ def build_review_section(output_dir: Path, current_episode: int) -> str:
     if recent_words:
         lines.append(
             "RECENTLY TAUGHT (do NOT re-teach these as new words, and pick a "
-            "DIFFERENT theme than they suggest): " + ", ".join(recent_words[:20]) + "."
+            "DIFFERENT theme than they suggest): " + ", ".join(recent_words[:24]) + "."
+        )
+    if wotd_history:
+        lines.append(
+            "ALREADY USED AS WORD OF THE DAY (NEVER pick any of these as today's "
+            "Word of the Day again — choose a brand-new word): "
+            + ", ".join(wotd_history) + "."
+        )
+    if recent_themes:
+        lines.append(
+            "RECENT THEMES (do NOT reuse any of these everyday domains — choose a "
+            "clearly different theme today): " + "; ".join(recent_themes) + "."
         )
     if len(lines) == 1:
         return ""

--- a/run_show.py
+++ b/run_show.py
@@ -2250,6 +2250,11 @@ def run(args: argparse.Namespace) -> None:
                     "(%d chars) — scaffold no longer published.", len(x_thread),
                 )
 
+            # Defensive scrub: drop raw "Source:" / "Источник:" scaffold
+            # lines BEFORE pronunciation — FP Ep059 voiced "Сорс MoneySense…"
+            # because a digest "Source:" line reached TTS.
+            podcast_script = _strip_source_scaffold_lines(podcast_script)
+
             # Apply pronunciation fixes
             podcast_script = _apply_pronunciation(podcast_script, args.show)
 
@@ -2350,6 +2355,23 @@ def run(args: argparse.Namespace) -> None:
                 podcast_script = _re.sub(r"^" + _esc + r"\s*", "", podcast_script, flags=_re.MULTILINE)
                 podcast_script = _re.sub(r"(?<=[.!?])\s+" + _esc + r"\s*", " ", podcast_script)
             podcast_script = _re.sub(r"\n{3,}", "\n\n", podcast_script).strip()
+
+            # Spoken-URL tripwire (MAB Ep081 read a Reddit permalink on air):
+            # warn loudly + record a metric when the final script contains a
+            # spoken-form URL ("reddit dot com/r/…"). Detection only — the
+            # content is NOT rewritten (that's an A/B-gated editorial change).
+            _spoken_url_count = _count_spoken_urls(podcast_script)
+            if _spoken_url_count:
+                logger.warning(
+                    "Final script contains %d spoken URL pattern(s) "
+                    "('X dot com…') — the prompt's spoken-URL ban failed; "
+                    "content left unchanged (rewrite is A/B-gated)",
+                    _spoken_url_count,
+                )
+            try:
+                metrics.record("spoken_url_count", _spoken_url_count)
+            except Exception:  # noqa: BLE001 — tripwire must never break a run
+                pass
 
             # Save TTS-ready script for debugging pronunciation/intro issues
             from engine.utils import strip_lone_surrogates as _scrub
@@ -3660,6 +3682,16 @@ def _normalize_tst_opening(script: str) -> str:
     produces variants like "Tesla Short's Time", "Tesla Shorts Time. Daily",
     or drops the canonical framing line. This post-processing normalizer
     makes the spoken intro bulletproof.
+
+    July 2026 (network editorial pass): the target brand is "Tesla Shorts
+    Time" — WITHOUT "Daily". This normalizer was the missed second half of
+    the June-10 brand decision: the June-20 generator fix
+    (``_correct_common_llm_text_mistakes``) drops the LLM-appended "Daily",
+    but this runner-side normalizer ran AFTER it and rewrote the intro back
+    TOWARD "Tesla Shorts Time Daily" — so "Daily" still shipped spoken in
+    14/14 post-fix episodes. The optional ``Daily`` (with any separating
+    punctuation) is consumed by the match so no ", episode"-style artifacts
+    are left behind.
     """
     import re
 
@@ -3670,15 +3702,77 @@ def _normalize_tst_opening(script: str) -> str:
     # Fix common show name variants in the first ~4 lines (the welcome block)
     for i in range(min(4, len(lines))):
         original = lines[i]
-        # Normalize all common manglings of the show name
+        # Normalize all common manglings of the show name; consume a stray
+        # trailing "Daily" (and the punctuation gluing it on) so the spoken
+        # brand matches the listing brand "Tesla Shorts Time".
         fixed = re.sub(
-            r"(?i)\bTesla\s+Short'?s?\s+Time(?:\s*\.?\s*Daily)?\b",
-            "Tesla Shorts Time Daily",
+            r"(?i)\bTesla\s+Short'?s?\s+Time(?:[.,;\s]*Daily)?\b",
+            "Tesla Shorts Time",
             original,
         )
         lines[i] = fixed
 
     return "".join(lines)
+
+
+# "Source:" / "Sources:" / "Источник(и):" scaffold labels at line start
+# (with optional markdown bullet / bold prefixes). A line BEGINNING with a
+# source label inside a spoken script is always digest scaffold, never
+# prose — FP Ep059 voiced "Сорс MoneySense…" because a raw "Source:
+# MoneySense" line from the digest reached TTS on the Olya voice.
+_SOURCE_SCAFFOLD_RE = re.compile(
+    r"^\s*(?:[-*•>]\s*)*(?:\*\*|__)?\s*(?:sources?|источники?)\s*:",
+    re.IGNORECASE,
+)
+
+
+def _strip_source_scaffold_lines(text: str) -> str:
+    """Drop raw 'Source:'-label scaffold lines from the spoken script.
+
+    Defensive scrub in the script-save path (July 2026 network editorial
+    pass) — runs BEFORE pronunciation so the label never reaches TTS,
+    the transcript, or the blog. Deterministic line-level drop; never
+    touches prose (a sentence merely *containing* the word "source" does
+    not start with the label + colon).
+    """
+    lines = text.split("\n")
+    kept = [ln for ln in lines if not _SOURCE_SCAFFOLD_RE.match(ln)]
+    dropped = len(lines) - len(kept)
+    if dropped:
+        logger.warning(
+            "Stripped %d 'Source:' scaffold line(s) from the spoken script "
+            "(digest scaffold leaked into the podcast — FP Ep059 class)",
+            dropped,
+        )
+        return re.sub(r"\n{3,}", "\n\n", "\n".join(kept))
+    return text
+
+
+# Spoken-URL tripwire (July 2026): MAB Ep081 read a full Reddit permalink
+# letter-by-letter on air. The prompts ban spoken URLs but the ban fails
+# silently; this detector makes failures visible (warning + metric only —
+# rewriting spoken content is an A/B-gated editorial change, NOT done here).
+_SPOKEN_URL_RE = re.compile(
+    r"\b[\w-]+\s+dot\s+(?:com|net|org|io|ai|ca|de)\b(?:\s*(?:/|slash\s+)\S+)*",
+    re.IGNORECASE,
+)
+
+
+def _count_spoken_urls(text: str) -> int:
+    """Count spoken-form URL patterns ("reddit dot com/r/…") in a script.
+
+    Matches near the network's own CTA domain ("nerra network dot com" /
+    "nerranetwork dot com" — injected deliberately by intros/promo and
+    converted to spoken form by the pronunciation layer) are excluded so
+    the tripwire only fires on LLM-written URLs.
+    """
+    count = 0
+    for m in _SPOKEN_URL_RE.finditer(text):
+        context = text[max(0, m.start() - 24):m.end()].lower()
+        if "nerra" in context:
+            continue
+        count += 1
+    return count
 
 
 def _strip_post_pronunciation_artifacts(text: str) -> str:

--- a/scripts/review_snapshot.py
+++ b/scripts/review_snapshot.py
@@ -38,7 +38,12 @@ def count_words(text: str) -> int:
 
 
 def _tokens(text: str) -> list[str]:
-    return re.findall(r"[a-z']+", text.lower())
+    # Unicode-aware word tokens (letters only, internal apostrophes kept).
+    # The old ``[a-z']+`` pattern was Cyrillic-blind: every Russian word
+    # tokenized to nothing, so the tic detector reported "no cross-episode
+    # repeated phrases" for Финансы Просто while a template ran 7/8
+    # episodes (July 2026 network editorial pass).
+    return re.findall(r"[^\W\d_]+(?:['’][^\W\d_]+)*", text.lower())
 
 
 def _stitch_windows(grams: dict[str, int], n: int) -> dict[str, int]:
@@ -135,6 +140,14 @@ def chapter_issues(chapters: list[dict]) -> list[str]:
         issues.append("multiple 'Introduction' chapters")
     if len(titles) <= 1:
         issues.append(f"only {len(titles)} chapter(s)")
+    # Orphan-closing class (July 2026): episodes whose FINAL chapter is not
+    # a Closing slipped past the old checks — EI Ep049/050/051 ended on
+    # promo-collision body chapters and still counted as "clean". The
+    # network shape is body → (Tomorrow Teaser →) Closing, so anything
+    # else ending the episode is a flag. "Outro" is accepted as a Closing
+    # synonym.
+    if len(titles) > 1 and not re.search(r"(?i)\b(closing|outro)\b", titles[-1]):
+        issues.append(f"final chapter is not a Closing (ends on {titles[-1]!r})")
     return issues
 
 

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -287,41 +287,61 @@ chapters:
     - pattern: "(?:This is|Welcome to) Environmental Intelligence"
       title: "Introduction"
       where: start
+    # July 2 2026 pass: Closing + Tomorrow Teaser now come BEFORE all body
+    # markers (the EI June-11 / SpaceX June-18 / FF June-24 ordering class).
+    # Ep049/050/051 shipped with NO Closing chapter because (a) unconsumed
+    # BODY markers ate the closing paragraph — `science|technical` matched
+    # the network promo "…covering tech, science, markets" (Ep049/051) and
+    # bare `deep dive` matched the Tesla cross-promo "daily deep dive into
+    # everything Tesla" (Ep050) — and (b) the parser's `where: end` window
+    # (last 15%) EXCLUDED the closing line itself on these short episodes:
+    # EI's closing block (sign-off + YouTube CTA + network promo + AI
+    # disclosure) runs ~120-140 words on a ~650-870-word episode, so the
+    # sign-off sentence lands at ~82-84% (Ep049 word 539 vs window 555;
+    # Ep050 730 vs 738; Ep051 676 vs 685). The Closing marker therefore
+    # drops `where: end` and relies on its brand-anchored pattern instead
+    # ("That's/That covers today's Environmental Intelligence" only ever
+    # occurs in the closing pool — engine/intros.py); listing it first plus
+    # once-per-title keeps the June-11 merged-line behaviour (Closing wins
+    # a fused teaser+closing paragraph; separate lines still yield both).
+    # `.?s` tolerates curly apostrophes.
+    - pattern: "That.?s Environmental Intelligence|That covers today.?s environmental intelligence"
+      title: "Closing"
+    - pattern: "Before we wrap|Tomorrow"
+      title: "Tomorrow Teaser"
+      where: end
     - pattern: "executive summary|here's what matters"
       title: "Executive Summary"
     - pattern: "lead story|centrepiece|most significant"
       title: "Lead Story"
     - pattern: "regulatory|policy watch"
       title: "Regulatory & Policy Watch"
-    - pattern: "science|technical"
+    # July 2 2026: word-bounded + a no-following-punctuation guard so the
+    # marker can't match the closing promos ("…covering tech, science,
+    # markets", "…on tech, science, and markets", "…in science, health, and
+    # longevity", "…news from space and science.") or "geotechnical"
+    # mid-story (Ep047/Ep050 false chapters). The real spoken section label
+    # ("In Science and Technical, …") still matches on "Science and".
+    - pattern: "\\b(?:science|technical)\\b(?![,.])"
       title: "Science & Technical"
     # "industry" never appears in practice; bare "practice" was matching
     # the closing's "useful to your practice" and stealing the final
     # segment's title (Ep040). Exclude that phrase with a lookbehind.
     - pattern: "industry|(?<!your )practice"
       title: "Industry & Practice"
-    - pattern: "practitioner deep dive|deep dive|under the hood"
+    # July 2 2026: bare `deep dive` + `under the hood` dropped (the FF
+    # June-24 class) — the spoken script never announces the deep dive
+    # (the prompt rotates its entry point), so the bare pattern only ever
+    # matched the Tesla cross-promo. Anchor on the section's signature
+    # "most common mistake + fix" beat instead (present in 7/7 recent
+    # episodes: "The mistake I see most often…" / "the most common
+    # mistake…").
+    - pattern: "practitioner deep dive|mistake I see most often|most common mistake"
       title: "Practitioner Deep Dive"
     - pattern: "action items|if you're working on"
       title: "Action Items"
     - pattern: "week ahead|mark your calendar"
       title: "Week Ahead"
-    # June 11 2026 follow-up: Closing is listed BEFORE Tomorrow Teaser so
-    # that when the LLM merges the teaser sentence and the {closing_block}
-    # into ONE paragraph (Ep044, 2026-06-11 — "Tomorrow, watch for… That's
-    # Environmental Intelligence for today…" on a single line), the
-    # line-level "first marker wins" rule titles that line "Closing" rather
-    # than "Tomorrow Teaser", so the episode still gets its standard final
-    # Closing chapter. When the two sentences land on SEPARATE lines (the
-    # normal case) both chapters are produced as before — the closing
-    # pattern doesn't match the teaser-only line. The June 10 anchors +
-    # once-per-title dedup keep the positions correct regardless of order.
-    - pattern: "That's Environmental Intelligence|That covers today.?s environmental intelligence"
-      title: "Closing"
-      where: end
-    - pattern: "Before we wrap|Tomorrow"
-      title: "Tomorrow Teaser"
-      where: end
 
 slow_news:
   enabled: true

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -111,6 +111,16 @@ exclude_title_patterns:
 - \bmerger\b.{0,25}\b(valued|deal|shareholders?|billion|trillion)\b
 - \bindex\b.{0,20}\b(inclusion|rebalanc|addition)\b
 - \badded to\b.{0,20}\bindex\b
+# July 2 2026: nightly-ephemeris almanac items kept slipping past the
+# calendar/sky-tonight filters above ("Moon Passes Near the Sickle of Leo
+# Tonight", "Mars passes within 5 degrees of the Pleiades", "Neptune
+# reaches 30 degrees altitude before dawn", "Venus Shines Beneath Leo's
+# Sickle This Evening" — 4 episodes in the June 18-July 2 window). Anchor
+# on a planet/Moon SUBJECT at the start of the title + an almanac verb, so
+# real news survives: "Asteroid passes near Earth" (subject not a planet),
+# "Mars may host large subsurface magma systems" (verb not almanac), and
+# the FF June-16 lesson — never a bare "passes near".
+- ^(the )?(moon|mercury|venus|mars|jupiter|saturn|uranus|neptune)\b.{0,60}\b(passes|shines|reaches \d+ degrees)\b
 keywords:
 - space
 - astronomy
@@ -283,7 +293,11 @@ slow_news:
   cooldown_days: 30
   repeat_trigger_threshold: 5
 content_freshness:
-  lookback_days: 2
+  # July 2 2026: 2 -> 7. A 2-day window let a slow news day re-run stories
+  # already aired earlier the same week (Ep116, 2026-06-29, repeated 4 of
+  # Ep111/112's stories verbatim). A full week matches the cross-episode
+  # dedup horizon listeners actually notice.
+  lookback_days: 7
   similarity_threshold: 0.72
 youtube:
   podcast_playlist_id: PLRHMnzNNXPYDC7-f8Dary-bTZyvwxR-dR

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -145,8 +145,12 @@ def pre_fetch(config, *, episode_num: int | None = None, today_str: str | None =
     # Evaluate yesterday's open trade (if any)
     _evaluate_open_trade(tracker, tracker_path)
 
-    # Build yesterday's trade review text
+    # Build yesterday's trade review text. This may stamp
+    # ``reviewed_in_episode`` on the latest closed trade (double-review
+    # guard) — persist it immediately so a later benchmark-refresh failure
+    # can't lose the stamp and re-review the same trade next episode.
     context["yesterday_trade_review"] = _build_trade_review(tracker, episode_num)
+    _save_tracker(tracker, tracker_path)
 
     # Build portfolio summary
     context["portfolio_summary"] = _build_portfolio_summary(tracker)
@@ -591,13 +595,24 @@ def _close_trade(trade: dict, tracker: dict) -> None:
         exit_price = None
 
     if entry_price is None or exit_price is None:
-        logger.warning("Could not fetch prices for %s — marking as data_unavailable", symbol)
-        trade["status"] = "closed"
+        # VOID, don't breakeven-close (July 2026 review). Recording a
+        # data-fetch failure as a $0.00 breakeven CLOSE lied twice: it
+        # counted the phantom trade in the spoken record ("41 trades… 7
+        # breakeven outcomes") AND let the trade-review/lookback narration
+        # later present it as a real market outcome ("ROKU closed flat…
+        # illustrates how announced deals require extended holding
+        # periods"). A voided trade is excluded from every aggregation and
+        # never narrated as a result — it only records that the sim could
+        # not be evaluated. (Ep74 XLF / Ep75 KO / Ep77 ROKU / Ep79 ION,
+        # plus the DELL/HIMS NaN-exit shape.)
+        logger.warning("Could not fetch prices for %s — voiding trade (market data unavailable)", symbol)
+        trade["status"] = "voided"
+        trade["void_reason"] = "market_data_unavailable"
         trade["entry_price"] = None
         trade["exit_price"] = None
-        trade["pnl_pct"] = 0.0
-        trade["pnl_dollars"] = 0.0
-        trade["lesson"] = "Market data was unavailable for evaluation."
+        trade["pnl_pct"] = None
+        trade["pnl_dollars"] = None
+        trade["lesson"] = "Trade voided — market data was unavailable for evaluation."
     else:
         pnl_pct = ((exit_price - entry_price) / entry_price) * 100
         position_size = tracker["metadata"].get("position_size", 1000)
@@ -721,7 +736,13 @@ def _fetch_weekly_prices(symbol: str) -> tuple[float | None, float | None]:
 
 
 def _recompute_summary(tracker: dict) -> None:
-    """Recompute summary statistics from all closed trades."""
+    """Recompute summary statistics from all closed trades.
+
+    Voided trades (``status == "voided"`` — a market-data-fetch failure,
+    July 2026 review) are excluded here by the ``status == "closed"``
+    filter, so they never inflate ``total_trades`` / ``breakeven`` or land
+    in the spoken record.
+    """
     closed = [t for t in tracker["trades"] if t.get("status") == "closed"]
     if not closed:
         return
@@ -1035,33 +1056,67 @@ def _extract_lesson_tags(text: str) -> list[str]:
 # Trade review text builders
 # ---------------------------------------------------------------------------
 
+def _weekly_hold_update(open_trades: list) -> str:
+    """Mid-week unrealized-P&L update for the latest open weekly hold, or ''."""
+    if not open_trades:
+        return ""
+    hold = open_trades[-1]
+    current = hold.get("current_price")
+    if current and hold.get("entry_price"):
+        unrealized = ((current - hold["entry_price"]) / hold["entry_price"]) * 100
+        direction = "up" if unrealized >= 0 else "down"
+        return (
+            f"**Current Weekly Hold:** {hold.get('symbol', '???')} — {hold.get('strategy', '')}\n"
+            f"**Entry:** ${hold['entry_price']:.2f} (Monday open)\n"
+            f"**Current:** ${current:.2f} ({direction} {abs(unrealized):.2f}%)\n"
+            f"**Status:** Holding until Friday evaluation\n"
+        )
+    return ""
+
+
 def _build_trade_review(tracker: dict, episode_num: int | None = None) -> str:
     """Build the Trade Review text block for the digest prompt.
 
-    Handles both weekly holds and flash trades, with appropriate framing for each.
+    Handles both weekly holds and flash trades, with appropriate framing
+    for each. Voided trades (market-data failures) are excluded by the
+    ``status == "closed"`` filter — they are never narrated as outcomes.
+
+    Double-review guard (July 2026 review): each closed trade is reviewed
+    EXACTLY ONCE. Previously the block always reviewed the most-recent
+    closed trade, so on days when nothing new closed (the between-trade
+    cadence gap) the same result was re-narrated as if fresh — the MU
+    flash trade was re-told as "yesterday's" on Ep089/091/093. We stamp
+    ``reviewed_in_episode`` on the trade the first time it's narrated; if
+    the latest closed trade was already reviewed in a PRIOR episode, we
+    give an open-hold update instead, or state holdings are pending.
     """
     if episode_num and episode_num <= 1:
         return ""  # No review for Episode 1
 
     closed = [t for t in tracker["trades"] if t.get("status") == "closed"]
+    open_trades = [t for t in tracker["trades"] if t.get("status") == "open"]
     if not closed:
         # Check for open weekly hold — provide mid-week update
-        open_trades = [t for t in tracker["trades"] if t.get("status") == "open"]
-        if open_trades:
-            hold = open_trades[-1]
-            current = hold.get("current_price")
-            if current and hold.get("entry_price"):
-                unrealized = ((current - hold["entry_price"]) / hold["entry_price"]) * 100
-                direction = "up" if unrealized >= 0 else "down"
-                return (
-                    f"**Current Weekly Hold:** {hold.get('symbol', '???')} — {hold.get('strategy', '')}\n"
-                    f"**Entry:** ${hold['entry_price']:.2f} (Monday open)\n"
-                    f"**Current:** ${current:.2f} ({direction} {abs(unrealized):.2f}%)\n"
-                    f"**Status:** Holding until Friday evaluation\n"
-                )
-        return ""
+        return _weekly_hold_update(open_trades)
 
     last = closed[-1]
+
+    # Double-review guard: don't re-narrate an already-reviewed result.
+    already = last.get("reviewed_in_episode")
+    if already is not None and already != episode_num:
+        hold_update = _weekly_hold_update(open_trades)
+        if hold_update:
+            return hold_update
+        return (
+            "**No newly closed trade since the last review.** The most "
+            "recent Practice Investment has already been reviewed; current "
+            "holdings remain open and pending their scheduled evaluation, "
+            "so there is no new realized result to report today.\n"
+        )
+
+    # Stamp so this result is narrated once (persisted by the caller's save).
+    if episode_num is not None:
+        last["reviewed_in_episode"] = episode_num
     symbol = last.get("symbol", "???")
     strategy = last.get("strategy", "")
     trade_type = last.get("trade_type", "weekly")
@@ -1348,7 +1403,10 @@ def _compute_sector_exposure(tracker: dict) -> dict:
     """Return {sector: {trade_count, exposure_pct, cumulative_pnl}} over the
     last ``_CONCENTRATION_WINDOW`` trades (open + closed combined).
     """
-    trades = tracker.get("trades", [])[-_CONCENTRATION_WINDOW:]
+    # Exclude voided trades (July 2026): a data-fetch failure isn't real
+    # market exposure and must not count toward a concentration warning.
+    real = [t for t in tracker.get("trades", []) if t.get("status") != "voided"]
+    trades = real[-_CONCENTRATION_WINDOW:]
     if not trades:
         return {}
     counts: dict[str, int] = {}

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -42,8 +42,11 @@ sources:
   label: r/LocalLLaMA
 - url: https://research.google/blog/rss/
   label: Google Research Blog
-- url: http://export.arxiv.org/rss/cs.CL
-  label: arXiv cs.CL
+# July 2 2026: removed the duplicate arXiv cs.CL feed
+# (http://export.arxiv.org/rss/cs.CL) — cs.CL is already subscribed above
+# as "arXiv NLP" (https://arxiv.org/rss/cs.CL). Subscribing the same feed
+# twice double-weighted arXiv preprints in the pool (root cause of the
+# arXiv flood that crowded out Codex Record Replay / Gemini Computer Use).
 - url: https://venturebeat.com/feed/
   label: VentureBeat
 - url: https://arstechnica.com/feed/

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -93,6 +93,45 @@ x_accounts:
 
 min_articles_skip: 2
 
+# July 2 2026 scope-drift backstop: Planetterrian is a life-science show
+# (longevity / neuroscience / microbiome / cellular biology), but the
+# shared science RSS feeds (Phys.org, ScienceDaily, Science Magazine)
+# push pure-astronomy items that the LLM selection didn't reject —
+# Ep094-107 shipped exoplanet clouds, galaxy clusters, black holes,
+# GRBs, Mars magma, comets, and Swift-telescope reboost, several of them
+# DUPLICATING Fascinating Frontiers the same day. This deterministic
+# fetch-side filter drops unambiguous astronomy/space-physics titles.
+# Deliberately CONSERVATIVE (under-filter): it excludes only terms with
+# no life-science reading. Notably NOT filtered: "mercury" (a toxin in
+# health contexts), "ISS/space station" (plant/bio experiments aboard
+# are legit PT content — e.g. the grape-seed study), "meteorite" and
+# "extraterrestrial life"/"Fermi paradox" (origin-of-life/astrobiology
+# is borderline-legit). Verified against all 189 story titles in the
+# June 18-July 2 digests: 14 astronomy items dropped, zero health/
+# longevity/neuro/microbiome titles matched.
+exclude_title_patterns:
+- \bexoplanets?\b
+- \bgalax(y|ies)\b
+- \bblack hole\b
+- \bquasars?\b
+- \bsupernovae?\b
+- \bgamma-ray burst\b
+- \bGRB\b
+- \bcomets?\b
+- ^asteroid\b
+- \bjames webb\b
+- \bjwst\b
+- \bhubble\b
+- \btelescope\b
+- \bspacecraft\b
+- \brover\b
+- \borbiter\b
+- \bsolar wind\b
+- \bsolar storms?\b
+- \bsuperstorm\b
+- \bspace weather\b
+- \b(mars|jupiter|saturn|venus|neptune|uranus)\b
+
 keywords:
   - longevity
   - anti-aging

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -108,6 +108,19 @@ x_accounts:
 min_articles: 8
 min_articles_skip: 5
 
+# July 2 2026: a pirate soccer-stream SEO title — "SpaceX Falcon 9
+# Launches Starlink 6-103 Fiorentina Vs Genoa (RvpT3PF26j)" — was
+# laundered into an on-air "fact" (Ep18 spoke "designated Fiorentina
+# versus Genoa"). These stream-spam titles append a YouTube-style video
+# ID in trailing parentheses. The narrowest pattern that kills the class
+# without touching legit content is a trailing 8+-char alphanumeric
+# parenthetical: it drops "(RvpT3PF26j)" but keeps "(video)" (5 chars)
+# and legit "… vs …" comparison articles that carry no video ID.
+# Verified against all 117 story titles in the June 13-July 1 digests:
+# exactly one drop (the spam title), zero false positives.
+exclude_title_patterns:
+- \([A-Za-z0-9_-]{8,}\)\s*$
+
 multilingual:
   enabled: true
   auto: true

--- a/shows/topic_queues/first_principles.yaml
+++ b/shows/topic_queues/first_principles.yaml
@@ -181,13 +181,6 @@ queue:
   produced: true
   episode_number: 26
   produced_date: '2026-07-01'
-- id: insulin-pricing
-  title: 'Insulin: A Century-Old Molecule at a Modern Price'
-  brief: 'Opportunity area / concrete tension. Insulin was discovered in 1921 and its patent sold for a dollar so it would be affordable; a century later list prices in some markets run hundreds of dollars a vial. The magic-wand floor is revealing: the manufacturing cost of an analog insulin is estimated in the low single-digit dollars per vial, so the Idiot Index here is set almost entirely by regulation, patents on delivery devices and incremental formulations, and a rebate-driven pricing system — not by chemistry or scale. Walk through the genuine biologics-manufacturing cost, the "evergreening" and pen-device patent thicket, the role of pharmacy-benefit middlemen, and what actually moved prices (biosimilars, state caps). Lesson: when a price floats far above its physical floor and the gap is institutional, the redesign target is the system, not the molecule — and naming which it is matters.'
-  category: opportunity_area
-  produced: false
-  episode_number: null
-  produced_date: null
 - id: lighthouse-led-efficiency
   title: 'From Whale Oil to LED: The 10,000-Fold Drop'
   brief: 'Concrete example (historical/modern). The cost of artificial light has fallen by something like a factor of ten thousand over two centuries — economist William Nordhaus famously measured it by reasoning from lumens, not from the price of lamps. Trace the chain of first-principles redesigns: each step (candle, whale oil, kerosene, incandescent, fluorescent, LED) attacked the dominant loss term of its predecessor — wasted heat, fuel, then electrical inefficiency — driving lumens-per-dollar and lumens-per-watt toward the physical limits of converting energy to visible photons. Use it to teach the "learning curve" idea concretely and to show how measuring the SERVICE (light) rather than the PRODUCT (lamps) reveals progress invisible in any single market. Lesson: define the thing you actually want, in physical units, and the magic-wand floor becomes visible.'
@@ -195,16 +188,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: water-pipes-lead-replacement
-  title: 'Replacing Every Lead Pipe: A Logistics Floor'
-  brief: 'Opportunity area. Millions of lead service lines still connect homes to mains across North America, and replacing them is "just" digging and swapping pipe — the materials (copper or PEX) are cheap, so the magic-wand floor is low and the Idiot Index is set almost entirely by locating, excavating, permitting, and restoring each individual connection. Walk through why a conceptually trivial job costs thousands per line and decades at current rates (records don''t exist, each dig is bespoke, split public/private ownership, restoration of driveways and sidewalks), and where the genuine opportunity sits — keyhole/trenchless methods, predictive records from machine learning on old data, crew standardization. Lesson: when the material floor is trivial and the price is all coordination and per-unit field labor, the opportunity is an operations-and-logistics redesign, the least glamorous and most valuable kind.'
-  category: opportunity_area
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: air-conditioning-heat-pumps
-  title: Heating by Moving Heat Instead of Making It
-  brief: 'Opportunity area. Burning fuel to make heat is capped at 100% efficiency by definition; a heat pump MOVES existing heat and routinely delivers 300-400% — three to four units of heat per unit of electricity — because it''s pumping, not creating. The first-principles insight is that for most building heating the magic-wand floor isn''t the fuel at all, it''s the small amount of work needed to move heat across a temperature gap. Walk through why heat pumps are physically superior yet under-deployed (upfront cost, cold-climate performance myths now largely solved, electrician and installer bottlenecks, retrofit friction), what the real cost stack is, and the lesson: when a process is fighting a law of physics (making heat) and an alternative sidesteps it (moving heat), the ceiling on the old way is the opportunity in the new one.'
+- id: insulin-pricing
+  title: 'Insulin: A Century-Old Molecule at a Modern Price'
+  brief: 'Opportunity area / concrete tension. Insulin was discovered in 1921 and its patent sold for a dollar so it would be affordable; a century later list prices in some markets run hundreds of dollars a vial. The magic-wand floor is revealing: the manufacturing cost of an analog insulin is estimated in the low single-digit dollars per vial, so the Idiot Index here is set almost entirely by regulation, patents on delivery devices and incremental formulations, and a rebate-driven pricing system — not by chemistry or scale. Walk through the genuine biologics-manufacturing cost, the "evergreening" and pen-device patent thicket, the role of pharmacy-benefit middlemen, and what actually moved prices (biosimilars, state caps). Lesson: when a price floats far above its physical floor and the gap is institutional, the redesign target is the system, not the molecule — and naming which it is matters.'
   category: opportunity_area
   produced: false
   episode_number: null
@@ -216,6 +202,13 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
+- id: water-pipes-lead-replacement
+  title: 'Replacing Every Lead Pipe: A Logistics Floor'
+  brief: 'Opportunity area. Millions of lead service lines still connect homes to mains across North America, and replacing them is "just" digging and swapping pipe — the materials (copper or PEX) are cheap, so the magic-wand floor is low and the Idiot Index is set almost entirely by locating, excavating, permitting, and restoring each individual connection. Walk through why a conceptually trivial job costs thousands per line and decades at current rates (records don''t exist, each dig is bespoke, split public/private ownership, restoration of driveways and sidewalks), and where the genuine opportunity sits — keyhole/trenchless methods, predictive records from machine learning on old data, crew standardization. Lesson: when the material floor is trivial and the price is all coordination and per-unit field labor, the opportunity is an operations-and-logistics redesign, the least glamorous and most valuable kind.'
+  category: opportunity_area
+  produced: false
+  episode_number: null
+  produced_date: null
 - id: interchangeable-parts-armory
   title: 'Interchangeable Parts: Mass Production Before the Assembly Line'
   brief: Concrete example (historical). Long before Ford, gunsmiths built each musket as a one-off, hand-fitting every part, so a broken lock meant a custom repair and skilled fitters dominated the cost. Reasoning from the real constraint, armories pursued parts made to tight enough tolerances that any one fit any gun — jigs, gauges, and machine tools instead of master craftsmen. Trace how interchangeability attacked the labor-and-fitting term that set the Idiot Index, why the gauges and machines were the hard part rather than the metal, and how the idea generalized from guns to clocks to cars. The materials were always cheap; the precision interface was the unlock. Hedge the figures and note it took decades to fully achieve.
@@ -223,9 +216,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: tunneling-transit-cost
-  title: Why a Mile of Subway Costs What It Does
-  brief: 'Opportunity area. The raw inputs to a transit tunnel — concrete, steel, a boring machine, electricity — are a modest fraction of the delivered cost, yet a mile of urban subway can cost several times more in some cities than others for similar geology. Reason about the magic-wand floor (materials plus machine-hours of boring) versus the finished price, and locate where the Idiot Index actually sits: station design, utility relocation, procurement, change orders, soft costs, and risk premia rather than the digging itself. Lay out the from-first-principles levers — standardized stations, repeatable designs, fewer bespoke contracts — and the honest hard parts of politics and right-of-way. Flag every comparison as approximate.'
+- id: air-conditioning-heat-pumps
+  title: Heating by Moving Heat Instead of Making It
+  brief: 'Opportunity area. Burning fuel to make heat is capped at 100% efficiency by definition; a heat pump MOVES existing heat and routinely delivers 300-400% — three to four units of heat per unit of electricity — because it''s pumping, not creating. The first-principles insight is that for most building heating the magic-wand floor isn''t the fuel at all, it''s the small amount of work needed to move heat across a temperature gap. Walk through why heat pumps are physically superior yet under-deployed (upfront cost, cold-climate performance myths now largely solved, electrician and installer bottlenecks, retrofit friction), what the real cost stack is, and the lesson: when a process is fighting a law of physics (making heat) and an alternative sidesteps it (moving heat), the ceiling on the old way is the opportunity in the new one.'
   category: opportunity_area
   produced: false
   episode_number: null
@@ -237,9 +230,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: low-carbon-cement
-  title: 'Cement: The Material Floor We Bake Twice'
-  brief: 'Opportunity area. Concrete is mostly cheap rock and sand, but the cement that binds it is made by cooking limestone at high heat, which both burns fuel and releases the carbon dioxide locked in the stone — so the magic-wand floor is set by chemistry and heat, not scarcity. Reason about where the Idiot Index and the emissions actually live in the process, and examine first-principles levers: alternative chemistries that need less heat, supplementary materials that replace some clinker, electrified or carbon-captured kilns, and designing structures to use less cement for the same strength. Cover the honest constraints — standards, durability proof, and the sheer scale of the industry. Treat all figures as approximate.'
+- id: tunneling-transit-cost
+  title: Why a Mile of Subway Costs What It Does
+  brief: 'Opportunity area. The raw inputs to a transit tunnel — concrete, steel, a boring machine, electricity — are a modest fraction of the delivered cost, yet a mile of urban subway can cost several times more in some cities than others for similar geology. Reason about the magic-wand floor (materials plus machine-hours of boring) versus the finished price, and locate where the Idiot Index actually sits: station design, utility relocation, procurement, change orders, soft costs, and risk premia rather than the digging itself. Lay out the from-first-principles levers — standardized stations, repeatable designs, fewer bespoke contracts — and the honest hard parts of politics and right-of-way. Flag every comparison as approximate.'
   category: opportunity_area
   produced: false
   episode_number: null
@@ -251,9 +244,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: dental-care-access
-  title: 'Dental Care: A High Idiot Index in the Mouth'
-  brief: 'Opportunity area. Routine dental work uses modest materials and well-understood procedures, yet delivered cost and access vary enormously, so the magic-wand floor is not what sets the price. Reason about where the Idiot Index actually sits — chairside time of highly-trained clinicians, fragmented small practices, equipment, and billing overhead rather than the filling material itself. Examine first-principles levers: tasks safely shifted to hygienists and therapists, prevention that removes demand entirely, standardized imaging and tele-dentistry, and cheaper digital fabrication of crowns and aligners. Cover honest constraints around safety, licensing, and outcomes, and avoid giving medical advice. Treat all figures as approximate.'
+- id: low-carbon-cement
+  title: 'Cement: The Material Floor We Bake Twice'
+  brief: 'Opportunity area. Concrete is mostly cheap rock and sand, but the cement that binds it is made by cooking limestone at high heat, which both burns fuel and releases the carbon dioxide locked in the stone — so the magic-wand floor is set by chemistry and heat, not scarcity. Reason about where the Idiot Index and the emissions actually live in the process, and examine first-principles levers: alternative chemistries that need less heat, supplementary materials that replace some clinker, electrified or carbon-captured kilns, and designing structures to use less cement for the same strength. Cover the honest constraints — standards, durability proof, and the sheer scale of the industry. Treat all figures as approximate.'
   category: opportunity_area
   produced: false
   episode_number: null
@@ -265,37 +258,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: last-mile-delivery
-  title: 'The Last Mile: Where Cheap Shipping Gets Expensive'
-  brief: 'Opportunity area. A package can cross an ocean for pennies per kilogram thanks to containerization, then absorb a large share of its total delivery cost in the final few kilometers to a doorstep — so the magic-wand floor of long-haul transport is already near solved while the Idiot Index has migrated to the last mile. Reason about why: many stops, low package density per stop, failed deliveries, labor, and idle vehicle time rather than fuel or the goods. Examine first-principles levers — route density, parcel lockers and pickup points, right-sized vehicles, and batching — and the honest constraints of geography, wages, and customer expectations. Flag all figures as approximate.'
-  category: opportunity_area
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: aluminum-electrolysis
-  title: 'Aluminum: From Precious Metal to Soda Can'
-  brief: Concrete example (historical). Aluminum is one of the most common metals in the earth's crust, yet for decades it was so costly to refine that it was displayed beside crown jewels and capped the Washington Monument as a precious metal. The magic-wand floor was never the ore — it was the energy and chemistry needed to pull aluminum away from the oxygen it clings to. Reasoning from that, Charles Hall and Paul Heroult independently found that dissolving alumina in molten cryolite and passing electricity through it would split out the metal, and the price collapsed by orders of magnitude within a generation, moving aluminum's Idiot Index toward the cost of the electricity itself. Trace the first-principles reasoning, how cheap aluminum then unlocked aircraft and cheap packaging, and the honest catch that the process is enormously power-hungry. Treat every figure as approximate.
-  category: concrete_example
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: heat-pumps-space-heating
-  title: 'Heat Pumps: Paying for Moved Heat, Not Burned Fuel'
-  brief: 'Opportunity area. Most space heating still works by burning something to make heat, but physics says you do not have to make heat at all — you can move it, and the thermodynamic floor (the Carnot limit and the resulting coefficient of performance) lets a good heat pump deliver several units of heat per unit of energy it draws. Reason about where the delivered cost actually lives: not the refrigerant or the sealed system, which are cheap, but installation labor, electrical-panel and ductwork constraints, cold-climate performance, and financing. Examine first-principles levers — standardized drop-in units, better cold-weather refrigerant cycles, cheaper clean electricity, and a trained installer base — that could push the delivered cost of comfort toward its physical floor. Cover the honest constraints around retrofits and grid load, and flag all figures as approximate.'
-  category: opportunity_area
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: led-lighting-cost-per-lumen
-  title: 'LED Light: A Lumen for the Cost of a Chip'
-  brief: 'Concrete example (modern). An incandescent bulb is mostly a tiny heater that happens to glow, throwing away most of its energy as heat, so no amount of tuning could clear that physical ceiling. Reasoning to light from a semiconductor instead, engineers attacked the real constraint: growing efficient light-emitting crystals and the blue emitter that finally made practical white light. Trace how the cost per lumen of LEDs fell along a steep, sustained curve while efficiency climbed, the materials-science breakthroughs behind it, and how lighting went from a noticeable share of electricity demand toward a rounding error. The materials are cheap; the Idiot Index lived in the physics of the emitter. Hedge the figures and note remaining limits like driver electronics and thermal management.'
-  category: concrete_example
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: urban-mining-metal-recycling
-  title: 'Urban Mining: The Richest Ore Is in the Landfill'
-  brief: 'Opportunity area. A ton of discarded electronics can hold far more gold, copper, and rare metals than a ton of freshly mined ore, so the magic-wand insight is that the materials are already concentrated and above ground — the floor is not scarcity. Reason about where the Idiot Index actually sits: collection, sorting, disassembly, and cleanly separating mixed materials, rather than the metals themselves. Examine first-principles levers — design-for-disassembly, automated sorting, hydrometallurgical and bio-based separation, and denser reverse logistics — that could turn waste streams into cheaper feedstock than primary mining. Cover the honest constraints of contamination, toxic handling, and fragmented collection, and treat all figures as approximate.'
+- id: dental-care-access
+  title: 'Dental Care: A High Idiot Index in the Mouth'
+  brief: 'Opportunity area. Routine dental work uses modest materials and well-understood procedures, yet delivered cost and access vary enormously, so the magic-wand floor is not what sets the price. Reason about where the Idiot Index actually sits — chairside time of highly-trained clinicians, fragmented small practices, equipment, and billing overhead rather than the filling material itself. Examine first-principles levers: tasks safely shifted to hygienists and therapists, prevention that removes demand entirely, standardized imaging and tele-dentistry, and cheaper digital fabrication of crowns and aligners. Cover honest constraints around safety, licensing, and outcomes, and avoid giving medical advice. Treat all figures as approximate.'
   category: opportunity_area
   produced: false
   episode_number: null
@@ -307,9 +272,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: modular-housing-construction
-  title: 'Modular Housing: The Building Cost That Is Not the Materials'
-  brief: Opportunity area. A house is mostly cheap, abundant materials - lumber, gypsum, concrete, glass - yet the delivered price per square foot stays stubbornly high, so the magic-wand insight is that the floor is not the materials but the way we build. Reason about where the Idiot Index actually sits - on-site labor done in the weather, permitting and inspection cycles, financing carry, and the one-off custom nature of each build - rather than the bill of materials. Examine first-principles levers like factory-built modules, standardized designs, automated framing, and permitting reform that could push delivered housing cost toward its material floor. Cover the honest constraints of transport limits, local code fragmentation, and site preparation, and treat all figures as approximate.
+- id: last-mile-delivery
+  title: 'The Last Mile: Where Cheap Shipping Gets Expensive'
+  brief: 'Opportunity area. A package can cross an ocean for pennies per kilogram thanks to containerization, then absorb a large share of its total delivery cost in the final few kilometers to a doorstep — so the magic-wand floor of long-haul transport is already near solved while the Idiot Index has migrated to the last mile. Reason about why: many stops, low package density per stop, failed deliveries, labor, and idle vehicle time rather than fuel or the goods. Examine first-principles levers — route density, parcel lockers and pickup points, right-sized vehicles, and batching — and the honest constraints of geography, wages, and customer expectations. Flag all figures as approximate.'
   category: opportunity_area
   produced: false
   episode_number: null
@@ -321,9 +286,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: precision-fermentation-protein
-  title: 'Protein Without the Animal: Reasoning Down the Cost'
-  brief: Opportunity area. Producing protein by raising an animal spends most of its input energy on the animal living its life, so the magic-wand insight is that the molecule you actually want - a specific protein - can in principle be brewed directly by microbes for a fraction of the thermodynamic input. Reason about where the delivered cost truly lives - bioreactor capacity, feedstock sugars, purification, and regulatory approval - rather than the protein itself, which is cheap once the process works. Examine first-principles levers like cheaper feedstocks, larger and continuous fermentation, strain engineering, and downstream-processing improvements that could drive cost toward the input-energy floor. Cover the honest constraints of scale-up economics, taste and texture, and consumer acceptance, and treat all figures as approximate.
+- id: urban-mining-metal-recycling
+  title: 'Urban Mining: The Richest Ore Is in the Landfill'
+  brief: 'Opportunity area. A ton of discarded electronics can hold far more gold, copper, and rare metals than a ton of freshly mined ore, so the magic-wand insight is that the materials are already concentrated and above ground — the floor is not scarcity. Reason about where the Idiot Index actually sits: collection, sorting, disassembly, and cleanly separating mixed materials, rather than the metals themselves. Examine first-principles levers — design-for-disassembly, automated sorting, hydrometallurgical and bio-based separation, and denser reverse logistics — that could turn waste streams into cheaper feedstock than primary mining. Cover the honest constraints of contamination, toxic handling, and fragmented collection, and treat all figures as approximate.'
   category: opportunity_area
   produced: false
   episode_number: null
@@ -335,9 +300,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: space-launch-insurance-reuse
-  title: 'Satellites: Why Orbit Costs More Than the Silicon'
-  brief: 'Opportunity area. A working satellite is mostly solar cells, aluminum, and electronics that share a parts bin with terrestrial hardware, yet the delivered cost of a capability in orbit has historically been dominated by launch price, one-off bespoke spacecraft built to never be touched again, and the insurance and testing that expendability demands. Reason about the magic-wand floor (the hardware) versus the finished cost, and locate where the Idiot Index actually sits now that reusable launch is dragging the transport term down. Examine the first-principles levers — mass-produced standardized satellite buses, cheaper launch, accepting higher failure rates on cheap replaceable units instead of gold-plating one — and the honest hard parts (radiation, no repair access, orbital debris). Flag every figure as approximate.'
+- id: modular-housing-construction
+  title: 'Modular Housing: The Building Cost That Is Not the Materials'
+  brief: Opportunity area. A house is mostly cheap, abundant materials - lumber, gypsum, concrete, glass - yet the delivered price per square foot stays stubbornly high, so the magic-wand insight is that the floor is not the materials but the way we build. Reason about where the Idiot Index actually sits - on-site labor done in the weather, permitting and inspection cycles, financing carry, and the one-off custom nature of each build - rather than the bill of materials. Examine first-principles levers like factory-built modules, standardized designs, automated framing, and permitting reform that could push delivered housing cost toward its material floor. Cover the honest constraints of transport limits, local code fragmentation, and site preparation, and treat all figures as approximate.
   category: opportunity_area
   produced: false
   episode_number: null
@@ -349,9 +314,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: freight-rail-vs-trucking
-  title: 'Moving a Ton a Mile: The Cost Floor of Freight'
-  brief: 'Opportunity area. Steel wheel on steel rail has a rolling-resistance advantage rooted in physics — it takes far less energy to move a ton a mile by rail than by truck — so the magic-wand floor for bulk overland freight is set by that energy difference, yet trucks carry the majority of freight ton-miles in much of North America. Reason about why the physically cheaper mode loses on delivered cost: rail''s first-and-last-mile handling, terminal transfers, schedule inflexibility, and network geometry, versus trucking''s door-to-door convenience. Examine the first-principles levers — intermodal standardization, terminal automation, electrification, and where autonomy changes the math — and the honest hard parts (network effects, right-of-way, capital intensity). Flag all figures as approximate.'
+- id: precision-fermentation-protein
+  title: 'Protein Without the Animal: Reasoning Down the Cost'
+  brief: Opportunity area. Producing protein by raising an animal spends most of its input energy on the animal living its life, so the magic-wand insight is that the molecule you actually want - a specific protein - can in principle be brewed directly by microbes for a fraction of the thermodynamic input. Reason about where the delivered cost truly lives - bioreactor capacity, feedstock sugars, purification, and regulatory approval - rather than the protein itself, which is cheap once the process works. Examine first-principles levers like cheaper feedstocks, larger and continuous fermentation, strain engineering, and downstream-processing improvements that could drive cost toward the input-energy floor. Cover the honest constraints of scale-up economics, taste and texture, and consumer acceptance, and treat all figures as approximate.
   category: opportunity_area
   produced: false
   episode_number: null
@@ -363,9 +328,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: prosthetics-3d-printing
-  title: 'Prosthetics: A $50,000 Limb From $50 of Plastic'
-  brief: 'Opportunity area. A custom prosthetic limb can be billed at tens of thousands of dollars, yet the materials — thermoplastics, a few actuators, fasteners — are a tiny fraction of that: a textbook high Idiot Index where the cost lives in bespoke fitting, skilled prosthetist labor, low volume, and reimbursement complexity rather than the parts. State the magic-wand floor honestly, then walk the cost stack. Cover the live natural experiment of open-source and 3D-printed hands (the e-NABLE movement), what actually got cheaper (simple body-powered devices for children who outgrow them fast), and where it stalled (myoelectric control, durability, clinical fitting for serious cases). The opportunity: parametric digital design, printable sockets, and unbundled fitting. Honest hard parts — real amputation cases need clinicians, and fit is genuinely physical. Treat all figures as approximate.'
+- id: space-launch-insurance-reuse
+  title: 'Satellites: Why Orbit Costs More Than the Silicon'
+  brief: 'Opportunity area. A working satellite is mostly solar cells, aluminum, and electronics that share a parts bin with terrestrial hardware, yet the delivered cost of a capability in orbit has historically been dominated by launch price, one-off bespoke spacecraft built to never be touched again, and the insurance and testing that expendability demands. Reason about the magic-wand floor (the hardware) versus the finished cost, and locate where the Idiot Index actually sits now that reusable launch is dragging the transport term down. Examine the first-principles levers — mass-produced standardized satellite buses, cheaper launch, accepting higher failure rates on cheap replaceable units instead of gold-plating one — and the honest hard parts (radiation, no repair access, orbital debris). Flag every figure as approximate.'
   category: opportunity_area
   produced: false
   episode_number: null
@@ -377,9 +342,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: legal-services-access
-  title: 'Legal Help: The $400-an-Hour Idiot Index'
-  brief: 'Opportunity area. Much routine legal work — a simple will, an incorporation, an uncontested filing, a standard lease — is the application of well-known templates, yet delivered cost is dominated by billable hours of highly-trained lawyers, fragmented small practices, and rules that restrict who may do the work. Reason about the magic-wand floor (the marginal cost of a filled-in, correct document is near zero) versus the price, and where the Idiot Index actually sits. Examine first-principles levers — document automation, standardized forms, tasks safely shifted to paralegals or software, and transparent fixed-fee pricing — while being honest that adversarial and high-stakes matters genuinely need expert judgment and that unauthorized-practice rules exist partly to protect clients. Avoid giving legal advice; treat all figures as approximate.'
+- id: freight-rail-vs-trucking
+  title: 'Moving a Ton a Mile: The Cost Floor of Freight'
+  brief: 'Opportunity area. Steel wheel on steel rail has a rolling-resistance advantage rooted in physics — it takes far less energy to move a ton a mile by rail than by truck — so the magic-wand floor for bulk overland freight is set by that energy difference, yet trucks carry the majority of freight ton-miles in much of North America. Reason about why the physically cheaper mode loses on delivered cost: rail''s first-and-last-mile handling, terminal transfers, schedule inflexibility, and network geometry, versus trucking''s door-to-door convenience. Examine the first-principles levers — intermodal standardization, terminal automation, electrification, and where autonomy changes the math — and the honest hard parts (network effects, right-of-way, capital intensity). Flag all figures as approximate.'
   category: opportunity_area
   produced: false
   episode_number: null
@@ -391,9 +356,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: water-treatment-decentralized
-  title: 'Clean Water: The Cost Is the Pipe, Not the Purification'
-  brief: 'Opportunity area. Making a liter of water safe to drink takes very little energy and cheap treatment chemistry, yet delivering safe water at scale is dominated by the capital cost of centralized plants and vast networks of buried pipe — so in many places the magic-wand floor (purification) is trivial while the Idiot Index lives in distribution infrastructure and its maintenance. Reason about where the real cost sits, and examine the first-principles case for decentralized and point-of-use treatment — small modular systems, cheaper membranes, sensors that catch contamination early — that could bring safe water to places a pipe network will never reach economically. Cover the honest hard parts (reliability, maintenance, monitoring, waterborne-disease stakes). Flag every figure as approximate.'
+- id: prosthetics-3d-printing
+  title: 'Prosthetics: A $50,000 Limb From $50 of Plastic'
+  brief: 'Opportunity area. A custom prosthetic limb can be billed at tens of thousands of dollars, yet the materials — thermoplastics, a few actuators, fasteners — are a tiny fraction of that: a textbook high Idiot Index where the cost lives in bespoke fitting, skilled prosthetist labor, low volume, and reimbursement complexity rather than the parts. State the magic-wand floor honestly, then walk the cost stack. Cover the live natural experiment of open-source and 3D-printed hands (the e-NABLE movement), what actually got cheaper (simple body-powered devices for children who outgrow them fast), and where it stalled (myoelectric control, durability, clinical fitting for serious cases). The opportunity: parametric digital design, printable sockets, and unbundled fitting. Honest hard parts — real amputation cases need clinicians, and fit is genuinely physical. Treat all figures as approximate.'
   category: opportunity_area
   produced: false
   episode_number: null
@@ -405,9 +370,9 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: elder-care-labor-floor
-  title: 'Elder Care: The Cost That Is Almost All Time'
-  brief: 'Opportunity area — with an honest verdict. Caring for an aging person is dominated by human hours: help with daily living, supervision, and companionship. Unlike most episodes there is barely any material floor to attack — the magic-wand number is mostly labor, and labor is the point, so reason carefully about where technology can genuinely lower delivered cost versus where it cannot and shouldn''t. Examine the honest levers — remote monitoring that lets people age in place longer, mobility and lifting aids that let one worker safely do what took two, scheduling and logistics software, and prevention that delays acuity — against the hard truth that presence and dignity are irreducibly human. The lesson: sometimes first-principles analysis tells you the Idiot Index is LOW (price already near the labor floor) and the real opportunity is making the labor more humane and productive, not conjuring the cost away. Treat all figures as approximate.'
+- id: legal-services-access
+  title: 'Legal Help: The $400-an-Hour Idiot Index'
+  brief: 'Opportunity area. Much routine legal work — a simple will, an incorporation, an uncontested filing, a standard lease — is the application of well-known templates, yet delivered cost is dominated by billable hours of highly-trained lawyers, fragmented small practices, and rules that restrict who may do the work. Reason about the magic-wand floor (the marginal cost of a filled-in, correct document is near zero) versus the price, and where the Idiot Index actually sits. Examine first-principles levers — document automation, standardized forms, tasks safely shifted to paralegals or software, and transparent fixed-fee pricing — while being honest that adversarial and high-stakes matters genuinely need expert judgment and that unauthorized-practice rules exist partly to protect clients. Avoid giving legal advice; treat all figures as approximate.'
   category: opportunity_area
   produced: false
   episode_number: null
@@ -416,6 +381,20 @@ queue:
   title: 'The Steam Engine: Reasoning About Wasted Heat'
   brief: 'Concrete example (historical). Early Newcomen steam engines were so inefficient they were only economic pumping water out of coal mines, where fuel was free at the pithead — the binding constraint was staggering heat waste, most of it spent re-heating a cylinder that had just been cooled every stroke. James Watt reasoned from where the heat actually went and added a separate condenser so the working cylinder stayed hot, cutting fuel use by a large fraction and making the engine economic almost anywhere. Trace the first-principles diagnosis (find the dominant loss term — cooling and reheating — and eliminate it) that turned a niche mine pump into the prime mover of the Industrial Revolution, and how measuring efficiency drove a century of further gains. Lesson: the biggest wins come from finding the largest waste term and attacking it directly, not from tuning everything a little. Hedge the figures.'
   category: concrete_example
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: water-treatment-decentralized
+  title: 'Clean Water: The Cost Is the Pipe, Not the Purification'
+  brief: 'Opportunity area. Making a liter of water safe to drink takes very little energy and cheap treatment chemistry, yet delivering safe water at scale is dominated by the capital cost of centralized plants and vast networks of buried pipe — so in many places the magic-wand floor (purification) is trivial while the Idiot Index lives in distribution infrastructure and its maintenance. Reason about where the real cost sits, and examine the first-principles case for decentralized and point-of-use treatment — small modular systems, cheaper membranes, sensors that catch contamination early — that could bring safe water to places a pipe network will never reach economically. Cover the honest hard parts (reliability, maintenance, monitoring, waterborne-disease stakes). Flag every figure as approximate.'
+  category: opportunity_area
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: elder-care-labor-floor
+  title: 'Elder Care: The Cost That Is Almost All Time'
+  brief: 'Opportunity area — with an honest verdict. Caring for an aging person is dominated by human hours: help with daily living, supervision, and companionship. Unlike most episodes there is barely any material floor to attack — the magic-wand number is mostly labor, and labor is the point, so reason carefully about where technology can genuinely lower delivered cost versus where it cannot and shouldn''t. Examine the honest levers — remote monitoring that lets people age in place longer, mobility and lifting aids that let one worker safely do what took two, scheduling and logistics software, and prevention that delays acuity — against the hard truth that presence and dignity are irreducibly human. The lesson: sometimes first-principles analysis tells you the Idiot Index is LOW (price already near the labor floor) and the real opportunity is making the labor more humane and productive, not conjuring the cost away. Treat all figures as approximate.'
+  category: opportunity_area
   produced: false
   episode_number: null
   produced_date: null

--- a/shows/topic_queues/unintended_consequences.yaml
+++ b/shows/topic_queues/unintended_consequences.yaml
@@ -254,7 +254,7 @@ queue:
 - id: biofuels-deforestation
   title: Biofuels and Deforestation
   brief: EU and US biofuel mandates in the 2000s aimed to reduce greenhouse-gas emissions from transportation. They drove a global expansion of palm-oil and corn cultivation, much of it on freshly cleared rainforest land. Multiple lifecycle analyses have since concluded that some biofuel programs produced more emissions than the gasoline they replaced.
-  category: medicine
+  category: policy
   produced: true
   episode_number: 37
   produced_date: '2026-06-22'
@@ -321,31 +321,10 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: quantitative-easing
-  title: Quantitative Easing
-  brief: The Federal Reserve's post-2008 quantitative easing programs were emergency monetary policy designed to prevent another Depression. They worked at that. They also inflated asset prices for a decade, widened wealth inequality measurably, and made the rich richer while leaving wages largely flat — a side effect Fed officials acknowledged but couldn't solve.
-  category: economics
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: gamification-of-everything
-  title: Gamification of Everything
-  brief: Game designers spent decades figuring out what makes humans return to a screen. Around 2010, the rest of the economy adopted those techniques — Strava, Duolingo, Snapchat streaks, classroom point systems, productivity apps. Some of it produced genuine engagement; much of it turned learning, fitness, and work into dopamine treadmills with measurable burnout costs.
-  category: economics
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: fast-fashion
-  title: Fast Fashion
-  brief: 'Zara, H&M, and later Shein collapsed clothing''s cost and time-to-shelf, putting style within reach of working-class consumers. The receipts: a textile industry now responsible for 8–10% of global emissions, garment workers paid below subsistence wages, and the 92 million tonnes of textile waste going to landfill annually.'
-  category: economics
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: uber-gig-economy
-  title: Uber and the Gig Economy
-  brief: Uber's 2009 launch promised flexible, well-paid driving work and democratized urban mobility. Fifteen years on, real driver earnings have fallen below minimum wage in many markets, the company has spent over $200 million successfully fighting laws that would classify drivers as employees, and the original 'flexibility' has hardened into precarity for millions of workers worldwide.
-  category: economics
+- id: smokey-bear-fire-suppression
+  title: Smokey Bear and the Century of Fuel
+  brief: 'America''s most successful PSA campaign taught generations that all forest fire is bad — and the Forest Service backed it with total-suppression policy for most of the 20th century. But many western ecosystems evolved with frequent low-intensity fire; suppressing every small burn let fuel accumulate for decades. The unintended result: megafires hot enough to sterilize soil, and a fire season that now consumes the agency''s budget. Cover the 10am policy, the science of fire ecology that emerged mid-century, the slow pivot to prescribed burning, and why undoing 80 years of accumulated consequence is harder than creating it.'
+  category: classic
   produced: false
   episode_number: null
   produced_date: null
@@ -356,66 +335,10 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: smokey-bear-fire-suppression
-  title: Smokey Bear and the Century of Fuel
-  brief: 'America''s most successful PSA campaign taught generations that all forest fire is bad — and the Forest Service backed it with total-suppression policy for most of the 20th century. But many western ecosystems evolved with frequent low-intensity fire; suppressing every small burn let fuel accumulate for decades. The unintended result: megafires hot enough to sterilize soil, and a fire season that now consumes the agency''s budget. Cover the 10am policy, the science of fire ecology that emerged mid-century, the slow pivot to prescribed burning, and why undoing 80 years of accumulated consequence is harder than creating it.'
-  category: classic
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: wolves-yellowstone-removal
-  title: Killing the Wolves of Yellowstone
-  brief: 'Early 20th-century predator-control programs exterminated wolves from Yellowstone to protect elk and livestock — a goal fully achieved by 1926. Elk populations exploded, overbrowsed willow and aspen, riverbanks eroded, beavers declined, and songbird habitat collapsed: a trophic cascade documented over decades. The 1995 reintroduction became ecology''s most famous natural experiment (with honest caveats about how much recovery the wolves alone caused). The lesson: top-down effects in systems are invisible until you remove the top.'
-  category: classic
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: kudzu-vine
-  title: 'Kudzu: The Vine That Ate the South'
-  brief: 'In the 1930s the US government paid southern farmers to plant kudzu — a fast-growing Japanese vine — to fight Dust Bowl-era soil erosion, distributing tens of millions of seedlings through the Soil Conservation Service. The vine worked, then kept working: smothering trees, power lines, and buildings across the South. Cover the genuine erosion crisis, why kudzu seemed ideal, the moment enthusiasm turned (USDA reclassified it a weed in 1970), the honest modern correction that its spread is often overstated, and the lesson about deploying a self-replicating solution.'
-  category: classic
-  produced: false
-  episode_number: null
-  produced_date: null
 - id: peanut-allergy-guidelines
   title: The Peanut Allergy Paradox
   brief: 'In 2000 the American Academy of Pediatrics advised parents to delay peanut exposure for at-risk infants until age three. Peanut allergy rates then climbed sharply. The 2015 LEAP trial demonstrated the opposite of the guidance: EARLY exposure dramatically reduced allergy development, and the guidelines were reversed in 2017. A rare case where the harmful feedback loop was caught, measured in a randomized trial, and corrected — but a generation of children lived under the inverted advice. Lesson: precaution itself carries risk, and "do the cautious thing" is still a causal intervention.'
   category: medicine
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: food-pyramid-low-fat
-  title: The Low-Fat Pyramid
-  brief: 'From the late 1970s, US dietary guidance pushed fat reduction as the path to heart health, crystallized in the 1992 food pyramid with its 6-11 daily servings of bread and grain at the base. The food industry responded with thousands of low-fat, sugar-compensated products, and consumers treated "low fat" as "healthy." What followed — rising obesity and type-2 diabetes alongside falling fat intake — has contested causes, and the episode should be honest about correlation versus causation and what the guidelines did and didn''t say. The lesson: population-scale advice gets refracted through industry incentives into something its authors never wrote.'
-  category: medicine
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: cigarette-filters
-  title: The Filter Illusion
-  brief: 'Filters were added to cigarettes in the 1950s as a health reassurance amid the first cancer studies — and marketed exactly that way. Smokers responded by inhaling more deeply and smoking more of the cigarette; internal industry documents later showed companies knew filters'' protective value was largely illusory, and some designs (ventilation holes smokers'' fingers covered) made measured "tar" numbers meaningless. Bonus consequence: cellulose-acetate filters became one of the most littered plastic items on Earth. Lesson: a safety feature that changes behavior can cancel itself — and a reassuring signal can do harm a plain warning would not.'
-  category: economics
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: flood-insurance-levee-effect
-  title: 'Building in the Floodplain: The Levee Effect'
-  brief: 'The US National Flood Insurance Program (1968) was designed to make flood risk insurable and steer development away from floodplains. In practice, subsidized premiums and the perceived safety of levees encouraged MORE building in flood-prone areas — the "levee effect" geographers had warned about since the 1940s: protection works until it fails, and by then far more value sits behind it. Cover repetitive-loss properties rebuilt many times at public expense, the program''s multibillion-dollar debt after Katrina, and the reform attempts (Biggert-Waters) that were rolled back when accurate pricing proved politically intolerable. Lesson: subsidizing risk reshapes where people put their lives.'
-  category: policy
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: scared-straight-programs
-  title: Scared Straight
-  brief: Beginning with a 1978 documentary, "Scared Straight" programs brought at-risk teens into prisons for confrontational sessions with inmates, on the theory that fear would deter crime. The format spread internationally and won an Academy Award. Randomized evaluations then found the programs INCREASED later offending — the Campbell Collaboration meta-analysis put the effect at meaningfully higher odds of crime versus doing nothing at all. Cover why the intuition felt irresistible, the mechanisms researchers propose (defiance, status, normalization), and why emotionally satisfying interventions are the ones that most need testing.
-  category: policy
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: dare-program
-  title: 'D.A.R.E.: Just Say Nothing'
-  brief: 'Drug Abuse Resistance Education put uniformed police officers into classrooms from 1983 onward, reaching tens of millions of children at its peak — and became one of the most evaluated school programs in history. The consistent finding: little to no effect on drug use, with some studies suggesting curiosity effects from detailed drug descriptions. Cover why the program persisted for decades after the evidence (community buy-in, visible activity, the political cost of cancellation), the eventual curriculum rebuild (keepin'' it REAL), and the lesson that an intervention''s popularity and its efficacy are independent variables.'
-  category: policy
   produced: false
   episode_number: null
   produced_date: null
@@ -426,48 +349,6 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: open-plan-offices
-  title: Tearing Down the Walls
-  brief: 'Open-plan offices were sold for decades as collaboration machines — and as a happy coincidence, they cut real-estate cost per employee. Then researchers measured what actually happened: a 2018 Harvard study using sociometric badges found face-to-face interaction DROPPED roughly 70% after walls came down, with electronic messaging rising to compensate, while noise and surveillance effects pushed workers into headphones. Cover the Bürolandschaft origins, the cost story hiding inside the collaboration story, and the lesson: when a design''s stated goal and its budget benefit point the same direction, audit which one is driving.'
-  category: economics
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: plastic-bag-bans
-  title: The Tote Bag Problem
-  brief: 'Single-use plastic bag bans and fees swept cities and countries through the 2010s. The consequences were messier than the headlines: purchases of small trash-bin liners jumped (people had been reusing grocery bags), some jurisdictions saw shifts to thicker "reusable" plastic bags discarded almost as fast, and life-cycle studies found a cotton tote must be used over a hundred times to beat the single-use bag it replaced. Be honest in both directions — bans demonstrably cut bag litter in waterways — and land the lesson: when you ban one behavior, you are choosing its substitutes, so measure those too.'
-  category: classic
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: scurvy-cure-lost
-  title: How the Cure for Scurvy Was Lost
-  brief: 'The Royal Navy conquered scurvy with citrus in the early 1800s — then lost the cure within a century. As steam shortened voyages, scurvy became rare; the Navy switched from Sicilian lemons to West Indian limes (far lower vitamin C, further destroyed by copper piping and storage), and nothing bad happened, so the weaker remedy was credited. The vitamin wasn''t known to exist, so when long polar expeditions returned, scorbutic men and lime juice "failed," sophisticated theories blamed tainted meat, and Scott''s expeditions suffered for it. Lesson: a fix that works for unknown reasons degrades silently when conditions change — institutional knowledge needs the WHY, not just the procedure.'
-  category: medicine
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: asbestos-miracle-mineral
-  title: The Fireproof Miracle That Killed
-  brief: 'For most of the twentieth century asbestos was sold as a safety miracle — a cheap, abundant mineral that fireproofed schools, ships, homes, and firefighters'' suits, and by insulating pipes and boilers it genuinely saved energy and prevented fires. The same indestructible fibres that made it wonderful made it lethal: inhaled, they lodge in the lungs for decades and cause asbestosis and mesothelioma, a cancer with a 20-to-50-year latency that hid the harm long past the point of mass installation. Trace how a material adopted expressly to protect people seeded a slow-motion epidemic still killing tens of thousands a year, why the latency defeated early warnings, and the lesson: when a product''s virtue is that it never breaks down, ask what never breaking down does inside a human body. Treat all figures as approximate.'
-  category: medicine
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: nile-perch-lake-victoria
-  title: The Fish That Ate a Lake
-  brief: 'In the mid-twentieth century the Nile perch was deliberately introduced into Lake Victoria to boost fisheries — a big, marketable fish to feed and employ the region, and for a while it worked, spawning a lucrative export trade in perch fillets. Then the predator did what predators do: it helped drive hundreds of endemic cichlid species toward extinction in one of the fastest vertebrate collapses ever recorded, and processing the oily perch (unlike the old sun-dried catch) demanded firewood, accelerating shoreline deforestation and, with nutrient runoff, algal blooms and dead zones. Cover the boom that was real, the ecological and social bill that came due, and the lesson: adding one profitable piece to an ecosystem is not addition — it is rewriting the whole web. Figures are approximate.'
-  category: classic
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: africanized-killer-bees
-  title: The Bees That Escaped the Lab
-  brief: 'In 1950s Brazil, researchers crossbred European honeybees with an African subspecies hoping to build a bee better suited to the tropics and more productive for local beekeepers — a sensible agricultural improvement. In 1957 a couple dozen swarms escaped, and the hybrids proved not just hardy but intensely defensive, spreading across South and Central America and into the southern United States over the following decades, displacing gentler bees and causing rare but real human and livestock deaths that earned the "killer bee" headlines. Be honest in both directions — the bees are also vigorous foragers and pollinators — and land the lesson: when you breed for one trait in a living thing that can reproduce and travel on its own, containment, not just the trait, is the hard problem. Treat figures as approximate.'
-  category: classic
-  produced: false
-  episode_number: null
-  produced_date: null
 - id: three-gorges-dam-seismicity
   title: 'The Three Gorges Dam: Weighing a Reservoir Against the Earth'
   brief: 'China''s Three Gorges Dam, fully operational by 2012, was the world''s largest hydroelectric project — flood control and clean power for hundreds of millions. It also displaced over a million people, submerged archaeological sites and towns, triggered hundreds of landslides along newly saturated reservoir banks, and prompted serious scientific debate about reservoir-induced seismicity from the immense water load pressing on faults. Cover the genuine benefits, the human relocation, the geological cascade downstream sediment starvation and bank collapse, and the lesson about interventions so large they alter the physical stresses of the landscape itself. Treat figures as approximate.'
@@ -475,9 +356,30 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: antibiotics-in-livestock
-  title: 'Growth Promoters: Antibiotics on the Farm'
-  brief: 'Starting in the 1950s, farmers discovered that low doses of antibiotics in animal feed made livestock grow faster and cheaper — a boon that helped make meat affordable for a generation. The unintended consequence was a vast reservoir of antibiotic exposure that accelerated resistance in bacteria, some of which reach humans through food and the environment; the majority of antibiotics sold in some countries went to animals, not people. Cover the economics that drove adoption, the resistance science, the regulatory pushback (EU bans, US voluntary phase-outs), and the honest complexity of separating farm use from hospital overuse in the resistance story. Treat figures as approximate.'
+- id: quantitative-easing
+  title: Quantitative Easing
+  brief: The Federal Reserve's post-2008 quantitative easing programs were emergency monetary policy designed to prevent another Depression. They worked at that. They also inflated asset prices for a decade, widened wealth inequality measurably, and made the rich richer while leaving wages largely flat — a side effect Fed officials acknowledged but couldn't solve.
+  category: economics
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: wolves-yellowstone-removal
+  title: Killing the Wolves of Yellowstone
+  brief: 'Early 20th-century predator-control programs exterminated wolves from Yellowstone to protect elk and livestock — a goal fully achieved by 1926. Elk populations exploded, overbrowsed willow and aspen, riverbanks eroded, beavers declined, and songbird habitat collapsed: a trophic cascade documented over decades. The 1995 reintroduction became ecology''s most famous natural experiment (with honest caveats about how much recovery the wolves alone caused). The lesson: top-down effects in systems are invisible until you remove the top.'
+  category: classic
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: flood-insurance-levee-effect
+  title: 'Building in the Floodplain: The Levee Effect'
+  brief: 'The US National Flood Insurance Program (1968) was designed to make flood risk insurable and steer development away from floodplains. In practice, subsidized premiums and the perceived safety of levees encouraged MORE building in flood-prone areas — the "levee effect" geographers had warned about since the 1940s: protection works until it fails, and by then far more value sits behind it. Cover repetitive-loss properties rebuilt many times at public expense, the program''s multibillion-dollar debt after Katrina, and the reform attempts (Biggert-Waters) that were rolled back when accurate pricing proved politically intolerable. Lesson: subsidizing risk reshapes where people put their lives.'
+  category: policy
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: food-pyramid-low-fat
+  title: The Low-Fat Pyramid
+  brief: 'From the late 1970s, US dietary guidance pushed fat reduction as the path to heart health, crystallized in the 1992 food pyramid with its 6-11 daily servings of bread and grain at the base. The food industry responded with thousands of low-fat, sugar-compensated products, and consumers treated "low fat" as "healthy." What followed — rising obesity and type-2 diabetes alongside falling fat intake — has contested causes, and the episode should be honest about correlation versus causation and what the guidelines did and didn''t say. The lesson: population-scale advice gets refracted through industry incentives into something its authors never wrote.'
   category: medicine
   produced: false
   episode_number: null
@@ -489,6 +391,90 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
+- id: dam-removal-salmon
+  title: 'Tearing Down the Dams We Built'
+  brief: 'Twentieth-century dams delivered power, irrigation, and flood control — real benefits that built the American West and beyond. But many also blocked salmon and other migratory fish from spawning grounds, collapsing fisheries and the ecosystems and cultures that depended on them, an unintended consequence that took decades to fully register. Now some of those dams are being removed at great expense (the Klamath, the Elwha) to restore rivers. Cover the original benefits, the ecological blockade nobody priced, the surprising modern reversal of deliberately undoing major infrastructure, and the lesson that the full cost of an intervention can take a generation to surface — and even longer to unwind. Treat figures as approximate.'
+  category: infrastructure
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: gamification-of-everything
+  title: Gamification of Everything
+  brief: Game designers spent decades figuring out what makes humans return to a screen. Around 2010, the rest of the economy adopted those techniques — Strava, Duolingo, Snapchat streaks, classroom point systems, productivity apps. Some of it produced genuine engagement; much of it turned learning, fitness, and work into dopamine treadmills with measurable burnout costs.
+  category: economics
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: kudzu-vine
+  title: 'Kudzu: The Vine That Ate the South'
+  brief: 'In the 1930s the US government paid southern farmers to plant kudzu — a fast-growing Japanese vine — to fight Dust Bowl-era soil erosion, distributing tens of millions of seedlings through the Soil Conservation Service. The vine worked, then kept working: smothering trees, power lines, and buildings across the South. Cover the genuine erosion crisis, why kudzu seemed ideal, the moment enthusiasm turned (USDA reclassified it a weed in 1970), the honest modern correction that its spread is often overstated, and the lesson about deploying a self-replicating solution.'
+  category: classic
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: scared-straight-programs
+  title: Scared Straight
+  brief: Beginning with a 1978 documentary, "Scared Straight" programs brought at-risk teens into prisons for confrontational sessions with inmates, on the theory that fear would deter crime. The format spread internationally and won an Academy Award. Randomized evaluations then found the programs INCREASED later offending — the Campbell Collaboration meta-analysis put the effect at meaningfully higher odds of crime versus doing nothing at all. Cover why the intuition felt irresistible, the mechanisms researchers propose (defiance, status, normalization), and why emotionally satisfying interventions are the ones that most need testing.
+  category: policy
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: scurvy-cure-lost
+  title: How the Cure for Scurvy Was Lost
+  brief: 'The Royal Navy conquered scurvy with citrus in the early 1800s — then lost the cure within a century. As steam shortened voyages, scurvy became rare; the Navy switched from Sicilian lemons to West Indian limes (far lower vitamin C, further destroyed by copper piping and storage), and nothing bad happened, so the weaker remedy was credited. The vitamin wasn''t known to exist, so when long polar expeditions returned, scorbutic men and lime juice "failed," sophisticated theories blamed tainted meat, and Scott''s expeditions suffered for it. Lesson: a fix that works for unknown reasons degrades silently when conditions change — institutional knowledge needs the WHY, not just the procedure.'
+  category: medicine
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: y2k-preparedness-paradox
+  title: 'Y2K: The Disaster That Didn''t Happen'
+  brief: 'The Year 2000 computer bug — decades of software storing years as two digits — threatened to crash systems worldwide at midnight. Governments and companies spent an estimated $300-plus billion remediating code. Almost nothing broke, which produced a peculiar unintended consequence: many concluded the threat had been overblown or fake, when the more defensible reading is that massive quiet effort prevented the failures. Cover the real technical risk, the enormous remediation, the "prevention paradox" (success looks like nothing happened, so it gets no credit), and the lesson about how invisible averted disasters distort our judgment of which threats were ever real. Treat figures as approximate.'
+  category: tech
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: fast-fashion
+  title: Fast Fashion
+  brief: 'Zara, H&M, and later Shein collapsed clothing''s cost and time-to-shelf, putting style within reach of working-class consumers. The receipts: a textile industry now responsible for 8–10% of global emissions, garment workers paid below subsistence wages, and the 92 million tonnes of textile waste going to landfill annually.'
+  category: economics
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: plastic-bag-bans
+  title: The Tote Bag Problem
+  brief: 'Single-use plastic bag bans and fees swept cities and countries through the 2010s. The consequences were messier than the headlines: purchases of small trash-bin liners jumped (people had been reusing grocery bags), some jurisdictions saw shifts to thicker "reusable" plastic bags discarded almost as fast, and life-cycle studies found a cotton tote must be used over a hundred times to beat the single-use bag it replaced. Be honest in both directions — bans demonstrably cut bag litter in waterways — and land the lesson: when you ban one behavior, you are choosing its substitutes, so measure those too.'
+  category: classic
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: dare-program
+  title: 'D.A.R.E.: Just Say Nothing'
+  brief: 'Drug Abuse Resistance Education put uniformed police officers into classrooms from 1983 onward, reaching tens of millions of children at its peak — and became one of the most evaluated school programs in history. The consistent finding: little to no effect on drug use, with some studies suggesting curiosity effects from detailed drug descriptions. Cover why the program persisted for decades after the evidence (community buy-in, visible activity, the political cost of cancellation), the eventual curriculum rebuild (keepin'' it REAL), and the lesson that an intervention''s popularity and its efficacy are independent variables.'
+  category: policy
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: asbestos-miracle-mineral
+  title: The Fireproof Miracle That Killed
+  brief: 'For most of the twentieth century asbestos was sold as a safety miracle — a cheap, abundant mineral that fireproofed schools, ships, homes, and firefighters'' suits, and by insulating pipes and boilers it genuinely saved energy and prevented fires. The same indestructible fibres that made it wonderful made it lethal: inhaled, they lodge in the lungs for decades and cause asbestosis and mesothelioma, a cancer with a 20-to-50-year latency that hid the harm long past the point of mass installation. Trace how a material adopted expressly to protect people seeded a slow-motion epidemic still killing tens of thousands a year, why the latency defeated early warnings, and the lesson: when a product''s virtue is that it never breaks down, ask what never breaking down does inside a human body. Treat all figures as approximate.'
+  category: medicine
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: uber-gig-economy
+  title: Uber and the Gig Economy
+  brief: Uber's 2009 launch promised flexible, well-paid driving work and democratized urban mobility. Fifteen years on, real driver earnings have fallen below minimum wage in many markets, the company has spent over $200 million successfully fighting laws that would classify drivers as employees, and the original 'flexibility' has hardened into precarity for millions of workers worldwide.
+  category: economics
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: nile-perch-lake-victoria
+  title: The Fish That Ate a Lake
+  brief: 'In the mid-twentieth century the Nile perch was deliberately introduced into Lake Victoria to boost fisheries — a big, marketable fish to feed and employ the region, and for a while it worked, spawning a lucrative export trade in perch fillets. Then the predator did what predators do: it helped drive hundreds of endemic cichlid species toward extinction in one of the fastest vertebrate collapses ever recorded, and processing the oily perch (unlike the old sun-dried catch) demanded firewood, accelerating shoreline deforestation and, with nutrient runoff, algal blooms and dead zones. Cover the boom that was real, the ecological and social bill that came due, and the lesson: adding one profitable piece to an ecosystem is not addition — it is rewriting the whole web. Figures are approximate.'
+  category: classic
+  produced: false
+  episode_number: null
+  produced_date: null
 - id: bail-reform-tradeoffs
   title: 'Bail Reform and the Law of Second Effects'
   brief: 'Cash bail was criticized for decades for jailing poor defendants who hadn''t been convicted, so reform movements pushed to eliminate or restrict it — a genuine equity goal. The rollout produced fierce, contested debate about second-order effects: critics pointed to specific re-offense cases and rising unease, supporters pointed to data showing little change in overall crime and thousands kept out of pretrial detention. Cover the original injustice, the reform designs (New Jersey, New York, California), the difficulty of cleanly measuring the consequences amid a pandemic crime wave, and the honest lesson that removing a flawed mechanism forces you to design its replacement carefully — and to measure, not assume. Treat all claims as contested and figures approximate.'
@@ -496,9 +482,37 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: subsidized-corn-syrup
-  title: 'Cheap Corn: How a Farm Subsidy Sweetened Everything'
-  brief: 'Decades of US farm policy encouraged massive corn overproduction to stabilize farm income and secure the food supply — a New Deal-era goal that succeeded. A cascade of unintended consequences followed: super-cheap corn found its way into high-fructose corn syrup that displaced sugar across the processed-food supply, into feedlot beef, and into ethanol mandates. Cover the subsidy machinery, the surprising path from a farm-income program to the sweetener in nearly every packaged product, the contested links to dietary shifts, and the lesson that subsidizing an input reshapes an entire downstream economy in ways no one legislated. Treat the health links as contested and figures approximate.'
+- id: antibiotics-in-livestock
+  title: 'Growth Promoters: Antibiotics on the Farm'
+  brief: 'Starting in the 1950s, farmers discovered that low doses of antibiotics in animal feed made livestock grow faster and cheaper — a boon that helped make meat affordable for a generation. The unintended consequence was a vast reservoir of antibiotic exposure that accelerated resistance in bacteria, some of which reach humans through food and the environment; the majority of antibiotics sold in some countries went to animals, not people. Cover the economics that drove adoption, the resistance science, the regulatory pushback (EU bans, US voluntary phase-outs), and the honest complexity of separating farm use from hospital overuse in the resistance story. Treat figures as approximate.'
+  category: medicine
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: cigarette-filters
+  title: The Filter Illusion
+  brief: 'Filters were added to cigarettes in the 1950s as a health reassurance amid the first cancer studies — and marketed exactly that way. Smokers responded by inhaling more deeply and smoking more of the cigarette; internal industry documents later showed companies knew filters'' protective value was largely illusory, and some designs (ventilation holes smokers'' fingers covered) made measured "tar" numbers meaningless. Bonus consequence: cellulose-acetate filters became one of the most littered plastic items on Earth. Lesson: a safety feature that changes behavior can cancel itself — and a reassuring signal can do harm a plain warning would not.'
+  category: economics
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: africanized-killer-bees
+  title: The Bees That Escaped the Lab
+  brief: 'In 1950s Brazil, researchers crossbred European honeybees with an African subspecies hoping to build a bee better suited to the tropics and more productive for local beekeepers — a sensible agricultural improvement. In 1957 a couple dozen swarms escaped, and the hybrids proved not just hardy but intensely defensive, spreading across South and Central America and into the southern United States over the following decades, displacing gentler bees and causing rare but real human and livestock deaths that earned the "killer bee" headlines. Be honest in both directions — the bees are also vigorous foragers and pollinators — and land the lesson: when you breed for one trait in a living thing that can reproduce and travel on its own, containment, not just the trait, is the hard problem. Treat figures as approximate.'
+  category: classic
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: seatbelt-risk-compensation
+  title: 'Seatbelts and the Risk Thermostat'
+  brief: 'Mandatory seatbelt laws unambiguously save the lives of the people wearing them — that part is settled. But economists studying the rollout raised a subtler, contested effect: "risk compensation," the idea that feeling safer leads some drivers to drive a little faster or less carefully, potentially shifting risk onto pedestrians and cyclists. Cover the clear occupant-safety win, the Peltzman-effect debate and the messy evidence for and against it, and the broader lesson that safety interventions can change behavior in ways that partly offset them — a hypothesis worth taking seriously without overstating. Be scrupulously honest that the net effect of seatbelts is strongly positive; the interesting story is the behavioral wrinkle. Treat figures as approximate.'
+  category: policy
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: open-plan-offices
+  title: Tearing Down the Walls
+  brief: 'Open-plan offices were sold for decades as collaboration machines — and as a happy coincidence, they cut real-estate cost per employee. Then researchers measured what actually happened: a 2018 Harvard study using sociometric badges found face-to-face interaction DROPPED roughly 70% after walls came down, with electronic messaging rising to compensate, while noise and surveillance effects pushed workers into headphones. Cover the Bürolandschaft origins, the cost story hiding inside the collaboration story, and the lesson: when a design''s stated goal and its budget benefit point the same direction, audit which one is driving.'
   category: economics
   produced: false
   episode_number: null
@@ -510,10 +524,10 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
-- id: y2k-preparedness-paradox
-  title: 'Y2K: The Disaster That Didn''t Happen'
-  brief: 'The Year 2000 computer bug — decades of software storing years as two digits — threatened to crash systems worldwide at midnight. Governments and companies spent an estimated $300-plus billion remediating code. Almost nothing broke, which produced a peculiar unintended consequence: many concluded the threat had been overblown or fake, when the more defensible reading is that massive quiet effort prevented the failures. Cover the real technical risk, the enormous remediation, the "prevention paradox" (success looks like nothing happened, so it gets no credit), and the lesson about how invisible averted disasters distort our judgment of which threats were ever real. Treat figures as approximate.'
-  category: tech
+- id: subsidized-corn-syrup
+  title: 'Cheap Corn: How a Farm Subsidy Sweetened Everything'
+  brief: 'Decades of US farm policy encouraged massive corn overproduction to stabilize farm income and secure the food supply — a New Deal-era goal that succeeded. A cascade of unintended consequences followed: super-cheap corn found its way into high-fructose corn syrup that displaced sugar across the processed-food supply, into feedlot beef, and into ethanol mandates. Cover the subsidy machinery, the surprising path from a farm-income program to the sweetener in nearly every packaged product, the contested links to dietary shifts, and the lesson that subsidizing an input reshapes an entire downstream economy in ways no one legislated. Treat the health links as contested and figures approximate.'
+  category: economics
   produced: false
   episode_number: null
   produced_date: null
@@ -521,20 +535,6 @@ queue:
   title: 'Loving a Place to Death: Overtourism'
   brief: 'Cheap flights, cruise ships, and social-media geotagging democratized travel to once-remote wonders — Venice, Machu Picchu, Icelandic waterfalls, Maya Bay — a genuine good that spread the joy of the world''s treasures. The unintended consequence was overtourism: crowds that erode the very thing they came to see, price out local residents, strain water and waste systems, and degrade fragile ecosystems, forcing closures and visitor caps. Cover the accessibility that everyone wanted, the tipping point where volume destroys value, the specific interventions (Maya Bay''s closure, Venice''s day-tripper fee), and the lesson that a shared resource with no gatekeeping trends toward its own ruin. Treat figures as approximate.'
   category: economics
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: seatbelt-risk-compensation
-  title: 'Seatbelts and the Risk Thermostat'
-  brief: 'Mandatory seatbelt laws unambiguously save the lives of the people wearing them — that part is settled. But economists studying the rollout raised a subtler, contested effect: "risk compensation," the idea that feeling safer leads some drivers to drive a little faster or less carefully, potentially shifting risk onto pedestrians and cyclists. Cover the clear occupant-safety win, the Peltzman-effect debate and the messy evidence for and against it, and the broader lesson that safety interventions can change behavior in ways that partly offset them — a hypothesis worth taking seriously without overstating. Be scrupulously honest that the net effect of seatbelts is strongly positive; the interesting story is the behavioral wrinkle. Treat figures as approximate.'
-  category: policy
-  produced: false
-  episode_number: null
-  produced_date: null
-- id: dam-removal-salmon
-  title: 'Tearing Down the Dams We Built'
-  brief: 'Twentieth-century dams delivered power, irrigation, and flood control — real benefits that built the American West and beyond. But many also blocked salmon and other migratory fish from spawning grounds, collapsing fisheries and the ecosystems and cultures that depended on them, an unintended consequence that took decades to fully register. Now some of those dams are being removed at great expense (the Klamath, the Elwha) to restore rivers. Cover the original benefits, the ecological blockade nobody priced, the surprising modern reversal of deliberately undoing major infrastructure, and the lesson that the full cost of an intervention can take a generation to surface — and even longer to unwind. Treat figures as approximate.'
-  category: infrastructure
   produced: false
   episode_number: null
   produced_date: null

--- a/tests/test_editorial_pass_fixes.py
+++ b/tests/test_editorial_pass_fixes.py
@@ -1,0 +1,420 @@
+"""Drift guards for the July 2026 network-wide editorial pass fixes.
+
+Covers (each verified against shipped episodes by review agents):
+1. Comma-blind currency/ordinal normalization (assets/pronunciation.py) —
+   the shipped-input regressions live in tests/test_pronunciation.py; here
+   we pin the end-to-end prepare_text_for_tts path.
+2. Missing-closing guard fuzzy signature match (engine/pipeline.py) — the
+   literal check double-appended the closing on 5 of 15 MAB episodes.
+3. Expansion-retry paraphrase-duplication dedup (engine/generator.py) —
+   M&A Ep087 shipped verbatim doubled sentences in audio.
+4. "Source:" scaffold line scrub in the script-save path (run_show.py) —
+   FP Ep059 voiced "Сорс MoneySense…".
+6. Phonetic-garble restore additions (engine/utils.py).
+7. Review-snapshot blind spots (scripts/review_snapshot.py) — Cyrillic-blind
+   tic detector; final-chapter-not-Closing shape check.
+8. Spoken-URL tripwire (run_show.py) — MAB Ep081 read a Reddit permalink
+   letter-by-letter on air.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _load_script(name):
+    spec = importlib.util.spec_from_file_location(
+        name, PROJECT_ROOT / "scripts" / f"{name}.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# 1. Comma-grouped currency/ordinals through the full TTS-prep path
+# ---------------------------------------------------------------------------
+
+class TestCommaNormalizationEndToEnd:
+    def test_tesla_hook_price_and_milestone(self):
+        from assets.pronunciation import prepare_text_for_tts
+
+        out = prepare_text_for_tts(
+            "Tesla cut the Model Y to $59,990 and delivered its 1,000th "
+            "Cybertruck, with a cheaper trim under $20,000 planned."
+        )
+        assert "fifty-nine thousand nine hundred ninety dollars" in out
+        assert "twenty thousand dollars" in out
+        assert "one thousandth" in out
+        # None of the shipped garble shapes may survive.
+        assert "dollars,990" not in out
+        assert "dollars,000" not in out
+        assert "zeroth" not in out
+
+    def test_spacex_landing_milestone(self):
+        from assets.pronunciation import prepare_text_for_tts
+
+        out = prepare_text_for_tts("Falcon 9 notched its 1,500th landing.")
+        assert "one thousand five hundredth" in out
+        assert "1," not in out
+
+
+# ---------------------------------------------------------------------------
+# 2. Missing-closing guard: fuzzy signature match (engine/pipeline.py)
+# ---------------------------------------------------------------------------
+
+class TestClosingGuardFuzzyMatch:
+    """The June-10 guard compared the closing's first-5-words signature
+    LITERALLY, so the LLM's de-contracted "And that is a wrap!" missed and
+    the guard appended the ENTIRE closing again — 5 of 15 MAB episodes
+    shipped the closing spoken twice (Ep075/076/077/079/084)."""
+
+    CLOSING = (
+        "And that's a wrap! If you enjoyed today's episode, subscribe "
+        "wherever you get your podcasts and share it with a friend."
+    )
+    BODY = (
+        "Today we looked at three model releases and what they mean for "
+        "developers building agents. " * 10
+    )
+
+    def test_exact_closing_is_present(self):
+        from engine.pipeline import closing_block_present
+
+        script = self.BODY + "\n\n" + self.CLOSING
+        assert closing_block_present(script, self.CLOSING) is True
+
+    def test_decontracted_closing_is_present_not_appended(self):
+        from engine.pipeline import closing_block_present
+
+        # The MAB double-closing class: LLM expands "that's" → "that is".
+        script = self.BODY + (
+            "\n\nAnd that is a wrap! If you enjoyed today's episode, "
+            "subscribe wherever you get your podcasts and share it with "
+            "a friend."
+        )
+        assert closing_block_present(script, self.CLOSING) is True
+
+    def test_punctuation_variant_is_present(self):
+        from engine.pipeline import closing_block_present
+
+        script = self.BODY + (
+            "\n\nAnd that's a wrap — if you enjoyed today's episode, "
+            "subscribe wherever you get your podcasts, and share it with "
+            "a friend!"
+        )
+        assert closing_block_present(script, self.CLOSING) is True
+
+    def test_recontracted_closing_is_present(self):
+        from engine.pipeline import closing_block_present
+
+        # Reverse drift: supplied closing de-contracted, LLM contracts it.
+        closing = "And that is a wrap! If you enjoyed today's episode, share it."
+        script = self.BODY + "\n\nAnd that's a wrap! If you enjoyed today's episode, share it."
+        assert closing_block_present(script, closing) is True
+
+    def test_host_prefix_on_closing_is_ignored(self):
+        from engine.pipeline import closing_block_present
+
+        script = self.BODY + "\n\n" + self.CLOSING
+        assert closing_block_present(script, "Host: " + self.CLOSING) is True
+
+    def test_genuinely_absent_closing_triggers_append(self):
+        from engine.pipeline import closing_block_present
+
+        # PT Ep084 class: episode ends mid-teaser with no sign-off.
+        script = self.BODY + "\n\nTomorrow we dig into the new benchmark suite."
+        assert closing_block_present(script, self.CLOSING) is False
+
+    def test_similar_words_but_different_closing_is_absent(self):
+        from engine.pipeline import closing_block_present
+
+        script = self.BODY + "\n\nThanks for listening and see you next time."
+        assert closing_block_present(script, self.CLOSING) is False
+
+    def test_empty_inputs(self):
+        from engine.pipeline import closing_block_present
+
+        assert closing_block_present("", self.CLOSING) is False
+        assert closing_block_present(self.BODY, "") is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Expansion-retry paraphrase-duplication dedup (engine/generator.py)
+# ---------------------------------------------------------------------------
+
+_DISTINCT_SENTENCES = [
+    "Sui deployed Seal MPC on mainnet, bringing threshold encryption to decentralized apps.",
+    "Meanwhile the robotics lab in Zurich published a dexterity benchmark using cheap hobby servos.",
+    "A separate filing shows the chip startup raised forty million dollars at a flat valuation.",
+    "Regulators in Brussels opened a consultation on synthetic media labeling for election ads.",
+    "The open-weights release ships with a permissive license and a sixteen-language tokenizer.",
+    "Battery researchers at Dalhousie reported a dry-electrode cathode that survives long cycling.",
+    "One hospital network cut transcription costs by piping visits through an on-premise model.",
+    "The maintainers of the popular inference server merged speculative decoding support overnight.",
+]
+
+
+class TestExpansionRetryDedup:
+    def test_doubled_sentences_are_stripped(self):
+        from engine.generator import _dedup_expansion_sentences
+
+        original = " ".join(_DISTINCT_SENTENCES)
+        # M&A Ep087 class: the "expansion" re-states what it already wrote.
+        expanded = original + " " + original
+        deduped, removed = _dedup_expansion_sentences(expanded)
+        assert removed == len(_DISTINCT_SENTENCES)
+        assert deduped.count("Sui deployed Seal MPC on mainnet") == 1
+
+    def test_near_paraphrase_is_stripped(self):
+        from engine.generator import _dedup_expansion_sentences
+
+        expanded = (
+            "Sui deployed Seal MPC on mainnet, bringing threshold encryption "
+            "to decentralized apps. "
+            + _DISTINCT_SENTENCES[1] + " "
+            + "Sui has deployed Seal MPC on mainnet, bringing threshold "
+            "encryption to decentralized applications."
+        )
+        deduped, removed = _dedup_expansion_sentences(expanded)
+        assert removed == 1
+        assert deduped.count("Seal MPC") == 1
+
+    def test_legit_expansion_passes_through_untouched(self):
+        from engine.generator import _dedup_expansion_sentences
+
+        expanded = "\n\n".join(_DISTINCT_SENTENCES)
+        deduped, removed = _dedup_expansion_sentences(expanded)
+        assert removed == 0
+        assert deduped == expanded  # order + paragraph structure preserved
+
+    def test_short_rhetorical_beats_survive(self):
+        from engine.generator import _dedup_expansion_sentences
+
+        expanded = (
+            _DISTINCT_SENTENCES[0] + " Not bad, right? "
+            + _DISTINCT_SENTENCES[1] + " Not bad, right?"
+        )
+        deduped, removed = _dedup_expansion_sentences(expanded)
+        assert removed == 0
+        assert deduped.count("Not bad, right?") == 2
+
+    def test_degenerate_expansion_falls_back_to_original(self, monkeypatch):
+        """End-to-end: an expansion that only re-states the original must
+        NOT be accepted — the original script ships instead."""
+        from types import SimpleNamespace
+        from engine import generator as gen
+
+        original = " ".join(_DISTINCT_SENTENCES)  # ~110 words, well below target
+        calls = []
+
+        def fake_call_grok(prompt, **kwargs):
+            calls.append(prompt)
+            if len(calls) == 1:
+                return original, {"finish_reason": "stop"}
+            # Paraphrase-padding: the same script, stated twice.
+            return original + " " + original, {"finish_reason": "stop"}
+
+        monkeypatch.setattr(gen, "_call_grok", fake_call_grok)
+        monkeypatch.setattr(gen, "load_prompt", lambda *a, **k: "PROMPT")
+
+        config = SimpleNamespace(
+            name="Models & Agents",
+            llm=SimpleNamespace(
+                model="grok-4.3", podcast_prompt_file="x",
+                system_prompt_file="", podcast_temperature=0.7,
+                max_tokens=5000, podcast_max_tokens=10000,
+                min_podcast_words=1500, podcast_expand_below_target=True,
+                podcast_chain=False,
+            ),
+        )
+        result = gen.generate_podcast_script(
+            {"digest": "Top stories...", "episode_num": 87}, config,
+        )
+        assert len(calls) >= 2, "expansion retry did not fire"
+        # The doubled restatement must never ship.
+        assert result.count("Sui deployed Seal MPC on mainnet") == 1
+        # And the original (not a truncated dedup residue) was kept.
+        assert len(result.split()) <= len(original.split()) + 5
+
+
+# ---------------------------------------------------------------------------
+# 4. "Source:" scaffold lines never reach TTS (run_show.py)
+# ---------------------------------------------------------------------------
+
+class TestSourceScaffoldScrub:
+    def test_source_label_lines_dropped(self):
+        from run_show import _strip_source_scaffold_lines
+
+        script = (
+            "Great story about mortgage renewals today.\n"
+            "Source: MoneySense\n"
+            "Sources: Reuters, AP\n"
+            "**Source:** The Globe and Mail\n"
+            "- Source: BNN Bloomberg\n"
+            "Источник: РБК\n"
+            "Источники: Ведомости, Коммерсант\n"
+            "More prose follows here."
+        )
+        out = _strip_source_scaffold_lines(script)
+        assert "MoneySense" not in out
+        assert "Reuters" not in out
+        assert "Globe and Mail" not in out
+        assert "BNN Bloomberg" not in out
+        assert "РБК" not in out
+        assert "Ведомости" not in out
+        assert "Great story about mortgage renewals today." in out
+        assert "More prose follows here." in out
+
+    def test_prose_mentioning_sources_is_kept(self):
+        from run_show import _strip_source_scaffold_lines
+
+        script = (
+            "The source: a leaked memo — is worth naming.\n"
+            "Analysts trace the source of the rally to short covering.\n"
+            "According to three sources, the deal closed Friday."
+        )
+        # Only lines BEGINNING with the bare label are scaffold; the first
+        # line here starts with "The", so all three survive.
+        assert _strip_source_scaffold_lines(script) == script
+
+
+# ---------------------------------------------------------------------------
+# 6. Phonetic-garble restore additions (engine/utils.py)
+# ---------------------------------------------------------------------------
+
+class TestJulyGarbleAdditions:
+    def test_new_garbles_restored(self):
+        from engine.utils import fix_phonetic_garbles
+
+        assert fix_phonetic_garbles("Mee-stral shipped a new model.") == (
+            "Mistral shipped a new model."
+        )
+        assert fix_phonetic_garbles("as Kar-pathy noted on stream") == (
+            "as Karpathy noted on stream"
+        )
+        assert fix_phonetic_garbles("Mid-journey's new render mode") == (
+            "Midjourney's new render mode"
+        )
+        assert fix_phonetic_garbles("a deal with Notpower for storage") == (
+            "a deal with NatPower for storage"
+        )
+
+    def test_case_insensitive(self):
+        from engine.utils import fix_phonetic_garbles
+
+        assert fix_phonetic_garbles("MEE-STRAL and KAR-PATHY") == (
+            "Mistral and Karpathy"
+        )
+
+    def test_correct_spellings_untouched(self):
+        from engine.utils import fix_phonetic_garbles
+
+        text = "Mistral, Karpathy, Midjourney, and NatPower are all fine."
+        assert fix_phonetic_garbles(text) == text
+
+
+# ---------------------------------------------------------------------------
+# 7. Review-snapshot blind spots (scripts/review_snapshot.py)
+# ---------------------------------------------------------------------------
+
+class TestSnapshotCyrillicTicDetector:
+    def test_russian_template_phrase_detected(self):
+        snap = _load_script("review_snapshot")
+        template = (
+            "Спасибо, что провели это время со мной, и до новой встречи "
+            "в следующем выпуске подкаста."
+        )
+        fillers = [
+            "Сегодня мы обсуждали ипотеку и ставки по кредитам.",
+            "Сегодня мы говорили про детский вычет и налоги.",
+            "Сегодня разобрали страхование жизни и полисы.",
+            "Сегодня тема выпуска пенсионные накопления и взносы.",
+            "Сегодня речь шла о бюджете семьи и планировании.",
+            "Сегодня новый разговор об инвестициях и фондах.",
+            "Сегодня выпуск о сбережениях и подушке безопасности.",
+            "Сегодня подробно о кредитных картах и кэшбэке.",
+        ]
+        texts = [f"{filler} {template}" for filler in fillers]
+        phrases = [p for p, _ in snap.find_repeated_ngrams(texts)]
+        assert any("спасибо" in p or "до новой встречи" in p for p in phrases), (
+            f"Cyrillic template not detected; got: {phrases}"
+        )
+
+    def test_tokenizer_is_unicode_aware(self):
+        snap = _load_script("review_snapshot")
+        toks = snap._tokens("Спасибо, что слушали — that's all folks!")
+        assert "спасибо" in toks
+        assert "слушали" in toks
+        assert "that's" in toks
+
+
+class TestSnapshotFinalChapterCheck:
+    def test_final_non_closing_chapter_flagged(self):
+        snap = _load_script("review_snapshot")
+        chapters = [
+            {"title": "Introduction"},
+            {"title": "Compliance Brief"},
+            {"title": "Week Ahead"},  # EI Ep049-051 class: no Closing at all
+        ]
+        issues = " ".join(snap.chapter_issues(chapters))
+        assert "final chapter is not a Closing" in issues
+
+    def test_closing_last_is_clean(self):
+        snap = _load_script("review_snapshot")
+        chapters = [
+            {"title": "Introduction"},
+            {"title": "Compliance Brief"},
+            {"title": "Tomorrow Teaser"},
+            {"title": "Closing"},
+        ]
+        assert snap.chapter_issues(chapters) == []
+
+    def test_outro_accepted_as_closing_synonym(self):
+        snap = _load_script("review_snapshot")
+        chapters = [{"title": "Introduction"}, {"title": "Outro"}]
+        assert snap.chapter_issues(chapters) == []
+
+
+# ---------------------------------------------------------------------------
+# 8. Spoken-URL tripwire (run_show.py)
+# ---------------------------------------------------------------------------
+
+class TestSpokenUrlTripwire:
+    def test_reddit_permalink_detected(self):
+        from run_show import _count_spoken_urls
+
+        # MAB Ep081 class: a full permalink in spoken form.
+        assert _count_spoken_urls(
+            "the thread is at reddit dot com/r/LocalLLaMA/comments/abc123"
+        ) == 1
+        assert _count_spoken_urls(
+            "head to reddit dot com slash r slash LocalLLaMA for details"
+        ) == 1
+
+    def test_bare_spoken_domains_detected(self):
+        from run_show import _count_spoken_urls
+
+        text = "compare huggingface dot co — sorry, huggingface dot com and github dot io"
+        assert _count_spoken_urls(text) == 2
+
+    def test_network_cta_domain_excluded(self):
+        from run_show import _count_spoken_urls
+
+        assert _count_spoken_urls(
+            "Find every show, free, at nerranetwork dot com."
+        ) == 0
+        assert _count_spoken_urls(
+            "Find every show, free, at nerra network dot com."
+        ) == 0
+
+    def test_plain_prose_clean(self):
+        from run_show import _count_spoken_urls
+
+        assert _count_spoken_urls(
+            "Connect the dots: communities online drive adoption."
+        ) == 0

--- a/tests/test_env_intel_quality_pass.py
+++ b/tests/test_env_intel_quality_pass.py
@@ -66,9 +66,21 @@ class TestChapterPositionalAnchors:
     def test_introduction_anchored_to_start(self):
         assert _markers()["Introduction"].get("where") == "start"
 
-    def test_closing_and_teaser_anchored_to_end(self):
+    def test_closing_unanchored_and_teaser_anchored_to_end(self):
+        """July 2 2026: Closing deliberately carries NO `where: end` anymore.
+        The parser's end window (last 15%) EXCLUDED the closing line itself
+        on short episodes (Ep049 word 539 vs window 555; Ep050 730 vs 738;
+        Ep051 676 vs 685 — EI's sign-off + promo + disclosure block runs
+        ~120-140 words on a ~650-870-word episode), which is why those
+        episodes shipped with no Closing chapter. The brand-anchored
+        pattern ("That's/That covers today's Environmental Intelligence")
+        provides the positional safety instead."""
         by = _markers()
-        assert by["Closing"].get("where") == "end"
+        assert not by["Closing"].get("where"), (
+            "Closing must NOT be `where: end` — the last-15% window "
+            "excludes EI's early-starting closing block on short episodes "
+            "(the Ep049/050/051 orphan-Closing bug)"
+        )
         assert by["Tomorrow Teaser"].get("where") == "end"
 
     def test_closing_pattern_matches_every_closing_variant(self):
@@ -229,6 +241,92 @@ class TestDeepDiveOpenerNotTic:
         # the old verbatim transition must no longer be the sole seeded option
         assert "vary the lead-in" in prompt
         assert "avoid starting every deep dive" in prompt
+
+
+class TestChapterClosingOrderingJuly2:
+    """July 2 2026 pass (orphan-Closing variant 3, the EI June-11 /
+    SpaceX June-18 / FF June-24 ordering class). Ep049/050/051 shipped
+    with NO Closing chapter: unconsumed BODY markers ate the closing
+    paragraph — `science|technical` matched the network promo "…covering
+    tech, science, markets" (Ep049/051) and bare `deep dive` matched the
+    Tesla cross-promo "daily deep dive into everything Tesla" (Ep050).
+    Fixes pinned here: Closing + Tomorrow Teaser listed BEFORE all body
+    markers; the Science & Technical pattern can't match the promos or
+    "geotechnical"; the Practitioner Deep Dive pattern dropped bare
+    `deep dive`/`under the hood` and anchors on the section's signature
+    "most common mistake" beat; and the five real committed episodes
+    re-parse to a shape that ends on Closing."""
+
+    _BODY_TITLES = (
+        "Executive Summary", "Lead Story", "Regulatory & Policy Watch",
+        "Science & Technical", "Industry & Practice",
+        "Practitioner Deep Dive", "Action Items", "Week Ahead",
+    )
+
+    def test_closing_and_teaser_listed_before_all_body_markers(self):
+        titles = [m["title"] for m in _marker_list()]
+        first_body = min(titles.index(t) for t in self._BODY_TITLES)
+        assert titles.index("Closing") < first_body, (
+            "Closing must precede every body marker so an unconsumed body "
+            "marker can't steal the closing paragraph (Ep049/050/051)"
+        )
+        assert titles.index("Tomorrow Teaser") < first_body
+
+    def test_science_pattern_cannot_match_closing_promos(self):
+        rx = re.compile(_markers()["Science & Technical"]["pattern"], re.IGNORECASE)
+        promos = [
+            "a family of daily podcasts covering tech, science, markets, and more.",
+            "a family of daily podcasts on tech, science, and markets, each one a short briefing.",
+            "give Planetterrian Daily a listen: daily breakthroughs in science, health, and longevity.",
+            "Fascinating Frontiers, the most fascinating news from space and science. Find every show at nerranetwork dot com.",
+            "Your briefing on environmental regulatory, science, and compliance developments.",
+        ]
+        for promo in promos:
+            assert not rx.search(promo), f"promo must not open a Science & Technical chapter: {promo!r}"
+
+    def test_science_pattern_still_matches_real_section_not_geotechnical(self):
+        rx = re.compile(_markers()["Science & Technical"]["pattern"], re.IGNORECASE)
+        # The real spoken section label (Ep048).
+        assert rx.search("In Science and Technical, a long-term grassland experiment examined soils.")
+        # "geotechnical" mid-story created false chapters (Ep047/Ep050).
+        assert not rx.search("citing improved geotechnical stability and reduced disturbance")
+
+    def test_deep_dive_pattern_cannot_match_tesla_cross_promo(self):
+        rx = re.compile(_markers()["Practitioner Deep Dive"]["pattern"], re.IGNORECASE)
+        assert not rx.search(
+            "here's your next listen — Tesla Shorts Time, your daily deep dive into everything Tesla"
+        )
+        assert not rx.search("let's go under the hood")
+        # Signature deep-dive beat, present in 7/7 recent episodes.
+        assert rx.search("The mistake I see most often is treating glacial lake risks separately.")
+        assert rx.search("the most common mistake is skipping the vapour pathway check")
+
+    def test_closing_pattern_tolerates_curly_apostrophe(self):
+        rx = re.compile(_markers()["Closing"]["pattern"], re.IGNORECASE)
+        assert rx.search("That’s Environmental Intelligence for today.")
+        assert rx.search("That's Environmental Intelligence for today.")
+        assert rx.search("That covers today's environmental intelligence.")
+
+    def test_real_committed_episodes_reparse_ends_on_closing(self):
+        """Re-parse the actual shipped scripts (the FF June-24
+        TestChapterClosingOrdering method): every episode must start on
+        Introduction and end on Closing — Ep049/050/051 previously ended
+        on a bogus Science & Technical / Practitioner Deep Dive chapter
+        opened by the closing promos."""
+        markers = [_Marker(m) for m in _marker_list()]
+        scripts = sorted((_ROOT / "digests/env_intel").glob("Env_Intel_Ep0*_tts.txt"))
+        scripts = [p for p in scripts if any(
+            f"Ep{ep}_" in p.name for ep in ("047", "048", "049", "050", "051"))]
+        if not scripts:
+            pytest.skip("EI Ep047-051 scripts not present")
+        for p in scripts:
+            titles = [c.title for c in parse_chapters(
+                p.read_text(encoding="utf-8"), markers, show_name="env_intel")]
+            assert titles, f"{p.name}: no chapters parsed"
+            assert titles[0] == "Introduction", f"{p.name}: {titles}"
+            assert titles[-1] == "Closing", (
+                f"{p.name} must end on a Closing chapter; got {titles}"
+            )
 
 
 class TestUnifiedLengthTarget:

--- a/tests/test_fascinating_frontiers_quality_pass.py
+++ b/tests/test_fascinating_frontiers_quality_pass.py
@@ -143,6 +143,74 @@ class TestStockMarketTitleFilter:
         assert "NO STOCK / MARKET ITEMS" in txt
 
 
+class TestEphemerisTitleFilterAndFreshness:
+    """July 2 2026 pass. (1) Nightly-ephemeris almanac items kept slipping
+    past the calendar/sky-tonight filters — "Moon Passes Near the Sickle of
+    Leo Tonight" (Ep105), "Mars passes within 5 degrees of the Pleiades"
+    (Ep114), "Neptune reaches 30 degrees altitude before dawn" (Ep117),
+    "Venus Shines Beneath Leo's Sickle This Evening" (Ep118). The new
+    pattern anchors on a planet/Moon SUBJECT + almanac verb; verified
+    against all 180 story titles in the June 18-July 2 digests (5 drops,
+    all ephemeris; zero real-news drops). (2) content_freshness
+    lookback_days 2 -> 7: the 2-day window let Ep116 re-run 4 stories
+    already aired within the week."""
+
+    @staticmethod
+    def _cfg():
+        return yaml.safe_load(
+            (REPO / "shows/fascinating_frontiers.yaml").read_text(encoding="utf-8")
+        )
+
+    EPHEMERIS_TITLES = [
+        "Moon Passes Near the Sickle of Leo Tonight — Astronomy Magazine",
+        "Mars passes within 5 degrees of the Pleiades cluster",
+        "Neptune reaches 30 degrees altitude before dawn in Pisces",
+        "Venus Shines Beneath Leo’s Sickle This Evening — Astronomy Magazine",
+        # Same almanac class, shipped Ep112:
+        "Saturn’s moon Iapetus passes north of the ringed planet — Astronomy Magazine",
+    ]
+
+    KEEP_TITLES = [
+        # subject is not a planet — real news (FF June-16 false-drop lesson:
+        # never use a bare "passes near").
+        "A sizable asteroid is set to pass Earth this weekend",
+        # planet subject but not an almanac verb — real science.
+        "Mars may host large subsurface magma systems",
+        "Uranus and Neptune May Contain Magma Oceans Instead of Icy Mantles — Universe Today",
+        "Perseverance confirms organic carbon in Bright Angel rocks on Mars — Phys.org",
+        # planet mid-title with an almanac-ish verb elsewhere — anchor must hold.
+        "NASA Shares Stunning New View of Jupiter's Aurora",
+        "Star TOI-5882 shows evidence it recently swallowed a planet — Universe Today",
+    ]
+
+    def test_drops_ephemeris_titles(self):
+        from engine.utils import drop_excluded_titles
+        pats = self._cfg().get("exclude_title_patterns", [])
+        kept, dropped = drop_excluded_titles(
+            [{"title": t} for t in self.EPHEMERIS_TITLES], pats)
+        assert dropped == len(self.EPHEMERIS_TITLES), (
+            f"survivors: {[a['title'] for a in kept]}"
+        )
+
+    def test_keeps_real_news_titles(self):
+        from engine.utils import drop_excluded_titles
+        pats = self._cfg().get("exclude_title_patterns", [])
+        kept, dropped = drop_excluded_titles(
+            [{"title": t} for t in self.KEEP_TITLES], pats)
+        survivors = [a["title"] for a in kept]
+        assert dropped == 0, (
+            "ephemeris filter over-dropped real news: "
+            f"{[t for t in self.KEEP_TITLES if t not in survivors]}"
+        )
+
+    def test_content_freshness_lookback_is_a_week(self):
+        cf = self._cfg().get("content_freshness", {})
+        assert cf.get("lookback_days", 0) >= 7, (
+            "lookback_days regressed below 7 — a 2-day window let Ep116 "
+            "re-run 4 stories already aired within the week"
+        )
+
+
 def _ff_markers():
     cfg = yaml.safe_load(
         (REPO / "shows/fascinating_frontiers.yaml").read_text(encoding="utf-8")

--- a/tests/test_mit_quality_pass.py
+++ b/tests/test_mit_quality_pass.py
@@ -78,16 +78,21 @@ class TestNaNImmunity:
         assert s["cumulative_alpha_vs_nasdaq"] == 3.0
         assert s["trades_with_alpha"] == 2
 
-    def test_close_trade_rejects_nan_prices(self):
+    def test_close_trade_voids_on_nan_prices(self):
+        # July 2026: a data-fetch failure now VOIDS the trade instead of
+        # recording a $0.00 breakeven close (which was counted in the
+        # record and later narrated as a real market outcome).
         trade = {"symbol": "DELL", "trade_type": "flash"}
         tracker = _tracker_with_trades([])
         with patch.object(mi, "_fetch_trade_prices",
                           return_value=(426.15, NAN)):
             mi._close_trade(trade, tracker)
-        assert trade["status"] == "closed"
+        assert trade["status"] == "voided"
+        assert trade["void_reason"] == "market_data_unavailable"
         assert trade["exit_price"] is None
-        assert trade["pnl_dollars"] == 0.0
-        assert "unavailable" in trade["lesson"].lower()
+        assert trade["pnl_pct"] is None
+        assert trade["pnl_dollars"] is None
+        assert "voided" in trade["lesson"].lower()
 
     def test_sector_exposure_finite(self):
         tracker = _tracker_with_trades([
@@ -96,6 +101,111 @@ class TestNaNImmunity:
         ])
         sectors = mi._compute_sector_exposure(tracker)
         assert math.isfinite(sectors["other"]["cumulative_pnl"])
+
+
+def _voided(symbol, sector="tech"):
+    return {
+        "symbol": symbol, "status": "voided",
+        "void_reason": "market_data_unavailable",
+        "entry_price": None, "exit_price": None,
+        "pnl_pct": None, "pnl_dollars": None, "alpha_pct": None,
+    }
+
+
+class TestVoidedTradesExcluded:
+    """July 2026 review: four trades (Ep74 XLF / Ep75 KO / Ep77 ROKU /
+    Ep79 ION) closed with null prices as $0.00 breakevens — counted in the
+    spoken record and later narrated as real market outcomes. Voided trades
+    must be excluded from every aggregation."""
+
+    def test_recompute_summary_ignores_voided(self):
+        tracker = _tracker_with_trades([
+            _closed("AAA", 10.0, 100.0, alpha=5.0),
+            _voided("XLF"),
+            _closed("CCC", -4.0, -40.0, alpha=-2.0),
+            _voided("KO"),
+        ])
+        mi._recompute_summary(tracker)
+        s = tracker["summary"]
+        # Only the two real closed trades count — not the voided pair.
+        assert s["total_trades"] == 2
+        assert s["breakeven"] == 0
+        assert s["cumulative_pnl"] == 60.0
+
+    def test_sector_exposure_ignores_voided(self):
+        tracker = _tracker_with_trades([
+            _closed("AAA", 5.0, 50.0, sector="tech"),
+            _voided("XLF", sector="financials"),
+        ])
+        sectors = mi._compute_sector_exposure(tracker)
+        assert "financials" not in sectors
+        assert sectors["tech"]["trade_count"] == 1
+
+    def test_trade_review_never_narrates_voided(self):
+        # The most recent trade is voided → it must not become the review.
+        tracker = _tracker_with_trades([
+            _closed("AAA", 8.0, 80.0, alpha=4.0),
+            _voided("ROKU"),
+        ])
+        # AAA is the only real closed trade; it becomes the review, not ROKU.
+        review = mi._build_trade_review(tracker, episode_num=90)
+        assert "ROKU" not in review
+        assert "AAA" in review
+
+    def test_committed_tracker_has_four_voided_and_37_closed(self):
+        import json
+        d = json.loads(
+            (_ROOT / "digests/modern_investing/investment_tracker.json").read_text())
+        voided = [t for t in d["trades"] if t.get("status") == "voided"]
+        closed = [t for t in d["trades"] if t.get("status") == "closed"]
+        voided_ids = {(t["episode_num"], t["symbol"]) for t in voided}
+        assert {(74, "XLF"), (75, "KO"), (77, "ROKU"), (79, "ION")} <= voided_ids
+        assert d["summary"]["total_trades"] == len(closed) == 37
+        # The migration recomputed derived numbers, not hand-edited them.
+        assert d["summary"]["breakeven"] == 3
+        for t in voided:
+            assert t["pnl_pct"] is None and t["pnl_dollars"] is None
+
+
+class TestDoubleReviewPrevented:
+    """The MU flash trade was re-narrated as 'yesterday's' on Ep089/091/093
+    because the review always picked the latest closed trade. Each result is
+    now reviewed exactly once via ``reviewed_in_episode``."""
+
+    def test_stamps_on_first_review(self):
+        tracker = _tracker_with_trades([_closed("MU", 3.0, 30.0, alpha=1.0)])
+        review = mi._build_trade_review(tracker, episode_num=89)
+        assert "MU" in review
+        assert tracker["trades"][-1]["reviewed_in_episode"] == 89
+
+    def test_no_re_review_next_episode(self):
+        trade = _closed("MU", 3.0, 30.0, alpha=1.0)
+        trade["reviewed_in_episode"] = 89
+        tracker = _tracker_with_trades([trade])
+        review = mi._build_trade_review(tracker, episode_num=91)
+        assert "MU" not in review
+        assert "pending" in review.lower()
+
+    def test_same_episode_rerun_still_reviews(self):
+        # Regenerating the SAME episode must still produce the review.
+        trade = _closed("MU", 3.0, 30.0, alpha=1.0)
+        trade["reviewed_in_episode"] = 91
+        tracker = _tracker_with_trades([trade])
+        review = mi._build_trade_review(tracker, episode_num=91)
+        assert "MU" in review
+
+    def test_open_hold_update_when_latest_already_reviewed(self):
+        reviewed = _closed("MU", 3.0, 30.0, alpha=1.0)
+        reviewed["reviewed_in_episode"] = 89
+        hold = {
+            "symbol": "NVDA", "status": "open",
+            "strategy": "momentum", "entry_price": 100.0,
+            "current_price": 105.0,
+        }
+        tracker = _tracker_with_trades([reviewed, hold])
+        review = mi._build_trade_review(tracker, episode_num=91)
+        assert "NVDA" in review
+        assert "Holding until Friday" in review
 
 
 class TestRecursiveLearningLoopAlive:

--- a/tests/test_network_quality_pass.py
+++ b/tests/test_network_quality_pass.py
@@ -205,6 +205,127 @@ class TestNarrativeQueueRunway:
         assert "concrete_example" in cats
         assert "opportunity_area" in cats
 
+    def test_first_principles_unproduced_alternates(self):
+        """July 2 2026 hygiene pass: the unproduced FP queue was
+        re-sequenced to alternate concrete_example / opportunity_area. The
+        produced tail ended on an opportunity_area (recycling-economics), so
+        the first unproduced entry must be a concrete_example, and adjacent
+        same-category pairs must stay at the theoretical minimum (the
+        |#C - #O| overflow that can't be interleaved away)."""
+        q = yaml.safe_load(
+            (_ROOT / "shows" / "topic_queues" / "first_principles.yaml").read_text(
+                encoding="utf-8"))["queue"]
+        seq = [e.get("category") for e in q if not e.get("produced")]
+        assert seq[0] == "concrete_example", seq[:3]
+        n_c = seq.count("concrete_example")
+        n_o = seq.count("opportunity_area")
+        same_adj = sum(1 for a, b in zip(seq, seq[1:]) if a == b)
+        assert same_adj <= abs(n_c - n_o), (
+            f"FP unproduced queue not minimally alternated: {same_adj} "
+            f"adjacent same-category pairs (C={n_c}, O={n_o}): {seq}"
+        )
+
+    def test_no_duplicate_topics_reintroduced(self):
+        """FP had true-duplicate unproduced entries — aluminum-electrolysis
+        (a second Hall-Héroult story), a second LED entry, and a second
+        heat-pump entry. They were removed; guard against re-adding them."""
+        q = yaml.safe_load(
+            (_ROOT / "shows" / "topic_queues" / "first_principles.yaml").read_text(
+                encoding="utf-8"))["queue"]
+        ids = {e["id"] for e in q}
+        for removed in ("aluminum-electrolysis", "led-lighting-cost-per-lumen",
+                        "heat-pumps-space-heating"):
+            assert removed not in ids, f"{removed} duplicate re-introduced"
+        # The kept canonical entries survive.
+        for kept in ("aluminum-hall-heroult", "lighthouse-led-efficiency",
+                     "air-conditioning-heat-pumps"):
+            assert kept in ids
+
+    def test_uc_biofuels_category_accurate(self):
+        """biofuels-deforestation was mislabeled category: medicine; it's a
+        policy-mandate backfire."""
+        q = yaml.safe_load(
+            (_ROOT / "shows" / "topic_queues" / "unintended_consequences.yaml").read_text(
+                encoding="utf-8"))["queue"]
+        b = next(e for e in q if e["id"] == "biofuels-deforestation")
+        assert b["category"] == "policy"
+
+    def test_uc_unproduced_interleaved_not_clustered(self):
+        """The window shipped 8 consecutive medicine then 5 consecutive
+        infrastructure episodes. The unproduced queue is now round-robin
+        interleaved — no long single-category run at the head."""
+        q = yaml.safe_load(
+            (_ROOT / "shows" / "topic_queues" / "unintended_consequences.yaml").read_text(
+                encoding="utf-8"))["queue"]
+        seq = [e.get("category") for e in q if not e.get("produced")]
+        # No 3-in-a-row of the same category anywhere before the dominant
+        # category's unavoidable tail overflow (economics = 10 of 33).
+        from collections import Counter
+        counts = Counter(seq)
+        dominant = counts.most_common(1)[0][0]
+        head = seq[: len(seq) - counts[dominant]]  # region before overflow can bite
+        runs = [sum(1 for _ in g) for _, g in __import__("itertools").groupby(head)]
+        assert max(runs, default=0) <= 1, f"clustered head: {seq}"
+
+
+class TestNoDuplicateFeedUrls:
+    """July 2 2026: Models & Agents subscribed arXiv cs.CL twice —
+    ``https://arxiv.org/rss/cs.CL`` (label "arXiv NLP") and
+    ``http://export.arxiv.org/rss/cs.CL`` (label "arXiv cs.CL"). Same feed,
+    double-weighted preprints (root cause of the arXiv flood that crowded
+    out Codex Record Replay / Gemini Computer Use). This guard normalizes
+    scheme + the export.arxiv.org host alias so a re-subscribed feed under a
+    different scheme/host can't slip back in.
+    """
+
+    # Pre-existing, out-of-scope duplicate on a show not owned by this pass
+    # (omni_view subscribes BBC News over both http and https). Recorded so
+    # this guard is meaningful network-wide without failing on a file this
+    # pass may not touch; the omni_view owner should collapse it. Any NEW
+    # duplicate — including a second one on omni_view — still fails.
+    _ALLOWED = {
+        "omni_view": {"feeds.bbci.co.uk/news/rss.xml"},
+    }
+
+    @staticmethod
+    def _norm(url: str) -> str:
+        import re
+        u = (url or "").strip().lower()
+        u = re.sub(r"^https?://", "", u)
+        u = u.replace("export.arxiv.org", "arxiv.org")
+        return u.rstrip("/")
+
+    def test_no_show_subscribes_the_same_feed_twice(self):
+        import glob
+        offenders = {}
+        for f in glob.glob(str(_ROOT / "shows" / "*.yaml")):
+            slug = Path(f).stem
+            cfg = yaml.safe_load(Path(f).read_text(encoding="utf-8")) or {}
+            seen = {}
+            for src in cfg.get("sources") or []:
+                if not isinstance(src, dict):
+                    continue
+                n = self._norm(src.get("url", ""))
+                if not n:
+                    continue
+                seen.setdefault(n, 0)
+                seen[n] += 1
+            allowed = self._ALLOWED.get(slug, set())
+            dups = [n for n, c in seen.items() if c > 1 and n not in allowed]
+            if dups:
+                offenders[slug] = dups
+        assert not offenders, f"duplicate feed URLs found: {offenders}"
+
+    def test_models_agents_has_single_cs_cl_feed(self):
+        cfg = _yaml("models_agents")
+        cs_cl = [
+            s for s in (cfg.get("sources") or [])
+            if isinstance(s, dict) and "cs.cl" in self._norm(s.get("url", ""))
+        ]
+        assert len(cs_cl) == 1, (
+            f"arXiv cs.CL must be subscribed exactly once; got {cs_cl}"
+        )
+
 
 class TestFinansyProstoCategoryFix:
     def test_youtube_category_is_education(self):

--- a/tests/test_planetterrian_quality_pass.py
+++ b/tests/test_planetterrian_quality_pass.py
@@ -125,6 +125,74 @@ class TestChapterShapeJune18:
         assert titles.index("Tomorrow Teaser") < titles.index("Closing")
 
 
+class TestAstronomyScopeFilter:
+    """July 2 2026 scope-drift backstop. Planetterrian is a life-science
+    show, but the shared science RSS feeds pushed pure-astronomy items the
+    LLM selection didn't reject — Ep094-107 shipped exoplanet clouds,
+    galaxy clusters, black holes, GRBs, Mars magma, comets, and a
+    Swift-telescope reboost, several DUPLICATING Fascinating Frontiers the
+    same day. A conservative fetch-side ``exclude_title_patterns`` drops
+    unambiguous astronomy/space-physics titles while preserving
+    astrobiology / in-space-biology / origin-of-life edge cases."""
+
+    @staticmethod
+    def _pats():
+        cfg = yaml.safe_load(
+            (_ROOT / "shows/planetterrian.yaml").read_text(encoding="utf-8"))
+        return cfg.get("exclude_title_patterns", []) or []
+
+    # The real astronomy titles PT shipped in the June 18-July 2 window.
+    ASTRO_TITLES = [
+        "Black hole winds strip star-forming gas from giant galaxies",
+        "Distant galaxy cluster shows unexpected maturity",
+        "Super-puff exoplanets exhibit densities lower than cotton candy",
+        "James Webb detects salty clouds on the pink exoplanet — Science Daily",
+        "Mars once held large magmatic systems like Earth’s — Phys.org",
+        "ExoMars rover tests prepare for 2030 Mars soil analysis",
+        "Ancient stellar flyby still influences long-period comets — Phys.org",
+        "Asteroid Donaldjohanson rotates on two axes, Lucy data show — Phys.org",
+        "Submillimeter Array captures earliest GRB observations at mm wavelengths — Phys.org",
+        "NASA prepares robotic mission to extend Swift telescope life — Phys.org",
+        "May 2024 superstorm drew most ring current ions from Earth rather than solar wind — Phys.org",
+        "Solar storms briefly suppress precipitation across North America — Phys.org",
+        "NASA selects mission to study space weather-atmosphere links",
+    ]
+
+    # Real life-science titles that MUST survive (deliberately including the
+    # astrobiology / in-space-biology / toxicology edge cases the filter is
+    # designed NOT to touch).
+    KEEP_TITLES = [
+        "Spatial Proteomics Atlas Covers 13,000 Proteins in Human Tissues — Nature",
+        "Amyloid beta disrupts tau before plaque formation in Alzheimer's",
+        "Probiotic products show mismatch between microbes and claimed benefits",
+        "HIIT preserves muscle while reducing fat in adults over 70 — Science Daily",
+        "Meta-analysis defines shared gut microbiome signature for colon cancer",
+        # astrobiology / in-space biology — legit PT content, must NOT drop
+        "Texas A&M Sends Grape Seeds to International Space Station — Phys.org",
+        "Cold Atom Lab Advances Quantum Research Aboard ISS — Science Daily",
+        # "mercury" is a toxin in health contexts — must NOT be filtered
+        "Mercury exposure linked to cognitive decline in coastal populations",
+        # origin-of-life meteorite chemistry — deliberately not filtered
+        "Meteorite Points to Destroyed Early Solar System World — Science Daily",
+    ]
+
+    def test_drops_astronomy_titles(self):
+        from engine.utils import drop_excluded_titles
+        kept, dropped = drop_excluded_titles(
+            [{"title": t} for t in self.ASTRO_TITLES], self._pats())
+        assert dropped == len(self.ASTRO_TITLES), (
+            f"survivors: {[a['title'] for a in kept]}")
+
+    def test_keeps_life_science_and_edge_cases(self):
+        from engine.utils import drop_excluded_titles
+        kept, dropped = drop_excluded_titles(
+            [{"title": t} for t in self.KEEP_TITLES], self._pats())
+        survivors = [a["title"] for a in kept]
+        assert dropped == 0, (
+            "scope filter over-dropped legitimate life-science titles: "
+            f"{[t for t in self.KEEP_TITLES if t not in survivors]}")
+
+
 class TestUnifiedLength:
     def test_floor_and_single_target(self):
         cfg = yaml.safe_load((_ROOT / "shows/planetterrian.yaml").read_text(encoding="utf-8"))

--- a/tests/test_pronunciation.py
+++ b/tests/test_pronunciation.py
@@ -264,6 +264,45 @@ class TestReplaceCurrency:
         assert "one hundred pounds" in result
 
 
+class TestCommaGroupedCurrency:
+    """July 2026 comma-blindness regression tests: the currency handlers
+    matched only the digits before the thousands comma, so shipped audio
+    said "fifty-nine dollars,990" ($59,990 \u2014 Tesla Ep515 hook),
+    "twenty dollars,000" ($20,000 \u2014 Ep523, Whisper: "under $20 in $1000"),
+    and "eighty dollars,000" ($80,000 \u2014 Ep521)."""
+
+    def test_tesla_ep515_price(self):
+        result = replace_currency("The Model Y now starts at $59,990 in the US.")
+        assert "fifty-nine thousand nine hundred ninety dollars" in result
+        assert "," not in result.replace(", ", " ")  # no stranded ",990"
+        assert "990" not in result
+
+    def test_tesla_ep523_price(self):
+        result = replace_currency("a compact EV under $20,000 for the first time")
+        assert "twenty thousand dollars" in result
+        assert "000" not in result
+
+    def test_tesla_ep521_price(self):
+        result = replace_currency("the $80,000 trim")
+        assert "eighty thousand dollars" in result
+        assert "000" not in result
+
+    def test_comma_grouped_with_cents(self):
+        result = replace_currency("a $1,250.50 invoice")
+        assert "one thousand two hundred fifty dollars and fifty cents" in result
+
+    def test_comma_grouped_large_unit(self):
+        result = replace_currency("a $1,200 million raise")
+        assert "one thousand two hundred million dollars" in result
+
+    def test_plain_amounts_unchanged(self):
+        # The pre-fix behavior for non-comma amounts must be preserved.
+        assert "five hundred dollars" in replace_currency("Cost $500")
+        assert "four hundred seventeen dollars and forty-four cents" in (
+            replace_currency("Price is $417.44")
+        )
+
+
 class TestReplacePercentages:
     def test_simple_percentage(self):
         result = replace_percentages("Up 30%")
@@ -401,6 +440,21 @@ class TestReplaceOrdinalNumbers:
     def test_twenty_second(self):
         result = replace_ordinal_numbers("22nd item")
         assert "twenty-second" in result
+
+    # July 2026 comma-blindness regression tests: the ordinal matcher
+    # matched only the digits after the thousands comma, so "1,000th"
+    # shipped as "1,zeroth" (Tesla Ep518/524) and "1,500th" as
+    # "1,five hundredth" (SpaceX Ep10).
+    def test_comma_grouped_thousandth(self):
+        result = replace_ordinal_numbers("delivered its 1,000th Cybertruck")
+        assert "one thousandth" in result
+        assert "zeroth" not in result
+        assert "1," not in result
+
+    def test_comma_grouped_fifteen_hundredth(self):
+        result = replace_ordinal_numbers("the 1,500th Falcon landing")
+        assert "one thousand five hundredth" in result
+        assert "1," not in result
 
 
 class TestReplaceRomanNumerals:

--- a/tests/test_russian_shows_quality_pass.py
+++ b/tests/test_russian_shows_quality_pass.py
@@ -132,6 +132,57 @@ class TestVocabTracker:
     def test_empty_state_is_noop(self, tmp_path):
         assert vocab_tracker.build_review_section(tmp_path, 5) == ""
 
+    def test_no_reteach_window_is_a_full_theme_cycle(self):
+        # July 2 2026: raised 3 -> 8 (Food/Animals/Weather looped 2.3× in 8
+        # episodes; 3 was one cycle short).
+        assert vocab_tracker._RECENT_EPISODES_NO_RETEACH >= 8
+
+
+class TestVocabThemeAndWordOfDay:
+    """July 2 2026 PR vocabulary-loop fixes: permanent Word-of-the-Day
+    exclusion (хлеб was WotD 3× in 12 days) + recent-theme rotation."""
+
+    FOOD = (
+        "> **Today we feast on everyday Russian food words.**\n\n"
+        "### Word of the Day\n**хлеб**\nхлеб хлеб молоко молоко сыр сыр"
+    )
+    WEATHER = (
+        "> **Let's explore sunny Russian weather words!**\n\n"
+        "### Word of the Day\n**Russian (Cyrillic):** солнце\n"
+        "солнце солнце дождь дождь ветер ветер"
+    )
+
+    def test_extract_word_of_day_section_and_label(self):
+        assert vocab_tracker.extract_word_of_day(self.FOOD) == "хлеб"
+        # tolerates the "Russian (Cyrillic):" label
+        assert vocab_tracker.extract_word_of_day(self.WEATHER) == "солнце"
+        # inline lesson-prose phrasing
+        assert vocab_tracker.extract_word_of_day(
+            "Our word of the day is яблоко.") == "яблоко"
+
+    def test_extract_theme_from_hook(self):
+        assert "food" in vocab_tracker.extract_theme(self.FOOD).lower()
+        assert "weather" in vocab_tracker.extract_theme(self.WEATHER).lower()
+
+    def test_word_of_day_history_dedups_and_persists(self, tmp_path):
+        vocab_tracker.record_episode_vocab(tmp_path, 43, self.FOOD)
+        vocab_tracker.record_episode_vocab(tmp_path, 45, self.WEATHER)
+        vocab_tracker.record_episode_vocab(tmp_path, 46, self.FOOD)  # хлеб again
+        data = json.loads((tmp_path / vocab_tracker.VOCAB_FILENAME).read_text())
+        # Recorded once each, no duplicate хлеб.
+        assert data["word_of_day_history"] == ["хлеб", "солнце"]
+
+    def test_review_section_excludes_used_wotd_and_lists_recent_themes(self, tmp_path):
+        vocab_tracker.record_episode_vocab(tmp_path, 43, self.FOOD)
+        vocab_tracker.record_episode_vocab(tmp_path, 45, self.WEATHER)
+        section = vocab_tracker.build_review_section(tmp_path, 47)
+        assert "WORD OF THE DAY" in section.upper()
+        assert "хлеб" in section  # named in the never-again list
+        assert "RECENT THEMES" in section
+        # both recent theme domains present so the LLM rotates away
+        assert "food" in section.lower()
+        assert "weather" in section.lower()
+
     def test_prompts_carry_placeholder(self):
         for f in ("shows/prompts/privet_russian_podcast.txt",
                   "shows/prompts/privet_russian_digest.txt"):

--- a/tests/test_spacex_show.py
+++ b/tests/test_spacex_show.py
@@ -66,6 +66,38 @@ class TestConfigLoads:
         assert "starlink" in mem.default_programs
 
 
+class TestJunkTitleFilter:
+    """July 2 2026: a pirate soccer-stream SEO title was laundered into an
+    on-air 'fact' — Ep18 shipped "SpaceX Falcon 9 Launches Starlink 6-103
+    Fiorentina Vs Genoa (RvpT3PF26j)" and the host spoke "designated
+    Fiorentina versus Genoa". The stream-spam class appends a YouTube-style
+    video ID in trailing parens; the exclude pattern drops that while
+    keeping "(video)" and legit "… vs …" comparison articles."""
+
+    @staticmethod
+    def _pats():
+        cfg = yaml.safe_load((_ROOT / "shows/spacex.yaml").read_text(encoding="utf-8"))
+        return cfg.get("exclude_title_patterns", []) or []
+
+    def test_drops_the_pirate_stream_title(self):
+        from engine.utils import drop_excluded_titles
+        arts = [{"title": "SpaceX Falcon 9 Launches Starlink 6-103 Fiorentina Vs Genoa (RvpT3PF26j)"}]
+        kept, dropped = drop_excluded_titles(arts, self._pats())
+        assert dropped == 1 and not kept
+
+    def test_keeps_legit_titles(self):
+        from engine.utils import drop_excluded_titles
+        keep = [
+            "SpaceX's next Starship breathes fire for 1st time in prelaunch test (video)",
+            "Starship vs Falcon 9: a full comparison of the two rockets",
+            "SpaceX launches 24 Starlink satellites from California, sticks landing",
+            "SPCX: Should you Buy the Dip?",
+        ]
+        kept, dropped = drop_excluded_titles([{"title": t} for t in keep], self._pats())
+        survivors = [a["title"] for a in kept]
+        assert dropped == 0, f"over-dropped: {[t for t in keep if t not in survivors]}"
+
+
 class TestChapterPositionalAnchors:
     def test_introduction_anchored_to_start(self):
         by_title = {m["title"]: m for m in _spacex_markers()}

--- a/tests/test_tesla_quality_pass.py
+++ b/tests/test_tesla_quality_pass.py
@@ -473,6 +473,54 @@ class TestSpokenBrandDropsDaily:
             ), f"normalizer left a stray Daily in: {sample!r}"
 
 
+class TestRunnerOpeningNormalizerDropsDaily:
+    """July 2026 network editorial pass: ``_normalize_tst_opening`` in
+    run_show.py was the missed second half of the June-10 brand decision.
+    It runs AFTER the June-20 generator fix and was still normalizing the
+    intro TOWARD "Tesla Shorts Time Daily" — re-adding the "Daily" the
+    generator layer had just dropped, so "Daily" shipped spoken in 14/14
+    post-fix episodes. It now targets the listing brand "Tesla Shorts
+    Time" and consumes the gluing punctuation so no ", episode"-style
+    artifacts remain."""
+
+    def test_daily_dropped_from_opening(self):
+        from run_show import _normalize_tst_opening as fix
+
+        assert fix("Welcome to Tesla Shorts Time Daily, episode 516.\nBody.") == (
+            "Welcome to Tesla Shorts Time, episode 516.\nBody."
+        )
+        # Mangled-spelling variants still normalized — without "Daily".
+        assert fix("This is Tesla Short's Time Daily. Let's go.") == (
+            "This is Tesla Shorts Time. Let's go."
+        )
+        assert fix("Welcome to Tesla Shorts Time. Daily, episode 500.") == (
+            "Welcome to Tesla Shorts Time, episode 500."
+        )
+
+    def test_never_produces_daily_or_artifacts(self):
+        import re
+        from run_show import _normalize_tst_opening as fix
+
+        for sample in (
+            "Welcome to Tesla Shorts Time Daily, episode 516.",
+            "Tesla Short's Time Daily — Tesla never sleeps.",
+            "Welcome to Tesla Shorts Time. Daily.",
+        ):
+            out = fix(sample)
+            assert not re.search(r"(?i)Shorts?\s+Time[.,;\s]*Daily", out), (
+                f"runner normalizer left a stray Daily in: {sample!r} -> {out!r}"
+            )
+            assert " , " not in out and " ," not in out, (
+                f"punctuation artifact in: {sample!r} -> {out!r}"
+            )
+
+    def test_clean_opening_untouched(self):
+        from run_show import _normalize_tst_opening as fix
+
+        clean = "Welcome to Tesla Shorts Time, episode 500. Tesla never sleeps.\n"
+        assert fix(clean) == clean
+
+
 class TestInstitutionalFilingSpamFilter:
     """13F institutional-filing spam ("LLC Purchases New Stake in Tesla",
     "Invests $X Million in Tesla") is filtered at fetch time via


### PR DESCRIPTION
**TLDR:** Every transcript from the last two weeks (~150 episodes, all 13 shows) read and judged for fit, interest, content quality, and positioning. The formats are working — every show has a segment delivering its brand promise — but four cross-cutting classes were shipping defects: (1) number/name normalization garbles in hook positions, (2) guard/retry mechanisms degrading the audio they protect (double-spoken closings, paraphrase-padding), (3) third-generation seeded-template convergence (any quotable example in a prompt becomes the next tic), and (4) sibling-show beat overlap (Planetterrian duplicated Fascinating Frontiers' astronomy stories verbatim six days straight; Tesla led with SpaceX corporate finance). Full review: `docs/reviews/network_review_2026_07_02.md`.

**Note on branch name:** this sandbox's git proxy only permits pushing the session's designated branch, so this review ships on `claude/review-recent-changes-vjjww9` rather than the `agent/review-network-20260702` convention. Rotation still advances normally on merge via `docs/reviews/review_state.yaml` (`network: 2026-07-02`).

## What shipped (deterministic, code/config/data only)

**Engine layer:**
- Comma-blind currency/ordinal normalization fixed — Tesla hooks had shipped as "fifty-nine dollars,990" / "under $20 in $1000" (Whisper-confirmed), SpaceX as "1,five hundredth". Regression tests for all five shipped forms.
- Missing-closing guard now fuzzy-matches (an LLM de-contraction of "that's"→"that is" had double-spoken the ENTIRE closing on 5 of 15 MAB episodes); genuinely missing closings still get appended.
- Expansion-retry paraphrase dedup — M&amp;A Ep087 shipped verbatim doubled sentences in audio; expansions are now intra-deduped and fall back to the original below 5% real gain.
- `Source:`/`Источник:` scaffold scrub before TTS (FP Ep059 voiced "Сорс MoneySense" on air); spoken-URL tripwire metric (MAB read a full Reddit permalink letter-by-letter).
- Tesla brand bug root-caused and fixed: a second normalizer in run_show.py rewrote intros TOWARD "Tesla Shorts Time Daily", undoing the June-20 fix — the wrong brand aired 14/14 episodes.
- Garble restores: Mee-stral→Mistral, Kar-pathy→Karpathy, Mid-journey→Midjourney, Notpower→NatPower.
- Review tooling: snapshot's phrase detector is now Unicode-aware (it was Cyrillic-blind — cleared FP while a template ran 7/8 episodes) and flags non-Closing final chapters (cleared EI while 3/5 shipped orphaned).

**Per show:**
- **env_intel:** orphan-Closing variant 3 fixed (Closing before body markers; bare `deep dive` dropped; promo-proofed patterns; where:end window removed — it was excluding the closing on short episodes). Re-parse verified: Ep047–051 all now end on Closing.
- **planetterrian:** astronomy fetch filter (verified: 14 astro drops, 0 life-science false positives on 189 window titles) — kills the 6-day FF duplication deterministically.
- **fascinating_frontiers:** freshness lookback 2→7 days (Ep116 re-ran 4 of its own week's stories) + ephemeris filter (5 drops / 180 titles, zero real news lost).
- **spacex:** video-ID junk-title filter (a pirate-soccer-stream SEO title had been laundered into on-air "fact": "designated Fiorentina versus Genoa").
- **models_agents:** duplicate arXiv cs.CL feed removed + network-wide no-duplicate-feeds guard.
- **modern_investing:** phantom trades (yfinance failures recorded as breakeven) had been narrated as market outcomes ("ROKU closed flat"); now voided and excluded everywhere. Honest record: 41→37 trades, win rate 51.2%→56.8%. Each closed trade reviewed exactly once (MU had been "yesterday's flash trade" three times).
- **privet_russian:** vocab loop fixed — no-reteach window 3→8 (the show looped Food/Animals/Weather 2.3× in 8 episodes; «хлеб» was Word of the Day 3× in 12 days), permanent WotD history, theme-rotation guidance.
- **Queues:** UC interleaved by category (8 consecutive medicine episodes had shipped); FP deduped (3 duplicate topics) + concrete/opportunity alternation restored. Runways: UC 4.7wk, FP 4.6wk.

**Deliverables:** review doc, prediction verdicts scored in 11 ledgers (headline: Tesla brand-"Daily" MISS root-caused; EI nuance-tic MISS reopened; OV strongest-case PARTIAL — script ban held, digest regressed 24×), new ledgers for privet_russian/modern_investing/network, rotation advanced, CLAUDE.md section added. Three ledgers had pre-existing YAML parse failures at HEAD — minimally quote-fixed.

## ⚠️ A/B-listen required (landmine #17)

**Applied in this PR (all deterministic-correctness class, spot-check advised):** comma currency/ordinals (one episode with a comma-grouped price); Tesla "Daily" drop (pre-approved June-10 decision — listen to the next Tesla intro); closing-guard / expansion-dedup / scaffold-scrub / garble restores (change TTS input only in the failure cases they repair).

**Proposed, NOT applied (no GROK_API_KEY here to render before/after; 12 per-show prompt de-seeds and rules listed in the review doc §A/B):** highest priority — OV's "Both sides agree X; they differ on Y" de-seed + no-manufactured-sides escape hatch (it ran on 12/12 stories incl. a shark attack and Naomi Osaka's outfit); EI thin-day single-story rule + "Canada Gazette" terminology; MAB/FP/MIT/EI template de-seeds (de-seed by *shape*, never quotable examples — three shows elected their prompt menu's first item as the next tic); SpaceX xAI-entity discipline; Tesla recap hardening + SpaceX-beat rule; PT prompt-side scope guard.

## Test results

Full suite: **3,561 passed, 3 skipped, 0 failed** (was 3,489 before this branch; ~70 new drift guards). EI chapter fix verified by re-parsing all five real episodes; every fetch filter verified against every story title in the window (drop/keep lists in the review doc).

## Deferred / operator items (review doc §Operator)

Double-publish forensics (Tesla Jun 23, PR Jun 22, OV Jun 19) + SpaceX's silently-missed Jun-28 recap; EI Ep050 permitting-claim verification; MIT "Qualys surged 65%" source-tier demotion; FP cadence contradiction; Tesla narrative status refresh; EI all-province promise vs zero QC/SK/Atlantic coverage; M&amp;A x_enabled vs CLAUDE.md contradiction; chronic under-length stays deferred everywhere (digest ceiling — not re-litigated per ledgers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX

---
_Generated by [Claude Code](https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX)_