### PR TITLE
Prompt + Grok API/Voice review: cache routing, TTS speed, Russian max_chars

### DIFF
--- a/digests/xai_grok.py
+++ b/digests/xai_grok.py
@@ -28,12 +28,16 @@ def grok_generate_text(
     enable_x_search: bool = False,
     x_handles: Optional[List[str]] = None,
     max_turns: Optional[int] = None,
+    cache_key: Optional[str] = None,
 ) -> Tuple[str, Dict[str, Any]]:
     """Generate text from Grok.
 
     When search tools are requested, uses the Responses API
     (``client.responses.create``) with ``x_search`` / ``web_search``
     built-in tools.  Otherwise uses Chat Completions.
+
+    *cache_key* (optional) sticky-routes for prompt-cache reuse: Chat
+    Completions via ``x-grok-conv-id``, Responses via ``prompt_cache_key``.
 
     Returns ``(text, meta)``.
     """
@@ -68,11 +72,17 @@ def grok_generate_text(
         )
 
         try:
-            resp = client.responses.create(
-                model=model,
-                input=[{"role": "user", "content": prompt}],
-                tools=tools,
-            )
+            create_kwargs: Dict[str, Any] = {
+                "model": model,
+                "input": [{"role": "user", "content": prompt}],
+                "tools": tools,
+            }
+            if cache_key:
+                # Responses API sticky routing (same role as x-grok-conv-id).
+                create_kwargs["extra_body"] = {
+                    "prompt_cache_key": str(cache_key),
+                }
+            resp = client.responses.create(**create_kwargs)
             text = getattr(resp, "output_text", "") or ""
             text = text.strip()
             logging.info(
@@ -94,11 +104,14 @@ def grok_generate_text(
         base_url="https://api.x.ai/v1",
         timeout=timeout_seconds,
     )
-    resp = client.chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": prompt}],
-        temperature=temperature,
-        max_tokens=max_tokens,
-    )
+    create_kwargs = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    if cache_key:
+        create_kwargs["extra_headers"] = {"x-grok-conv-id": str(cache_key)}
+    resp = client.chat.completions.create(**create_kwargs)
     text = resp.choices[0].message.content.strip()
     return text, {"provider": "openai_compat", "model": model, "usage": getattr(resp, "usage", None)}

