### PR TITLE
MIT fidelity batch: stop-loss enforcement, alpha significance honesty, execution health

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,7 +413,30 @@ nerranetwork/
   (weekdays 13:50 UTC, yfinance only, no secrets); the read-only/no
   order-placement contract still pinned. `scripts/mit_shadow_report.py`
   = sim-vs-shadow slippage table. Scoreboard/lessons-block additions
-  change prompt context → A/B-listen per landmine #17.
+  change prompt context → A/B-listen per landmine #17. Same-PR second
+  batch: shadow EXITS (paired idempotent `would_sell` on the sim's exit
+  calendar → round-trip shadow P&L + sim-vs-shadow gap in the report),
+  regime block (rolling last-10 alpha + drawdown → cold streak makes
+  no-trade the default / hot streak holds the bar), FAVOR/AVOID now
+  requires n≥5 samples (was 2-3 — coin flips steered picks), performance
+  page gained the matched-window headline tile + "not capital-matched"
+  relabel + major-index sweep.
+  **July 4 2026 fidelity batch** (drift guards:
+  `tests/test_mit_benchmark_integrity.py::{TestStopLossExtraction,TestStopBreach,TestAlphaTStat}`,
+  `tests/test_dashboard_mit_section.py::TestExecutionHealth`): stop-loss
+  ENFORCEMENT — the digest narrates a stop on every pick but the sim
+  never enforced it; the stop is now parsed at pick time (never guessed),
+  carried on the trade + trade signal (future bracket orders), and
+  enforced at evaluation against intraday lows (bars carry a 4th
+  low element; gap-aware fills; entry-bar breaches never claimed; the
+  benchmark window follows the shortened hold; the review narrates
+  "stopped out" as stop discipline working). Per-trade alpha **t-stat**
+  (`alpha_t_stat` / `alpha_statistically_significant`) in the summary +
+  an on-air honesty rule in the scoreboard block (hedge "not yet
+  statistically significant" until t≥2). Dashboard `execution_health`
+  block (trade-signal freshness/staleness + shadow-ledger vitals).
+  Stop enforcement changes sim outcomes going forward; the honesty line
+  + stop narration are new prompt context → A/B-listen per landmine #17.
 
 **Tesla Shorts Time Recursive Memory System (May 2026+)**  
 TST received a full recursive improvement architecture (analogous to MIT):

--- a/docs/reviews/ledger/modern_investing.yaml
+++ b/docs/reviews/ledger/modern_investing.yaml
@@ -200,4 +200,50 @@ reviews:
         evidence: null
     agent_cost_usd: null
 
+  - date: 2026-07-04
+    pr: null
+    doc: docs/mit_snaptrade_live_trading_plan.md
+    reviewer: claude-code (fidelity batch, operator "continue improvements")
+    summary: >
+      Sim-fidelity + statistical-honesty batch. (1) Stop-loss enforcement:
+      the digest narrates a stop on every pick but the sim never enforced
+      it — stops are now parsed at pick time (never guessed), stored on
+      the trade AND in the trade signal (future bracket orders), and
+      enforced at evaluation against intraday lows (gap-aware fills;
+      entry-bar breaches never claimed; benchmark window follows the
+      shortened hold). (2) Per-trade alpha t-stat in the summary; the
+      scoreboard block instructs the model to hedge on air when the edge
+      is not yet statistically distinguishable from luck. (3) Dashboard
+      execution_health: signal freshness/staleness + shadow-ledger vitals
+      (decision counts, round trips, avg round-trip).
+    shipped:
+      - _extract_stop_loss + _stop_breach + enforcement in _close_trade;
+        stopped_out narration in the trade review; stop_loss in the trade
+        signal schema
+      - bars carry intraday lows (4th element, None-safe for legacy)
+      - alpha_t_stat + alpha_statistically_significant in summary +
+        honesty line in the benchmark block
+      - execution_health block in aggregate_mit_performance
+    deferred:
+      - "same-day (entry-bar) stop breaches — unknowable from daily bars;
+        revisit with intraday data if ever needed"
+      - "carried: slippage->sim cost model (~20 shadow round trips),
+        recompute --apply (operator), closing-price lesson retirement
+        (operator A/B)"
+    predictions:
+      - metric: trades with a parsed stop_loss on the trade record
+        baseline: "0 of 46 (never captured)"
+        expected: ">= 70% of new picks carry stop_loss (the Risk
+          Assessment states one nearly every episode); no trade ever
+          carries a stop above its entry"
+        verdict: pending
+        evidence: null
+      - metric: spoken outperformance claims without a significance hedge
+        baseline: "n/a (t-stat never computed)"
+        expected: "while alpha_statistically_significant is false, episodes
+          claiming outperformance also say it is early/not yet significant"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
 do_not_retry: []

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1540,6 +1540,59 @@ def aggregate_mit_performance(root: Path) -> Dict[str, Any]:
         "monthly": raw_alpha.get("monthly") or {},
     }
 
