### PR TITLE
DP Pod Ep001 review fixes: pronoun-I spoken garble, truncated Ep1 closing, plural disclosure

### DIFF
--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -1165,7 +1165,17 @@ def replace_ordinal_numbers(text: str) -> str:
 
 
 def replace_roman_numerals(text: str) -> str:
-    """Convert Roman numerals in context: 'Phase III' -> 'Phase three'."""
+    """Convert Roman numerals in context: 'Phase III' -> 'Phase three'.
+
+    The bare numeral "I" collides with the pronoun after context words —
+    "the part I want to dig into" and "that part I'll give you" shipped as
+    "part one want" / "part one'll" in DP Pod Ep001 (July 2026), a spoken
+    garble the two-host dialogue format makes common. Bare "I" therefore
+    only converts in title-like position — followed by punctuation, "of",
+    or end of line — and never before an apostrophe (I'll, I've, I'm) or
+    another running word. Multi-character numerals (II, IV, X, ...) have
+    no pronoun collision and keep the original behaviour.
+    """
     # Only convert when preceded by a context word to avoid false positives
     context_words = r"(?:Phase|Part|Chapter|Section|Act|Type|Class|Mark|Version|Vol|Volume|Title|Book|Level|Stage|Grade|Tier|Step|Round|Series|Season|Episode|Generation|Gen)"
 
@@ -1177,8 +1187,16 @@ def replace_roman_numerals(text: str) -> str:
             return f"{prefix}{number_to_words(val)}"
         return m.group(0)
 
