### PR TITLE
YouTube visual pass: image-first thumbnails, clean gallery, compelling descriptions

### DIFF
--- a/assets/js/gallery.js
+++ b/assets/js/gallery.js
@@ -713,6 +713,26 @@
             .then(function (manifest) {
                 var images = manifest.images || [];
                 var shows = manifest.shows || [];
+                // Defense-in-depth: text-burned YouTube thumbnail composites
+                // (intended_use: thumbnail_variant) are not useful in the
+                // public gallery. The manifest builder already excludes them;
+                // this filter covers older manifests until the next rebuild.
+                var EXCLUDED_USES = {
+                    thumbnail_variant: 1,
+                    thumbnail: 1,
+                    youtube_thumbnail: 1,
+                };
+                images = images.filter(function (i) {
+                    var use = (i.intended_use || '').toLowerCase();
+                    if (EXCLUDED_USES[use]) return false;
+                    var tags = i.tags || [];
+                    for (var t = 0; t < tags.length; t++) {
+                        if (EXCLUDED_USES[String(tags[t]).toLowerCase()]) {
+                            return false;
+                        }
+                    }
+                    return true;
+                });
                 if (fixedShowSlug) {
                     images = images.filter(function (i) {
                         return i.show_slug === fixedShowSlug;

--- a/docs/reviews/youtube_visual_pass_2026_07_09.md
+++ b/docs/reviews/youtube_visual_pass_2026_07_09.md
@@ -1,0 +1,72 @@
+# YouTube visual + description pass (July 9, 2026)
+
+Operator ask: gallery images all have text overlaid and aren't useful;
+YouTube keyframes look like a dark image behind white text; want videos,
+Shorts, and descriptions that are beautiful and compelling while keeping
+the key elements already built (UTM links, chapters, disclosure, hashtags,
+show page, performance title loop).
+
+**Scope:** render / metadata / gallery only — **no audio / TTS / podcast
+prompts** (outside landmine #17).
+
+## Root causes found
+
+1. **Thumbnail compositor** (`engine/publisher.generate_episode_thumbnail`)
+   full-frame `Brightness(0.55)` + centred white hook → every keyframe
+   read as a title card, not photography.
+2. **Gallery pollution** — text-burned `thumbnail_variant` composites were
+   uploaded to the public `nerra-gallery` bucket and surfaced newest-first
+   in `gallery-manifest.json` (~7% of images, often the ones visitors see
+   first).
+3. **Grok Imagine prompts** appended the full episode headline after
+   `depicting: …`, which the model painted as on-image chyron text despite
+   a soft "no text" hint.
+4. **Shorts titles** used `text[:80]` mid-word truncation from the smart
+   selector's `opening_text`.
+5. **Descriptions** buried entity hashtags after body/chapters (below the
+   mobile "Show more" fold); intro template was bland.
+6. **Performance iteration** — code path is live
+   (`engine/youtube_titles` + `scripts/update_youtube_performance.py`) but
+   **data-dormant** until OAuth is re-authed with `yt-analytics.readonly`
+   and a few weeks of retention accrue. No code change required for the
+   loop itself; operator action noted below.
+
+## Shipped
+
+| Change | Why |
+|---|---|
+| Image-first thumbnail: bottom gradient scrim + lower-third hook (no full darken) | Keyframes stay photographic and enticing |
+| Public gallery excludes `thumbnail_variant` / `thumbnail` / `youtube_thumbnail` (manifest builder + JS defense) | Gallery shows clean Grok scenes only |
+| Grok prompts: `visual subject:` short phrase + hard ZERO-text cue (no `depicting:` dump) | Fewer on-image text overlays in new scenes |
+| Shorts end card prefers a clean scene still over the text-burned long-form thumb | End card isn't a slide-of-a-slide |
+| Word-boundary Shorts `opening_text` trim | Titles don't cut mid-word |
+| Hashtags moved above the fold (long-form + Shorts); stronger description intro | Discovery tags + compelling copy visible without "Show more" |
+
+## Operator follow-ups (not code)
+
+1. **Re-auth YouTube OAuth** with `yt-analytics.readonly` so
+   `youtube_performance.json` / title hints start accruing (see
+   [`docs/youtube_feedback_loop.md`](../youtube_feedback_loop.md)).
+2. **Rebuild the gallery manifest** once (nightly workflow or
+   `python scripts/build_gallery_manifest.py`) so existing
+   `thumbnail_variant` sidecars drop from the public page. R2 objects
+   can stay for Studio A/B; they just won't list publicly.
+3. Spot-check the next 2–3 YouTube publishes (Tesla + one Shorts-heavy
+   show) for thumbnail look + description fold.
+
+## Drift guards
+
+- `tests/test_thumbnail_autofit.py` — bright top-of-frame + 160-char cap
+- `tests/test_grok_imagine.py` — no `depicting:`, ZERO-text, subject compress
+- `tests/test_build_gallery_manifest.py` — excludes thumbnail variants
+- `tests/test_youtube.py` — hashtags before show-page line
+- `tests/test_shorts_selector.py` — word-boundary trim
+
+## Predictions (next review scores)
+
+1. New gallery uploads after merge are ≥95% `segment_card`/`social` (no
+   new `thumbnail_variant` in the public manifest).
+2. Fresh Grok scenes show on-image text in ≤1 of 10 spot-checks (was
+   near-universal when headlines were dumped).
+3. Long-form / Shorts thumbnails keep mean top-band brightness clearly
+   above the old 0.55-darkened look (visual A/B on next publish).

--- a/docs/youtube_visual_reuse.md
+++ b/docs/youtube_visual_reuse.md
@@ -55,8 +55,11 @@ Layers (bottom-up):
   over the episode's first fresh 16:9 scene (cover fallback), and up to
   `thumbnail_variants` (2) additional composites are rendered from OTHER
   scenes (same hook text/autofit) and uploaded to the gallery R2 bucket
-  (`intended_use: thumbnail_variant`, ignored by the scene selector) for the
-  operator's Studio "Test & Compare" A/B. URLs land in the episode metrics.
+  (`intended_use: thumbnail_variant`) for the operator's Studio "Test &
+  Compare" A/B. URLs land in the episode metrics. **July 2026:** those
+  text-burned variants are **excluded from the public gallery manifest**
+  (and filtered client-side) so visitors only see clean Grok Imagine
+  scenes — variants remain in R2 for Studio.
 - **Evergreen b-roll** — up to 3 curated silent clips interleave into the
   long-form slideshow. A clean no-op until the operator publishes a
   `digests/<dir>/broll.json` pool (below).

--- a/engine/grok_imagine.py
+++ b/engine/grok_imagine.py
@@ -200,20 +200,22 @@ def build_image_prompts(
         if is_vertical
         else "wide cinematic 16:9 framing, photojournalism style"
     )
-    # Network-wide visual-quality cue (June 14 2026): a compact, tasteful set of
-    # modifiers so every generated image reads as a polished editorial photo
-    # rather than a flat stock render. Kept short so it sharpens look without
-    # overriding the subject/narrative the rest of the prompt carries.
+    # Network-wide visual-quality cue (June 14 2026; retuned July 2026):
+    # polished editorial photo, not a flat stock render or title card.
     quality_hint = (
         "dramatic natural lighting, rich depth of field, sharp focus, "
-        "high detail, vivid color grading, professional editorial photography"
+        "high detail, vivid color grading, professional editorial photography, "
+        "cinematic atmosphere, beautiful and enticing"
     )
-    # Operator caught: Grok Imagine renders any free-text "context" hint
-    # as a banner / on-image text overlay. Telling it explicitly to
-    # produce a clean image stops the headline appearing as a chyron
-    # across every slide. This is a soft signal — Grok still occasionally
-    # emits text, but compliance is dramatically better with the cue.
-    no_text_hint = "clean photographic composition, no text or words rendered in the image"
+    # Hard no-text contract. Operator review (July 2026): dumping the full
+    # episode headline after ``depicting:`` made Grok paint white chyron
+    # text onto nearly every gallery image. We now pass only short visual
+    # subject phrases (see ``_visual_subject_phrase``) and reinforce the
+    # ban with an explicit negative.
+    no_text_hint = (
+        "clean photographic composition with ZERO text, letters, words, "
+        "captions, logos, watermarks, or typography of any kind in the frame"
+    )
 
     safe_hook = (hook or "").strip().rstrip(".")
     descriptor = (show_descriptor or "photorealistic news photo").strip()
@@ -245,9 +247,9 @@ def build_image_prompts(
         if not q:
             continue
         parts = [q, descriptor, framing_hint, quality_hint, no_text_hint]
-        ctx = _context_for(len(prompts))
-        if ctx:
-            parts.append(f"depicting: {ctx}")
+        subject = _visual_subject_phrase(_context_for(len(prompts)))
+        if subject:
+            parts.append(f"visual subject: {subject}")
         if narrative_boost:
             parts.append(narrative_boost)
         prompts.append(", ".join(parts))
@@ -261,14 +263,35 @@ def build_image_prompts(
         if not q:
             break
         parts = [q, descriptor, framing_hint, quality_hint, no_text_hint, f"variant {len(prompts) + 1}"]
-        ctx = _context_for(len(prompts))
-        if ctx:
-            parts.append(f"depicting: {ctx}")
+        subject = _visual_subject_phrase(_context_for(len(prompts)))
+        if subject:
+            parts.append(f"visual subject: {subject}")
         if narrative_boost:
             parts.append(narrative_boost)
         prompts.append(", ".join(parts))
 
     return prompts
+
+
+def _visual_subject_phrase(raw: str, *, max_words: int = 8) -> str:
+    """Compress a headline into a short visual-subject phrase.
+
+    Full-sentence hooks after ``depicting:`` were being painted as on-image
+    text by Grok Imagine. Keep only the first ``max_words`` content-ish
+    tokens so the model gets a subject cue without a quotable caption.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return ""
+    # Drop trailing clause noise that reads as caption copy.
+    for sep in (" — ", " - ", ": ", "; ", ". "):
+        if sep in text:
+            text = text.split(sep, 1)[0].strip()
+            break
+    words = [w for w in text.split() if w]
+    if len(words) <= max_words:
+        return " ".join(words)
+    return " ".join(words[:max_words])
 
 
 # ---------------------------------------------------------------------------

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -1320,6 +1320,43 @@ def _wrap_text(text: str, font, max_width: int) -> list:
     return lines
 
 
+def _draw_bottom_scrim(img, *, start_frac: float = 0.42) -> None:
+    """Paint a bottom-up dark gradient so lower-third text stays readable.
+
+    Image-first redesign (July 2026): the previous full-frame Brightness
+    0.55 darken made every thumbnail look like "dark photo + white text".
+    A scrim keeps the upper ~60 % of the frame at full photographic
+    brightness (the enticing part of a Grok Imagine scene) while giving
+    the hook / footer a legible bed. Mutates ``img`` in place.
+    """
+    from PIL import Image
+
+    width, height = img.size
+    overlay = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    start_y = max(0, int(height * start_frac))
+    band = max(1, height - start_y)
+    # Build one column of alpha, then stretch — cheap and smooth.
+    col = Image.new("RGBA", (1, height), (0, 0, 0, 0))
+    col_px = col.load()
+    for y in range(start_y, height):
+        # 0 at start_y → ~200 at the bottom (not fully opaque — imagery
+        # still peeks through so the frame doesn't read as a black bar).
+        t = (y - start_y) / band
+        alpha = int(30 + 170 * (t ** 1.15))
+        col_px[0, y] = (0, 0, 0, alpha)
+    overlay = col.resize((width, height), Image.BILINEAR)
+    base = img.convert("RGBA")
+    composed = Image.alpha_composite(base, overlay)
+    img.paste(composed.convert("RGB"))
+
+
+def _draw_text_with_shadow(draw, xy, text, *, font, fill, shadow=(0, 0, 0)):
+    """White (or coloured) text with a soft 2-px drop shadow for contrast."""
+    x, y = xy
+    draw.text((x + 2, y + 2), text, font=font, fill=shadow)
+    draw.text((x, y), text, font=font, fill=fill)
+
+
 def generate_episode_thumbnail(
     base_image_path: Path,
     episode_num: int,
@@ -1330,18 +1367,22 @@ def generate_episode_thumbnail(
     show_name: str = "",
     size: tuple = (1280, 720),
 ) -> tuple[Path, int | None]:
-    """Returns (thumbnail_path, hook_font_size_used or None)."""
-    """Render an episode thumbnail by overlaying text on the show cover.
+    """Render an image-first episode thumbnail for YouTube.
 
-    Output is a JPEG at YouTube's recommended 1280x720 thumbnail spec by
-    default. The cover is scaled-and-cropped to fill the frame, darkened
-    for legibility, then overlaid with the show name (top-left), the
-    headline ``hook`` (large, centred), and an "Ep N — date" footer.
+    Returns ``(thumbnail_path, hook_font_size_used or None)``.
+
+    Output is a JPEG at YouTube's recommended 1280×720 (or 1080×1920 for
+    Shorts). The cover/scene is scaled-and-cropped to fill the frame at
+    **full brightness**, a bottom gradient scrim is painted for text
+    legibility, then a compact lower-third hook + show label + Ep footer
+    are overlaid. Deliberately NOT a full-frame darken + centred white
+    block — that look made gallery/keyframe graphics feel like slides
+    rather than enticing photography (July 2026 visual pass).
 
     Parameters
     ----------
     base_image_path:
-        Source cover image (e.g. ``assets/covers/<show>.jpg``).
+        Source cover or Grok Imagine scene.
     episode_num:
         Episode number for the footer line.
     date_str:
@@ -1350,14 +1391,14 @@ def generate_episode_thumbnail(
         Output file path. Suffix ``.jpg``/``.jpeg`` writes JPEG (what
         YouTube prefers); anything else writes PNG.
     hook:
-        Optional one-line headline. Wrapped to fit and rendered as the
-        dominant text. When empty, only the show name + footer appear.
+        Optional one-line headline. Wrapped to fit and rendered in the
+        lower third. When empty, only the show name + footer appear.
     show_name:
         Optional small label rendered top-left.
     size:
         Output ``(width, height)`` in pixels.
     """
-    from PIL import Image, ImageDraw, ImageEnhance
+    from PIL import Image, ImageDraw
 
     width, height = size
     img = Image.open(base_image_path).convert("RGB")
@@ -1376,48 +1417,37 @@ def generate_episode_thumbnail(
     top = (new_h - height) // 2
     img = img.crop((left, top, left + width, top + height))
 
-    # Darken so white text reads cleanly.
-    img = ImageEnhance.Brightness(img).enhance(0.55)
+    # Image-first: keep the photograph bright; only darken the lower third.
+    _draw_bottom_scrim(img, start_frac=0.48 if height > width else 0.42)
 
     draw = ImageDraw.Draw(img)
     margin = max(32, width // 32)
 
     if show_name:
-        label_font = _load_font(max(28, width // 32))
-        draw.text((margin, margin), show_name, font=label_font,
-                  fill=(255, 255, 255))
+        # Compact brand chip — small enough that the scene stays the hero.
+        label_font = _load_font(max(22, width // 40))
+        _draw_text_with_shadow(
+            draw, (margin, margin), show_name,
+            font=label_font, fill=(255, 255, 255),
+        )
 
+    font_size = None
     if hook:
         clean_hook = hook.strip()
-        # Safety cap — anything longer than 220 chars is almost
-        # certainly an LLM run-on; truncate to keep the auto-fit loop
-        # from producing illegible 5-line micro-text on a thumbnail.
-        # The hook is also the first paragraph of the script; the
-        # extra context is preserved on the actual show notes / RSS.
-        if len(clean_hook) > 220:
-            clean_hook = clean_hook[:217].rstrip() + "…"
-        # Auto-shrink-to-fit. Operator caught (May 2026) hooks like
-        # "Tesla is hiring engineers to build a wireless Battery
-        # Management System for Cybercab that removes heavy wiring"
-        # rendering as 5+ lines on Shorts (1080×1920) and clipping
-        # against the top of the safe area at the legacy fixed
-        # 77 px size. Instead of clipping or hard-truncating mid-word,
-        # we shrink the font until the wrapped block fits inside the
-        # text-safe area (60 % of frame height — leaves room for the
-        # show label at top and the footer at bottom). The descent
-        # cap on font size also keeps the smallest legible reading
-        # at ~32 px which is readable on a phone preview thumbnail.
+        # Safety cap — anything longer than 160 chars is almost
+        # certainly an LLM run-on; lower-third layout wants punchy
+        # copy (the full hook still lives in the description).
+        if len(clean_hook) > 160:
+            cut = clean_hook[:157].rsplit(" ", 1)[0].rstrip(",.;:—-")
+            clean_hook = (cut or clean_hook[:157]).rstrip() + "…"
+        # Auto-shrink-to-fit into the LOWER THIRD (not the full centre).
+        # Portrait Shorts get 3 lines; landscape long-form gets 2 — denser
+        # copy belongs in the title/description, not the keyframe.
         max_text_width = width - 2 * margin
-        # Leave 20 % top + 20 % bottom for show label / footer breathing
-        # room. The hook block can fill the central 60 %.
-        max_block_h = int(height * 0.60)
-        max_lines = 4 if height >= width else 3
-        # Try sizes from the YouTube-preferred large size all the way
-        # down to a hard floor. The fall-through floor (32 px) is set
-        # so even on a runaway-long hook the text is still readable
-        # on a 320-px-wide YouTube mobile preview tile.
-        max_font = max(56, width // 14)
-        min_font = max(32, width // 24)
+        max_block_h = int(height * (0.28 if height > width else 0.32))
+        max_lines = 3 if height >= width else 2
+        max_font = max(48, width // 16)
+        min_font = max(28, width // 28)
         font_size = max_font
         lines: list = []
         line_h = 0
@@ -1425,48 +1455,46 @@ def generate_episode_thumbnail(
             hook_font = _load_font(font_size)
             lines = _wrap_text(clean_hook, hook_font, max_text_width)
             ascent_descent = hook_font.getbbox("Ay")
-            line_h = (ascent_descent[3] - ascent_descent[1]) + 12
+            line_h = (ascent_descent[3] - ascent_descent[1]) + 10
             block_h = line_h * len(lines)
             if block_h <= max_block_h and len(lines) <= max_lines:
                 break
-            # Shrink by 8 px per pass — fine-grained enough to find a
-            # good fit without spending many PIL renders on a single
-            # thumbnail (hot path during YouTube publish).
-            font_size -= 8
+            font_size -= 6
         else:
-            # We hit the floor and still don't fit. Render at the
-            # floor; visual review will catch any pathological case
-            # and the operator can hand-edit the hook in the YAML
-            # rather than ship a bad thumbnail.
             hook_font = _load_font(min_font)
             lines = _wrap_text(clean_hook, hook_font, max_text_width)
             ascent_descent = hook_font.getbbox("Ay")
-            line_h = (ascent_descent[3] - ascent_descent[1]) + 12
+            line_h = (ascent_descent[3] - ascent_descent[1]) + 10
         block_h = line_h * len(lines)
-        y = (height - block_h) // 2
+        # Sit the hook block just above the footer, inside the scrim.
+        footer_reserve = max(48, height // 14)
+        y = height - margin - footer_reserve - block_h
+        y = max(int(height * 0.52), y)
         for line in lines:
             bbox = hook_font.getbbox(line)
             line_w = bbox[2] - bbox[0]
             x = (width - line_w) // 2
-            draw.text((x, y), line, font=hook_font, fill=(255, 255, 255))
+            _draw_text_with_shadow(
+                draw, (x, y), line,
+                font=hook_font, fill=(255, 255, 255),
+            )
             y += line_h
 
-    footer_font = _load_font(max(28, width // 32))
+    footer_font = _load_font(max(22, width // 40))
     footer = f"Ep {episode_num} — {date_str}" if date_str else f"Ep {episode_num}"
     footer_bbox = footer_font.getbbox(footer)
     footer_h = footer_bbox[3] - footer_bbox[1]
-    draw.text((margin, height - margin - footer_h), footer,
-              font=footer_font, fill=(255, 255, 255))
+    _draw_text_with_shadow(
+        draw, (margin, height - margin - footer_h), footer,
+        font=footer_font, fill=(220, 224, 232),
+    )
 
     suffix = output_path.suffix.lower()
     if suffix in (".jpg", ".jpeg"):
-        img.save(output_path, "JPEG", quality=88, optimize=True)
+        img.save(output_path, "JPEG", quality=90, optimize=True)
     else:
         img.save(output_path, "PNG")
-    # Return the final hook font size used by autofit so callers can record
-    # the decision for observability of the May 2026 thumbnail improvements.
-    final_hook_font = font_size if 'font_size' in locals() else None
-    return output_path, final_hook_font
+    return output_path, font_size
 
 
 def generate_thumbnail_variants(
@@ -1544,26 +1572,17 @@ def generate_shorts_end_card(
     main_text: str = "WATCH FULL EPISODE",
     sub_text: str = "Tap Subscribe ↗",
     size: tuple = (1080, 1920),
+    scene_image_path: "Path | None" = None,
 ) -> Path:
     """Render the 1080×1920 PNG end-card overlay for a Shorts MP4.
 
-    The drawn card composites the long-form 1280×720 thumbnail into
-    the upper third of a dark vertical frame, then layers a big
-    headline ("WATCH FULL EPISODE") + cyan sub-line ("Tap Subscribe
-    ↗") + a small ``nerranetwork.com`` footer below it. The output
-    is a PNG (transparent background pixels would be wasted — the
-    image fills the whole frame), used as an ffmpeg overlay input
-    on the Shorts MP4 during the last 3 seconds in
-    ``engine.video._short_form_filter_graph``.
+    Prefers a **clean scene image** (``scene_image_path`` — a raw Grok
+    Imagine still without burned-in hook text) when provided; falls
+    back to the long-form thumbnail composite. July 2026: embedding the
+    text-burned thumbnail made the end card look like a slide of a
+    slide. The CTA copy still lives below the image.
 
-    This is the visual upgrade over the drawtext-only end card
-    shipped in PR #417: viewers see what the actual long-form
-    episode looks like, which is significantly more compelling
-    than a text-only "WATCH FULL EPISODE" prompt.
-
-    Falls back to a text-only render when ``long_form_thumbnail_path``
-    is missing or fails to load (defensive: thumbnail generation can
-    fail upstream and we want the end card to still ship).
+    Falls back to a text-only render when neither image loads.
     """
     from PIL import Image, ImageDraw
 
@@ -1573,13 +1592,12 @@ def generate_shorts_end_card(
     # slideshow behind a PNG overlay).
     bg = Image.new("RGB", (width, height), (11, 15, 26))  # --nn-bg
 
-    # Crop the long-form thumbnail into the upper third. Long-form
-    # thumbs are 1280×720 (16:9). Scale to 1080 wide → 1080×608.
-    # Centre vertically inside a 1080×~720 slot at y≈300..1020.
+    # Prefer the clean scene (no burned-in hook) over the text composite.
+    preview_path = scene_image_path or long_form_thumbnail_path
     thumb_section_top = int(height * 0.16)   # y ≈ 307
     thumb_section_h = int(height * 0.38)     # h ≈ 730
     try:
-        thumb = Image.open(long_form_thumbnail_path).convert("RGB")
+        thumb = Image.open(preview_path).convert("RGB")
         # Scale-to-fit (preserve aspect, fit inside thumb_section).
         src_ratio = thumb.width / thumb.height
         target_w = width
@@ -1598,11 +1616,11 @@ def generate_shorts_end_card(
              thumb_x + target_w + 4, thumb_y + target_h + 4),
             outline=(255, 255, 255), width=4,
         )
-    except (FileNotFoundError, OSError) as exc:
+    except (FileNotFoundError, OSError, TypeError) as exc:
         logger.warning(
-            "Shorts end card: long-form thumbnail unavailable (%s) — "
+            "Shorts end card: preview image unavailable (%s) — "
             "rendering text-only card. (%s)",
-            long_form_thumbnail_path, exc,
+            preview_path, exc,
         )
         # No thumbnail to paste — the rest of the card still renders.
 

--- a/engine/shorts_selector.py
+++ b/engine/shorts_selector.py
@@ -93,6 +93,22 @@ _NUMERIC_PATTERNS = (
 # ---------------------------------------------------------------------------
 
 
+def _trim_opening_text(text: str, *, max_chars: int = 80) -> str:
+    """Trim Shorts window labels on a word boundary (not mid-word).
+
+    July 2026: ``text[:80]`` was cutting titles mid-word ("Cybercab
+    wirele…") which then became the Shorts upload title. Prefer a clean
+    last-space cut + ellipsis when over budget.
+    """
+    cleaned = (text or "").strip()
+    if len(cleaned) <= max_chars:
+        return cleaned
+    cut = cleaned[: max_chars - 1].rsplit(" ", 1)[0].rstrip(",.;:—-")
+    if not cut or len(cut) < max_chars // 3:
+        cut = cleaned[: max_chars - 1].rstrip()
+    return cut + "…"
+
+
 @dataclass(frozen=True)
 class ScoredWindow:
     """One candidate Shorts window with its engagement score."""
@@ -287,7 +303,7 @@ def score_candidates(
             start_seconds=start_final,
             end_seconds=start_final + window_duration,
             score=score,
-            opening_text=text[:80],
+            opening_text=_trim_opening_text(text, max_chars=80),
         ))
     out.sort(key=lambda w: w.score, reverse=True)
     return out

--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -376,9 +376,25 @@ def build_long_form_metadata(
     except Exception:  # noqa: BLE001 — never block a YouTube upload
         discovery_line = ""
 
+    # Hashtags early: YouTube surfaces the first 3 as clickable topic links
+    # above the title. July 2026 — moved above the fold (was buried after
+    # body/chapters) so discovery tags aren't lost under "Show more".
+    _hashtag_line = ""
+    try:
+        from engine.shorts_hashtags import extract_hashtags, format_hashtag_line
+        _extracted = extract_hashtags(
+            hook, show_keywords=list(getattr(config, "keywords", []) or []),
+            max_hashtags=5,
+        )
+        _hashtag_line = format_hashtag_line(_extracted, ("#podcast",))
+    except Exception:  # noqa: BLE001 — hashtags must never block an upload
+        _hashtag_line = ""
+
     pieces: List[str] = []
     if hook:
         pieces.append(hook.strip())
+    if _hashtag_line:
+        pieces.append(_hashtag_line)
     pieces.append(show_page_line)
     pieces.append(subscribe_line)
     if discovery_line:
@@ -393,20 +409,6 @@ def build_long_form_metadata(
         cleaned = [line.strip() for line in photo_attribution if line.strip()]
         if cleaned:
             pieces.append("Photos via Pexels:\n" + "\n".join(cleaned))
-    # SEO: entity hashtags so YouTube renders the first 3 as clickable topic
-    # links above the title (a discovery lever Shorts already had but long-form
-    # was missing). Same heuristic extractor as Shorts; static tail "#podcast".
-    try:
-        from engine.shorts_hashtags import extract_hashtags, format_hashtag_line
-        _extracted = extract_hashtags(
-            hook, show_keywords=list(getattr(config, "keywords", []) or []),
-            max_hashtags=5,
-        )
-        _hashtag_line = format_hashtag_line(_extracted, ("#podcast",))
-        if _hashtag_line:
-            pieces.append(_hashtag_line)
-    except Exception:  # noqa: BLE001 — hashtags must never block an upload
-        pass
     disclosure = (config.youtube.synthetic_disclosure or "").strip()
     if disclosure:
         pieces.append(disclosure)
@@ -489,9 +491,21 @@ def build_short_metadata(
     # hint even when the headline is long.
     title = _build_seo_title(headline, rss_title, suffix="#Shorts")
 
+    # Hashtags immediately after the headline so the first 3 become
+    # clickable topic links above the Shorts title (discovery lever).
+    from engine.shorts_hashtags import extract_hashtags, format_hashtag_line
+    extracted = extract_hashtags(
+        hook,
+        show_keywords=list(getattr(config, "keywords", []) or []),
+        max_hashtags=5,
+    )
+    hashtag_line = format_hashtag_line(extracted, ("#Shorts", "#podcast"))
+
     pieces: List[str] = [headline]
+    if hashtag_line:
+        pieces.append(hashtag_line)
     if long_form_url:
-        pieces.append(f"Full episode: {long_form_url}")
+        pieces.append(f"▶ Full episode: {long_form_url}")
     base_url = getattr(config.publishing, "base_url",
                        "https://nerranetwork.com").rstrip("/")
     rss_link = getattr(config.publishing, "rss_link", "") or base_url
@@ -499,29 +513,11 @@ def build_short_metadata(
         f"{rss_link}{'&' if '?' in rss_link else '?'}"
         f"utm_source=youtube&utm_medium=shorts&utm_campaign=ep{episode_num}"
     )
-    # Show page link near the top — YouTube Shorts descriptions are
-    # short by design, so listeners who tap the title or "more" want
-    # the show page one click away.
     pieces.append(f"🌐 Show page: {rss_link}")
     pieces.append(f"Subscribe to the podcast: {utm_link}")
     disclosure = (config.youtube.synthetic_disclosure or "").strip()
     if disclosure:
         pieces.append(disclosure)
-
-    # Auto-extract hashtags from the hook so the Shorts description
-    # carries the day's entities (Tesla / Cybercab / OpenAI etc.) as
-    # search-indexable + above-the-title topic tags. YouTube renders
-    # the FIRST 3 hashtags as clickable links above the video title
-    # — biggest discovery lever on Shorts after the title itself.
-    # Falls back cleanly to the static ``#Shorts #podcast`` line when
-    # the hook has nothing extractable.
-    from engine.shorts_hashtags import extract_hashtags, format_hashtag_line
-    extracted = extract_hashtags(
-        hook,
-        show_keywords=list(getattr(config, "keywords", []) or []),
-        max_hashtags=5,
-    )
-    pieces.append(format_hashtag_line(extracted, ("#Shorts", "#podcast")))
 
     # Same ``invalidDescription`` defense as build_long_form_metadata —
     # YouTube rejects ``<`` / ``>`` even though Shorts hasn't tripped

--- a/run_show.py
+++ b/run_show.py
@@ -5018,23 +5018,47 @@ def _publish_youtube(
                 getattr(_yt, "shorts_end_card_duration_seconds", 3.0) or 3.0
             )
             _end_card_image_path = None
-            if _end_card_enabled and thumbnail_path and Path(thumbnail_path).exists():
-                try:
-                    _end_card_image_candidate = work_dir / f"{base_name}_end_card.png"
-                    generate_shorts_end_card(
-                        thumbnail_path,
-                        _end_card_image_candidate,
-                        show_name=config.name,
-                        main_text=_end_card_main,
-                        sub_text=_end_card_sub,
-                    )
-                    if _end_card_image_candidate.exists():
-                        _end_card_image_path = _end_card_image_candidate
-                except Exception as exc:  # pragma: no cover — best-effort
-                    logger.warning(
-                        "Shorts end-card PNG render failed: %s — "
-                        "falling back to drawtext-only end card", exc,
-                    )
+            if _end_card_enabled:
+                # Prefer a clean Grok scene (no burned-in hook text) for the
+                # end-card preview; fall back to the long-form thumbnail.
+                _cover = Path(cover_path) if cover_path else None
+                _end_card_scene = None
+                for _cand in list(fresh_long_scenes or []) + list(
+                    short_scene_paths or []
+                ) + list(long_scene_paths or []):
+                    if not _cand:
+                        continue
+                    _p = Path(_cand)
+                    if _cover is not None and _p.resolve() == _cover.resolve():
+                        continue
+                    if _p.exists():
+                        _end_card_scene = _p
+                        break
+                _end_card_base = (
+                    Path(thumbnail_path)
+                    if thumbnail_path and Path(thumbnail_path).exists()
+                    else None
+                )
+                if _end_card_base or _end_card_scene:
+                    try:
+                        _end_card_image_candidate = (
+                            work_dir / f"{base_name}_end_card.png"
+                        )
+                        generate_shorts_end_card(
+                            _end_card_base or _end_card_scene,
+                            _end_card_image_candidate,
+                            show_name=config.name,
+                            main_text=_end_card_main,
+                            sub_text=_end_card_sub,
+                            scene_image_path=_end_card_scene,
+                        )
+                        if _end_card_image_candidate.exists():
+                            _end_card_image_path = _end_card_image_candidate
+                    except Exception as exc:  # pragma: no cover — best-effort
+                        logger.warning(
+                            "Shorts end-card PNG render failed: %s — "
+                            "falling back to drawtext-only end card", exc,
+                        )
 
             _caption_offset = float(
                 getattr(config.audio, "voice_intro_delay", 0.0) or 0.0

--- a/scripts/build_gallery_manifest.py
+++ b/scripts/build_gallery_manifest.py
@@ -133,6 +133,16 @@ REQUIRED_SIDECAR_FIELDS = (
     "episode_date", "format",
 )
 
+# Text-burned YouTube thumbnail composites are stored in R2 for Studio
+# "Test & Compare" A/B, but they are NOT useful in the public gallery
+# (dark image + white hook text). Filter them out of the public
+# manifest so visitors only see clean Grok Imagine scenes.
+PUBLIC_GALLERY_EXCLUDED_USES = frozenset({
+    "thumbnail_variant",
+    "thumbnail",
+    "youtube_thumbnail",
+})
+
 
 def _public_url(config: GalleryConfig, key: str) -> str:
     if config.public_base_url:
@@ -206,6 +216,16 @@ def build_manifest(
             continue
         # _validate_sidecar already logs; just check the return.
         if not _validate_sidecar(sidecar, sidecar.get("image_id", "?")):
+            continue
+
+        # Skip text-burned thumbnail composites from the public gallery.
+        use = str(sidecar.get("intended_use") or "").strip().lower()
+        if use in PUBLIC_GALLERY_EXCLUDED_USES:
+            continue
+        tags = sidecar.get("tags") or []
+        if isinstance(tags, list) and any(
+            str(t).strip().lower() in PUBLIC_GALLERY_EXCLUDED_USES for t in tags
+        ):
             continue
 
         original_key, thumb_key, sidecar_key = _build_object_keys(sidecar)

--- a/shows/prompts/youtube_description_intro.txt
+++ b/shows/prompts/youtube_description_intro.txt
@@ -1,3 +1,3 @@
 {hook}
 
-Today's {show_name} episode (Ep {episode_num}, {today_str}) covers the stories above in full — listen on Spotify, Apple Podcasts, or any podcast app via the show page below.
+In this episode of {show_name} (Ep {episode_num} · {today_str}) we go deep on the stories above — the numbers, the stakes, and what it means next. Full audio on Spotify, Apple Podcasts, or any podcast app via the show page below.

--- a/tests/test_build_gallery_manifest.py
+++ b/tests/test_build_gallery_manifest.py
@@ -44,6 +44,8 @@ def _sidecar(
     episode_id="ep001", episode_title="Ep 1", episode_date="2026-05-24",
     generated_at="2026-05-24T15:00:00+00:00", fmt="jpeg",
     prompt="a tesla cybertruck",
+    intended_use="segment_card",
+    tags=None,
 ):
     return {
         "image_id": image_id,
@@ -56,12 +58,12 @@ def _sidecar(
         "format": fmt,
         "prompt": prompt,
         "model": "grok-imagine-image",
-        "intended_use": "segment_card",
+        "intended_use": intended_use,
         "width": 1792,
         "height": 1024,
         "file_size": 215000,
         "caption": "",
-        "tags": [slug, "segment_card"],
+        "tags": list(tags) if tags is not None else [slug, intended_use],
         "license": "CC BY-SA 4.0",
         "license_url": "https://creativecommons.org/licenses/by-sa/4.0/",
         "attribution": "Nerra Network",
@@ -155,6 +157,22 @@ def test_build_manifest_skips_invalid_sidecars(config, caplog):
     manifest = bgm.build_manifest([bad, good], config=config)
     assert manifest["image_count"] == 1
     assert manifest["images"][0]["image_id"] == "ok"
+
+
+def test_build_manifest_excludes_thumbnail_variants(config):
+    """July 2026: text-burned YouTube thumbnail composites must not
+    appear in the public gallery (dark image + white hook text)."""
+    scene = _sidecar(image_id="scene", intended_use="segment_card")
+    variant = _sidecar(image_id="variant", intended_use="thumbnail_variant")
+    tagged = _sidecar(
+        image_id="tagged",
+        intended_use="segment_card",
+        tags=["tesla", "thumbnail_variant"],
+    )
+    manifest = bgm.build_manifest([scene, variant, tagged], config=config)
+    ids = {img["image_id"] for img in manifest["images"]}
+    assert ids == {"scene"}
+    assert manifest["image_count"] == 1
 
 
 def test_build_manifest_attaches_urls_to_every_image(config):

--- a/tests/test_grok_imagine.py
+++ b/tests/test_grok_imagine.py
@@ -38,9 +38,14 @@ class TestBuildImagePrompts:
             aspect="16:9",
         )
         assert len(prompts) == 3
-        # Hook is woven in to every prompt so episodes get unique imagery.
+        # Hook is woven in as a SHORT visual-subject phrase (not a
+        # full ``depicting:`` sentence — that made Grok paint chyron
+        # text onto gallery images).
         for p in prompts:
-            assert "Tesla unveils Cybertruck price drop" in p
+            assert "visual subject:" in p
+            assert "depicting:" not in p
+            # First words of the hook survive the subject compressor.
+            assert "Tesla unveils" in p or "Cybertruck" in p
 
     def test_recycles_queries_when_count_exceeds_query_list(self):
         """If the operator's image_queries list has 3 entries but we
@@ -97,15 +102,34 @@ class TestBuildImagePrompts:
 
     def test_no_text_hint_blocks_banner_overlay(self):
         """Operator caught (Tesla YouTube long-form + Shorts, May 7
-        2026) Grok Imagine rendering the prompt's headline as a chyron
-        across every slide. Every prompt now ships an explicit
-        ``no text or words`` instruction to suppress the overlay."""
+        2026; reinforced July 2026) Grok Imagine rendering the prompt's
+        headline as a chyron across every slide. Every prompt now ships
+        an explicit ZERO-text instruction to suppress the overlay."""
         from engine.grok_imagine import build_image_prompts
         prompts = build_image_prompts(
             hook="hook", image_queries=["q1", "q2"], count=2,
         )
         for p in prompts:
-            assert "no text" in p or "no words" in p
+            assert "ZERO text" in p or "no text" in p.lower()
+            assert "depicting:" not in p
+            assert "visual subject:" in p
+
+    def test_long_hook_is_compressed_to_visual_subject(self):
+        """Full headlines must not appear verbatim — only a short
+        subject phrase — so Grok has nothing quotable to paint."""
+        from engine.grok_imagine import build_image_prompts
+        long_hook = (
+            "Tesla is hiring engineers to build a wireless Battery "
+            "Management System for Cybercab that removes heavy wiring"
+        )
+        prompts = build_image_prompts(
+            hook=long_hook, image_queries=["cybercab"], count=1,
+        )
+        assert len(prompts) == 1
+        assert long_hook not in prompts[0]
+        assert "visual subject:" in prompts[0]
+        # Subject keeps the lead nouns, drops the long tail.
+        assert "Tesla is hiring" in prompts[0]
 
 
 # ---------------------------------------------------------------------------
@@ -135,9 +159,13 @@ class TestPerSceneContexts:
             count=3,
             per_scene_contexts=contexts,
         )
-        # Each headline appears in exactly one prompt, in document order.
+        # Each headline's LEAD appears as a visual-subject phrase
+        # (compressed — not the full sentence after ``depicting:``).
         for ctx, prompt in zip(contexts, prompts):
-            assert ctx in prompt
+            lead = " ".join(ctx.split()[:4])
+            assert lead in prompt
+            assert "depicting:" not in prompt
+            assert "visual subject:" in prompt
         # The lone episode hook is NOT repeated as a banner across slides.
         assert sum(1 for p in prompts if "lead hook line" in p) == 0
 
@@ -167,7 +195,7 @@ class TestPerSceneContexts:
             count=1,
             per_scene_contexts=[],
         )
-        assert prompts and "lead hook" in prompts[0]
+        assert prompts and "visual subject: lead hook" in prompts[0]
 
     def test_none_contexts_falls_back_to_hook(self):
         from engine.grok_imagine import build_image_prompts
@@ -177,7 +205,7 @@ class TestPerSceneContexts:
             count=1,
             per_scene_contexts=None,
         )
-        assert prompts and "lead hook" in prompts[0]
+        assert prompts and "visual subject: lead hook" in prompts[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shorts_selector.py
+++ b/tests/test_shorts_selector.py
@@ -33,6 +33,27 @@ def test_empty_text_scores_zero():
     assert score_text(None) == 0.0  # type: ignore[arg-type]
 
 
+def test_trim_opening_text_cuts_on_word_boundary():
+    """July 2026: Shorts titles must not truncate mid-word."""
+    from engine.shorts_selector import _trim_opening_text
+    long = (
+        "Tesla is hiring engineers to build a wireless Battery "
+        "Management System for Cybercab that removes heavy wiring"
+    )
+    out = _trim_opening_text(long, max_chars=80)
+    assert len(out) <= 80
+    assert out.endswith("…")
+    assert " " not in out[-2:]  # ellipsis, not a mid-word cut
+    # Last visible char before ellipsis is not mid-word garbage.
+    assert not out.rstrip("…").endswith("wirele")
+    assert "wireless" in out or out.rstrip("…").endswith("a")
+
+
+def test_trim_opening_text_leaves_short_alone():
+    from engine.shorts_selector import _trim_opening_text
+    assert _trim_opening_text("Short hook", max_chars=80) == "Short hook"
+
+
 def test_neutral_text_scores_zero():
     assert score_text("The company released its quarterly report.") == 0.0
 

--- a/tests/test_thumbnail_autofit.py
+++ b/tests/test_thumbnail_autofit.py
@@ -106,17 +106,13 @@ def test_shorts_thumbnail_long_hook_renders(tmp_path):
         assert img.size == (1080, 1920)
 
 
-def test_runaway_hook_truncates_at_220_chars(cover, tmp_path, monkeypatch):
+def test_runaway_hook_truncates_at_160_chars(cover, tmp_path, monkeypatch):
     """A 400-char hook is almost certainly an LLM run-on. The hard
-    cap is 220 chars — anything longer gets truncated with a single
-    trailing ellipsis so the auto-fit loop doesn't have to chase
-    illegible micro-text."""
+    cap is 160 chars for the lower-third layout (July 2026) — anything
+    longer gets truncated on a word boundary with a trailing ellipsis
+    so the auto-fit loop doesn't chase illegible micro-text."""
     captured_strings: list[str] = []
 
-    # Hook the wrapper so we can read what the rendered string was
-    # after truncation. We patch _wrap_text in the publisher module
-    # and just record the input — the underlying behaviour still
-    # runs after recording.
     import engine.publisher as pub
     real_wrap = pub._wrap_text
 
@@ -132,13 +128,34 @@ def test_runaway_hook_truncates_at_220_chars(cover, tmp_path, monkeypatch):
         output_path=tmp_path / "out.jpg", hook=runaway,
         show_name="Tesla Shorts Time",
     )
-    # First call to _wrap_text used the truncated string.
     assert captured_strings, "expected at least one wrap call"
     first = captured_strings[0]
-    # Truncated to 217 chars + "…" = 218 grapheme positions, but the
-    # important contract is "no longer than 220 chars".
-    assert len(first) <= 220, f"truncation failed: len={len(first)}"
+    assert len(first) <= 160, f"truncation failed: len={len(first)}"
     assert first.endswith("…"), f"missing ellipsis: {first[-5:]!r}"
+
+
+def test_thumbnail_keeps_image_bright_not_full_darken(cover, tmp_path):
+    """July 2026 image-first redesign: the upper half of the frame must
+    stay near the source brightness (no full-frame 0.55 darken). A
+    bright cyan cover should still read bright in the top third."""
+    # Bright cyan cover so the mean of the top band is easy to assert.
+    bright = tmp_path / "bright.jpg"
+    Image.new("RGB", (1280, 720), (0, 200, 255)).save(bright, format="JPEG")
+    out = tmp_path / "thumb.jpg"
+    generate_episode_thumbnail(
+        bright, episode_num=1, date_str="Jul 9, 2026",
+        output_path=out, hook="Bright scene stays bright",
+        show_name="Test Show",
+    )
+    with Image.open(out) as img:
+        # Sample a 40×40 patch in the upper-left (below the show label
+        # margin but above the scrim). Mean channel should stay high.
+        patch = list(img.crop((80, 80, 120, 120)).getdata())
+        mean_b = sum(p[2] for p in patch) / len(patch)
+        assert mean_b > 150, (
+            f"top-of-frame still looks darkened (mean blue={mean_b:.0f}); "
+            "expected image-first scrim, not full Brightness 0.55"
+        )
 
 
 def test_shrink_loop_picks_smaller_font_for_long_hook(cover, tmp_path, monkeypatch):

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -289,6 +289,10 @@ def test_long_form_description_has_entity_hashtags():
     assert "#podcast" in hashtag_lines[0]
     # At least one entity hashtag derived from the hook.
     assert any("#Tesla" in l or "#Cybercab" in l for l in hashtag_lines)
+    # July 2026: hashtags sit above the fold (before show-page / body),
+    # not buried after chapters.
+    desc = meta["description"]
+    assert desc.index("#") < desc.index("Show page:")
 
 
 def test_short_title_keeps_shorts_suffix_when_hook_is_long():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Operator review of the YouTube pipeline: gallery images were text-overlaid / not useful, and video/Shorts keyframes looked like dark photos behind white text. This pass makes keyframes photographic and enticing, keeps the public gallery clean, and strengthens descriptions — while preserving UTM links, chapters, disclosure, hashtags, show page, and the performance title loop.

**No audio / TTS / podcast prompt changes** (outside landmine #17).

## Root causes

1. Thumbnail compositor full-frame `Brightness(0.55)` + centred white hook
2. Text-burned `thumbnail_variant` composites listed in the public gallery
3. Grok Imagine prompts dumping full headlines after `depicting:`
4. Shorts titles truncating mid-word (`text[:80]`)
5. Hashtags buried below the mobile “Show more” fold

## Changes

- **Thumbnails:** bottom gradient scrim + lower-third hook (image stays bright)
- **Gallery:** exclude `thumbnail_variant` / `thumbnail` / `youtube_thumbnail` from public manifest + JS defense
- **Grok prompts:** short `visual subject:` phrases + hard ZERO-text cue
- **Shorts end card:** prefer clean scene still over text-burned long-form thumb
- **Shorts titles:** word-boundary trim
- **Descriptions:** hashtags above the fold; stronger intro template

## Performance iteration

Code path is already live (`engine/youtube_titles` + nightly analytics scripts) but **data-dormant** until YouTube OAuth is re-authed with `yt-analytics.readonly`. No loop code change in this PR — operator follow-up documented in `docs/reviews/youtube_visual_pass_2026_07_09.md`.

## Tests

246 related tests passed (`test_thumbnail_autofit`, `test_grok_imagine`, `test_build_gallery_manifest`, `test_shorts_selector`, `test_youtube`, `test_video_commands`).

## Operator after merge

1. Re-auth YouTube OAuth with analytics scope (title feedback loop)
2. Let nightly gallery-manifest rebuild drop existing variants from the public page (or run `scripts/build_gallery_manifest.py`)
3. Spot-check next 2–3 YouTube publishes for thumbnail look

Full writeup: `docs/reviews/youtube_visual_pass_2026_07_09.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

