### PR TITLE
Fix Tesla Ep537 pipeline timeout (74-scene slideshow)

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -454,7 +454,10 @@ jobs:
           # (e.g. newsletter send failure). Without it here those alerts
           # were silently dead (July 2026 reliability pass).
           NOTIFICATION_WEBHOOK_URL: ${{ secrets.NOTIFICATION_WEBHOOK_URL }}
-          PIPELINE_TIMEOUT_SECONDS: '2400'
+          # 50 min — Tesla Ep537 timed out at 40 min mid-slideshow after a
+          # 15-min TTS + 74-scene xfade graph. Slot cap (24) is the primary
+          # fix; this headroom covers long TTS + long-form + 2 Shorts.
+          PIPELINE_TIMEOUT_SECONDS: '3000'
 
       - name: Validate output
         if: steps.pipeline.outputs.skipped != 'true'

--- a/docs/youtube_visual_reuse.md
+++ b/docs/youtube_visual_reuse.md
@@ -37,7 +37,9 @@ Layers (bottom-up):
   `chapters_ep<NNN>.json` boundaries (subdivided into 6–15 s holds), with
   per-chapter scene choice scored by title↔prompt overlap (fresh scenes win
   ties; reuse penalised for variety). `<2` usable chapters → uniform plan
-  identical to legacy.
+  identical to legacy. **Slot cap:** plans are clamped to
+  `_MAX_SLIDESHOW_SLOTS` (24) so a long episode cannot ask ffmpeg for 60–70+
+  xfade inputs (Tesla Ep537 timeout class); holds stretch instead.
 - **Sentence-snapped Shorts cuts** — scene changes snap to sentence-ending
   words from the faster-whisper word-level transcript (already generated for
   captions — no new transcription cost) instead of the flat 7 s grid.

--- a/engine/gallery_library.py
+++ b/engine/gallery_library.py
@@ -45,6 +45,13 @@ DEFAULT_MANIFEST = PROJECT_ROOT / "site" / "data" / "gallery-manifest.json"
 
 DOWNLOAD_TIMEOUT_SECONDS = 20
 
+# Abort library blending after this many consecutive download failures.
+# Without a breaker, a CDN outage (gallery.nerranetwork.com 403 from GHA —
+# Tesla Ep537) walks every historical candidate (~150+ HTTP round-trips)
+# and still returns zero paths. Fail fast; the caller already degrades to
+# fresh-only scenes.
+_MAX_CONSECUTIVE_DOWNLOAD_FAILURES = 5
+
 # Aspect → the manifest's ``intended_use`` value (see gallery_uploader):
 # ``segment_card`` is the 16:9 long-form scene, ``social`` the 9:16 Short.
 _ASPECT_TO_USE = {"16:9": "segment_card", "9:16": "social"}
@@ -151,12 +158,77 @@ def _cache_filename(entry: dict) -> str:
     return f"{stem}{ext}"
 
 
