### PR TITLE
Harden Grok TTS retries + fix validation self-matching today's headlines

### DIFF
--- a/engine/content_tracker.py
+++ b/engine/content_tracker.py
@@ -623,15 +623,34 @@ class ContentTracker:
 
     # ----- Querying recent content -----
 
-    def get_recent_headlines(self, days: Optional[int] = None) -> List[str]:
-        """Return headlines from recent episodes for cross-day dedup."""
+    def get_recent_headlines(
+        self,
+        days: Optional[int] = None,
+        *,
+        exclude_today: bool = False,
+    ) -> List[str]:
+        """Return headlines from recent episodes for cross-day dedup.
+
+        ``exclude_today=True`` drops the current calendar day's episode
+        record. Required for post-generate validation: ``run_show`` used
+        to ``record_episode`` *before* ``validate_digest``, so
+        ``get_recent_headlines(days=7)`` included the digest under test
+        and every headline flagged as a 100% "BLOCKING cross-episode
+        repeat" against itself (FF Ep128 2026-07-11 — 15 false positives
+        that also fed the exact-dup stripper and gutted the podcast body).
+        """
+        today = datetime.date.today().isoformat()
         cutoff = (
             datetime.date.today() - datetime.timedelta(days=days or self.max_days)
         ).isoformat()
         headlines = []
         for ep in self.data["episodes"]:
-            if ep.get("date", "") >= cutoff:
-                headlines.extend(ep.get("headlines", []))
+            ep_date = ep.get("date", "")
+            if ep_date < cutoff:
+                continue
+            if exclude_today and ep_date == today:
+                continue
+            headlines.extend(ep.get("headlines", []))
         return headlines
 
     def get_recent_urls(self, days: Optional[int] = None) -> set:

--- a/engine/tts.py
+++ b/engine/tts.py
@@ -46,6 +46,15 @@ GROK_MAX_CHARS_PER_REQUEST = 14000
 # voice + ~14k-char chunk under load; normal calls finish in 30-60s and
 # don't notice the higher cap.
 GROK_TTS_TIMEOUT_SECONDS = 300
+# July 2026: Grok occasionally closes the streamed TTS connection mid-
+# body (RemoteDisconnected / ConnectionError) after several minutes of
+# synthesis. Three quick retries were not enough — FF Ep128 burned ~13
+# minutes across 3 attempts and still failed. Five attempts with a longer
+# backoff give the endpoint time to recover without blowing the pipeline
+# timeout (each successful call is typically 1–4 min).
+GROK_TTS_RETRY_ATTEMPTS = 5
+GROK_TTS_RETRY_WAIT_MIN = 5
+GROK_TTS_RETRY_WAIT_MAX = 90
 
 
 def _ffmpeg_escape(path: Path) -> str:
@@ -642,12 +651,59 @@ class _GrokTTSServerError(requests.HTTPError):
     """Retryable Grok TTS server error (5xx / 429)."""
 
 
