### PR TITLE
YouTube after-merge: Analytics API enablement + clearer 403s

### DIFF
--- a/docs/reviews/youtube_after_merge_2026_07_10.md
+++ b/docs/reviews/youtube_after_merge_2026_07_10.md
@@ -1,0 +1,87 @@
+# YouTube after-merge follow-up (July 10, 2026)
+
+Status of the three operator items from
+[`youtube_visual_pass_2026_07_09.md`](youtube_visual_pass_2026_07_09.md)
+after PR #793 merged.
+
+## 1. Gallery rebuild — DONE
+
+- Post-merge `Build Gallery Manifest` run succeeded
+  ([run 29027676783](https://github.com/Planetterrian/nerranetwork/actions/runs/29027676783)).
+- Nightly 2026-07-09 rebuilt from **2506** R2 sidecars → public manifest
+  **2312** images (`segment_card` 1158 + `social` 1154).
+- **0** `thumbnail_variant` / text-burned composites in
+  `site/data/gallery-manifest.json`.
+- Live gallery: https://nerranetwork.com/gallery.html
+
+No further action.
+
+## 2. Spot-check next publishes — PARTIAL (looks good)
+
+Episodes that ran **after** the merge (e.g. Env Intel Ep055, 2026-07-09
+~18:21 UTC) already used the image-first compositor. Local variant thumbs
+for Ep055 show a bright top band (mean ~144) vs the older full-darken look
+(Ep054 top ~58). Bottom band stays darker (scrim) as designed.
+
+Worth a quick human look in YouTube Studio on the next Tesla + one Shorts
+upload (titles/descriptions/hashtag fold), but no code blocker.
+
+## 3. YouTube Analytics / performance loop — NEEDS YOUR LOCAL STEPS
+
+Nightly already calls `fetch_youtube_analytics.py` with all four YouTube
+secrets set. On 2026-07-09 it failed with:
+
+> YouTube Analytics API has not been used in project **141610975484**
+> before or it is disabled.
+
+So the blocker is **API enablement first**, then (if still 403) OAuth
+re-consent. The fetch script previously labelled every 403 as “re-auth
+needed”; that message is now split so the next nightly log is actionable.
+
+### Do this on your machine (browser required)
+
+**A. Enable the API (~1 minute)**
+
+1. Open Google Cloud Console for the project that owns
+   `YOUTUBE_CLIENT_ID` (number `141610975484` from the log).
+2. **APIs & Services → Library → YouTube Analytics API → Enable**.
+3. Confirm **YouTube Data API v3** is still Enabled (uploads).
+
+**B. Re-mint refresh tokens with analytics scope (~5 minutes)**
+
+```bash
+# 1. Revoke the old grant so Google re-shows consent:
+#    https://myaccount.google.com/permissions
+
+# 2. From a local clone with google-auth-oauthlib installed:
+python scripts/youtube_oauth_bootstrap.py ~/Downloads/client_secrets.json
+# Sign in as the @NerraNetwork Google account → copy refresh token
+# → GitHub → Settings → Secrets → YOUTUBE_REFRESH_TOKEN_EN
+
+python scripts/youtube_oauth_bootstrap.py ~/Downloads/client_secrets.json
+# Sign in as @NerraRU → YOUTUBE_REFRESH_TOKEN_RU
+```
+
+**C. Verify (optional, same night or next morning)**
+
+```bash
+# After secrets are updated, either wait for Nightly Maintenance or:
+gh workflow run nightly-maintenance.yml
+
+# Or locally with secrets in .env:
+python scripts/fetch_youtube_analytics.py --dry-run --days 90
+python scripts/update_youtube_performance.py
+cat digests/tesla_shorts_time/youtube_performance.json
+```
+
+Title hints turn on once a show has ≥4 videos with retention numbers
+(usually a few weeks of watch data after the API starts returning rows).
+
+This cloud agent **cannot** complete A/B: no browser OAuth, no write access
+to GitHub Actions secrets, no GCP console.
+
+## Code shipped in this follow-up
+
+- Clearer 403 classification in `scripts/fetch_youtube_analytics.py`
+- Docs: `docs/youtube_feedback_loop.md`, `docs/youtube_setup.md` list
+  Analytics API enablement before re-auth

--- a/docs/youtube_feedback_loop.md
+++ b/docs/youtube_feedback_loop.md
@@ -59,25 +59,40 @@ If the hint is empty (no data yet) the title prompt renders exactly as before.
 
 ## Operator one-time setup
 
-1. **Re-authorise the OAuth token** with the analytics scope. The June 2026
+Two GCP/OAuth steps — both required. Nightly logs on 2026-07-09 showed the
+**API was disabled** on the project (not only a missing OAuth scope), so do
+them in this order:
+
+1. **Enable YouTube Analytics API v2** in the same Google Cloud project that
+   owns `YOUTUBE_CLIENT_ID` (project number was `141610975484` in the July
+   2026 403). Console → **APIs & Services → Library → "YouTube Analytics
+   API"** → Enable. Wait 1–5 minutes for propagation. Uploads use Data API
+   v3 (already enabled); analytics is a separate product.
+
+2. **Re-authorise the OAuth token** with the analytics scope. The June 2026
    change added `https://www.googleapis.com/auth/yt-analytics.readonly` to
-   `engine.youtube.YOUTUBE_SCOPES`. Google rejects a stored refresh token that
-   lacks a requested scope, so re-run:
+   `engine.youtube.YOUTUBE_SCOPES`. Google will not expand scopes on an
+   existing refresh token, so:
 
+   ```bash
+   # Revoke the old grant first so Google re-shows consent:
+   # https://myaccount.google.com/permissions  → remove the Nerra / GCP app
+
+   python scripts/youtube_oauth_bootstrap.py ~/Downloads/client_secrets.json
+   # Sign in as @NerraNetwork → paste token into YOUTUBE_REFRESH_TOKEN_EN
+
+   python scripts/youtube_oauth_bootstrap.py ~/Downloads/client_secrets.json
+   # Sign in as @NerraRU → paste token into YOUTUBE_REFRESH_TOKEN_RU
    ```
-   python scripts/youtube_oauth_bootstrap.py        # @NerraNetwork (EN)
-   ```
 
-   and re-consent, then update the `YOUTUBE_REFRESH_TOKEN_EN` secret (and
-   `YOUTUBE_REFRESH_TOKEN_RU` for @NerraRU if RU shows are publishing). **Until
-   this is done, uploads keep working on the old token; only the analytics
-   read no-ops** (it logs "Analytics query rejected … re-auth needed").
+   **Until both steps are done, uploads keep working; only the analytics
+   read no-ops.**
 
-2. That's it. The nightly job already passes the YouTube secrets to the fetch
+3. That's it. The nightly job already passes the YouTube secrets to the fetch
    step; `api/youtube_stats.json` and the per-show `youtube_performance.json`
-   files start populating once the scope is live and videos have a few weeks of
-   watch data. The title hint switches on the moment a show has ≥4 videos with
-   retention numbers.
+   files start populating once the API + scope are live and videos have a few
+   weeks of watch data. The title hint switches on the moment a show has ≥4
+   videos with retention numbers.
 
 ## Verifying
 

--- a/docs/youtube_setup.md
+++ b/docs/youtube_setup.md
@@ -30,7 +30,9 @@ Per-show YAML: `youtube.channel: en` or `ru`.
 
 ## One-time GCP + OAuth setup
 
-1. Create a Google Cloud project and enable **YouTube Data API v3**.
+1. Create a Google Cloud project and enable **YouTube Data API v3** *and*
+   **YouTube Analytics API** (the retention feedback loop needs Analytics;
+   Data API alone is enough for uploads).
 2. OAuth consent screen: External, add yourself as test user until verified.
 3. Create **Desktop** OAuth credentials; download JSON (never commit).
 4. Mint refresh tokens locally:
@@ -40,8 +42,8 @@ Per-show YAML: `youtube.channel: en` or `ru`.
    ```
 
    Run once per channel (English account, then Russian). The bootstrap script
-   requests `youtube.upload`, `youtube`, and **`youtube.force-ssl`** (required
-   for `captions.insert` / CC track upload).
+   requests `youtube.upload`, `youtube`, **`youtube.force-ssl`** (captions),
+   and **`yt-analytics.readonly`** (title feedback loop).
 
 5. Paste tokens into GitHub secrets:
 
@@ -52,9 +54,12 @@ Per-show YAML: `youtube.channel: en` or `ru`.
    | `YOUTUBE_REFRESH_TOKEN_EN` | English channel run |
    | `YOUTUBE_REFRESH_TOKEN_RU` | Russian channel run |
 
-If captions fail with HTTP 403 after upgrading scopes, **revoke** the app at
-https://myaccount.google.com/permissions and re-run the bootstrap script so
-Google issues a new refresh token with `force-ssl`.
+If captions or analytics fail with HTTP 403 after upgrading scopes, **revoke**
+the app at https://myaccount.google.com/permissions and re-run the bootstrap
+script so Google issues a new refresh token with the full scope set. Also
+confirm **YouTube Analytics API** is Enabled on the GCP project (a disabled
+API returns a 403 that looks like a scope problem — see
+[`docs/youtube_feedback_loop.md`](youtube_feedback_loop.md)).
 
 ## Quota
 

--- a/scripts/fetch_youtube_analytics.py
+++ b/scripts/fetch_youtube_analytics.py
@@ -130,10 +130,30 @@ def _query_batch(service, video_ids: List[str], start: str, end: str) -> Dict[st
         ).execute()
     except Exception as exc:
         msg = str(exc)
-        if "insufficient" in msg.lower() or "scope" in msg.lower() or "403" in msg:
+        low = msg.lower()
+        # Distinguish the two common 403s so the operator doesn't re-auth
+        # when the real fix is enabling the Analytics API in GCP (July 2026
+        # nightly log: "YouTube Analytics API has not been used in project
+        # … or it is disabled" was mis-labelled as a scope problem).
+        if "has not been used" in low or "is disabled" in low or "accessnotconfigured" in low:
             logger.warning(
-                "Analytics query rejected (likely missing yt-analytics.readonly "
-                "scope — re-auth needed): %s", msg[:200],
+                "Analytics query rejected — enable YouTube Analytics API v2 "
+                "in the Google Cloud project (APIs & Services → Library → "
+                "YouTube Analytics API), then wait a few minutes: %s",
+                msg[:220],
+            )
+        elif "insufficient" in low or "scope" in low or "access_denied" in low:
+            logger.warning(
+                "Analytics query rejected — refresh token lacks "
+                "yt-analytics.readonly; revoke the app at "
+                "myaccount.google.com/permissions and re-run "
+                "scripts/youtube_oauth_bootstrap.py: %s",
+                msg[:220],
+            )
+        elif "403" in msg:
+            logger.warning(
+                "Analytics query rejected (HTTP 403 — check API enablement "
+                "and OAuth scopes): %s", msg[:220],
             )
         else:
             logger.warning("Analytics query failed: %s", msg[:200])

--- a/tests/test_youtube_feedback_loop.py
+++ b/tests/test_youtube_feedback_loop.py
@@ -255,3 +255,42 @@ class TestScriptsAreCleanNoOps:
         fya = _load_script("fetch_youtube_analytics.py")
         # No per-show indexes under an empty digests dir → None (no-op).
         assert fya.fetch(tmp_path, days=90) is None
+
+
+class TestAnalytics403Classification:
+    """July 2026: nightly 403 was 'API disabled', not missing scope —
+    the warning must tell the operator which fix to apply."""
+
+    def test_disabled_api_message(self, caplog):
+        import logging
+        from unittest.mock import MagicMock
+
+        fya = _load_script("fetch_youtube_analytics.py")
+        svc = MagicMock()
+        svc.reports.return_value.query.return_value.execute.side_effect = (
+            RuntimeError(
+                "HttpError 403 … YouTube Analytics API has not been used "
+                "in project 141610975484 before or it is disabled"
+            )
+        )
+        with caplog.at_level(logging.WARNING):
+            assert fya._query_batch(svc, ["vid1"], "2026-01-01", "2026-07-09") == {}
+        joined = " ".join(r.message for r in caplog.records)
+        assert "Enable" in joined or "enable" in joined
+        assert "YouTube Analytics API" in joined
+        assert "re-run scripts/youtube_oauth_bootstrap" not in joined
+
+    def test_missing_scope_message(self, caplog):
+        import logging
+        from unittest.mock import MagicMock
+
+        fya = _load_script("fetch_youtube_analytics.py")
+        svc = MagicMock()
+        svc.reports.return_value.query.return_value.execute.side_effect = (
+            RuntimeError("HttpError 403 insufficient authentication scopes")
+        )
+        with caplog.at_level(logging.WARNING):
+            assert fya._query_batch(svc, ["vid1"], "2026-01-01", "2026-07-09") == {}
+        joined = " ".join(r.message for r in caplog.records)
+        assert "yt-analytics.readonly" in joined
+        assert "youtube_oauth_bootstrap" in joined


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Follow-up to merged PR #793 (YouTube visual pass). Checked the three after-merge items against live CI/logs.

## Status

| Item | Status |
|---|---|
| Gallery rebuild | **Done** — 0 text-burned thumbs in public manifest (2312 clean scenes) |
| Spot-check publishes | **Partial** — Ep055 post-merge thumbs already brighter (image-first); human Studio glance still useful |
| Performance / Analytics loop | **Needs your local GCP + OAuth** — nightly 403 was **API disabled**, not only missing scope |

## What this PR does

- Splits `fetch_youtube_analytics.py` 403 warnings: disabled API vs missing `yt-analytics.readonly`
- Updates `docs/youtube_feedback_loop.md` + `docs/youtube_setup.md` with enable-API-then-reauth order
- Status writeup: `docs/reviews/youtube_after_merge_2026_07_10.md`

## What you still need to do (browser / secrets — agent cannot)

1. GCP project `141610975484` → enable **YouTube Analytics API**
2. Revoke old OAuth grant → re-run `scripts/youtube_oauth_bootstrap.py` for EN + RU → update `YOUTUBE_REFRESH_TOKEN_EN` / `_RU`
3. Wait for next Nightly Maintenance (or `gh workflow run nightly-maintenance.yml`) and confirm `api/youtube_stats.json` appears

Details in the review doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

