### PR TITLE
MIT: SnapTrade live-trading plan (Wealthsimple + Webull) + trade-signal bridge

### DIFF
--- a/.github/workflows/snaptrade-mirror.yml
+++ b/.github/workflows/snaptrade-mirror.yml
@@ -1,0 +1,52 @@
+name: SnapTrade Account Mirror
+
+# Phase 1 of docs/mit_snaptrade_live_trading_plan.md: a READ-ONLY daily
+# snapshot of the operator's connected Wealthsimple/Webull accounts.
+# Proves connection stability before any executor code exists. The
+# mirror JSON is uploaded as a short-lived artifact — NEVER committed
+# (public repo). Clean no-op until the SNAPTRADE_* secrets are set.
+
+on:
+  schedule:
+    - cron: '40 13 * * 1-5'   # 13:40 UTC ≈ 9:40 ET, weekdays (post-open)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: snaptrade-mirror
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install requests snaptrade-python-sdk
+
+      - name: Run mirror
+        env:
+          SNAPTRADE_CLIENT_ID: ${{ secrets.SNAPTRADE_CLIENT_ID }}
+          SNAPTRADE_CONSUMER_KEY: ${{ secrets.SNAPTRADE_CONSUMER_KEY }}
+          SNAPTRADE_USER_ID: ${{ secrets.SNAPTRADE_USER_ID }}
+          SNAPTRADE_USER_SECRET: ${{ secrets.SNAPTRADE_USER_SECRET }}
+          NOTIFICATION_WEBHOOK_URL: ${{ secrets.NOTIFICATION_WEBHOOK_URL }}
+        run: python scripts/snaptrade_mirror.py
+
+      - name: Upload mirror artifact
+        if: hashFiles('digests/modern_investing/live_account_mirror.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-account-mirror
+          path: digests/modern_investing/live_account_mirror.json
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,7 @@ workers/**/node_modules/
 workers/**/.wrangler/
 workers/**/.dev.vars
 workers/**/dist/
+
+# SnapTrade live-account mirror — the repo is public; balances/positions
+# must never be committed (execution/ Phase 1; CI uploads an artifact).
+digests/modern_investing/live_account_mirror.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,6 +369,27 @@ nerranetwork/
   readiness verdict (NOT READY — honest record +$304 over 40 sequential
   $1k trades vs NASDAQ +15.46% ITD; accumulate 2-3 months of clean
   post-fix record first).
+  **July 3 2026 SnapTrade execution plan** (doc:
+  [`docs/mit_snaptrade_live_trading_plan.md`](docs/mit_snaptrade_live_trading_plan.md);
+  drift guards: `tests/test_mit_benchmark_integrity.py::TestTradeSignal`):
+  design for live trading via SnapTrade (the only sanctioned Wealthsimple
+  API route; Webull US/CA trading added Dec 2025). Shipped the execution
+  bridge: `post_generate` now writes a schema-versioned
+  `trade_signal_latest.json` + per-episode copy (explicit
+  new_trade/no_trade with drift-distinguishing reason, SnapTrade-format
+  symbol — Yahoo `.TO` convention matches the tracker's resolved symbols
+  1:1 — CAD→Wealthsimple / USD→Webull routing, deterministic uuid5
+  `client_order_id` for idempotent placement; read-only runs write
+  nothing). The future `execution/` package consumes ONLY this artifact
+  — the LLM never touches the order path. Phased rollout in the doc
+  (read-only mirror → shadow mode → $150-250 micro-live on Webull →
+  scale), fail-closed risk caps, and an operator checklist (SnapTrade's
+  per-broker matrix must be verified in the dashboard: trade enablement
+  for Wealthsimple, Limit+Day support, fractional/notional). NOTE:
+  SnapTrade's sandbox is READ-ONLY (no simulated fills) — shadow mode is
+  the paper-trading layer. Podcast stays a simulation on air; live
+  execution is a private layer decoupled from the 08:16 UTC episode run
+  (executor runs its own ~13:50 UTC slot).
 
 **Tesla Shorts Time Recursive Memory System (May 2026+)**  
 TST received a full recursive improvement architecture (analogous to MIT):

--- a/docs/mit_snaptrade_live_trading_plan.md
+++ b/docs/mit_snaptrade_live_trading_plan.md
@@ -154,12 +154,23 @@ brokerages via the portal, set `SNAPTRADE_CLIENT_ID` /
 `SNAPTRADE_CONSUMER_KEY` / `SNAPTRADE_USER_ID` / `SNAPTRADE_USER_SECRET`
 secrets.
 
-**Phase 1 — read-only mirror (1 PR).** `execution/` package +
-`reconcile.py`: pull accounts/balances/positions daily, publish a
-"live account mirror" block to the dashboard, register webhooks
-(`CONNECTION_BROKEN` → notification). Zero orders possible (no
-`place` call in the codebase yet). Proves connection stability with
-Wealthsimple/Webull for a few weeks — the thing we genuinely don't know.
+**Phase 1 — read-only mirror (SHIPPED, same PR).** `execution/` package
+(`snaptrade_client.py` lazy-SDK wrapper + `mirror.py`),
+`scripts/snaptrade_setup.py` (one-time local: `--register` mints the
+user secret, `--connect` prints the Connection Portal URL per broker,
+`--status` verifies), `scripts/snaptrade_mirror.py` +
+`.github/workflows/snaptrade-mirror.yml` (weekdays 13:40 UTC): pulls
+accounts/balances/positions daily, one-line summary to
+`NOTIFICATION_WEBHOOK_URL`, **mirror JSON gitignored + uploaded as a
+14-day CI artifact — never committed (public repo)**. Zero orders
+possible (no `place` call in the package; pinned by
+`tests/test_snaptrade_execution.py`, along with the
+podcast-never-imports-execution isolation contract). Proves connection
+stability with Wealthsimple/Webull for a few weeks — the thing we
+genuinely don't know. Webhook registration (CONNECTION_BROKEN → push)
+is a dashboard setting (Webhooks tab → point at the existing
+notification endpoint); a dedicated receiver Worker is Phase-2 scope if
+signature verification is wanted.
 
 **Phase 2 — shadow mode (1 PR, ≥4 weeks running).** `executor.py` runs
 the FULL pipeline — signal → risk checks → symbol verification → live

--- a/docs/mit_snaptrade_live_trading_plan.md
+++ b/docs/mit_snaptrade_live_trading_plan.md
@@ -1,0 +1,234 @@
+# MIT → SnapTrade live-trading plan (Wealthsimple + Webull)
+
+**Date:** 2026-07-03 · **Status:** design + Phase-1 bridge shipped (trade
+signal artifact). Follows the July 3 benchmark-integrity pass
+([`docs/reviews/modern_investing_review_2026_07_03.md`](reviews/modern_investing_review_2026_07_03.md))
+whose verdict — accumulate 2–3 months of clean simulated record first —
+still gates real-dollar orders. This plan builds the execution layer *in
+parallel* with that clock so nothing blocks when the record earns it.
+
+---
+
+## 1. SnapTrade review — what it is and what matters for us
+
+SnapTrade (docs.snaptrade.com) is a brokerage-connectivity API: one
+interface for account data + order placement across ~35 institutions. It
+is the **only sanctioned API route into Wealthsimple** (Wealthsimple has
+no developer API; SnapTrade is its integration partner) and it added
+**Webull (US and Canada as separate integrations) with real-time trading
+in December 2025**. That makes it exactly the right choice for the
+operator's two accounts.
+
+### Auth model (three tiers)
+1. **Partner keys** — `clientId` + `consumerKey` from the SnapTrade
+   dashboard. Every server-side call signs with these.
+2. **User registration** — register one SnapTrade user (the operator) →
+   `userId` + `userSecret`. The secret is shown once; store alongside the
+   other pipeline secrets.
+3. **Connection Portal** — generate a redirect URI; the operator logs in
+   to Wealthsimple and Webull once through SnapTrade's hosted portal
+   (credentials + MFA go to SnapTrade, never to us; we hold scoped
+   tokens). Each brokerage = one "connection" containing its accounts.
+
+### Trading API surface (what the executor will call)
+- `POST /trade/place` (**place equity order**): `account_id`, `action`
+  (BUY/SELL), `symbol` **or** `universal_symbol_id`, `order_type`
+  (`Market` | `Limit` | `Stop` | `StopLimit`), `time_in_force` (`Day` |
+  `GTC` | `FOK` | `IOC` | `GTD`), `units` (fractional supported) or
+  `notional_value` (Market+Day only, select brokerages), `price` /
+  `stop` as required, and — critically for a cron-driven system —
+  **`client_order_id` for idempotent placement** (a retried job cannot
+  double-buy).
+- **Checked-order flow**: `check order impact` → returns buying-power /
+  commission impact + a `tradeId` → `place checked order`. SnapTrade
+  recommends the direct flow, but the impact check is a free extra
+  guardrail; we'll use it when available and fall through with a log.
+- **Cancel order** (all asset types) + **get order detail** for status
+  (`PENDING/ACCEPTED/EXECUTED/PARTIAL/REJECTED/EXPIRED…`).
+- Post-order: trigger a **manual account refresh** (docs recommend it;
+  default sync is only guaranteed once/day).
+- Rate guidance: **≤1 trade/sec/account** (we do ~1 trade/day — a
+  non-issue).
+
+### Symbology — a happy accident
+SnapTrade's canonical symbols follow the **Yahoo Finance ticker format**
+(`SHOP.TO` for TSX, bare for US listings), with distinct
+universal-symbol IDs per venue. The July 3 pass already made the MIT
+tracker resolve picks to exactly this format (`resolved_symbol`), so the
+sim and the executor speak the same language with zero mapping code. For
+belt-and-braces, the executor should cache each account's
+`listAllBrokerageInstruments` (tradeable flags, fractionability,
+exchange MIC) and refuse any symbol not present.
+
+### Webhooks (wire to the existing `NOTIFICATION_WEBHOOK_URL` plumbing)
+HMAC-SHA256-signed (consumer key), 3 retries w/ backoff. The ones we
+want: `CONNECTION_BROKEN` / `CONNECTION_FIXED` (Wealthsimple
+credential-based connections can and do break — **trading must
+fail-closed on a broken connection**), `TRADE_UPDATE` (status changes
+for SnapTrade-placed orders), `TRADE_DETECTION` (executions detected —
+catches manual trades too), `ACCOUNT_HOLDINGS_UPDATED`.
+
+### Environments, SDK, pricing
+- **The sandbox is READ-ONLY** — simulated connections/holdings/orders
+  but **no order placement, no simulated fills**. Consequence: *paper
+  trading cannot be delegated to SnapTrade*; our own shadow mode (§3
+  Phase 2) is the paper-trading layer, and first live orders must be
+  real-but-tiny.
+- Python SDK: `snaptrade-python-sdk` (PyPI); TypeScript etc. also exist.
+- Pricing: free tier ≈ 5 connections; pay-as-you-go ~$1.50/connected
+  user/month. We are 1 user + 2 connections → **effectively free**.
+
+### Open items to verify in the SnapTrade dashboard (operator, ~30 min)
+The per-broker capability matrix is a Notion page that couldn't be read
+programmatically, and some brokers gate *trading* (vs read) behind
+partner enablement. Before writing executor code against assumptions:
+1. Confirm **trade access is enabled** for Wealthsimple and Webull on
+   your key (message SnapTrade support if the connection portal shows
+   read-only).
+2. Confirm per-broker support for: `Limit` orders (must-have), `Day`
+   TIF (must-have), fractional units, `notional_value`, `Stop`/
+   `StopLimit` (nice-to-have — see §4 stops), extended hours.
+3. Confirm which **Webull entity** your account is (Webull US vs Webull
+   Canada — separate integrations) and which Wealthsimple account types
+   surface (TFSA/RRSP/non-registered; business accounts have limited
+   support).
+4. Ask about order limits/velocity checks on the Wealthsimple side.
+
+## 2. Target architecture
+
+```
+run_show.py (08:16 UTC, unchanged)
+  └─ shows/hooks/modern_investing.py post_generate
+       ├─ investment_tracker.json          (sim record — unchanged)
+       └─ trade_signal_ep{N}.json + trade_signal_latest.json   ← SHIPPED
+                                                (schema v1, see §5)
+execution/ (NEW — isolated package, never imported by the podcast path)
+  ├─ snaptrade_client.py    thin wrapper over snaptrade-python-sdk
+  ├─ risk.py                hard caps + kill switch (deterministic)
+  ├─ executor.py            signal → validated order → ledger
+  ├─ reconcile.py           order status / holdings / sim-vs-live report
+  └─ live_ledger.json       every order ever sent, with full audit trail
+.github/workflows/execute-trade.yml (NEW — 13:50 UTC ≈ 9:50 ET)
+```
+
+Design rules (non-negotiable):
+- **The LLM never touches the order path.** It produces the pick; the
+  signal artifact is deterministic parsed data; `execution/` is plain
+  code with hard caps. No prompt output is ever interpolated into an
+  order.
+- **Fail closed.** No signal file → no trade. Stale signal (>1 day) →
+  no trade. Broken connection → no trade. Any validation failure → no
+  trade + loud notification. There is no retry-until-it-works.
+- **Separate schedule.** MIT generates at 08:16 UTC = 4:16 a.m. ET,
+  pre-market. Orders placed then would sit in a queue or be rejected.
+  The executor runs in its own workflow at ~9:50 ET (after the opening
+  auction volatility), consuming the morning's signal. This also means a
+  podcast failure and a trading failure can never entangle.
+- **Idempotent.** `client_order_id` = uuid5(episode, symbol, date) —
+  already in the signal. A re-run workflow re-sends the same id;
+  SnapTrade dedupes.
+
+### Account routing
+| Pick market | Currency | Account | Why |
+|---|---|---|---|
+| TSX / TSX-V | CAD | Wealthsimple (non-registered or TFSA) | native CAD; avoids Wealthsimple's ~1.5% FX on USD trades |
+| NYSE / NASDAQ | USD | Webull US | $0 commission USD-native; better order-type coverage |
+
+### Order policy (v1)
+- **Marketable limit, never market**: buy limit = min(quote ask,
+  reference × (1 + `max_slippage_pct` 0.5%)), TIF `Day`. Unfilled after
+  30 min → cancel; one requote attempt; then give up and record
+  `unfilled` (the sim's "you always fill at the open" optimism is
+  measured, not replicated).
+- **Exits on the sim's calendar**: flash → sell next trading day;
+  weekly → sell Friday ~15:45 ET (a second executor slot), so live
+  windows track the (fixed) sim windows as closely as reality allows.
+- **Position size**: start at $150–250/trade (Phase 3), not the sim's
+  $1,000, until slippage data exists.
+
+## 3. Rollout phases
+
+**Phase 0 — account facts (operator, this week).** Dashboard signup,
+verify §1 open items, create sandbox + production keys, connect both
+brokerages via the portal, set `SNAPTRADE_CLIENT_ID` /
+`SNAPTRADE_CONSUMER_KEY` / `SNAPTRADE_USER_ID` / `SNAPTRADE_USER_SECRET`
+secrets.
+
+**Phase 1 — read-only mirror (1 PR).** `execution/` package +
+`reconcile.py`: pull accounts/balances/positions daily, publish a
+"live account mirror" block to the dashboard, register webhooks
+(`CONNECTION_BROKEN` → notification). Zero orders possible (no
+`place` call in the codebase yet). Proves connection stability with
+Wealthsimple/Webull for a few weeks — the thing we genuinely don't know.
+
+**Phase 2 — shadow mode (1 PR, ≥4 weeks running).** `executor.py` runs
+the FULL pipeline — signal → risk checks → symbol verification → live
+quote → computed limit price — and then, instead of placing, appends the
+would-be order to `live_ledger.json` with `mode: "shadow"`. Nightly
+reconcile compares shadow fills (next real bar) against the sim's
+entries → the first real **slippage model**, which then feeds back into
+the sim's cost assumptions (the review's execution-modeling item). This
+IS the paper-trading layer, since SnapTrade's sandbox can't fill orders.
+
+**Phase 3 — micro-live (operator flips `LIVE_TRADING_ENABLED=1`).**
+Real orders at $150–250, Webull US only at first (single account, USD,
+simplest), 20–30 trades. Every order → notification with fill vs sim
+delta. Halt automatically on: 2 consecutive rejected orders, daily loss
+> cap, connection broken, or sim-vs-live divergence > threshold.
+
+**Phase 4 — scale decision (operator).** Add Wealthsimple/TSX routing,
+raise size toward $1,000 — only if Phase 3's matched-window alpha net of
+measured costs is still positive AND the sim's clean 2–3-month record
+holds. Then, optionally: enforceable stops (see §4), TFSA
+considerations (frequent trading inside a TFSA can be deemed business
+income by the CRA — talk to an accountant before running this strategy
+in a registered account).
+
+## 4. Risk controls (`execution/risk.py`, all hard-coded, env-tunable)
+
+| Control | Default | Note |
+|---|---|---|
+| `LIVE_TRADING_ENABLED` | unset (off) | global kill switch; shadow mode ignores it |
+| `MAX_POSITION_USD` | 250 | Phase-3 cap |
+| `MAX_OPEN_POSITIONS` | 1 | matches the sim's model |
+| `MAX_DAILY_ORDERS` | 2 | 1 entry + 1 exit |
+| `MAX_DAILY_LOSS_USD` | 100 | realized, from ledger; halts entries |
+| `MAX_SLIPPAGE_PCT` | 0.5 | limit-price collar vs reference |
+| Symbol gates | — | must be in brokerage instrument cache; price ≥ $2; no OTC (blocks the SSNLF/BTC/ION pick classes); reject if `pick_validated: false` |
+| Confidence gate | optional | skip `Low`-confidence picks once calibration data exists |
+| PDT guard | — | flash trades buy day-D / sell day-D+1 (not day trades), but track the 5-day window anyway on Webull margin < $25k; prefer a cash account |
+| Stops | software | if the broker matrix confirms native `StopLimit`, attach one at Phase 4; until then a 15-min position monitor sells on breach (gaps are NOT protected — stated honestly in the ledger) |
+
+## 5. Trade-signal schema v1 (shipped this PR)
+
+Written by `post_generate` to `digests/modern_investing/`
+(`trade_signal_latest.json` + `trade_signal_ep{N}.json`); read-only runs
+write nothing. `action: "new_trade" | "no_trade"` with an explicit
+`reason` (`explicit_no_trade` vs `no_pick_extracted`) so the executor
+can fail closed on drift. Trade block carries `snaptrade_symbol`
+(Yahoo/SnapTrade format), `currency` + `suggested_account` routing,
+`pick_reference_price` + `pick_validated` (from the July-3 probe), and
+the deterministic `client_order_id`. Drift guards:
+`tests/test_mit_benchmark_integrity.py::TestTradeSignal`.
+
+## 6. What this does NOT change
+
+The podcast remains a simulation on air — the $1,000 sim tracker stays
+the show's record and the disclaimers stay exactly as they are. Live
+execution is the operator's private layer; if it ever becomes content
+("we put real money on the line"), that's an editorial decision with
+its own compliance review, out of scope here.
+
+## Sources
+- https://docs.snaptrade.com/docs/getting-started
+- https://docs.snaptrade.com/docs/trading-with-snaptrade
+- https://docs.snaptrade.com/reference/Trading/Trading_placeForceOrder
+- https://docs.snaptrade.com/docs/symbology.md
+- https://docs.snaptrade.com/docs/webhooks
+- https://docs.snaptrade.com/docs/sandbox.md (read-only sandbox)
+- https://docs.snaptrade.com/docs/faq
+- https://snaptrade.com/brokerage-integrations/wealthsimple-api
+- https://snaptrade.com/brokerage-integrations/webull-api ·
+  https://snaptrade.com/brokerage-integrations/webull-ca-api
+- https://snaptrade.com/pricing
+- Webull partnership (Dec 2025): https://finance.yahoo.com/news/snaptrade-partners-webull-140000135.html

