### PR TITLE
MIT Phase 3: live executor (Wealthsimple/Webull via SnapTrade) — shipped dormant behind the kill switch

### DIFF
--- a/.github/workflows/mit-live-executor.yml
+++ b/.github/workflows/mit-live-executor.yml
@@ -1,0 +1,75 @@
+name: MIT Live Executor
+
+# Phase 3 of docs/mit_snaptrade_live_trading_plan.md — DORMANT BY DEFAULT.
+# Places real micro-live orders ONLY when the repository variable
+# LIVE_TRADING_ENABLED is "1" AND the SNAPTRADE_* secrets are set AND all
+# risk gates pass. While dormant every run is a logged clean no-op.
+# Morning slot places at most one entry from today's signal; the
+# afternoon slot (~15:45 ET) sells positions due on the sim's calendar.
+# Committed state carries only the halt flag + id-level order index; the
+# full ledger is gitignored and uploaded as an artifact.
+
+on:
+  schedule:
+    - cron: '52 13 * * 1-5'   # 13:52 UTC ≈ 9:52 ET — entries
+    - cron: '45 19 * * 1-5'   # 19:45 UTC ≈ 3:45 PM ET — exits
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: mit-live-executor
+  cancel-in-progress: false
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install requests yfinance snaptrade-python-sdk
+
+      - name: Determine slot
+        id: slot
+        run: |
+          if [ "${{ github.event.schedule }}" = "52 13 * * 1-5" ]; then
+            echo "mode=--entries" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event.schedule }}" = "45 19 * * 1-5" ]; then
+            echo "mode=--exits" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=" >> "$GITHUB_OUTPUT"   # dispatch: both
+          fi
+
+      - name: Run live executor
+        env:
+          LIVE_TRADING_ENABLED: ${{ vars.LIVE_TRADING_ENABLED }}
+          MIT_MAX_POSITION_USD: ${{ vars.MIT_MAX_POSITION_USD }}
+          SNAPTRADE_CLIENT_ID: ${{ secrets.SNAPTRADE_CLIENT_ID }}
+          SNAPTRADE_CONSUMER_KEY: ${{ secrets.SNAPTRADE_CONSUMER_KEY }}
+          SNAPTRADE_USER_ID: ${{ secrets.SNAPTRADE_USER_ID }}
+          SNAPTRADE_USER_SECRET: ${{ secrets.SNAPTRADE_USER_SECRET }}
+          NOTIFICATION_WEBHOOK_URL: ${{ secrets.NOTIFICATION_WEBHOOK_URL }}
+        run: python scripts/mit_live_executor.py ${{ steps.slot.outputs.mode }}
+
+      - name: Upload full ledger artifact
+        if: hashFiles('digests/modern_investing/live_ledger.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-ledger
+          path: digests/modern_investing/live_ledger.json
+          retention-days: 90
+
+      - name: Commit execution state (id-level index only)
+        uses: ./.github/actions/safe-commit-push
+        with:
+          add-paths: digests/modern_investing/live_execution_state.json
+          commit-message: "MIT live executor state: ${{ github.run_id }}"

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ workers/**/dist/
 # SnapTrade live-account mirror — the repo is public; balances/positions
 # must never be committed (execution/ Phase 1; CI uploads an artifact).
 digests/modern_investing/live_account_mirror.json
+# Full live-execution audit trail — real account activity never committed
+# (public repo); the id-only index in live_execution_state.json IS committed.
+digests/modern_investing/live_ledger.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,6 +438,27 @@ nerranetwork/
   block (trade-signal freshness/staleness + shadow-ledger vitals).
   Stop enforcement changes sim outcomes going forward; the honesty line
   + stop narration are new prompt context → A/B-listen per landmine #17.
+  **July 4 2026 Phase-3 live executor (DORMANT)** (drift guards:
+  `tests/test_snaptrade_execution.py::{TestLiveEntry,TestLiveExits,TestLiveStatePrivacy}`):
+  operator-directed "build the next layer" — real order placement now
+  EXISTS but cannot run until armed. `execution/live.py` +
+  `scripts/mit_live_executor.py` + `mit-live-executor.yml` (13:52 UTC
+  entries / 19:45 UTC exits). Gate order, all fail-closed: kill switch
+  (repo var `LIVE_TRADING_ENABLED=1`; unset → logged no-op that never
+  loads credentials) → SnapTrade config → self-halt (2 consecutive
+  rejects halt the layer via committed `live_execution_state.json`;
+  exits still run so positions are never unmanaged) → shared risk gates
+  → daily/open-position caps → account resolution (institution match on
+  the signal's routing hint) → live quote (none = never place blind).
+  Integer-share marketable limits under `MIT_MAX_POSITION_USD` (default
+  $250); idempotent `client_order_id`; the narrated stop rides on the
+  signal for future bracket orders. Privacy split: committed state =
+  ids/status only; full `live_ledger.json` (account ids/amounts) is
+  gitignored + 90-day CI artifact. The Phase-1/2 "no placement code"
+  contract is superseded by a narrower pinned one: the SDK trading call
+  exists ONLY in `snaptrade_client.py`, invoked ONLY by `live.py`, whose
+  FIRST gate is the kill switch (a poisoned-client test proves disabled
+  runs touch nothing). No prompt/audio changes (outside landmine #17).
 
 **Tesla Shorts Time Recursive Memory System (May 2026+)**  
 TST received a full recursive improvement architecture (analogous to MIT):

--- a/docs/mit_snaptrade_live_trading_plan.md
+++ b/docs/mit_snaptrade_live_trading_plan.md
@@ -194,11 +194,32 @@ shadow-vs-sim P&L gap. Entry timing note: the sim enters at the
 pick-date OPEN; shadow quotes at ~9:50 ET — the measured gap between
 them is exactly the execution cost the sim currently ignores.
 
-**Phase 3 — micro-live (operator flips `LIVE_TRADING_ENABLED=1`).**
-Real orders at $150–250, Webull US only at first (single account, USD,
-simplest), 20–30 trades. Every order → notification with fill vs sim
-delta. Halt automatically on: 2 consecutive rejected orders, daily loss
-> cap, connection broken, or sim-vs-live divergence > threshold.
+**Phase 3 — micro-live (CODE SHIPPED July 4, DORMANT; operator arms it).**
+`execution/live.py` + `scripts/mit_live_executor.py` +
+`.github/workflows/mit-live-executor.yml` (13:52 UTC entries / 19:45 UTC
+≈ 3:45 PM ET exits). Gate order, each fail-closed: kill switch
+(`LIVE_TRADING_ENABLED` repo **variable** = "1"; while unset every run
+is a logged no-op that never loads credentials) → SnapTrade config →
+self-halt state → the shared risk gates → daily-order + open-position
+caps → resolvable account (institution match on the signal's routing
+hint, currency-preferring; no match = no order) → live quote (no quote =
+never place blind). Orders are integer-share marketable limits under
+`MIT_MAX_POSITION_USD` (default $250; a $1,200 stock correctly skips),
+idempotent via the signal's `client_order_id`. Exits sell at most the
+units the account actually holds (an expired unfilled Day entry marks
+itself flat instead of shorting). **Two consecutive rejected/errored
+placements self-halt the layer** (committed
+`live_execution_state.json`; operator clears it after investigating) —
+exits still run while halted so no position goes unmanaged. Every
+placement/failure/halt notifies. Privacy split: the committed state file
+carries ids/status only; the full audit ledger (`live_ledger.json`,
+account ids + amounts) is gitignored and uploaded as a 90-day CI
+artifact. To arm: set the 4 SnapTrade secrets + repo variable
+`LIVE_TRADING_ENABLED=1` (optionally `MIT_MAX_POSITION_USD`). The
+original sequencing advice stands: arm only after the shadow record and
+the clean sim record support it. Remaining v1.1 items: realized
+daily-loss halt (needs fill data), native bracket/stop attachment once
+the broker matrix confirms Stop orders, sim-vs-live divergence alarm.
 
 **Phase 4 — scale decision (operator).** Add Wealthsimple/TSX routing,
 raise size toward $1,000 — only if Phase 3's matched-window alpha net of

--- a/docs/reviews/ledger/modern_investing.yaml
+++ b/docs/reviews/ledger/modern_investing.yaml
@@ -246,4 +246,45 @@ reviews:
         evidence: null
     agent_cost_usd: null
 
+  - date: 2026-07-04
+    pr: null
+    doc: docs/mit_snaptrade_live_trading_plan.md
+    reviewer: claude-code (operator "build the next layer")
+    summary: >
+      Phase 3 live executor shipped DORMANT. execution/live.py places
+      integer-share marketable-limit BUYs from the trade signal and SELLs
+      on the sim's exit calendar, behind ordered fail-closed gates: kill
+      switch (repo var LIVE_TRADING_ENABLED; unset = no-op that never
+      loads credentials) -> SnapTrade config -> self-halt (2 consecutive
+      rejects; exits still run while halted) -> shared risk gates ->
+      daily/open-position caps -> account resolution -> live quote.
+      Idempotent client_order_id; unfilled Day entries mark flat instead
+      of shorting; every action notifies. Privacy: committed
+      live_execution_state.json is id/status-only; full live_ledger.json
+      gitignored + CI artifact. Phase-1/2 no-placement contract
+      superseded by a narrower pinned one (SDK call only in the wrapper,
+      wrapper called only by live.py, kill switch first — poisoned-client
+      test).
+    shipped:
+      - execution/live.py (run_live_entry/run_live_exits + halt logic)
+      - snaptrade_client.place_limit_order/order_status (single SDK
+        trading call site)
+      - scripts/mit_live_executor.py + mit-live-executor.yml (13:52
+        entries / 19:45 exits slots)
+      - contract re-pin + 13 live-layer drift guards
+    deferred:
+      - "arming is the OPERATOR's call, gated on the shadow record + clean
+        sim record per the plan; set 4 secrets + LIVE_TRADING_ENABLED=1"
+      - "v1.1: realized daily-loss halt (needs fill polling), native
+        bracket/stop attachment (broker-matrix dependent), sim-vs-live
+        divergence alarm"
+    predictions:
+      - metric: mit-live-executor workflow runs while dormant
+        baseline: "workflow new"
+        expected: "every scheduled run green with 'live layer dormant'
+          no-op; zero SnapTrade calls until the operator arms it"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
 do_not_retry: []

--- a/execution/live.py
+++ b/execution/live.py
@@ -1,0 +1,385 @@
+"""Live executor (Phase 3 of the SnapTrade plan) — DORMANT until armed.
+
+Places real micro-live orders from the trade signal, behind gates that
+must ALL pass, in order, before any brokerage call happens:
+
+1. ``LIVE_TRADING_ENABLED=1`` (the kill switch; unset = this module
+   returns immediately without loading credentials),
+2. SnapTrade env config present,
+3. not halted (two consecutive rejected orders self-halt the layer
+   until the operator clears ``live_execution_state.json``),
+4. the same pure risk gates shadow mode uses (``execution/risk.py``),
+5. daily-order and open-position caps,
+6. a resolvable target account and a live decision-time quote —
+   no quote means no order, never a blind placement.
+
+State model (public repo — privacy by construction):
+- ``live_execution_state.json`` (committed): halt flag, reject counter,
+  and an order INDEX carrying only client_order_ids/symbols/status —
+  the idempotency memory across CI runs. No account ids, no dollar
+  amounts.
+- ``live_ledger.json`` (GITIGNORED, uploaded as CI artifact): the full
+  audit trail (account id, units, prices).
+
+Sizing is INTEGER shares under ``max_position_usd`` (fractional support
+is broker-dependent; a price above the cap skips the trade — correct
+behavior for micro-live). Exits follow the sim's calendar via
+``execution.shadow._exit_due_date`` and sell no more than the units the
+account actually holds.
+
+The LLM never touches this path: inputs are the deterministic signal
+artifact and prior state, nothing else.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import os
+from pathlib import Path
+
+from execution import shadow
+from execution.risk import RiskConfig, validate_signal
+
+logger = logging.getLogger(__name__)
+
+STATE_SCHEMA_VERSION = 1
+
+
+def notify(line: str) -> None:
+    """Best-effort operator notification — every live action must be seen."""
+    url = os.environ.get("NOTIFICATION_WEBHOOK_URL", "").strip()
+    if not url:
+        return
+    try:
+        import requests
+        requests.post(url, json={"text": line}, timeout=10)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("notification failed (non-fatal): %s", exc)
+
+
+def load_state(path: Path) -> dict:
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            data.setdefault("orders", [])
+            data.setdefault("halted", False)
+            data.setdefault("consecutive_rejects", 0)
+            return data
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to load live state: %s — starting fresh", exc)
+    return {
+        "schema_version": STATE_SCHEMA_VERSION,
+        "halted": False,
+        "halt_reason": None,
+        "consecutive_rejects": 0,
+        "orders": [],
+    }
+
+
+def save_state(state: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(state, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def load_ledger(path: Path) -> dict:
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            data.setdefault("orders", [])
+            return data
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {"schema_version": STATE_SCHEMA_VERSION, "mode": "live", "orders": []}
+
+
+save_ledger = shadow.save_ledger  # same shape/serialization
+
+
+def _default_client():
+    from execution import snaptrade_client
+    return snaptrade_client
+
+
+def resolve_account(accounts: list[dict], suggested: str, currency: str) -> dict | None:
+    """Pick the connected account for a signal's routing hint.
+
+    Institution-name substring match on the suggestion (``wealthsimple``
+    / ``webull``); among matches, prefer one whose reported currency
+    matches. None when nothing matches — the caller skips loudly rather
+    than guessing an account for a real order.
+    """
+    needle = (suggested or "").lower()
+    matches = [
+        a for a in accounts or []
+        if needle and needle in str(a.get("institution_name", "")).lower()
+    ]
+    if not matches:
+        return None
+    for acct in matches:
+        bal = acct.get("balance") or {}
+        total = bal.get("total") if isinstance(bal, dict) else None
+        acct_ccy = (total or {}).get("currency") if isinstance(total, dict) else None
+        if acct_ccy and str(acct_ccy).upper() == (currency or "").upper():
+            return acct
+    return matches[0]
+
+
+def _is_rejected(result: dict) -> bool:
+    return str(result.get("status", "")).upper() in ("REJECTED", "FAILED")
+
+
+def _halt(state: dict, reason: str) -> None:
+    state["halted"] = True
+    state["halt_reason"] = reason
+    logger.error("LIVE TRADING HALTED: %s", reason)
+    notify(f"MIT LIVE HALTED: {reason} — clear live_execution_state.json "
+           f"after investigating.")
+
+
+def run_live_entry(
+    signal: dict,
+    state: dict,
+    ledger: dict,
+    config: RiskConfig,
+    *,
+    client=None,
+    quote_fn=shadow.decision_quote,
+    now: datetime.datetime | None = None,
+) -> dict:
+    """Process today's signal into at most one real BUY. Returns a decision
+    dict; appends to state+ledger only when something noteworthy happened."""
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    today = now.date()
+
+    # Gate 1 — kill switch, before anything else (no credential loads).
+    if not config.live_trading_enabled:
+        return {"decision": "disabled",
+                "note": "LIVE_TRADING_ENABLED is not 1 — live layer dormant"}
+    client = client or _default_client()
+    if not client.is_configured():
+        return {"decision": "skipped", "skip_reasons": ["SnapTrade env not configured"]}
+
+    # Gate 2 — self-halt.
+    if state.get("halted"):
+        notify("MIT LIVE: still halted "
+               f"({state.get('halt_reason')}) — no entry attempted.")
+        return {"decision": "halted", "skip_reasons": [state.get("halt_reason")]}
+
+    prior_ids = {o.get("client_order_id") for o in state.get("orders", [])}
+    ok, reasons = validate_signal(
+        signal, config, today=today, prior_order_ids=prior_ids)
+    if not ok:
+        return {"decision": "skipped", "skip_reasons": reasons}
+
+    trade = signal["trade"]
+
+    # Gate 3 — position/order caps from the committed index.
+    todays = [o for o in state["orders"]
+              if str(o.get("logged_at", ""))[:10] == today.isoformat()]
+    if len(todays) >= config.max_daily_orders:
+        return {"decision": "skipped",
+                "skip_reasons": [f"daily order cap ({config.max_daily_orders}) reached"]}
+    open_entries = [
+        o for o in state["orders"]
+        if o.get("kind") == "entry" and not o.get("exited")
+        and not _is_rejected(o)
+    ]
+    if len(open_entries) >= config.max_open_positions:
+        return {"decision": "skipped",
+                "skip_reasons": [f"open-position cap ({config.max_open_positions}) reached"]}
+
+    # Gate 4 — a real account and a real quote.
+    accounts = client.list_accounts()
+    account = resolve_account(
+        accounts, trade.get("suggested_account"), trade.get("currency"))
+    if account is None:
+        notify(f"MIT LIVE: no connected account matches "
+               f"'{trade.get('suggested_account')}' — entry skipped.")
+        return {"decision": "skipped", "skip_reasons": ["no matching account"]}
+    quote = quote_fn(trade["snaptrade_symbol"])
+    if not isinstance(quote, (int, float)) or quote <= 0:
+        return {"decision": "skipped",
+                "skip_reasons": ["no live quote — never place blind"]}
+
+    limit_price = round(quote * (1 + config.max_slippage_pct / 100), 2)
+    units = int(config.max_position_usd // limit_price)
+    if units < 1:
+        return {"decision": "skipped",
+                "skip_reasons": [f"price ${limit_price:.2f} exceeds the "
+                                 f"${config.max_position_usd:.0f} position cap"]}
+
+    try:
+        result = client.place_limit_order(
+            account_id=str(account.get("id")),
+            symbol=trade["snaptrade_symbol"],
+            action="BUY",
+            units=units,
+            limit_price=limit_price,
+            client_order_id=trade["client_order_id"],
+        )
+    except Exception as exc:  # noqa: BLE001
+        state["consecutive_rejects"] = int(state.get("consecutive_rejects", 0)) + 1
+        if state["consecutive_rejects"] >= 2:
+            _halt(state, f"placement raised twice in a row (last: {exc})")
+        notify(f"MIT LIVE: BUY {trade['snaptrade_symbol']} FAILED to place: {exc}")
+        return {"decision": "error", "skip_reasons": [str(exc)]}
+
+    status = str(result.get("status", "UNKNOWN")).upper()
+    index_entry = {
+        "kind": "entry",
+        "client_order_id": trade["client_order_id"],
+        "symbol": trade["snaptrade_symbol"],
+        "trade_type": trade.get("trade_type"),
+        "pick_date": trade.get("pick_date"),
+        "status": status,
+        "logged_at": now.isoformat(timespec="seconds"),
+    }
+    state["orders"].append(index_entry)
+    ledger["orders"].append({
+        **index_entry,
+        "mode": "live",
+        "account_id": str(account.get("id")),
+        "units": units,
+        "limit_price": limit_price,
+        "quote": round(float(quote), 4),
+        "position_usd": round(units * limit_price, 2),
+        "brokerage_order_id": result.get("brokerage_order_id"),
+        "stop_loss": trade.get("stop_loss"),
+    })
+
+    if _is_rejected(result):
+        state["consecutive_rejects"] = int(state.get("consecutive_rejects", 0)) + 1
+        if state["consecutive_rejects"] >= 2:
+            _halt(state, "two consecutive rejected orders")
+        notify(f"MIT LIVE: BUY {units}x {trade['snaptrade_symbol']} "
+               f"@ ${limit_price:.2f} was {status}.")
+    else:
+        state["consecutive_rejects"] = 0
+        notify(f"MIT LIVE: placed BUY {units}x {trade['snaptrade_symbol']} "
+               f"@ limit ${limit_price:.2f} ({status}).")
+    logger.info("Live entry %s: %s x%d @ $%.2f",
+                status, trade["snaptrade_symbol"], units, limit_price)
+    return {"decision": "placed", "status": status, "units": units,
+            "limit_price": limit_price}
+
+
+def run_live_exits(
+    state: dict,
+    ledger: dict,
+    config: RiskConfig,
+    *,
+    client=None,
+    quote_fn=shadow.decision_quote,
+    now: datetime.datetime | None = None,
+) -> list[dict]:
+    """Sell open live positions past their sim exit date. Idempotent."""
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    today = now.date()
+    if not config.live_trading_enabled:
+        return []
+    client = client or _default_client()
+    if not client.is_configured():
+        return []
+    if state.get("halted"):
+        # Exits still run when halted? NO for placement of anything new —
+        # but leaving real positions unmanaged is worse. Exits proceed.
+        logger.warning("Live layer halted — exits still processed to avoid "
+                       "unmanaged open positions.")
+
+    exit_ids = {o.get("client_order_id") for o in state.get("orders", [])
+                if o.get("kind") == "exit"}
+    results: list[dict] = []
+    accounts = None
+    for entry in [o for o in state.get("orders", [])
+                  if o.get("kind") == "entry" and not o.get("exited")
+                  and not _is_rejected(o)]:
+        exit_id = f"{entry.get('client_order_id')}-exit"
+        if exit_id in exit_ids:
+            entry["exited"] = True
+            continue
+        try:
+            pick_date = datetime.date.fromisoformat(str(entry.get("pick_date"))[:10])
+        except (ValueError, TypeError):
+            pick_date = datetime.date.fromisoformat(str(entry.get("logged_at"))[:10])
+        due = shadow._exit_due_date(pick_date, entry.get("trade_type", "weekly"))
+        if today < due:
+            continue
+
+        if accounts is None:
+            accounts = client.list_accounts()
+        # Find the ledger record for account/units; fall back to position scan.
+        full = next((o for o in ledger.get("orders", [])
+                     if o.get("client_order_id") == entry.get("client_order_id")
+                     and o.get("kind") == "entry"), {})
+        account_id = full.get("account_id")
+        if not account_id and accounts:
+            account_id = str(accounts[0].get("id"))
+        positions = client.account_positions(account_id) if account_id else []
+        held = 0.0
+        for pos in positions:
+            sym = pos.get("symbol") or {}
+            inner = sym.get("symbol") if isinstance(sym, dict) else None
+            ticker = (inner.get("symbol") if isinstance(inner, dict)
+                      else inner or (sym if isinstance(sym, str) else None))
+            if ticker == entry.get("symbol"):
+                try:
+                    held = float(pos.get("units") or 0)
+                except (TypeError, ValueError):
+                    held = 0.0
+                break
+        units = min(int(full.get("units") or 0), int(held))
+        if units < 1:
+            # Entry never filled (Day limit expired) or already flat.
+            entry["exited"] = True
+            entry["exit_note"] = "no position to sell (entry unfilled or flat)"
+            notify(f"MIT LIVE: {entry.get('symbol')} exit due but no position "
+                   f"held — entry likely never filled.")
+            continue
+
+        quote = quote_fn(entry.get("symbol"))
+        if not isinstance(quote, (int, float)) or quote <= 0:
+            logger.warning("Live exit: no quote for %s — retry next run",
+                           entry.get("symbol"))
+            continue
+        limit_price = round(quote * (1 - config.max_slippage_pct / 100), 2)
+        try:
+            result = client.place_limit_order(
+                account_id=str(account_id),
+                symbol=entry.get("symbol"),
+                action="SELL",
+                units=units,
+                limit_price=limit_price,
+                client_order_id=exit_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            notify(f"MIT LIVE: SELL {entry.get('symbol')} FAILED: {exc}")
+            continue
+        status = str(result.get("status", "UNKNOWN")).upper()
+        exit_record = {
+            "kind": "exit",
+            "client_order_id": exit_id,
+            "symbol": entry.get("symbol"),
+            "status": status,
+            "logged_at": now.isoformat(timespec="seconds"),
+        }
+        state["orders"].append(exit_record)
+        ledger["orders"].append({
+            **exit_record,
+            "mode": "live",
+            "account_id": str(account_id),
+            "units": units,
+            "limit_price": limit_price,
+            "quote": round(float(quote), 4),
+            "entry_client_order_id": entry.get("client_order_id"),
+        })
+        entry["exited"] = True
+        exit_ids.add(exit_id)
+        notify(f"MIT LIVE: placed SELL {units}x {entry.get('symbol')} "
+               f"@ limit ${limit_price:.2f} ({status}).")
+        results.append(exit_record)
+    return results

--- a/execution/snaptrade_client.py
+++ b/execution/snaptrade_client.py
@@ -139,3 +139,52 @@ def recent_orders(account_id: str) -> list[dict]:
     resp = snaptrade.account_information.get_user_account_orders(
         account_id=account_id, **_user_kwargs())
     return list(_body(resp) or [])
+
+
+# ---------------------------------------------------------------------------
+# Trading (Phase 3 — reachable ONLY through execution/live.py, whose first
+# gate is the LIVE_TRADING_ENABLED kill switch; see execution/__init__.py)
+# ---------------------------------------------------------------------------
+
+def place_limit_order(
+    *,
+    account_id: str,
+    symbol: str,
+    action: str,
+    units: float,
+    limit_price: float,
+    client_order_id: str | None = None,
+    time_in_force: str = "Day",
+) -> dict:
+    """Place a Limit/Day equity order; returns the order confirmation.
+
+    Thin pass-through to SnapTrade's place-equity-order endpoint. The
+    ``client_order_id`` makes placement idempotent server-side — a
+    retried workflow re-sends the same id instead of double-buying.
+    All risk decisions happen in ``execution/live.py`` BEFORE this call;
+    this function never adjusts an order.
+    """
+    snaptrade = _sdk()
+    kwargs = dict(
+        _user_kwargs(),
+        account_id=account_id,
+        action=action,
+        symbol=symbol,
+        order_type="Limit",
+        time_in_force=time_in_force,
+        units=units,
+        price=limit_price,
+    )
+    if client_order_id:
+        kwargs["client_order_id"] = client_order_id
+    resp = snaptrade.trading.place_force_order(**kwargs)
+    return dict(_body(resp) or {})
+
+
+def order_status(account_id: str, brokerage_order_id: str) -> dict:
+    """Best-effort status of a previously placed order."""
+    snaptrade = _sdk()
+    resp = snaptrade.account_information.get_user_account_order_detail(
+        account_id=account_id, brokerage_order_id=brokerage_order_id,
+        **_user_kwargs())
+    return dict(_body(resp) or {})

--- a/scripts/mit_live_executor.py
+++ b/scripts/mit_live_executor.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Run one live-executor pass (Phase 3 — DORMANT until armed).
+
+Modes (schedule slots pass one; dispatch may pass both):
+  --entries   morning slot (~9:52 ET): today's signal → at most one BUY
+  --exits     afternoon slot (~15:45 ET): due positions → SELLs
+
+Fail-closed everywhere: LIVE_TRADING_ENABLED unset, missing SnapTrade
+config, missing/stale signal, halted state, no matching account, or no
+quote all mean NO order, with the reason logged (and notified for
+anything surprising). Exit code is 0 for every no-op path so the
+workflow stays green while dormant.
+
+State files: live_execution_state.json (committed — halt flag + id-only
+order index) and live_ledger.json (gitignored full audit; CI artifact).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from execution import live  # noqa: E402
+from execution.risk import RiskConfig  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("mit_live_executor")
+
+MIT_DIR = ROOT / "digests" / "modern_investing"
+SIGNAL_PATH = MIT_DIR / "trade_signal_latest.json"
+STATE_PATH = MIT_DIR / "live_execution_state.json"
+LEDGER_PATH = MIT_DIR / "live_ledger.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--entries", action="store_true")
+    parser.add_argument("--exits", action="store_true")
+    args = parser.parse_args()
+    if not (args.entries or args.exits):
+        args.entries = args.exits = True
+
+    config = RiskConfig.from_env()
+    if not config.live_trading_enabled:
+        logger.info("LIVE_TRADING_ENABLED is not 1 — live layer dormant "
+                    "(clean no-op).")
+        return 0
+
+    state = live.load_state(STATE_PATH)
+    ledger = live.load_ledger(LEDGER_PATH)
+
+    if args.entries:
+        if SIGNAL_PATH.exists():
+            try:
+                signal = json.loads(SIGNAL_PATH.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.error("Unreadable trade signal: %s", exc)
+                signal = None
+            if signal is not None:
+                decision = live.run_live_entry(signal, state, ledger, config)
+                logger.info("Live entry decision: %s%s",
+                            decision.get("decision"),
+                            f" — {'; '.join(decision.get('skip_reasons', []))}"
+                            if decision.get("skip_reasons") else "")
+        else:
+            logger.info("No trade signal — no entry (fail-closed).")
+
+    if args.exits:
+        exits = live.run_live_exits(state, ledger, config)
+        for x in exits:
+            logger.info("Live exit: %s %s", x.get("symbol"), x.get("status"))
+
+    live.save_state(state, STATE_PATH)
+    live.save_ledger(ledger, LEDGER_PATH)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_snaptrade_execution.py
+++ b/tests/test_snaptrade_execution.py
@@ -42,13 +42,44 @@ class TestIsolationContract:
         assert offenders == [], (
             f"podcast-path files import execution/: {offenders}")
 
-    def test_phase1_has_no_order_placement_code(self):
-        # Trading code arrives in a later phase behind its own risk layer.
+    def test_order_placement_confined_to_live_path(self):
+        # Phase 3 (operator-directed) supersedes the Phase-1/2 no-placement
+        # contract with a narrower one: the SDK trading call exists ONLY in
+        # the snaptrade_client wrapper, and the only module invoking that
+        # wrapper is execution/live.py — whose first gate is the
+        # LIVE_TRADING_ENABLED kill switch. Shadow/mirror stay order-free.
         for f in sorted((_ROOT / "execution").rglob("*.py")):
-            text = f.read_text(encoding="utf-8").lower()
-            assert "place_order" not in text and "placeforceorder" not in text, (
-                f"{f.name} contains order-placement code — Phase 1 is "
-                f"read-only by contract")
+            text = f.read_text(encoding="utf-8")
+            if f.name == "snaptrade_client.py":
+                assert "place_force_order" in text  # the single SDK call site
+                continue
+            assert "place_force_order" not in text.lower(), (
+                f"{f.name} calls the SDK trading endpoint directly — only "
+                f"the snaptrade_client wrapper may")
+            if f.name == "live.py":
+                continue
+            assert "place_limit_order" not in text, (
+                f"{f.name} places orders — only execution/live.py may")
+
+    def test_live_entry_first_gate_is_the_kill_switch(self):
+        # With the switch off, run_live_entry must return 'disabled' BEFORE
+        # touching credentials, accounts, or quotes.
+        import datetime as _dt
+
+        class _Boom:
+            def __getattr__(self, name):
+                raise AssertionError(
+                    "live layer touched the client while disabled")
+
+        decision = __import__("execution.live", fromlist=["live"]).run_live_entry(
+            {"schema_version": 1, "action": "new_trade", "trade": {}},
+            {"orders": []}, {"orders": []},
+            RiskConfig(live_trading_enabled=False),
+            client=_Boom(),
+            now=_dt.datetime(2026, 7, 6, 13, 52,
+                             tzinfo=_dt.timezone.utc),
+        )
+        assert decision["decision"] == "disabled"
 
     def test_mirror_output_is_gitignored(self):
         # Public repo: balances/positions must never be committable.
@@ -341,3 +372,254 @@ class TestShadowExits:
             ledger, RiskConfig(), quote_fn=lambda s: None, now=self._NOW)
         assert exits == []
         assert len(ledger["orders"]) == 1  # nothing logged; retried later
+
+
+# ---------------------------------------------------------------------------
+# Live executor (Phase 3 — dormant by default)
+# ---------------------------------------------------------------------------
+
+from execution import live  # noqa: E402
+
+
+class _FakeClient:
+    """Configured SnapTrade client with scriptable placement results."""
+
+    def __init__(self, *, accounts=None, positions=None,
+                 place_result=None, place_raises=None):
+        self.accounts = accounts if accounts is not None else [{
+            "id": "acct-webull", "institution_name": "Webull",
+            "balance": {"total": {"amount": 5000.0, "currency": "USD"}},
+        }]
+        self.positions = positions or []
+        self.place_result = place_result or {
+            "brokerage_order_id": "bo-1", "status": "ACCEPTED"}
+        self.place_raises = place_raises
+        self.placed = []
+
+    def is_configured(self):
+        return True
+
+    def list_accounts(self):
+        return self.accounts
+
+    def account_positions(self, account_id):
+        return self.positions
+
+    def place_limit_order(self, **kwargs):
+        if self.place_raises:
+            raise self.place_raises
+        self.placed.append(kwargs)
+        return dict(self.place_result)
+
+
+_LIVE_NOW = datetime.datetime(2026, 7, 6, 13, 52,
+                              tzinfo=datetime.timezone.utc)  # Monday
+
+
+def _live_config(**kw):
+    return RiskConfig(live_trading_enabled=True, **kw)
+
+
+def _live_signal(**overrides):
+    sig = _signal(**overrides)
+    sig["generated_at"] = "2026-07-06"
+    sig["trade"]["pick_date"] = "2026-07-06"
+    return sig
+
+
+class TestLiveEntry:
+    def test_places_integer_share_marketable_limit(self, monkeypatch):
+        monkeypatch.delenv("NOTIFICATION_WEBHOOK_URL", raising=False)
+        client = _FakeClient()
+        state, ledger = live.load_state(Path("/nope")), live.load_ledger(Path("/nope"))
+        decision = live.run_live_entry(
+            _live_signal(), state, ledger, _live_config(),
+            client=client, quote_fn=lambda s: 100.0, now=_LIVE_NOW)
+        assert decision["decision"] == "placed"
+        order = client.placed[0]
+        assert order["action"] == "BUY"
+        assert order["symbol"] == "NVDA"
+        assert order["units"] == 2            # int(250 // 100.5)
+        assert order["limit_price"] == 100.5  # quote * 1.005
+        assert order["client_order_id"] == _live_signal()["trade"]["client_order_id"]
+        # Committed index carries ids/status only — no dollar amounts.
+        idx = state["orders"][0]
+        assert "limit_price" not in idx and "units" not in idx
+        # Full ledger carries the audit detail.
+        assert ledger["orders"][0]["units"] == 2
+        assert ledger["orders"][0]["account_id"] == "acct-webull"
+
+    def test_duplicate_signal_not_replaced(self, monkeypatch):
+        monkeypatch.delenv("NOTIFICATION_WEBHOOK_URL", raising=False)
+        client = _FakeClient()
+        state, ledger = live.load_state(Path("/nope")), live.load_ledger(Path("/nope"))
+        live.run_live_entry(_live_signal(), state, ledger, _live_config(),
+                            client=client, quote_fn=lambda s: 100.0, now=_LIVE_NOW)
+        second = live.run_live_entry(
+            _live_signal(), state, ledger, _live_config(),
+            client=client, quote_fn=lambda s: 100.0, now=_LIVE_NOW)
+        assert second["decision"] == "skipped"
+        assert any("duplicate" in r for r in second["skip_reasons"])
+        assert len(client.placed) == 1
+
+    def test_price_above_cap_skips(self, monkeypatch):
+        monkeypatch.delenv("NOTIFICATION_WEBHOOK_URL", raising=False)
+        client = _FakeClient()
+        state, ledger = live.load_state(Path("/nope")), live.load_ledger(Path("/nope"))
+        decision = live.run_live_entry(
+            _live_signal(), state, ledger, _live_config(),
+            client=client, quote_fn=lambda s: 1200.0, now=_LIVE_NOW)
+        assert decision["decision"] == "skipped"
+        assert any("position cap" in r for r in decision["skip_reasons"])
+        assert client.placed == []
+
+    def test_no_quote_never_places_blind(self, monkeypatch):
+        monkeypatch.delenv("NOTIFICATION_WEBHOOK_URL", raising=False)
+        client = _FakeClient()
+        state, ledger = live.load_state(Path("/nope")), live.load_ledger(Path("/nope"))
+        decision = live.run_live_entry(
+            _live_signal(), state, ledger, _live_config(),
+            client=client, quote_fn=lambda s: None, now=_LIVE_NOW)
+        assert decision["decision"] == "skipped"
+        assert client.placed == []
+
+    def test_no_matching_account_skips(self, monkeypatch):
+        monkeypatch.delenv("NOTIFICATION_WEBHOOK_URL", raising=False)
+        client = _FakeClient(accounts=[{
+            "id": "a", "institution_name": "Questrade",
+            "balance": {"total": {"amount": 1.0, "currency": "CAD"}}}])
+        state, ledger = live.load_state(Path("/nope")), live.load_ledger(Path("/nope"))
+        decision = live.run_live_entry(
+            _live_signal(), state, ledger, _live_config(),
+            client=client, quote_fn=lambda s: 100.0, now=_LIVE_NOW)
+        assert decision["decision"] == "skipped"
+        assert any("no matching account" in r for r in decision["skip_reasons"])
+
+    def test_two_consecutive_rejects_halt_the_layer(self, monkeypatch):
+        monkeypatch.delenv("NOTIFICATION_WEBHOOK_URL", raising=False)
+        state, ledger = live.load_state(Path("/nope")), live.load_ledger(Path("/nope"))
+        client = _FakeClient(place_result={"status": "REJECTED"})
+        sig1 = _live_signal()
+        live.run_live_entry(sig1, state, ledger, _live_config(),
+                            client=client, quote_fn=lambda s: 100.0, now=_LIVE_NOW)
+        assert state["halted"] is False
+        sig2 = _live_signal(
+            trade_overrides={"client_order_id": "22222222-3333-4444-5555-666666666666"})
+        # Second reject on a fresh day (daily cap would otherwise block).
+        later = _LIVE_NOW + datetime.timedelta(days=1)
+        sig2["generated_at"] = "2026-07-07"
+        live.run_live_entry(sig2, state, ledger, _live_config(),
+                            client=client, quote_fn=lambda s: 100.0, now=later)
+        assert state["halted"] is True
+        # Third attempt: refused outright.
+        sig3 = _live_signal(
+            trade_overrides={"client_order_id": "33333333-4444-5555-6666-777777777777"})
+        sig3["generated_at"] = "2026-07-08"
+        decision = live.run_live_entry(
+            sig3, state, ledger, _live_config(), client=client,
+            quote_fn=lambda s: 100.0,
+            now=_LIVE_NOW + datetime.timedelta(days=2))
+        assert decision["decision"] == "halted"
+
+    def test_open_position_cap_blocks_second_entry(self, monkeypatch):
+        monkeypatch.delenv("NOTIFICATION_WEBHOOK_URL", raising=False)
+        client = _FakeClient()
+        state, ledger = live.load_state(Path("/nope")), live.load_ledger(Path("/nope"))
+        live.run_live_entry(_live_signal(), state, ledger, _live_config(),
+                            client=client, quote_fn=lambda s: 100.0, now=_LIVE_NOW)
+        sig2 = _live_signal(
+            trade_overrides={"client_order_id": "22222222-3333-4444-5555-666666666666"})
+        sig2["generated_at"] = "2026-07-07"
+        decision = live.run_live_entry(
+            sig2, state, ledger, _live_config(), client=client,
+            quote_fn=lambda s: 100.0,
+            now=_LIVE_NOW + datetime.timedelta(days=1))
+        assert decision["decision"] == "skipped"
+        assert any("open-position cap" in r for r in decision["skip_reasons"])
+
+
+class TestLiveExits:
+    def _state_with_entry(self, pick_date="2026-07-06"):
+        state = live.load_state(Path("/nope"))
+        ledger = live.load_ledger(Path("/nope"))
+        state["orders"].append({
+            "kind": "entry", "client_order_id": "e1", "symbol": "NVDA",
+            "trade_type": "flash", "pick_date": pick_date,
+            "status": "EXECUTED", "logged_at": f"{pick_date}T13:52:00+00:00",
+        })
+        ledger["orders"].append({
+            "kind": "entry", "client_order_id": "e1", "symbol": "NVDA",
+            "mode": "live", "account_id": "acct-webull", "units": 2,
+            "limit_price": 100.5,
+        })
+        return state, ledger
+
+    def _position(self, units):
+        return [{"symbol": {"symbol": {"symbol": "NVDA"}}, "units": units}]
+
+    def test_due_exit_sells_held_units(self, monkeypatch):
+        monkeypatch.delenv("NOTIFICATION_WEBHOOK_URL", raising=False)
+        state, ledger = self._state_with_entry()
+        client = _FakeClient(positions=self._position(2))
+        exits = live.run_live_exits(
+            state, ledger, _live_config(), client=client,
+            quote_fn=lambda s: 110.0,
+            now=datetime.datetime(2026, 7, 7, 19, 45,
+                                  tzinfo=datetime.timezone.utc))
+        assert len(exits) == 1
+        order = client.placed[0]
+        assert order["action"] == "SELL"
+        assert order["units"] == 2
+        assert order["limit_price"] == round(110.0 * 0.995, 2)
+        assert order["client_order_id"] == "e1-exit"
+
+    def test_unfilled_entry_marks_flat_instead_of_selling(self, monkeypatch):
+        monkeypatch.delenv("NOTIFICATION_WEBHOOK_URL", raising=False)
+        state, ledger = self._state_with_entry()
+        client = _FakeClient(positions=self._position(0))
+        exits = live.run_live_exits(
+            state, ledger, _live_config(), client=client,
+            quote_fn=lambda s: 110.0,
+            now=datetime.datetime(2026, 7, 7, 19, 45,
+                                  tzinfo=datetime.timezone.utc))
+        assert exits == []
+        assert client.placed == []
+        assert state["orders"][0]["exited"] is True
+        assert "no position" in state["orders"][0]["exit_note"]
+
+    def test_not_due_yet_no_sell(self, monkeypatch):
+        monkeypatch.delenv("NOTIFICATION_WEBHOOK_URL", raising=False)
+        state, ledger = self._state_with_entry()
+        client = _FakeClient(positions=self._position(2))
+        exits = live.run_live_exits(
+            state, ledger, _live_config(), client=client,
+            quote_fn=lambda s: 110.0,
+            now=datetime.datetime(2026, 7, 6, 19, 45,
+                                  tzinfo=datetime.timezone.utc))
+        assert exits == [] and client.placed == []
+
+    def test_disabled_layer_never_sells(self):
+        state, ledger = self._state_with_entry()
+        client = _FakeClient(positions=self._position(2))
+        exits = live.run_live_exits(
+            state, ledger, RiskConfig(live_trading_enabled=False),
+            client=client, quote_fn=lambda s: 110.0,
+            now=datetime.datetime(2026, 7, 7, 19, 45,
+                                  tzinfo=datetime.timezone.utc))
+        assert exits == [] and client.placed == []
+
+
+class TestLiveStatePrivacy:
+    def test_live_ledger_is_gitignored(self):
+        result = subprocess.run(
+            ["git", "check-ignore",
+             "digests/modern_investing/live_ledger.json"],
+            cwd=_ROOT, capture_output=True, text=True)
+        assert result.returncode == 0, (
+            "live_ledger.json must never be committable (real account "
+            "activity, public repo)")
+
+    def test_executor_script_dormant_without_kill_switch(self):
+        src = (_ROOT / "scripts/mit_live_executor.py").read_text()
+        assert "live layer dormant" in src
+        assert "return 0" in src


### PR DESCRIPTION
# TLDR

The next layer of the live-trading plan: **real order placement now exists, and cannot run until you arm it.** `execution/live.py` places integer-share marketable-limit BUYs from the daily trade signal and SELLs on the sim's exit calendar — behind ordered, fail-closed gates. While dormant, every scheduled run is a logged clean no-op that never even loads credentials.

# Gate order (each one fail-closed)

1. **Kill switch** — repo *variable* `LIVE_TRADING_ENABLED` must be `"1"`. A poisoned-client test pins that disabled runs touch nothing.
2. SnapTrade env config present (the 4 secrets).
3. **Self-halt** — two consecutive rejected/errored placements halt the layer via committed `live_execution_state.json` until you clear it. Exits still run while halted so no real position is ever left unmanaged.
4. The same pure risk gates shadow mode uses (signal freshness, validation, price floor, duplicate `client_order_id`).
5. Daily-order + open-position caps.
6. Account resolution (institution match on the signal's `suggested_account`, currency-preferring — no match, no order) and a live decision-time quote (no quote, never place blind).

# Behavior

- Integer-share marketable limits under `MIT_MAX_POSITION_USD` (default $250 — a $1,200 stock correctly skips; fractional support is broker-dependent and deliberately not assumed).
- Idempotent via the signal's uuid5 `client_order_id` — a retried workflow cannot double-buy.
- Exits sell at most the units the account actually holds; an expired unfilled Day entry marks itself flat instead of shorting.
- Every placement / rejection / halt sends a notification.
- Workflow slots: 13:52 UTC (≈9:52 ET) entries, 19:45 UTC (≈3:45 PM ET) exits; `workflow_dispatch` runs both.

# Privacy (public repo)

Committed `live_execution_state.json` = halt flag + id/symbol/status index only (the cross-run idempotency memory). The full audit ledger (`live_ledger.json` — account ids, units, prices) is **gitignored** and uploaded as a 90-day CI artifact.

# Contract change (deliberate)

The Phase-1/2 "no placement code in `execution/`" test is superseded by a narrower pinned invariant: the SDK trading call exists **only** in `snaptrade_client.py`, is invoked **only** by `live.py`, and the kill switch is the first gate. Podcast-path isolation is unchanged.

# ⚠️ A/B-listen required (landmine #17)

**None** — no prompt, audio, or spoken-content changes.

# Test results

`TestLiveEntry` (7 — sizing, dedup, caps, no-quote/no-account skips, reject-halt), `TestLiveExits` (4 — due-date sells, unfilled-entry flat-marking, dormant no-op), `TestLiveStatePrivacy` (2), contract re-pins. **319 tests green** across the touched suites; `ruff` clean.

# To arm (your call, when the record supports it)

1. Set the 4 `SNAPTRADE_*` secrets (from `scripts/snaptrade_setup.py`).
2. Set repo **variable** `LIVE_TRADING_ENABLED=1` (Settings → Variables) — and optionally `MIT_MAX_POSITION_USD`.
3. To stand down instantly: delete/zero the variable. To clear a self-halt: reset `live_execution_state.json`.

The plan's sequencing advice stands: arm after the shadow record accumulates and the clean sim record (post recompute) supports it. v1.1 items in the ledger: realized daily-loss halt, native bracket/stop attachment (broker-matrix dependent), sim-vs-live divergence alarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKwLmJRykLH8oFskoXiVVp

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKwLmJRykLH8oFskoXiVVp)_