+    # Multi-character numerals + bare V/X: no pronoun ambiguity.
     text = re.sub(
-        rf"({context_words}\s+)(I{{1,4}}V?|VI{{0,4}}|IX|X{{1,3}}I{{0,4}}V?)\b",
+        rf"({context_words}\s+)(I{{2,4}}V?|IV|VI{{0,4}}|IX|X{{1,3}}I{{0,4}}V?|V)\b",
+        _roman,
+        text,
+        flags=re.IGNORECASE,
+    )
+    # Bare "I": title-like position only.
+    text = re.sub(
+        rf"({context_words}\s+)(I)(?!['’])(?=\s*(?:$|[,.:;!?)\]]|of\b))",
         _roman,
         text,
         flags=re.IGNORECASE,

--- a/run_show.py
+++ b/run_show.py
@@ -79,6 +79,15 @@ _AI_DISCLOSURE = (
     "editorial selection and analysis are my own."
 )
 
+# Two-host dialogue shows (The DP Pod): the single-host line says "my
+# voice" but two synthesized voices just spoke — the plural variant keeps
+# the disclosure factually accurate. Spoken change → A/B-listen per
+# landmine #17 (it replaces one sentence at the very end of the episode).
+_AI_DISCLOSURE_DIALOGUE = (
+    "This episode used AI voice synthesis of our voices — "
+    "the editorial selection and analysis are our own."
+)
+
 _AI_DISCLOSURE_RSS = (
     "AI Disclosure: This podcast is curated by Patrick but uses AI-generated "
     "voice synthesis for audio production."
@@ -2012,29 +2021,56 @@ def run(args: argparse.Namespace) -> None:
                     "@NerraRU" if config.youtube.channel == "ru" else "@NerraNetwork"
                 )
             if episode_num == 1:
-                pod_vars.setdefault(
-                    "intro_line",
-                    f"{host}: Welcome to the very first episode of {config.name}! "
-                    f"Today is {today_str}. {effective_hook}",
-                )
-                _ep1_close = (
-                    f"{host}: That wraps up our very first episode of {config.name}! "
-                    f"If you enjoyed this, please subscribe on Apple Podcasts, Spotify, "
-                    f"or wherever you listen — and a rating or review really helps new "
-                    f"listeners find us. "
-                    f"I'm {host} in Vancouver. Thanks for joining me on this journey, "
-                    f"and I'll see you tomorrow for episode two."
-                )
-                # Route the YouTube call-out through the shared helper so the
-                # "@" is stripped (no "at at" stutter) and the EN handle is
-                # split to the spaced "Nerra Network" — matching every other
-                # episode's closing.
-                _ep1_close = _maybe_append_youtube_cta(
-                    _ep1_close,
-                    _yt_handle,
-                    is_ru=args.show in _RUSSIAN_SPOKEN_SHOWS,
-                )
-                pod_vars.setdefault("closing_block", _ep1_close)
+                if config.tts.dialogue_mode:
+                    # Dialogue shows: the generic single-host Ep1 closing
+                    # ("I'm X in Vancouver... see you tomorrow") fights the
+                    # dialogue prompt's speaker-label + exact-sign-off rules
+                    # — DP Pod Ep001 shipped it truncated to "please
+                    # subscribe..." mid-sentence. Use a labeled debut intro
+                    # (the personality's lead host) and the personality's
+                    # own labeled closing, which already carries the
+                    # subscribe ask and ends with the exact sign-off.
+                    _lead = get_show_host(args.show)
+                    pod_vars.setdefault(
+                        "intro_line",
+                        f"{_lead}: Welcome to the very first episode of "
+                        f"{config.name}! Today is {today_str}. {effective_hook}",
+                    )
+                    pod_vars.setdefault(
+                        "closing_block",
+                        build_closing_block(
+                            args.show,
+                            episode_num=episode_num,
+                            today_str=today_str,
+                            date=today,
+                            extra_context=extra_context,
+                            youtube_channel_handle=_yt_handle,
+                        ),
+                    )
+                else:
+                    pod_vars.setdefault(
+                        "intro_line",
+                        f"{host}: Welcome to the very first episode of {config.name}! "
+                        f"Today is {today_str}. {effective_hook}",
+                    )
+                    _ep1_close = (
+                        f"{host}: That wraps up our very first episode of {config.name}! "
+                        f"If you enjoyed this, please subscribe on Apple Podcasts, Spotify, "
+                        f"or wherever you listen — and a rating or review really helps new "
+                        f"listeners find us. "
+                        f"I'm {host} in Vancouver. Thanks for joining me on this journey, "
+                        f"and I'll see you tomorrow for episode two."
+                    )
+                    # Route the YouTube call-out through the shared helper so the
+                    # "@" is stripped (no "at at" stutter) and the EN handle is
+                    # split to the spaced "Nerra Network" — matching every other
+                    # episode's closing.
+                    _ep1_close = _maybe_append_youtube_cta(
+                        _ep1_close,
+                        _yt_handle,
+                        is_ru=args.show in _RUSSIAN_SPOKEN_SHOWS,
+                    )
+                    pod_vars.setdefault("closing_block", _ep1_close)
             else:
                 pod_vars.setdefault(
                     "intro_line",
@@ -2346,9 +2382,13 @@ def run(args: argparse.Namespace) -> None:
                 _AI_DISCLOSURE_RU if args.show in _RUSSIAN_SHOWS else _AI_DISCLOSURE
             )
             if config.tts.dialogue_mode:
-                # Unlabeled text inherits the previous speaker's voice —
-                # make the disclosure explicitly the host's line.
-                _disclosure = f"{(config.publishing.host_name or 'PATRICK').upper()}: {_disclosure}"
+                # Two voices spoke, so the disclosure is plural ("our
+                # voices"), and unlabeled text inherits the previous
+                # speaker's voice — make it explicitly the host's line.
+                _disclosure = (
+                    f"{(config.publishing.host_name or 'PATRICK').upper()}: "
+                    f"{_AI_DISCLOSURE_DIALOGUE}"
+                )
             podcast_script = podcast_script.rstrip() + "\n\n" + _disclosure
 
             # Parse chapter markers from the cleaned script (before TTS).

--- a/shows/prompts/dp_pod_podcast.txt
+++ b/shows/prompts/dp_pod_podcast.txt
@@ -54,7 +54,7 @@ One host announces the segment BY NAME ("...time for The Positive Papers"). Cove
 One host announces it BY NAME ("...that brings us to The Lever"). The heart of the show: walk through the ONE action — what it is, what it costs in dollars and hours, what it returns, the honest payback, and the multiplication at honest scale. This is a natural home for the disagreement: is this really the highest-leverage hour a listener has this week? Keep the numbers hedged exactly as the briefing hedges them.
 
 [Do Positive Dispatch]
-One host announces it BY NAME ("...now the Do Positive Dispatch"). If the briefing says there's no listener mail: say so honestly, have ONE host share one thing THEY actually did recently from a previous Lever-style action (framed as their own action, kept plausible and small), and invite listeners to send what they did — "tell us what you did, and we'll read it here." NEVER fabricate listener submissions.
+One host announces it BY NAME ("...now the Do Positive Dispatch"). If the briefing says there's no listener mail: say so honestly, then have ONE host commit to trying this episode's Lever themselves ("I'm doing this one this week — I'll report back") or reference the show's own prep work in general terms, and invite listeners to send what they did — "tell us what you did, and we'll read it here." NEVER fabricate listener submissions, and NEVER invent specific past personal anecdotes for the hosts (real places, dates, or claimed past actions) — Dan and Patrick are real people; a forward commitment is honest, an invented memory is not.
 
 [Sign-Off]
 End with this exact closing, labels included (do not rewrite it):

--- a/tests/test_dp_pod_show.py
+++ b/tests/test_dp_pod_show.py
@@ -164,6 +164,32 @@ class TestClubPage:
         assert "Dispatch" not in levers[0]["lever_text"]
 
 
+class TestEp001Fixes:
+    """Regression guards from the Episode 1 review (July 2 2026)."""
+
+    def test_dialogue_disclosure_is_plural(self):
+        # Ep001 spoke the single-host line ("my voice") on a two-voice
+        # episode; dialogue mode now uses the plural variant.
+        src = (PROJECT_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "_AI_DISCLOSURE_DIALOGUE" in src
+        assert "our voices" in src
+
+    def test_ep1_dialogue_branch_uses_personality_closing(self):
+        # The generic single-host Ep1 closing fought the dialogue prompt
+        # (Ep001 shipped "please subscribe..." truncated mid-sentence);
+        # dialogue shows now debut with the personality's labeled closing.
+        src = (PROJECT_ROOT / "run_show.py").read_text(encoding="utf-8")
+        ep1_block = src.split("if episode_num == 1:", 1)[1][:2200]
+        assert "config.tts.dialogue_mode" in ep1_block
+        assert "build_closing_block" in ep1_block
+
+    def test_dispatch_prompt_bans_invented_host_anecdotes(self):
+        prompt = (PROJECT_ROOT / "shows" / "prompts" / "dp_pod_podcast.txt").read_text(
+            encoding="utf-8")
+        assert "NEVER invent specific past personal anecdotes" in prompt
+        assert "forward commitment" in prompt
+
+
 class TestIntrosPersonality:
     def test_intro_is_dan_labeled_dialogue(self):
         from engine.intros import build_intro_line

--- a/tests/test_pronunciation.py
+++ b/tests/test_pronunciation.py
@@ -475,6 +475,35 @@ class TestReplaceRomanNumerals:
         result = replace_roman_numerals("Generation IV reactor")
         assert "Generation four" in result
 
+    # ---- Pronoun-collision guards (DP Pod Ep001, July 2026) ----
+    # "the part I want" / "that part I'll give you" shipped as "part one
+    # want" / "part one'll" — the bare-I numeral matched the pronoun after
+    # a context word. Bare "I" now converts only in title-like position.
+
+    def test_part_i_pronoun_untouched(self):
+        text = "That's the part I want to dig into today."
+        assert replace_roman_numerals(text) == text
+
+    def test_part_i_contraction_untouched(self):
+        text = "Okay, that part I'll give you."
+        assert replace_roman_numerals(text) == text
+
+    def test_section_i_wrote_untouched(self):
+        text = "the section I wrote yesterday"
+        assert replace_roman_numerals(text) == text
+
+    def test_part_i_of_still_converts(self):
+        assert "Part one of" in replace_roman_numerals("Part I of the series")
+
+    def test_part_i_before_punctuation_still_converts(self):
+        assert "Part one." in replace_roman_numerals("Read Part I.")
+
+    def test_act_i_at_end_still_converts(self):
+        assert replace_roman_numerals("Act I") == "Act one"
+
+    def test_mark_v_still_converts(self):
+        assert "Mark five" in replace_roman_numerals("Mark V engine")
+
 
 class TestReplaceQuarterNotation:
     def test_quarter_with_year(self):


### PR DESCRIPTION
# Episode 1 quality review — verdict and fixes

Reviewed `DP_Pod_Ep001_20260702` end-to-end (digest, TTS script, Whisper transcript of the shipped audio, chapters, metrics). **The engine worked**: 33 labeled turns routed to the right voices, zero single-voice fallback, zero tag leaks, all 5 chapters in perfect order with Sign-Off pinned last, a genuine host disagreement with concessions ("I'll concede the per-person cost is negligible"), an honest no-mail Dispatch, 1,387 words / 8:52 audio. Four findings fixed:

## P1 — the pronoun "I" was spoken as "one" (network-wide bug, Whisper-confirmed ×2)

`assets/pronunciation.py:replace_roman_numerals` matches the bare numeral "I" after context words (*Part, Section, Step, …*) case-insensitively — which also matches the **pronoun**. Ep001 aired *"That's the part **one** want to dig into today"* and *"that part **one'll** give you"*. Two-host conversation makes "the part I…" constructions common, so DP Pod surfaced a bug that's been latent for every show. Fix: bare "I" only converts in title-like position (before punctuation, "of", or end of line; never before an apostrophe). "Part I of the series", "Phase III", "Mark V" all still convert — 7 new regression guards in `tests/test_pronunciation.py`.

## P1 — Ep1 closing truncated mid-sentence

The generic single-host Episode-1 closing ("I'm Patrick in Vancouver… see you tomorrow for episode two") conflicted with the dialogue prompt's speaker-label + exact-sign-off rules, so the model compromised: Ep001 aired *"If you enjoyed this please subscribe."* then the sign-off — dropping the Apple/Spotify ask and the rating request. `run_show.py`'s episode-1 special case is now dialogue-aware: labeled debut intro + the personality's own labeled closing (which carries the subscribe ask and ends with the exact sign-off).

## P2 — disclosure said "my voice" after two voices spoke

Dialogue shows now speak a plural variant: *"This episode used AI voice synthesis of our voices — the editorial selection and analysis are our own."*

## P2 — invented host anecdote

Ep001's Dispatch had Patrick claiming *"I actually did it last week on a walk near the seawall"* — a fabricated memory for a real person (my prompt instructed a "plausible" personal action; that was wrong). The prompt now requires a **forward commitment** ("I'm doing this one this week — I'll report back") or general show-prep framing, and explicitly bans invented past personal anecdotes for the hosts.

## ⚠️ A/B-listen (landmine #17)

The disclosure wording and future Ep1-class closings change spoken audio; the pronunciation fix removes a garble (correctness class). Episode 2 tomorrow is the natural check: listen for "the part I…" constructions reading naturally and the plural disclosure.

Full suite green: **3,623 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXEvkULRuFNLXEHb3rkvnc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXEvkULRuFNLXEHb3rkvnc)_