### PR TITLE
Fix CI smoke: Tesla web_search_queries count pin (unblocks all shows)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -430,10 +430,21 @@ class TestLoadConfigRealFiles:
         cfg = load_config(SHOWS_DIR / "tesla.yaml")
         assert cfg.name == "Tesla Shorts Time"
         assert cfg.slug == "tesla"
-        assert len(cfg.sources) >= 16  # electrek.co + driveteslacanada.ca removed (blocked sources)
+        # electrek.co + driveteslacanada.ca removed (blocked); July 2026
+        # full-business pass added Optimus/Energy/Solar/Cortex Google News.
+        assert len(cfg.sources) >= 20
         assert cfg.sources[0].label == "Teslarati"
         assert "tsla" in cfg.keywords
-        assert len(cfg.web_search_queries) == 4
+        # July 2026 full-business coverage pass expanded searches from 4 → 10
+        # (Optimus, Robotaxi, Energy, Solar, Cortex/Dojo, Semi/Supercharger).
+        # Pin a floor + required coverage terms, not an exact count — same
+        # pattern as sources so intentional expansions don't brick every
+        # show's CI smoke step (the failure mode that killed all 2026-07-11
+        # scheduled runs).
+        assert len(cfg.web_search_queries) >= 10
+        joined = " ".join(cfg.web_search_queries).lower()
+        for term in ("optimus", "megapack", "solar", "cortex", "robotaxi"):
+            assert term in joined, term
         # Tesla inherits the network default (grok-4.3) — always-on
         # reasoning at lower cost than the previous grok-4.20-reasoning
         # override.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

All 2026-07-11 scheduled podcast runs failed in the **CI smoke** step with the same root cause:

```
tests/test_config.py::TestLoadConfigRealFiles::test_tesla_show
AssertionError: assert 10 == 4  # web_search_queries
```

PR #800 (full-business coverage) intentionally expanded Tesla `web_search_queries` from 4 → 10. The smoke suite pins that exact count, so **every** show run failed before episode generation (smoke loads Tesla YAML regardless of which show is scheduled).

## Fix

Replace `== 4` with a floor (`>= 10`) plus required coverage terms (optimus, megapack, solar, cortex, robotaxi), matching the existing soft floor on `sources`.

## Failed shows to re-dispatch after merge

omni_view, planetterrian, fascinating_frontiers, models_agents, models_agents_beginners, modern_investing, first_principles, tesla, unintended_consequences, spacex, dp_pod

## Test plan

- [x] `pytest tests/test_config.py::TestLoadConfigRealFiles::test_tesla_show`
- [ ] Merge to main
- [ ] `workflow_dispatch` each failed show
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50376128-3433-42ad-8440-b12df9b05731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50376128-3433-42ad-8440-b12df9b05731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

