### PR TITLE
RU dubs: optimized long title + distinct Short title on @NerraRU

### DIFF
--- a/engine/ru_dub.py
+++ b/engine/ru_dub.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -33,6 +34,16 @@ logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _MANIFEST = PROJECT_ROOT / "site" / "data" / "gallery-manifest.json"
+
+# YouTube's hard title cap (chars) — the RU title + " #Shorts" must clear it.
+_YT_TITLE_MAX = 100
+_SHORTS_SUFFIX = " #Shorts"
+
+# Leading "Эп. N:" / "Выпуск N:" episode-number label dropped when deriving the
+# punchy Short title from the long title (the Short doesn't need the episode
+# number in its ≤70-char headline).
+_EP_PREFIX_RE = re.compile(
+    r"^\s*(?:Эп\.?|Выпуск)\s*№?\s*\d+\s*[:：.\-—]\s*", re.IGNORECASE)
 
 # Russian AI-voice disclosure appended to every RU description (same text the
 # native RU shows speak; kept in sync with run_show._AI_DISCLOSURE_RU).
@@ -215,6 +226,83 @@ def _cap_title(title: str, limit: int = 95) -> str:
     return title if len(title) <= limit else title[: limit - 1].rstrip() + "…"
 
 
+def _has_cyrillic(text: str) -> bool:
+    return any("Ѐ" <= c <= "ӿ" for c in (text or ""))
+
+
+def _en_optimized_long_title(config, episode_num: int) -> str:
+    """The EN long-form YouTube title recorded for this episode.
+
+    Read from the show's own EN ``youtube_videos.json`` index — the ``title``
+    on the ``long`` record is the LLM-*optimized* YouTube title (or the SEO
+    title where a show has ``optimized_titles`` off), a COMPLETE, non-truncated
+    line unlike the mid-sentence spoken hook. Returns "" when the index is
+    absent/unreadable or has no long record for the episode (best-effort: the
+    caller keeps its legacy hook-based title)."""
+    import json
+    idx = PROJECT_ROOT / config.episode.output_dir / "youtube_videos.json"
+    try:
+        data = json.loads(idx.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 — best-effort lookup
+        return ""
+    best = ""
+    for v in data.get("videos", []):
+        if (v.get("episode") == episode_num and v.get("kind") == "long"
+                and v.get("title")):
+            best = str(v["title"]).strip()  # newest matching row wins
+    return best
+
+
+def _translate_title_to_ru(en_title: str) -> str:
+    """Best-effort Russian translation of a short YouTube title.
+
+    Cheap: a title-only Grok call via the shared ``engine.translate`` helper —
+    NOT a re-translation of the whole script. ``translate_metadata`` falls back
+    to the English input on failure, so a result with no Cyrillic is treated as
+    "no translation" (we never want an English title on @NerraRU). Returns ""
+    on any failure so the caller keeps the legacy hook-based title."""
+    en_title = (en_title or "").strip()
+    if not en_title:
+        return ""
+    try:
+        from engine import translate
+        ru_title, _desc = translate.translate_metadata(en_title, "", "ru")
+        ru_title = (ru_title or "").strip()
+        if ru_title and _has_cyrillic(ru_title):
+            return ru_title
+    except Exception as exc:  # noqa: BLE001 — title translation is best-effort
+        logger.warning("ru_dub: title translation failed (%s) — using hook", exc)
+    return ""
+
+
+def _word_trim(text: str, limit: int) -> str:
+    """Trim *text* to <= *limit* chars on a WORD boundary (never mid-word).
+
+    No trailing ellipsis — the Short appends " #Shorts", and "…" + "#Shorts"
+    reads awkwardly. Trailing punctuation left by the cut is stripped."""
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text.rstrip(" ,.:;—-…")
+    cut = text[:limit]
+    if " " in cut:
+        cut = cut[:cut.rfind(" ")]  # break before the partial last word
+    return cut.rstrip(" ,.:;—-…")
+
+
+def _ru_short_title(long_title: str, *, body_limit: int = 70) -> str:
+    """A distinct, punchy Short title derived from the RU long title.
+
+    Drops the "Эп. N:" episode prefix, word-boundary-trims the body to a short
+    headline (never mid-word, no trailing "…"), and appends " #Shorts" — always
+    within YouTube's 100-char cap. Distinct from the long title (at minimum by
+    the suffix; usually also by the dropped prefix + trim)."""
+    body = _EP_PREFIX_RE.sub("", (long_title or "").strip()).strip()
+    body = body.rstrip("…").rstrip()
+    ceiling = min(body_limit, _YT_TITLE_MAX - len(_SHORTS_SUFFIX))
+    body = _word_trim(body, ceiling)
+    return f"{body}{_SHORTS_SUFFIX}".strip()
+
+
 def publish_ru_dub(
     config, episode_num: int, *,
     build_short: bool = True,
@@ -249,12 +337,23 @@ def publish_ru_dub(
         return result
 
     ru_title = _cap_title(ru_track.get("title") or rec.get("episode_title") or "")
+    # Prefer the EN *optimized* YouTube long-form title (translated to Russian)
+    # over the raw hook the translation step produced — the hook is written for
+    # the ear and ships mid-sentence-truncated (…), while the optimized title is
+    # a complete, keyword-front-loaded line (EN long-form parity). Best-effort:
+    # any lookup/translation failure keeps the legacy ru_title.
+    en_long_title = _en_optimized_long_title(config, episode_num)
+    if en_long_title:
+        ru_opt = _translate_title_to_ru(en_long_title)
+        if ru_opt:
+            ru_title = _cap_title(ru_opt)
     ru_desc = ru_track.get("description") or ru_title
 
     # Dry-run is creds-independent so the operator can preview the resolved
     # RU title before doing the @NerraRU OAuth.
     if dry_run:
-        result.update(status="dryrun", title=ru_title)
+        result.update(status="dryrun", title=ru_title,
+                      short_title=_ru_short_title(ru_title))
         return result
 
     from engine.youtube import get_channel_credentials_from_env
@@ -442,7 +541,7 @@ def publish_ru_dub(
                     end_card_image_path=end_card_png)
                 sup = upload_video(
                     short_mp4, credentials=creds,
-                    title=_cap_title(ru_title, 90) + " #Shorts",
+                    title=_ru_short_title(ru_title),
                     description=_ru_long_description(config, ru_desc),
                     tags=list(getattr(config, "keywords", []) or []),
                     category_id=int(getattr(yt, "category_id", 28)),

--- a/tests/test_ru_dub.py
+++ b/tests/test_ru_dub.py
@@ -104,6 +104,125 @@ class TestShortParity:
         assert "end_card=True" in src
 
 
+class TestRuShortTitle:
+    """The RU Short title must be DISTINCT from the long title, word-boundary
+    trimmed (never mid-word), carry ' #Shorts', and clear YouTube's 100-char
+    cap. Replaces the old `_cap_title(ru_title, 90) + ' #Shorts'` which was a
+    carbon copy of the long, truncated mid-word."""
+
+    def test_appends_shorts_and_drops_episode_prefix(self):
+        t = ru_dub._ru_short_title(
+            "Эп. 5: Патент Tesla превращает компрессор в бойлер")
+        assert t.endswith(" #Shorts")
+        assert not t.lstrip().startswith("Эп")
+        assert "Патент Tesla" in t
+        assert len(t) <= 100
+
+    def test_word_boundary_never_mid_word(self):
+        long = "Эп. 5: " + "Патент " * 30  # far over the ceiling
+        t = ru_dub._ru_short_title(long)
+        body = t[: -len(" #Shorts")]
+        # The trim breaks between words, so the last token is a whole "Патент".
+        assert body.split()[-1] == "Патент"
+        assert len(t) <= 100
+
+    def test_no_ellipsis_before_shorts_and_distinct_from_long(self):
+        long_title = "Эп. 5: " + "слово " * 40
+        long_cap = ru_dub._cap_title(long_title)   # long form (ends with …)
+        short = ru_dub._ru_short_title(long_title)
+        assert short != long_cap
+        assert "…" not in short
+        assert short.endswith(" #Shorts")
+        assert len(short) <= 100
+
+    def test_short_title_short_input_still_distinct(self):
+        # Even a short title (no prefix, no trim) differs by the suffix.
+        long = "Патент Tesla"
+        short = ru_dub._ru_short_title(long)
+        assert short == "Патент Tesla #Shorts"
+        assert short != long
+
+
+class TestRuLongTitleFromOptimized:
+    """The RU long-form title prefers the EN optimized YouTube title
+    (translated), falling back to the legacy hook-based ru_track title when
+    there's no optimized title or translation fails — never raises."""
+
+    _LEGACY = "Эп. 5: старый хук из перевода который довольно длинный текст для проверки"
+
+    def _cfg_with(self, tmp_path, *, en_long_title="Tesla Patent Runs Compressor As Boiler"):
+        out = tmp_path / "out"
+        out.mkdir()
+        if en_long_title is not None:
+            (out / "youtube_videos.json").write_text(json.dumps({"videos": [
+                {"episode": 5, "kind": "long", "title": en_long_title,
+                 "hook": "Tesla's new winter heat patent turns the compressor..."},
+                {"episode": 5, "kind": "short", "title": "some short headline"},
+            ]}), encoding="utf-8")
+        summaries = tmp_path / "summaries.json"
+        summaries.write_text(json.dumps({"podcast": "TST", "summaries": [{
+            "episode_num": 5, "date": "2026-07-01", "episode_title": "Ep 5",
+            "translations": {"ru": {"title": self._LEGACY, "description": "Оп",
+                                    "audio_url": ""}}}]}), encoding="utf-8")
+        cfg = _cfg()
+        cfg.publishing.summaries_json = str(summaries)
+        cfg.episode.output_dir = str(out)
+        return cfg
+
+    def test_reads_optimized_long_title_from_index(self, tmp_path):
+        cfg = self._cfg_with(tmp_path)
+        assert ru_dub._en_optimized_long_title(cfg, 5) == \
+            "Tesla Patent Runs Compressor As Boiler"
+
+    def test_missing_index_returns_empty(self, tmp_path):
+        cfg = self._cfg_with(tmp_path, en_long_title=None)
+        assert ru_dub._en_optimized_long_title(cfg, 5) == ""
+
+    def test_long_title_prefers_translated_optimized(self, tmp_path, monkeypatch):
+        cfg = self._cfg_with(tmp_path)
+        import engine.translate as tr
+        monkeypatch.setattr(tr, "translate_metadata", lambda title, desc, lang: (
+            "Патент Tesla превращает компрессор в бойлер", desc))
+        res = ru_dub.publish_ru_dub(cfg, 5, dry_run=True)
+        assert res["status"] == "dryrun"
+        assert res["title"] == "Патент Tesla превращает компрессор в бойлер"
+        # Short is derived + distinct.
+        assert res["short_title"].endswith(" #Shorts")
+        assert res["short_title"] != res["title"]
+        assert len(res["short_title"]) <= 100
+
+    def test_falls_back_to_hook_when_no_optimized(self, tmp_path, monkeypatch):
+        cfg = self._cfg_with(tmp_path, en_long_title=None)
+        import engine.translate as tr
+
+        def boom(*a, **k):
+            raise AssertionError("translate must not be called without a title")
+        monkeypatch.setattr(tr, "translate_metadata", boom)
+        res = ru_dub.publish_ru_dub(cfg, 5, dry_run=True)
+        assert res["title"] == ru_dub._cap_title(self._LEGACY)
+
+    def test_translate_failure_keeps_legacy_title(self, tmp_path, monkeypatch):
+        cfg = self._cfg_with(tmp_path)
+        import engine.translate as tr
+
+        def boom(*a, **k):
+            raise RuntimeError("grok down")
+        monkeypatch.setattr(tr, "translate_metadata", boom)
+        res = ru_dub.publish_ru_dub(cfg, 5, dry_run=True)  # must NOT raise
+        assert res["status"] == "dryrun"
+        assert res["title"] == ru_dub._cap_title(self._LEGACY)
+
+    def test_english_result_rejected_keeps_legacy_title(self, tmp_path, monkeypatch):
+        # translate_metadata falls back to the English input on failure — a
+        # no-Cyrillic result must not ship an English title on @NerraRU.
+        cfg = self._cfg_with(tmp_path)
+        import engine.translate as tr
+        monkeypatch.setattr(tr, "translate_metadata",
+                            lambda title, desc, lang: (title, desc))
+        res = ru_dub.publish_ru_dub(cfg, 5, dry_run=True)
+        assert res["title"] == ru_dub._cap_title(self._LEGACY)
+
+
 class TestGuards:
     def test_skip_when_not_enabled(self):
         cfg = _cfg()


### PR DESCRIPTION
Fixes the RU-dub title gap found in today's @NerraRU performance review: the Russian long-form and Short were shipping an **identical** title — just the translated episode hook truncated mid-sentence — while the EN side gets an LLM-optimized long title and distinct Short headlines.

## What changed (`engine/ru_dub.py`)
- **Long title** now prefers the show's EN *optimized* YouTube title (from its own `youtube_videos.json` long record) translated to Russian via a cheap title-only Grok call, falling back to the legacy hook title. A complete line instead of a cut-off sentence.
- **Short title** drops the `Эп. N:` prefix, word-boundary-trims to a punchy headline (never mid-word, no trailing `…`), appends ` #Shorts`, and stays within YouTube's 100-char cap — distinct from the long title.

## Before → after (tesla Ep529)
- **Before** (long *and* short, identical): `Эп. 529: Новый патент Tesla на зимний обогрев превращает компрессор в бойлер, чтобы сохранить…`
- **After long**: translated optimized title, e.g. `Патент Tesla превращает компрессор в бойлер ради запаса хода` (complete, no `…`)
- **After short**: same body, `Эп.`-prefix dropped, word-trimmed, ` #Shorts` suffix — distinct from the long.

## Safety
Fully best-effort — a missing EN index, a translate failure, or an English (no-Cyrillic) result all fall back to the current behaviour, so a dub never breaks. **YouTube metadata only — outside landmine #17**; no R2/RSS/voice paths touched. Drift guards added in `tests/test_ru_dub.py` (`TestRuShortTitle`, `TestRuLongTitleFromOptimized`).

Tests: `tests/test_ru_dub.py tests/test_multilingual.py tests/test_language_feeds.py` → 125 passed; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX

---
_Generated by [Claude Code](https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX)_