### PR TITLE
Verify YouTube Analytics is live after operator re-auth

### DIFF
--- a/.github/workflows/verify-youtube-analytics.yml
+++ b/.github/workflows/verify-youtube-analytics.yml
@@ -1,0 +1,63 @@
+name: Verify YouTube Analytics
+
+# One-shot / on-demand check that the Analytics API + OAuth refresh
+# tokens are live after operator re-auth (July 2026). Runs on push when
+# this workflow file changes (so merging the verify PR exercises the
+# live secrets) and via workflow_dispatch for later re-checks.
+#
+# Soft-fails with a clear ::error:: annotation rather than red-X'ing the
+# whole Actions UI when the loop is still dormant — uploads must never
+# look "broken" because analytics isn't ready.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/verify-youtube-analytics.yml'
+      - 'scripts/verify_youtube_analytics.py'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: verify-youtube-analytics
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: '3.12'
+          requirements-file: 'requirements.txt'
+          skip-checkout: 'true'
+
+      - name: Probe YouTube Analytics + write performance hints
+        id: probe
+        env:
+          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+          YOUTUBE_REFRESH_TOKEN_EN: ${{ secrets.YOUTUBE_REFRESH_TOKEN_EN }}
+          YOUTUBE_REFRESH_TOKEN_RU: ${{ secrets.YOUTUBE_REFRESH_TOKEN_RU }}
+        run: |
+          set -o pipefail
+          python scripts/verify_youtube_analytics.py --days 90 \
+            --out api/youtube_stats.json | tee /tmp/yt-verify.txt
+          status=$(grep -E '^STATUS=' /tmp/yt-verify.txt | tail -n1 | cut -d= -f2)
+          echo "status=${status:-fail}" >> "$GITHUB_OUTPUT"
+          echo "Probe finished with STATUS=${status:-fail}"
+
+      - name: Commit analytics artifacts when live
+        if: steps.probe.outputs.status == 'ok'
+        uses: ./.github/actions/safe-commit-push
+        with:
+          commit-message: "YouTube analytics: first live stats + performance hints"
+          add-paths: |
+            api/youtube_stats.json
+            digests/**/youtube_performance.json

