### PR TITLE
Fix data-coupled dp_pod lever test breaking CI on every PR

### DIFF
--- a/tests/test_dp_pod_show.py
+++ b/tests/test_dp_pod_show.py
@@ -13,6 +13,7 @@ Pins the launch decisions so a partial revert or config drift fails CI:
 from __future__ import annotations
 
 import datetime
+import re
 import sys
 from pathlib import Path
 
@@ -249,12 +250,22 @@ class TestDebutRework:
         # The quoted lever body (after the colon) must be a real aired action —
         # not a phantom heat-pump callback. The instruction preamble may still
         # mention heat pumps as a forbidden example.
-        quoted = prev.split("):", 1)[-1].lower()
-        assert "heat-pump" not in quoted
-        assert "heat pump" not in quoted
-        assert any(
-            token in quoted
-            for token in ("solar", "diesel", "filter", "pledge", "doomscroll")
+        quoted = prev.split("):", 1)[-1]
+        assert "heat-pump" not in quoted.lower()
+        assert "heat pump" not in quoted.lower()
+        # Data-independent reality check (the old hard-coded token list broke
+        # the suite whenever a new episode's lever used different words): the
+        # quoted text must come verbatim from the cited episode's committed
+        # digest, proving it is an aired action rather than an invention.
+        ep_match = re.search(r"\[Ep(\d+)\]\s*(.+)", quoted, re.DOTALL)
+        assert ep_match, f"no [EpNNN] citation in: {quoted[:120]}"
+        digest_glob = f"DP_Pod_Ep{int(ep_match.group(1)):03d}_*.md"
+        sources = list((PROJECT_ROOT / "digests" / "dp_pod").glob(digest_glob))
+        assert sources, f"cited digest {digest_glob} not found"
+        digest_text = re.sub(r"\s+", " ", sources[0].read_text(encoding="utf-8"))
+        lever_snippet = re.sub(r"\s+", " ", ep_match.group(2)).rstrip("…").strip()
+        assert lever_snippet[:120] in digest_text, (
+            f"quoted lever not found in {sources[0].name}: {lever_snippet[:120]}"
         )
         ctx = hook.pre_fetch(CFG, episode_num=5, today_str="July 9, 2026")
         assert "PREVIOUS LEVER" in ctx["nerra_network_context"]


### PR DESCRIPTION
Main's CI has been red since DP Pod Ep009 shipped (it's what failed #810's check before you admin-merged): `test_hook_injects_previous_lever_for_dispatch_continuity` hard-coded a token list from the levers that existed when it was written (solar/diesel/filter/pledge/doomscroll). Ep009's real lever — "Record a one-hour conversation with an older family member…" — uses none of those words, so the test failed even though **the hook is working exactly as designed** (it quotes the newest real aired lever). Same brittle data-coupled test class the 2026-07-02 network review flagged.

**Fix:** the reality check is now data-independent — the quoted lever must appear verbatim in the cited episode's committed digest, proving it's an aired action rather than an invention. Robust to every future episode. The heat-pump phantom-callback guard (the regression this test exists for) is unchanged.

`tests/test_dp_pod_show.py` → 69 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX

---
_Generated by [Claude Code](https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production hook or prompt behavior is modified.
> 
> **Overview**
> Fixes **CI failures** when a new episode’s real prior lever doesn’t match a stale hard-coded word list (e.g. Ep009’s family-conversation lever).
> 
> In `test_hook_injects_previous_lever_for_dispatch_continuity`, the **heat-pump phantom-callback** checks stay the same, but the “real aired action” assertion no longer requires tokens like solar/diesel/filter. It now parses the `[EpNNN]` citation, loads that episode’s committed digest under `digests/dp_pod`, and asserts the quoted lever snippet appears **verbatim** in the digest text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db71f05cb6d0d7fd11ecfb550eb6bd973e7508dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->