+    # Execution-layer health (July 2026 live-trading prep): signal
+    # freshness + shadow-ledger vitals so the operator sees at a glance
+    # whether the bridge artifacts are flowing. All best-effort.
+    execution_health: Dict[str, Any] = {
+        "signal": None,
+        "shadow": None,
+    }
+    signal_path = mit_dir / "trade_signal_latest.json"
+    if signal_path.exists():
+        try:
+            sig = json.loads(signal_path.read_text(encoding="utf-8"))
+            gen = str(sig.get("generated_at") or "")[:10]
+            age_days = None
+            try:
+                age_days = (_dt.date.today()
+                            - _dt.date.fromisoformat(gen)).days
+            except ValueError:
+                pass
+            execution_health["signal"] = {
+                "generated_at": sig.get("generated_at"),
+                "age_days": age_days,
+                "action": sig.get("action"),
+                "symbol": (sig.get("trade") or {}).get("snaptrade_symbol"),
+                "stale": bool(age_days is not None and age_days > 1),
+            }
+        except (json.JSONDecodeError, OSError):
+            pass
+    shadow_path = mit_dir / "shadow_ledger.json"
+    if shadow_path.exists():
+        try:
+            ledger = json.loads(shadow_path.read_text(encoding="utf-8"))
+            orders = ledger.get("orders") or []
+            decisions: Dict[str, int] = {}
+            for o in orders:
+                d = str(o.get("decision") or "?")
+                decisions[d] = decisions.get(d, 0) + 1
+            round_trips = [
+                o.get("shadow_return_pct") for o in orders
+                if o.get("decision") == "would_sell"
+                and isinstance(o.get("shadow_return_pct"), (int, float))
+            ]
+            execution_health["shadow"] = {
+                "orders": len(orders),
+                "decisions": decisions,
+                "round_trips": len(round_trips),
+                "avg_round_trip_pct": (
+                    round(sum(round_trips) / len(round_trips), 3)
+                    if round_trips else None),
+                "last_logged_at": orders[-1].get("logged_at") if orders else None,
+            }
+        except (json.JSONDecodeError, OSError):
+            pass
+
     return {
         "available": True,
         "summary": tracker.get("summary") or {},
@@ -1551,6 +1604,7 @@ def aggregate_mit_performance(root: Path) -> Dict[str, Any]:
         "lessons_learned": lessons_active,
         "taught_lessons_hot": taught_hot,
         "sector_concentration_warning": concentration_warning,
+        "execution_health": execution_health,
         "last_updated": (tracker.get("metadata") or {}).get("last_updated"),
     }
 

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -533,6 +533,13 @@ def post_generate(config, *, digest_text: str = "", episode_num: int | None = No
             trade["sector"] = _classify_sector(
                 trade.get("symbol", ""), trade.get("strategy", ""), trade.get("market", ""),
             )
+        # Stop-loss capture (July 2026): store the narrated stop so the
+        # close-time evaluation can ENFORCE it (and the future live layer
+        # can attach it to a bracket order). None when unparseable — the
+        # sim never invents a stop the show didn't state.
+        stop = _extract_stop_loss(digest_text)
+        if stop:
+            trade["stop_loss"] = stop
         # Rule-effectiveness stamping (July 2026): record which
         # recursive-improvement rules were shown to the model when it made
         # this pick. Read BEFORE today's lesson is appended below, so the
@@ -781,14 +788,17 @@ def _trade_symbol_candidates(trade: dict) -> list[str]:
     return _yf_symbol_candidates(trade.get("symbol", ""), trade.get("market", ""))
 
 
-def _bars_from_history(hist) -> list[tuple[datetime.date, float, float]]:
-    """Convert a yfinance history frame to ``[(bar_date, open, close)]``.
+def _bars_from_history(hist) -> list[tuple]:
+    """Convert a yfinance history frame to ``[(bar_date, open, close, low)]``.
 
     Bars with a non-finite open or close are dropped — yfinance returns
     NaN floats for halted/missing bars (the DELL/HIMS shape) and a NaN
-    must never become an entry or exit price.
+    must never become an entry or exit price. The intraday ``low`` (July
+    2026 stop-enforcement pass) is best-effort: ``None`` when the column
+    is missing/NaN, and every consumer treats bars as len>=3 tuples so
+    3-tuple fixtures keep working.
     """
-    bars: list[tuple[datetime.date, float, float]] = []
+    bars: list[tuple] = []
     if hist is None or getattr(hist, "empty", True):
         return bars
     for idx, row in hist.iterrows():
@@ -799,9 +809,22 @@ def _bars_from_history(hist) -> list[tuple[datetime.date, float, float]]:
             continue
         if not (math.isfinite(open_) and math.isfinite(close)):
             continue
+        try:
+            low = float(row["Low"])
+            if not math.isfinite(low):
+                low = None
+        except (KeyError, TypeError, ValueError):
+            low = None
         bar_date = idx.date() if hasattr(idx, "date") else idx
-        bars.append((bar_date, open_, close))
+        bars.append((bar_date, open_, close, low))
     return bars
+
+
+def _bar_low(bar) -> float | None:
+    """Intraday low of a bar tuple; None for legacy 3-tuple bars."""
+    if len(bar) > 3 and isinstance(bar[3], (int, float)):
+        return bar[3]
+    return None
 
 
 def _fetch_history_bars(
@@ -956,6 +979,7 @@ def _write_trade_signal(
             "pick_date": trade.get("date", today_iso),
             "pick_reference_price": trade.get("pick_reference_price"),
             "pick_validated": bool(trade.get("pick_reference_price")),
+            "stop_loss": trade.get("stop_loss"),
             "currency": "CAD" if is_canadian else "USD",
             "suggested_account": "wealthsimple" if is_canadian else "webull",
             "client_order_id": str(uuid.uuid5(_SIGNAL_ORDER_NAMESPACE, seed)),
@@ -1009,6 +1033,70 @@ def _pick_weekly_bars(bars, pick_date):
     if not window:
         return None, None
     return window[0], window[-1]
+
+
+_STOP_PRICE_RE = re.compile(
+    r"stop[- ]?loss[^.\n%$]{0,60}?\$\s*([\d,]+(?:\.\d+)?)", re.IGNORECASE)
+_STOP_PCT_RE = re.compile(
+    r"stop[- ]?loss[^.\n%$]{0,60}?(\d{1,2}(?:\.\d+)?)\s*%", re.IGNORECASE)
+
+
+def _extract_stop_loss(digest_text: str) -> dict | None:
+    """Pull the narrated stop-loss from the Practice Investment section.
+
+    July 2026 fidelity pass: the digest states a stop-loss level in every
+    Risk Assessment, but the sim never enforced it — losers rode to the
+    scheduled exit while the show TAUGHT stop discipline. Returns
+    ``{"price": x}`` or ``{"pct": y}`` (percent below entry), or ``None``
+    when no parseable stop exists (enforcement simply doesn't apply —
+    never guess one).
+    """
+    if not digest_text:
+        return None
+    # Scope to the Practice Investment block when present so a stop
+    # mentioned in the education section can't leak onto the trade.
+    section = digest_text
+    m = re.search(r"### Practice Investment.*?(?=\n### |\Z)", digest_text,
+                  re.DOTALL | re.IGNORECASE)
+    if m:
+        section = m.group(0)
+    price_m = _STOP_PRICE_RE.search(section)
+    if price_m:
+        try:
+            return {"price": float(price_m.group(1).replace(",", ""))}
+        except ValueError:
+            pass
+    pct_m = _STOP_PCT_RE.search(section)
+    if pct_m:
+        try:
+            pct = float(pct_m.group(1))
+            if 0 < pct < 50:
+                return {"pct": pct}
+        except ValueError:
+            pass
+    return None
+
+
+def _stop_breach(bars, entry_bar, exit_bar, stop_price: float):
+    """First bar in (entry, exit] whose low (or close) breaches the stop.
+
+    Returns ``(bar_date, exit_price)`` or ``None``. Gap-aware: a bar that
+    OPENS below the stop fills at its open (a real stop order can't fill
+    better than the gap), otherwise the stop price itself is used. The
+    entry bar is excluded — intraday ordering within the entry bar is
+    unknowable from daily data, so same-day breaches are not claimed.
+    """
+    if stop_price is None or entry_bar is None or exit_bar is None:
+        return None
+    for bar in bars:
+        if bar[0] <= entry_bar[0] or bar[0] > exit_bar[0]:
+            continue
+        low = _bar_low(bar)
+        probe = low if low is not None else bar[2]
+        if probe <= stop_price:
+            fill = min(stop_price, bar[1])  # gap-through fills at the open
+            return bar[0], round(fill, 2)
+    return None
 
 
 def _trade_pick_date(trade: dict) -> datetime.date | None:
@@ -1119,8 +1207,33 @@ def _close_trade(trade: dict, tracker: dict) -> None:
         trade["lesson"] = "Trade voided — market data was unavailable for evaluation."
         return
 
-    entry_date, entry_price, _ = entry_bar[0], entry_bar[1], entry_bar[2]
+    entry_date, entry_price = entry_bar[0], entry_bar[1]
     exit_date, exit_price = exit_bar[0], exit_bar[2]
+
+    # Stop-loss enforcement (July 2026 fidelity pass): the digest narrates
+    # a stop on every pick but the sim let losers ride to the scheduled
+    # exit. If the pick carried a parseable stop and any bar between entry
+    # and scheduled exit breached it, the trade closes AT THE STOP on the
+    # breach day (gap-aware) — matching what the show tells listeners it
+    # would do, and what a live bracket order will actually do.
+    stop = trade.get("stop_loss")
+    if isinstance(stop, dict) and bars:
+        stop_price = None
+        if isinstance(stop.get("price"), (int, float)):
+            stop_price = float(stop["price"])
+        elif isinstance(stop.get("pct"), (int, float)):
+            stop_price = round(entry_price * (1 - float(stop["pct"]) / 100), 2)
+        # Sanity: a "stop" at/above entry is a parse artifact — ignore it.
+        if stop_price is not None and 0 < stop_price < entry_price:
+            breach = _stop_breach(bars, entry_bar, exit_bar, stop_price)
+            if breach:
+                exit_date, exit_price = breach
+                trade["stopped_out"] = True
+                trade["stop_price"] = stop_price
+                logger.info(
+                    "STOP ENFORCED for %s: breached %s, exit at $%.2f",
+                    symbol, exit_date, exit_price,
+                )
 
     pnl_pct = ((exit_price - entry_price) / entry_price) * 100
     position_size = tracker["metadata"].get("position_size", 1000)
@@ -1211,6 +1324,18 @@ def _recompute_summary(tracker: dict) -> None:
     ]
     cum_alpha = sum(alphas)
 
+    # Statistical significance of the per-trade alpha (July 2026): "are
+    # we beating the index?" needs "…and is that distinguishable from
+    # luck?". One-sample t-stat on per-trade alpha; |t| >= 2 ≈ 95%
+    # confidence the true mean isn't zero. Spoken honestly either way.
+    alpha_t_stat = None
+    if len(alphas) >= 2:
+        mean_alpha = sum(alphas) / len(alphas)
+        variance = sum((a - mean_alpha) ** 2 for a in alphas) / (len(alphas) - 1)
+        std = variance ** 0.5
+        if std > 0:
+            alpha_t_stat = round(mean_alpha / (std / len(alphas) ** 0.5), 2)
+
     # Matched-window compounded score (July 2026 review): the honest
     # "are the picks beating the NASDAQ?" number. Compounds each
     # benchmarked trade's return against the index's return over the SAME
@@ -1299,6 +1424,9 @@ def _recompute_summary(tracker: dict) -> None:
         "benchmark_scores": benchmark_scores,
         "indices_beaten": indices_beaten,
         "indices_scored": len(benchmark_scores),
+        "alpha_t_stat": alpha_t_stat,
+        "alpha_statistically_significant": bool(
+            alpha_t_stat is not None and alpha_t_stat >= 2.0),
         "current_streak": current_streak,
         "longest_win_streak": longest_win,
         "longest_loss_streak": longest_loss,
@@ -1731,8 +1859,17 @@ def _build_trade_review(tracker: dict, episode_num: int | None = None) -> str:
         )
 
     direction = "gained" if pnl_pct >= 0 else "lost"
+    stop_note = ""
+    if last.get("stopped_out"):
+        stop_note = (
+            f"**Stopped out:** the narrated stop-loss "
+            f"(${_finite(last.get('stop_price')):.2f}) was breached and the "
+            f"position exited at the stop — say so plainly; stop discipline "
+            f"working as designed is a teachable win.\n"
+        )
     return (
         f"**Last {type_label}:** {symbol} — {strategy}\n"
+        f"{stop_note}"
         f"**Entry:** ${entry:.2f} ({entry_label}) → **Exit:** ${exit_:.2f} ({exit_label})\n"
         f"**Result:** {direction} {abs(pnl_pct):.2f}% (${pnl_dollars:+.2f} on $1,000 position)\n"
         f"**Running Total:** ${summary.get('cumulative_pnl', 0):.2f} across "
@@ -1805,6 +1942,23 @@ def _build_benchmark_block(tracker: dict) -> str:
                 + ". NASDAQ stays the headline benchmark; mention the sweep "
                   "at most once per episode. "
             )
+        t_stat = summary.get("alpha_t_stat")
+        if t_stat is not None:
+            if summary.get("alpha_statistically_significant"):
+                matched_line += (
+                    f"STATISTICAL CONFIDENCE: per-trade alpha t-stat "
+                    f"{t_stat:+.2f} across {matched_n} trades — the edge is "
+                    f"statistically meaningful (~95%+); you may say the "
+                    f"record shows genuine outperformance. "
+                )
+            else:
+                matched_line += (
+                    f"STATISTICAL CONFIDENCE: per-trade alpha t-stat "
+                    f"{t_stat:+.2f} across {matched_n} trades — NOT yet "
+                    f"statistically distinguishable from luck; if the "
+                    f"episode claims outperformance, say 'early and not yet "
+                    f"statistically significant' in the same breath. "
+                )
     return (
         f"NASDAQ Composite ^IXIC: {close:,.0f} "
         f"(YTD {_sign(bench_ytd)}, since inception {_sign(bench_itd)}).\n"

--- a/tests/test_dashboard_mit_section.py
+++ b/tests/test_dashboard_mit_section.py
@@ -213,3 +213,54 @@ class TestBuildDashboardIntegration:
         result = build_dashboard(tmp_path, offline=True)
         assert "mit_performance" in result
         assert result["mit_performance"]["available"] is True
+
+
+class TestExecutionHealth:
+    """July 2026 live-trading prep: the dashboard surfaces signal
+    freshness + shadow-ledger vitals so the operator sees at a glance
+    whether the execution bridge artifacts are flowing."""
+
+    def test_execution_health_none_when_artifacts_missing(self, tmp_path: Path):
+        root = _write_mit(tmp_path, tracker={
+            "metadata": {}, "summary": {}, "trades": [],
+        })
+        result = aggregate_mit_performance(root)
+        assert result["execution_health"] == {"signal": None, "shadow": None}
+
+    def test_signal_freshness_and_staleness(self, tmp_path: Path):
+        root = _write_mit(tmp_path, tracker={
+            "metadata": {}, "summary": {}, "trades": [],
+        })
+        mit_dir = root / "digests" / "modern_investing"
+        (mit_dir / "trade_signal_latest.json").write_text(json.dumps({
+            "schema_version": 1, "generated_at": "2020-01-01",
+            "action": "new_trade",
+            "trade": {"snaptrade_symbol": "CNR.TO"},
+        }), encoding="utf-8")
+        result = aggregate_mit_performance(root)
+        sig = result["execution_health"]["signal"]
+        assert sig["action"] == "new_trade"
+        assert sig["symbol"] == "CNR.TO"
+        assert sig["stale"] is True  # ancient signal must be flagged
+
+    def test_shadow_ledger_vitals(self, tmp_path: Path):
+        root = _write_mit(tmp_path, tracker={
+            "metadata": {}, "summary": {}, "trades": [],
+        })
+        mit_dir = root / "digests" / "modern_investing"
+        (mit_dir / "shadow_ledger.json").write_text(json.dumps({
+            "schema_version": 1, "mode": "shadow", "orders": [
+                {"decision": "would_place", "logged_at": "2026-07-06T13:50:00+00:00"},
+                {"decision": "skipped", "logged_at": "2026-07-07T13:50:00+00:00"},
+                {"decision": "would_sell", "shadow_return_pct": 2.5,
+                 "logged_at": "2026-07-10T13:50:00+00:00"},
+            ],
+        }), encoding="utf-8")
+        result = aggregate_mit_performance(root)
+        sh = result["execution_health"]["shadow"]
+        assert sh["orders"] == 3
+        assert sh["decisions"] == {"would_place": 1, "skipped": 1,
+                                   "would_sell": 1}
+        assert sh["round_trips"] == 1
+        assert sh["avg_round_trip_pct"] == 2.5
+        assert sh["last_logged_at"] == "2026-07-10T13:50:00+00:00"

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -763,3 +763,164 @@ class TestPerformancePageMultiIndex:
         assert "Buy-and-Hold Gap vs NASDAQ" in src
         assert "not capital-matched" in src
         assert "Major-Index Sweep" in src
+
+
+# ---------------------------------------------------------------------------
+# Stop-loss enforcement (July 2026 fidelity pass)
+# ---------------------------------------------------------------------------
+
+_BARS_WITH_LOWS = [
+    (datetime.date(2026, 6, 29), 102.0, 103.0, 101.5),  # Mon
+    (datetime.date(2026, 6, 30), 103.5, 104.0, 103.0),  # Tue
+    (datetime.date(2026, 7, 1), 104.5, 96.0, 94.0),     # Wed — plunge
+    (datetime.date(2026, 7, 2), 95.5, 97.0, 95.0),      # Thu
+]
+
+
+class TestStopLossExtraction:
+    def test_dollar_stop_extracted(self):
+        digest = ("### Practice Investment of the Day\n"
+                  "**Risk Assessment:** Momentum could fade; stop-loss at "
+                  "$98.50, max acceptable loss 4%.\n")
+        assert mi._extract_stop_loss(digest) == {"price": 98.5}
+
+    def test_percent_stop_extracted(self):
+        digest = ("### Practice Investment of the Day\n"
+                  "**Risk Assessment:** Set a stop-loss of 5% below entry.\n")
+        assert mi._extract_stop_loss(digest) == {"pct": 5.0}
+
+    def test_no_stop_returns_none_never_guesses(self):
+        digest = ("### Practice Investment of the Day\n"
+                  "**Risk Assessment:** Volatility is elevated.\n")
+        assert mi._extract_stop_loss(digest) is None
+
+    def test_stop_outside_practice_section_ignored(self):
+        digest = ("### Investor Education\n"
+                  "A stop-loss at $50 protects capital.\n"
+                  "### Practice Investment of the Day\n"
+                  "**Risk Assessment:** thesis intact.\n")
+        assert mi._extract_stop_loss(digest) is None
+
+
+class TestStopBreach:
+    def test_breach_fills_at_stop_price(self):
+        entry_bar, exit_bar = _BARS_WITH_LOWS[0], _BARS_WITH_LOWS[-1]
+        breach = mi._stop_breach(_BARS_WITH_LOWS, entry_bar, exit_bar, 97.0)
+        assert breach == (datetime.date(2026, 7, 1), 97.0)
+
+    def test_gap_through_stop_fills_at_open(self):
+        bars = [
+            (datetime.date(2026, 6, 29), 102.0, 103.0, 101.5),
+            (datetime.date(2026, 6, 30), 90.0, 92.0, 89.0),  # gaps below stop
+        ]
+        breach = mi._stop_breach(bars, bars[0], bars[-1], 97.0)
+        assert breach == (datetime.date(2026, 6, 30), 90.0)  # open, not stop
+
+    def test_entry_bar_never_claims_same_day_breach(self):
+        bars = [(datetime.date(2026, 6, 29), 102.0, 103.0, 90.0)]
+        assert mi._stop_breach(bars, bars[0], bars[0], 97.0) is None
+
+    def test_no_breach_returns_none(self):
+        entry_bar, exit_bar = _BARS_WITH_LOWS[0], _BARS_WITH_LOWS[1]
+        assert mi._stop_breach(
+            _BARS_WITH_LOWS[:2], entry_bar, exit_bar, 90.0) is None
+
+    def test_close_trade_enforces_stop(self):
+        trade = {
+            "symbol": "GIS", "market": "NYSE", "trade_type": "weekly",
+            "date": "2026-06-29", "stop_loss": {"pct": 4.0},
+        }
+        with patch.object(mi, "_fetch_bars_for_trade",
+                          return_value=_BARS_WITH_LOWS), \
+             patch.object(mi, "_fetch_history_bars",
+                          return_value=_BARS_WITH_LOWS):
+            mi._close_trade(trade, {"metadata": {"position_size": 1000},
+                                    "trades": [], "summary": {}})
+        assert trade["stopped_out"] is True
+        # stop = 102 * 0.96 = 97.92; breached Wed (low 94), fills at stop.
+        assert trade["exit_price"] == 97.92
+        assert trade["exit_bar_date"] == "2026-07-01"
+        # Benchmark window matches the ACTUAL shortened holding period.
+        assert trade["nasdaq_exit_date"] == "2026-07-01"
+
+    def test_close_trade_without_stop_unchanged(self):
+        trade = {
+            "symbol": "GIS", "market": "NYSE", "trade_type": "weekly",
+            "date": "2026-06-29",
+        }
+        with patch.object(mi, "_fetch_bars_for_trade",
+                          return_value=_BARS_WITH_LOWS), \
+             patch.object(mi, "_fetch_history_bars",
+                          return_value=_BARS_WITH_LOWS):
+            mi._close_trade(trade, {"metadata": {"position_size": 1000},
+                                    "trades": [], "summary": {}})
+        assert "stopped_out" not in trade
+        assert trade["exit_bar_date"] == "2026-07-02"
+
+    def test_review_narrates_stop_out(self):
+        tracker = {
+            "metadata": {"position_size": 1000},
+            "trades": [{
+                "symbol": "GIS", "status": "closed", "trade_type": "weekly",
+                "strategy": "earnings play", "entry_price": 102.0,
+                "exit_price": 97.92, "pnl_pct": -4.0, "pnl_dollars": -40.0,
+                "stopped_out": True, "stop_price": 97.92,
+                "entry_bar_date": "2026-06-29", "exit_bar_date": "2026-07-01",
+            }],
+            "summary": {"cumulative_pnl": 0.0, "total_trades": 1, "wins": 0,
+                        "win_rate_pct": 0.0, "current_streak": -1},
+        }
+        review = mi._build_trade_review(tracker, episode_num=101)
+        assert "Stopped out" in review
+        assert "$97.92" in review
+
+
+class TestAlphaTStat:
+    def _closed(self, alpha):
+        return {"status": "closed", "pnl_pct": alpha, "pnl_dollars": alpha,
+                "alpha_pct": alpha, "nasdaq_return_pct": 0.0}
+
+    def test_consistent_edge_is_significant(self):
+        # 10 trades, alpha ~ +1% with tiny spread → t >> 2.
+        tracker = {"metadata": {"position_size": 1000}, "summary": {},
+                   "trades": [self._closed(1.0 + 0.01 * i) for i in range(10)]}
+        mi._recompute_summary(tracker)
+        assert tracker["summary"]["alpha_t_stat"] > 2
+        assert tracker["summary"]["alpha_statistically_significant"] is True
+
+    def test_noisy_record_is_not_significant(self):
+        tracker = {"metadata": {"position_size": 1000}, "summary": {},
+                   "trades": [self._closed(a) for a in
+                              (5.0, -4.0, 3.0, -3.5, 4.0, -4.2)]}
+        mi._recompute_summary(tracker)
+        assert tracker["summary"]["alpha_statistically_significant"] is False
+
+    def test_block_tells_the_model_to_hedge_when_not_significant(self):
+        tracker = mi._fresh_tracker()
+        tracker["benchmark"] = {"current_close": 25000.0, "ytd_pct": 11.0,
+                                "inception_to_date_pct": 15.0,
+                                "last_updated": "2026-07-04"}
+        tracker["summary"] = {
+            "matched_window_alpha_pct": 3.0, "matched_window_trades": 12,
+            "compounded_return_pct": 5.0,
+            "compounded_nasdaq_matched_pct": 2.0,
+            "alpha_t_stat": 0.9, "alpha_statistically_significant": False,
+        }
+        block = mi._build_benchmark_block(tracker)
+        assert "NOT yet statistically distinguishable from luck" in block
+
+    def test_signal_carries_stop_loss(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("NERRA_HOOKS_READONLY", raising=False)
+        config = SimpleNamespace(episode=SimpleNamespace(output_dir=str(tmp_path)))
+        digest = ("### Practice Investment of the Day\n"
+                  "**Trade Type:** Flash Trade\n"
+                  "**Today's Pick:** NVDA — Nvidia\n"
+                  "**Market:** NASDAQ\n"
+                  "**Strategy:** Momentum play\n"
+                  "**Risk Assessment:** stop-loss at $190.00.\n"
+                  "**Confidence Level:** High\n")
+        with patch.object(mi, "_probe_pick", return_value=True):
+            mi.post_generate(config, digest_text=digest, episode_num=102)
+        signal = json.loads(
+            (tmp_path / mi.TRADE_SIGNAL_LATEST_FILENAME).read_text())
+        assert signal["trade"]["stop_loss"] == {"price": 190.0}

--- a/tests/test_mit_quality_pass.py
+++ b/tests/test_mit_quality_pass.py
@@ -111,7 +111,9 @@ class TestNaNImmunity:
                 yield _FakeIdx(datetime.date(2026, 6, 1)), {"Open": 430.0, "Close": 432.5}
 
         bars = mi._bars_from_history(_FakeHist())
-        assert bars == [(datetime.date(2026, 6, 1), 430.0, 432.5)]
+        # July 2026 stop-enforcement pass: bars carry a best-effort 4th
+        # element (intraday low; None when the column is absent).
+        assert bars == [(datetime.date(2026, 6, 1), 430.0, 432.5, None)]
 
     def test_sector_exposure_finite(self):
         tracker = _tracker_with_trades([


### PR DESCRIPTION
# TLDR

Third improvement batch on the MIT trading loop — this one closes the gap between what the show *says* it does and what the sim *actually* does:

1. **Stop-losses are now enforced.** The digest narrates a stop-loss in every Risk Assessment, but the sim let losers ride to the scheduled exit while the show taught stop discipline. The narrated stop is now parsed at pick time (dollar or percent form, scoped to the Practice Investment section — never guessed when unparseable), stored on the trade **and in the trade signal** (the future live layer attaches it to a bracket order), and enforced at evaluation against intraday lows: first breach bar after entry exits **at the stop**, gap-through days fill at the open (a real stop can't beat a gap), entry-bar breaches are never claimed (intraday ordering is unknowable from daily bars), and the benchmark window follows the shortened holding period. The trade review narrates "stopped out" as discipline working.
2. **Statistical honesty on the alpha.** The summary now carries a one-sample **t-stat on per-trade alpha** (`alpha_statistically_significant` at t≥2 ≈ 95%). The scoreboard block instructs the model: while the edge isn't statistically distinguishable from luck, any outperformance claim must carry an "early, not yet significant" hedge — and once it is significant, it may be said plainly. "Beat the indices regularly" now has a defensible statistical test attached, on air.
3. **Execution health on the dashboard.** `aggregate_mit_performance` gains an `execution_health` block: trade-signal freshness (age + stale flag + action/symbol) and shadow-ledger vitals (decision counts, round trips, average round-trip return, last activity) — one glance tells you whether the bridge artifacts are flowing.

# ⚠️ A/B-listen required (landmine #17)

- **Stop enforcement changes sim outcomes going forward** (some scheduled-exit losses become smaller stop-outs; some would-be recoveries become realized stops). Historical trades are untouched.
- The significance-hedge line and stopped-out narration are new prompt context — listen to the next 1–2 episodes.

# Test results

- New drift guards: `TestStopLossExtraction` (4), `TestStopBreach` (7 — gap fills, entry-bar exclusion, benchmark-window follow), `TestAlphaTStat` (4), `TestExecutionHealth` (3), signal `stop_loss` field.
- **319 passed, 1 skipped** across the touched suites; `ruff` clean on the CI scope; performance page dry-run renders.

# Deferred (ledger, with predictions)

Same-day (entry-bar) stop breaches — unknowable from daily bars; carried items: shadow-slippage → sim cost model (~20 round trips), recompute `--apply` (operator), closing-price lesson retirement (operator A/B). Ledger predictions added: ≥70% of new picks carry a parsed stop; outperformance claims are hedged while t<2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKwLmJRykLH8oFskoXiVVp

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKwLmJRykLH8oFskoXiVVp)_