### PR TITLE
Fix day-dependent assertion in FP queue-alternation drift guard

### DIFF
--- a/tests/test_network_quality_pass.py
+++ b/tests/test_network_quality_pass.py
@@ -207,16 +207,27 @@ class TestNarrativeQueueRunway:
 
     def test_first_principles_unproduced_alternates(self):
         """July 2 2026 hygiene pass: the unproduced FP queue was
-        re-sequenced to alternate concrete_example / opportunity_area. The
-        produced tail ended on an opportunity_area (recycling-economics), so
-        the first unproduced entry must be a concrete_example, and adjacent
-        same-category pairs must stay at the theoretical minimum (the
-        |#C - #O| overflow that can't be interleaved away)."""
+        re-sequenced to alternate concrete_example / opportunity_area.
+
+        The original assertion hardcoded ``seq[0] == "concrete_example"``,
+        which was only true on the day it was written — FP produces one
+        topic per day, so the expected head category flips daily and the
+        test broke the same afternoon (the 08:31 UTC episode consumed the
+        next concrete_example). The durable invariant is that alternation
+        CONTINUES from the produced tail: the first unproduced entry
+        differs from the last produced entry's category, and adjacent
+        same-category pairs stay at the theoretical minimum (the |#C - #O|
+        overflow that can't be interleaved away)."""
         q = yaml.safe_load(
             (_ROOT / "shows" / "topic_queues" / "first_principles.yaml").read_text(
                 encoding="utf-8"))["queue"]
         seq = [e.get("category") for e in q if not e.get("produced")]
-        assert seq[0] == "concrete_example", seq[:3]
+        produced_cats = [e.get("category") for e in q if e.get("produced")]
+        if produced_cats and seq:
+            assert seq[0] != produced_cats[-1], (
+                f"FP alternation broken at the produced/unproduced boundary: "
+                f"last produced was {produced_cats[-1]!r}, next up is {seq[0]!r}"
+            )
         n_c = seq.count("concrete_example")
         n_o = seq.count("opportunity_area")
         same_adj = sum(1 for a, b in zip(seq, seq[1:]) if a == b)


### PR DESCRIPTION
# CI fix: FP queue-alternation test breaks every other day

`tests/test_network_quality_pass.py::TestNarrativeQueueRunway::test_first_principles_unproduced_alternates` (added in today's queue-hygiene pass) hardcodes that the first unproduced First Principles topic is a `concrete_example`. That was only true on the day it was written: **FP produces one topic per day**, so the expected head category flips daily — the test broke the same afternoon when the 08:31 UTC episode consumed the next concrete_example, and it failed CI on PR #755 (which was otherwise green and has since merged).

## The fix

Replace the hardcoded head-category assertion with the durable invariant: **alternation must continue across the produced/unproduced boundary** — the first unproduced entry's category differs from the last *produced* entry's category. The minimal-alternation check on the rest of the queue (`same_adj <= |#C − #O|`) is unchanged.

This passes today, keeps passing after every daily episode, and still catches the real regression it was written for (a re-sequencing that breaks the alternation).

## Verification

Full suite green locally on latest main: **3,611 passed, 5 skipped** — including this test both before (fails, as CI showed) and after (passes) the change, and it stays green regardless of which category FP produced last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXEvkULRuFNLXEHb3rkvnc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXEvkULRuFNLXEHb3rkvnc)_