### PR TITLE
ci(deps): bump actions/checkout from 4 to 7

### DIFF
--- a/.github/workflows/mit-live-executor.yml
+++ b/.github/workflows/mit-live-executor.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/mit-shadow-executor.yml
+++ b/.github/workflows/mit-shadow-executor.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nerra_voices_fire_interview.yml
+++ b/.github/workflows/nerra_voices_fire_interview.yml
@@ -20,7 +20,7 @@ jobs:
   fire:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/.github/workflows/nerra_voices_post_interview.yml
+++ b/.github/workflows/nerra_voices_post_interview.yml
@@ -14,7 +14,7 @@ jobs:
   process:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/.github/workflows/nerra_voices_prep_briefs.yml
+++ b/.github/workflows/nerra_voices_prep_briefs.yml
@@ -14,7 +14,7 @@ jobs:
   prep_briefs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/.github/workflows/nerra_voices_produce_episode.yml
+++ b/.github/workflows/nerra_voices_produce_episode.yml
@@ -13,7 +13,7 @@ jobs:
   produce:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/.github/workflows/nerra_voices_publish.yml
+++ b/.github/workflows/nerra_voices_publish.yml
@@ -24,7 +24,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v6

--- a/.github/workflows/snaptrade-mirror.yml
+++ b/.github/workflows/snaptrade-mirror.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Completes Dependabot #780 after it conflicted with the already-merged `actions/setup-python@v6` (#782).

Resolution: `checkout@v7` + `setup-python@v6` (and `upload-artifact@v7` already on main) across the MIT/SnapTrade/Nerra Voices workflows that Dependabot targeted.

Supersedes #780.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

