### PR TITLE
The Do Positive Club: evidence-based membership redesign of thedppod.html

### DIFF
--- a/docs/dp_pod_market_assessment_2026_07.md
+++ b/docs/dp_pod_market_assessment_2026_07.md
@@ -1,0 +1,155 @@
+# The DP Pod — Market Assessment & Club Positioning (July 2026)
+
+Deep-research pass (104 agents: 5 search angles → source fetch → 3-vote
+adversarial verification per claim → synthesis). Every claim below marked
+**verified** survived 3-0 adversarial verification against its primary
+source. This document is the evidence base for the club-styled redesign of
+`thedppod.html` and the membership mechanics roadmap.
+
+## 1. The market
+
+- **Optimistic/solutions media is a proven niche with five-figure engaged
+  audiences.** Fix The News alone reports **77,000+ subscribers across 195
+  countries** (verified live; independently corroborated ~70k by Mediaweek,
+  Dec 2025). ([fixthenews.com](https://fixthenews.com/))
+- **Incumbents monetize belonging, not access.** Reasons to be Cheerful's
+  membership is **$1/month pay-what-you-can**, and its core benefits are a
+  **public member wall** and an **official membership card** (a $7+ "Most
+  Cheerful" tier adds event invites/giveaways). Fix The News **donates 30%
+  of paid-subscription revenue to charity** so paying feels like
+  contributing. Nothing is paywalled at either. (verified against
+  [reasonstobecheerful.world/membership](https://reasonstobecheerful.world/membership/),
+  fixthenews.com)
+- **Belonging-framed membership converts loyal audiences fast.** Defector
+  sold **10,000 subscriptions in 24 hours** on a "support the writers
+  directly" frame and drew **~95% of $3.8M revenue** from reader
+  subscriptions; Maximum Fun's CTA is patronage of the co-op, not access.
+  (verified: Defector Year-2 annual report, TheWrap, maximumfun.org/co-op)
+- **Referral is the proven zero-paywall growth engine.** Morning Brew grew
+  **100k → 1.5M subscribers in ~18 months** while its milestone-reward
+  referral program operated (first-person account by the program's builder;
+  he attributes ~80% of pre-paid-acquisition growth to it).
+
+## 2. The gap The DP Pod fits
+
+Optimistic-media incumbents are **text-first** and their belonging is
+**passive** (walls, cards, charity ties). Action communities (parkrun,
+Giving What We Can, Buy Nothing) are **free and identity-driven but have no
+daily audio product**. **No player combines a daily good-news podcast with a
+structured, on-air listener-action loop.** The DP Pod's Dispatch segment IS
+that loop — the redesign's job is to make the website state it as a club you
+join, not a show you follow.
+
+*Positioning sentence:* **The DP Pod is a free club whose product is what
+its members do — the daily episode is the briefing, The Lever is the
+assignment, and the Dispatch is the proof.**
+
+(Caveat: the gap statement is an inference from verified sources; Tangle,
+1440, The Progress Network, Good Good Good, Upworthy, Nerdfighteria, Action
+for Happiness, Precious Plastic, 80,000 Hours, One Small Step, Duolingo and
+Doomberg claims did not survive verification and are not relied on.)
+
+## 3. The three communities to model (all claims verified 3-0)
+
+1. **parkrun — free-forever, low-barrier contribution, belonging-driven
+   retention.** 2,200+ free weekly events in 22-23 countries, 8M+
+   registrants, delivered by **~51 paid staff** worldwide; 1M+ participants
+   and 150k volunteers in Australia alone. Leadership treats "**free
+   forever**" as non-negotiable. Retention runs on identity ("*a social
+   intervention masquerading as a 5-kilometre running event*"), and the
+   participant→contributor on-ramp is **deliberately low-skill roles**
+   ("*an easy role, you just need to smile a bit*"). (two peer-reviewed
+   studies: Voluntas 2026; Qualitative Health Research 2025, 67 interviews)
+2. **Giving What We Can — the free public pledge + member wall.** 10,000+
+   members pledged to give 10% of income; design explicitly grounded in
+   Schelling pre-commitment + Cialdini consistency; a public pledge list
+   exists "to normalise giving." Experimental evidence that pledge
+   mechanics work: **visible social proof of a pledger majority raised
+   pledge uptake by 24 percentage points**; non-binding pledges were kept
+   **83%** of the time by lone pledgers and **99.1%** when the whole group
+   pledged; asking the most-likely pledgers FIRST manufactured pledger
+   majorities in 75% of groups vs 42%. (Koessler 2022, J. Behav. Exp.
+   Econ.; single lab study — transfer is an inference, direction is clear)
+3. **Buy Nothing — the constrained contribution grammar + welcome
+   ritual.** Every post must be an **offer, a request, or public
+   gratitude**; new members are **ritually welcomed in batches**; bystanders
+   witness "vicarious gifting." Result: median strongly-connected component
+   of **57% of members vs 15%** in matched Facebook groups, and much lower
+   contribution inequality (Gini 0.69 vs 0.87). Participation is broad, not
+   power-user-dominated. (Herdagdelen, Adamic & State 2022, N=5,622 groups)
+
+## 4. Ranked mechanics for the DP Pod's free launch
+
+Join mechanism = email list; contribution mechanism = listener action
+reports. Ranked by strength of evidence:
+
+1. **A named public pledge + member wall, seeded before the general ask.**
+   "The Do Positive Pledge" — joining the list = signing the pledge. Show
+   the count/wall at the join point (+24pp effect); seed it with the hosts
+   and committed early listeners first (75% vs 42% majority formation);
+   don't fear that it's non-binding (83-99% follow-through).
+2. **A fixed Dispatch grammar, read on air.** Constrain submissions to
+   three parts — *what I did / the honest numbers / a gratitude shoutout*
+   (Buy Nothing's exact three-type structure) — and read them on the show
+   so non-contributors witness contribution.
+3. **Low-barrier starter actions + ritual batch welcomes.** parkrun's
+   "you just need to smile a bit" on-ramp: the first asks must be nearly
+   effortless (send the page to one doomscroller, reply with good news you
+   saw, pull one starter lever). Welcome new members by name/batch.
+4. **Collective-impact counter + club artifacts.** Numbered founding
+   membership, a membership card, a levers-pulled ledger (RtbC's wall +
+   card, validated at $1/mo — ours are free).
+5. **Referral ladder dispensing club artifacts** (Morning Brew): referral
+   milestones award the card, wall placement, founding numbers — zero-cost
+   swag. Needs per-subscriber referral tracking; **deferred** until the
+   list justifies the infra.
+
+**Brand language:** club/patronage/co-op — "member #N", "free forever",
+"the club", "your dispatch" — over media-property language ("subscribe",
+"content", "audience"). Defector/MaxFun prove the posture converts; RtbC
+proves the artifacts; parkrun proves free-forever is a feature, not a
+compromise.
+
+## 5. What ships now vs later
+
+**Now (this PR — static site + existing pipeline):**
+- Club-styled `thedppod.html` via a bespoke template
+  (`templates/show_page_dp_pod.html.j2`, `show_page_template` registry
+  override): pledge-led hero, The Do Positive Pledge join section (Buttondown
+  email = signing; pledge text on the card), Dispatch grammar section with a
+  prefilled mailto submission (the constrained format), Lever board fed from
+  episode digests (`_collect_dp_levers`), starter actions, membership-card
+  visual, founding-member window ("join before Episode 100"), free-forever
+  charter, hosts-as-cofounders section, episodes + player.
+- Prompts already read dispatches on air and never fabricate them (launch
+  shape) — mechanic #2's on-air half is live from Episode 1.
+
+**Later (operator/infra decisions):**
+- **Member wall with real names** — needs consented name collection
+  (Buttondown metadata or a small form + JSON in repo). Ship the wall
+  seeded with the hosts + "your name here" until then.
+- **Numbered membership + card issuance** — derivable from Buttondown
+  subscriber order; needs a small nightly script → `api/dp_club.json`
+  (member count for live social proof at the join point).
+- **Batch welcome ritual on air** — feed new-member first names into the
+  Dispatch section of the digest via a pre-fetch hook (consent first).
+- **Collective ledger totals** ("club has pulled N levers") — count
+  dispatch emails; manual tally at first is fine and honest.
+- **Referral ladder** — Buttondown has no native referral program;
+  revisit at ~1k subscribers (SparkLoop/custom Worker).
+- **Newsletter enablement** (`newsletter.enabled: true`) — the join list
+  only becomes a relationship when something arrives; recommend enabling
+  once Ep1 ships so joining triggers the welcome + daily episode email.
+
+## 6. Sources (all fetched + adversarially verified July 2026)
+
+- https://fixthenews.com/
+- https://reasonstobecheerful.world/membership/
+- https://www.givingwhatwecan.org/why-pledge and /about-us/members
+- Koessler 2022, J. Behavioral & Experimental Economics 98:101848
+- Herdagdelen, Adamic & State 2022 (arxiv 2211.09043 / JQD:DM)
+- PMC12552763 (Qualitative Health Research 2025, parkrun Australia)
+- Voluntas 2026 ("Because I Love parkrun")
+- Tyler Denk, "How Morning Brew's referral program built an audience of
+  1.5 million subscribers" (Medium/Mission.org 2019)
+- https://maximumfun.org/co-op/ and the Defector Year-2 annual report

--- a/generate_html.py
+++ b/generate_html.py
@@ -1532,6 +1532,55 @@ _SHOW_PICKER_TAGS = {
 _merge_scaffolded_network_registry()
 
 
+def _collect_dp_levers(limit: int = 6) -> list:
+    """Extract recent "The Lever" actions from The DP Pod's digests.
+
+    Each episode's digest carries a ``### The Lever`` section — one concrete
+    individual action with honest numbers. The club page surfaces the most
+    recent ones as an action board. Returns newest-first
+    ``{episode_num, hook, lever_text, blog_url}`` dicts; empty list when no
+    episodes exist yet (pre-launch) or parsing fails (never blocks the page).
+    """
+    import re as _re
+
+    levers = []
+    try:
+        from engine.blog import extract_blog_metadata
+        digest_dir = ROOT / "digests" / "dp_pod"
+        if not digest_dir.exists():
+            return []
+        seen: dict[int, dict] = {}
+        for md_file in sorted(digest_dir.glob("*.md")):
+            text = md_file.read_text(encoding="utf-8")
+            m = _re.search(
+                r"###\s*The Lever\s*\n(.*?)(?:\n[━#]|\Z)", text, _re.DOTALL,
+            )
+            if not m:
+                continue
+            lever_text = " ".join(m.group(1).split())
+            # Strip markdown bold/links for the card blurb; keep it short.
+            lever_text = _re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", lever_text)
+            lever_text = lever_text.replace("**", "").strip()
+            if len(lever_text) > 340:
+                cut = lever_text[:340]
+                lever_text = cut[: cut.rfind(" ")] + "…"
+            meta = extract_blog_metadata(text, "dp_pod", md_file.name, file_path=md_file)
+            ep = meta.get("episode_num", 0)
+            entry = {
+                "episode_num": ep,
+                "hook": meta.get("hook", ""),
+                "lever_text": lever_text,
+                "blog_url": f"blog/dp_pod/ep{ep:03d}.html",
+                "filename": md_file.name,
+            }
+            if ep not in seen or md_file.name > seen[ep]["filename"]:
+                seen[ep] = entry
+        levers = sorted(seen.values(), key=lambda e: e["episode_num"], reverse=True)[:limit]
+    except Exception as e:
+        print(f"Warning: could not collect DP Pod levers: {e}")
+    return levers
+
+
 def _newsletter_tag_for_slug(slug: str, fallback_name: str) -> str:
     """Return the Buttondown tag for a show.
 
@@ -2078,10 +2127,17 @@ def generate_all_narrative_pages(*, dry_run=False):
 
 
 def generate_show_page(slug, *, dry_run=False):
-    """Render and write a show page for a single show."""
+    """Render and write a show page for a single show.
+
+    A show can declare ``show_page_template`` in its registry entry
+    (``shows/network_meta.yaml`` or the hardcoded dict) to swap the shared
+    template for a bespoke one — same context, different presentation.
+    The DP Pod's club-styled page (``show_page_dp_pod.html.j2``) is the
+    first user.
+    """
     cfg = NETWORK_SHOWS[slug]
     env = _get_jinja_env()
-    template = env.get_template("show_page.html.j2")
+    template = env.get_template(cfg.get("show_page_template", "show_page.html.j2"))
 
     podcast_image_url = cfg["podcast_image"]
 
@@ -2206,6 +2262,14 @@ def generate_show_page(slug, *, dry_run=False):
     if slug == "modern_investing":
         performance_data = _load_mit_performance_data()
 
+    # The DP Pod: extract recent "The Lever" actions from committed digests
+    # so the club page can render a live action board ("pull a lever, write
+    # in"). Empty list pre-launch — the template renders a founding-era
+    # empty state.
+    dp_levers = []
+    if slug == "dp_pod":
+        dp_levers = _collect_dp_levers()
+
     is_russian = slug in ("finansy_prosto", "privet_russian")
 
     yt_meta = _read_show_youtube(slug)
@@ -2276,6 +2340,7 @@ def generate_show_page(slug, *, dry_run=False):
         "blog_page": f"blog/{cfg['slug']}/index.html",
         "latest_blog_posts": latest_blog_posts,
         "static_episodes": static_episodes,
+        "dp_levers": dp_levers,
         "newsletter_tag": _newsletter_tag_for_slug(cfg["slug"], cfg["name"]),
         "all_shows": _build_all_shows_list(),
         "performance_data": performance_data,

--- a/index.html
+++ b/index.html
@@ -2023,7 +2023,7 @@
                     </picture>
                     <div class="subscribe-show-meta">
                         <div class="subscribe-show-name">The DP Pod: The Do Positive Podcast</div>
-                        <div class="subscribe-show-tagline">Good news, honest numbers, and one action that counts — every day.</div>
+                        <div class="subscribe-show-tagline">The club for people who do something about it — good news, honest numbers, one action a day.</div>
                     </div>
                     <div class="subscribe-show-links">
                         
@@ -2107,7 +2107,7 @@
                     
                     <label><input type="checkbox" name="tag" value="First Principles Daily" checked> First Principles Daily</label>
                     
-                    <label><input type="checkbox" name="tag" value="The DP Pod: The Do Positive Podcast" checked> The DP Pod: The Do Positive Podcast</label>
+                    <label><input type="checkbox" name="tag" value="DP Pod" checked> The DP Pod: The Do Positive Podcast</label>
                     
                     <label><input type="checkbox" name="tag" value="SpaceX Daily" checked> SpaceX Daily</label>
                     

--- a/shows/dp_pod.yaml
+++ b/shows/dp_pod.yaml
@@ -174,6 +174,9 @@ chapters:
 
 newsletter:
   enabled: false
+  # Buttondown tag for the club's pledge/join form on thedppod.html — set
+  # explicitly so the tag stays stable if the display name ever changes.
+  tag: "DP Pod"
   short_label: "DP Pod"
   emoji: "🌱"
 

--- a/shows/network_meta.yaml
+++ b/shows/network_meta.yaml
@@ -31,7 +31,12 @@ dp_pod:
     to doomscrolling that actually asks something of you.'
   display_order: 99
   episode_length: ~10 min
-  hero_tagline: Good news, honest numbers, and one action that counts — every day.
+  hero_tagline: The club for people who do something about it — good news, honest
+    numbers, one action a day. Free forever.
+  # Bespoke club-styled page (July 2026 redesign; evidence base in
+  # docs/dp_pod_market_assessment_2026_07.md). generate_show_page swaps the
+  # shared template for this one; same context, club presentation.
+  show_page_template: show_page_dp_pod.html.j2
   json_format: wrapped
   json_path: digests/dp_pod/summaries_dp_pod.json
   meta_description: 'The DP Pod — the Do Positive Podcast with Dan and Patrick.
@@ -64,7 +69,8 @@ dp_pod:
   - Google News
   spotify_url: null
   summaries_page: thedppod-summaries.html
-  tagline: Good news, honest numbers, and one action that counts — every day.
+  tagline: The club for people who do something about it — good news, honest numbers,
+    one action a day.
   theme_color: '#0B7A45'
   x_account: null
 spacex:

--- a/templates/show_page_dp_pod.html.j2
+++ b/templates/show_page_dp_pod.html.j2
@@ -1,0 +1,471 @@
+{% extends "base.html.j2" %}
+{#-
+  The DP Pod club page (July 2026 redesign).
+
+  Bespoke template selected via the registry's `show_page_template` override
+  — same generate_show_page context as every other show, different
+  presentation. Design decisions trace to the verified market assessment in
+  docs/dp_pod_market_assessment_2026_07.md:
+
+  * pledge-led join (Giving What We Can: public pledge + wall; +24pp uptake
+    with visible social proof; 83-99% follow-through on non-binding pledges)
+  * seeded member wall (hosts are members #001/#002 — pledger-majority
+    sequencing)
+  * constrained Dispatch grammar: what I did / honest numbers / a shoutout
+    (Buy Nothing's three-post-type structure → broad, reciprocal
+    participation)
+  * low-barrier starter levers (parkrun's "you just need to smile a bit"
+    contribution on-ramp)
+  * free-forever charter + club/patronage language, never "content"/
+    "audience" (parkrun, Maximum Fun, Defector)
+  * membership-card artifact (Reasons to be Cheerful's card + wall,
+    validated at $1/mo — ours are free)
+-#}
+
+{% block og_type %}website{% endblock %}
+
+{% block head_extra %}
+<style>
+  /* ---- The Do Positive Club design system (scoped .dpc-) ---- */
+  .dpc-page { --dp-green:#12B76A; --dp-green-deep:#0B7A45; --dp-ink:#07130C;
+              --dp-cream:#F4FBF7; --dp-gold:#E8C468; --dp-line:rgba(18,183,106,0.25); }
+  .dpc-page { font-family:'DM Sans',system-ui,sans-serif; }
+  .dpc-serif { font-family:'Source Serif 4',Georgia,serif; }
+
+  .dpc-section { max-width:1060px; margin:0 auto; padding:4.5rem 1.25rem; }
+  .dpc-eyebrow { display:inline-flex; align-items:center; gap:0.6rem;
+    font-size:0.72rem; font-weight:700; letter-spacing:0.16em; text-transform:uppercase;
+    color:var(--dp-green); }
+  .dpc-eyebrow::before, .dpc-eyebrow::after { content:""; height:1px; width:34px;
+    background:var(--dp-line); }
+  .dpc-h2 { font-family:'Source Serif 4',Georgia,serif; font-size:clamp(1.7rem,3.6vw,2.5rem);
+    line-height:1.15; margin:0.65rem 0 0.9rem; color:var(--dp-cream); }
+  .dpc-sub { color:var(--nn-text-muted,#9aa7b8); max-width:46rem; margin:0 auto;
+    font-size:1.02rem; line-height:1.65; }
+
+  /* Hero */
+  .dpc-hero { position:relative; overflow:hidden;
+    background:
+      radial-gradient(1100px 500px at 70% -10%, rgba(18,183,106,0.16), transparent 60%),
+      radial-gradient(700px 420px at 10% 110%, rgba(232,196,104,0.07), transparent 60%),
+      linear-gradient(180deg, #07130C 0%, #0B0F1A 100%);
+    border-bottom:1px solid var(--dp-line); }
+  .dpc-hero-inner { max-width:1060px; margin:0 auto; padding:5rem 1.25rem 4.2rem;
+    display:grid; grid-template-columns:1.25fr 0.85fr; gap:3rem; align-items:center; }
+  .dpc-hero h1 { font-family:'Source Serif 4',Georgia,serif;
+    font-size:clamp(2.3rem,5.4vw,3.7rem); line-height:1.08; margin:1rem 0 1.1rem;
+    color:var(--dp-cream); }
+  .dpc-hero h1 em { font-style:italic; color:var(--dp-green); }
+  .dpc-hero-desc { color:#b8c6bd; font-size:1.1rem; line-height:1.7; max-width:34rem; }
+  .dpc-hero-ctas { display:flex; gap:0.8rem; flex-wrap:wrap; margin-top:1.7rem; }
+  .dpc-cta { display:inline-flex; align-items:center; gap:0.5rem; padding:0.85rem 1.5rem;
+    border-radius:999px; font-weight:700; font-size:0.98rem; text-decoration:none;
+    transition:transform .15s ease, box-shadow .15s ease; }
+  .dpc-cta--primary { background:var(--dp-green); color:#06130b;
+    box-shadow:0 8px 28px rgba(18,183,106,0.35); }
+  .dpc-cta--primary:hover { transform:translateY(-2px); box-shadow:0 12px 34px rgba(18,183,106,0.45); }
+  .dpc-cta--ghost { border:1px solid var(--dp-line); color:var(--dp-cream); background:rgba(18,183,106,0.06); }
+  .dpc-cta--ghost:hover { background:rgba(18,183,106,0.12); }
+  .dpc-hero-note { margin-top:1.1rem; font-size:0.85rem; color:#7ba893; }
+
+  /* Membership card */
+  .dpc-card-wrap { perspective:1000px; }
+  .dpc-membercard { position:relative; border-radius:18px; padding:1.6rem 1.7rem;
+    background:linear-gradient(135deg,#0E2418 0%,#0A1A11 55%,#123A24 100%);
+    border:1px solid rgba(232,196,104,0.35);
+    box-shadow:0 24px 60px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.06);
+    transform:rotate(2.5deg); transition:transform .3s ease; aspect-ratio:1.586; max-width:400px;
+    display:flex; flex-direction:column; justify-content:space-between; margin-left:auto; }
+  .dpc-membercard:hover { transform:rotate(0deg) scale(1.02); }
+  .dpc-membercard .mc-top { display:flex; justify-content:space-between; align-items:flex-start; }
+  .dpc-membercard .mc-club { font-size:0.68rem; letter-spacing:0.18em; text-transform:uppercase;
+    color:var(--dp-gold); font-weight:700; }
+  .dpc-membercard .mc-free { font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase;
+    color:#7ba893; border:1px solid rgba(123,168,147,0.4); border-radius:999px; padding:0.2rem 0.6rem; }
+  .dpc-membercard .mc-name { font-family:'Source Serif 4',Georgia,serif; font-size:1.5rem;
+    color:var(--dp-cream); }
+  .dpc-membercard .mc-name span { color:var(--dp-green); }
+  .dpc-membercard .mc-bottom { display:flex; justify-content:space-between; align-items:flex-end; }
+  .dpc-membercard .mc-motto { font-size:0.78rem; color:#9db8a8; font-style:italic; }
+  .dpc-membercard .mc-num { font-size:0.9rem; color:var(--dp-gold); font-weight:700;
+    font-variant-numeric:tabular-nums; }
+
+  /* Steps */
+  .dpc-steps { display:grid; grid-template-columns:repeat(3,1fr); gap:1.1rem; margin-top:2rem; }
+  .dpc-step { background:rgba(18,183,106,0.05); border:1px solid var(--dp-line);
+    border-radius:16px; padding:1.5rem; position:relative; }
+  .dpc-step .num { position:absolute; top:1.1rem; right:1.2rem;
+    font-family:'Source Serif 4',Georgia,serif; font-size:2rem; color:rgba(18,183,106,0.35);
+    font-weight:700; }
+  .dpc-step h3 { margin:0 0 0.5rem; color:var(--dp-cream); font-size:1.08rem; }
+  .dpc-step .tag { display:inline-block; font-size:0.68rem; letter-spacing:0.12em;
+    text-transform:uppercase; color:var(--dp-green); font-weight:700; margin-bottom:0.55rem; }
+  .dpc-step p { margin:0; color:var(--nn-text-muted,#9aa7b8); font-size:0.92rem; line-height:1.6; }
+
+  /* Pledge */
+  .dpc-pledge { background:
+      radial-gradient(700px 340px at 50% 0%, rgba(18,183,106,0.13), transparent 65%);
+    border-top:1px solid var(--dp-line); border-bottom:1px solid var(--dp-line); }
+  .dpc-pledge-card { max-width:640px; margin:2.2rem auto 0; border-radius:20px;
+    background:linear-gradient(180deg,#0E2418,#0A160F); border:1px solid rgba(232,196,104,0.28);
+    padding:2.3rem 2.2rem; box-shadow:0 24px 70px rgba(0,0,0,0.45); text-align:center; }
+  .dpc-pledge-card .pl-label { font-size:0.7rem; letter-spacing:0.2em; text-transform:uppercase;
+    color:var(--dp-gold); font-weight:700; }
+  .dpc-pledge-text { font-family:'Source Serif 4',Georgia,serif; font-size:1.35rem;
+    line-height:1.55; color:var(--dp-cream); margin:1.1rem 0 1.4rem; font-style:italic; }
+  .dpc-pledge-form { display:flex; gap:0.6rem; flex-wrap:wrap; justify-content:center; }
+  .dpc-pledge-form input[type=email] { flex:1 1 240px; max-width:330px; padding:0.85rem 1.1rem;
+    border-radius:999px; border:1px solid var(--dp-line); background:rgba(7,19,12,0.8);
+    color:var(--dp-cream); font-size:0.95rem; }
+  .dpc-pledge-form button { padding:0.85rem 1.5rem; border-radius:999px; border:none;
+    background:var(--dp-green); color:#06130b; font-weight:700; font-size:0.95rem; cursor:pointer; }
+  .dpc-pledge-form button:hover { filter:brightness(1.08); }
+  .dpc-pledge-fine { margin-top:1rem; font-size:0.8rem; color:#7ba893; }
+  .dpc-founding { margin-top:1.3rem; padding-top:1.2rem; border-top:1px dashed rgba(232,196,104,0.25);
+    font-size:0.88rem; color:#c9b98a; }
+
+  /* Member wall (seeded) */
+  .dpc-wall { display:flex; gap:0.6rem; flex-wrap:wrap; justify-content:center; margin-top:1.6rem; }
+  .dpc-wall .member { border:1px solid var(--dp-line); border-radius:999px; padding:0.45rem 1rem;
+    font-size:0.85rem; color:var(--dp-cream); background:rgba(18,183,106,0.06);
+    font-variant-numeric:tabular-nums; }
+  .dpc-wall .member b { color:var(--dp-gold); font-weight:700; margin-right:0.4rem; }
+  .dpc-wall .member.you { border-style:dashed; color:#7ba893; }
+
+  /* Lever board */
+  .dpc-levers { display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
+    gap:1.1rem; margin-top:2rem; }
+  .dpc-lever { background:rgba(18,183,106,0.05); border:1px solid var(--dp-line);
+    border-radius:16px; padding:1.4rem; display:flex; flex-direction:column; gap:0.7rem; }
+  .dpc-lever .lv-ep { font-size:0.68rem; letter-spacing:0.12em; text-transform:uppercase;
+    color:var(--dp-green); font-weight:700; }
+  .dpc-lever h3 { margin:0; font-size:1rem; color:var(--dp-cream); line-height:1.4; }
+  .dpc-lever p { margin:0; color:var(--nn-text-muted,#9aa7b8); font-size:0.88rem; line-height:1.6; flex:1; }
+  .dpc-lever .lv-actions { display:flex; gap:0.55rem; flex-wrap:wrap; }
+  .dpc-lever .lv-btn { font-size:0.82rem; font-weight:700; padding:0.5rem 0.95rem; border-radius:999px;
+    text-decoration:none; }
+  .dpc-lever .lv-did { background:var(--dp-green); color:#06130b; }
+  .dpc-lever .lv-listen { border:1px solid var(--dp-line); color:var(--dp-cream); }
+
+  /* Dispatch */
+  .dpc-grammar { display:grid; grid-template-columns:repeat(3,1fr); gap:1.1rem; margin:2rem 0; }
+  .dpc-grammar .g { border:1px dashed rgba(232,196,104,0.35); border-radius:14px; padding:1.2rem;
+    text-align:center; }
+  .dpc-grammar .g .gt { font-family:'Source Serif 4',Georgia,serif; color:var(--dp-gold);
+    font-size:1.05rem; margin-bottom:0.4rem; }
+  .dpc-grammar .g p { margin:0; font-size:0.85rem; color:var(--nn-text-muted,#9aa7b8); line-height:1.55; }
+
+  /* Charter */
+  .dpc-charter { display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:1rem;
+    margin-top:2rem; counter-reset:tenet; }
+  .dpc-tenet { border-left:2px solid var(--dp-green); padding:0.2rem 0 0.2rem 1.1rem; }
+  .dpc-tenet h4 { margin:0 0 0.3rem; color:var(--dp-cream); font-size:0.98rem; }
+  .dpc-tenet p { margin:0; font-size:0.84rem; color:var(--nn-text-muted,#9aa7b8); line-height:1.55; }
+
+  /* Hosts */
+  .dpc-hosts { display:grid; grid-template-columns:1fr 1fr; gap:1.2rem; margin-top:2rem; }
+  .dpc-host { background:rgba(18,183,106,0.05); border:1px solid var(--dp-line); border-radius:16px;
+    padding:1.6rem; }
+  .dpc-host .hn { font-family:'Source Serif 4',Georgia,serif; font-size:1.25rem; color:var(--dp-cream); }
+  .dpc-host .hr { font-size:0.78rem; letter-spacing:0.1em; text-transform:uppercase;
+    color:var(--dp-green); font-weight:700; margin:0.25rem 0 0.7rem; }
+  .dpc-host p { margin:0; font-size:0.92rem; color:var(--nn-text-muted,#9aa7b8); line-height:1.65; }
+  .dpc-nerra { text-align:center; margin-top:1.6rem; font-size:0.9rem; color:#7ba893; }
+  .dpc-nerra b { color:var(--dp-gold); }
+
+  /* Episodes */
+  .dpc-latest { max-width:760px; margin:2rem auto 0; background:rgba(18,183,106,0.05);
+    border:1px solid var(--dp-line); border-radius:18px; padding:1.8rem; }
+  .dpc-latest .lt-label { font-size:0.7rem; letter-spacing:0.16em; text-transform:uppercase;
+    color:var(--dp-green); font-weight:700; }
+  .dpc-latest h3 { margin:0.5rem 0 1rem; color:var(--dp-cream);
+    font-family:'Source Serif 4',Georgia,serif; font-size:1.25rem; line-height:1.4; }
+  .dpc-latest audio { width:100%; }
+  .dpc-eplist { max-width:760px; margin:1.4rem auto 0; }
+  .dpc-ep { display:flex; align-items:center; gap:1rem; padding:0.9rem 0.4rem;
+    border-bottom:1px solid rgba(18,183,106,0.14); }
+  .dpc-ep .ed { font-size:0.78rem; color:#7ba893; min-width:120px; font-variant-numeric:tabular-nums; }
+  .dpc-ep .et { flex:1; font-size:0.92rem; color:var(--dp-cream); line-height:1.45; }
+  .dpc-ep audio { max-width:230px; height:36px; }
+  .dpc-sub-chips { display:flex; gap:0.6rem; flex-wrap:wrap; justify-content:center; margin-top:1.6rem; }
+  .dpc-sub-chips a { border:1px solid var(--dp-line); border-radius:999px; padding:0.5rem 1.05rem;
+    font-size:0.85rem; color:var(--dp-cream); text-decoration:none; }
+  .dpc-sub-chips a:hover { background:rgba(18,183,106,0.1); }
+
+  .dpc-center { text-align:center; }
+  @media (max-width: 860px) {
+    .dpc-hero-inner { grid-template-columns:1fr; }
+    .dpc-membercard { margin:0 auto; transform:rotate(0); }
+    .dpc-steps, .dpc-grammar, .dpc-hosts { grid-template-columns:1fr; }
+    .dpc-ep { flex-wrap:wrap; }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+{% from "_macros.html.j2" import ai_badge %}
+{%- set dispatch_mailto = "mailto:patrick@planetterrian.com?subject=Do%20Positive%20Dispatch%20%E2%80%94%20what%20I%20did&body=WHAT%20I%20DID%3A%0A%0ATHE%20HONEST%20NUMBERS%20(cost%2C%20time%2C%20impact%20%E2%80%94%20rough%20is%20fine)%3A%0A%0ASHOUTOUT%20(who%20helped%2C%20or%20who%20should%20try%20it%20next)%3A%0A%0AFirst%20name%20%2B%20city%20(how%20we%27ll%20read%20it%20on%20air)%3A%0A" -%}
+<div class="dpc-page">
+
+  <!-- ================= Hero ================= -->
+  <section class="dpc-hero">
+    <div class="dpc-hero-inner">
+      <div>
+        <span class="dpc-eyebrow" style="justify-content:flex-start;">The Do Positive Club · Est. 2026 · Free forever</span>
+        <h1>Most media tells you what's wrong.<br>This club <em>does something about it.</em></h1>
+        <p class="dpc-hero-desc">
+          The DP Pod is a ten-minute daily briefing of genuinely good news in science and
+          tech — with honest numbers, healthy disagreement, and one concrete action a
+          regular person can take. Members don't just listen. They pull the lever, write
+          in, and get read on the show.
+        </p>
+        <div class="dpc-hero-ctas">
+          <a class="dpc-cta dpc-cta--primary" href="#pledge">Take the Pledge</a>
+          <a class="dpc-cta dpc-cta--ghost" href="#briefing">▶ Today's briefing</a>
+        </div>
+        <p class="dpc-hero-note">No paywall. No guilt. Just the good news and something to do about it.</p>
+      </div>
+      <div class="dpc-card-wrap">
+        <div class="dpc-membercard" aria-label="The Do Positive Club membership card">
+          <div class="mc-top">
+            <span class="mc-club">The Do Positive Club</span>
+            <span class="mc-free">Free forever</span>
+          </div>
+          <div class="mc-name">Member: <span>you, hopefully</span></div>
+          <div class="mc-bottom">
+            <span class="mc-motto">“Do something about it.”</span>
+            <span class="mc-num">№ ____</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= Today's briefing ================= -->
+  <section class="dpc-section dpc-center" id="briefing">
+    <span class="dpc-eyebrow">Today's briefing</span>
+    <h2 class="dpc-h2">Ten minutes of things going right.</h2>
+    <p class="dpc-sub">Dan and Patrick, every day: The Positive Papers, The Lever, and the Do Positive Dispatch.</p>
+    {% if static_episodes %}
+    <div class="dpc-latest">
+      <span class="lt-label">Latest episode</span>
+      <h3>{{ static_episodes[0].title }}</h3>
+      <audio controls preload="none" src="{{ static_episodes[0].audio_url }}">
+        Your browser does not support the audio element.
+      </audio>
+    </div>
+    {% else %}
+    <div class="dpc-latest">
+      <span class="lt-label">Episode one</span>
+      <h3>The first briefing drops soon. Founding members hear it first — take the pledge below.</h3>
+    </div>
+    {% endif %}
+    <div class="dpc-sub-chips">
+      <a href="{{ rss_url }}">RSS feed</a>
+      <a href="{{ path_prefix }}{{ blog_page }}">Episode notes &amp; transcripts</a>
+      <a href="#archive">All episodes</a>
+    </div>
+    <div style="margin-top:1.2rem;">{{ ai_badge(path_prefix=path_prefix) }}</div>
+  </section>
+
+  <!-- ================= How the club works ================= -->
+  <section class="dpc-section dpc-center">
+    <span class="dpc-eyebrow">How the club works</span>
+    <h2 class="dpc-h2">Briefing. Assignment. Proof.</h2>
+    <div class="dpc-steps" style="text-align:left;">
+      <div class="dpc-step"><span class="num">1</span>
+        <span class="tag">The Positive Papers</span>
+        <h3>You get the briefing</h3>
+        <p>Two or three real developments that are legitimately good news — the result,
+        the mechanism, the honest caveat, and the source. No fluff, no hype, no doom.</p>
+      </div>
+      <div class="dpc-step"><span class="num">2</span>
+        <span class="tag">The Lever</span>
+        <h3>You get one assignment</h3>
+        <p>One action with outsized impact, with honest numbers: what it costs in dollars
+        and hours, what it returns, and what it adds up to if the club pulls it together.</p>
+      </div>
+      <div class="dpc-step"><span class="num">3</span>
+        <span class="tag">The Do Positive Dispatch</span>
+        <h3>You send the proof</h3>
+        <p>Did it? Write in. Dispatches get read on the show — real ones only, that's the
+        whole point. The club runs on receipts, not intentions.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= The Pledge ================= -->
+  <section class="dpc-pledge" id="pledge">
+    <div class="dpc-section dpc-center">
+      <span class="dpc-eyebrow">Membership</span>
+      <h2 class="dpc-h2">Take the Do Positive Pledge.</h2>
+      <p class="dpc-sub">Joining isn't a subscription — it's a pledge. It costs nothing and it
+        never will. It just asks something of you.</p>
+      <div class="dpc-pledge-card">
+        <span class="pl-label">The Pledge</span>
+        <p class="dpc-pledge-text">“I'll take ten minutes a day for the good news —
+          and once a week, I'll do one positive thing about it.”</p>
+        <form class="dpc-pledge-form" action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow">
+          <input type="hidden" name="tag" value="{{ newsletter_tag }}">
+          <input type="email" name="email" required placeholder="you@example.com" aria-label="Email address">
+          <button type="submit">Sign the pledge — join the club</button>
+        </form>
+        <p class="dpc-pledge-fine">Free forever. Your email is the membership card — episode
+          alerts and the club dispatch, no spam, leave anytime.</p>
+        <div class="dpc-founding">
+          ⭐ <b>Founding Members:</b> everyone who signs before Episode 100 is a Founding
+          Member — numbered in order of joining, first on the wall, permanently.
+        </div>
+      </div>
+      <div class="dpc-wall" aria-label="Member wall">
+        <span class="member"><b>№ 001</b> Dan Perra — co-founder</span>
+        <span class="member"><b>№ 002</b> Patrick Novak — co-founder</span>
+        <span class="member you"><b>№ 003</b> your name goes here</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= The Lever Board ================= -->
+  <section class="dpc-section dpc-center" id="levers">
+    <span class="dpc-eyebrow">The Lever Board</span>
+    <h2 class="dpc-h2">This week's assignments.</h2>
+    <p class="dpc-sub">Every episode leaves one lever on the board. Pull one, then tell the club.</p>
+    <div class="dpc-levers" style="text-align:left;">
+      {% if dp_levers %}
+        {% for lv in dp_levers %}
+        <div class="dpc-lever">
+          <span class="lv-ep">Lever № {{ '%03d' % lv.episode_num }}{% if lv.hook %} · Ep {{ lv.episode_num }}{% endif %}</span>
+          {% if lv.hook %}<h3>{{ lv.hook }}</h3>{% endif %}
+          <p>{{ lv.lever_text }}</p>
+          <div class="lv-actions">
+            <a class="lv-btn lv-did" href="{{ dispatch_mailto }}">I did this →</a>
+            <a class="lv-btn lv-listen" href="{{ path_prefix }}{{ lv.blog_url }}">Episode notes</a>
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+        <div class="dpc-lever">
+          <span class="lv-ep">Starter lever № 001</span>
+          <h3>Recruit one doomscroller</h3>
+          <p>Know someone drowning in bad news? Send them this page. One message, thirty
+          seconds — that's how the club grows and how their feed gets better.</p>
+          <div class="lv-actions">
+            <a class="lv-btn lv-did" href="{{ dispatch_mailto }}">I did this →</a>
+          </div>
+        </div>
+        <div class="dpc-lever">
+          <span class="lv-ep">Starter lever № 002</span>
+          <h3>Send us the good news you saw</h3>
+          <p>Spotted genuinely good news this week — a result, a recovery, a price drop
+          that matters? Send it in. The best submissions make The Positive Papers.</p>
+          <div class="lv-actions">
+            <a class="lv-btn lv-did" href="mailto:patrick@planetterrian.com?subject=Good%20news%20for%20The%20DP%20Pod">Send it →</a>
+          </div>
+        </div>
+        <div class="dpc-lever">
+          <span class="lv-ep">Starter lever № 003</span>
+          <h3>Take the pledge</h3>
+          <p>The easiest lever on the board. Sign the pledge above and you're a Founding
+          Member — Episode 1's levers land in your inbox the moment they drop.</p>
+          <div class="lv-actions">
+            <a class="lv-btn lv-did" href="#pledge">Sign it →</a>
+          </div>
+        </div>
+      {% endif %}
+    </div>
+  </section>
+
+  <!-- ================= The Dispatch ================= -->
+  <section class="dpc-section dpc-center" id="dispatch">
+    <span class="dpc-eyebrow">The Do Positive Dispatch</span>
+    <h2 class="dpc-h2">Did something? Get read on the show.</h2>
+    <p class="dpc-sub">Dispatches follow the club format — three parts, honest numbers, real
+      actions only. We will never invent listener mail, which means every dispatch we read
+      is a real member doing a real thing.</p>
+    <div class="dpc-grammar">
+      <div class="g"><div class="gt">1 · What you did</div>
+        <p>The action, plainly. “Sealed the three worst drafts in my house.”</p></div>
+      <div class="g"><div class="gt">2 · The honest numbers</div>
+        <p>Cost, hours, savings, impact — rough is fine, honest is required.</p></div>
+      <div class="g"><div class="gt">3 · A shoutout</div>
+        <p>Who helped, or who should try it next. Gratitude fuels the club.</p></div>
+    </div>
+    <a class="dpc-cta dpc-cta--primary" href="{{ dispatch_mailto }}">Send your dispatch</a>
+    <p class="dpc-hero-note" style="margin-top:1rem;">New members and first dispatches get
+      welcomed on the show by first name — tell us how to read yours.</p>
+  </section>
+
+  <!-- ================= Club charter ================= -->
+  <section class="dpc-section dpc-center">
+    <span class="dpc-eyebrow">The Club Charter</span>
+    <h2 class="dpc-h2">Five things we'll never break.</h2>
+    <div class="dpc-charter" style="text-align:left;">
+      <div class="dpc-tenet"><h4>Free forever</h4>
+        <p>Membership never costs money. The club asks for action, not dollars.</p></div>
+      <div class="dpc-tenet"><h4>Honest numbers</h4>
+        <p>Every claim gets its caveat. Every lever states its real cost and payback.</p></div>
+      <div class="dpc-tenet"><h4>No guilt</h4>
+        <p>Empowerment, not obligation. Miss a week? The next lever is tomorrow.</p></div>
+      <div class="dpc-tenet"><h4>Real actions only</h4>
+        <p>No performative gestures, no fabricated mail. The Dispatch runs on receipts.</p></div>
+      <div class="dpc-tenet"><h4>Do something about it</h4>
+        <p>Every episode ends the same way, and it means you.</p></div>
+    </div>
+  </section>
+
+  <!-- ================= Hosts ================= -->
+  <section class="dpc-section dpc-center">
+    <span class="dpc-eyebrow">Your co-founders</span>
+    <h2 class="dpc-h2">Two friends with genuine skin in the game.</h2>
+    <div class="dpc-hosts" style="text-align:left;">
+      <div class="dpc-host">
+        <div class="hn">Dan Perra</div>
+        <div class="hr">Member № 001 · Airline pilot · Systems thinker</div>
+        <p>A commercial airline pilot and longtime technology enthusiast, Dan brings the
+        operator's perspective — what works in the real world, at altitude, under
+        pressure. Grounded skepticism that resolves into optimism when the numbers hold.</p>
+      </div>
+      <div class="dpc-host">
+        <div class="hn">Patrick Novak</div>
+        <div class="hr">Member № 002 · Physical chemist · Sci-fi novelist</div>
+        <p>A Vancouver-based entrepreneur, published science fiction novelist, and physical
+        chemist by training, Patrick brings the “why this actually matters” layer —
+        mechanisms, magnitudes, and whether a number survives scrutiny.</p>
+      </div>
+    </div>
+    <p class="dpc-nerra">Novak + Perra = <b>Nerra</b>. They built the Nerra Network together —
+      this is the show where they step in front of the microphone.</p>
+  </section>
+
+  <!-- ================= Archive ================= -->
+  {% if static_episodes and static_episodes|length > 1 %}
+  <section class="dpc-section dpc-center" id="archive">
+    <span class="dpc-eyebrow">The archive</span>
+    <h2 class="dpc-h2">Every briefing so far.</h2>
+    <div class="dpc-eplist" style="text-align:left;">
+      {% for ep in static_episodes %}
+      <div class="dpc-ep">
+        <span class="ed">{{ ep.date_display }}</span>
+        <span class="et">{{ ep.title }}</span>
+        <audio controls preload="none" src="{{ ep.audio_url }}"></audio>
+      </div>
+      {% endfor %}
+    </div>
+    <div class="dpc-sub-chips">
+      <a href="{{ path_prefix }}{{ blog_page }}">Full archive with notes &amp; transcripts →</a>
+    </div>
+  </section>
+  {% endif %}
+
+  <!-- ================= Final CTA ================= -->
+  <section class="dpc-section dpc-center" style="padding-bottom:6rem;">
+    <h2 class="dpc-h2 dpc-serif" style="font-style:italic;">“Do something about it.”</h2>
+    <p class="dpc-sub">It's exactly what it sounds like.</p>
+    <div class="dpc-hero-ctas" style="justify-content:center;">
+      <a class="dpc-cta dpc-cta--primary" href="#pledge">Take the Pledge</a>
+      <a class="dpc-cta dpc-cta--ghost" href="{{ dispatch_mailto }}">Send a dispatch</a>
+    </div>
+  </section>
+
+</div>
+{% endblock %}

--- a/tests/test_dp_pod_show.py
+++ b/tests/test_dp_pod_show.py
@@ -93,6 +93,61 @@ class TestChapterMarkers:
         assert by_title["Sign-Off"].where == "end"
 
 
+class TestClubPage:
+    """July 2026 club redesign (docs/dp_pod_market_assessment_2026_07.md):
+    the page is a membership pitch, not a media property — pledge-led join,
+    constrained Dispatch grammar, seeded member wall, free-forever charter."""
+
+    def test_registry_uses_club_template(self):
+        from generate_html import NETWORK_SHOWS
+
+        assert NETWORK_SHOWS["dp_pod"].get("show_page_template") == "show_page_dp_pod.html.j2"
+        assert (PROJECT_ROOT / "templates" / "show_page_dp_pod.html.j2").exists()
+
+    def test_club_page_renders_with_core_mechanics(self, tmp_path):
+        import generate_html as gh
+
+        html_path = gh.generate_show_page("dp_pod", dry_run=False)
+        html = Path(html_path).read_text(encoding="utf-8")
+        # Mechanic 1: pledge-led join via Buttondown with the show tag
+        assert "buttondown.com/api/emails/embed-subscribe" in html
+        assert 'value="DP Pod"' in html
+        assert "Do Positive Pledge" in html
+        # Mechanic 1b: seeded member wall (pledger-majority sequencing)
+        assert "№ 001" in html and "Dan Perra" in html
+        assert "№ 002" in html and "Patrick Novak" in html
+        # Mechanic 2: constrained Dispatch grammar with a real submission path
+        assert "mailto:" in html and "Do%20Positive%20Dispatch" in html
+        assert "The honest numbers" in html
+        # Mechanic 3/4: starter levers pre-launch + free-forever charter
+        assert "Free forever" in html
+        assert "Do something about it" in html
+
+    def test_lever_board_extracts_from_digest(self, tmp_path, monkeypatch):
+        import generate_html as gh
+
+        digest_dir = tmp_path / "digests" / "dp_pod"
+        digest_dir.mkdir(parents=True)
+        (digest_dir / "DP_Pod_Ep001_20260703.md").write_text(
+            "# The DP Pod: The Do Positive Podcast\n"
+            "**Date:** July 03, 2026\n\n"
+            "**HOOK:** Heat pumps just crossed the payback line.\n\n"
+            "### The Positive Papers\n1. **Solar: Source**\n   Text.\n\n"
+            "### The Lever\n"
+            "Get a free home heat-loss assessment and seal the top three leaks. "
+            "Costs roughly forty dollars and two hours; saves in the range of "
+            "one hundred fifty dollars a year.\n\n"
+            "### Do Positive Dispatch\nNo dispatches in the bag today.\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gh, "ROOT", tmp_path)
+        levers = gh._collect_dp_levers()
+        assert len(levers) == 1
+        assert levers[0]["episode_num"] == 1
+        assert "heat-loss assessment" in levers[0]["lever_text"]
+        assert "Dispatch" not in levers[0]["lever_text"]
+
+
 class TestIntrosPersonality:
     def test_intro_is_dan_labeled_dialogue(self):
         from engine.intros import build_intro_line

--- a/thedppod.html
+++ b/thedppod.html
@@ -62,40 +62,180 @@
     <link rel="stylesheet" href="styles/main.css">
 
     
-<!-- Schema.org PodcastSeries -->
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "PodcastSeries",
-  "name": "The DP Pod: The Do Positive Podcast",
-  "description": "The DP Pod — the Do Positive Podcast with Dan and Patrick. Daily good news in science and tech plus one concrete individual action with honest numbers. Do something about it.",
-  "url": "https://nerranetwork.com/thedppod.html",
-  "webFeed": "https://nerranetwork.com/dp_pod_podcast.rss",
-  "image": "https://nerranetwork.com/assets/covers/dp-pod.jpg"
-}
-</script>
 <style>
-    @keyframes shimmer {
-        0% { background-position: -200% 0; }
-        100% { background-position: 200% 0; }
-    }
-    .skeleton-card {
-        background: rgba(255,255,255,0.05);
-        border-radius: 12px;
-        padding: 1.5rem;
-    }
-    .skeleton-line {
-        height: 14px;
-        background: linear-gradient(90deg, rgba(255,255,255,0.06) 25%, rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.06) 75%);
-        background-size: 200% 100%;
-        animation: shimmer 1.5s infinite;
-        border-radius: 4px;
-        margin-bottom: 0.75rem;
-    }
-    .skeleton-title { width: 70%; height: 18px; }
-    .skeleton-date { width: 30%; }
-    .skeleton-text { width: 100%; }
-    .skeleton-text.short { width: 60%; }
+  /* ---- The Do Positive Club design system (scoped .dpc-) ---- */
+  .dpc-page { --dp-green:#12B76A; --dp-green-deep:#0B7A45; --dp-ink:#07130C;
+              --dp-cream:#F4FBF7; --dp-gold:#E8C468; --dp-line:rgba(18,183,106,0.25); }
+  .dpc-page { font-family:'DM Sans',system-ui,sans-serif; }
+  .dpc-serif { font-family:'Source Serif 4',Georgia,serif; }
+
+  .dpc-section { max-width:1060px; margin:0 auto; padding:4.5rem 1.25rem; }
+  .dpc-eyebrow { display:inline-flex; align-items:center; gap:0.6rem;
+    font-size:0.72rem; font-weight:700; letter-spacing:0.16em; text-transform:uppercase;
+    color:var(--dp-green); }
+  .dpc-eyebrow::before, .dpc-eyebrow::after { content:""; height:1px; width:34px;
+    background:var(--dp-line); }
+  .dpc-h2 { font-family:'Source Serif 4',Georgia,serif; font-size:clamp(1.7rem,3.6vw,2.5rem);
+    line-height:1.15; margin:0.65rem 0 0.9rem; color:var(--dp-cream); }
+  .dpc-sub { color:var(--nn-text-muted,#9aa7b8); max-width:46rem; margin:0 auto;
+    font-size:1.02rem; line-height:1.65; }
+
+  /* Hero */
+  .dpc-hero { position:relative; overflow:hidden;
+    background:
+      radial-gradient(1100px 500px at 70% -10%, rgba(18,183,106,0.16), transparent 60%),
+      radial-gradient(700px 420px at 10% 110%, rgba(232,196,104,0.07), transparent 60%),
+      linear-gradient(180deg, #07130C 0%, #0B0F1A 100%);
+    border-bottom:1px solid var(--dp-line); }
+  .dpc-hero-inner { max-width:1060px; margin:0 auto; padding:5rem 1.25rem 4.2rem;
+    display:grid; grid-template-columns:1.25fr 0.85fr; gap:3rem; align-items:center; }
+  .dpc-hero h1 { font-family:'Source Serif 4',Georgia,serif;
+    font-size:clamp(2.3rem,5.4vw,3.7rem); line-height:1.08; margin:1rem 0 1.1rem;
+    color:var(--dp-cream); }
+  .dpc-hero h1 em { font-style:italic; color:var(--dp-green); }
+  .dpc-hero-desc { color:#b8c6bd; font-size:1.1rem; line-height:1.7; max-width:34rem; }
+  .dpc-hero-ctas { display:flex; gap:0.8rem; flex-wrap:wrap; margin-top:1.7rem; }
+  .dpc-cta { display:inline-flex; align-items:center; gap:0.5rem; padding:0.85rem 1.5rem;
+    border-radius:999px; font-weight:700; font-size:0.98rem; text-decoration:none;
+    transition:transform .15s ease, box-shadow .15s ease; }
+  .dpc-cta--primary { background:var(--dp-green); color:#06130b;
+    box-shadow:0 8px 28px rgba(18,183,106,0.35); }
+  .dpc-cta--primary:hover { transform:translateY(-2px); box-shadow:0 12px 34px rgba(18,183,106,0.45); }
+  .dpc-cta--ghost { border:1px solid var(--dp-line); color:var(--dp-cream); background:rgba(18,183,106,0.06); }
+  .dpc-cta--ghost:hover { background:rgba(18,183,106,0.12); }
+  .dpc-hero-note { margin-top:1.1rem; font-size:0.85rem; color:#7ba893; }
+
+  /* Membership card */
+  .dpc-card-wrap { perspective:1000px; }
+  .dpc-membercard { position:relative; border-radius:18px; padding:1.6rem 1.7rem;
+    background:linear-gradient(135deg,#0E2418 0%,#0A1A11 55%,#123A24 100%);
+    border:1px solid rgba(232,196,104,0.35);
+    box-shadow:0 24px 60px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.06);
+    transform:rotate(2.5deg); transition:transform .3s ease; aspect-ratio:1.586; max-width:400px;
+    display:flex; flex-direction:column; justify-content:space-between; margin-left:auto; }
+  .dpc-membercard:hover { transform:rotate(0deg) scale(1.02); }
+  .dpc-membercard .mc-top { display:flex; justify-content:space-between; align-items:flex-start; }
+  .dpc-membercard .mc-club { font-size:0.68rem; letter-spacing:0.18em; text-transform:uppercase;
+    color:var(--dp-gold); font-weight:700; }
+  .dpc-membercard .mc-free { font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase;
+    color:#7ba893; border:1px solid rgba(123,168,147,0.4); border-radius:999px; padding:0.2rem 0.6rem; }
+  .dpc-membercard .mc-name { font-family:'Source Serif 4',Georgia,serif; font-size:1.5rem;
+    color:var(--dp-cream); }
+  .dpc-membercard .mc-name span { color:var(--dp-green); }
+  .dpc-membercard .mc-bottom { display:flex; justify-content:space-between; align-items:flex-end; }
+  .dpc-membercard .mc-motto { font-size:0.78rem; color:#9db8a8; font-style:italic; }
+  .dpc-membercard .mc-num { font-size:0.9rem; color:var(--dp-gold); font-weight:700;
+    font-variant-numeric:tabular-nums; }
+
+  /* Steps */
+  .dpc-steps { display:grid; grid-template-columns:repeat(3,1fr); gap:1.1rem; margin-top:2rem; }
+  .dpc-step { background:rgba(18,183,106,0.05); border:1px solid var(--dp-line);
+    border-radius:16px; padding:1.5rem; position:relative; }
+  .dpc-step .num { position:absolute; top:1.1rem; right:1.2rem;
+    font-family:'Source Serif 4',Georgia,serif; font-size:2rem; color:rgba(18,183,106,0.35);
+    font-weight:700; }
+  .dpc-step h3 { margin:0 0 0.5rem; color:var(--dp-cream); font-size:1.08rem; }
+  .dpc-step .tag { display:inline-block; font-size:0.68rem; letter-spacing:0.12em;
+    text-transform:uppercase; color:var(--dp-green); font-weight:700; margin-bottom:0.55rem; }
+  .dpc-step p { margin:0; color:var(--nn-text-muted,#9aa7b8); font-size:0.92rem; line-height:1.6; }
+
+  /* Pledge */
+  .dpc-pledge { background:
+      radial-gradient(700px 340px at 50% 0%, rgba(18,183,106,0.13), transparent 65%);
+    border-top:1px solid var(--dp-line); border-bottom:1px solid var(--dp-line); }
+  .dpc-pledge-card { max-width:640px; margin:2.2rem auto 0; border-radius:20px;
+    background:linear-gradient(180deg,#0E2418,#0A160F); border:1px solid rgba(232,196,104,0.28);
+    padding:2.3rem 2.2rem; box-shadow:0 24px 70px rgba(0,0,0,0.45); text-align:center; }
+  .dpc-pledge-card .pl-label { font-size:0.7rem; letter-spacing:0.2em; text-transform:uppercase;
+    color:var(--dp-gold); font-weight:700; }
+  .dpc-pledge-text { font-family:'Source Serif 4',Georgia,serif; font-size:1.35rem;
+    line-height:1.55; color:var(--dp-cream); margin:1.1rem 0 1.4rem; font-style:italic; }
+  .dpc-pledge-form { display:flex; gap:0.6rem; flex-wrap:wrap; justify-content:center; }
+  .dpc-pledge-form input[type=email] { flex:1 1 240px; max-width:330px; padding:0.85rem 1.1rem;
+    border-radius:999px; border:1px solid var(--dp-line); background:rgba(7,19,12,0.8);
+    color:var(--dp-cream); font-size:0.95rem; }
+  .dpc-pledge-form button { padding:0.85rem 1.5rem; border-radius:999px; border:none;
+    background:var(--dp-green); color:#06130b; font-weight:700; font-size:0.95rem; cursor:pointer; }
+  .dpc-pledge-form button:hover { filter:brightness(1.08); }
+  .dpc-pledge-fine { margin-top:1rem; font-size:0.8rem; color:#7ba893; }
+  .dpc-founding { margin-top:1.3rem; padding-top:1.2rem; border-top:1px dashed rgba(232,196,104,0.25);
+    font-size:0.88rem; color:#c9b98a; }
+
+  /* Member wall (seeded) */
+  .dpc-wall { display:flex; gap:0.6rem; flex-wrap:wrap; justify-content:center; margin-top:1.6rem; }
+  .dpc-wall .member { border:1px solid var(--dp-line); border-radius:999px; padding:0.45rem 1rem;
+    font-size:0.85rem; color:var(--dp-cream); background:rgba(18,183,106,0.06);
+    font-variant-numeric:tabular-nums; }
+  .dpc-wall .member b { color:var(--dp-gold); font-weight:700; margin-right:0.4rem; }
+  .dpc-wall .member.you { border-style:dashed; color:#7ba893; }
+
+  /* Lever board */
+  .dpc-levers { display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
+    gap:1.1rem; margin-top:2rem; }
+  .dpc-lever { background:rgba(18,183,106,0.05); border:1px solid var(--dp-line);
+    border-radius:16px; padding:1.4rem; display:flex; flex-direction:column; gap:0.7rem; }
+  .dpc-lever .lv-ep { font-size:0.68rem; letter-spacing:0.12em; text-transform:uppercase;
+    color:var(--dp-green); font-weight:700; }
+  .dpc-lever h3 { margin:0; font-size:1rem; color:var(--dp-cream); line-height:1.4; }
+  .dpc-lever p { margin:0; color:var(--nn-text-muted,#9aa7b8); font-size:0.88rem; line-height:1.6; flex:1; }
+  .dpc-lever .lv-actions { display:flex; gap:0.55rem; flex-wrap:wrap; }
+  .dpc-lever .lv-btn { font-size:0.82rem; font-weight:700; padding:0.5rem 0.95rem; border-radius:999px;
+    text-decoration:none; }
+  .dpc-lever .lv-did { background:var(--dp-green); color:#06130b; }
+  .dpc-lever .lv-listen { border:1px solid var(--dp-line); color:var(--dp-cream); }
+
+  /* Dispatch */
+  .dpc-grammar { display:grid; grid-template-columns:repeat(3,1fr); gap:1.1rem; margin:2rem 0; }
+  .dpc-grammar .g { border:1px dashed rgba(232,196,104,0.35); border-radius:14px; padding:1.2rem;
+    text-align:center; }
+  .dpc-grammar .g .gt { font-family:'Source Serif 4',Georgia,serif; color:var(--dp-gold);
+    font-size:1.05rem; margin-bottom:0.4rem; }
+  .dpc-grammar .g p { margin:0; font-size:0.85rem; color:var(--nn-text-muted,#9aa7b8); line-height:1.55; }
+
+  /* Charter */
+  .dpc-charter { display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:1rem;
+    margin-top:2rem; counter-reset:tenet; }
+  .dpc-tenet { border-left:2px solid var(--dp-green); padding:0.2rem 0 0.2rem 1.1rem; }
+  .dpc-tenet h4 { margin:0 0 0.3rem; color:var(--dp-cream); font-size:0.98rem; }
+  .dpc-tenet p { margin:0; font-size:0.84rem; color:var(--nn-text-muted,#9aa7b8); line-height:1.55; }
+
+  /* Hosts */
+  .dpc-hosts { display:grid; grid-template-columns:1fr 1fr; gap:1.2rem; margin-top:2rem; }
+  .dpc-host { background:rgba(18,183,106,0.05); border:1px solid var(--dp-line); border-radius:16px;
+    padding:1.6rem; }
+  .dpc-host .hn { font-family:'Source Serif 4',Georgia,serif; font-size:1.25rem; color:var(--dp-cream); }
+  .dpc-host .hr { font-size:0.78rem; letter-spacing:0.1em; text-transform:uppercase;
+    color:var(--dp-green); font-weight:700; margin:0.25rem 0 0.7rem; }
+  .dpc-host p { margin:0; font-size:0.92rem; color:var(--nn-text-muted,#9aa7b8); line-height:1.65; }
+  .dpc-nerra { text-align:center; margin-top:1.6rem; font-size:0.9rem; color:#7ba893; }
+  .dpc-nerra b { color:var(--dp-gold); }
+
+  /* Episodes */
+  .dpc-latest { max-width:760px; margin:2rem auto 0; background:rgba(18,183,106,0.05);
+    border:1px solid var(--dp-line); border-radius:18px; padding:1.8rem; }
+  .dpc-latest .lt-label { font-size:0.7rem; letter-spacing:0.16em; text-transform:uppercase;
+    color:var(--dp-green); font-weight:700; }
+  .dpc-latest h3 { margin:0.5rem 0 1rem; color:var(--dp-cream);
+    font-family:'Source Serif 4',Georgia,serif; font-size:1.25rem; line-height:1.4; }
+  .dpc-latest audio { width:100%; }
+  .dpc-eplist { max-width:760px; margin:1.4rem auto 0; }
+  .dpc-ep { display:flex; align-items:center; gap:1rem; padding:0.9rem 0.4rem;
+    border-bottom:1px solid rgba(18,183,106,0.14); }
+  .dpc-ep .ed { font-size:0.78rem; color:#7ba893; min-width:120px; font-variant-numeric:tabular-nums; }
+  .dpc-ep .et { flex:1; font-size:0.92rem; color:var(--dp-cream); line-height:1.45; }
+  .dpc-ep audio { max-width:230px; height:36px; }
+  .dpc-sub-chips { display:flex; gap:0.6rem; flex-wrap:wrap; justify-content:center; margin-top:1.6rem; }
+  .dpc-sub-chips a { border:1px solid var(--dp-line); border-radius:999px; padding:0.5rem 1.05rem;
+    font-size:0.85rem; color:var(--dp-cream); text-decoration:none; }
+  .dpc-sub-chips a:hover { background:rgba(18,183,106,0.1); }
+
+  .dpc-center { text-align:center; }
+  @media (max-width: 860px) {
+    .dpc-hero-inner { grid-template-columns:1fr; }
+    .dpc-membercard { margin:0 auto; transform:rotate(0); }
+    .dpc-steps, .dpc-grammar, .dpc-hosts { grid-template-columns:1fr; }
+    .dpc-ep { flex-wrap:wrap; }
+  }
 </style>
 
 
@@ -335,11 +475,12 @@
                     </div>
                 </li>
                 
-<li><a href="start-here.html">Start Here</a></li>
-<li><a href="how-to-listen.html">Listen</a></li>
-<li><a href="about.html">About</a></li>
-<li><a href="player.html">Player</a></li>
-
+                <li><a href="start-here.html">Start Here</a></li>
+                <li><a href="how-to-listen.html">Listen</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="player.html">Player</a></li>
+                <li><a href="index.html">Home</a></li>
+                
             </ul>
 
             <button class="nn-hamburger" aria-label="Toggle menu" aria-expanded="false" onclick="var m=document.getElementById('mobileMenu');m.classList.toggle('open');this.setAttribute('aria-expanded',m.classList.contains('open'));document.body.classList.toggle('menu-open')">&#9776;</button>
@@ -349,18 +490,12 @@
     <!-- Mobile Menu -->
     <div id="mobileMenu" class="nn-mobile-menu">
         
-<a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Start Here</a>
-<a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Listen</a>
-<a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
-<a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Player</a>
-<a href="thedppod.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Home</a>
-<a href="blog/dp_pod/index.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Blog</a>
-<a href="thedppod-summaries.html" onclick="document.getElementById('mobileMenu').classList.remove('open')">Summaries</a>
-<a href="#episodes" onclick="document.getElementById('mobileMenu').classList.remove('open')">Episodes</a>
-<a href="#about" onclick="document.getElementById('mobileMenu').classList.remove('open')">About</a>
-<a href="#resources" onclick="document.getElementById('mobileMenu').classList.remove('open')">Resources</a>
-<a href="#faq" onclick="document.getElementById('mobileMenu').classList.remove('open')">FAQ</a>
-
+        <a href="start-here.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Start Here</a>
+        <a href="how-to-listen.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">How to Listen</a>
+        <a href="about.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">About</a>
+        <a href="player.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Player</a>
+        <a href="index.html" onclick="document.getElementById('mobileMenu').classList.remove('open');document.body.classList.remove('menu-open')">Home</a>
+        
         <div class="nn-mobile-shows">
             <div class="nn-mobile-shows-title">All Shows</div>
             
@@ -516,381 +651,237 @@
 
     <main id="main-content">
     
+<div class="dpc-page">
+
+  <!-- ================= Hero ================= -->
+  <section class="dpc-hero">
+    <div class="dpc-hero-inner">
+      <div>
+        <span class="dpc-eyebrow" style="justify-content:flex-start;">The Do Positive Club · Est. 2026 · Free forever</span>
+        <h1>Most media tells you what's wrong.<br>This club <em>does something about it.</em></h1>
+        <p class="dpc-hero-desc">
+          The DP Pod is a ten-minute daily briefing of genuinely good news in science and
+          tech — with honest numbers, healthy disagreement, and one concrete action a
+          regular person can take. Members don't just listen. They pull the lever, write
+          in, and get read on the show.
+        </p>
+        <div class="dpc-hero-ctas">
+          <a class="dpc-cta dpc-cta--primary" href="#pledge">Take the Pledge</a>
+          <a class="dpc-cta dpc-cta--ghost" href="#briefing">▶ Today's briefing</a>
+        </div>
+        <p class="dpc-hero-note">No paywall. No guilt. Just the good news and something to do about it.</p>
+      </div>
+      <div class="dpc-card-wrap">
+        <div class="dpc-membercard" aria-label="The Do Positive Club membership card">
+          <div class="mc-top">
+            <span class="mc-club">The Do Positive Club</span>
+            <span class="mc-free">Free forever</span>
+          </div>
+          <div class="mc-name">Member: <span>you, hopefully</span></div>
+          <div class="mc-bottom">
+            <span class="mc-motto">“Do something about it.”</span>
+            <span class="mc-num">№ ____</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= Today's briefing ================= -->
+  <section class="dpc-section dpc-center" id="briefing">
+    <span class="dpc-eyebrow">Today's briefing</span>
+    <h2 class="dpc-h2">Ten minutes of things going right.</h2>
+    <p class="dpc-sub">Dan and Patrick, every day: The Positive Papers, The Lever, and the Do Positive Dispatch.</p>
     
-    <!-- Hero -->
-    <section class="show-hero">
-        <div class="show-hero-bg"></div>
-        <div class="show-hero-inner">
-            
-            <picture>
-                <source type="image/webp" srcset="assets/covers/dp-pod-400.webp 400w, assets/covers/dp-pod-800.webp 800w, assets/covers/dp-pod.webp 1400w" sizes="(max-width: 600px) 240px, 360px">
-                <img src="assets/covers/dp-pod.jpg" alt="The DP Pod: The Do Positive Podcast cover art" class="show-hero-art"
-                     width="1400" height="1400" fetchpriority="high"
-                     onerror="this.style.display='none'">
-            </picture>
-            <div class="show-hero-info">
-                <h1>The DP Pod: The Do Positive Podcast</h1>
-                <p class="show-hero-tagline">Good news, honest numbers, and one action that counts — every day.</p>
-                <div style="display:flex;gap:var(--sp-2);align-items:center;margin-bottom:var(--sp-3);font-family:var(--font-ui);font-size:0.85rem;color:var(--nn-text-muted);"><span style="background:var(--nn-card);border:1px solid var(--nn-border);padding:2px 10px;border-radius:6px;">Daily</span>
-                    <span style="background:var(--nn-card);border:1px solid var(--nn-border);padding:2px 10px;border-radius:6px;">~10 min</span>
-                </div>
-                <p class="show-hero-desc">Most media tells you what's going wrong and who's to blame. The Do Positive Podcast starts from a different conviction: individuals are not powerless. Every day, Dan and Patrick dig into genuinely good news in science, technology, and everyday life — and then get practical about it, connecting each story to a real action a regular person can take. Not performative gestures. Not guilt. Concrete choices, backed by honest numbers, that add up. Each episode: The Positive Papers (two or three real developments that are legitimately good news), The Lever (one individual action with honest numbers on its impact), and the Do Positive Dispatch (what listeners actually did). The name is a wink. The mission is sincere — and every episode closes with the same challenge: do something about it.</p>
-                
-                <p style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);margin-bottom:var(--sp-4);font-style:italic;">Curious, action-oriented listeners tired of feeling helpless — early adopters, science enthusiasts, EV owners, parents thinking about the future, professionals who want their choices to count</p>
-                
-                
-                <div class="show-hero-actions">
-                    <a href="#episodes" class="nn-btn nn-btn-primary">Listen Now</a>
-                    <a href="blog/dp_pod/index.html" class="nn-btn">Read Blog</a>
-                    <a href="thedppod-summaries.html" class="nn-btn">View Summaries</a>
-                    
-                    
-                    
-                    
-                </div>
-
-                
-                <div class="show-hero-subscribe">
-                    <span class="subscribe-label">Subscribe</span>
-                    
-                    
-                    <a href="dp_pod_podcast.rss" class="nn-chip" data-show="dp_pod">RSS</a>
-                    
-                    
-                </div>
-
-                
-                <div style="margin-top:var(--sp-3);">
-                    <a href="ai-disclosure.html" class="nn-ai-badge" rel="nofollow"
+    <div class="dpc-latest">
+      <span class="lt-label">Episode one</span>
+      <h3>The first briefing drops soon. Founding members hear it first — take the pledge below.</h3>
+    </div>
+    
+    <div class="dpc-sub-chips">
+      <a href="dp_pod_podcast.rss">RSS feed</a>
+      <a href="blog/dp_pod/index.html">Episode notes &amp; transcripts</a>
+      <a href="#archive">All episodes</a>
+    </div>
+    <div style="margin-top:1.2rem;"><a href="ai-disclosure.html" class="nn-ai-badge" rel="nofollow"
    title="How we use AI — full transparency"
    style="display:inline-flex;align-items:center;gap:6px;padding:3px 10px;border:1px solid var(--nn-border);border-radius:100px;font-family:var(--font-ui);font-size:0.72rem;font-weight:600;color:var(--nn-text-muted);text-decoration:none;line-height:1.4;white-space:nowrap;">
   <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8v.01M11 12h1v4h1"/></svg>
   Made with AI — transparently
-</a>
-                </div>
-                
-                
-            </div>
+</a></div>
+  </section>
+
+  <!-- ================= How the club works ================= -->
+  <section class="dpc-section dpc-center">
+    <span class="dpc-eyebrow">How the club works</span>
+    <h2 class="dpc-h2">Briefing. Assignment. Proof.</h2>
+    <div class="dpc-steps" style="text-align:left;">
+      <div class="dpc-step"><span class="num">1</span>
+        <span class="tag">The Positive Papers</span>
+        <h3>You get the briefing</h3>
+        <p>Two or three real developments that are legitimately good news — the result,
+        the mechanism, the honest caveat, and the source. No fluff, no hype, no doom.</p>
+      </div>
+      <div class="dpc-step"><span class="num">2</span>
+        <span class="tag">The Lever</span>
+        <h3>You get one assignment</h3>
+        <p>One action with outsized impact, with honest numbers: what it costs in dollars
+        and hours, what it returns, and what it adds up to if the club pulls it together.</p>
+      </div>
+      <div class="dpc-step"><span class="num">3</span>
+        <span class="tag">The Do Positive Dispatch</span>
+        <h3>You send the proof</h3>
+        <p>Did it? Write in. Dispatches get read on the show — real ones only, that's the
+        whole point. The club runs on receipts, not intentions.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= The Pledge ================= -->
+  <section class="dpc-pledge" id="pledge">
+    <div class="dpc-section dpc-center">
+      <span class="dpc-eyebrow">Membership</span>
+      <h2 class="dpc-h2">Take the Do Positive Pledge.</h2>
+      <p class="dpc-sub">Joining isn't a subscription — it's a pledge. It costs nothing and it
+        never will. It just asks something of you.</p>
+      <div class="dpc-pledge-card">
+        <span class="pl-label">The Pledge</span>
+        <p class="dpc-pledge-text">“I'll take ten minutes a day for the good news —
+          and once a week, I'll do one positive thing about it.”</p>
+        <form class="dpc-pledge-form" action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow">
+          <input type="hidden" name="tag" value="DP Pod">
+          <input type="email" name="email" required placeholder="you@example.com" aria-label="Email address">
+          <button type="submit">Sign the pledge — join the club</button>
+        </form>
+        <p class="dpc-pledge-fine">Free forever. Your email is the membership card — episode
+          alerts and the club dispatch, no spam, leave anytime.</p>
+        <div class="dpc-founding">
+          ⭐ <b>Founding Members:</b> everyone who signs before Episode 100 is a Founding
+          Member — numbered in order of joining, first on the wall, permanently.
         </div>
-    </section>
-    <section style="padding:var(--sp-3) var(--sp-6);background:var(--nn-card);border-bottom:1px solid var(--nn-border);">
-        <div class="container" style="max-width:760px;display:flex;flex-wrap:wrap;align-items:center;gap:var(--sp-3);justify-content:center;">
-            <span style="font-family:var(--font-ui);font-size:0.92rem;color:var(--nn-text);">
-                📬 Get tomorrow's episode in your inbox:
-            </span>
-            <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" style="display:flex;gap:var(--sp-2);flex-wrap:wrap;">
-                <input type="hidden" name="tag" value="The DP Pod: The Do Positive Podcast">
-                <input type="hidden" value="1" name="embed">
-                <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address" style="padding:6px 12px;border-radius:6px;border:1px solid var(--nn-border);background:var(--nn-bg);color:var(--nn-text);font-size:0.92rem;min-width:200px;">
-                <button type="submit" style="padding:6px 14px;border-radius:6px;background:var(--show-color);color:#ffffff;border:none;font-size:0.92rem;font-weight:600;cursor:pointer;">Subscribe</button>
-            </form>
+      </div>
+      <div class="dpc-wall" aria-label="Member wall">
+        <span class="member"><b>№ 001</b> Dan Perra — co-founder</span>
+        <span class="member"><b>№ 002</b> Patrick Novak — co-founder</span>
+        <span class="member you"><b>№ 003</b> your name goes here</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= The Lever Board ================= -->
+  <section class="dpc-section dpc-center" id="levers">
+    <span class="dpc-eyebrow">The Lever Board</span>
+    <h2 class="dpc-h2">This week's assignments.</h2>
+    <p class="dpc-sub">Every episode leaves one lever on the board. Pull one, then tell the club.</p>
+    <div class="dpc-levers" style="text-align:left;">
+      
+        <div class="dpc-lever">
+          <span class="lv-ep">Starter lever № 001</span>
+          <h3>Recruit one doomscroller</h3>
+          <p>Know someone drowning in bad news? Send them this page. One message, thirty
+          seconds — that's how the club grows and how their feed gets better.</p>
+          <div class="lv-actions">
+            <a class="lv-btn lv-did" href="mailto:patrick@planetterrian.com?subject=Do%20Positive%20Dispatch%20%E2%80%94%20what%20I%20did&body=WHAT%20I%20DID%3A%0A%0ATHE%20HONEST%20NUMBERS%20(cost%2C%20time%2C%20impact%20%E2%80%94%20rough%20is%20fine)%3A%0A%0ASHOUTOUT%20(who%20helped%2C%20or%20who%20should%20try%20it%20next)%3A%0A%0AFirst%20name%20%2B%20city%20(how%20we%27ll%20read%20it%20on%20air)%3A%0A">I did this →</a>
+          </div>
         </div>
-    </section>
-    
-
-    <!-- Latest Episode -->
-    <section class="nn-section" style="padding-top: var(--sp-8);">
-        <div class="container">
-            <div class="latest-episode glass-card" id="latest-player">
-                <div class="latest-episode-label">Latest Episode</div>
-                <div class="latest-episode-title" id="latest-title">Loading...</div>
-                <div class="latest-episode-date" id="latest-date"></div>
-                <audio id="latest-audio" controls preload="none" aria-label="Latest episode audio player" style="width:100%;height:42px;border-radius:8px;"></audio>
-                
-                <div id="latest-langs" style="display:none;margin-top:10px;align-items:center;flex-wrap:wrap;gap:6px;" aria-label="Listen in another language"></div>
-                <div id="latest-summary" style="margin-top:var(--sp-4);color:var(--nn-text-muted);font-size:0.92rem;display:none;"></div>
-
-                
-                <noscript>
-                    
-                </noscript>
-            </div>
+        <div class="dpc-lever">
+          <span class="lv-ep">Starter lever № 002</span>
+          <h3>Send us the good news you saw</h3>
+          <p>Spotted genuinely good news this week — a result, a recovery, a price drop
+          that matters? Send it in. The best submissions make The Positive Papers.</p>
+          <div class="lv-actions">
+            <a class="lv-btn lv-did" href="mailto:patrick@planetterrian.com?subject=Good%20news%20for%20The%20DP%20Pod">Send it →</a>
+          </div>
         </div>
-    </section>
-
-    
-
-    <!-- Episode Archive -->
-    <section id="episodes" class="nn-section" style="padding-top: 0;">
-        <div class="container">
-            <div class="nn-section-header" style="text-align:left;">
-                <h2>Recent Episodes</h2>
-            </div>
-            <div id="episodes-grid" class="episodes-grid">
-                
-                <div class="skeleton-card"><div class="skeleton-line skeleton-title"></div><div class="skeleton-line skeleton-date"></div><div class="skeleton-line skeleton-text"></div><div class="skeleton-line skeleton-text short"></div></div>
-                <div class="skeleton-card"><div class="skeleton-line skeleton-title"></div><div class="skeleton-line skeleton-date"></div><div class="skeleton-line skeleton-text"></div><div class="skeleton-line skeleton-text short"></div></div>
-                <div class="skeleton-card"><div class="skeleton-line skeleton-title"></div><div class="skeleton-line skeleton-date"></div><div class="skeleton-line skeleton-text"></div><div class="skeleton-line skeleton-text short"></div></div>
-                
-            </div>
-            <div style="text-align:center;margin-top:var(--sp-6);">
-                <a href="thedppod-summaries.html" class="nn-btn">View All Episodes</a>
-            </div>
-
-            
-            
+        <div class="dpc-lever">
+          <span class="lv-ep">Starter lever № 003</span>
+          <h3>Take the pledge</h3>
+          <p>The easiest lever on the board. Sign the pledge above and you're a Founding
+          Member — Episode 1's levers land in your inbox the moment they drop.</p>
+          <div class="lv-actions">
+            <a class="lv-btn lv-did" href="#pledge">Sign it →</a>
+          </div>
         </div>
-    </section>
+      
+    </div>
+  </section>
 
-    <!-- About -->
-    <section id="about" class="nn-section" style="border-top:1px solid var(--nn-border);">
-        <div class="container">
-            <div class="nn-section-header">
-                <h2>About The DP Pod: The Do Positive Podcast</h2>
-            </div>
-            <div class="about-section-text">
-                <p>Most media tells you what's going wrong and who's to blame. The Do Positive Podcast starts from a different conviction: individuals are not powerless. Every day, Dan and Patrick dig into genuinely good news in science, technology, and everyday life — and then get practical about it, connecting each story to a real action a regular person can take. Not performative gestures. Not guilt. Concrete choices, backed by honest numbers, that add up. Each episode: The Positive Papers (two or three real developments that are legitimately good news), The Lever (one individual action with honest numbers on its impact), and the Do Positive Dispatch (what listeners actually did). The name is a wink. The mission is sincere — and every episode closes with the same challenge: do something about it.</p>
-                
-                <p>Hosted by Dan Perra and Patrick Novak — the co-founders of the Nerra Network (Novak + Perra = Nerra). Patrick is a Vancouver-based entrepreneur, published science fiction novelist, and physical chemist by training. Dan is a commercial airline pilot and longtime technology enthusiast.</p>
-                
-            </div>
-        </div>
-    </section>
+  <!-- ================= The Dispatch ================= -->
+  <section class="dpc-section dpc-center" id="dispatch">
+    <span class="dpc-eyebrow">The Do Positive Dispatch</span>
+    <h2 class="dpc-h2">Did something? Get read on the show.</h2>
+    <p class="dpc-sub">Dispatches follow the club format — three parts, honest numbers, real
+      actions only. We will never invent listener mail, which means every dispatch we read
+      is a real member doing a real thing.</p>
+    <div class="dpc-grammar">
+      <div class="g"><div class="gt">1 · What you did</div>
+        <p>The action, plainly. “Sealed the three worst drafts in my house.”</p></div>
+      <div class="g"><div class="gt">2 · The honest numbers</div>
+        <p>Cost, hours, savings, impact — rough is fine, honest is required.</p></div>
+      <div class="g"><div class="gt">3 · A shoutout</div>
+        <p>Who helped, or who should try it next. Gratitude fuels the club.</p></div>
+    </div>
+    <a class="dpc-cta dpc-cta--primary" href="mailto:patrick@planetterrian.com?subject=Do%20Positive%20Dispatch%20%E2%80%94%20what%20I%20did&body=WHAT%20I%20DID%3A%0A%0ATHE%20HONEST%20NUMBERS%20(cost%2C%20time%2C%20impact%20%E2%80%94%20rough%20is%20fine)%3A%0A%0ASHOUTOUT%20(who%20helped%2C%20or%20who%20should%20try%20it%20next)%3A%0A%0AFirst%20name%20%2B%20city%20(how%20we%27ll%20read%20it%20on%20air)%3A%0A">Send your dispatch</a>
+    <p class="dpc-hero-note" style="margin-top:1rem;">New members and first dispatches get
+      welcomed on the show by first name — tell us how to read yours.</p>
+  </section>
 
-    <!-- Resources (categorized) -->
-    
+  <!-- ================= Club charter ================= -->
+  <section class="dpc-section dpc-center">
+    <span class="dpc-eyebrow">The Club Charter</span>
+    <h2 class="dpc-h2">Five things we'll never break.</h2>
+    <div class="dpc-charter" style="text-align:left;">
+      <div class="dpc-tenet"><h4>Free forever</h4>
+        <p>Membership never costs money. The club asks for action, not dollars.</p></div>
+      <div class="dpc-tenet"><h4>Honest numbers</h4>
+        <p>Every claim gets its caveat. Every lever states its real cost and payback.</p></div>
+      <div class="dpc-tenet"><h4>No guilt</h4>
+        <p>Empowerment, not obligation. Miss a week? The next lever is tomorrow.</p></div>
+      <div class="dpc-tenet"><h4>Real actions only</h4>
+        <p>No performative gestures, no fabricated mail. The Dispatch runs on receipts.</p></div>
+      <div class="dpc-tenet"><h4>Do something about it</h4>
+        <p>Every episode ends the same way, and it means you.</p></div>
+    </div>
+  </section>
 
-    <!-- Recommended Tools -->
-    
+  <!-- ================= Hosts ================= -->
+  <section class="dpc-section dpc-center">
+    <span class="dpc-eyebrow">Your co-founders</span>
+    <h2 class="dpc-h2">Two friends with genuine skin in the game.</h2>
+    <div class="dpc-hosts" style="text-align:left;">
+      <div class="dpc-host">
+        <div class="hn">Dan Perra</div>
+        <div class="hr">Member № 001 · Airline pilot · Systems thinker</div>
+        <p>A commercial airline pilot and longtime technology enthusiast, Dan brings the
+        operator's perspective — what works in the real world, at altitude, under
+        pressure. Grounded skepticism that resolves into optimism when the numbers hold.</p>
+      </div>
+      <div class="dpc-host">
+        <div class="hn">Patrick Novak</div>
+        <div class="hr">Member № 002 · Physical chemist · Sci-fi novelist</div>
+        <p>A Vancouver-based entrepreneur, published science fiction novelist, and physical
+        chemist by training, Patrick brings the “why this actually matters” layer —
+        mechanisms, magnitudes, and whether a number survives scrutiny.</p>
+      </div>
+    </div>
+    <p class="dpc-nerra">Novak + Perra = <b>Nerra</b>. They built the Nerra Network together —
+      this is the show where they step in front of the microphone.</p>
+  </section>
 
-    <!-- Referral -->
-    
+  <!-- ================= Archive ================= -->
+  
 
-    <!-- Key Concepts / FAQ -->
-    
+  <!-- ================= Final CTA ================= -->
+  <section class="dpc-section dpc-center" style="padding-bottom:6rem;">
+    <h2 class="dpc-h2 dpc-serif" style="font-style:italic;">“Do something about it.”</h2>
+    <p class="dpc-sub">It's exactly what it sounds like.</p>
+    <div class="dpc-hero-ctas" style="justify-content:center;">
+      <a class="dpc-cta dpc-cta--primary" href="#pledge">Take the Pledge</a>
+      <a class="dpc-cta dpc-cta--ghost" href="mailto:patrick@planetterrian.com?subject=Do%20Positive%20Dispatch%20%E2%80%94%20what%20I%20did&body=WHAT%20I%20DID%3A%0A%0ATHE%20HONEST%20NUMBERS%20(cost%2C%20time%2C%20impact%20%E2%80%94%20rough%20is%20fine)%3A%0A%0ASHOUTOUT%20(who%20helped%2C%20or%20who%20should%20try%20it%20next)%3A%0A%0AFirst%20name%20%2B%20city%20(how%20we%27ll%20read%20it%20on%20air)%3A%0A">Send a dispatch</a>
+    </div>
+  </section>
 
-    
-
-    <!-- Related Show Recommendation -->
-    
-    <section class="nn-section" style="padding-top:0;padding-bottom:var(--sp-8);">
-        <div class="container" style="max-width:700px;">
-            <div class="glass-card" style="padding:var(--sp-6);border-color:color-mix(in srgb, var(--show-color) 30%, var(--nn-border));">
-                <div style="font-family:var(--font-ui);font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;color:var(--show-color-text, var(--show-color));margin-bottom:var(--sp-3);">Recommended for you</div>
-                <a href="fascinating-frontiers.html" style="display:flex;align-items:center;gap:var(--sp-4);text-decoration:none;">
-                    <picture>
-                        <source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp">
-                        <img src="assets/covers/fascinating-frontiers.jpg" alt="Fascinating Frontiers" width="72" height="72" style="width:72px;height:72px;border-radius:12px;object-fit:cover;flex-shrink:0;" loading="lazy">
-                    </picture>
-                    <div>
-                        <div style="font-family:var(--font-heading);font-weight:600;color:var(--nn-white);font-size:1.05rem;margin-bottom:var(--sp-1);">Fascinating Frontiers</div>
-                        <div style="font-family:var(--font-ui);font-size:0.88rem;color:var(--nn-text-muted);line-height:1.5;">If you enjoy The DP Pod, you might also like Fascinating Frontiers.</div>
-                    </div>
-                </a>
-            </div>
-        </div>
-    </section>
-    
-
-    <!-- Latest from the Blog -->
-    
-
-    <!-- Newsletter Subscribe -->
-    <section class="nn-section" style="padding-top:0;">
-        <div class="container" style="max-width:700px;">
-            <div class="show-subscribe-inline">
-                <h3>Get The DP Pod: The Do Positive Podcast in your inbox</h3>
-                <p>New episode alerts delivered straight to your email — no spam, unsubscribe anytime.</p>
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow">
-                    <input type="hidden" name="tag" value="The DP Pod: The Do Positive Podcast">
-                    <input type="hidden" value="1" name="embed">
-                    <div class="nn-subscribe-row">
-                        <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <button type="submit">Subscribe</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </section>
-    <!-- More from Nerra Network --><section class="cross-network nn-section">
-        <div class="container">
-            <div class="nn-section-header">
-                <h2>More from Nerra Network</h2>
-                <p>Keeping you informed.</p>
-            </div>
-            <div class="cross-network-grid">
-                
-                
-                <div class="cross-network-card" style="display:flex;flex-direction:column;">
-                    <a href="models-agents.html" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
-                        <picture>
-                            <source type="image/webp" srcset="assets/covers/models-agents-400.webp">
-                            <img src="assets/covers/models-agents.jpg" alt="Models & Agents cover art" width="1400" height="1400" loading="lazy">
-                        </picture>
-                        <div class="cross-network-card-info">
-                            <div class="cross-network-card-name">Models & Agents</div>
-                            <div class="cross-network-card-tagline">Daily AI models, agents, and practical developments.</div>
-                        </div>
-                    </a>
-                    <a href="blog/models_agents/index.html" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
-                </div>
-                
-                
-                
-                <div class="cross-network-card" style="display:flex;flex-direction:column;">
-                    <a href="planetterrian.html" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
-                        <picture>
-                            <source type="image/webp" srcset="assets/covers/planetterrian-daily-400.webp">
-                            <img src="assets/covers/planetterrian-daily.jpg" alt="Planetterrian Daily cover art" width="1400" height="1400" loading="lazy">
-                        </picture>
-                        <div class="cross-network-card-info">
-                            <div class="cross-network-card-name">Planetterrian Daily</div>
-                            <div class="cross-network-card-tagline">Science, longevity, and the frontier of human health.</div>
-                        </div>
-                    </a>
-                    <a href="blog/planetterrian/index.html" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
-                </div>
-                
-                
-                
-                <div class="cross-network-card" style="display:flex;flex-direction:column;">
-                    <a href="omni-view.html" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
-                        <picture>
-                            <source type="image/webp" srcset="assets/covers/omni-view-400.webp">
-                            <img src="assets/covers/omni-view.jpg" alt="Omni View cover art" width="1400" height="1400" loading="lazy">
-                        </picture>
-                        <div class="cross-network-card-info">
-                            <div class="cross-network-card-name">Omni View</div>
-                            <div class="cross-network-card-tagline">See every side. Decide for yourself.</div>
-                        </div>
-                    </a>
-                    <a href="blog/omni_view/index.html" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
-                </div>
-                
-                
-                
-                <div class="cross-network-card" style="display:flex;flex-direction:column;">
-                    <a href="models-agents-beginners.html" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
-                        <picture>
-                            <source type="image/webp" srcset="assets/covers/models-agents-beginners-400.webp">
-                            <img src="assets/covers/models-agents-beginners.jpg" alt="Models & Agents for Beginners cover art" width="1400" height="1400" loading="lazy">
-                        </picture>
-                        <div class="cross-network-card-info">
-                            <div class="cross-network-card-name">Models & Agents for Beginners</div>
-                            <div class="cross-network-card-tagline">AI explained simply — for beginners and teens.</div>
-                        </div>
-                    </a>
-                    <a href="blog/models_agents_beginners/index.html" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
-                </div>
-                
-                
-                
-                <div class="cross-network-card" style="display:flex;flex-direction:column;">
-                    <a href="fascinating-frontiers.html" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
-                        <picture>
-                            <source type="image/webp" srcset="assets/covers/fascinating-frontiers-400.webp">
-                            <img src="assets/covers/fascinating-frontiers.jpg" alt="Fascinating Frontiers cover art" width="1400" height="1400" loading="lazy">
-                        </picture>
-                        <div class="cross-network-card-info">
-                            <div class="cross-network-card-name">Fascinating Frontiers</div>
-                            <div class="cross-network-card-tagline">Journey to the stars with today's discoveries.</div>
-                        </div>
-                    </a>
-                    <a href="blog/fascinating_frontiers/index.html" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
-                </div>
-                
-                
-                
-                <div class="cross-network-card" style="display:flex;flex-direction:column;">
-                    <a href="modern-investing.html" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
-                        <picture>
-                            <source type="image/webp" srcset="assets/covers/modern-investing-400.webp">
-                            <img src="assets/covers/modern-investing.jpg" alt="Modern Investing Techniques cover art" width="1400" height="1400" loading="lazy">
-                        </picture>
-                        <div class="cross-network-card-info">
-                            <div class="cross-network-card-name">Modern Investing Techniques</div>
-                            <div class="cross-network-card-tagline">AI-Powered Market Intelligence</div>
-                        </div>
-                    </a>
-                    <a href="blog/modern_investing/index.html" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
-                </div>
-                
-                
-                
-                <div class="cross-network-card" style="display:flex;flex-direction:column;">
-                    <a href="tesla.html" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
-                        <picture>
-                            <source type="image/webp" srcset="assets/covers/tesla-shorts-time-400.webp">
-                            <img src="assets/covers/tesla-shorts-time.jpg" alt="Tesla Shorts Time cover art" width="1400" height="1400" loading="lazy">
-                        </picture>
-                        <div class="cross-network-card-info">
-                            <div class="cross-network-card-name">Tesla Shorts Time</div>
-                            <div class="cross-network-card-tagline">Shorting Tesla? Time's Up.</div>
-                        </div>
-                    </a>
-                    <a href="blog/tesla/index.html" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
-                </div>
-                
-                
-                
-                <div class="cross-network-card" style="display:flex;flex-direction:column;">
-                    <a href="env-intel.html" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
-                        <picture>
-                            <source type="image/webp" srcset="assets/covers/environmental-intelligence-400.webp">
-                            <img src="assets/covers/environmental-intelligence.jpg" alt="Environmental Intelligence cover art" width="1400" height="1400" loading="lazy">
-                        </picture>
-                        <div class="cross-network-card-info">
-                            <div class="cross-network-card-name">Environmental Intelligence</div>
-                            <div class="cross-network-card-tagline">Environmental regulatory and compliance briefing.</div>
-                        </div>
-                    </a>
-                    <a href="blog/env_intel/index.html" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
-                </div>
-                
-                
-                
-                <div class="cross-network-card" style="display:flex;flex-direction:column;">
-                    <a href="unintended-consequences.html" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
-                        <picture>
-                            <source type="image/webp" srcset="assets/covers/unintended-consequences-400.webp">
-                            <img src="assets/covers/unintended-consequences.jpg" alt="Unintended Consequences cover art" width="1400" height="1400" loading="lazy">
-                        </picture>
-                        <div class="cross-network-card-info">
-                            <div class="cross-network-card-name">Unintended Consequences</div>
-                            <div class="cross-network-card-tagline">Good intentions. Surprising results. Real lessons.</div>
-                        </div>
-                    </a>
-                    <a href="blog/unintended_consequences/index.html" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
-                </div>
-                
-                
-                
-                <div class="cross-network-card" style="display:flex;flex-direction:column;">
-                    <a href="first-principles.html" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
-                        <picture>
-                            <source type="image/webp" srcset="assets/covers/first-principles-daily-400.webp">
-                            <img src="assets/covers/first-principles-daily.jpg" alt="First Principles Daily cover art" width="1400" height="1400" loading="lazy">
-                        </picture>
-                        <div class="cross-network-card-info">
-                            <div class="cross-network-card-name">First Principles Daily</div>
-                            <div class="cross-network-card-tagline">Reason from raw materials, not analogy.</div>
-                        </div>
-                    </a>
-                    <a href="blog/first_principles/index.html" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
-                </div>
-                
-                
-                
-                
-                
-                <div class="cross-network-card" style="display:flex;flex-direction:column;">
-                    <a href="spacex.html" style="display:flex;align-items:center;gap:var(--sp-3);text-decoration:none;flex:1;">
-                        <picture>
-                            <source type="image/webp" srcset="assets/covers/spacex-400.webp">
-                            <img src="assets/covers/spacex.jpg" alt="SpaceX Daily cover art" width="1400" height="1400" loading="lazy">
-                        </picture>
-                        <div class="cross-network-card-info">
-                            <div class="cross-network-card-name">SpaceX Daily</div>
-                            <div class="cross-network-card-tagline">Follow SpaceX as a public company — launches, Starlink, Starship, and the SPCX market picture, every day.</div>
-                        </div>
-                    </a>
-                    <a href="blog/spacex/index.html" style="font-family:var(--font-ui);font-size:0.75rem;color:var(--nn-text-muted);text-decoration:none;margin-top:var(--sp-2);padding-top:var(--sp-2);border-top:1px solid var(--nn-border);">Read blog &rarr;</a>
-                </div>
-                
-                
-            </div>
-        </div>
-    </section>
+</div>
 
     </main>
 
@@ -1092,248 +1083,6 @@
     }
     </script>
     
-    
-    <script>
-        const JSON_URL = 'digests/dp_pod/summaries_dp_pod.json';
-        const JSON_FORMAT = 'wrapped';
-        const RSS_URL = 'dp_pod_podcast.rss';
-        const SHOW_NAME = "The DP Pod: The Do Positive Podcast";
-
-        // --- Helpers ---
-        function formatDate(d) {
-            try {
-                const date = new Date(d);
-                return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
-            } catch { return d; }
-        }
-        function escapeHtml(s) {
-            const el = document.createElement('span');
-            el.textContent = s;
-            return el.innerHTML;
-        }
-        function getPreviewText(content) {
-            if (!content) return '';
-            let plain = content
-                .replace(/^###\s+/gm, '')
-                .replace(/\*\*(.+?)\*\*/g, '$1')
-                .replace(/https?:\/\/[^\s]+/g, '')
-                .replace(/[━─]+/g, '')
-                .replace(/[\n\r]+/g, ' ')
-                .replace(/\s+/g, ' ')
-                .trim();
-            return plain.length > 200 ? plain.substring(0, 200) + '...' : plain;
-        }
-
-        // --- Load episodes ---
-        async function loadEpisodes() {
-            try {
-                const resp = await fetch(JSON_URL);
-                if (!resp.ok) throw new Error('JSON not found');
-                const data = await resp.json();
-                const episodes = (JSON_FORMAT === 'array') ? (Array.isArray(data) ? data : []) : (data.summaries || data);
-                if (!episodes || !episodes.length) {
-                    console.warn(`[${SHOW_NAME}] JSON loaded but no episodes found, falling back to RSS`);
-                    loadFromRSS();
-                    return;
-                }
-                renderEpisodes(episodes);
-            } catch (err) {
-                console.warn(`[${SHOW_NAME}] JSON load failed, falling back to RSS:`, err.message);
-                loadFromRSS();
-            }
-        }
-
-        function renderEpisodes(episodes) {
-            if (!episodes || !episodes.length) { loadFromRSS(); return; }
-            episodes.sort((a, b) => new Date(b.date) - new Date(a.date));
-            const latest = episodes[0];
-            document.getElementById('latest-title').textContent = latest.episode_title || 'Latest Episode';
-            document.getElementById('latest-date').textContent = formatDate(latest.date);
-            document.getElementById('latest-audio').src = latest.audio_url || '';
-
-            if (latest.content) {
-                const summaryEl = document.getElementById('latest-summary');
-                summaryEl.textContent = getPreviewText(latest.content);
-                summaryEl.style.display = 'block';
-            }
-
-            renderLatestLangs(latest);
-
-            const grid = document.getElementById('episodes-grid');
-            grid.innerHTML = '';
-            episodes.slice(1, 13).forEach((ep, i) => {
-                const card = document.createElement('div');
-                card.className = 'episode-card glass-card';
-                card.innerHTML = `
-                    <div class="episode-card-date">${formatDate(ep.date)}</div>
-                    <div class="episode-card-title" data-role="title">${escapeHtml(ep.episode_title || 'Episode')}</div>
-                    <div style="color:var(--nn-text-muted);font-size:0.85rem;margin-bottom:var(--sp-3);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;">${escapeHtml(getPreviewText(ep.content))}</div>
-                    <audio controls preload="none" data-role="audio" src="${ep.audio_url || ''}" aria-label="Play ${escapeHtml(ep.episode_title || 'episode')}" style="width:100%;height:36px;border-radius:8px;"></audio>
-                    <div data-role="langs" style="display:none;margin-top:6px;"></div>
-                `;
-                grid.appendChild(card);
-                // Per-episode language switcher (any translated archive episode,
-                // not just the latest) — directly addresses "listen to older
-                // episodes in another language" on the show page.
-                const tr = ep.translations || {};
-                if (Object.keys(tr).some((l) => tr[l] && tr[l].audio_url)) {
-                    attachLangSwitcher({
-                        box: card.querySelector('[data-role=langs]'),
-                        audioEl: card.querySelector('[data-role=audio]'),
-                        titleEl: card.querySelector('[data-role=title]'),
-                        enUrl: ep.audio_url || '',
-                        enTitle: ep.episode_title || 'Episode',
-                        translations: tr,
-                    });
-                }
-            });
-        }
-
-        // Shared per-player language switcher. Builds EN + available-language
-        // pills for ONE episode and swaps that player's audio/title/summary in
-        // place. Honors the site-wide `nn-pref-lang` and live `nn-langchange`,
-        // so it works for the latest player AND every archive card. Russian
-        // shows opt out of multilingual, so this no-ops (no translations).
-        function attachLangSwitcher(opts) {
-            const box = opts.box;
-            if (!box) return;
-            const tr = opts.translations || {};
-            const langs = Object.keys(tr).filter((l) => tr[l] && tr[l].audio_url);
-            if (!langs.length) { box.style.display = 'none'; return; }
-            const LABELS = { en: 'English', fr: 'Français', ru: 'Русский', zh: '中文' };
-            const order = ['en'].concat(langs);
-            const audioEl = opts.audioEl, titleEl = opts.titleEl, summaryEl = opts.summaryEl;
-            const enTitle = opts.enTitle || 'Episode';
-            const enSummary = opts.enSummary || (summaryEl ? summaryEl.textContent : '');
-            const track = (code) => {
-                if (code === 'en') return { url: opts.enUrl || '', title: enTitle, desc: enSummary };
-                const t = tr[code] || {};
-                return { url: t.audio_url || '', title: t.title || enTitle, desc: t.description || enSummary };
-            };
-            const savedPref = () => { try { return localStorage.getItem('nn-pref-lang') || ''; } catch (e) { return ''; } };
-            const apply = (code, persist) => {
-                const t = track(code);
-                if (audioEl && t.url) { const playing = !audioEl.paused && !audioEl.ended; audioEl.src = t.url; if (playing) audioEl.play().catch(() => {}); }
-                if (titleEl && t.title) titleEl.textContent = t.title;
-                if (summaryEl && t.desc) summaryEl.textContent = t.desc;
-                box.querySelectorAll('button[data-lang]').forEach((b) => {
-                    const on = b.dataset.lang === code;
-                    b.setAttribute('aria-pressed', on ? 'true' : 'false');
-                    b.style.borderColor = on ? 'var(--show-color)' : 'var(--nn-border)';
-                    b.style.background = on ? 'color-mix(in srgb, var(--show-color) 15%, transparent)' : 'var(--nn-card)';
-                    b.style.color = on ? 'var(--show-color-text, var(--show-color))' : 'var(--nn-text-muted)';
-                });
-                if (persist) { try { localStorage.setItem('nn-pref-lang', code); } catch (e) {} }
-            };
-            box.innerHTML = '';
-            box.style.display = 'flex';
-            box.style.alignItems = 'center';
-            box.style.flexWrap = 'wrap';
-            box.style.gap = '6px';
-            const label = document.createElement('span');
-            label.textContent = opts.labelText || 'Listen in:';
-            label.style.cssText = 'font-size:0.78rem;color:var(--nn-text-muted);';
-            box.appendChild(label);
-            order.forEach((code) => {
-                const b = document.createElement('button');
-                b.type = 'button';
-                b.dataset.lang = code;
-                b.textContent = LABELS[code] || code.toUpperCase();
-                b.setAttribute('aria-pressed', 'false');
-                b.style.cssText = 'font:600 0.78rem/1.4 var(--font-ui,sans-serif);padding:2px 11px;border-radius:100px;border:1px solid var(--nn-border);background:var(--nn-card);color:var(--nn-text-muted);cursor:pointer;';
-                b.addEventListener('click', () => apply(code, true));
-                box.appendChild(b);
-            });
-            // Live-switch when the global header language control changes.
-            document.addEventListener('nn-langchange', (e) => {
-                const lang = (e.detail && e.detail.lang) || 'en';
-                apply((lang === 'en' || tr[lang]) ? lang : 'en', false);
-            });
-            const pref = savedPref();
-            apply((pref && (pref === 'en' || tr[pref])) ? pref : 'en', false);
-        }
-
-        function renderLatestLangs(latest) {
-            const summaryEl = document.getElementById('latest-summary');
-            attachLangSwitcher({
-                box: document.getElementById('latest-langs'),
-                audioEl: document.getElementById('latest-audio'),
-                titleEl: document.getElementById('latest-title'),
-                summaryEl: summaryEl,
-                enUrl: latest.audio_url || '',
-                enTitle: latest.episode_title || 'Latest Episode',
-                enSummary: summaryEl ? summaryEl.textContent : '',
-                translations: (latest && latest.translations) || {},
-            });
-        }
-
-        function loadFromRSS() {
-            fetch(RSS_URL)
-                .then(r => r.text())
-                .then(xml => {
-                    const parser = new DOMParser();
-                    const doc = parser.parseFromString(xml, 'text/xml');
-                    const nodeList = doc.querySelectorAll('item');
-                    if (!nodeList.length) { showNoEpisodes(); return; }
-
-                    // The pipeline appends new items to the END of the
-                    // RSS file, so the raw node order is OLDEST first.
-                    // Sort by pubDate desc so the page always shows
-                    // the most recent episode as "latest." Operator
-                    // caught (May 23 2026 env-intel screenshot) the
-                    // old code treating items[0] = oldest as latest
-                    // when the JSON-format path silently fell back
-                    // here.
-                    const items = Array.from(nodeList).sort((a, b) => {
-                        const da = new Date(a.querySelector('pubDate')?.textContent || 0);
-                        const db = new Date(b.querySelector('pubDate')?.textContent || 0);
-                        return db - da;
-                    });
-
-                    const first = items[0];
-                    document.getElementById('latest-title').textContent = first.querySelector('title')?.textContent || 'Latest Episode';
-                    const pubDate = first.querySelector('pubDate')?.textContent || '';
-                    document.getElementById('latest-date').textContent = pubDate ? formatDate(pubDate) : '';
-                    const enc = first.querySelector('enclosure');
-                    if (enc) document.getElementById('latest-audio').src = enc.getAttribute('url') || '';
-
-                    const grid = document.getElementById('episodes-grid');
-                    grid.innerHTML = '';
-                    items.slice(1, 13).forEach(item => {
-                        const title = item.querySelector('title')?.textContent || 'Episode';
-                        const pd = item.querySelector('pubDate')?.textContent || '';
-                        const enclosure = item.querySelector('enclosure');
-                        const url = enclosure ? enclosure.getAttribute('url') : '';
-                        const desc = item.querySelector('description')?.textContent || '';
-                        const card = document.createElement('div');
-                        card.className = 'episode-card glass-card';
-                        card.innerHTML = `
-                            <div class="episode-card-date">${pd ? formatDate(pd) : ''}</div>
-                            <div class="episode-card-title">${escapeHtml(title)}</div>
-                            <div style="color:var(--nn-text-muted);font-size:0.85rem;margin-bottom:var(--sp-3);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;">${escapeHtml(getPreviewText(desc))}</div>
-                            <audio controls preload="none" src="${url}" aria-label="Play ${escapeHtml(title)}" style="width:100%;height:36px;border-radius:8px;"></audio>
-                        `;
-                        grid.appendChild(card);
-                    });
-                })
-                .catch(err => {
-                    console.warn(`[${SHOW_NAME}] RSS load failed:`, err.message);
-                    showNoEpisodes();
-                });
-        }
-
-        function showNoEpisodes() {
-            document.getElementById('latest-title').textContent = 'No episodes available yet';
-            document.getElementById('episodes-grid').innerHTML = '<p style="color:var(--nn-text-muted);grid-column:1/-1;text-align:center;padding:2rem 0;">Episodes will appear here once available.</p>';
-        }
-
-        
-
-        
-
-        loadEpisodes();
-    </script>
-
 
     <!-- Centralized, improved global search -->
     <script src="assets/js/search.js" defer></script>


### PR DESCRIPTION
# The Do Positive Club — DP Pod look-and-feel redesign

Turns `thedppod.html` from a standard show page into a **club you join**: pledge-led membership, a lever board of assignments, a structured dispatch loop, and a free-forever charter. Every design decision traces to a verified research finding.

## The market assessment (new: `docs/dp_pod_market_assessment_2026_07.md`)

104-agent deep-research pass; every claim 3-vote adversarially verified against primary sources:

- **Optimistic media monetizes belonging, not access**: Reasons to be Cheerful's $1/mo membership sells a **member wall + membership card**; Fix The News (77k+ subscribers, 195 countries) donates 30% of paid revenue to charity. Nothing is paywalled.
- **Free action communities scale on identity + low-barrier contribution**: parkrun (free-forever as doctrine, 8M+ registrants on ~51 staff, "*a social intervention masquerading as a 5-kilometre running event*"); **Giving What We Can** (10k+ public pledgers; experiments: **+24pp** pledge uptake with visible social proof, **83–99%** follow-through on *non-binding* pledges, ask committed members first); **Buy Nothing** (constrained offer/request/gratitude post grammar + batch welcome rituals → 57% vs 15% strongly-connected participation).
- **The gap DP Pod fits**: nobody combines a daily good-news podcast with a structured on-air listener-action loop. The Dispatch *is* the differentiator; the site now says so.

## What the page does now (`templates/show_page_dp_pod.html.j2`)

| Verified mechanic | Implementation |
|---|---|
| Public pledge + member wall (GWWC) | "The Do Positive Pledge" — the Buttondown email form IS signing the pledge (tag `DP Pod`); wall seeded with Dan №001 / Patrick №002 / "your name goes here" |
| Founding-member window + numbered membership + card (RtbC) | "Sign before Episode 100" framing, membership-card visual, № numbering language |
| Constrained contribution grammar (Buy Nothing) | Dispatch = *what I did / the honest numbers / a shoutout*, submitted via a prefilled mailto; the show's prompts already read real dispatches on air and ban fabricated mail |
| Low-barrier starter actions (parkrun) | Pre-launch Lever Board ships three starter levers (recruit one doomscroller / send good news / take the pledge); post-launch it auto-fills from episode digests via new `_collect_dp_levers()` |
| Free-forever + patronage language (parkrun/MaxFun/Defector) | Club charter section; zero "subscribe/content/audience" language anywhere |

**Plumbing:** new per-show `show_page_template` registry override in `generate_show_page` (same context, bespoke presentation — the MIT-performance-page pattern generalized); `_collect_dp_levers()` extracts each episode's `### The Lever` section for the board.

## Verification

- Full suite green: **3,538 passed, 5 skipped**. `tests/test_dp_pod_show.py` gains `TestClubPage` (template override, pledge form + tag, seeded wall, dispatch grammar, lever extraction from a fixture digest).
- Desktop (1280px) and mobile (390px) renders verified via headless Chromium — hero/card, pledge, lever board, dispatch, charter, hosts, archive all render; grids collapse to one column on mobile.

## Deferred (rationale + levers in the assessment doc)

Real member-wall names (needs consented collection), numbered card issuance (Buttondown order → nightly `api/dp_club.json`), on-air batch welcomes, collective ledger totals, referral ladder (revisit ~1k members), and enabling `newsletter.enabled` so signing the pledge triggers a welcome + daily episode email (recommended once Ep1 ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXEvkULRuFNLXEHb3rkvnc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXEvkULRuFNLXEHb3rkvnc)_