+def _r2_object_key(entry: dict) -> Optional[str]:
+    """R2 object key for an authenticated get — prefer the manifest's
+    ``original_key``, else derive from the public URL path."""
+    key = (entry.get("original_key") or "").strip().lstrip("/")
+    if key:
+        return key
+    url = (entry.get("original_url") or "").strip()
+    if not url:
+        return None
+    # https://gallery.nerranetwork.com/tesla/2026-07-08/ep535/abc.jpeg
+    # → tesla/2026-07-08/ep535/abc.jpeg
+    try:
+        from urllib.parse import urlparse
+        path = urlparse(url).path.lstrip("/")
+        return path or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _download_via_r2(entry: dict, dest: Path) -> bool:
+    """Authenticated R2 download when the public CDN rejects the GET.
+
+    Reuses the same gallery-bucket credentials the uploader already has
+    in CI (``R2_GALLERY_BUCKET`` + shared R2 account keys). Returns True
+    on a successful write; False on any miss/misconfig/error (caller
+    treats it as another soft failure).
+    """
+    key = _r2_object_key(entry)
+    if not key:
+        return False
+    try:
+        from engine.gallery_uploader import gallery_config_from_env
+        cfg = gallery_config_from_env()
+        if not cfg.is_configured:
+            return False
+        import boto3
+        from botocore.config import Config as BotoConfig
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=cfg.endpoint_url,
+            aws_access_key_id=cfg.access_key,
+            aws_secret_access_key=cfg.secret_key,
+            config=BotoConfig(
+                signature_version="s3v4",
+                retries={"max_attempts": 2, "mode": "standard"},
+            ),
+        )
+        s3.download_file(cfg.bucket, key, str(dest))
+        return dest.exists() and dest.stat().st_size > 0
+    except Exception as exc:  # noqa: BLE001 — soft fallback
+        logger.warning(
+            "gallery_library: R2 fallback failed for key=%s: %s", key, exc,
+        )
+        dest.unlink(missing_ok=True)
+        return False
+
+
 def _download_entry(entry: dict, cache_dir: Path) -> Optional[Path]:
-    """Fetch one image into the cache (or reuse); None on failure."""
+    """Fetch one image into the cache (or reuse); None on failure.
+
+    Tries the public CDN URL first (fast path when the custom domain is
+    healthy). On any HTTP/network failure, falls back to an authenticated
+    R2 get via ``original_key`` — the Ep537 failure mode was a blanket
+    403 from ``gallery.nerranetwork.com`` while the same bucket accepted
+    uploads with the CI credentials.
+    """
     dest = cache_dir / _cache_filename(entry)
     if dest.exists() and dest.stat().st_size > 0:
         _PATH_REGISTRY[dest] = entry
         return dest
+    public_err: Optional[Exception] = None
     try:
         resp = requests.get(entry["original_url"],
                             timeout=DOWNLOAD_TIMEOUT_SECONDS)
@@ -164,9 +236,20 @@ def _download_entry(entry: dict, cache_dir: Path) -> Optional[Path]:
         if not resp.content:
             raise ValueError("empty response body")
         dest.write_bytes(resp.content)
-    except Exception as exc:  # noqa: BLE001 — skip the image, keep going
-        logger.warning("gallery_library: failed to fetch %s: %s",
-                       entry.get("original_url"), exc)
+    except Exception as exc:  # noqa: BLE001 — try R2 before giving up
+        public_err = exc
+        dest.unlink(missing_ok=True)
+        if _download_via_r2(entry, dest):
+            logger.info(
+                "gallery_library: public CDN failed (%s); R2 fallback OK "
+                "for %s", public_err, entry.get("image_id") or dest.name,
+            )
+            _PATH_REGISTRY[dest] = entry
+            return dest
+        logger.warning(
+            "gallery_library: failed to fetch %s: %s",
+            entry.get("original_url"), public_err,
+        )
         return None
     _PATH_REGISTRY[dest] = entry
     return dest
