### PR TITLE
DP Pod: operator CLI for the Dispatch Wall + Ep001 v5 verification

### DIFF
--- a/scripts/add_dp_dispatch.py
+++ b/scripts/add_dp_dispatch.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Operator tooling for The DP Pod's Dispatch Wall.
+
+Appends a REAL listener dispatch to ``digests/dp_pod/dispatches.json`` — the
+operator-curated file the club page's Dispatch Wall renders from — without
+hand-editing JSON. Per the club charter the wall is never generated or
+fabricated: this script exists so curating real listener mail is a one-liner,
+and it validates the entry shape the page collector expects
+(``generate_html._collect_dp_dispatches``).
+
+Usage examples:
+    # Minimal — what they did is the only required field
+    python scripts/add_dp_dispatch.py --did "Sealed the three worst drafts in my house."
+
+    # Full entry, as read on air
+    python scripts/add_dp_dispatch.py \
+        --name "Sarah, Calgary" \
+        --did "Sealed the three worst drafts in my house before the cold snap." \
+        --numbers "\$14 in foam tape, about 2 hours, roughly \$90 a year saved" \
+        --shoutout "My dad held the ladder." \
+        --episode 3
+
+    # View the current wall
+    python scripts/add_dp_dispatch.py --show
+
+Then commit the file and the wall updates on the next site regen (nightly, or
+``python generate_html.py --show dp_pod``).
+"""
+
+import argparse
+import json
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DISPATCHES_PATH = ROOT / "digests" / "dp_pod" / "dispatches.json"
+
+
+def _load() -> dict:
+    if not DISPATCHES_PATH.exists():
+        return {"dispatches": []}
+    data = json.loads(DISPATCHES_PATH.read_text(encoding="utf-8"))
+    if isinstance(data, list):  # tolerate a bare-list file
+        data = {"dispatches": data}
+    data.setdefault("dispatches", [])
+    return data
+
+
+def _show(data: dict) -> None:
+    entries = data.get("dispatches", [])
+    if not entries:
+        print("Dispatch Wall is empty — the page renders its how-to-send state.")
+        return
+    print(f"{len(entries)} dispatch(es) on the wall (newest first on the page):\n")
+    for e in sorted(entries, key=lambda d: d.get("date") or "", reverse=True):
+        name = e.get("name") or "A club member"
+        when = f"  ({e['date']})" if e.get("date") else ""
+        print(f"- {name}{when}: {e.get('did', '')}")
+        if e.get("numbers"):
+            print(f"    numbers: {e['numbers']}")
+        if e.get("shoutout"):
+            print(f"    shoutout: {e['shoutout']}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    ap.add_argument("--did", help="What they did (required to add; plain sentence)")
+    ap.add_argument("--name", default="", help='How to credit them, e.g. "Sarah, Calgary"')
+    ap.add_argument("--numbers", default="", help="The honest numbers line (cost/hours/impact)")
+    ap.add_argument("--shoutout", default="", help="Who helped, or who should try it next")
+    ap.add_argument("--episode", type=int, default=None,
+                    help="Episode number whose Lever this answers (optional)")
+    ap.add_argument("--date", default=None,
+                    help="YYYY-MM-DD received date (default: today)")
+    ap.add_argument("--show", action="store_true", help="Print the current wall and exit")
+    args = ap.parse_args()
+
+    data = _load()
+
+    if args.show:
+        _show(data)
+        return
+
+    if not args.did or not args.did.strip():
+        ap.error("--did is required (or pass --show to view the wall)")
+
+    when = args.date or date.today().isoformat()
+    try:
+        date.fromisoformat(when)
+    except ValueError:
+        raise SystemExit(f"--date must be YYYY-MM-DD, got: {when!r}")
+
+    entry = {"date": when, "did": args.did.strip()}
+    if args.name.strip():
+        entry["name"] = args.name.strip()
+    if args.numbers.strip():
+        entry["numbers"] = args.numbers.strip()
+    if args.shoutout.strip():
+        entry["shoutout"] = args.shoutout.strip()
+    if args.episode is not None:
+        entry["episode_num"] = args.episode
+
+    # Guard against accidental double-adds of the same mail.
+    for existing in data["dispatches"]:
+        if existing.get("did") == entry["did"] and existing.get("name", "") == entry.get("name", ""):
+            raise SystemExit(
+                "An identical dispatch (same name + did) is already on the wall — not adding."
+            )
+
+    data["dispatches"].append(entry)
+    DISPATCHES_PATH.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    who = entry.get("name", "A club member")
+    print(f"Added dispatch from {who} ({when}). Wall now has {len(data['dispatches'])} entry(ies).")
+    print("Commit digests/dp_pod/dispatches.json — the wall updates on the next site regen.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dp_pod_show.py
+++ b/tests/test_dp_pod_show.py
@@ -596,3 +596,34 @@ class TestCommunityLayer:
         assert "{% if dp_dispatches %}" in tpl
         assert "{% if dp_mindsets %}" in tpl
         assert "The shelf opens with Episode 1" in tpl
+
+    def test_operator_dispatch_cli_round_trips(self, tmp_path, monkeypatch):
+        # scripts/add_dp_dispatch.py writes entries the page collector reads —
+        # pin the round-trip so the two never drift apart.
+        import importlib.util
+        import json as _json
+
+        spec = importlib.util.spec_from_file_location(
+            "add_dp_dispatch", PROJECT_ROOT / "scripts" / "add_dp_dispatch.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        wall = tmp_path / "digests" / "dp_pod" / "dispatches.json"
+        wall.parent.mkdir(parents=True)
+        wall.write_text(_json.dumps({"dispatches": []}), encoding="utf-8")
+        monkeypatch.setattr(mod, "DISPATCHES_PATH", wall)
+        monkeypatch.setattr(
+            sys, "argv",
+            ["add_dp_dispatch.py", "--name", "Sarah, Calgary",
+             "--did", "Sealed three drafts.", "--numbers", "$14, 2h",
+             "--date", "2026-07-10", "--episode", "3"],
+        )
+        mod.main()
+
+        import generate_html as gh
+        monkeypatch.setattr(gh, "ROOT", tmp_path)
+        dispatches = gh._collect_dp_dispatches()
+        assert len(dispatches) == 1
+        assert dispatches[0]["name"] == "Sarah, Calgary"
+        assert dispatches[0]["numbers"] == "$14, 2h"
+        assert dispatches[0]["episode_num"] == 3


### PR DESCRIPTION
## Summary

Follow-up to #768: the operational piece the Dispatch Wall was missing, plus the verification record for the regenerated Episode 1.

### scripts/add_dp_dispatch.py

Curating real listener dispatches is the Dispatch Wall's bottleneck — this makes it a one-liner instead of hand-editing `digests/dp_pod/dispatches.json` (same operator-tooling pattern as `scripts/update_tesla_narrative.py`):

```bash
python scripts/add_dp_dispatch.py --name "Sarah, Calgary" \
  --did "Sealed the three worst drafts before the cold snap." \
  --numbers "$14 in foam tape, 2 hours, ~$90/yr saved" \
  --shoutout "My dad held the ladder." --episode 3
python scripts/add_dp_dispatch.py --show   # view the wall
```

Validates the entry shape the page collector expects, guards against double-adding the same mail, defaults the date to today. A round-trip drift guard (CLI writes → `_collect_dp_dispatches` reads) was added to `TestCommunityLayer`.

### Ep001 v5 verification (run 28691407474, commit e5bd18c)

All three #768 fixes verified against the shipped artifacts:

| v4 defect | v5 result |
|---|---|
| Digest paraphrase-duplication wall | **0** near-duplicate sentence pairs across 51 digest sentences |
| Raw markdown header spoken as hook | Spoken opening is the clean hook sentence ("Two friends built a fourteen-show daily network…") — the sanitized fallback caught the LLM's blockquote-style hook |
| Lever chapter stolen at 74 s | Lever at **400 s**, full 6-chapter shape in order (Cold Open 20s → Positive Papers 87s → Think Positive 355s → Lever 400s → Dispatch 428s → Sign-Off 465s) |

Render quality: 41 labeled turns (Dan 20 / Patrick 21, max 2 same-speaker in a row), 0 tag leaks, 0 single-voice fallback, dual-voice AI disclosure, sign-off "Do something about it.", full song appended after the closing. Whisper transcript scan: no "Fast." leaks, no spoken labels, no scaffold echoes.

Known shortfall (existing digest-ceiling class, no code change): script shipped 1,294 words vs the 1,550 target (~8 min of dialogue before the song).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXEvkULRuFNLXEHb3rkvnc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXEvkULRuFNLXEHb3rkvnc)_