--- a/execution/__init__.py
+++ b/execution/__init__.py
@@ -1,0 +1,17 @@
+"""Live-account execution layer (SnapTrade) — ISOLATED from the podcast path.
+
+Contract (see docs/mit_snaptrade_live_trading_plan.md):
+
+- Nothing in ``engine/``, ``run_show.py``, or ``shows/hooks/`` may import
+  this package. The podcast pipeline's only interface to execution is the
+  ``trade_signal_*.json`` artifact it writes; this package's only
+  interface back is its own ledger/mirror files.
+- The LLM never touches the order path: this package consumes the
+  deterministic signal artifact, never digest prose.
+- Fail closed: unconfigured environment, missing/stale signal, or a
+  broken brokerage connection means NO action, loudly.
+- Phase 1 (current) is READ-ONLY: there is deliberately no order-placing
+  code in this package yet. Phases in the plan doc gate what gets added.
+- Privacy: the repo is public. Balances/positions are written only to
+  gitignored local files or CI artifacts — never committed.
+"""

--- a/execution/mirror.py
+++ b/execution/mirror.py
@@ -1,0 +1,136 @@
+"""Read-only live-account mirror (Phase 1 of the SnapTrade plan).
+
+Builds a privacy-conscious snapshot of the operator's connected accounts:
+institution, masked account number, cash + total value, and positions.
+The output goes to a **gitignored** local file / CI artifact — the repo
+is public, so balances must never be committed (see execution/__init__).
+
+``build_mirror`` is a pure function over already-fetched data so it can
+be unit-tested without the SDK; ``fetch_mirror`` does the network calls.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+
+from execution import snaptrade_client as st
+
+logger = logging.getLogger(__name__)
+
+MIRROR_SCHEMA_VERSION = 1
+
+
+def _mask_number(number) -> str:
+    s = str(number or "")
+    return f"***{s[-3:]}" if len(s) >= 3 else "***"
+
+
+def _num(value, default=None):
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return default
+    return f
+
+
+def build_mirror(accounts: list[dict],
+                 positions_by_account: dict[str, list[dict]],
+                 balances_by_account: dict[str, list[dict]],
+                 *, now_iso: str | None = None) -> dict:
+    """Normalize SnapTrade account/position/balance payloads to one dict."""
+    out_accounts = []
+    for acct in accounts or []:
+        acct_id = str(acct.get("id", ""))
+        balances = balances_by_account.get(acct_id) or []
+        cash_lines = [
+            {
+                "currency": ((b.get("currency") or {}).get("code")
+                             if isinstance(b.get("currency"), dict)
+                             else b.get("currency")),
+                "cash": _num(b.get("cash")),
+            }
+            for b in balances
+        ]
+        positions = []
+        for pos in positions_by_account.get(acct_id) or []:
+            sym = pos.get("symbol") or {}
+            # SnapTrade nests symbol → symbol → raw/description.
+            inner = sym.get("symbol") if isinstance(sym, dict) else None
+            if isinstance(inner, dict):
+                ticker = inner.get("symbol") or inner.get("raw_symbol")
+                description = inner.get("description")
+            else:
+                ticker = inner or (sym if isinstance(sym, str) else None)
+                description = None
+            units = _num(pos.get("units") or pos.get("fractional_units"))
+            price = _num(pos.get("price"))
+            positions.append({
+                "symbol": ticker,
+                "description": description,
+                "units": units,
+                "price": price,
+                "value": round(units * price, 2)
+                if units is not None and price is not None else None,
+            })
+        total = acct.get("balance") or {}
+        total_value = total.get("total") if isinstance(total, dict) else None
+        if isinstance(total_value, dict):
+            total_amount = _num(total_value.get("amount"))
+            total_currency = total_value.get("currency")
+        else:
+            total_amount = _num(total_value)
+            total_currency = None
+        out_accounts.append({
+            "id": acct_id,
+            "name": acct.get("name"),
+            "institution": acct.get("institution_name"),
+            "number_masked": _mask_number(acct.get("number")),
+            "total_value": total_amount,
+            "total_currency": total_currency,
+            "cash": cash_lines,
+            "positions": positions,
+            "sync_status": (acct.get("sync_status") or {}),
+        })
+    return {
+        "schema_version": MIRROR_SCHEMA_VERSION,
+        "generated_at": now_iso
+        or datetime.datetime.now(datetime.timezone.utc).isoformat(
+            timespec="seconds"),
+        "account_count": len(out_accounts),
+        "accounts": out_accounts,
+    }
+
+
+def fetch_mirror() -> dict:
+    """Fetch everything and build the mirror. Raises on network failure —
+    the caller (script/workflow) decides how loud to be."""
+    accounts = st.list_accounts()
+    positions_by_account: dict[str, list[dict]] = {}
+    balances_by_account: dict[str, list[dict]] = {}
+    for acct in accounts:
+        acct_id = str(acct.get("id", ""))
+        try:
+            positions_by_account[acct_id] = st.account_positions(acct_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("positions fetch failed for %s: %s", acct_id, exc)
+            positions_by_account[acct_id] = []
+        try:
+            balances_by_account[acct_id] = st.account_balances(acct_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("balances fetch failed for %s: %s", acct_id, exc)
+            balances_by_account[acct_id] = []
+    return build_mirror(accounts, positions_by_account, balances_by_account)
+
+
+def mirror_summary_line(mirror: dict) -> str:
+    """One-line human summary (safe for notifications/logs)."""
+    n_accounts = mirror.get("account_count", 0)
+    n_positions = sum(
+        len(a.get("positions") or []) for a in mirror.get("accounts") or [])
+    institutions = sorted({
+        a.get("institution") or "?" for a in mirror.get("accounts") or []})
+    return (
+        f"SnapTrade mirror OK: {n_accounts} account(s) "
+        f"[{', '.join(institutions) or 'none'}], {n_positions} position(s)."
+    )

--- a/execution/snaptrade_client.py
+++ b/execution/snaptrade_client.py
@@ -1,0 +1,141 @@
+"""Thin, defensive wrapper around the SnapTrade Python SDK.
+
+Phase 1 (read-only) of docs/mit_snaptrade_live_trading_plan.md. There is
+deliberately NO order-placing method here — trading code arrives in a
+later phase behind its own risk layer.
+
+Configuration comes from four environment variables (dashboard → API
+Keys for the first two; ``scripts/snaptrade_setup.py`` mints the last
+two once):
+
+- ``SNAPTRADE_CLIENT_ID``
+- ``SNAPTRADE_CONSUMER_KEY``
+- ``SNAPTRADE_USER_ID``
+- ``SNAPTRADE_USER_SECRET``
+
+The SDK (``pip install snaptrade-python-sdk``) is imported lazily so the
+podcast pipeline never needs it installed. Responses are normalized to
+plain dicts/lists via ``_body`` because SDK versions differ in whether
+they return a wrapped response object or raw data.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_ENV_KEYS = (
+    "SNAPTRADE_CLIENT_ID",
+    "SNAPTRADE_CONSUMER_KEY",
+    "SNAPTRADE_USER_ID",
+    "SNAPTRADE_USER_SECRET",
+)
+
+
+def is_configured() -> bool:
+    """True when all four SnapTrade env vars are non-empty."""
+    return all(os.environ.get(k, "").strip() for k in _ENV_KEYS)
+
+
+def missing_config() -> list[str]:
+    return [k for k in _ENV_KEYS if not os.environ.get(k, "").strip()]
+
+
+def _sdk():
+    """Import and construct the SDK client (lazy; clear error if absent)."""
+    try:
+        from snaptrade_client import SnapTrade
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise RuntimeError(
+            "snaptrade-python-sdk is not installed. "
+            "Run: pip install snaptrade-python-sdk"
+        ) from exc
+    return SnapTrade(
+        client_id=os.environ["SNAPTRADE_CLIENT_ID"],
+        consumer_key=os.environ["SNAPTRADE_CONSUMER_KEY"],
+    )
+
+
+def _user_kwargs() -> dict:
+    return {
+        "user_id": os.environ["SNAPTRADE_USER_ID"],
+        "user_secret": os.environ["SNAPTRADE_USER_SECRET"],
+    }
+
+
+def _body(resp):
+    """Normalize SDK responses across versions (``.body``/``.data``/raw)."""
+    for attr in ("body", "data", "parsed"):
+        value = getattr(resp, attr, None)
+        if value is not None:
+            return value
+    return resp
+
+
+def register_user(user_id: str) -> dict:
+    """Register a SnapTrade user; returns {userId, userSecret}.
+
+    One-time operation — the secret is only returned once. Requires only
+    the two API-key env vars.
+    """
+    snaptrade = _sdk()
+    resp = snaptrade.authentication.register_snap_trade_user(user_id=user_id)
+    return dict(_body(resp))
+
+
+def connection_portal_url(broker: str | None = None,
+                          connection_type: str = "trade") -> str:
+    """Return a login URL for the hosted Connection Portal.
+
+    ``connection_type='trade'`` requests read+trade scope up front so a
+    later phase doesn't force a reconnection; pass ``'read'`` to be
+    conservative. ``broker`` (e.g. ``WEALTHSIMPLETRADE``) preselects an
+    institution when given; omitted, the portal shows the picker.
+    """
+    snaptrade = _sdk()
+    kwargs = dict(_user_kwargs(), connection_type=connection_type)
+    if broker:
+        kwargs["broker"] = broker
+    resp = snaptrade.authentication.login_snap_trade_user(**kwargs)
+    body = _body(resp)
+    url = body.get("redirectURI") if isinstance(body, dict) else None
+    if not url:
+        raise RuntimeError(f"Unexpected login response shape: {body!r}")
+    return url
+
+
+def list_connections() -> list[dict]:
+    """Brokerage authorizations (one per connected institution)."""
+    snaptrade = _sdk()
+    resp = snaptrade.connections.list_brokerage_authorizations(**_user_kwargs())
+    return list(_body(resp) or [])
+
+
+def list_accounts() -> list[dict]:
+    """All accounts across the user's connections."""
+    snaptrade = _sdk()
+    resp = snaptrade.account_information.list_user_accounts(**_user_kwargs())
+    return list(_body(resp) or [])
+
+
+def account_positions(account_id: str) -> list[dict]:
+    snaptrade = _sdk()
+    resp = snaptrade.account_information.get_user_account_positions(
+        account_id=account_id, **_user_kwargs())
+    return list(_body(resp) or [])
+
+
+def account_balances(account_id: str) -> list[dict]:
+    snaptrade = _sdk()
+    resp = snaptrade.account_information.get_user_account_balance(
+        account_id=account_id, **_user_kwargs())
+    return list(_body(resp) or [])
+
+
+def recent_orders(account_id: str) -> list[dict]:
+    snaptrade = _sdk()
+    resp = snaptrade.account_information.get_user_account_orders(
+        account_id=account_id, **_user_kwargs())
+    return list(_body(resp) or [])

