### PR TITLE
MIT optimize-the-loop: multi-index benchmarking, rule self-audit, shadow mode live

### DIFF
--- a/.github/workflows/mit-shadow-executor.yml
+++ b/.github/workflows/mit-shadow-executor.yml
@@ -1,0 +1,45 @@
+name: MIT Shadow Executor
+
+# Phase 2 of docs/mit_snaptrade_live_trading_plan.md: run the FULL order
+# pipeline (signal → risk gates → decision-time quote → marketable-limit
+# sizing) at ~9:50 ET and log the would-be order to the committed shadow
+# ledger — no order is ever placed (no SnapTrade credentials are even
+# loaded here). The accumulating ledger is the sim-vs-reality slippage
+# dataset (scripts/mit_shadow_report.py).
+
+on:
+  schedule:
+    - cron: '50 13 * * 1-5'   # 13:50 UTC ≈ 9:50 ET, weekdays (post-open)
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: mit-shadow-executor
+  cancel-in-progress: false
+
+jobs:
+  shadow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install yfinance
+
+      - name: Run shadow executor
+        run: python scripts/mit_shadow_executor.py
+
+      - name: Commit shadow ledger
+        uses: ./.github/actions/safe-commit-push
+        with:
+          add-paths: digests/modern_investing/shadow_ledger.json
+          commit-message: "MIT shadow executor: ${{ github.run_id }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,6 +390,30 @@ nerranetwork/
   the paper-trading layer. Podcast stays a simulation on air; live
   execution is a private layer decoupled from the 08:16 UTC episode run
   (executor runs its own ~13:50 UTC slot).
+  **July 4 2026 optimize-the-loop pass** (drift guards:
+  `tests/test_mit_benchmark_integrity.py::{TestMultiIndexBenchmark,TestRuleEffectiveness}`,
+  `tests/test_snaptrade_execution.py::{TestRiskGates,TestShadowExecutor}`):
+  three workstreams toward "beat all major indices". (1) **Multi-index
+  matched-window benchmarking** — every closed trade now carries
+  `benchmark_returns` for ^IXIC + ^GSPC + ^GSPTSE over the SAME bar
+  window; summary gains per-index compounded `benchmark_scores` +
+  `indices_beaten`; the scoreboard block adds a once-per-episode
+  "beating N of 3 major indices" sweep (NASDAQ stays the headline;
+  legacy trades fall back to the nasdaq field; recompute script rebuilds
+  history for all three). (2) **Rule-effectiveness scoring** — trades are
+  stamped with `rules_in_effect` (the exact rule IDs shown on pick day);
+  `_build_rule_scoreboard` compares stamped-trade alpha vs trades
+  without each rule and flags ≥8-trade no-edge rules as RETIREMENT
+  CANDIDATES (operator decision — never auto-retired). The learning loop
+  now measures whether its own rules work. (3) **Shadow mode (Phase 2)
+  LIVE** — `execution/risk.py` (pure, env-tunable hard gates; kill
+  switch defaults off) + `execution/shadow.py` (signal → gates →
+  decision-time quote → would-be marketable-limit order → committed
+  `shadow_ledger.json`, idempotent) + `mit-shadow-executor.yml`
+  (weekdays 13:50 UTC, yfinance only, no secrets); the read-only/no
+  order-placement contract still pinned. `scripts/mit_shadow_report.py`
+  = sim-vs-shadow slippage table. Scoreboard/lessons-block additions
+  change prompt context → A/B-listen per landmine #17.
 
 **Tesla Shorts Time Recursive Memory System (May 2026+)**  
 TST received a full recursive improvement architecture (analogous to MIT):

--- a/docs/mit_snaptrade_live_trading_plan.md
+++ b/docs/mit_snaptrade_live_trading_plan.md
@@ -172,14 +172,23 @@ is a dashboard setting (Webhooks tab → point at the existing
 notification endpoint); a dedicated receiver Worker is Phase-2 scope if
 signature verification is wanted.
 
-**Phase 2 — shadow mode (1 PR, ≥4 weeks running).** `executor.py` runs
-the FULL pipeline — signal → risk checks → symbol verification → live
-quote → computed limit price — and then, instead of placing, appends the
-would-be order to `live_ledger.json` with `mode: "shadow"`. Nightly
-reconcile compares shadow fills (next real bar) against the sim's
-entries → the first real **slippage model**, which then feeds back into
-the sim's cost assumptions (the review's execution-modeling item). This
-IS the paper-trading layer, since SnapTrade's sandbox can't fill orders.
+**Phase 2 — shadow mode (SHIPPED July 4; run ≥4 weeks).**
+`execution/risk.py` (env-tunable hard gates: kill switch off by default,
+$250 cap, 0.5% slippage collar, $2 price floor, 1-day signal freshness,
+duplicate-order rejection — all pure/unit-tested) +
+`execution/shadow.py` (full pipeline: signal → gates → decision-time
+yfinance quote → marketable-limit price + sizing → committed
+`digests/modern_investing/shadow_ledger.json`; idempotent by
+`client_order_id`; hypothetical orders only, safe to commit) +
+`.github/workflows/mit-shadow-executor.yml` (weekdays 13:50 UTC ≈ 9:50
+ET — **live now, needs no secrets**). `scripts/mit_shadow_report.py`
+compares shadow decision-time quotes against the sim's entry-bar opens —
+the first real **slippage model**, feeding the sim's cost assumptions
+once ~20 trades accumulate. This IS the paper-trading layer, since
+SnapTrade's sandbox can't fill orders. Shadow EXITS (would-be sells) are
+Phase-2.5 scope. Entry timing note: the sim enters at the pick-date
+OPEN; shadow quotes at ~9:50 ET — the measured gap between them is
+exactly the execution cost the sim currently ignores.
 
 **Phase 3 — micro-live (operator flips `LIVE_TRADING_ENABLED=1`).**
 Real orders at $150–250, Webull US only at first (single account, USD,

--- a/docs/mit_snaptrade_live_trading_plan.md
+++ b/docs/mit_snaptrade_live_trading_plan.md
@@ -185,10 +185,14 @@ ET — **live now, needs no secrets**). `scripts/mit_shadow_report.py`
 compares shadow decision-time quotes against the sim's entry-bar opens —
 the first real **slippage model**, feeding the sim's cost assumptions
 once ~20 trades accumulate. This IS the paper-trading layer, since