@@ -196,7 +279,8 @@ def select_library_scenes(
     Downloads are cached by ``image_id`` under ``cache_dir`` (default:
     ``gallery_cache/`` in the system temp dir). Failed downloads are
     skipped and the next-best candidate backfills, so the return is
-    best-first local Paths, up to ``limit``. Never raises.
+    best-first local Paths, up to ``limit``. A streak of consecutive
+    failures aborts early (CDN/R2 outage circuit breaker). Never raises.
     """
     try:
         use = _ASPECT_TO_USE.get(aspect)
@@ -215,12 +299,24 @@ def select_library_scenes(
         cdir = Path(cache_dir) if cache_dir else _default_cache_dir()
         cdir.mkdir(parents=True, exist_ok=True)
         paths: List[Path] = []
+        consecutive_failures = 0
         for entry in _rank(entries, context_text):
             if len(paths) >= limit:
+                break
+            if consecutive_failures >= _MAX_CONSECUTIVE_DOWNLOAD_FAILURES:
+                logger.warning(
+                    "gallery_library: aborting after %d consecutive "
+                    "download failures for %s (CDN/R2 likely unavailable) "
+                    "— returning %d of %d requested",
+                    consecutive_failures, show_slug, len(paths), limit,
+                )
                 break
             p = _download_entry(entry, cdir)
             if p is not None:
                 paths.append(p)
+                consecutive_failures = 0
+            else:
+                consecutive_failures += 1
         return paths
     except Exception as exc:  # noqa: BLE001 — library reuse is optional
         logger.warning("gallery_library: scene selection failed for %s: %s",

--- a/engine/scene_scheduler.py
+++ b/engine/scene_scheduler.py
@@ -72,6 +72,15 @@ _SENTENCE_END_CHARS = (".", "!", "?")
 # sub-second "chapters" would produce unwatchable flicker.
 _MIN_CHAPTER_GAP_S = 1.0
 
+# Hard cap on ffmpeg slideshow inputs. The xfade+zoompan filter graph
+# scales poorly past ~30–40 scenes; Tesla Ep537 (1044 s @ 15 s hold →
+# 74 slots, only 4 unique images after gallery CDN 403s) timed out the
+# 2400 s pipeline mid-slideshow. 24 matches the historical ~10-min /
+# 25 s-hold cadence and keeps a 17-min episode renderable (~43 s holds,
+# still watchable under Ken Burns). Shared with engine.video's uniform
+# cycling path.
+_MAX_SLIDESHOW_SLOTS = 24
+
 
 def _tokenize(text: Optional[str]) -> frozenset:
     """Lower-cased alphanumeric token set for overlap scoring."""
@@ -166,6 +175,37 @@ def _pick_scene(
     return best_path
 
 
+def _cap_slots(
+    plan: List[Tuple[Path, float]],
+    max_slots: int = _MAX_SLIDESHOW_SLOTS,
+) -> List[Tuple[Path, float]]:
+    """Merge adjacent slots until ``len(plan) <= max_slots``.
+
+    Prefers merging consecutive same-path slots (no visual change), then
+    the shortest adjacent pair — so chapter-boundary switches on longer
+    chapters survive when a long episode would otherwise explode the
+    ffmpeg input count. Durations always sum to the original total.
+    """
+    if max_slots < 1 or len(plan) <= max_slots:
+        return plan
+    out = list(plan)
+    while len(out) > max_slots:
+        best_i = 0
+        best_key: Optional[Tuple[int, float]] = None
+        for i in range(len(out) - 1):
+            same = 0 if out[i][0] == out[i + 1][0] else 1
+            combined = out[i][1] + out[i + 1][1]
+            key = (same, combined)
+            if best_key is None or key < best_key:
+                best_key = key
+                best_i = i
+        left_path, left_d = out[best_i]
+        _right_path, right_d = out[best_i + 1]
+        out[best_i] = (left_path, left_d + right_d)
+        del out[best_i + 1]
+    return out
+
+
 def _uniform_plan(
     pool: Sequence[Path], audio_duration_s: float, max_hold_s: float,
 ) -> List[Tuple[Path, float]]:
@@ -178,6 +218,9 @@ def _uniform_plan(
     slots: List[Path] = list(pool)
     if hold > max_hold_s and len(pool) > 1:
         target = math.ceil(audio_duration_s / max_hold_s)
+        # Render-safe cap — see _MAX_SLIDESHOW_SLOTS. Without this a
+        # 17-min episode at 15 s hold asks for ~70 ffmpeg inputs.
+        target = min(target, _MAX_SLIDESHOW_SLOTS)
         slots = [pool[i % len(pool)] for i in range(target)]
         hold = max(_UNIFORM_MIN_HOLD_S, audio_duration_s / len(slots))
     plan = [(path, hold) for path in slots]
@@ -272,6 +315,15 @@ def plan_chapter_schedule(
     diff = audio_duration_s - math.fsum(d for _, d in plan)
     if plan and plan[-1][1] + diff >= 1.0:
         plan[-1] = (plan[-1][0], plan[-1][1] + diff)
+
+    uncapped = len(plan)
+    plan = _cap_slots(plan)
+    if len(plan) < uncapped:
+        logger.info(
+            "scene_scheduler: capped slideshow slots %d → %d "
+            "(max=%d; audio=%.0fs) to keep ffmpeg renderable",
+            uncapped, len(plan), _MAX_SLIDESHOW_SLOTS, audio_duration_s,
+        )
     logger.debug(
         "scene_scheduler: %d chapter windows → %d slots over %.1fs",
         len(windows), len(plan), audio_duration_s,

--- a/engine/video.py
+++ b/engine/video.py
@@ -433,6 +433,10 @@ _SHORT_SCENE_DURATION_SECONDS = 7.0
 # Ken-Burns zoom + slideshow crossfades keep each hold watchable (the hybrid
 # Grok video clips were retired June 29 2026 — images-only pipeline).
 # Visual-only — no audio impact.
+#
+# Paired with engine.scene_scheduler._MAX_SLIDESHOW_SLOTS: a long episode at
+# 15 s/hold would otherwise ask for 60–70+ ffmpeg inputs (Ep537 timeout).
+# The cycling path below clamps to that shared cap so holds stretch instead.
 _MAX_SCENE_HOLD_S = 15.0
 
 
@@ -1571,7 +1575,11 @@ def build_long_form_video(
                 # visually static. Reusing the SAME images in rotation restores
                 # visual rhythm at zero additional image cost.
                 if scene_duration_s > _MAX_SCENE_HOLD_S and len(slideshow_scenes) > 1:
+                    from engine.scene_scheduler import _MAX_SLIDESHOW_SLOTS
                     target = math.ceil(audio_duration_s / _MAX_SCENE_HOLD_S)
+                    # Cap ffmpeg inputs — see scene_scheduler._MAX_SLIDESHOW_SLOTS
+                    # (Ep537: 74 uncapped slots timed out the pipeline).
+                    target = min(target, _MAX_SLIDESHOW_SLOTS)
                     slideshow_scenes = [
                         slideshow_scenes[i % len(slideshow_scenes)]
                         for i in range(target)

--- a/tests/test_gallery_library.py
+++ b/tests/test_gallery_library.py
@@ -196,11 +196,53 @@ class TestSelection:
     def test_failed_download_skipped_and_backfilled(self, tmp_path, monkeypatch):
         fail = "https://gallery.test/tesla/ccc333.jpeg"
         _stub_requests(monkeypatch, fail_urls={fail})
+        # Kill R2 fallback so a public failure stays a soft skip.
+        monkeypatch.setattr(gl, "_download_via_r2", lambda *a, **k: False)
         got = gl.select_library_scenes(
             "tesla", aspect="16:9", limit=2,
             manifest=_manifest(), cache_dir=tmp_path)
         # Best candidate failed → next two backfill, still limit results.
         assert _stems(got) == ["bbb222", "aaa111"]
+
+    def test_circuit_breaker_stops_after_consecutive_failures(
+            self, tmp_path, monkeypatch):
+        """Ep537 class: gallery CDN 403s every URL. Without a breaker we
+        walked 150+ candidates; with it we abort after N consecutive
+        misses and return whatever we have (usually empty)."""
+        big = {"images": [
+            _entry(f"img{i:03d}", episode=f"ep{i}",
+                   date=f"2026-06-{(i % 28) + 1:02d}",
+                   prompt=f"scene {i}")
+            for i in range(40)
+        ]}
+        calls = _stub_requests(monkeypatch, fail_urls={
+            e["original_url"] for e in big["images"]
+        })
+        monkeypatch.setattr(gl, "_download_via_r2", lambda *a, **k: False)
+        got = gl.select_library_scenes(
+            "tesla", aspect="16:9", limit=8,
+            manifest=big, cache_dir=tmp_path)
+        assert got == []
+        assert len(calls) == gl._MAX_CONSECUTIVE_DOWNLOAD_FAILURES
+
+    def test_r2_fallback_used_when_public_cdn_fails(
+            self, tmp_path, monkeypatch):
+        m = _manifest()
+        for e in m["images"]:
+            e["original_key"] = f"tesla/{e['image_id']}.jpeg"
+        fail_all = {e["original_url"] for e in m["images"] if e.get("original_url")}
+        _stub_requests(monkeypatch, fail_urls=fail_all)
+
+        def _fake_r2(entry, dest):
+            dest.write_bytes(b"r2:" + entry["image_id"].encode())
+            return True
+
+        monkeypatch.setattr(gl, "_download_via_r2", _fake_r2)
+        got = gl.select_library_scenes(
+            "tesla", aspect="16:9", limit=2,
+            manifest=m, cache_dir=tmp_path)
+        assert len(got) == 2
+        assert got[0].read_bytes().startswith(b"r2:")
 
     def test_never_raises_on_garbage_manifest(self, tmp_path):
         assert gl.select_library_scenes(

--- a/tests/test_scene_scheduler.py
+++ b/tests/test_scene_scheduler.py
@@ -11,7 +11,11 @@ chapters available changes nothing.
 import math
 from pathlib import Path
 
-from engine.scene_scheduler import plan_chapter_schedule, sentence_cut_times
+from engine.scene_scheduler import (
+    _MAX_SLIDESHOW_SLOTS,
+    plan_chapter_schedule,
+    sentence_cut_times,
+)
 
 
 def _scenes(prefix: str, n: int):
@@ -30,13 +34,26 @@ class TestUniformFallback:
     def test_no_chapters_mirrors_legacy_rotation(self):
         """4 scenes over 360 s: legacy math says 90 s/scene > 15 s max
         hold → cycle to ceil(360/15) = 24 slots of 15 s, rotating
-        through the pool in order."""
+        through the pool in order. 24 is also the render-safe cap, so
+        this case sits exactly on the boundary."""
         pool = _scenes("fresh", 4)
         plan = plan_chapter_schedule(pool, [], None, 360.0)
         assert len(plan) == 24
+        assert len(plan) <= _MAX_SLIDESHOW_SLOTS
         assert all(abs(d - 15.0) < 1e-9 for _, d in plan)
         assert [p for p, _ in plan] == [pool[i % 4] for i in range(24)]
         assert abs(math.fsum(d for _, d in plan) - 360.0) < 1e-6
+
+    def test_long_episode_uniform_plan_respects_slot_cap(self):
+        """Ep537-class: 1044 s @ 15 s hold would be ~70 slots and timed
+        out the pipeline. Cap stretches holds instead of exploding the
+        ffmpeg input count."""
+        pool = _scenes("fresh", 4)
+        plan = plan_chapter_schedule(pool, [], None, 1044.0)
+        assert len(plan) == _MAX_SLIDESHOW_SLOTS
+        assert abs(math.fsum(d for _, d in plan) - 1044.0) < 1e-6
+        # Holds stretch above the 15 s preference but stay finite.
+        assert all(d >= 15.0 for _, d in plan)
 
     def test_no_cycling_when_even_split_fits(self):
         """10 scenes over 100 s → 10 s/scene ≤ 15 s: one slot per scene,
@@ -133,6 +150,24 @@ class TestChapterAlignment:
         chapters = _chapters((5.0, "Intro"), (25.0, "Closing"))
         plan = plan_chapter_schedule(pool, [], chapters, 40.0)
         assert abs(math.fsum(d for _, d in plan) - 40.0) < 1e-6
+
+    def test_long_episode_chapter_plan_respects_slot_cap(self):
+        """Ep537 shape: ~11 chapters over ~17 min at 15 s hold → 70+
+        slots uncapped. Cap merges adjacent slots; duration sum and
+        chapter-boundary coverage survive."""
+        pool = _scenes("fresh", 4)
+        # 11 chapter anchors across 1044 s (mirrors auto-segmented Ep537).
+        starts = [0, 60, 150, 250, 350, 450, 550, 650, 750, 900, 1000]
+        chapters = _chapters(*[(float(s), f"Ch{i}") for i, s in enumerate(starts)])
+        plan = plan_chapter_schedule(pool, [], chapters, 1044.0,
+                                     max_hold_s=15.0, min_hold_s=6.0)
+        assert len(plan) <= _MAX_SLIDESHOW_SLOTS
+        assert len(plan) >= 2
+        assert abs(math.fsum(d for _, d in plan) - 1044.0) < 1e-6
+        # Uncapped would be ceil(1044/15) ≈ 70; prove the cap fired.
+        uncapped_floor = math.ceil(1044.0 / 15.0)
+        assert uncapped_floor > _MAX_SLIDESHOW_SLOTS
+        assert len(plan) < uncapped_floor
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_slideshow_scene_cadence.py
+++ b/tests/test_slideshow_scene_cadence.py
@@ -86,16 +86,53 @@ class TestSceneCadenceMatchesAudio:
     def test_six_minute_episode_cycles_to_15s_cap(self, stub_paths):
         """June 2026 motion pass: scenes CYCLE so no image holds longer than
         ~15 s (was 25 s; 360 s/8 = 45 s/scene used to ship — visually static;
-        the scene list now repeats in rotation at zero added image cost)."""
+        the scene list now repeats in rotation at zero added image cost).
+        360/15 = 24 slots — exactly the render-safe slot cap, so the 15 s
+        preference still wins."""
         dur = _capture_scene_duration(stub_paths, audio_duration_s=360.0)
         assert dur is not None and 8.0 <= dur <= 15.0, (
             f"Expected ≤15 s/scene after cycling for 360 s/8, got {dur}"
         )
 
-    def test_ten_minute_episode_cycles_to_15s_cap(self, stub_paths):
-        """600 s/8 = 75 s/scene pre-fix; cycling caps the hold at ≤15 s."""
+    def test_ten_minute_episode_respects_slot_cap(self, stub_paths):
+        """600 s @ 15 s would be 40 slots; the render-safe cap (24) binds
+        and holds stretch to 600/24 = 25 s. Still far below the pre-motion
+        75 s/scene static look."""
+        from engine.scene_scheduler import _MAX_SLIDESHOW_SLOTS
         dur = _capture_scene_duration(stub_paths, audio_duration_s=600.0)
-        assert dur is not None and 8.0 <= dur <= 15.0
+        assert dur is not None
+        assert 8.0 <= dur <= (600.0 / _MAX_SLIDESHOW_SLOTS) + 0.01
+        # Cap must have fired — uncapped would be ≤15 s.
+        assert dur > 15.0
+
+    def test_seventeen_minute_episode_stays_under_slot_cap(self, stub_paths):
+        """Ep537-class (1044 s): prove the uniform cycling path never asks
+        ffmpeg for more than _MAX_SLIDESHOW_SLOTS inputs."""
+        from engine import video
+        from engine.scene_scheduler import _MAX_SLIDESHOW_SLOTS
+
+        captured = {}
+
+        def _fake_render_slideshow(scene_paths, output, *,
+                                   scene_duration=None, **kwargs):
+            captured["n_scenes"] = len(scene_paths)
+            captured["scene_duration"] = scene_duration
+            Path(output).write_bytes(b"\x00")
+            return Path(output)
+
+        with patch.object(video, "_render_slideshow", _fake_render_slideshow), \
+             patch.object(video, "_long_form_cmd", lambda *a, **k: ["true"]), \
+             patch("subprocess.run",
+                   lambda *a, **k: type("R", (), {"returncode": 0, "stderr": b""})()), \
+             patch("engine.audio.get_audio_duration", return_value=1044.0):
+            video.build_long_form_video(
+                stub_paths["audio"], stub_paths["cover"], stub_paths["out"],
+                scene_paths=stub_paths["scenes"][:4],
+            )
+        assert captured["n_scenes"] == _MAX_SLIDESHOW_SLOTS
+        assert captured["scene_duration"] == pytest.approx(
+            1044.0 / _MAX_SLIDESHOW_SLOTS, rel=0.01,
+        )
 
     def test_thirty_second_teaser_clamps_to_floor(self, stub_paths):
         """Very short audio gets clamped to the 8 s floor so scenes

--- a/tests/test_youtube_quality_pass.py
+++ b/tests/test_youtube_quality_pass.py
@@ -64,6 +64,20 @@ class TestSlideshowSceneCycling:
         assert "_MAX_SCENE_HOLD_S = 15.0" in src
         assert "slideshow_scenes" in src
 
+    def test_slideshow_slot_cap_shared_with_scheduler(self):
+        """Ep537 timeout class: long episodes must clamp ffmpeg inputs via
+        the shared _MAX_SLIDESHOW_SLOTS (not unbounded 15 s cycling)."""
+        from engine.scene_scheduler import _MAX_SLIDESHOW_SLOTS
+        video_src = (_ROOT / "engine" / "video.py").read_text(encoding="utf-8")
+        sched_src = (_ROOT / "engine" / "scene_scheduler.py").read_text(
+            encoding="utf-8")
+        assert "_MAX_SLIDESHOW_SLOTS" in video_src
+        assert "_MAX_SLIDESHOW_SLOTS = 24" in sched_src
+        assert _MAX_SLIDESHOW_SLOTS == 24
+        assert "PIPELINE_TIMEOUT_SECONDS: '3000'" in (
+            _ROOT / ".github" / "workflows" / "run-show.yml"
+        ).read_text(encoding="utf-8")
+
 
 class TestObservability:
     def test_ru_token_warning(self):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Tesla Ep537 hit `PIPELINE TIMEOUT: exceeded 2400s` mid long-form slideshow render:

```
visual_reuse: long-form plan for tesla ep537 — mode=chapter_schedule fresh=4 library=0 broll=0 slots=74
Rendering slideshow (74 scenes, 1920x1080, crossfade=0.6s) → …
PIPELINE TIMEOUT: exceeded 2400s
```

Root causes stacked:

1. **74 ffmpeg inputs** — 1044s audio × 15s max hold → ~70 slots; xfade+zoompan chains do not finish in time after a 910s TTS.
2. **Gallery CDN 403 storm** — `gallery.nerranetwork.com` returned 403 for every historical image (~150 attempts), so `library=0` and only 4 fresh images cycled through those 74 slots.
3. **Tight 40-min budget** — TTS alone burned 15 min; video stage had ~11 min left including the 7-min commit reserve.

## Fix

- Cap slideshow slots at **24** (`engine.scene_scheduler._MAX_SLIDESHOW_SLOTS`), shared by chapter-aligned plans (adjacent-slot merge) and the uniform cycling path in `engine.video`. Holds stretch on long episodes instead of exploding the filter graph.
- Gallery library: **circuit breaker** after 5 consecutive download failures + **authenticated R2 fallback** via `original_key` when the public CDN 403s.
- Raise CI `PIPELINE_TIMEOUT_SECONDS` **2400 → 3000** for long-TTS + long-form + 2 Shorts headroom.

Render/metadata only — no audio path changes (outside landmine #17).

## Tests

- `tests/test_scene_scheduler.py` — Ep537-class 1044s chapter + uniform plans stay ≤24 slots
- `tests/test_slideshow_scene_cadence.py` — uniform cycling path respects the cap
- `tests/test_gallery_library.py` — circuit breaker + R2 fallback
- `tests/test_youtube_quality_pass.py` — pins the shared constant + 3000s timeout

96 related tests passed locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50376128-3433-42ad-8440-b12df9b05731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50376128-3433-42ad-8440-b12df9b05731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