--- a/scripts/snaptrade_mirror.py
+++ b/scripts/snaptrade_mirror.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Daily read-only SnapTrade account mirror (Phase 1).
+
+Fetches connected accounts/balances/positions and writes
+``digests/modern_investing/live_account_mirror.json`` (GITIGNORED — the
+repo is public and balances must never be committed; in CI the file is
+uploaded as a workflow artifact instead). Prints a one-line summary and
+POSTs it to ``NOTIFICATION_WEBHOOK_URL`` when set.
+
+Exit codes: 0 on success OR when SnapTrade env vars are unset (clean
+no-op, so the workflow can run before setup is done); 1 on a real
+fetch/serialization failure.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from execution import mirror as mirror_mod  # noqa: E402
+from execution import snaptrade_client as st  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("snaptrade_mirror")
+
+DEFAULT_OUT = ROOT / "digests" / "modern_investing" / "live_account_mirror.json"
+
+
+def _notify(line: str) -> None:
+    url = os.environ.get("NOTIFICATION_WEBHOOK_URL", "").strip()
+    if not url:
+        return
+    try:
+        import requests
+        requests.post(url, json={"text": line}, timeout=10)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("notification failed (non-fatal): %s", exc)
+
+
+def main() -> int:
+    out_path = Path(sys.argv[sys.argv.index("--out") + 1]) \
+        if "--out" in sys.argv else DEFAULT_OUT
+
+    if not st.is_configured():
+        logger.info(
+            "SnapTrade env vars not set (%s) — mirror is a clean no-op. "
+            "Run scripts/snaptrade_setup.py first.",
+            ", ".join(st.missing_config()),
+        )
+        return 0
+
+    try:
+        mirror = mirror_mod.fetch_mirror()
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Mirror fetch FAILED: %s", exc)
+        _notify(f"SnapTrade mirror FAILED: {exc}")
+        return 1
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(mirror, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    line = mirror_mod.mirror_summary_line(mirror)
+    logger.info("%s → %s", line, out_path)
+    if mirror["account_count"] == 0:
+        logger.warning(
+            "No accounts returned — connections may be broken or not yet "
+            "created (scripts/snaptrade_setup.py --status).")
+        _notify("SnapTrade mirror: 0 accounts returned — check connections.")
+    else:
+        _notify(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/snaptrade_setup.py
+++ b/scripts/snaptrade_setup.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""One-time SnapTrade setup for the MIT execution layer (Phase 1).
+
+Run this LOCALLY (it prints a secret once and opens browser URLs — never
+run it in CI). Prerequisites: ``pip install snaptrade-python-sdk`` and
+the two API-key env vars from the dashboard (API Keys tab):
+
+    export SNAPTRADE_CLIENT_ID=...
+    export SNAPTRADE_CONSUMER_KEY=...
+
+Steps it performs:
+
+1. ``--register`` — registers the SnapTrade user (default userId
+   ``nerra-mit-operator``) and prints the ``userSecret``. SnapTrade
+   returns the secret ONCE; copy both values into your local ``.env``
+   AND the GitHub Actions secrets:
+       SNAPTRADE_USER_ID / SNAPTRADE_USER_SECRET
+2. ``--connect`` — prints a Connection Portal URL (optionally
+   ``--broker WEALTHSIMPLETRADE`` / ``--broker WEBULL``). Open it in a
+   browser and log in to the brokerage; repeat per brokerage.
+3. ``--status`` — lists connections + accounts so you can confirm both
+   brokerages are linked and whether the connection is read-only or
+   trade-enabled.
+
+Usage:
+    python scripts/snaptrade_setup.py --register
+    python scripts/snaptrade_setup.py --connect --broker WEALTHSIMPLETRADE
+    python scripts/snaptrade_setup.py --connect --broker WEBULL
+    python scripts/snaptrade_setup.py --status
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from execution import snaptrade_client as st  # noqa: E402
+
+DEFAULT_USER_ID = "nerra-mit-operator"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--register", action="store_true",
+                        help="register the SnapTrade user (one-time)")
+    parser.add_argument("--user-id", default=DEFAULT_USER_ID)
+    parser.add_argument("--connect", action="store_true",
+                        help="print a Connection Portal URL")
+    parser.add_argument("--broker", default=None,
+                        help="preselect an institution (e.g. "
+                             "WEALTHSIMPLETRADE, WEBULL)")
+    parser.add_argument("--connection-type", default="trade",
+                        choices=("read", "trade"),
+                        help="scope to request in the portal (default: trade)")
+    parser.add_argument("--status", action="store_true",
+                        help="list connections and accounts")
+    args = parser.parse_args()
+
+    if not (os.environ.get("SNAPTRADE_CLIENT_ID")
+            and os.environ.get("SNAPTRADE_CONSUMER_KEY")):
+        print("Set SNAPTRADE_CLIENT_ID and SNAPTRADE_CONSUMER_KEY first "
+              "(dashboard → API Keys).")
+        return 1
+
+    if args.register:
+        result = st.register_user(args.user_id)
+        secret = result.get("userSecret")
+        print("Registered SnapTrade user.")
+        print(f"  SNAPTRADE_USER_ID={result.get('userId', args.user_id)}")
+        print(f"  SNAPTRADE_USER_SECRET={secret}")
+        print("\nStore BOTH in your local .env and in GitHub Actions "
+              "secrets NOW — the secret is not shown again.")
+        return 0
+
+    if args.connect:
+        if st.missing_config():
+            print(f"Missing env vars: {', '.join(st.missing_config())} "
+                  "(run --register first).")
+            return 1
+        url = st.connection_portal_url(
+            broker=args.broker, connection_type=args.connection_type)
+        print("Open this URL in a browser and log in to the brokerage:\n")
+        print(f"  {url}\n")
+        print("Then re-run with --status to confirm the connection.")
+        return 0
+
+    if args.status:
+        if st.missing_config():
+            print(f"Missing env vars: {', '.join(st.missing_config())}.")
+            return 1
+        connections = st.list_connections()
+        print(f"{len(connections)} connection(s):")
+        for c in connections:
+            broker = (c.get("brokerage") or {}).get("name") or c.get("name")
+            print(f"  - {broker}: disabled={c.get('disabled')} "
+                  f"type={c.get('type')} id={c.get('id')}")
+        accounts = st.list_accounts()
+        print(f"{len(accounts)} account(s):")
+        for a in accounts:
+            print(f"  - {a.get('institution_name')} {a.get('name')} "
+                  f"(id={a.get('id')})")
+        return 0
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -15,6 +15,7 @@ import logging
 import math
 import os
 import re
+import uuid
 from pathlib import Path
 
 
@@ -444,6 +445,16 @@ def post_generate(config, *, digest_text: str = "", episode_num: int | None = No
     else:
         logger.warning("Could not extract Practice Investment pick from digest")
 
+    # Execution bridge (July 2026 live-trading prep): emit a
+    # machine-readable trade signal for the (future, isolated) SnapTrade
+    # execution layer. The executor consumes THIS artifact — never the
+    # digest prose — so LLM formatting drift can't reach an order ticket.
+    # Best-effort: a signal-write failure must never block the pipeline.
+    try:
+        _write_trade_signal(output_dir, trade, digest_text, episode_num, tracker)
+    except Exception as exc:
+        logger.warning("Trade-signal write failed (non-fatal): %s", exc)
+
     # Repetition guard: record whichever lesson tags the digest taught.
     taught_path = output_dir / TAUGHT_LESSONS_FILENAME
     taught = _load_taught_lessons(taught_path)
@@ -741,6 +752,106 @@ def _probe_pick(trade: dict) -> bool:
         trade.get("symbol"), trade.get("market"), ", ".join(candidates) or "nothing",
     )
     return False
+
+
+TRADE_SIGNAL_LATEST_FILENAME = "trade_signal_latest.json"
+TRADE_SIGNAL_SCHEMA_VERSION = 1
+
+# uuid5 namespace for deterministic client_order_ids — SnapTrade's
+# place-order endpoint accepts a caller-supplied ``client_order_id`` for
+# idempotent placement, which protects a retried cron from double-buying.
+_SIGNAL_ORDER_NAMESPACE = uuid.UUID("6d49f5a4-1a68-4f6e-9c7e-a1b2c3d4e5f6")
+
+
+def _write_trade_signal(
+    output_dir: Path,
+    trade: dict | None,
+    digest_text: str,
+    episode_num: int | None,
+    tracker: dict,
+) -> None:
+    """Write the per-episode machine-readable trade signal.
+
+    July 2026 live-trading prep: the future SnapTrade execution layer (and
+    the shadow-mode logger before it) must consume a schema-versioned
+    artifact, not the digest markdown — the tracker has already lost real
+    picks to LLM formatting drift, which is survivable for a sim and
+    unacceptable for an order ticket. The signal is explicit about
+    NO-trade days too, so the executor can distinguish "the show chose
+    not to trade" from "the signal never arrived" (fail-closed either way).
+
+    Fields are chosen for SnapTrade specifically:
+    - ``snaptrade_symbol`` is the Yahoo-format symbol (``CNR.TO``) —
+      SnapTrade's canonical symbology follows the Yahoo ticker format, so
+      the tracker's resolved symbol maps 1:1;
+    - ``currency``/``suggested_account`` route TSX picks to a CAD account
+      (Wealthsimple) and US picks to a USD account (Webull) so no order
+      eats a cross-currency conversion spread;
+    - ``client_order_id`` is a deterministic uuid5 of
+      (episode, symbol, date) for idempotent placement across cron
+      retries.
+    """
+    today_iso = datetime.date.today().isoformat()
+    signal: dict = {
+        "schema_version": TRADE_SIGNAL_SCHEMA_VERSION,
+        "generated_at": today_iso,
+        "episode_num": episode_num,
+        "show": "modern_investing",
+        "simulated_position_size_usd": (
+            tracker.get("metadata", {}).get("position_size", 1000)
+        ),
+    }
+
+    if trade is None:
+        explicit_no_trade = bool(
+            digest_text
+            and re.search(r"Today's Pick[:*\s]+No\b", digest_text, re.IGNORECASE)
+        )
+        signal["action"] = "no_trade"
+        signal["reason"] = (
+            "explicit_no_trade" if explicit_no_trade else "no_pick_extracted"
+        )
+        signal["trade"] = None
+    else:
+        symbol = trade.get("symbol", "")
+        market = trade.get("market", "")
+        resolved = trade.get("resolved_symbol")
+        if not resolved:
+            candidates = _yf_symbol_candidates(symbol, market)
+            resolved = candidates[0] if candidates else symbol
+        is_canadian = (market or "").upper().startswith("TSX")
+        seed = f"mit-ep{episode_num or 0}-{symbol}-{trade.get('date', today_iso)}"
+        signal["action"] = "new_trade"
+        signal["reason"] = None
+        signal["trade"] = {
+            "symbol": symbol,
+            "market": market,
+            "snaptrade_symbol": resolved,
+            "side": "BUY",
+            "trade_type": trade.get("trade_type", "weekly"),
+            "confidence": trade.get("confidence", "Unknown"),
+            "strategy": trade.get("strategy", ""),
+            "target_range": trade.get("target_range", ""),
+            "sector": trade.get("sector", ""),
+            "pick_date": trade.get("date", today_iso),
+            "pick_reference_price": trade.get("pick_reference_price"),
+            "pick_validated": bool(trade.get("pick_reference_price")),
+            "currency": "CAD" if is_canadian else "USD",
+            "suggested_account": "wealthsimple" if is_canadian else "webull",
+            "client_order_id": str(uuid.uuid5(_SIGNAL_ORDER_NAMESPACE, seed)),
+        }
+
+    payload = json.dumps(signal, indent=2, ensure_ascii=False) + "\n"
+    latest = output_dir / TRADE_SIGNAL_LATEST_FILENAME
+    latest.write_text(payload, encoding="utf-8")
+    if episode_num is not None:
+        per_episode = output_dir / f"trade_signal_ep{episode_num:03d}.json"
+        per_episode.write_text(payload, encoding="utf-8")
+    logger.info(
+        "Trade signal written: action=%s%s",
+        signal["action"],
+        f" {signal['trade']['snaptrade_symbol']}" if signal.get("trade") else "",
+    )
 
 
 def _pick_flash_bar(bars, pick_date):

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import datetime
 import json
-import math
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -499,3 +498,82 @@ class TestHonestCloseLabels:
         assert "Monday open" in review
         assert "Thursday close" in review
         assert "Friday close" not in review
+
+
+# ---------------------------------------------------------------------------
+# Trade signal (SnapTrade execution bridge, July 2026)
+# ---------------------------------------------------------------------------
+
+class TestTradeSignal:
+    """The future execution layer consumes trade_signal_latest.json — never
+    the digest prose — so LLM formatting drift can't reach an order ticket."""
+
+    _DIGEST = (
+        "### Practice Investment of the Day\n"
+        "**Trade Type:** Weekly Hold\n"
+        "**Today's Pick:** CNR — Canadian National Railway (TSX:CNR)\n"
+        "**Market:** TSX\n"
+        "**Strategy:** Dividend-growth entry\n"
+        "**Confidence Level:** Medium\n"
+    )
+
+    def _run_post_generate(self, tmp_path, digest, monkeypatch):
+        monkeypatch.delenv("NERRA_HOOKS_READONLY", raising=False)
+        config = SimpleNamespace(episode=SimpleNamespace(output_dir=str(tmp_path)))
+        with patch.object(mi, "_probe_pick", return_value=True):
+            mi.post_generate(config, digest_text=digest, episode_num=96)
+        return json.loads(
+            (tmp_path / mi.TRADE_SIGNAL_LATEST_FILENAME).read_text())
+
+    def test_new_trade_signal_routes_tsx_to_cad_wealthsimple(
+            self, tmp_path, monkeypatch):
+        signal = self._run_post_generate(tmp_path, self._DIGEST, monkeypatch)
+        assert signal["schema_version"] == mi.TRADE_SIGNAL_SCHEMA_VERSION
+        assert signal["action"] == "new_trade"
+        t = signal["trade"]
+        assert t["snaptrade_symbol"] == "CNR.TO"  # Yahoo == SnapTrade format
+        assert t["currency"] == "CAD"
+        assert t["suggested_account"] == "wealthsimple"
+        assert t["side"] == "BUY"
+        # Per-episode copy also written.
+        assert (tmp_path / "trade_signal_ep096.json").exists()
+
+    def test_us_pick_routes_to_usd_webull(self, tmp_path, monkeypatch):
+        digest = self._DIGEST.replace(
+            "CNR — Canadian National Railway (TSX:CNR)", "NVDA — Nvidia"
+        ).replace("**Market:** TSX", "**Market:** NASDAQ")
+        signal = self._run_post_generate(tmp_path, digest, monkeypatch)
+        t = signal["trade"]
+        assert t["snaptrade_symbol"] == "NVDA"
+        assert t["currency"] == "USD"
+        assert t["suggested_account"] == "webull"
+
+    def test_client_order_id_is_deterministic(self, tmp_path, monkeypatch):
+        s1 = self._run_post_generate(tmp_path, self._DIGEST, monkeypatch)
+        s2 = self._run_post_generate(tmp_path, self._DIGEST, monkeypatch)
+        # A retried cron produces the SAME id → idempotent placement.
+        assert (s1["trade"]["client_order_id"]
+                == s2["trade"]["client_order_id"])
+        assert len(s1["trade"]["client_order_id"]) == 36  # uuid string
+
+    def test_explicit_no_trade_day_is_explicit_in_signal(
+            self, tmp_path, monkeypatch):
+        digest = ("### Practice Investment of the Day\n"
+                  "**Today's Pick:** No trade today.\n")
+        signal = self._run_post_generate(tmp_path, digest, monkeypatch)
+        assert signal["action"] == "no_trade"
+        assert signal["reason"] == "explicit_no_trade"
+        assert signal["trade"] is None
+
+    def test_extraction_drift_is_distinguishable(self, tmp_path, monkeypatch):
+        signal = self._run_post_generate(
+            tmp_path, "**Today's Pick** is Nvidia at current levels.",
+            monkeypatch)
+        assert signal["action"] == "no_trade"
+        assert signal["reason"] == "no_pick_extracted"
+
+    def test_readonly_mode_writes_no_signal(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NERRA_HOOKS_READONLY", "1")
+        config = SimpleNamespace(episode=SimpleNamespace(output_dir=str(tmp_path)))
+        mi.post_generate(config, digest_text=self._DIGEST, episode_num=96)
+        assert not (tmp_path / mi.TRADE_SIGNAL_LATEST_FILENAME).exists()

--- a/tests/test_snaptrade_execution.py
+++ b/tests/test_snaptrade_execution.py
@@ -1,0 +1,135 @@
+"""Drift guards for the SnapTrade execution layer (Phase 1, July 2026).
+
+Pins the isolation + privacy contract from
+docs/mit_snaptrade_live_trading_plan.md:
+
+* the podcast path never imports ``execution/`` (the trade-signal
+  artifact is the only bridge);
+* Phase 1 is read-only — no order-placing code exists in the package;
+* the account mirror masks account numbers and its output file is
+  gitignored (public repo: balances are never committed);
+* everything is a clean no-op until the SNAPTRADE_* env vars are set.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from execution import mirror as mirror_mod  # noqa: E402
+from execution import snaptrade_client as st  # noqa: E402
+
+
+class TestIsolationContract:
+    def test_podcast_path_never_imports_execution(self):
+        # The signal artifact is the ONLY bridge between the podcast
+        # pipeline and the execution layer.
+        offenders = []
+        for path in ["run_show.py", "engine", "shows"]:
+            p = _ROOT / path
+            files = [p] if p.is_file() else sorted(p.rglob("*.py"))
+            for f in files:
+                text = f.read_text(encoding="utf-8")
+                if "from execution" in text or "import execution" in text:
+                    offenders.append(str(f.relative_to(_ROOT)))
+        assert offenders == [], (
+            f"podcast-path files import execution/: {offenders}")
+
+    def test_phase1_has_no_order_placement_code(self):
+        # Trading code arrives in a later phase behind its own risk layer.
+        for f in sorted((_ROOT / "execution").rglob("*.py")):
+            text = f.read_text(encoding="utf-8").lower()
+            assert "place_order" not in text and "placeforceorder" not in text, (
+                f"{f.name} contains order-placement code — Phase 1 is "
+                f"read-only by contract")
+
+    def test_mirror_output_is_gitignored(self):
+        # Public repo: balances/positions must never be committable.
+        result = subprocess.run(
+            ["git", "check-ignore",
+             "digests/modern_investing/live_account_mirror.json"],
+            cwd=_ROOT, capture_output=True, text=True)
+        assert result.returncode == 0, (
+            "live_account_mirror.json is not gitignored — a mirror run "
+            "would commit account balances to a public repo")
+
+
+class TestConfigGating:
+    def test_unconfigured_env_reports_missing(self, monkeypatch):
+        for key in ("SNAPTRADE_CLIENT_ID", "SNAPTRADE_CONSUMER_KEY",
+                    "SNAPTRADE_USER_ID", "SNAPTRADE_USER_SECRET"):
+            monkeypatch.delenv(key, raising=False)
+        assert st.is_configured() is False
+        assert len(st.missing_config()) == 4
+
+    def test_configured_when_all_set(self, monkeypatch):
+        for key in ("SNAPTRADE_CLIENT_ID", "SNAPTRADE_CONSUMER_KEY",
+                    "SNAPTRADE_USER_ID", "SNAPTRADE_USER_SECRET"):
+            monkeypatch.setenv(key, "x")
+        assert st.is_configured() is True
+
+    def test_mirror_script_noop_without_config(self, monkeypatch):
+        for key in ("SNAPTRADE_CLIENT_ID", "SNAPTRADE_CONSUMER_KEY",
+                    "SNAPTRADE_USER_ID", "SNAPTRADE_USER_SECRET"):
+            monkeypatch.delenv(key, raising=False)
+        result = subprocess.run(
+            [sys.executable, "scripts/snaptrade_mirror.py"],
+            cwd=_ROOT, capture_output=True, text=True, env={
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+            })
+        assert result.returncode == 0
+        assert "no-op" in (result.stdout + result.stderr)
+
+
+class TestMirrorBuilder:
+    _ACCOUNTS = [{
+        "id": "acc-1",
+        "name": "Margin",
+        "institution_name": "Webull",
+        "number": "U87654321",
+        "balance": {"total": {"amount": 1234.56, "currency": "USD"}},
+        "sync_status": {"holdings": {"initial_sync_completed": True}},
+    }]
+    _POSITIONS = {"acc-1": [{
+        "symbol": {"symbol": {"symbol": "NVDA", "description": "NVIDIA"}},
+        "units": 2, "price": 200.0,
+    }]}
+    _BALANCES = {"acc-1": [{"currency": {"code": "USD"}, "cash": 100.5}]}
+
+    def test_masks_account_numbers(self):
+        mirror = mirror_mod.build_mirror(
+            self._ACCOUNTS, self._POSITIONS, self._BALANCES,
+            now_iso="2026-07-03T14:00:00+00:00")
+        acct = mirror["accounts"][0]
+        assert acct["number_masked"] == "***321"
+        assert "U87654321" not in str(mirror)
+
+    def test_normalizes_positions_and_totals(self):
+        mirror = mirror_mod.build_mirror(
+            self._ACCOUNTS, self._POSITIONS, self._BALANCES,
+            now_iso="2026-07-03T14:00:00+00:00")
+        acct = mirror["accounts"][0]
+        assert acct["total_value"] == 1234.56
+        pos = acct["positions"][0]
+        assert pos["symbol"] == "NVDA"
+        assert pos["value"] == 400.0
+        assert acct["cash"] == [{"currency": "USD", "cash": 100.5}]
+
+    def test_summary_line_is_privacy_safe(self):
+        mirror = mirror_mod.build_mirror(
+            self._ACCOUNTS, self._POSITIONS, self._BALANCES,
+            now_iso="2026-07-03T14:00:00+00:00")
+        line = mirror_mod.mirror_summary_line(mirror)
+        assert "Webull" in line and "1 account" in line
+        # No dollar amounts in the notification line.
+        assert "1234" not in line and "400" not in line
+
+    def test_empty_accounts_yield_empty_mirror(self):
+        mirror = mirror_mod.build_mirror([], {}, {}, now_iso="t")
+        assert mirror["account_count"] == 0
+        assert mirror["accounts"] == []


### PR DESCRIPTION
# TLDR

Thorough review of SnapTrade (docs.snaptrade.com) + a phased plan to connect the MIT pipeline to the operator's **Wealthsimple** and **Webull** accounts, and the first shipped implementation step: `post_generate` now emits a **schema-versioned machine-readable trade signal** per episode — the artifact every later phase (shadow mode, live executor) consumes instead of parsing digest prose.

Full plan: `docs/mit_snaptrade_live_trading_plan.md`

# Why SnapTrade fits

- It is the **only sanctioned API route into Wealthsimple** (WS has no developer API), and Webull US/CA trading went live on SnapTrade in Dec 2025 — exactly the operator's two brokerages.
- Its canonical symbology follows the **Yahoo ticker format** (`CNR.TO`) — a 1:1 match with the `resolved_symbol` field the July-3 benchmark pass added to the tracker; zero mapping code needed.
- Trading surface: place/checked/cancel equity order, `Market|Limit|Stop|StopLimit`, `Day|GTC|FOK|IOC|GTD`, fractional units, and **`client_order_id` idempotency** (a retried cron can't double-buy).
- Webhooks (`CONNECTION_BROKEN`, `TRADE_UPDATE`) wire into the existing notification plumbing; pricing is effectively free at 1 user / 2 connections.
- **Key constraint discovered: the SnapTrade sandbox is READ-ONLY — no order placement, no simulated fills.** Paper trading therefore has to be our own shadow-mode layer; it can't be delegated to SnapTrade.

# What shipped in this PR

- **`docs/mit_snaptrade_live_trading_plan.md`** — SnapTrade capability review with sources; target architecture (isolated `execution/` package, LLM never in the order path, fail-closed rules, separate ~9:50 ET executor schedule since episodes generate pre-market at 4:16 ET); CAD/TSX→Wealthsimple + USD→Webull routing; marketable-limit order policy; hard risk-cap table incl. kill switch; phased rollout (account-facts → read-only mirror → ≥4-week shadow mode → $150–250 micro-live on Webull → scale decision); PDT/TFSA cautions; operator dashboard checklist.
- **Trade-signal bridge** (`shows/hooks/modern_investing.py`): `trade_signal_latest.json` + `trade_signal_ep{N}.json` written after every digest — explicit `new_trade` / `no_trade` action with a drift-distinguishing `reason` (`explicit_no_trade` vs `no_pick_extracted`, so the executor fails closed on LLM formatting drift), `snaptrade_symbol`, `currency`/`suggested_account` routing, `pick_reference_price` + `pick_validated`, deterministic uuid5 `client_order_id`. Read-only (`--test`/`--rehearse`) runs write nothing; a signal-write failure never blocks the pipeline.

# ⚠️ A/B-listen required (landmine #17)

**None** — no prompt, audio, or spoken-content changes. The signal is a new metadata artifact only.

# Test results

- New drift guards: `tests/test_mit_benchmark_integrity.py::TestTradeSignal` (6 tests — routing, determinism, no-trade explicitness, readonly no-op).
- Touched suites all green: 199 passed (`test_mit_benchmark_integrity`, `test_mit_quality_pass`, `test_modern_investing_hooks`, `test_prompt_fidelity`, `test_generator`); `ruff check` clean.

# Operator checklist (Phase 0 — before any executor code lands)

1. Create a SnapTrade dashboard account; generate keys; connect Wealthsimple + Webull via the Connection Portal.
2. **Verify trade access is enabled for both brokers on your key** (some brokers gate trading behind partner enablement; the per-broker support matrix is only visible in the dashboard/Notion).
3. Confirm per-broker support for Limit + Day orders (must-have), fractional/notional (nice-to-have), Stop/StopLimit (determines whether stops can be native or stay software-enforced).
4. Confirm your Webull entity (US vs Canada — separate integrations) and which WS account types surface.

The July-3 review's gate still stands: shadow mode can start now, but real dollars wait for the recompute-verified, 2–3-month clean sim record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKwLmJRykLH8oFskoXiVVp

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKwLmJRykLH8oFskoXiVVp)_