--- a/docs/reviews/prompt_grok_review_2026_07_09.md
+++ b/docs/reviews/prompt_grok_review_2026_07_09.md
@@ -1,0 +1,90 @@
+# Prompt + Grok API / Voice Review (July 9, 2026)
+
+Follow-up to [`docs/prompt_review_2026_06_10.md`](../prompt_review_2026_06_10.md).
+Scope: every show prompt surface, `_call_grok` / tracking, Grok TTS wiring, and
+stale newsletter copy — checked against current xAI Chat Completions + TTS docs
+(prompt caching via `x-grok-conv-id`, `cached_tokens` telemetry, TTS `speed`
+0.7–1.5, 15k char cap). Drift guards: `tests/test_prompt_grok_review_2026_07_09.py`.
+
+## Verdict
+
+The June 10 prompt pass still holds for editorial quality. The biggest
+**unclaimed** wins since then are infrastructure: sticky prompt-cache routing
+was never wired, TTS `speed` never reached the single-voice Grok path, and two
+Russian shows still capped chunks at 10k (risking the multi-chunk `<fast>` drop).
+Those ship here. Bulk prompt rewrites and Voice/prosody experiments stay behind
+landmine #17.
+
+## Implemented (safe — no spoken-script change)
+
+### 1. Prompt-cache sticky routing + telemetry
+`engine.generator._call_grok` now accepts `cache_key` and sends
+`x-grok-conv-id: nerra-<slug>` on every digest/podcast/retry call for that show.
+`digests/xai_grok.grok_generate_text` gained the same optional `cache_key`
+(Chat Completions header + Responses `prompt_cache_key`); fetch paths use
+`nerra-fetch-x` / `nerra-fetch-web`. xAI automatically caches identical message
+prefixes; the header maximizes hit rate by sticky-routing to one server. Cache
+hits log `usage.prompt_tokens_details.cached_tokens` and flow into
+`engine.tracking.record_llm_usage(..., cached_tokens=)`. Cost math still uses
+full prompt tokens until cached pricing is added to `GROK_PRICING` (deferred —
+needs a confirmed cached rate in the pricing table).
+
+### 2. Grok TTS `speed` on the single-voice path
+`synthesize()` / `synthesize_sections()` already accepted `speed` but only the
+ElevenLabs branch and the dialogue path (`tts_dialogue.py`) forwarded it.
+`_speak_with_grok` → `grok_speak_chunk` now pass `speed` through. Default `1.0`
+keeps the request payload byte-identical for every show that does not opt in
+(dp_pod already uses `1.05` on the dialogue path).
+
+### 3. Russian shows `max_chars: 14000`
+`finansy_prosto` and `privet_russian` overrode the network 14k default with
+10k. Long scripts could split into multiple Grok TTS chunks and drop the
+network `<fast>` wrap (landmine #17 safety guard). Aligned to 14000.
+
+### 4. Anti-refusal educational fallback is show-generic
+The digest refusal retry told every show to invent "financial concepts" —
+wrong for SpaceX / FF / PT / etc. Now: "2–3 core concepts from this show's
+topic domain."
+
+### 5. Weekly newsletter prompts: "recap edition" retired
+`shows/prompts/spacex_weekly.txt` and `shows/templates/weekly.txt.template`
+still said "weekly recap edition" after the July 2026 full-Sunday-recap
+retirement. Reworded to "weekly newsletter digest" + an explicit note that
+this is email, not a spoken Sunday recap.
+
+## Checked and left alone (with reasons)
+
+| Item | Why |
+|------|-----|
+| Bulk `<<include:>>` of `_shared/accuracy_rules.txt` into show prompts | Mechanism is opt-in; README + June 10 review forbid bulk rewrites without per-show A/B. Snippets stay available for new shows / surgical edits. |
+| Migrating digest/podcast to Responses API | Chat Completions still supported; Responses is preferred for *new* features. Migration is a large contract change (tools, streaming, cache key field name) with no listener benefit until we need those features. |
+| `reasoning_effort` / Grok 4.5 model bump | Network is on grok-4.3 by design (landmine #13). Model bumps are operator cost/quality decisions, not a prompt-pass default. |
+| Re-introducing speech tags / phonetic respellings / DELIVERY blocks | Landmine #17 — 100% regression rate on theory-driven TTS mods. |
+| De-seeding third-gen tics (OV "Both sides agree…", EI menus, MAB openers) | July 2 network review already proposed these as A/B-gated; not auto-applied. |
+| Digest length-ceiling / Cosmic Deep Dive expansion | Deferred behind the four-show length A/B (FF/PT/UC/Tesla class). |
+| Cached-token discount in `_estimate_grok_cost` | Telemetry first; apply discount once `GROK_PRICING` has an explicit cached rate. |
+
+## A/B-gated recommendations (NOT applied)
+
+1. **Per-show few-shot exemplars** for podcast prompts that still describe
+   shape without an ideal story block (OV/EI/M&A class) — high editorial
+   leverage, one show at a time.
+2. **Convert ban-lists → rotation menus** where June passes already proved
+   the pattern (openers, deep-dive entries).
+3. **Sunday weekly-summary segment prompt note** in daily podcast prompts
+   for shows with `weekly_summary_segment: true` — clarify the host weaves
+   one short look-back without turning the episode into a full recap.
+4. **Optional `tts.speed` A/B** on one English show (e.g. 1.05 like dp_pod)
+   only with operator listen evidence — the wire is now live for single-voice.
+5. **Stable system-prompt prefix hygiene** — keep system prompts short and
+   static; put day-varying context only in the user message so cache prefixes
+   stay long. Most shows already do this; audit stragglers when editing.
+
+## Operator follow-ups
+
+- Watch `cached_tokens` in the next few `credit_usage_*.json` files / logs
+  after merge; if consistently 0, verify sticky routing and system-prompt
+  stability.
+- When xAI publishes a clear cached-input rate for grok-4.3, add
+  `cached_input_per_1m` to `GROK_PRICING` and subtract from cost estimates.
+- Do **not** bulk-edit show prompts to use `_shared/` includes without A/B.

--- a/docs/reviews/review_state.yaml
+++ b/docs/reviews/review_state.yaml
@@ -14,7 +14,8 @@
 # network-scope passes on June 10).
 targets:
   tesla: 2026-06-10
-  network: 2026-07-02
+  # Prompt + Grok API/Voice infra review July 9 2026 (cache routing, TTS speed).
+  network: 2026-07-09
   modern_investing: 2026-07-03
   fascinating_frontiers: 2026-06-24
   models_agents: 2026-06-21

--- a/engine/fetcher.py
+++ b/engine/fetcher.py
@@ -627,6 +627,7 @@ def fetch_x_posts(
                 enable_x_search=True,
                 x_handles=[handle],
                 max_turns=5,
+                cache_key="nerra-fetch-x",
             )
         except Exception as exc:
             logger.error("X fetch @%s failed: %s — %s", handle, type(exc).__name__, exc)
@@ -933,6 +934,7 @@ def fetch_web_search_articles(
                 prompt=extraction_prompt,
                 enable_web_search=True,
                 max_turns=5,
+                cache_key="nerra-fetch-web",
             )
 
             if not text or "NO_RECENT_ARTICLES" in text:

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -134,10 +134,17 @@ def _call_grok(
     temperature: float = 0.7,
     max_tokens: int = 3500,
     timeout: float = 300.0,
+    cache_key: Optional[str] = None,
 ) -> tuple[str, Dict[str, Any]]:
     """Call xAI Grok via the OpenAI-compatible endpoint.
 
     Returns ``(text, meta)`` where *meta* contains usage info.
+
+    *cache_key* (optional) is sent as the ``x-grok-conv-id`` HTTP header so
+    xAI sticky-routes requests that share a stable system-prompt prefix to
+    the same server, maximizing automatic prompt-cache hits (see
+    https://docs.x.ai/developers/advanced-api-usage/prompt-caching). When
+    omitted the call is unchanged from the pre-caching path.
     """
     from openai import OpenAI
 
@@ -152,15 +159,24 @@ def _call_grok(
         messages.append({"role": "system", "content": system_prompt})
     messages.append({"role": "user", "content": prompt})
 
-    resp = client.chat.completions.create(
-        model=model,
-        messages=messages,
-        temperature=temperature,
-        max_tokens=max_tokens,
-    )
+    create_kwargs: Dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    # Sticky routing for prompt-cache reuse. Per-show keys keep digest /
+    # podcast / retry calls for the same show on one server so the stable
+    # system-prompt prefix can hit cache; different shows stay isolated.
+    if cache_key:
+        create_kwargs["extra_headers"] = {"x-grok-conv-id": str(cache_key)}
+
+    resp = client.chat.completions.create(**create_kwargs)
 
     text = resp.choices[0].message.content.strip()
     meta: Dict[str, Any] = {"provider": "openai_compat", "model": model}
+    if cache_key:
+        meta["cache_key"] = cache_key
     finish_reason = getattr(resp.choices[0], "finish_reason", None)
     meta["finish_reason"] = finish_reason
     # Only warn on length-truncation when the caller is actually trying
@@ -176,12 +192,44 @@ def _call_grok(
             max_tokens,
         )
     if hasattr(resp, "usage") and resp.usage:
-        meta["usage"] = {
+        usage_meta: Dict[str, Any] = {
             "prompt_tokens": resp.usage.prompt_tokens,
             "completion_tokens": resp.usage.completion_tokens,
             "total_tokens": resp.usage.total_tokens,
         }
+        # Prompt-cache telemetry (xAI returns this when a prefix hit).
+        # Nested under prompt_tokens_details on Chat Completions; also
+        # accept a top-level cached_tokens if the SDK flattens it.
+        cached = 0
+        details = getattr(resp.usage, "prompt_tokens_details", None)
+        if details is not None:
+            cached = int(getattr(details, "cached_tokens", 0) or 0)
+        if not cached:
+            cached = int(getattr(resp.usage, "cached_tokens", 0) or 0)
+        if cached:
+            usage_meta["cached_tokens"] = cached
+            logger.info(
+                "Grok prompt cache hit: %d / %d prompt tokens cached (key=%s)",
+                cached, usage_meta["prompt_tokens"], cache_key or "-",
+            )
+        meta["usage"] = usage_meta
     return text, meta
+
+
+def _show_cache_key(config: Any, stage: str = "") -> Optional[str]:
+    """Stable sticky-routing key for a show's Grok Chat Completions calls.
+
+    Format ``nerra-<slug>`` (stage is intentionally omitted so digest,
+    podcast, outline, and retry calls share one server affinity and can
+    reuse the system-prompt prefix cache). Returns ``None`` when the
+    config has no slug so callers without a show identity stay on the
+    legacy no-header path.
+    """
+    slug = getattr(config, "slug", None) or ""
+    slug = str(slug).strip()
+    if not slug:
+        return None
+    return f"nerra-{slug}"
 
 
 # ---------------------------------------------------------------------------
@@ -1355,6 +1403,7 @@ def generate_digest(
         system_prompt=system_prompt,
         temperature=config.llm.digest_temperature,
         max_tokens=config.llm.max_tokens,
+        cache_key=_show_cache_key(config),
     )
 
     # Retry once with 50% more tokens if the response was truncated
@@ -1370,6 +1419,7 @@ def generate_digest(
             system_prompt=system_prompt,
             temperature=config.llm.digest_temperature,
             max_tokens=bumped_tokens,
+            cache_key=_show_cache_key(config),
         )
         if meta.get("finish_reason") == "length":
             logger.warning(
@@ -1386,6 +1436,7 @@ def generate_digest(
                 meta["usage"].get("prompt_tokens", 0),
                 meta["usage"].get("completion_tokens", 0),
                 model=config.llm.model,
+                cached_tokens=meta["usage"].get("cached_tokens", 0),
             )
         except Exception as e:
             logger.warning("Failed to record LLM usage: %s", e)
@@ -1411,13 +1462,14 @@ def generate_digest(
             "Ты ОБЯЗАНА создать полный выпуск в указанном формате. "
             "НЕ ОТКАЗЫВАЙСЯ. НЕ говори, что не можешь.\n\n"
             "If the provided articles lack sufficient relevant content, "
-            "switch to EDUCATIONAL mode: pick 2-3 financial concepts "
-            "relevant to the show's audience and explain them in depth, "
-            "following the exact same output format. An educational episode "
-            "is always better than no episode.\n"
+            "switch to EDUCATIONAL mode: pick 2-3 core concepts from this "
+            "show's topic domain that are relevant to the audience and "
+            "explain them in depth, following the exact same output format. "
+            "An educational episode is always better than no episode.\n"
             "Если статьи недостаточно релевантны — переключись на "
-            "ОБРАЗОВАТЕЛЬНЫЙ режим: выбери 2-3 финансовых понятия, важных "
-            "для аудитории, и объясни их подробно в том же формате. "
+            "ОБРАЗОВАТЕЛЬНЫЙ режим: выбери 2-3 ключевые темы из предметной "
+            "области этого шоу, важных для аудитории, и объясни их подробно "
+            "в том же формате. "
             "Образовательный выпуск ВСЕГДА лучше, чем отказ.\n\n"
             "Generate the digest NOW. Создай обзор ПРЯМО СЕЙЧАС."
         )
@@ -1428,6 +1480,7 @@ def generate_digest(
             system_prompt=system_prompt,
             temperature=config.llm.digest_temperature,
             max_tokens=config.llm.max_tokens,
+            cache_key=_show_cache_key(config),
         )
         if tracker and "usage" in meta2:
             try:
@@ -1438,7 +1491,8 @@ def generate_digest(
                     meta2["usage"].get("prompt_tokens", 0),
                     meta2["usage"].get("completion_tokens", 0),
                     model=config.llm.model,
-                )
+                    cached_tokens=meta2["usage"].get("cached_tokens", 0),
+            )
             except Exception as e:
                 logger.warning("Failed to record retry LLM usage: %s", e)
 
@@ -1462,6 +1516,7 @@ def generate_digest(
                 system_prompt=system_prompt,
                 temperature=config.llm.podcast_temperature,  # slightly more creative
                 max_tokens=config.llm.max_tokens,
+                cache_key=_show_cache_key(config),
             )
             if tracker and "usage" in meta3:
                 try:
@@ -1472,7 +1527,8 @@ def generate_digest(
                         meta3["usage"].get("prompt_tokens", 0),
                         meta3["usage"].get("completion_tokens", 0),
                         model=config.llm.model,
-                    )
+                        cached_tokens=meta3["usage"].get("cached_tokens", 0),
+            )
                 except Exception as e:
                     logger.warning("Failed to record edu retry LLM usage: %s", e)
 
@@ -1498,6 +1554,7 @@ def generate_digest(
                     system_prompt=system_prompt,
                     temperature=config.llm.podcast_temperature,
                     max_tokens=config.llm.max_tokens,
+                    cache_key=_show_cache_key(config),
                 )
                 if tracker:
                     try:
@@ -1514,6 +1571,7 @@ def generate_digest(
                             meta4["usage"].get("prompt_tokens", 0),
                             meta4["usage"].get("completion_tokens", 0),
                             model=fallback_model,
+                            cached_tokens=meta4["usage"].get("cached_tokens", 0),
                         )
                     except Exception as e:
                         logger.warning("Failed to record fallback model LLM usage: %s", e)
@@ -1542,6 +1600,7 @@ def generate_digest(
                 system_prompt=system_prompt,
                 temperature=lower_temp,
                 max_tokens=config.llm.max_tokens,
+                cache_key=_show_cache_key(config),
             )
             _rep_retry = _validate_llm_output(
                 text_retry, stage="digest", show_name=config.name,
@@ -1604,6 +1663,7 @@ def generate_digest(
                     system_prompt=system_prompt,
                     temperature=config.llm.digest_temperature,
                     max_tokens=config.llm.max_tokens,
+                    cache_key=_show_cache_key(config),
                 )
                 # Validate the expanded draft is real content, not a refusal.
                 _validate_llm_output(expanded, stage="digest", show_name=config.name)
@@ -1636,7 +1696,8 @@ def generate_digest(
                                 meta_exp["usage"].get("prompt_tokens", 0),
                                 meta_exp["usage"].get("completion_tokens", 0),
                                 model=config.llm.model,
-                            )
+                                cached_tokens=meta_exp["usage"].get("cached_tokens", 0),
+            )
                         except Exception as e:
                             logger.warning("Failed to record expansion LLM usage: %s", e)
                 else:
@@ -1807,6 +1868,7 @@ def _generate_podcast_outline(
         system_prompt=system_prompt,
         temperature=config.llm.digest_temperature,  # Lower temp for planning
         max_tokens=1500,
+        cache_key=_show_cache_key(config),
     )
 
     if tracker and "usage" in meta:
@@ -1818,6 +1880,7 @@ def _generate_podcast_outline(
                 meta["usage"].get("prompt_tokens", 0),
                 meta["usage"].get("completion_tokens", 0),
                 model=config.llm.model,
+                cached_tokens=meta["usage"].get("cached_tokens", 0),
             )
         except Exception as e:
             logger.warning("Failed to record outline LLM usage: %s", e)
@@ -1899,6 +1962,7 @@ def generate_podcast_script(
         system_prompt=system_prompt,
         temperature=config.llm.podcast_temperature,
         max_tokens=podcast_tokens,
+        cache_key=_show_cache_key(config),
     )
 
     # Retry once with 50% more tokens if the response was truncated
@@ -1914,6 +1978,7 @@ def generate_podcast_script(
             system_prompt=system_prompt,
             temperature=config.llm.podcast_temperature,
             max_tokens=bumped_tokens,
+            cache_key=_show_cache_key(config),
         )
         if meta.get("finish_reason") == "length":
             logger.warning(
@@ -1930,6 +1995,7 @@ def generate_podcast_script(
                 meta["usage"].get("prompt_tokens", 0),
                 meta["usage"].get("completion_tokens", 0),
                 model=config.llm.model,
+                cached_tokens=meta["usage"].get("cached_tokens", 0),
             )
         except Exception as e:
             logger.warning("Failed to record LLM usage: %s", e)
@@ -1968,6 +2034,7 @@ def generate_podcast_script(
             system_prompt=system_prompt,
             temperature=lower_temp,
             max_tokens=podcast_tokens_for_retry,
+            cache_key=_show_cache_key(config),
         )
         if tracker and "usage" in meta_r1:
             try:
@@ -1977,7 +2044,8 @@ def generate_podcast_script(
                     meta_r1["usage"].get("prompt_tokens", 0),
                     meta_r1["usage"].get("completion_tokens", 0),
                     model=config.llm.model,
-                )
+                    cached_tokens=meta_r1["usage"].get("cached_tokens", 0),
+            )
             except Exception:
                 pass
         logger.info("Podcast refusal retry 1 generated (%d chars)", len(text))
@@ -2002,6 +2070,7 @@ def generate_podcast_script(
                 system_prompt=system_prompt,
                 temperature=lower_temp,
                 max_tokens=podcast_tokens_for_retry,
+                cache_key=_show_cache_key(config),
             )
             if tracker:
                 try:
@@ -2017,6 +2086,7 @@ def generate_podcast_script(
                         meta_r2["usage"].get("prompt_tokens", 0),
                         meta_r2["usage"].get("completion_tokens", 0),
                         model=fallback_model,
+                        cached_tokens=meta_r2["usage"].get("cached_tokens", 0),
                     )
                 except Exception:
                     pass
@@ -2075,6 +2145,7 @@ def generate_podcast_script(
             system_prompt=system_prompt,
             temperature=config.llm.podcast_temperature,
             max_tokens=podcast_tokens,
+            cache_key=_show_cache_key(config),
         )
 
         if tracker and "usage" in meta2:
@@ -2086,7 +2157,8 @@ def generate_podcast_script(
                     meta2["usage"].get("prompt_tokens", 0),
                     meta2["usage"].get("completion_tokens", 0),
                     model=config.llm.model,
-                )
+                    cached_tokens=meta2["usage"].get("cached_tokens", 0),
+            )
             except Exception as e:
                 logger.warning("Failed to record retry LLM usage: %s", e)
 
@@ -2139,6 +2211,7 @@ def generate_podcast_script(
                 system_prompt=system_prompt,
                 temperature=lower_temp,
                 max_tokens=podcast_tokens,
+                cache_key=_show_cache_key(config),
             )
             _rep_retry = _validate_llm_output(
                 text_retry, stage="podcast_script", show_name=config.name,
@@ -2211,6 +2284,7 @@ def generate_podcast_script(
                     system_prompt=system_prompt,
                     temperature=config.llm.podcast_temperature,
                     max_tokens=podcast_tokens,
+                    cache_key=_show_cache_key(config),
                 )
                 if tracker and "usage" in meta_rr:
                     try:
@@ -2220,7 +2294,8 @@ def generate_podcast_script(
                             meta_rr["usage"].get("prompt_tokens", 0),
                             meta_rr["usage"].get("completion_tokens", 0),
                             model=config.llm.model,
-                        )
+                            cached_tokens=meta_rr["usage"].get("cached_tokens", 0),
+            )
                     except Exception:
                         pass
                 reps_rr = detect_phrase_repetition(text_rr)

--- a/engine/tracking.py
+++ b/engine/tracking.py
@@ -135,6 +135,7 @@ def record_llm_usage(
     completion_tokens: int,
     estimated_cost_usd: float = 0.0,
     model: str = "",
+    cached_tokens: int = 0,
 ) -> None:
     """Record LLM token usage for a generation step.
 
@@ -143,6 +144,11 @@ def record_llm_usage(
 
     If *estimated_cost_usd* is 0 and *model* is provided, cost is
     estimated from the Grok pricing table.
+
+    *cached_tokens* (optional) is the prompt-cache hit count from xAI
+    ``usage.prompt_tokens_details.cached_tokens``. Tracked for telemetry;
+    cost estimation still uses full prompt_tokens until cached pricing
+    is wired into ``GROK_PRICING``.
     """
     grok = tracker["services"]["grok_api"]
     if model:
@@ -152,11 +158,19 @@ def record_llm_usage(
             "prompt_tokens": 0,
             "completion_tokens": 0,
             "total_tokens": 0,
+            "cached_tokens": 0,
             "estimated_cost_usd": 0.0,
         }
     grok[step]["prompt_tokens"] += prompt_tokens
     grok[step]["completion_tokens"] += completion_tokens
     grok[step]["total_tokens"] += prompt_tokens + completion_tokens
+    if cached_tokens:
+        grok[step]["cached_tokens"] = (
+            int(grok[step].get("cached_tokens", 0) or 0) + int(cached_tokens)
+        )
+        grok["cached_tokens"] = (
+            int(grok.get("cached_tokens", 0) or 0) + int(cached_tokens)
+        )
 
     if estimated_cost_usd > 0:
         grok[step]["estimated_cost_usd"] += estimated_cost_usd

--- a/engine/tts.py
+++ b/engine/tts.py
@@ -824,6 +824,7 @@ def _speak_with_grok(
     append_exclamation: bool = False,
     speech_wrap_open: str = "",
     speech_wrap_close: str = "",
+    speed: float = 1.0,
 ) -> None:
     """Grok-TTS counterpart of ``speak()``.
 
@@ -885,6 +886,7 @@ def _speak_with_grok(
             grok_speak_chunk(
                 out_text, voice_id, wav_chunk,
                 api_key=api_key, language_code=language_code, timeout=timeout,
+                speed=speed,
             )
             subprocess.run(
                 [
@@ -930,6 +932,7 @@ def _speak_with_grok(
             grok_speak_chunk(
                 chunk_text_str, voice_id, chunk_file,
                 api_key=api_key, language_code=language_code, timeout=timeout,
+                speed=speed,
             )
             chunk_files.append(chunk_file)
             wav_files.append(chunk_file)
@@ -1009,7 +1012,9 @@ def synthesize(
     output_path = Path(output_path)
     if provider == "grok":
         # Grok's "auto" detects language; explicit codes (e.g. "ru") are
-        # the safer choice for non-English shows.
+        # the safer choice for non-English shows. ``speed`` is a documented
+        # Grok TTS multiplier (0.7–1.5); default 1.0 keeps the payload
+        # byte-identical for every show that does not opt in.
         _speak_with_grok(
             text, voice_id, str(output_path),
             api_key=api_key,
@@ -1019,6 +1024,7 @@ def synthesize(
             append_exclamation=append_exclamation,
             speech_wrap_open=speech_wrap_open,
             speech_wrap_close=speech_wrap_close,
+            speed=speed,
         )
         return output_path
     # Default: ElevenLabs
@@ -1107,6 +1113,7 @@ def synthesize_sections(
                 timeout=timeout,
                 speech_wrap_open=speech_wrap_open,
                 speech_wrap_close=speech_wrap_close,
+                speed=speed,
             )
         else:
             speak(

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -155,7 +155,9 @@ tts:
   provider: grok
   voice_id: 0b875ae2
   language_code: ru
-  max_chars: 10000
+  # Align with network default so long Russian scripts keep the single-call
+  # <fast> wrap (multi-chunk drops the wrap — landmine #17).
+  max_chars: 14000
 multilingual:
   enabled: false
 audio:

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -97,7 +97,9 @@ tts:
   provider: grok
   voice_id: 0b875ae2
   language_code: ru
-  max_chars: 10000
+  # Align with network default so long scripts keep the single-call <fast>
+  # wrap (multi-chunk drops the wrap — landmine #17).
+  max_chars: 14000
 multilingual:
   enabled: false
 audio:

--- a/shows/prompts/spacex_weekly.txt
+++ b/shows/prompts/spacex_weekly.txt
@@ -1,6 +1,7 @@
-You are writing the weekly recap edition of "SpaceX Daily" for {today_str}.
+You are writing the weekly newsletter digest for "SpaceX Daily" for {today_str}.
 
 Synthesize the past week's themes from the provided episode summaries. Do NOT fetch new news.
+This is an EMAIL newsletter, not a spoken Sunday recap episode (full Sunday recap mode was retired).
 
 - Group related threads across the week
 - Name the week's most consequential development first

--- a/shows/templates/weekly.txt.template
+++ b/shows/templates/weekly.txt.template
@@ -1,6 +1,7 @@
-You are writing the weekly recap edition of "%SHOW_NAME%" for {today_str}.
+You are writing the weekly newsletter digest for "%SHOW_NAME%" for {today_str}.
 
 Synthesize the past week's themes from the provided episode summaries. Do NOT fetch new news.
+This is an EMAIL newsletter, not a spoken Sunday recap episode (full Sunday recap mode was retired).
 
 - Group related threads across the week
 - Name the week's most consequential development first

--- a/tests/test_prompt_grok_review_2026_07_09.py
+++ b/tests/test_prompt_grok_review_2026_07_09.py
@@ -1,0 +1,214 @@
+"""Drift guards for the July 9 2026 prompt + Grok API / Voice review.
+
+See ``docs/reviews/prompt_grok_review_2026_07_09.md``.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+SHOWS = ROOT / "shows"
+
+
+# ---------------------------------------------------------------------------
+# Prompt-cache sticky routing
+# ---------------------------------------------------------------------------
+
+class _FakeUsageDetails:
+    def __init__(self, cached_tokens=0):
+        self.cached_tokens = cached_tokens
+
+
+class _FakeUsage:
+    def __init__(self, cached=0):
+        self.prompt_tokens = 100
+        self.completion_tokens = 50
+        self.total_tokens = 150
+        self.prompt_tokens_details = _FakeUsageDetails(cached)
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content, finish_reason="stop"):
+        self.message = _FakeMessage(content)
+        self.finish_reason = finish_reason
+
+
+class _FakeResponse:
+    def __init__(self, content="ok", cached=0):
+        self.choices = [_FakeChoice(content)]
+        self.usage = _FakeUsage(cached)
+
+
+class _FakeCompletions:
+    def __init__(self, response, recorder):
+        self._response = response
+        self._recorder = recorder
+
+    def create(self, **kwargs):
+        self._recorder.update(kwargs)
+        return self._response
+
+
+class _FakeClient:
+    def __init__(self, response, recorder):
+        self.chat = SimpleNamespace(
+            completions=_FakeCompletions(response, recorder)
+        )
+
+
+@pytest.fixture
+def fake_openai_cache(monkeypatch):
+    recorder: dict = {}
+    response_holder = {"resp": _FakeResponse("  cached text  ", cached=40)}
+
+    def _make_openai(*args, **kwargs):
+        recorder["client_kwargs"] = kwargs
+        return _FakeClient(response_holder["resp"], recorder)
+
+    fake_mod = types.ModuleType("openai")
+    fake_mod.OpenAI = _make_openai
+    fake_mod.APITimeoutError = type("APITimeoutError", (Exception,), {})
+    fake_mod.APIConnectionError = type("APIConnectionError", (Exception,), {})
+    fake_mod.RateLimitError = type("RateLimitError", (Exception,), {})
+    monkeypatch.setitem(sys.modules, "openai", fake_mod)
+    monkeypatch.setenv("GROK_API_KEY", "test-key")
+    return recorder, response_holder
+
+
+class TestPromptCacheRouting:
+    def test_show_cache_key_format(self):
+        from engine.generator import _show_cache_key
+
+        cfg = SimpleNamespace(slug="tesla")
+        assert _show_cache_key(cfg) == "nerra-tesla"
+        assert _show_cache_key(SimpleNamespace(slug="")) is None
+        assert _show_cache_key(SimpleNamespace()) is None
+
+    def test_call_grok_sends_x_grok_conv_id(self, fake_openai_cache):
+        from engine.generator import _call_grok
+
+        recorder, _ = fake_openai_cache
+        text, meta = _call_grok(
+            "hello", model="grok-4.3", cache_key="nerra-tesla",
+        )
+        assert text == "cached text"
+        assert recorder.get("extra_headers", {}).get("x-grok-conv-id") == (
+            "nerra-tesla"
+        )
+        assert meta["cache_key"] == "nerra-tesla"
+        assert meta["usage"]["cached_tokens"] == 40
+
+    def test_call_grok_omits_header_without_cache_key(self, fake_openai_cache):
+        from engine.generator import _call_grok
+
+        recorder, _ = fake_openai_cache
+        _call_grok("hello", model="grok-4.3")
+        assert "extra_headers" not in recorder
+
+    def test_record_llm_usage_tracks_cached_tokens(self):
+        from engine.tracking import create_tracker, record_llm_usage
+
+        tracker = create_tracker("Tesla Shorts Time", 1)
+        record_llm_usage(
+            tracker, "x_thread_generation", 100, 50,
+            model="grok-4.3", cached_tokens=40,
+        )
+        step = tracker["services"]["grok_api"]["x_thread_generation"]
+        assert step["cached_tokens"] == 40
+        assert tracker["services"]["grok_api"]["cached_tokens"] == 40
+
+
+# ---------------------------------------------------------------------------
+# Grok TTS speed passthrough (single-voice path)
+# ---------------------------------------------------------------------------
+
+class TestGrokTtsSpeedPassthrough:
+    def test_speak_with_grok_signature_accepts_speed(self):
+        import inspect
+        from engine.tts import _speak_with_grok
+
+        params = inspect.signature(_speak_with_grok).parameters
+        assert "speed" in params
+        assert params["speed"].default == 1.0
+
+    def test_synthesize_forwards_speed_to_grok(self, monkeypatch, tmp_path):
+        """``synthesize(provider='grok', speed=…)`` must reach ``_speak_with_grok``."""
+        from engine import tts as tts_mod
+
+        captured = {}
+
+        def _fake_speak(*args, **kwargs):
+            captured.update(kwargs)
+            Path(args[2]).write_bytes(b"fake")
+
+        monkeypatch.setattr(tts_mod, "_speak_with_grok", _fake_speak)
+        out = tmp_path / "out.mp3"
+        tts_mod.synthesize(
+            "hello world",
+            "kdif6sqjcyiq",
+            out,
+            api_key="k",
+            provider="grok",
+            speed=1.05,
+        )
+        assert captured.get("speed") == 1.05
+
+
+# ---------------------------------------------------------------------------
+# Russian max_chars alignment + weekly newsletter wording
+# ---------------------------------------------------------------------------
+
+class TestRussianMaxChars:
+    def test_russian_shows_use_network_max_chars(self):
+        for slug in ("finansy_prosto", "privet_russian"):
+            data = yaml.safe_load(
+                (SHOWS / f"{slug}.yaml").read_text(encoding="utf-8")
+            ) or {}
+            assert (data.get("tts") or {}).get("max_chars") == 14000, (
+                f"{slug}.yaml: tts.max_chars must be 14000 so long scripts "
+                "keep the single-call <fast> wrap (landmine #17)"
+            )
+
+
+class TestWeeklyNewsletterWording:
+    def test_spacex_weekly_is_newsletter_not_recap_edition(self):
+        text = (SHOWS / "prompts" / "spacex_weekly.txt").read_text(
+            encoding="utf-8"
+        )
+        assert "weekly recap edition" not in text.lower()
+        assert "newsletter" in text.lower()
+
+    def test_weekly_template_is_newsletter_not_recap_edition(self):
+        text = (SHOWS / "templates" / "weekly.txt.template").read_text(
+            encoding="utf-8"
+        )
+        assert "weekly recap edition" not in text.lower()
+        assert "newsletter" in text.lower()
+
+
+class TestAntiRefusalGeneric:
+    def test_anti_refusal_not_finance_only(self):
+        src = (ROOT / "engine" / "generator.py").read_text(encoding="utf-8")
+        assert "2-3 financial concepts" not in src
+        assert "topic domain" in src
+
+
+class TestReviewDocExists:
+    def test_review_doc_present(self):
+        path = ROOT / "docs" / "reviews" / "prompt_grok_review_2026_07_09.md"
+        assert path.is_file()
+        body = path.read_text(encoding="utf-8")
+        assert "x-grok-conv-id" in body
+        assert "landmine #17" in body


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Thorough review of all prompts against current Grok API / Voice docs (follow-up to `docs/prompt_review_2026_06_10.md`). Full writeup: [`docs/reviews/prompt_grok_review_2026_07_09.md`](docs/reviews/prompt_grok_review_2026_07_09.md).

**Verdict:** June 10 editorial prompt quality still holds. Biggest unclaimed wins were infrastructure (prompt-cache sticky routing never wired; TTS `speed` never reached single-voice Grok; Russian shows at 10k `max_chars` risked dropping `<fast>`). Those ship here. Bulk prompt rewrites and Voice/prosody experiments stay behind landmine #17.

## Shipped (safe)

1. **Prompt-cache sticky routing** — `_call_grok` sends `x-grok-conv-id: nerra-<slug>`; logs + tracks `cached_tokens`. Fetch helper gets optional `cache_key` too (`nerra-fetch-x` / `nerra-fetch-web`).
2. **Grok TTS `speed`** on single-voice `synthesize` / `_speak_with_grok` (default 1.0 = byte-identical payload).
3. **FP/PR `max_chars: 14000`** — align with network default so long scripts keep single-call `<fast>` wrap.
4. **Anti-refusal fallback** — “financial concepts” → show topic domain (generic).
5. **Weekly newsletter prompts** — drop stale “recap edition” wording (full Sunday recap retired).

## Not applied (A/B / operator)

- Bulk `<<include:>>` of shared snippets into show prompts
- Responses API migration for digest/podcast
- Model bump / `reasoning_effort`
- Speech tags / phonetic respellings / tic de-seeds
- Cached-token discount in cost estimates (telemetry first)

## Tests

`tests/test_prompt_grok_review_2026_07_09.py` (+ existing `TestCallGrok` / Russian TTS guards).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