--- a/scripts/verify_youtube_analytics.py
+++ b/scripts/verify_youtube_analytics.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Verify YouTube Analytics API + OAuth are live after operator re-auth.
+
+Prints a human-readable report and a machine line ``STATUS=ok|fail|noop``
+as the last stdout line (consumed by the verify workflow). Exit code is
+always 0 so a dormant loop never red-X's Actions; failures are surfaced
+via ``::error::`` annotations.
+
+Usage::
+
+    python scripts/verify_youtube_analytics.py --days 90
+    python scripts/verify_youtube_analytics.py --days 90 --out api/youtube_stats.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("verify_youtube_analytics")
+
+
+def _secret_presence() -> dict:
+    return {
+        "YOUTUBE_CLIENT_ID": bool(os.environ.get("YOUTUBE_CLIENT_ID")),
+        "YOUTUBE_CLIENT_SECRET": bool(os.environ.get("YOUTUBE_CLIENT_SECRET")),
+        "YOUTUBE_REFRESH_TOKEN_EN": bool(os.environ.get("YOUTUBE_REFRESH_TOKEN_EN")),
+        "YOUTUBE_REFRESH_TOKEN_RU": bool(os.environ.get("YOUTUBE_REFRESH_TOKEN_RU")),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--days", type=int, default=90)
+    parser.add_argument("--out", default="api/youtube_stats.json")
+    parser.add_argument("--digests", default="digests")
+    args = parser.parse_args()
+
+    presence = _secret_presence()
+    logger.info("Secret presence: %s", presence)
+    if not presence["YOUTUBE_CLIENT_ID"] or not presence["YOUTUBE_CLIENT_SECRET"]:
+        print("::error::YOUTUBE_CLIENT_ID / YOUTUBE_CLIENT_SECRET missing")
+        print("STATUS=fail")
+        return 0
+    if not presence["YOUTUBE_REFRESH_TOKEN_EN"]:
+        print("::error::YOUTUBE_REFRESH_TOKEN_EN missing — re-run oauth bootstrap")
+        print("STATUS=fail")
+        return 0
+
+    # Import after env check so a missing google lib still reports clearly.
+    from scripts import fetch_youtube_analytics as fya  # type: ignore
+    # Prefer loading the sibling module the same way tests do when package
+    # import fails (scripts/ is not always a package).
+    try:
+        payload = fya.fetch(ROOT / args.digests, args.days)
+    except Exception:
+        import importlib.util
+        path = ROOT / "scripts" / "fetch_youtube_analytics.py"
+        spec = importlib.util.spec_from_file_location("fetch_youtube_analytics", path)
+        fya = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(fya)
+        payload = fya.fetch(ROOT / args.digests, args.days)
+
+    if payload is None:
+        print(
+            "::error::YouTube Analytics returned no data. Likely causes: "
+            "(1) YouTube Analytics API still disabled on the GCP project, "
+            "(2) refresh token lacks yt-analytics.readonly — revoke + "
+            "re-run scripts/youtube_oauth_bootstrap.py, "
+            "(3) indexed videos have no watch data in the window yet. "
+            "Check the WARNING lines above for the exact 403 reason."
+        )
+        print("STATUS=fail")
+        return 0
+
+    n_shows = len(payload.get("shows") or {})
+    n_videos = sum(len(s.get("videos") or []) for s in payload["shows"].values())
+    logger.info("OK — analytics for %d videos across %d shows", n_videos, n_shows)
+
+    out_path = ROOT / args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False),
+                        encoding="utf-8")
+    logger.info("Wrote %s", out_path)
+
+    # Distil per-show title hints (clean no-op when <4 rated videos/show).
+    import importlib.util
+    path = ROOT / "scripts" / "update_youtube_performance.py"
+    spec = importlib.util.spec_from_file_location("update_youtube_performance", path)
+    uyp = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(uyp)
+    # update_youtube_performance.main reads --stats from argv; call the
+    # file's entry helpers if exposed, else subprocess-style via main.
+    old_argv = sys.argv
+    try:
+        sys.argv = ["update_youtube_performance.py", "--stats", str(out_path)]
+        uyp.main()
+    finally:
+        sys.argv = old_argv
+
+    hints = sorted(ROOT.glob("digests/*/youtube_performance.json"))
+    logger.info("Performance hint files: %d", len(hints))
+    for p in hints[:8]:
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+            hint = (data.get("title_hint") or "").strip()
+            logger.info("  %s: %s", p.parent.name,
+                        (hint[:80] + "…") if len(hint) > 80 else (hint or "(empty — need ≥4 rated videos)"))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("  %s unreadable: %s", p, exc)
+
+    # Sample a few retention rows for the Actions log.
+    samples = []
+    for show, block in sorted(payload["shows"].items()):
+        for v in (block.get("videos") or [])[:2]:
+            samples.append(
+                f"{show} ep{v.get('episode')} {v.get('kind')}: "
+                f"{v.get('average_view_percentage')}% retention, "
+                f"{v.get('views')} views"
+            )
+    for line in samples[:12]:
+        logger.info("sample: %s", line)
+
+    print(f"::notice::YouTube Analytics LIVE — {n_videos} videos / {n_shows} shows")
+    print("STATUS=ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Operator completed GCP Analytics API enablement + OAuth re-auth. This agent cannot read GitHub secrets or `workflow_dispatch` Nightly Maintenance (403), so this PR adds a **push-triggered verify workflow** that exercises the live secrets on merge and commits `api/youtube_stats.json` + performance hints if the loop is healthy.

## What

- `scripts/verify_youtube_analytics.py` — fetch + update + clear `STATUS=ok|fail`
- `.github/workflows/verify-youtube-analytics.yml` — runs on push when these files change; also `workflow_dispatch` for later re-checks

## After merge

Watch the **Verify YouTube Analytics** Actions run. Success = notice “YouTube Analytics LIVE” + a commit with stats. Failure = `::error::` with the exact 403 reason.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