+def _unlink_partial_tts_output(out_path: Path) -> None:
+    """Remove a partial TTS file left by a failed streamed write.
+
+    ``grok_speak_chunk`` streams bytes into *out_path*; a mid-body
+    ``ConnectionError`` leaves a truncated WAV that must not be reused
+    on the next attempt.
+    """
+    try:
+        if out_path.exists():
+            out_path.unlink()
+            logger.info("Removed partial TTS output before retry: %s", out_path.name)
+    except OSError as exc:
+        logger.warning("Could not remove partial TTS output %s: %s", out_path, exc)
+
+
+def _before_sleep_grok_tts(retry_state) -> None:
+    """Log the retry and scrub any partial output file from the failed call."""
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    sleep_for = (
+        retry_state.next_action.sleep if retry_state.next_action else 0.0
+    )
+    logger.warning(
+        "Grok TTS attempt %s/%s failed (%s: %s) — retrying in %.1fs ...",
+        retry_state.attempt_number,
+        GROK_TTS_RETRY_ATTEMPTS,
+        type(exc).__name__ if exc else "?",
+        exc,
+        sleep_for,
+    )
+    out = None
+    if retry_state.kwargs:
+        out = retry_state.kwargs.get("out_path")
+    if out is None and retry_state.args and len(retry_state.args) >= 3:
+        out = retry_state.args[2]
+    if out is not None:
+        _unlink_partial_tts_output(Path(out))
+
+
 @retry(
-    stop=stop_after_attempt(3),
-    wait=wait_exponential(multiplier=1, min=2, max=10),
-    retry=retry_if_exception_type(
-        (requests.ConnectionError, requests.Timeout, _GrokTTSServerError),
+    stop=stop_after_attempt(GROK_TTS_RETRY_ATTEMPTS),
+    wait=wait_exponential(
+        multiplier=2, min=GROK_TTS_RETRY_WAIT_MIN, max=GROK_TTS_RETRY_WAIT_MAX,
     ),
+    retry=retry_if_exception_type(
+        (
+            requests.ConnectionError,
+            requests.Timeout,
+            requests.exceptions.ChunkedEncodingError,
+            _GrokTTSServerError,
+        ),
+    ),
+    before_sleep=_before_sleep_grok_tts,
+    reraise=True,
 )
 def grok_speak_chunk(
     text: str,

--- a/run_show.py
+++ b/run_show.py
@@ -1332,7 +1332,10 @@ def run(args: argparse.Namespace) -> None:
         # gate below) would false-positive on them — skip both for deep dives.
         if _val_factory and not is_deep_dive:
             _val_config = _val_factory()
-            _recent = content_tracker.get_recent_headlines(days=7)
+            # CRITICAL: exclude today's record. record_episode runs above, so
+            # without this every headline matches itself at 100% and is flagged
+            # as a BLOCKING cross-episode repeat (FF Ep128 2026-07-11).
+            _recent = content_tracker.get_recent_headlines(days=7, exclude_today=True)
             _val_passed, _val_issues, _exact_dups = _validate_digest(
                 x_thread, _val_config,
                 section_patterns=section_patterns,

--- a/tests/test_content_tracker.py
+++ b/tests/test_content_tracker.py
@@ -240,6 +240,34 @@ class TestContentTrackerBasics:
         assert "Headline A" in headlines
         assert "Headline B" in headlines
 
+    def test_get_recent_headlines_exclude_today(self, tmp_path):
+        """Validation must not see today's own headlines as cross-episode
+        repeats (FF Ep128 self-match class)."""
+        tracker = ContentTracker("test_show", tmp_path)
+        tracker.load()
+        today = datetime.date.today().isoformat()
+        yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+        tracker.data["episodes"] = [
+            {
+                "date": yesterday,
+                "headlines": ["Yesterday Story"],
+                "quote_author": None,
+                "sections": {},
+            },
+            {
+                "date": today,
+                "headlines": ["Today Self Match"],
+                "quote_author": None,
+                "sections": {},
+            },
+        ]
+        all_h = tracker.get_recent_headlines(days=7)
+        assert "Today Self Match" in all_h
+        assert "Yesterday Story" in all_h
+        prior = tracker.get_recent_headlines(days=7, exclude_today=True)
+        assert "Today Self Match" not in prior
+        assert "Yesterday Story" in prior
+
 
 class TestRecordEpisode:
     def test_record_ff_digest(self, tmp_path):

--- a/tests/test_tts_grok.py
+++ b/tests/test_tts_grok.py
@@ -422,6 +422,44 @@ def test_grok_tts_timeout_default_is_300_seconds():
     assert sig.parameters["timeout"].default == GROK_TTS_TIMEOUT_SECONDS
 
 
+def test_grok_tts_retry_policy_hardened_for_connection_drops():
+    """July 2026 FF Ep128: mid-stream RemoteDisconnected exhausted 3
+    short retries. Pin the longer policy so a partial revert fails CI."""
+    from engine import tts as tts_mod
+    from engine.tts import grok_speak_chunk
+    assert tts_mod.GROK_TTS_RETRY_ATTEMPTS >= 5
+    assert tts_mod.GROK_TTS_RETRY_WAIT_MAX >= 60
+    # Decorator is applied to the unbound function; tenacity stores stop/wait
+    # on the retry object.
+    retry_obj = grok_speak_chunk.retry
+    assert retry_obj.stop.max_attempt_number == tts_mod.GROK_TTS_RETRY_ATTEMPTS
+
+
+def test_before_sleep_grok_tts_removes_partial_output(tmp_path: Path):
+    from engine.tts import _before_sleep_grok_tts
+    from types import SimpleNamespace
+
+    partial = tmp_path / "chunk.wav"
+    partial.write_bytes(b"truncated-wav")
+
+    class _Outcome:
+        def exception(self):
+            return ConnectionError("Remote end closed connection")
+
+    class _Next:
+        sleep = 5.0
+
+    state = SimpleNamespace(
+        attempt_number=2,
+        outcome=_Outcome(),
+        next_action=_Next(),
+        kwargs={"out_path": partial},
+        args=(),
+    )
+    _before_sleep_grok_tts(state)
+    assert not partial.exists()
+
+
 def test_synthesize_sections_falls_back_on_timeout(tmp_path: Path, monkeypatch):
     """If a section TTS call raises (e.g. tenacity exhausted retries on
     a Grok read timeout), the function falls back to single-pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fascinating Frontiers Ep128 failed after digest/script succeeded. Two issues found — one hard failure, one network-wide correctness bug that also affected every other show that ran today.

### 1. Hard failure — Grok TTS connection drop (FF-specific today)

```
ConnectionError: Remote end closed connection without response
tenacity.RetryError  # after 3 attempts
```

TTS streamed ~13 minutes across 3 short retries, then died. **Fix:** 5 attempts, longer exponential backoff (5–90s), scrub partial WAV before retry, also retry `ChunkedEncodingError`.

### 2. Network-wide — validation self-match (all shows)

`record_episode` ran **before** `validate_digest`, so `get_recent_headlines(days=7)` included today's own digest. Every headline matched itself at 100% → 15 false "BLOCKING cross-episode repeat" warnings on FF, and the exact-dup stripper could gut podcast bodies on any show.

**Fix:** `get_recent_headlines(..., exclude_today=True)` for the validation path.

## Test plan

- [x] `test_get_recent_headlines_exclude_today`
- [x] `test_grok_tts_retry_policy_hardened_for_connection_drops`
- [x] `test_before_sleep_grok_tts_removes_partial_output`
- [ ] Merge; re-dispatch `fascinating_frontiers` (other today's shows already succeeded)

## Re-dispatch after merge

```bash
gh workflow run run-show.yml -f show=fascinating_frontiers -f test_mode=false
```

(Agent token still cannot `workflow_dispatch` — 403.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50376128-3433-42ad-8440-b12df9b05731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50376128-3433-42ad-8440-b12df9b05731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