-SnapTrade's sandbox can't fill orders. Shadow EXITS (would-be sells) are
-Phase-2.5 scope. Entry timing note: the sim enters at the pick-date
-OPEN; shadow quotes at ~9:50 ET — the measured gap between them is
-exactly the execution cost the sim currently ignores.
+SnapTrade's sandbox can't fill orders. **Phase 2.5 (shadow exits) also
+shipped**: each open shadow position gets a paired, idempotent
+`would_sell` on the sim's exit calendar (flash → next weekday, weekly →
+Friday; no-quote days retry), carrying the round-trip
+`shadow_return_pct`, and the report now shows the per-trade
+shadow-vs-sim P&L gap. Entry timing note: the sim enters at the
+pick-date OPEN; shadow quotes at ~9:50 ET — the measured gap between
+them is exactly the execution cost the sim currently ignores.
 
 **Phase 3 — micro-live (operator flips `LIVE_TRADING_ENABLED=1`).**
 Real orders at $150–250, Webull US only at first (single account, USD,

--- a/docs/reviews/ledger/modern_investing.yaml
+++ b/docs/reviews/ledger/modern_investing.yaml
@@ -160,10 +160,21 @@ reviews:
       - execution/risk.py hard gates + execution/shadow.py +
         mit-shadow-executor.yml (weekdays 13:50 UTC) +
         scripts/mit_shadow_report.py
+      - shadow EXITS (Phase 2.5, same PR) — would_sell entries on the
+        sim's exit calendar, idempotent, round-trip shadow_return_pct;
+        report gains the shadow-vs-sim P&L gap per trade
+      - regime block (rolling last-10 alpha + drawdown from high-water
+        mark → cold streak raises the pick bar / hot streak holds
+        discipline; rides in the strategy_performance slot)
+      - statistical discipline — FAVOR/AVOID and operating principles now
+        require n>=5 closed trades per sector/tag (was 2-3, coin-flip
+        samples were steering picks); small samples labeled inconclusive
+      - performance page — matched-window alpha tile (honest headline),
+        buy-and-hold gap relabeled "not capital-matched", major-index
+        sweep row
     deferred:
-      - "shadow EXITS (would-be sells) — Phase 2.5"
       - "feed measured shadow slippage into the sim's cost model once ~20
-        matched trades accumulate"
+        matched round trips accumulate"
       - "webhook receiver Worker for SnapTrade signature verification
         (Phase 2 scope if wanted)"
       - "carried: closing-price lesson retirement (operator A/B),

--- a/docs/reviews/ledger/modern_investing.yaml
+++ b/docs/reviews/ledger/modern_investing.yaml
@@ -136,4 +136,57 @@ reviews:
         evidence: null
     agent_cost_usd: null
 
+  - date: 2026-07-04
+    pr: null
+    doc: docs/mit_snaptrade_live_trading_plan.md
+    reviewer: claude-code (operator-requested optimize-the-loop pass)
+    summary: >
+      Follow-on to the July 3 benchmark-integrity pass, aimed at "beat all
+      major indices" + a learning loop that audits itself. Multi-index
+      matched-window benchmarking (^IXIC/^GSPC/^GSPTSE per trade,
+      benchmark_scores + indices_beaten in summary, index sweep in the
+      scoreboard block); rule-effectiveness scoring (trades stamped with
+      rules_in_effect; stamped-vs-without alpha per rule; >=8-trade
+      no-edge rules flagged as retirement candidates, operator-decided);
+      shadow mode (Phase 2) shipped and LIVE with no secrets needed
+      (risk gates + would-be marketable-limit orders in a committed
+      shadow ledger at 13:50 UTC weekdays; mit_shadow_report.py =
+      sim-vs-shadow slippage).
+    shipped:
+      - multi-index matched-window benchmark_returns + benchmark_scores +
+        indices_beaten (recompute script rebuilds all three for history)
+      - rules_in_effect stamping + rule scoreboard with retirement
+        candidates (never auto-retired)
+      - execution/risk.py hard gates + execution/shadow.py +
+        mit-shadow-executor.yml (weekdays 13:50 UTC) +
+        scripts/mit_shadow_report.py
+    deferred:
+      - "shadow EXITS (would-be sells) — Phase 2.5"
+      - "feed measured shadow slippage into the sim's cost model once ~20
+        matched trades accumulate"
+      - "webhook receiver Worker for SnapTrade signature verification
+        (Phase 2 scope if wanted)"
+      - "carried: closing-price lesson retirement (operator A/B),
+        under-length (four-show A/B), recompute --apply run (operator)"
+    predictions:
+      - metric: shadow ledger entries after 2 weeks of weekday runs
+        baseline: "0 (ledger created this pass)"
+        expected: ">= 8 entries with decision in {would_place, skipped};
+          zero duplicate client_order_ids; workflow green without secrets"
+        verdict: pending
+        evidence: null
+      - metric: closed trades carrying benchmark_returns for all 3 indices
+        baseline: "0 of 40"
+        expected: "every NEWLY closed trade has nasdaq+sp500+tsx returns
+          (history backfills when the operator runs the recompute script)"
+        verdict: pending
+        evidence: null
+      - metric: closed trades stamped with rules_in_effect
+        baseline: "0 of 40"
+        expected: "every new pick stamped; first rule scoreboard lines
+          appear after ~5 closes; retirement candidates only at >=8"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
 do_not_retry: []

--- a/execution/risk.py
+++ b/execution/risk.py
@@ -1,0 +1,118 @@
+"""Hard, deterministic risk gates for the MIT execution layer.
+
+Every order path — shadow (Phase 2) and, later, live (Phase 3) — runs
+through ``validate_signal`` before anything else happens. The gates are
+plain code with env-tunable caps: no LLM output is ever interpreted
+here, and every rejection is an explicit, logged reason. Fail closed:
+any doubt means no order.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import os
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, "") or default)
+    except ValueError:
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, "") or default)
+    except ValueError:
+        return default
+
+
+@dataclasses.dataclass(frozen=True)
+class RiskConfig:
+    """Caps for one executor run. Defaults are the Phase-3 micro-live
+    values from docs/mit_snaptrade_live_trading_plan.md §4."""
+
+    live_trading_enabled: bool = False   # global kill switch (unset = off)
+    max_position_usd: float = 250.0
+    max_slippage_pct: float = 0.5        # marketable-limit collar vs quote
+    min_price_usd: float = 2.0           # no penny/OTC-grade picks
+    max_signal_age_days: int = 1         # stale signal = no trade
+    max_open_positions: int = 1
+    max_daily_orders: int = 2
+
+    @classmethod
+    def from_env(cls) -> "RiskConfig":
+        return cls(
+            live_trading_enabled=(
+                os.environ.get("LIVE_TRADING_ENABLED", "").strip() == "1"),
+            max_position_usd=_env_float("MIT_MAX_POSITION_USD", 250.0),
+            max_slippage_pct=_env_float("MIT_MAX_SLIPPAGE_PCT", 0.5),
+            min_price_usd=_env_float("MIT_MIN_PRICE_USD", 2.0),
+            max_signal_age_days=_env_int("MIT_MAX_SIGNAL_AGE_DAYS", 1),
+            max_open_positions=_env_int("MIT_MAX_OPEN_POSITIONS", 1),
+            max_daily_orders=_env_int("MIT_MAX_DAILY_ORDERS", 2),
+        )
+
+
+def validate_signal(
+    signal: dict,
+    config: RiskConfig,
+    *,
+    today: datetime.date,
+    prior_order_ids: frozenset[str] | set[str] = frozenset(),
+) -> tuple[bool, list[str]]:
+    """Return ``(ok, reasons)``. Empty reasons ⇢ the order may proceed.
+
+    Pure function — no I/O, no clock reads — so every gate is unit-
+    testable and an executor run is reproducible from its inputs.
+    """
+    reasons: list[str] = []
+
+    if not isinstance(signal, dict) or signal.get("schema_version") != 1:
+        return False, ["unrecognized signal schema"]
+
+    if signal.get("action") != "new_trade":
+        reasons.append(
+            f"signal action is '{signal.get('action')}' "
+            f"(reason: {signal.get('reason')}) — nothing to trade")
+        return False, reasons
+
+    generated = signal.get("generated_at")
+    try:
+        generated_date = datetime.date.fromisoformat(str(generated)[:10])
+        age = (today - generated_date).days
+        if age > config.max_signal_age_days:
+            reasons.append(
+                f"signal is stale ({age}d old, max "
+                f"{config.max_signal_age_days}d)")
+        elif age < 0:
+            reasons.append(f"signal is from the future ({generated})")
+    except ValueError:
+        reasons.append(f"unparseable generated_at: {generated!r}")
+
+    trade = signal.get("trade") or {}
+    if not trade.get("snaptrade_symbol"):
+        reasons.append("no snaptrade_symbol on the trade")
+    if trade.get("side") != "BUY":
+        reasons.append(f"unsupported side {trade.get('side')!r}")
+    if not trade.get("pick_validated"):
+        reasons.append(
+            "pick was not validated at record time (no reference price) — "
+            "possible bogus ticker")
+    ref = trade.get("pick_reference_price")
+    if isinstance(ref, (int, float)):
+        if ref < config.min_price_usd:
+            reasons.append(
+                f"reference price ${ref:.2f} below the "
+                f"${config.min_price_usd:.2f} floor")
+    elif trade.get("pick_validated"):
+        reasons.append("pick_validated set but no reference price")
+
+    order_id = trade.get("client_order_id")
+    if not order_id:
+        reasons.append("missing client_order_id")
+    elif order_id in prior_order_ids:
+        reasons.append(f"duplicate client_order_id {order_id} (already processed)")
+
+    return (not reasons), reasons

--- a/execution/shadow.py
+++ b/execution/shadow.py
@@ -137,6 +137,7 @@ def run_shadow(
         "limit_price": limit_price,
         "units": units,
         "position_usd": config.max_position_usd,
+        "pick_date": trade.get("pick_date"),
     })
     logger.info(
         "Shadow: WOULD PLACE BUY %s x%s @ limit $%.2f (quote $%.4f, %s)",
@@ -144,3 +145,118 @@ def run_shadow(
     )
     ledger["orders"].append(entry)
     return entry
+
+
+# ---------------------------------------------------------------------------
+# Shadow exits (Phase 2.5) — the round trip that makes shadow P&L real
+# ---------------------------------------------------------------------------
+
+def _exit_due_date(pick_date: datetime.date, trade_type: str) -> datetime.date:
+    """The first executor run day on/after the sim's exit.
+
+    Mirrors the sim's calendar: flash trades close the next trading day
+    (executor runs weekdays, so the next weekday); weekly holds close on
+    the Friday run (this week's Friday for Mon-Thu picks, NEXT Friday
+    for Fri/Sat/Sun picks — a Friday pick isn't open yet on its own
+    Friday run, matching ``_evaluate_open_trade``).
+    """
+    wd = pick_date.weekday()
+    if trade_type == "flash":
+        days = 3 if wd == 4 else (2 if wd == 5 else 1)  # Fri→Mon, Sat→Mon
+        return pick_date + datetime.timedelta(days=days)
+    if wd == 4:
+        return pick_date + datetime.timedelta(days=7)
+    if wd == 5:
+        return pick_date + datetime.timedelta(days=6)
+    if wd == 6:
+        return pick_date + datetime.timedelta(days=5)
+    return pick_date + datetime.timedelta(days=4 - wd)
+
+
+def run_shadow_exits(
+    ledger: dict,
+    config: RiskConfig,
+    *,
+    quote_fn=decision_quote,
+    now: datetime.datetime | None = None,
+) -> list[dict]:
+    """Log would-be SELLs for every open shadow position past its due date.
+
+    Each ``would_place`` entry gets exactly one paired ``would_sell``
+    (idempotent via the ``exit_client_order_id`` = ``<entry id>-exit``),
+    carrying the decision-time quote and the round-trip shadow return —
+    quote-to-quote, so it's directly comparable against the sim's
+    open-to-close return for the same trade.
+    """
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    today = now.date()
+    orders = ledger.get("orders", [])
+    existing_exit_ids = {
+        o.get("exit_client_order_id") for o in orders
+        if o.get("exit_client_order_id")
+    }
+
+    exits: list[dict] = []
+    for entry in list(orders):
+        if entry.get("decision") != "would_place":
+            continue
+        exit_id = f"{entry.get('client_order_id')}-exit"
+        if exit_id in existing_exit_ids:
+            continue
+        pick_date = None
+        if isinstance(entry.get("pick_date"), str):
+            try:
+                pick_date = datetime.date.fromisoformat(entry["pick_date"])
+            except ValueError:
+                pick_date = None
+        if pick_date is None and isinstance(entry.get("logged_at"), str):
+            pick_date = datetime.date.fromisoformat(entry["logged_at"][:10])
+        if pick_date is None:
+            continue
+        due = _exit_due_date(pick_date, entry.get("trade_type", "weekly"))
+        if today < due:
+            continue
+
+        quote = quote_fn(entry.get("snaptrade_symbol"))
+        quote_source = "decision_time_quote"
+        if not isinstance(quote, (int, float)) or quote <= 0:
+            # No quote today — leave the position open; a later run
+            # retries (mirrors the sim's leave-open-when-no-bar rule).
+            logger.warning(
+                "Shadow exit: no quote for %s — will retry next run",
+                entry.get("snaptrade_symbol"))
+            continue
+
+        entry_quote = entry.get("quote")
+        shadow_return = (
+            round((quote - entry_quote) / entry_quote * 100, 3)
+            if isinstance(entry_quote, (int, float)) and entry_quote
+            else None
+        )
+        exit_entry = {
+            "logged_at": now.isoformat(timespec="seconds"),
+            "mode": "shadow",
+            "decision": "would_sell",
+            "episode_num": entry.get("episode_num"),
+            "client_order_id": entry.get("client_order_id"),
+            "exit_client_order_id": exit_id,
+            "symbol": entry.get("symbol"),
+            "snaptrade_symbol": entry.get("snaptrade_symbol"),
+            "trade_type": entry.get("trade_type"),
+            "order_type": "Limit",
+            "time_in_force": "Day",
+            "quote": round(float(quote), 4),
+            "quote_source": quote_source,
+            "limit_price": round(quote * (1 - config.max_slippage_pct / 100), 2),
+            "units": entry.get("units"),
+            "shadow_return_pct": shadow_return,
+        }
+        logger.info(
+            "Shadow: WOULD SELL %s x%s @ ~$%.4f (round trip %s%%)",
+            exit_entry["snaptrade_symbol"], exit_entry["units"], quote,
+            shadow_return,
+        )
+        orders.append(exit_entry)
+        existing_exit_ids.add(exit_id)
+        exits.append(exit_entry)
+    return exits

--- a/execution/shadow.py
+++ b/execution/shadow.py
@@ -1,0 +1,146 @@
+"""Shadow-mode executor (Phase 2 of the SnapTrade plan).
+
+Runs the FULL order pipeline — signal → risk gates → decision-time quote
+→ marketable-limit price + sizing — and then, instead of placing an
+order, appends the would-be order to a committed shadow ledger. This IS
+the paper-trading layer (SnapTrade's sandbox cannot place orders), and
+its accumulating decision-time quotes are the raw material for the
+sim-vs-reality slippage model.
+
+The ledger contains only hypothetical orders on public symbols — the
+same information class as the published sim tracker — so unlike the
+account mirror it is safe to commit.
+
+No SnapTrade credentials are needed in shadow mode; quotes come from
+yfinance. Deliberately NO order-placement call exists here (pinned by
+tests/test_snaptrade_execution.py — Phase-1/2 read-only contract).
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from pathlib import Path
+
+from execution.risk import RiskConfig, validate_signal
+
+logger = logging.getLogger(__name__)
+
+LEDGER_SCHEMA_VERSION = 1
+
+
+def load_ledger(path: Path) -> dict:
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            data.setdefault("orders", [])
+            return data
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to load shadow ledger: %s — starting fresh", exc)
+    return {"schema_version": LEDGER_SCHEMA_VERSION, "mode": "shadow", "orders": []}
+
+
+def save_ledger(ledger: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(ledger, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def decision_quote(yf_symbol: str) -> float | None:
+    """Best-effort quote at decision time (latest 1-minute bar close)."""
+    try:
+        import yfinance as yf
+        hist = yf.Ticker(yf_symbol).history(period="1d", interval="1m")
+        if hist is not None and not hist.empty:
+            price = float(hist["Close"].iloc[-1])
+            if price > 0:
+                return round(price, 4)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("decision quote failed for %s: %s", yf_symbol, exc)
+    return None
+
+
+def run_shadow(
+    signal: dict,
+    ledger: dict,
+    config: RiskConfig,
+    *,
+    quote_fn=decision_quote,
+    now: datetime.datetime | None = None,
+) -> dict:
+    """Process one signal; append exactly one ledger entry; return it.
+
+    Idempotent: a signal whose ``client_order_id`` already appears in the
+    ledger is skipped with a ``duplicate`` decision (a re-run workflow
+    cannot double-log, mirroring the live layer's idempotent placement).
+    """
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    today = now.date()
+    prior_ids = {
+        o.get("client_order_id") for o in ledger.get("orders", [])
+        if o.get("client_order_id")
+    }
+
+    trade = signal.get("trade") or {}
+    entry: dict = {
+        "logged_at": now.isoformat(timespec="seconds"),
+        "mode": "shadow",
+        "episode_num": signal.get("episode_num"),
+        "client_order_id": trade.get("client_order_id"),
+        "symbol": trade.get("symbol"),
+        "snaptrade_symbol": trade.get("snaptrade_symbol"),
+        "suggested_account": trade.get("suggested_account"),
+        "currency": trade.get("currency"),
+        "trade_type": trade.get("trade_type"),
+        "pick_reference_price": trade.get("pick_reference_price"),
+    }
+
+    order_id = trade.get("client_order_id")
+    if order_id and order_id in prior_ids:
+        entry["decision"] = "duplicate"
+        entry["skip_reasons"] = ["client_order_id already in ledger"]
+        logger.info("Shadow: duplicate signal %s — not re-logged", order_id)
+        return entry  # deliberately NOT appended
+
+    ok, reasons = validate_signal(
+        signal, config, today=today, prior_order_ids=prior_ids)
+    if not ok:
+        entry["decision"] = "skipped"
+        entry["skip_reasons"] = reasons
+        logger.info("Shadow: signal skipped — %s", "; ".join(reasons))
+        ledger["orders"].append(entry)
+        return entry
+
+    quote = quote_fn(trade["snaptrade_symbol"])
+    quote_source = "decision_time_quote"
+    if quote is None:
+        quote = trade.get("pick_reference_price")
+        quote_source = "pick_reference_fallback"
+    if not isinstance(quote, (int, float)) or quote <= 0:
+        entry["decision"] = "skipped"
+        entry["skip_reasons"] = ["no usable quote at decision time"]
+        ledger["orders"].append(entry)
+        return entry
+
+    limit_price = round(quote * (1 + config.max_slippage_pct / 100), 2)
+    units = round(config.max_position_usd / limit_price, 4)
+
+    entry.update({
+        "decision": "would_place",
+        "order_type": "Limit",
+        "time_in_force": "Day",
+        "quote": round(float(quote), 4),
+        "quote_source": quote_source,
+        "limit_price": limit_price,
+        "units": units,
+        "position_usd": config.max_position_usd,
+    })
+    logger.info(
+        "Shadow: WOULD PLACE BUY %s x%s @ limit $%.2f (quote $%.4f, %s)",
+        entry["snaptrade_symbol"], units, limit_price, quote, quote_source,
+    )
+    ledger["orders"].append(entry)
+    return entry

--- a/scripts/mit_shadow_executor.py
+++ b/scripts/mit_shadow_executor.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Run one shadow-executor pass over today's MIT trade signal (Phase 2).
+
+Scheduled at ~9:50 ET (13:50 UTC) — after the opening auction, on the
+signal the 08:16 UTC episode wrote. Fail-closed by design:
+
+- no signal file → clean no-op (exit 0, logged);
+- stale / no-trade / unvalidated signal → 'skipped' ledger entry with
+  explicit reasons;
+- duplicate client_order_id → nothing logged twice.
+
+The shadow ledger (``digests/modern_investing/shadow_ledger.json``) is
+committed by the workflow — it contains only hypothetical orders on
+public symbols. Compare against the sim with scripts/mit_shadow_report.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from execution import shadow  # noqa: E402
+from execution.risk import RiskConfig  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("mit_shadow_executor")
+
+SIGNAL_PATH = ROOT / "digests" / "modern_investing" / "trade_signal_latest.json"
+LEDGER_PATH = ROOT / "digests" / "modern_investing" / "shadow_ledger.json"
+
+
+def main() -> int:
+    if not SIGNAL_PATH.exists():
+        logger.info("No trade signal at %s — nothing to do (fail-closed).",
+                    SIGNAL_PATH)
+        return 0
+    try:
+        signal = json.loads(SIGNAL_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.error("Unreadable trade signal: %s", exc)
+        return 1
+
+    ledger = shadow.load_ledger(LEDGER_PATH)
+    config = RiskConfig.from_env()
+    entry = shadow.run_shadow(signal, ledger, config)
+    shadow.save_ledger(ledger, LEDGER_PATH)
+
+    logger.info("Shadow decision: %s%s", entry.get("decision"),
+                f" — {'; '.join(entry.get('skip_reasons', []))}"
+                if entry.get("skip_reasons") else "")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mit_shadow_executor.py
+++ b/scripts/mit_shadow_executor.py
@@ -49,11 +49,16 @@ def main() -> int:
     ledger = shadow.load_ledger(LEDGER_PATH)
     config = RiskConfig.from_env()
     entry = shadow.run_shadow(signal, ledger, config)
+    # Phase 2.5: close any open shadow positions past their sim exit date.
+    exits = shadow.run_shadow_exits(ledger, config)
     shadow.save_ledger(ledger, LEDGER_PATH)
 
     logger.info("Shadow decision: %s%s", entry.get("decision"),
                 f" — {'; '.join(entry.get('skip_reasons', []))}"
                 if entry.get("skip_reasons") else "")
+    for x in exits:
+        logger.info("Shadow exit: %s round trip %s%%",
+                    x.get("snaptrade_symbol"), x.get("shadow_return_pct"))
     return 0
 
 

--- a/scripts/mit_shadow_report.py
+++ b/scripts/mit_shadow_report.py
@@ -38,12 +38,19 @@ def main() -> int:
         if t.get("episode_num") is not None:
             by_episode[(t["episode_num"], t.get("symbol"))] = t
 
+    exits_by_id = {
+        o.get("client_order_id"): o
+        for o in ledger.get("orders", [])
+        if o.get("decision") == "would_sell"
+    }
+
     rows = []
     for order in ledger.get("orders", []):
         if order.get("decision") != "would_place":
             continue
         sim = by_episode.get((order.get("episode_num"), order.get("symbol")))
         sim_entry = sim.get("entry_price") if sim else None
+        sim_pnl = sim.get("pnl_pct") if sim else None
         quote = order.get("quote")
         slippage_pct = (
             round((quote - sim_entry) / sim_entry * 100, 3)
@@ -51,32 +58,43 @@ def main() -> int:
             and isinstance(sim_entry, (int, float)) and sim_entry
             else None
         )
+        exit_order = exits_by_id.get(order.get("client_order_id"))
+        shadow_pnl = exit_order.get("shadow_return_pct") if exit_order else None
         rows.append((order.get("episode_num"), order.get("symbol"),
-                     sim_entry, quote, order.get("limit_price"),
-                     slippage_pct, (sim or {}).get("status", "—")))
+                     sim_entry, quote, slippage_pct, sim_pnl, shadow_pnl,
+                     (sim or {}).get("status", "—")))
 
     if not rows:
         print("No would_place shadow entries yet.")
         return 0
 
     print(f"{'Ep':>4} {'Sym':6} {'sim entry':>10} {'shadow quote':>13} "
-          f"{'limit':>8} {'slip %':>8} {'sim status':>10}")
-    for ep, sym, sim_entry, quote, limit, slip, status in rows:
+          f"{'entry slip %':>13} {'sim P&L %':>10} {'shadow P&L %':>13} "
+          f"{'sim status':>10}")
+    for ep, sym, sim_entry, quote, slip, sim_pnl, shadow_pnl, status in rows:
         print(f"{ep!s:>4} {sym or '?':6} "
               f"{sim_entry if sim_entry is not None else '—':>10} "
               f"{quote if quote is not None else '—':>13} "
-              f"{limit if limit is not None else '—':>8} "
-              f"{slip if slip is not None else '—':>8} {status:>10}")
+              f"{slip if slip is not None else '—':>13} "
+              f"{sim_pnl if sim_pnl is not None else '—':>10} "
+              f"{shadow_pnl if shadow_pnl is not None else '—':>13} "
+              f"{status:>10}")
 
-    slips = [r[5] for r in rows if r[5] is not None]
+    slips = [r[4] for r in rows if r[4] is not None]
     if slips:
         avg = sum(slips) / len(slips)
         worst = max(slips, key=abs)
-        print(f"\n{len(slips)} matched trades · avg slippage vs sim entry: "
+        print(f"\n{len(slips)} matched trades · avg entry slippage vs sim: "
               f"{avg:+.3f}% · worst: {worst:+.3f}%")
-        print("Positive = the real fill would have been WORSE than the sim "
-              "assumes. Feed this into the sim's cost model once ~20 trades "
-              "accumulate.")
+    pairs = [(r[5], r[6]) for r in rows
+             if r[5] is not None and r[6] is not None]
+    if pairs:
+        gap = sum(shadow - sim for sim, shadow in pairs) / len(pairs)
+        print(f"{len(pairs)} round trips · avg shadow-vs-sim P&L gap: "
+              f"{gap:+.3f}%/trade")
+        print("Negative gap = the sim overstates what real execution would "
+              "earn. Feed this into the sim's cost model once ~20 round "
+              "trips accumulate.")
     return 0
 
 

--- a/scripts/mit_shadow_report.py
+++ b/scripts/mit_shadow_report.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Shadow-vs-sim execution report: the slippage model's raw numbers.
+
+For every shadow ledger entry with a ``would_place`` decision, find the
+matching sim trade (same ``client_order_id`` seed → episode + symbol)
+in the investment tracker and compare:
+
+- the sim's entry price (the entry bar's OPEN — the sim's "you always
+  fill at the open" optimism), vs
+- the shadow decision-time quote and the marketable limit that a real
+  order would have carried.
+
+The per-trade delta IS the execution-cost estimate the July-3 review
+said the sim lacks. Run ad hoc; prints a table + summary stats.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+LEDGER = ROOT / "digests" / "modern_investing" / "shadow_ledger.json"
+TRACKER = ROOT / "digests" / "modern_investing" / "investment_tracker.json"
+
+
+def main() -> int:
+    if not LEDGER.exists():
+        print("No shadow ledger yet — run scripts/mit_shadow_executor.py first.")
+        return 0
+    ledger = json.loads(LEDGER.read_text(encoding="utf-8"))
+    tracker = json.loads(TRACKER.read_text(encoding="utf-8"))
+    by_episode = {}
+    for t in tracker.get("trades", []):
+        if t.get("episode_num") is not None:
+            by_episode[(t["episode_num"], t.get("symbol"))] = t
+
+    rows = []
+    for order in ledger.get("orders", []):
+        if order.get("decision") != "would_place":
+            continue
+        sim = by_episode.get((order.get("episode_num"), order.get("symbol")))
+        sim_entry = sim.get("entry_price") if sim else None
+        quote = order.get("quote")
+        slippage_pct = (
+            round((quote - sim_entry) / sim_entry * 100, 3)
+            if isinstance(quote, (int, float))
+            and isinstance(sim_entry, (int, float)) and sim_entry
+            else None
+        )
+        rows.append((order.get("episode_num"), order.get("symbol"),
+                     sim_entry, quote, order.get("limit_price"),
+                     slippage_pct, (sim or {}).get("status", "—")))
+
+    if not rows:
+        print("No would_place shadow entries yet.")
+        return 0
+
+    print(f"{'Ep':>4} {'Sym':6} {'sim entry':>10} {'shadow quote':>13} "
+          f"{'limit':>8} {'slip %':>8} {'sim status':>10}")
+    for ep, sym, sim_entry, quote, limit, slip, status in rows:
+        print(f"{ep!s:>4} {sym or '?':6} "
+              f"{sim_entry if sim_entry is not None else '—':>10} "
+              f"{quote if quote is not None else '—':>13} "
+              f"{limit if limit is not None else '—':>8} "
+              f"{slip if slip is not None else '—':>8} {status:>10}")
+
+    slips = [r[5] for r in rows if r[5] is not None]
+    if slips:
+        avg = sum(slips) / len(slips)
+        worst = max(slips, key=abs)
+        print(f"\n{len(slips)} matched trades · avg slippage vs sim entry: "
+              f"{avg:+.3f}% · worst: {worst:+.3f}%")
+        print("Positive = the real fill would have been WORSE than the sim "
+              "assumes. Feed this into the sim's cost model once ~20 trades "
+              "accumulate.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/recompute_mit_benchmarks.py
+++ b/scripts/recompute_mit_benchmarks.py
@@ -142,6 +142,21 @@ def main() -> int:
             trade["alpha_pct"] = (
                 round(pnl - ndq_ret, 2) if isinstance(pnl, (int, float)) else None
             )
+            # Multi-index sweep over the identical window (July 2026).
+            returns = {"nasdaq": trade["nasdaq_return_pct"]}
+            for key, idx_symbol in mi.BENCHMARK_INDICES.items():
+                if key == "nasdaq":
+                    continue
+                idx_bars = _fetch_range_bars(
+                    idx_symbol, window_start, window_end)
+                idx_window = mi._matched_nasdaq_window(
+                    idx_bars, entry_bar[0], exit_bar[0]) if idx_bars else None
+                if idx_window:
+                    io, ic, _, _ = idx_window
+                    returns[key] = round(((ic - io) / io) * 100, 2)
+                else:
+                    returns[key] = None
+            trade["benchmark_returns"] = returns
             realigned += 1
             print(f"  Ep{ep:>3} {sym:6} window {d1}→{d2}  "
                   f"ndq {trade['nasdaq_return_pct']:+.2f}%  "
@@ -158,6 +173,11 @@ def main() -> int:
           f"{s.get('matched_window_alpha_pct'):+.2f}% across "
           f"{s.get('matched_window_trades')} trades")
     print(f"Per-trade alpha sum: {s.get('cumulative_alpha_vs_nasdaq'):+.2f}%")
+    for key, score in (s.get("benchmark_scores") or {}).items():
+        print(f"  vs {mi.BENCHMARK_LABELS.get(key, key)}: "
+              f"alpha {score['alpha_pct']:+.2f}% over {score['trades']} trades")
+    print(f"Beating {s.get('indices_beaten', 0)} of "
+          f"{s.get('indices_scored', 0)} major indices (matched windows)")
 
     if backdated:
         print("\nBACKDATED ENTRIES (hindsight gain in the published record):")

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -56,6 +56,21 @@ LESSONS_LEARNED_FILENAME = "lessons_learned.json"
 MONTHLY_EPISODES_FILENAME = "monthly_episodes.json"
 NASDAQ_SYMBOL = "^IXIC"
 
+# Multi-index benchmarking (July 2026 "beat all major indices" pass).
+# ^IXIC stays THE headline benchmark (the show's identity and every legacy
+# field); the other two majors are scored over the same matched windows so
+# the show can honestly say how many of the three it is beating.
+BENCHMARK_INDICES = {
+    "nasdaq": "^IXIC",
+    "sp500": "^GSPC",
+    "tsx": "^GSPTSE",
+}
+BENCHMARK_LABELS = {
+    "nasdaq": "NASDAQ Composite",
+    "sp500": "S&P 500",
+    "tsx": "TSX Composite",
+}
+
 # Sector vocabulary — canonical tags used across tracker, taught_lessons,
 # lessons_learned, and the dashboard. Keep this list in sync with
 # ``_SECTOR_BY_SYMBOL`` below and the digest prompt's required
@@ -202,7 +217,11 @@ def pre_fetch(config, *, episode_num: int | None = None, today_str: str | None =
     lessons = _load_lessons_learned(lessons_path)
     context["taught_lessons_block"] = _build_taught_lessons_block(taught)
     context["sector_warning"] = _build_sector_warning_block(tracker)
-    context["lessons_learned_block"] = _build_lessons_learned_block(lessons)
+    lessons_block = _build_lessons_learned_block(lessons)
+    scoreboard = _build_rule_scoreboard(lessons, tracker)
+    if scoreboard:
+        lessons_block = f"{lessons_block}\n\n{scoreboard}"
+    context["lessons_learned_block"] = lessons_block
     context["narrative_callback"] = _build_narrative_callback(tracker)
 
     # Evergreen deep-dive rotation — surfaces the previously-unused
@@ -426,6 +445,19 @@ def post_generate(config, *, digest_text: str = "", episode_num: int | None = No
             trade["sector"] = _classify_sector(
                 trade.get("symbol", ""), trade.get("strategy", ""), trade.get("market", ""),
             )
+        # Rule-effectiveness stamping (July 2026): record which
+        # recursive-improvement rules were shown to the model when it made
+        # this pick. Read BEFORE today's lesson is appended below, so the
+        # stamp reflects exactly the pick-day prompt. The rule scoreboard
+        # scores these stamps once trades close.
+        try:
+            pick_day_lessons = _load_lessons_learned(
+                output_dir / LESSONS_LEARNED_FILENAME)
+            trade["rules_in_effect"] = [
+                e["id"] for e in _selected_active_rules(pick_day_lessons)
+            ]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("rules_in_effect stamping failed: %s", exc)
         # Pick-time validation probe: resolve the Yahoo symbol (TSX picks
         # get their .TO/.V listing) and record a reference price so a
         # wrong-instrument resolution is caught at close (Ep50 CNR class).
@@ -1112,6 +1144,37 @@ def _recompute_summary(tracker: dict) -> None:
             comp_ndq *= 1 + ndq / 100
             n_matched += 1
 
+    # Per-index matched-window scores (July 2026 multi-index pass): the
+    # same compounding, one score per major index, so the show can state
+    # "beating N of 3 major indices" with a defensible number. Legacy
+    # trades that predate ``benchmark_returns`` fall back to the NASDAQ
+    # field for that index only.
+    def _finite_num(v):
+        return isinstance(v, (int, float)) and math.isfinite(v)
+
+    benchmark_scores: dict = {}
+    for key in BENCHMARK_INDICES:
+        comp_p = comp_i = 1.0
+        n = 0
+        for t in closed:
+            pnl = t.get("pnl_pct")
+            ret = (t.get("benchmark_returns") or {}).get(key)
+            if key == "nasdaq" and ret is None:
+                ret = t.get("nasdaq_return_pct")
+            if _finite_num(pnl) and _finite_num(ret):
+                comp_p *= 1 + pnl / 100
+                comp_i *= 1 + ret / 100
+                n += 1
+        if n:
+            benchmark_scores[key] = {
+                "portfolio_pct": round((comp_p - 1) * 100, 2),
+                "index_pct": round((comp_i - 1) * 100, 2),
+                "alpha_pct": round((comp_p - comp_i) * 100, 2),
+                "trades": n,
+            }
+    indices_beaten = sum(
+        1 for v in benchmark_scores.values() if v["alpha_pct"] > 0)
+
     # Streak calculation
     current_streak = 0
     longest_win = 0
@@ -1145,6 +1208,9 @@ def _recompute_summary(tracker: dict) -> None:
         "compounded_nasdaq_matched_pct": round((comp_ndq - 1) * 100, 2),
         "matched_window_alpha_pct": round((comp_port - comp_ndq) * 100, 2),
         "matched_window_trades": n_matched,
+        "benchmark_scores": benchmark_scores,
+        "indices_beaten": indices_beaten,
+        "indices_scored": len(benchmark_scores),
         "current_streak": current_streak,
         "longest_win_streak": longest_win,
         "longest_loss_streak": longest_loss,
@@ -1388,6 +1454,31 @@ def _annotate_trade_with_nasdaq(trade: dict, entry_date: datetime.date | None = 
         trade["nasdaq_return_pct"] = None
         trade["alpha_pct"] = None
 
+    # Multi-index annotation (July 2026): the same matched window scored
+    # against every major index, so the record can honestly answer "does
+    # this beat ALL of them?". Best-effort per index; NASDAQ reuses the
+    # window computed above rather than refetching.
+    returns: dict[str, float | None] = {}
+    for key, symbol in BENCHMARK_INDICES.items():
+        if key == "nasdaq":
+            returns[key] = trade.get("nasdaq_return_pct")
+            continue
+        try:
+            idx_bars = _fetch_history_bars(symbol, period="1mo")
+            idx_window = (
+                _matched_nasdaq_window(idx_bars, entry_date, exit_date)
+                if idx_bars else None
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Benchmark %s annotation failed: %s", symbol, exc)
+            idx_window = None
+        if idx_window:
+            idx_open, idx_close, _, _ = idx_window
+            returns[key] = round(((idx_close - idx_open) / idx_open) * 100, 2)
+        else:
+            returns[key] = None
+    trade["benchmark_returns"] = returns
+
 
 # ---------------------------------------------------------------------------
 # Sector classification + lesson-tag extraction
@@ -1608,6 +1699,24 @@ def _build_benchmark_block(tracker: dict) -> str:
             f"{_sign(summary.get('compounded_nasdaq_matched_pct'))} → alpha "
             f"{_sign(matched_alpha)} across {matched_n} benchmarked trades. "
         )
+        scores = summary.get("benchmark_scores") or {}
+        if len(scores) > 1:
+            parts = []
+            for key in ("nasdaq", "sp500", "tsx"):
+                s = scores.get(key)
+                if s:
+                    parts.append(
+                        f"{BENCHMARK_LABELS[key]} {_sign(s['alpha_pct'])}"
+                    )
+            beaten = summary.get("indices_beaten", 0)
+            scored = summary.get("indices_scored", 0)
+            matched_line += (
+                f"MAJOR-INDEX SWEEP (same matched windows): currently beating "
+                f"{beaten} of {scored} major indices — "
+                + "; ".join(parts)
+                + ". NASDAQ stays the headline benchmark; mention the sweep "
+                  "at most once per episode. "
+            )
     return (
         f"NASDAQ Composite ^IXIC: {close:,.0f} "
         f"(YTD {_sign(bench_ytd)}, since inception {_sign(bench_itd)}).\n"
@@ -1837,18 +1946,14 @@ def _append_lesson_learned(
     return entry
 
 
-def _build_lessons_learned_block(data: dict, *, max_active: int = 5) -> str:
-    """Block fed to the digest prompt as 'RECURSIVE IMPROVEMENT RULES IN EFFECT'.
+def _selected_active_rules(data: dict, *, max_active: int = 5) -> list[dict]:
+    """The distinct active rules shown to the LLM today (most recent first).
 
-    Selects the most recent DISTINCT rules — near-duplicate actives (the
-    pre-dedup backlog) collapse to their freshest instance so the block
-    never shows the same rule five times.
+    Shared by the prompt block AND the trade-stamping in post_generate so
+    the ``rules_in_effect`` recorded on each trade is exactly the set the
+    model was told to obey when it made the pick.
     """
     entries = [e for e in (data.get("entries") or []) if e.get("status") == "active"]
-    if not entries:
-        return "No active recursive-improvement rules yet — write one if today's trade teaches a generalisable lesson."
-    lines = ["The following rules are in effect today. Obey them in every section of the digest:"]
-    # Most-recent-first, capped, de-duplicated by rule similarity.
     selected: list[dict] = []
     for entry in reversed(entries):
         if len(selected) >= max_active:
@@ -1860,12 +1965,80 @@ def _build_lessons_learned_block(data: dict, *, max_active: int = 5) -> str:
         ):
             continue
         selected.append(entry)
+    return selected
+
+
+def _build_lessons_learned_block(data: dict, *, max_active: int = 5) -> str:
+    """Block fed to the digest prompt as 'RECURSIVE IMPROVEMENT RULES IN EFFECT'.
+
+    Selects the most recent DISTINCT rules — near-duplicate actives (the
+    pre-dedup backlog) collapse to their freshest instance so the block
+    never shows the same rule five times.
+    """
+    selected = _selected_active_rules(data, max_active=max_active)
+    if not selected:
+        return "No active recursive-improvement rules yet — write one if today's trade teaches a generalisable lesson."
+    lines = ["The following rules are in effect today. Obey them in every section of the digest:"]
     for entry in selected:
         lines.append(
             f"- [{entry['id']}] {entry.get('observation', '').rstrip('.')}. "
             f"Rule: {entry.get('adjustment', '').rstrip('.')}."
         )
     return "\n".join(lines)
+
+
+def _build_rule_scoreboard(data: dict, tracker: dict, *,
+                           min_trades: int = 5,
+                           retire_after: int = 8) -> str:
+    """Measured effectiveness of each active rule — the loop's own audit.
+
+    July 2026 "learn whether it's learning" pass: rules accumulated but
+    nothing ever checked whether obeying them helped. Every recorded
+    trade now carries ``rules_in_effect`` (the rule IDs shown to the
+    model on pick day); once a rule has been in effect for enough closed
+    trades, its stamped-trade average alpha is compared against the
+    average alpha of closed trades made WITHOUT it. Rules with enough
+    evidence and no measurable edge are flagged as retirement candidates
+    — surfaced for the OPERATOR (rules are never auto-retired).
+    """
+    closed = [
+        t for t in tracker.get("trades", [])
+        if t.get("status") == "closed"
+        and isinstance(t.get("alpha_pct"), (int, float))
+        and math.isfinite(t["alpha_pct"])
+    ]
+    active = [e for e in (data.get("entries") or []) if e.get("status") == "active"]
+    if not closed or not active:
+        return ""
+
+    lines = []
+    for entry in active:
+        rid = entry.get("id")
+        stamped = [t for t in closed if rid in (t.get("rules_in_effect") or [])]
+        if len(stamped) < min_trades:
+            continue
+        others = [t for t in closed if rid not in (t.get("rules_in_effect") or [])]
+        avg_with = sum(t["alpha_pct"] for t in stamped) / len(stamped)
+        line = (
+            f"- [{rid}] in effect for {len(stamped)} closed trades: "
+            f"avg alpha {avg_with:+.2f}%"
+        )
+        if others:
+            avg_without = sum(t["alpha_pct"] for t in others) / len(others)
+            line += f" (trades without it: {avg_without:+.2f}%)"
+            if len(stamped) >= retire_after and avg_with <= avg_without:
+                line += (
+                    " → RETIREMENT CANDIDATE: no measurable edge — flag for "
+                    "the operator; keep obeying it until retired"
+                )
+        lines.append(line)
+    if not lines:
+        return ""
+    return (
+        "RULE EFFECTIVENESS (measured on closed trades — weight proven "
+        "rules more heavily when selecting today's pick):\n"
+        + "\n".join(lines)
+    )
 
 
 def _extract_lesson_learned_from_digest(digest_text: str) -> tuple[str, str] | None:

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -245,8 +245,13 @@ def pre_fetch(config, *, episode_num: int | None = None, today_str: str | None =
 
     # Strategy-level performance analysis — tells the LLM which approaches
     # are producing alpha and which are underperforming, so it can refine
-    # future trade selection.
-    context["strategy_performance"] = _build_strategy_performance(tracker)
+    # future trade selection. The regime check (rolling streak + drawdown
+    # → selection pressure) rides in the same prompt slot.
+    strategy_block = _build_strategy_performance(tracker)
+    regime = _build_regime_block(tracker)
+    if regime:
+        strategy_block = f"{strategy_block}\n\n{regime}"
+    context["strategy_performance"] = strategy_block
 
     # Dynamic tone based on portfolio performance
     context["tone_hint"] = _tone_from_portfolio(tracker)
@@ -261,6 +266,9 @@ def pre_fetch(config, *, episode_num: int | None = None, today_str: str | None =
         context["mit_recursive_learning_context"] = "Learning context temporarily unavailable — focus on process discipline."
 
     return context
+
+
+_MIN_SAMPLE_TRADES = 5
 
 
 def _build_strategy_performance(tracker: dict) -> str:
@@ -303,13 +311,24 @@ def _build_strategy_performance(tracker: dict) -> str:
 
     lines = ["STRATEGY PERFORMANCE ANALYSIS (use this to improve trade selection):"]
 
-    # Sector breakdown
+    # Sector breakdown. Statistical discipline (July 2026): a ✓/✗ verdict
+    # on 2-3 trades is noise-chasing — the loop was steering picks off
+    # coin-flip samples. Verdict flags require n >= _MIN_SAMPLE_TRADES;
+    # smaller samples are shown but explicitly labeled inconclusive.
     lines.append("\nSector results (closed trades):")
     for sec, s in sorted(sector_stats.items(), key=lambda x: x[1]["total_alpha"], reverse=True):
         wr = (s["wins"] / s["trades"] * 100) if s["trades"] > 0 else 0
         avg_alpha = s["total_alpha"] / s["trades"] if s["trades"] > 0 else 0
-        flag = "✓" if avg_alpha > 0 else "✗"
-        lines.append(f"  {flag} {sec}: {s['trades']} trades, {wr:.0f}% win rate, avg alpha {avg_alpha:+.2f}%")
+        if s["trades"] >= _MIN_SAMPLE_TRADES:
+            flag = "✓" if avg_alpha > 0 else "✗"
+            suffix = ""
+        else:
+            flag = "·"
+            suffix = (f" [n={s['trades']} — insufficient sample, "
+                      f"no conclusion]")
+        lines.append(
+            f"  {flag} {sec}: {s['trades']} trades, {wr:.0f}% win rate, "
+            f"avg alpha {avg_alpha:+.2f}%{suffix}")
 
     # Lesson tag patterns
     if tag_stats:
@@ -322,15 +341,84 @@ def _build_strategy_performance(tracker: dict) -> str:
     lines.append(f"\nBest trade: {best.get('symbol')} ({best.get('sector')}) — alpha {best.get('alpha_pct', 0):+.2f}%")
     lines.append(f"Worst trade: {worst.get('symbol')} ({worst.get('sector')}) — alpha {worst.get('alpha_pct', 0):+.2f}%")
 
-    # Actionable guidance
-    winning_sectors = [sec for sec, s in sector_stats.items() if s["total_alpha"] > 0 and s["trades"] >= 2]
-    losing_sectors = [sec for sec, s in sector_stats.items() if s["total_alpha"] < 0 and s["trades"] >= 2]
+    # Actionable guidance — FAVOR/AVOID only on samples big enough to
+    # mean something (n >= _MIN_SAMPLE_TRADES; was 2, i.e. coin flips).
+    winning_sectors = [
+        sec for sec, s in sector_stats.items()
+        if s["total_alpha"] > 0 and s["trades"] >= _MIN_SAMPLE_TRADES]
+    losing_sectors = [
+        sec for sec, s in sector_stats.items()
+        if s["total_alpha"] < 0 and s["trades"] >= _MIN_SAMPLE_TRADES]
     if winning_sectors:
         lines.append(f"\nFAVOR these sectors (positive alpha track record): {', '.join(winning_sectors)}")
     if losing_sectors:
         lines.append(f"AVOID OR BE CAUTIOUS with these sectors (negative alpha): {', '.join(losing_sectors)}")
+    if not winning_sectors and not losing_sectors:
+        lines.append(
+            "\nNo sector has a large enough sample for FAVOR/AVOID guidance "
+            "yet — judge today's pick on its own merits.")
 
     return "\n".join(lines)
+
+
+_REGIME_WINDOW = 10
+
+
+def _build_regime_block(tracker: dict) -> str:
+    """Adaptive selectivity from the rolling record (July 2026).
+
+    The loop previously treated every day identically regardless of how
+    the last stretch of picks performed. This block turns the rolling
+    last-``_REGIME_WINDOW`` matched-window alpha + the drawdown from the
+    P&L high-water mark into explicit selection pressure: a cold streak
+    RAISES the bar (prefer explicit no-trade days, demand more aligned
+    factors); a hot streak holds discipline flat (never "press harder").
+    Deterministic — thresholds are code, not vibes.
+    """
+    closed = [t for t in tracker.get("trades", []) if t.get("status") == "closed"]
+    scored = [
+        t for t in closed
+        if isinstance(t.get("alpha_pct"), (int, float))
+        and math.isfinite(t["alpha_pct"])
+    ]
+    if len(scored) < 5:
+        return ""
+    recent = scored[-_REGIME_WINDOW:]
+    avg_alpha = sum(t["alpha_pct"] for t in recent) / len(recent)
+    wins = sum(1 for t in recent if _finite(t.get("pnl_pct")) > 0)
+
+    # Drawdown from the cumulative-P&L high-water mark (all closed trades).
+    running = peak = 0.0
+    for t in closed:
+        running += _finite(t.get("pnl_dollars"))
+        peak = max(peak, running)
+    drawdown = round(peak - running, 2)
+
+    header = (
+        f"REGIME CHECK (rolling last {len(recent)} closed trades): "
+        f"avg matched-window alpha {avg_alpha:+.2f}%, {wins}/{len(recent)} "
+        f"wins, ${drawdown:.2f} below the P&L high-water mark."
+    )
+    if avg_alpha < -0.5 or drawdown > 100:
+        guidance = (
+            " COLD STREAK — RAISE THE BAR for today's Practice Investment: "
+            "an explicit no-trade day is the DEFAULT unless a setup has 3+ "
+            "independent aligned factors (which also justifies High "
+            "confidence). Do not chase a comeback; smaller, clearer edges "
+            "only."
+        )
+    elif avg_alpha > 1.0:
+        guidance = (
+            " HOT STREAK — the process is working. Keep the SAME selection "
+            "bar and position discipline; do not loosen criteria or reach "
+            "for riskier names because recent picks worked."
+        )
+    else:
+        guidance = (
+            " NEUTRAL — apply the standard selection criteria; no-trade "
+            "days remain acceptable."
+        )
+    return header + guidance
 
 
 def _tone_from_portfolio(tracker: dict) -> str:
@@ -2419,7 +2507,7 @@ def _analyze_strategy_patterns(tracker: dict) -> str:
 
     favor, avoid = [], []
     for sec, alphas in sector_alpha.items():
-        if len(alphas) < 3:
+        if len(alphas) < _MIN_SAMPLE_TRADES:
             continue
         avg = sum(alphas) / len(alphas)
         if avg >= 1.0:
@@ -2525,7 +2613,7 @@ def _derive_operating_principles(tracker: dict) -> list:
         sector_stats[sec]["total_alpha"] += t.get("alpha_pct", 0)
 
     best_sector = max(sector_stats.items(), key=lambda x: x[1]["total_alpha"] / max(x[1]["count"], 1), default=None)
-    if best_sector and best_sector[1]["count"] >= 3 and (best_sector[1]["total_alpha"] / best_sector[1]["count"]) > 2:
+    if best_sector and best_sector[1]["count"] >= _MIN_SAMPLE_TRADES and (best_sector[1]["total_alpha"] / best_sector[1]["count"]) > 2:
         principles.append({
             "title": f"Favor {best_sector[0].replace('_', ' ').title()}",
             "description": f"Data shows strong positive alpha in this sector across {best_sector[1]['count']} trades.",
@@ -2543,7 +2631,7 @@ def _derive_operating_principles(tracker: dict) -> list:
 
     if tag_performance:
         best_tag = max(tag_performance.items(), key=lambda x: x[1]["total_alpha"] / max(x[1]["count"], 1))
-        if best_tag[1]["count"] >= 2 and (best_tag[1]["total_alpha"] / best_tag[1]["count"]) > 3:
+        if best_tag[1]["count"] >= _MIN_SAMPLE_TRADES and (best_tag[1]["total_alpha"] / best_tag[1]["count"]) > 3:
             principles.append({
                 "title": f"Prioritize setups matching '{best_tag[0]}'",
                 "description": "This lesson tag has shown the strongest alpha when present in winning trades.",

--- a/templates/mit_performance_page.html.j2
+++ b/templates/mit_performance_page.html.j2
@@ -55,14 +55,25 @@
       <h2 style="margin-top:0; font-size:1.4rem;">Current Track Record vs NASDAQ</h2>
       
       <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: var(--sp-4); margin: var(--sp-6) 0;">
+        {% set s = tracker.summary if tracker else none %}
+        {% if s and s.matched_window_alpha_pct is defined and s.matched_window_trades %}
         <div>
-          <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase;">Cumulative Alpha vs NASDAQ</div>
+          <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase;">Matched-Window Alpha vs NASDAQ</div>
+          <div style="font-size:2.2rem; font-weight:700; color: {% if (s.matched_window_alpha_pct or 0) >= 0 %}#10b981{% else %}#ef4444{% endif %};">
+            {{ "{:+.2f}".format(s.matched_window_alpha_pct or 0) }}%
+          </div>
+          <div style="font-size:0.85rem;">Each trade vs the index over the same holding window — the honest head-to-head ({{ s.matched_window_trades }} trades)</div>
+        </div>
+        {% endif %}
+
+        <div>
+          <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase;">Buy-and-Hold Gap vs NASDAQ</div>
           <div style="font-size:2.2rem; font-weight:700; color: {% if (performance_data.alpha.inception_to_date_pct or 0) >= 0 %}#10b981{% else %}#ef4444{% endif %};">
             {{ "{:+.2f}".format(performance_data.alpha.inception_to_date_pct or 0) }}%
           </div>
-          <div style="font-size:0.85rem;">Since inception</div>
+          <div style="font-size:0.85rem;">Since inception · not capital-matched (one $1,000 position at a time vs a fully-invested index)</div>
         </div>
-        
+
         <div>
           <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase;">YTD Alpha</div>
           <div style="font-size:2.2rem; font-weight:700; color: {% if (performance_data.alpha.ytd_pct or 0) >= 0 %}#10b981{% else %}#ef4444{% endif %};">
@@ -83,6 +94,28 @@
           <div style="font-size:2.2rem; font-weight:700;">{{ performance_data.summary.total_trades or 0 }}</div>
         </div>
       </div>
+
+      {% if s and s.benchmark_scores and s.benchmark_scores | length > 1 %}
+      <div style="border-top: 1px solid var(--nn-border, rgba(128,128,128,0.25)); padding-top: var(--sp-4); margin-top: var(--sp-4);">
+        <div style="font-size:0.8rem; color:var(--nn-text-muted); text-transform:uppercase; margin-bottom: 0.5rem;">
+          Major-Index Sweep (matched windows) — currently beating {{ s.indices_beaten or 0 }} of {{ s.indices_scored or 0 }} major indices
+        </div>
+        <div style="display:flex; gap: var(--sp-6); flex-wrap: wrap;">
+          {% for key, label in [("nasdaq", "NASDAQ Composite"), ("sp500", "S&P 500"), ("tsx", "TSX Composite")] %}
+            {% if s.benchmark_scores[key] is defined %}
+            {% set score = s.benchmark_scores[key] %}
+            <div>
+              <span style="font-weight:600;">{{ label }}</span>
+              <span style="font-weight:700; color: {% if (score.alpha_pct or 0) >= 0 %}#10b981{% else %}#ef4444{% endif %};">
+                {{ "{:+.2f}".format(score.alpha_pct or 0) }}%
+              </span>
+              <span style="font-size:0.8rem; color:var(--nn-text-muted);">({{ score.trades }} trades)</span>
+            </div>
+            {% endif %}
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
 
       <div style="font-size:0.85rem; color:var(--nn-text-muted);">
         Last updated: {{ performance_data.last_updated or "recently" }} • All figures are simulated with $1,000 per position for tracking purposes only.

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -714,3 +714,52 @@ class TestRuleEffectiveness:
         block = mi._build_lessons_learned_block(lessons)
         for rid in selected:
             assert rid in block
+
+
+# ---------------------------------------------------------------------------
+# Regime block (adaptive selectivity) + statistical discipline
+# ---------------------------------------------------------------------------
+
+class TestRegimeBlock:
+    def _closed(self, alpha, pnl_dollars):
+        return {"status": "closed", "alpha_pct": alpha,
+                "pnl_pct": alpha, "pnl_dollars": pnl_dollars}
+
+    def test_cold_streak_raises_the_bar(self):
+        tracker = {"trades": [self._closed(-2.0, -20.0) for _ in range(10)]}
+        block = mi._build_regime_block(tracker)
+        assert "COLD STREAK" in block
+        assert "no-trade day is the DEFAULT" in block
+
+    def test_hot_streak_holds_discipline_never_presses(self):
+        tracker = {"trades": [self._closed(2.5, 25.0) for _ in range(10)]}
+        block = mi._build_regime_block(tracker)
+        assert "HOT STREAK" in block
+        assert "do not loosen criteria" in block
+
+    def test_neutral_regime(self):
+        tracker = {"trades": [self._closed(0.2, 2.0) for _ in range(10)]}
+        block = mi._build_regime_block(tracker)
+        assert "NEUTRAL" in block
+
+    def test_drawdown_alone_triggers_cold(self):
+        # Strong early run, then a deep drawdown — even with recent alpha
+        # near zero, being far below the high-water mark tightens the bar.
+        trades = ([self._closed(5.0, 150.0) for _ in range(5)]
+                  + [self._closed(0.1, -30.0) for _ in range(5)])
+        block = mi._build_regime_block({"trades": trades})
+        assert "COLD STREAK" in block
+
+    def test_too_few_trades_yields_empty(self):
+        tracker = {"trades": [self._closed(1.0, 10.0) for _ in range(3)]}
+        assert mi._build_regime_block(tracker) == ""
+
+
+class TestPerformancePageMultiIndex:
+    def test_template_carries_matched_window_and_sweep(self):
+        src = (_ROOT / "templates/mit_performance_page.html.j2").read_text(
+            encoding="utf-8")
+        assert "Matched-Window Alpha vs NASDAQ" in src
+        assert "Buy-and-Hold Gap vs NASDAQ" in src
+        assert "not capital-matched" in src
+        assert "Major-Index Sweep" in src

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -577,3 +577,140 @@ class TestTradeSignal:
         config = SimpleNamespace(episode=SimpleNamespace(output_dir=str(tmp_path)))
         mi.post_generate(config, digest_text=self._DIGEST, episode_num=96)
         assert not (tmp_path / mi.TRADE_SIGNAL_LATEST_FILENAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# Multi-index benchmarking (July 2026 "beat all major indices" pass)
+# ---------------------------------------------------------------------------
+
+class TestMultiIndexBenchmark:
+    def _closed(self, pnl, ndq, sp500=None, tsx=None):
+        return {
+            "status": "closed", "pnl_pct": pnl, "pnl_dollars": pnl * 10,
+            "nasdaq_return_pct": ndq, "alpha_pct": pnl - ndq,
+            "benchmark_returns": {"nasdaq": ndq, "sp500": sp500, "tsx": tsx},
+        }
+
+    def test_summary_scores_every_index(self):
+        tracker = {"metadata": {"position_size": 1000}, "summary": {},
+                   "trades": [self._closed(10.0, 2.0, sp500=1.0, tsx=-1.0),
+                              self._closed(-2.0, 1.0, sp500=0.5, tsx=0.2)]}
+        mi._recompute_summary(tracker)
+        scores = tracker["summary"]["benchmark_scores"]
+        assert set(scores) == {"nasdaq", "sp500", "tsx"}
+        assert scores["sp500"]["trades"] == 2
+        # portfolio compounded: 1.10*0.98-1 = +7.8%; tsx: 0.99*1.002-1
+        assert scores["tsx"]["alpha_pct"] == pytest.approx(
+            (1.10 * 0.98 - 0.99 * 1.002) * 100, abs=0.05)
+        assert tracker["summary"]["indices_scored"] == 3
+        # Beats nasdaq (7.8 vs 3.02), sp500 (7.8 vs 1.5), tsx (7.8 vs -0.6).
+        assert tracker["summary"]["indices_beaten"] == 3
+
+    def test_legacy_trades_fall_back_to_nasdaq_field_only(self):
+        legacy = {"status": "closed", "pnl_pct": 5.0, "pnl_dollars": 50.0,
+                  "nasdaq_return_pct": 2.0, "alpha_pct": 3.0}
+        tracker = {"metadata": {"position_size": 1000}, "summary": {},
+                   "trades": [legacy]}
+        mi._recompute_summary(tracker)
+        scores = tracker["summary"]["benchmark_scores"]
+        assert scores["nasdaq"]["trades"] == 1
+        assert "sp500" not in scores  # no data — not silently zeroed
+
+    def test_annotate_fills_benchmark_returns_for_all_indices(self):
+        trade = {"symbol": "MU", "date": "2026-07-01",
+                 "trade_type": "flash", "pnl_pct": 1.0}
+        with patch.object(mi, "_fetch_history_bars", return_value=_BARS):
+            mi._annotate_trade_with_nasdaq(trade)
+        returns = trade["benchmark_returns"]
+        assert set(returns) == {"nasdaq", "sp500", "tsx"}
+        # Same stub bars for every index → same matched-window return.
+        assert returns["sp500"] == returns["nasdaq"] == pytest.approx(0.48, abs=0.01)
+
+    def test_benchmark_block_reports_index_sweep(self):
+        tracker = mi._fresh_tracker()
+        tracker["benchmark"] = {"current_close": 25000.0, "ytd_pct": 11.0,
+                                "inception_to_date_pct": 15.0,
+                                "last_updated": "2026-07-04"}
+        tracker["alpha"] = {"ytd_pct": -10.0, "inception_to_date_pct": -14.0,
+                            "monthly": {}}
+        tracker["summary"] = {
+            "matched_window_alpha_pct": 11.2, "matched_window_trades": 35,
+            "compounded_return_pct": 23.6,
+            "compounded_nasdaq_matched_pct": 12.4,
+            "indices_beaten": 2, "indices_scored": 3,
+            "benchmark_scores": {
+                "nasdaq": {"alpha_pct": 11.2, "trades": 35},
+                "sp500": {"alpha_pct": 5.0, "trades": 35},
+                "tsx": {"alpha_pct": -1.0, "trades": 35},
+            },
+        }
+        block = mi._build_benchmark_block(tracker)
+        assert "beating 2 of 3 major indices" in block
+        assert "S&P 500" in block and "TSX Composite" in block
+
+
+# ---------------------------------------------------------------------------
+# Rule-effectiveness scoring (the loop learns whether it's learning)
+# ---------------------------------------------------------------------------
+
+class TestRuleEffectiveness:
+    _RULE_A = {"id": "LL-017", "status": "active",
+               "observation": "Momentum faded without volume",
+               "adjustment": "Always require volume confirmation before momentum entries"}
+    _RULE_B = {"id": "LL-002", "status": "active",
+               "observation": "Sector concentration built up",
+               "adjustment": "Cap any single sector at 30% of the trailing window"}
+
+    def _closed(self, alpha, rules):
+        return {"status": "closed", "alpha_pct": alpha,
+                "rules_in_effect": rules}
+
+    def test_post_generate_stamps_rules_in_effect(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("NERRA_HOOKS_READONLY", raising=False)
+        lessons = {"metadata": {}, "entries": [self._RULE_A, self._RULE_B]}
+        (tmp_path / mi.LESSONS_LEARNED_FILENAME).write_text(
+            json.dumps(lessons), encoding="utf-8")
+        config = SimpleNamespace(episode=SimpleNamespace(output_dir=str(tmp_path)))
+        digest = ("**Trade Type:** Flash Trade\n"
+                  "**Today's Pick:** NVDA — Nvidia\n"
+                  "**Market:** NASDAQ\n"
+                  "**Strategy:** Momentum play\n"
+                  "**Confidence Level:** High\n")
+        with patch.object(mi, "_probe_pick", return_value=True):
+            mi.post_generate(config, digest_text=digest, episode_num=100)
+        tracker = json.loads((tmp_path / mi.TRACKER_FILENAME).read_text())
+        assert set(tracker["trades"][0]["rules_in_effect"]) == {"LL-017", "LL-002"}
+
+    def test_scoreboard_reports_with_and_without_alpha(self):
+        lessons = {"entries": [self._RULE_A]}
+        tracker = {"trades": (
+            [self._closed(2.0, ["LL-017"]) for _ in range(5)]
+            + [self._closed(-1.0, []) for _ in range(5)]
+        )}
+        board = mi._build_rule_scoreboard(lessons, tracker)
+        assert "[LL-017] in effect for 5 closed trades" in board
+        assert "+2.00%" in board
+        assert "-1.00%" in board
+        assert "RETIREMENT" not in board  # positive edge — keep
+
+    def test_ineffective_rule_flagged_for_retirement(self):
+        lessons = {"entries": [self._RULE_A]}
+        tracker = {"trades": (
+            [self._closed(0.0, ["LL-017"]) for _ in range(8)]
+            + [self._closed(1.0, []) for _ in range(4)]
+        )}
+        board = mi._build_rule_scoreboard(lessons, tracker)
+        assert "RETIREMENT CANDIDATE" in board
+        assert "keep obeying it until retired" in board  # never auto-retired
+
+    def test_too_few_stamped_trades_yields_empty_board(self):
+        lessons = {"entries": [self._RULE_A]}
+        tracker = {"trades": [self._closed(2.0, ["LL-017"])]}
+        assert mi._build_rule_scoreboard(lessons, tracker) == ""
+
+    def test_selected_rules_match_block_content(self):
+        lessons = {"entries": [self._RULE_A, self._RULE_B]}
+        selected = {e["id"] for e in mi._selected_active_rules(lessons)}
+        block = mi._build_lessons_learned_block(lessons)
+        for rid in selected:
+            assert rid in block

--- a/tests/test_mit_quality_pass.py
+++ b/tests/test_mit_quality_pass.py
@@ -250,14 +250,28 @@ class TestDoubleReviewPrevented:
 
 class TestRecursiveLearningLoopAlive:
     def test_analyze_strategy_patterns_defined_with_favor_avoid(self):
+        # July 2026 statistical-discipline pass: FAVOR/AVOID requires
+        # n >= 5 per sector (was 3 — coin-flip samples steered picks).
+        tracker = _tracker_with_trades(
+            [_closed(f"W{i}", 5, 50, alpha=4.0, sector="tech") for i in range(5)]
+            + [_closed(f"L{i}", -5, -50, alpha=-3.0, sector="energy")
+               for i in range(5)]
+        )
+        out = mi._analyze_strategy_patterns(tracker)
+        assert "FAVOR tech" in out
+        assert "AVOID energy" in out
+
+    def test_small_samples_get_no_favor_avoid_verdict(self):
         tracker = _tracker_with_trades(
             [_closed(f"W{i}", 5, 50, alpha=4.0, sector="tech") for i in range(3)]
             + [_closed(f"L{i}", -5, -50, alpha=-3.0, sector="energy")
                for i in range(3)]
         )
         out = mi._analyze_strategy_patterns(tracker)
-        assert "FAVOR tech" in out
-        assert "AVOID energy" in out
+        assert "FAVOR" not in out and "AVOID" not in out
+        block = mi._build_strategy_performance(tracker)
+        assert "insufficient sample" in block
+        assert "FAVOR these sectors" not in block
 
     def test_learning_context_runs_on_live_tracker(self):
         # The historical failure mode: NameError swallowed by pre_fetch.

--- a/tests/test_snaptrade_execution.py
+++ b/tests/test_snaptrade_execution.py
@@ -274,3 +274,70 @@ class TestShadowExecutor:
         src = (_ROOT / "scripts/mit_shadow_executor.py").read_text()
         assert "nothing to do (fail-closed)" in src
         assert "return 0" in src
+
+
+class TestShadowExits:
+    _NOW = datetime.datetime(2026, 7, 10, 13, 50,
+                             tzinfo=datetime.timezone.utc)  # Friday
+
+    def _ledger_with_entry(self, pick_date="2026-07-06", trade_type="weekly"):
+        ledger = shadow.load_ledger(Path("/nonexistent/ledger.json"))
+        ledger["orders"].append({
+            "logged_at": f"{pick_date}T13:50:00+00:00", "mode": "shadow",
+            "decision": "would_place", "episode_num": 99,
+            "client_order_id": "aaaa-bbbb", "symbol": "NVDA",
+            "snaptrade_symbol": "NVDA", "trade_type": trade_type,
+            "quote": 200.0, "limit_price": 201.0, "units": 1.24,
+            "pick_date": pick_date,
+        })
+        return ledger
+
+    def test_weekly_exit_due_friday(self):
+        # Monday pick → due this Friday.
+        assert shadow._exit_due_date(
+            datetime.date(2026, 7, 6), "weekly") == datetime.date(2026, 7, 10)
+        # Friday pick → due NEXT Friday (matches _evaluate_open_trade).
+        assert shadow._exit_due_date(
+            datetime.date(2026, 7, 10), "weekly") == datetime.date(2026, 7, 17)
+
+    def test_flash_exit_due_next_weekday(self):
+        assert shadow._exit_due_date(
+            datetime.date(2026, 7, 8), "flash") == datetime.date(2026, 7, 9)
+        # Friday flash → Monday.
+        assert shadow._exit_due_date(
+            datetime.date(2026, 7, 10), "flash") == datetime.date(2026, 7, 13)
+
+    def test_due_position_gets_would_sell_with_round_trip(self):
+        ledger = self._ledger_with_entry()
+        exits = shadow.run_shadow_exits(
+            ledger, RiskConfig(), quote_fn=lambda s: 210.0, now=self._NOW)
+        assert len(exits) == 1
+        x = exits[0]
+        assert x["decision"] == "would_sell"
+        assert x["shadow_return_pct"] == pytest.approx(5.0, abs=0.01)
+        assert x["exit_client_order_id"] == "aaaa-bbbb-exit"
+        assert len(ledger["orders"]) == 2
+
+    def test_exit_is_idempotent(self):
+        ledger = self._ledger_with_entry()
+        shadow.run_shadow_exits(ledger, RiskConfig(),
+                                quote_fn=lambda s: 210.0, now=self._NOW)
+        again = shadow.run_shadow_exits(ledger, RiskConfig(),
+                                        quote_fn=lambda s: 210.0, now=self._NOW)
+        assert again == []
+        assert len(ledger["orders"]) == 2
+
+    def test_not_yet_due_position_stays_open(self):
+        ledger = self._ledger_with_entry(pick_date="2026-07-09")  # Thu weekly
+        exits = shadow.run_shadow_exits(
+            ledger, RiskConfig(), quote_fn=lambda s: 210.0,
+            now=datetime.datetime(2026, 7, 9, 13, 50,
+                                  tzinfo=datetime.timezone.utc))
+        assert exits == []
+
+    def test_no_quote_leaves_position_open_for_retry(self):
+        ledger = self._ledger_with_entry()
+        exits = shadow.run_shadow_exits(
+            ledger, RiskConfig(), quote_fn=lambda s: None, now=self._NOW)
+        assert exits == []
+        assert len(ledger["orders"]) == 1  # nothing logged; retried later

--- a/tests/test_snaptrade_execution.py
+++ b/tests/test_snaptrade_execution.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest  # noqa: F401 (used by the Phase-2 tests below)
+
 _ROOT = Path(__file__).resolve().parent.parent
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
@@ -133,3 +135,142 @@ class TestMirrorBuilder:
         mirror = mirror_mod.build_mirror([], {}, {}, now_iso="t")
         assert mirror["account_count"] == 0
         assert mirror["accounts"] == []
+
+
+# ---------------------------------------------------------------------------
+# Risk gates + shadow executor (Phase 2)
+# ---------------------------------------------------------------------------
+
+import datetime  # noqa: E402
+
+from execution import shadow  # noqa: E402
+from execution.risk import RiskConfig, validate_signal  # noqa: E402
+
+_TODAY = datetime.date(2026, 7, 4)
+
+
+def _signal(**overrides):
+    trade = {
+        "symbol": "NVDA", "market": "NASDAQ", "snaptrade_symbol": "NVDA",
+        "side": "BUY", "trade_type": "flash", "confidence": "High",
+        "strategy": "momentum", "target_range": "", "sector": "tech",
+        "pick_date": "2026-07-04", "pick_reference_price": 200.0,
+        "pick_validated": True, "currency": "USD",
+        "suggested_account": "webull",
+        "client_order_id": "11111111-2222-3333-4444-555555555555",
+    }
+    trade.update(overrides.pop("trade_overrides", {}))
+    signal = {
+        "schema_version": 1, "generated_at": "2026-07-04",
+        "episode_num": 96, "show": "modern_investing",
+        "simulated_position_size_usd": 1000,
+        "action": "new_trade", "reason": None, "trade": trade,
+    }
+    signal.update(overrides)
+    return signal
+
+
+class TestRiskGates:
+    def test_valid_signal_passes(self):
+        ok, reasons = validate_signal(_signal(), RiskConfig(), today=_TODAY)
+        assert ok and reasons == []
+
+    def test_no_trade_signal_fails_closed(self):
+        ok, reasons = validate_signal(
+            _signal(action="no_trade", trade=None), RiskConfig(), today=_TODAY)
+        assert not ok
+        assert any("nothing to trade" in r for r in reasons)
+
+    def test_stale_signal_rejected(self):
+        ok, reasons = validate_signal(
+            _signal(generated_at="2026-06-30"), RiskConfig(), today=_TODAY)
+        assert not ok
+        assert any("stale" in r for r in reasons)
+
+    def test_unvalidated_pick_rejected(self):
+        ok, reasons = validate_signal(
+            _signal(trade_overrides={"pick_validated": False,
+                                     "pick_reference_price": None}),
+            RiskConfig(), today=_TODAY)
+        assert not ok
+        assert any("not validated" in r for r in reasons)
+
+    def test_penny_stock_rejected(self):
+        ok, reasons = validate_signal(
+            _signal(trade_overrides={"pick_reference_price": 0.85}),
+            RiskConfig(), today=_TODAY)
+        assert not ok
+        assert any("floor" in r for r in reasons)
+
+    def test_duplicate_order_id_rejected(self):
+        sig = _signal()
+        ok, reasons = validate_signal(
+            sig, RiskConfig(), today=_TODAY,
+            prior_order_ids={sig["trade"]["client_order_id"]})
+        assert not ok
+        assert any("duplicate" in r for r in reasons)
+
+    def test_kill_switch_defaults_off(self, monkeypatch):
+        monkeypatch.delenv("LIVE_TRADING_ENABLED", raising=False)
+        assert RiskConfig.from_env().live_trading_enabled is False
+
+
+class TestShadowExecutor:
+    _NOW = datetime.datetime(2026, 7, 4, 13, 50,
+                             tzinfo=datetime.timezone.utc)
+
+    def test_valid_signal_logs_would_place_order(self):
+        ledger = shadow.load_ledger(Path("/nonexistent/ledger.json"))
+        entry = shadow.run_shadow(
+            _signal(), ledger, RiskConfig(),
+            quote_fn=lambda s: 201.0, now=self._NOW)
+        assert entry["decision"] == "would_place"
+        assert entry["order_type"] == "Limit"
+        assert entry["limit_price"] == pytest.approx(201.0 * 1.005, abs=0.01)
+        assert entry["units"] == pytest.approx(250.0 / entry["limit_price"],
+                                               abs=0.001)
+        assert ledger["orders"] == [entry]
+
+    def test_rerun_is_idempotent(self):
+        ledger = shadow.load_ledger(Path("/nonexistent/ledger.json"))
+        shadow.run_shadow(_signal(), ledger, RiskConfig(),
+                          quote_fn=lambda s: 201.0, now=self._NOW)
+        second = shadow.run_shadow(_signal(), ledger, RiskConfig(),
+                                   quote_fn=lambda s: 201.0, now=self._NOW)
+        assert second["decision"] == "duplicate"
+        assert len(ledger["orders"]) == 1  # not re-logged
+
+    def test_gated_signal_logged_as_skipped_with_reasons(self):
+        ledger = shadow.load_ledger(Path("/nonexistent/ledger.json"))
+        entry = shadow.run_shadow(
+            _signal(generated_at="2026-06-01"), ledger, RiskConfig(),
+            quote_fn=lambda s: 201.0, now=self._NOW)
+        assert entry["decision"] == "skipped"
+        assert any("stale" in r for r in entry["skip_reasons"])
+        assert ledger["orders"] == [entry]
+
+    def test_quote_failure_falls_back_to_reference(self):
+        ledger = shadow.load_ledger(Path("/nonexistent/ledger.json"))
+        entry = shadow.run_shadow(
+            _signal(), ledger, RiskConfig(),
+            quote_fn=lambda s: None, now=self._NOW)
+        assert entry["decision"] == "would_place"
+        assert entry["quote_source"] == "pick_reference_fallback"
+        assert entry["quote"] == 200.0
+
+    def test_ledger_roundtrip(self, tmp_path):
+        path = tmp_path / "shadow_ledger.json"
+        ledger = shadow.load_ledger(path)
+        shadow.run_shadow(_signal(), ledger, RiskConfig(),
+                          quote_fn=lambda s: 201.0, now=self._NOW)
+        shadow.save_ledger(ledger, path)
+        reloaded = shadow.load_ledger(path)
+        assert len(reloaded["orders"]) == 1
+        assert reloaded["orders"][0]["snaptrade_symbol"] == "NVDA"
+
+    def test_shadow_executor_script_fails_closed_without_signal(self):
+        # The script uses ROOT-relative paths, so pin the fail-closed
+        # branch in source (a missing signal must be a clean no-op).
+        src = (_ROOT / "scripts/mit_shadow_executor.py").read_text()
+        assert "nothing to do (fail-closed)" in src
+        assert "return 0" in src


### PR DESCRIPTION
# TLDR

Three workstreams toward "continuously learn and beat **all** major indices":

1. **Multi-index matched-window benchmarking** — every closed trade is now scored against NASDAQ (^IXIC), S&P 500 (^GSPC) *and* TSX Composite (^GSPTSE) over the trade's own bar window. The summary carries per-index compounded `benchmark_scores` + `indices_beaten`, and the spoken scoreboard gains a once-per-episode "beating N of 3 major indices" sweep. NASDAQ stays the headline; legacy fields untouched; `scripts/recompute_mit_benchmarks.py` backfills history for all three when you run it.
2. **The learning loop now audits itself** — each pick is stamped with `rules_in_effect` (the exact recursive-improvement rule IDs the model was shown that day). Once a rule has been in effect for ≥5 closed trades, a rule scoreboard compares its stamped-trade alpha against trades made without it; at ≥8 trades with no measurable edge, it's flagged **RETIREMENT CANDIDATE** for you (rules are never auto-retired). This closes the gap where rules accumulated forever with nobody checking whether obeying them helped.
3. **Shadow mode (Phase 2) is LIVE as of merge — no secrets needed.** `execution/risk.py` (pure, env-tunable hard gates: kill switch defaults OFF, $250 cap, 0.5% slippage collar, $2 floor, 1-day freshness, duplicate rejection) + `execution/shadow.py` (signal → gates → decision-time yfinance quote → would-be marketable-limit order, logged idempotently to the committed `shadow_ledger.json`) + a weekday 13:50 UTC workflow. `scripts/mit_shadow_report.py` tabulates shadow-quote-vs-sim-entry slippage — the execution-cost model the sim has been missing, now measured instead of assumed. The no-order-placement contract on `execution/` remains pinned by tests.

# ⚠️ A/B-listen required (landmine #17)

The **index-sweep line** and **rule scoreboard** are new prompt context and will surface in spoken output (Market Pulse / Portfolio Performance). Listen to the next 1–2 episodes. Both are capped ("mention the sweep at most once per episode").

# Test results

- New drift guards: `TestMultiIndexBenchmark`, `TestRuleEffectiveness` (hook) and `TestRiskGates`, `TestShadowExecutor` (execution) — idempotency, fail-closed gating, retirement-candidate thresholds, legacy-trade fallback all pinned.
- **296 tests green** across the touched suites (`test_mit_benchmark_integrity`, `test_mit_quality_pass`, `test_modern_investing_hooks`, `test_snaptrade_execution`, `test_prompt_fidelity`, `test_generator`, `test_schedule`, `test_scheduling_punctuality`, `test_review_agent`); `ruff` clean.

# What happens after merge (no action needed)

- The shadow executor starts running weekday mornings at 9:50 ET, committing would-be orders to `digests/modern_investing/shadow_ledger.json`. After ~20 entries, run `python scripts/mit_shadow_report.py` for the first measured slippage numbers.
- New picks get `rules_in_effect` stamps; the rule scoreboard appears in prompts once ~5 stamped trades close.
- Newly closed trades carry all-three-index returns immediately; history backfills when you run the recompute script.

# Deferred (in the ledger with predictions)

Shadow exits (Phase 2.5); feeding measured slippage into the sim's cost model (~20 trades needed); SnapTrade webhook-receiver Worker; carried items (closing-price lesson retirement A/B, under-length, recompute `--apply` run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKwLmJRykLH8oFskoXiVVp

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKwLmJRykLH8oFskoXiVVp)_