### PR TITLE
[show-review] MIT two-week scoring review: 8 hits, 1 miss — regime deadlock + one-bar weekly fixed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,6 +492,34 @@ nerranetwork/
   exists ONLY in `snaptrade_client.py`, invoked ONLY by `live.py`, whose
   FIRST gate is the kill switch (a poisoned-client test proves disabled
   runs touch nothing). No prompt/audio changes (outside landmine #17).
+  **July 18 2026 two-week scoring review** (review:
+  [`docs/reviews/modern_investing_review_2026_07_18.md`](docs/reviews/modern_investing_review_2026_07_18.md);
+  drift guards: `tests/test_mit_benchmark_integrity.py::{TestRegimeDeadlockFix,TestWeeklyMinHold,TestSweepGating,TestNoTradeReasonTaxonomy}`):
+  scored the July 3-4 predictions — 8 HIT (tic 9/10→0/10, entry
+  integrity, stops 2/2, rule stamps, 3-index closes, shadow ledger
+  complete with paired exits, dormant live layer untouched), 1 MISS,
+  1 pending. Two production design flaws fixed: (1) the regime
+  cold-streak brake DEADLOCKED the Practice Investment (2 picks in 14
+  episodes; mean poisoned by the -11.8 MDA outlier, $100 drawdown
+  threshold permanently tripped at $164 standing, and cold suppressed
+  the closes that refresh the window) — regime v2 uses the MEDIAN, a
+  full-position $250 drawdown threshold, a >7-day pick-drought escape
+  valve (SELECTIVE RESET expects the next Monday pick), and tells the
+  show to narrate capital-preservation mode on air; (2) Ep101 COST was
+  picked Thursday and closed as a one-bar "weekly hold" (entry==exit
+  bar, -2.35% while the shadow layer holding Thu→Fri made +0.26%) —
+  weekly closes now require ≥2 days since pick, shadow calendar matched.
+  The MISSed prediction: the t-stat honesty hedge was spoken in ZERO
+  episodes while the alpha was quoted in most — the caveat now lives
+  INLINE in the alpha sentence (models echo data lines, drop separate
+  instructions — a reusable lesson). Index sweep gated on n≥5 per index
+  (was comparing 37-trade NASDAQ vs 2-trade S&P/TSX). No-trade signal
+  reasons: explicit forms broadened ("Today's Pick: None" was mislabeled
+  as extraction drift), `no_practice_section` for recaps. Regime/caveat
+  text changes prompt context → A/B-listen per landmine #17. Operator
+  items still open: recompute --apply (matched alpha retains old-window
+  inflation until backfill), SnapTrade Phase-0 verification, LL-054
+  family retirement.
 
 **Tesla Shorts Time Recursive Memory System (May 2026+)**  
 TST received a full recursive improvement architecture (analogous to MIT):

--- a/docs/reviews/ledger/modern_investing.yaml
+++ b/docs/reviews/ledger/modern_investing.yaml
@@ -116,24 +116,24 @@ reviews:
         baseline: "9/10 episodes"
         expected: "<= 2/10 within 10 episodes (dedup removed the echo; the
           rule is 1 of 11 distinct actives, no longer 5-of-5 in the block)"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-18: 0/10 in the last-10 snapshot (was 9/10); ledger stable at 11 distinct actives, no echo regrowth"
       - metric: flash trades with nasdaq_return_pct == 0.0
         baseline: "8/8 flash trades"
         expected: "0 new flash trades with a zero benchmark window"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-18: no flash trades occurred; both new closes (COST/DAL) carry real matched windows — thin n, re-score when a flash closes"
       - metric: weekly trades with entry_bar_date < pick date
         baseline: "all mid-week weekly picks backdated to Monday"
         expected: "0 new trades with entry before pick date"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-18: Ep101 COST and Ep102 DAL entry bars equal their pick dates"
       - metric: TSX picks priced on the .TO listing
         baseline: "0 (bare US symbols; Ep50 CNR wrong company)"
         expected: "every new TSX pick carries resolved_symbol ending .TO/.V
           or a loud PICK VALIDATION FAILED log"
         verdict: pending
-        evidence: null
+        evidence: "no TSX picks in the window yet; both US picks carry resolved_symbol"
     agent_cost_usd: null
 
   - date: 2026-07-04
@@ -184,20 +184,20 @@ reviews:
         baseline: "0 (ledger created this pass)"
         expected: ">= 8 entries with decision in {would_place, skipped};
           zero duplicate client_order_ids; workflow green without secrets"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-18: 12 entries covering every weekday, entries + paired exits, zero duplicate ids, workflow green with no secrets"
       - metric: closed trades carrying benchmark_returns for all 3 indices
         baseline: "0 of 40"
         expected: "every NEWLY closed trade has nasdaq+sp500+tsx returns
           (history backfills when the operator runs the recompute script)"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-18: both new closes carry nasdaq+sp500+tsx; history still awaits the operator recompute"
       - metric: closed trades stamped with rules_in_effect
         baseline: "0 of 40"
         expected: "every new pick stamped; first rule scoreboard lines
           appear after ~5 closes; retirement candidates only at >=8"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-18: both stamped with the exact 5 rule IDs; scoreboard activates at ~5 stamped closes"
     agent_cost_usd: null
 
   - date: 2026-07-04
@@ -236,14 +236,14 @@ reviews:
         expected: ">= 70% of new picks carry stop_loss (the Risk
           Assessment states one nearly every episode); no trade ever
           carries a stop above its entry"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-07-18: 2/2 new picks carry {pct: 6.0}; none above entry"
       - metric: spoken outperformance claims without a significance hedge
         baseline: "n/a (t-stat never computed)"
         expected: "while alpha_statistically_significant is false, episodes
           claiming outperformance also say it is early/not yet significant"
-        verdict: pending
-        evidence: null
+        verdict: miss
+        evidence: "2026-07-18: alpha quoted in most episodes, hedge spoken in ZERO — separate-instruction design failed; fixed by embedding the caveat inline in the alpha sentence"
     agent_cost_usd: null
 
   - date: 2026-07-04
@@ -283,6 +283,69 @@ reviews:
         baseline: "workflow new"
         expected: "every scheduled run green with 'live layer dormant'
           no-op; zero SnapTrade calls until the operator arms it"
+        verdict: hit
+        evidence: "2026-07-18: no live_execution_state.json exists — the dormant layer has never touched anything"
+    agent_cost_usd: null
+
+  - date: 2026-07-18
+    pr: null
+    doc: docs/reviews/modern_investing_review_2026_07_18.md
+    reviewer: claude-code (operator-requested two-week scoring review)
+    summary: >
+      First full scoring pass over the July 3-4 overhaul: 8 predictions
+      HIT, 1 MISS, 1 pending. The machinery works (signals every episode,
+      shadow ledger complete with paired exits, stops parsed 2/2, rules
+      stamped, tic eliminated, live layer untouched) — but two design
+      flaws surfaced in production: the regime cold-streak brake
+      DEADLOCKED the Practice Investment segment (2 picks in 14 episodes;
+      mean poisoned by the -11.8 MDA outlier + $100 drawdown threshold
+      permanently tripped at $164 standing + cold suppresses the very
+      closes that refresh the window), and a Thursday weekly pick closed
+      as a degenerate one-bar "weekly hold" (Ep101 COST, entry==exit bar,
+      -2.35% while the shadow layer holding Thu->Fri made +0.26% on the
+      same pick). The significance hedge never reached air (alpha quoted
+      most episodes, hedge spoken zero) — separate-instruction design
+      failure. Index sweep was comparing 37-trade vs 2-trade samples.
+    shipped:
+      - regime v2 — median (outlier-robust), drawdown threshold $100->$250
+        (full position), pick-drought escape valve (>7 days cold ->
+        SELECTIVE RESET expecting the next Monday pick), cold-streak
+        on-air transparency instruction
+      - weekly min-hold — Friday close requires >=2 days since pick
+        (Thu/Fri picks roll to next Friday); shadow _exit_due_date matches
+      - index sweep gated on n>=5 per index, 2+ qualifying
+      - significance caveat embedded INLINE in the alpha sentence
+      - no-trade reason taxonomy (explicit None/No Trade/Mid-Week forms;
+        no_practice_section for recaps; no_pick_extracted = real drift)
+    deferred:
+      - "watch: 'volume above the 20-day average' spoken 8/10 (LL-017
+        echo); rule scoreboard adjudicates at ~5 stamped closes"
+      - "product: performance-page execution-reality section at ~20 shadow
+        round trips; Sunday weekly-scoreboard ritual"
+      - "operator: recompute --apply still not run (current +6.59% matched
+        alpha retains old-window inflation; sweep suppressed until
+        backfill); SnapTrade Phase-0 status unverifiable from repo;
+        closing-price lesson retirement still open"
+      - "carried: under-length (digest ceiling); shadow executor cron
+        delays (runs 15:04-16:48 UTC vs 13:50 slot, landmine #24 class)"
+    predictions:
+      - metric: new picks per week (trade signals with action=new_trade)
+        baseline: "1/week over Jul 6-18 (both Monday weeklies suppressed)"
+        expected: ">=1 Monday weekly pick per week under regime v2; no
+          pick drought longer than 7 days while SELECTIVE RESET is
+          reachable"
+        verdict: pending
+        evidence: null
+      - metric: weekly holds with entry_bar_date == exit_bar_date
+        baseline: "1 (Ep101 COST, the Thursday degenerate)"
+        expected: "0 new one-bar weekly holds"
+        verdict: pending
+        evidence: null
+      - metric: episodes quoting the matched-window alpha with the
+          significance qualifier in the same breath
+        baseline: "0 of ~8 alpha mentions (hedge separate -> dropped)"
+        expected: "inline caveat echoed in >=70% of alpha mentions while
+          t<2"
         verdict: pending
         evidence: null
     agent_cost_usd: null

--- a/docs/reviews/modern_investing_review_2026_07_18.md
+++ b/docs/reviews/modern_investing_review_2026_07_18.md
@@ -1,0 +1,112 @@
+# Modern Investing Techniques — two-week scoring review (2026-07-18)
+
+**Question asked:** after the July 3–4 overhaul (benchmark integrity,
+learning-loop self-audit, stop enforcement, shadow mode, dormant live
+executor), is the system working as intended — and what makes it a
+better product for listeners? Evidence: Ep096–Ep110 (14 episodes),
+15 trade signals, the shadow ledger, the tracker, transcripts, and the
+snapshot tool.
+
+## Scorecard — every pending ledger prediction, now scored
+
+| Prediction (July 3–4) | Verdict | Evidence |
+|---|---|---|
+| "closing-price confirmation" tic ≤2/10 (was 9/10) | **HIT** | 0/10 in the last-10 transcript snapshot; the lessons dedup held (ledger stable at 65 total / 11 active, no echo regrowth). |
+| No new flash trade with a zero benchmark window | **HIT (thin n)** | No flash trades occurred; both new closes carry real windows. |
+| No new trade with entry before pick date | **HIT** | Ep101 COST entry bar = pick date (Jul 9); Ep102 DAL = Jul 10. |
+| TSX picks priced on `.TO`/`.V` | **PENDING** | No TSX picks in the window; both US picks carry `resolved_symbol`. |
+| Shadow ledger ≥8 entries, zero duplicate ids, green with no secrets | **HIT** | 12 entries, every weekday covered, entries+paired exits, idempotent. |
+| New closes carry all-3-index returns | **HIT** | Both trades have nasdaq/sp500/tsx matched returns. |
+| New picks stamped with `rules_in_effect` | **HIT** | Both stamped with the exact 5 rule IDs shown on pick day. |
+| ≥70% of picks carry a parsed stop | **HIT** | 2/2 picks carry `{"pct": 6.0}`; none above entry. |
+| Outperformance claims hedged while t<2 | **MISS** | Alpha quoted in most episodes ("the portfolio holds a 7.0% alpha…"), the hedge spoken in **zero**. Root cause: the caveat lived in a separate instruction line — models echo data lines and drop instructions. **Fixed this pass**: the caveat is now embedded in the same sentence as the alpha number. |
+| Live workflow green no-op while dormant | **HIT** | No `live_execution_state.json` exists — the layer has never touched anything. |
+
+Also verified working: matched-window labeling reached air (6/10
+episodes say "matched-window"), review-once guard, voided-trade
+exclusions, cost ~$0.10/episode, chapters clean (one recap exception).
+
+## What is NOT working as intended (found + fixed this pass)
+
+### P0 (product): the regime brake deadlocked the show's signature segment
+The Practice Investment made **2 picks in 14 episodes**, and both
+scheduled Monday weekly picks were suppressed. Cause: the cold-streak
+trigger used the **mean** of the last 10 alphas (poisoned indefinitely by
+Ep81 MDA's −11.8% outlier: mean −0.98) OR **drawdown > $100** (standing
+drawdown was $164 — permanently tripped for a strategy whose single
+trades swing ±$120). Worse, cold suppresses new trades, new trades are
+the only thing that refreshes the window → a self-reinforcing lockup.
+Fixed (`shows/hooks/modern_investing.py`): **median** instead of mean
+(−0.94 vs −1.0 threshold — today's record is borderline, not locked),
+drawdown threshold raised to a full position ($250), and an **escape
+valve**: when cold coincides with a >7-day pick drought, the guidance
+becomes a "SELECTIVE RESET" that *expects* the next Monday pick with
+honest moderate-conviction framing — because an extended pick drought
+teaches listeners nothing. The fresh-cold text now also instructs the
+show to SAY it's in capital-preservation mode and what re-opens trading
+— dead air becomes a narrative.
+
+### P0 (integrity): the one-bar "Weekly Hold"
+Ep101 COST was picked Thursday and closed on Friday's pre-market run
+with **entry and exit on the same Thursday bar** (−2.35% in a
+zero-day "weekly hold") — a degenerate artifact of the July-3 pick-date
+entry fix meeting the close-every-Friday rule. Fixed: a weekly hold now
+closes on a Friday run only when ≥2 calendar days have elapsed since the
+pick (Thu/Fri picks roll to the next Friday); the shadow executor's exit
+calendar matches (`_exit_due_date`: Thursday → +8 days). Notably, the
+shadow layer held COST Thu→Fri and made **+0.26% while the sim booked
+−2.35%** on the same pick — the divergence that proves the fix matters.
+
+### P1 (honesty): the index sweep compared a 37-trade score to 2-trade scores
+`benchmark_scores` showed "beating 1 of 3 major indices" with S&P/TSX
+samples of n=2 (history isn't backfilled until the operator's recompute
+runs). Never actually spoken, but it was live prompt context. Fixed: the
+sweep line only includes indices with ≥5 matched trades and needs 2+
+qualifying indices to appear at all.
+
+### P2: no-trade signals mislabeled as extraction drift
+5 of 12 no-trade signals said `no_pick_extracted` (the drift alarm), but
+the digests actually said "**Today's Pick:** None" / "**Trade Type:** No
+new trade" — deliberate no-trade days in phrasings the regex missed, so
+the drift alarm meant nothing. Fixed: broadened explicit-no-trade
+detection (None/No Trade/No new trade/Mid-Week Update) + a new
+`no_practice_section` reason for recap/weekend episodes.
+`no_pick_extracted` now genuinely means drift.
+
+## Watch list (no action yet)
+- **"volume above the 20-day average" spoken in 8/10 episodes** — the
+  LL-017 rule (reinforced ×23 pre-dedup) echoing on air. The rule
+  scoreboard will adjudicate LL-017 once ~5 stamped trades close
+  (currently 2); if it shows no edge it becomes a retirement candidate.
+- Chronic under-length (all 10 recent episodes below the 1800w floor) —
+  unchanged, still the network digest-ceiling deferral.
+- Shadow executor runs land 15:04–16:48 UTC vs the 13:50 cron (GitHub
+  delay, landmine #24) — quotes are mid-day rather than 9:50 ET.
+  Acceptable for now; the Cloudflare exact-time dispatcher could add
+  these slots if precision starts mattering.
+
+## Product recommendations (for listeners/users — not yet implemented)
+1. **Make the discipline visible** (shipped in part via the cold-streak
+   transparency line): no-trade stretches should be a story listeners
+   follow, not silence.
+2. **"Execution reality" section on the performance page** once ~20
+   shadow round trips exist: sim vs would-have-been-real, per trade —
+   no other investing podcast shows its slippage honestly.
+3. **Weekly scoreboard ritual**: the Sunday recap could own the weekly
+   numbers (matched-window alpha, indices sweep once qualified, rule
+   scoreboard movements) as a signature segment.
+4. Operator items still open: **run `scripts/recompute_mit_benchmarks.py
+   --apply`** (the current +6.59% matched alpha still contains
+   old-window inflation; the sweep stays suppressed until backfill),
+   SnapTrade Phase-0 status unknown from the repo (mirror artifacts
+   aren't committed — check the Actions runs), and the closing-price
+   lesson-family retirement (LL-054/005/013) remains a one-line flip.
+
+## Shipped this pass
+Regime v2 (median + $250 drawdown + drought escape valve + on-air
+transparency), weekly min-hold rule (sim + shadow calendars), sweep
+sample-gating, inline significance caveat, no-trade reason taxonomy.
+Drift guards: `TestRegimeDeadlockFix`, `TestWeeklyMinHold`,
+`TestSweepGating`, `TestNoTradeReasonTaxonomy` (+3 updated pins). 229
+tests green. ⚠️ A/B-listen (landmine #17): regime text, inline caveat,
+and cold-streak transparency are new/changed prompt context.

--- a/docs/reviews/review_state.yaml
+++ b/docs/reviews/review_state.yaml
@@ -17,7 +17,7 @@ targets:
   # Prompt + Grok API/Voice infra review July 9 2026 (cache routing, TTS speed).
   # Depth + network discovery pass July 9 2026.
   network: 2026-07-09
-  modern_investing: 2026-07-03
+  modern_investing: 2026-07-18
   fascinating_frontiers: 2026-07-14
   models_agents: 2026-06-21
   models_agents_beginners: 2026-06-25

--- a/execution/shadow.py
+++ b/execution/shadow.py
@@ -164,6 +164,10 @@ def _exit_due_date(pick_date: datetime.date, trade_type: str) -> datetime.date:
     if trade_type == "flash":
         days = 3 if wd == 4 else (2 if wd == 5 else 1)  # Fri→Mon, Sat→Mon
         return pick_date + datetime.timedelta(days=days)
+    if wd == 3:
+        # Thursday-picked weekly: this-week Friday would be a 1-day
+        # "weekly hold" (the sim's Ep101 COST degenerate) — next Friday.
+        return pick_date + datetime.timedelta(days=8)
     if wd == 4:
         return pick_date + datetime.timedelta(days=7)
     if wd == 5:

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -362,18 +362,42 @@ def _build_strategy_performance(tracker: dict) -> str:
 
 
 _REGIME_WINDOW = 10
+# July 18 2026 recalibration: the original mean-based trigger (avg < -0.5
+# or drawdown > $100) DEADLOCKED the show — one -11.8% outlier (Ep81 MDA)
+# poisoned the rolling mean, $164 of standing drawdown tripped the $100
+# threshold permanently, and the cold streak suppressed the very trades
+# that would refresh the window. Both Monday weekly picks were skipped
+# and the signature segment went dark 12 of 14 episodes. Now: MEDIAN
+# (outlier-robust), a full-position drawdown threshold, and an escape
+# valve — a pick drought longer than a week downgrades COLD to a
+# SELECTIVE reset so the show trades (and teaches) again.
+_REGIME_COLD_MEDIAN = -1.0
+_REGIME_COLD_DRAWDOWN = 250.0
+_REGIME_PICK_DROUGHT_DAYS = 7
+
+
+def _days_since_last_pick(tracker: dict) -> int | None:
+    dates = []
+    for t in tracker.get("trades", []):
+        d = t.get("date")
+        if isinstance(d, str):
+            try:
+                dates.append(datetime.date.fromisoformat(d))
+            except ValueError:
+                continue
+    if not dates:
+        return None
+    return (datetime.date.today() - max(dates)).days
 
 
 def _build_regime_block(tracker: dict) -> str:
     """Adaptive selectivity from the rolling record (July 2026).
 
-    The loop previously treated every day identically regardless of how
-    the last stretch of picks performed. This block turns the rolling
-    last-``_REGIME_WINDOW`` matched-window alpha + the drawdown from the
-    P&L high-water mark into explicit selection pressure: a cold streak
-    RAISES the bar (prefer explicit no-trade days, demand more aligned
-    factors); a hot streak holds discipline flat (never "press harder").
-    Deterministic — thresholds are code, not vibes.
+    Turns the rolling last-``_REGIME_WINDOW`` MEDIAN matched-window alpha
+    + the drawdown from the P&L high-water mark into explicit selection
+    pressure. A cold streak raises the bar; a hot streak holds discipline
+    flat (never "press harder"); a pick drought releases the brake so the
+    practice segment keeps teaching. Deterministic — thresholds are code.
     """
     closed = [t for t in tracker.get("trades", []) if t.get("status") == "closed"]
     scored = [
@@ -383,9 +407,11 @@ def _build_regime_block(tracker: dict) -> str:
     ]
     if len(scored) < 5:
         return ""
-    recent = scored[-_REGIME_WINDOW:]
-    avg_alpha = sum(t["alpha_pct"] for t in recent) / len(recent)
-    wins = sum(1 for t in recent if _finite(t.get("pnl_pct")) > 0)
+    recent = [t["alpha_pct"] for t in scored[-_REGIME_WINDOW:]]
+    median_alpha = sorted(recent)[len(recent) // 2] if len(recent) % 2 else (
+        sum(sorted(recent)[len(recent) // 2 - 1:len(recent) // 2 + 1]) / 2)
+    wins = sum(1 for t in scored[-_REGIME_WINDOW:]
+               if _finite(t.get("pnl_pct")) > 0)
 
     # Drawdown from the cumulative-P&L high-water mark (all closed trades).
     running = peak = 0.0
@@ -396,18 +422,33 @@ def _build_regime_block(tracker: dict) -> str:
 
     header = (
         f"REGIME CHECK (rolling last {len(recent)} closed trades): "
-        f"avg matched-window alpha {avg_alpha:+.2f}%, {wins}/{len(recent)} "
+        f"median matched-window alpha {median_alpha:+.2f}%, {wins}/{len(recent)} "
         f"wins, ${drawdown:.2f} below the P&L high-water mark."
     )
-    if avg_alpha < -0.5 or drawdown > 100:
+    is_cold = (median_alpha < _REGIME_COLD_MEDIAN
+               or drawdown > _REGIME_COLD_DRAWDOWN)
+    drought = _days_since_last_pick(tracker)
+    if is_cold and drought is not None and drought > _REGIME_PICK_DROUGHT_DAYS:
+        guidance = (
+            f" SELECTIVE RESET — the record is cold but the show has made "
+            f"no pick in {drought} days, and an extended drought teaches "
+            f"nothing. Take the best available setup (a Monday weekly hold "
+            f"is expected), state honestly that conviction is moderate and "
+            f"the playbook is rebuilding, and keep the risk framing tight. "
+            f"A no-trade day now requires a REASON specific to today's "
+            f"tape, not the streak."
+        )
+    elif is_cold:
         guidance = (
             " COLD STREAK — RAISE THE BAR for today's Practice Investment: "
-            "an explicit no-trade day is the DEFAULT unless a setup has 3+ "
-            "independent aligned factors (which also justifies High "
-            "confidence). Do not chase a comeback; smaller, clearer edges "
-            "only."
+            "an explicit no-trade day is acceptable and unremarkable, and "
+            "a pick needs 3+ independent aligned factors. Do not chase a "
+            "comeback. TELL LISTENERS PLAINLY that the playbook is in "
+            "capital-preservation mode after the recent drawdown and what "
+            "would re-open normal trading — that transparency is part of "
+            "the product, not an admission of failure."
         )
-    elif avg_alpha > 1.0:
+    elif median_alpha > 1.0:
         guidance = (
             " HOT STREAK — the process is working. Keep the SAME selection "
             "bar and position discipline; do not loosen criteria or reach "
@@ -900,6 +941,39 @@ def _probe_pick(trade: dict) -> bool:
 TRADE_SIGNAL_LATEST_FILENAME = "trade_signal_latest.json"
 TRADE_SIGNAL_SCHEMA_VERSION = 1
 
+# Explicit no-trade markers (July 18 2026 review): the original regex only
+# matched "Today's Pick: No…"; two weeks of real digests used
+# "**Today's Pick:** None", "**Trade Type:** No new trade" and
+# "**Trade Type:** No Trade" — all deliberate no-trade days that the
+# signal then mislabeled "no_pick_extracted" (extraction drift), making
+# the drift alarm meaningless. Recognize every observed deliberate form.
+_EXPLICIT_NO_TRADE_RE = re.compile(
+    r"(?:Today's Pick[:*\s]+(?:No\b|None\b|—?\s*None)"
+    r"|Trade Type[:*\s]+No(?:\s+new)?\s+[Tt]rade"
+    r"|Trade Type[:*\s]+Mid-?Week Update)",
+    re.IGNORECASE,
+)
+
+
+def _no_trade_reason(digest_text: str) -> str:
+    """Classify why today's signal carries no trade.
+
+    - ``explicit_no_trade`` — the digest deliberately declared no pick
+      (or a mid-week update, which by design creates no new trade);
+    - ``no_practice_section`` — no Practice Investment section at all
+      (weekend/recap episodes);
+    - ``no_pick_extracted`` — a pick section exists but nothing matched:
+      the only remaining case that genuinely means formatting drift.
+    """
+    if not digest_text:
+        return "no_practice_section"
+    if _EXPLICIT_NO_TRADE_RE.search(digest_text):
+        return "explicit_no_trade"
+    if re.search(r"Today's Pick|Practice Investment", digest_text,
+                 re.IGNORECASE):
+        return "no_pick_extracted"
+    return "no_practice_section"
+
 # uuid5 namespace for deterministic client_order_ids — SnapTrade's
 # place-order endpoint accepts a caller-supplied ``client_order_id`` for
 # idempotent placement, which protects a retried cron from double-buying.
@@ -946,14 +1020,8 @@ def _write_trade_signal(
     }
 
     if trade is None:
-        explicit_no_trade = bool(
-            digest_text
-            and re.search(r"Today's Pick[:*\s]+No\b", digest_text, re.IGNORECASE)
-        )
         signal["action"] = "no_trade"
-        signal["reason"] = (
-            "explicit_no_trade" if explicit_no_trade else "no_pick_extracted"
-        )
+        signal["reason"] = _no_trade_reason(digest_text)
         signal["trade"] = None
     else:
         symbol = trade.get("symbol", "")
@@ -1132,8 +1200,20 @@ def _evaluate_open_trade(tracker: dict, tracker_path: Path) -> None:
 
         trade_type = trade.get("trade_type", "weekly")
 
-        # Flash trades close the next day; weekly holds close on Friday only
-        should_close = (trade_type == "flash") or is_friday
+        # Flash trades close the next day; weekly holds close on Friday —
+        # but ONLY when the hold spans at least 2 calendar days (July 18
+        # 2026 review: Ep101 COST was picked Thursday and closed on the
+        # very next Friday pre-market run with a single bar of data —
+        # entry AND exit on Thursday's bar, a same-day trade wearing a
+        # "Weekly Hold" costume. A Thu/Fri-picked weekly now rolls to the
+        # NEXT Friday, matching the shadow executor's exit calendar).
+        pick_date = _trade_pick_date(trade)
+        weekly_held_long_enough = (
+            pick_date is None
+            or (datetime.date.today() - pick_date).days >= 2
+        )
+        should_close = (trade_type == "flash") or (
+            is_friday and weekly_held_long_enough)
 
         if should_close:
             _close_trade(trade, tracker)
@@ -1917,48 +1997,59 @@ def _build_benchmark_block(tracker: dict) -> str:
     matched_n = summary.get("matched_window_trades", 0)
     matched_line = ""
     if matched_n and matched_alpha is not None:
+        # July 18 2026: the significance caveat now lives INSIDE the alpha
+        # sentence. The previous design put it in a separate STATISTICAL
+        # CONFIDENCE instruction, and 2 weeks of transcripts show the
+        # model quoted the alpha in most episodes while speaking the
+        # hedge in zero — models echo data lines and drop instructions,
+        # so the hedge must be part of the data line it qualifies.
+        t_stat = summary.get("alpha_t_stat")
+        if summary.get("alpha_statistically_significant"):
+            caveat = (
+                f" — statistically significant (t={t_stat:+.2f}); the record "
+                f"shows genuine outperformance and you may say so plainly"
+            )
+        elif t_stat is not None:
+            caveat = (
+                f" — EARLY AND NOT YET STATISTICALLY SIGNIFICANT "
+                f"(t={t_stat:+.2f}); never quote this alpha without that "
+                f"qualifier in the same sentence"
+            )
+        else:
+            caveat = ""
         matched_line = (
             f"1) MATCHED-WINDOW SCORE (the honest head-to-head — each $1,000 "
             f"trade vs the NASDAQ over the SAME holding window, compounded): "
             f"portfolio {_sign(summary.get('compounded_return_pct'))} vs NASDAQ "
             f"{_sign(summary.get('compounded_nasdaq_matched_pct'))} → alpha "
-            f"{_sign(matched_alpha)} across {matched_n} benchmarked trades. "
+            f"{_sign(matched_alpha)} across {matched_n} benchmarked trades"
+            f"{caveat}. "
         )
+        # Index sweep — only from samples big enough to mean something.
+        # July 18 2026: before the gate, the sweep compared a 37-trade
+        # NASDAQ score against 2-trade S&P/TSX scores ("beating 1 of 3")
+        # — technically true, statistically meaningless. Indices qualify
+        # at n >= _MIN_SAMPLE_TRADES; the sweep appears once 2+ qualify
+        # (i.e. after the operator's recompute backfills history or
+        # enough new trades close).
         scores = summary.get("benchmark_scores") or {}
-        if len(scores) > 1:
-            parts = []
-            for key in ("nasdaq", "sp500", "tsx"):
-                s = scores.get(key)
-                if s:
-                    parts.append(
-                        f"{BENCHMARK_LABELS[key]} {_sign(s['alpha_pct'])}"
-                    )
-            beaten = summary.get("indices_beaten", 0)
-            scored = summary.get("indices_scored", 0)
+        qualified = {
+            key: s for key, s in scores.items()
+            if s.get("trades", 0) >= _MIN_SAMPLE_TRADES
+        }
+        if len(qualified) > 1:
+            parts = [
+                f"{BENCHMARK_LABELS[key]} {_sign(qualified[key]['alpha_pct'])}"
+                for key in ("nasdaq", "sp500", "tsx") if key in qualified
+            ]
+            beaten = sum(1 for s in qualified.values() if s["alpha_pct"] > 0)
             matched_line += (
                 f"MAJOR-INDEX SWEEP (same matched windows): currently beating "
-                f"{beaten} of {scored} major indices — "
+                f"{beaten} of {len(qualified)} major indices — "
                 + "; ".join(parts)
                 + ". NASDAQ stays the headline benchmark; mention the sweep "
                   "at most once per episode. "
             )
-        t_stat = summary.get("alpha_t_stat")
-        if t_stat is not None:
-            if summary.get("alpha_statistically_significant"):
-                matched_line += (
-                    f"STATISTICAL CONFIDENCE: per-trade alpha t-stat "
-                    f"{t_stat:+.2f} across {matched_n} trades — the edge is "
-                    f"statistically meaningful (~95%+); you may say the "
-                    f"record shows genuine outperformance. "
-                )
-            else:
-                matched_line += (
-                    f"STATISTICAL CONFIDENCE: per-trade alpha t-stat "
-                    f"{t_stat:+.2f} across {matched_n} trades — NOT yet "
-                    f"statistically distinguishable from luck; if the "
-                    f"episode claims outperformance, say 'early and not yet "
-                    f"statistically significant' in the same breath. "
-                )
     return (
         f"NASDAQ Composite ^IXIC: {close:,.0f} "
         f"(YTD {_sign(bench_ytd)}, since inception {_sign(bench_itd)}).\n"
@@ -2555,7 +2646,7 @@ def _extract_trade_from_digest(digest_text: str, episode_num: int | None = None)
         # 2026 review: silent extraction failures were indistinguishable
         # from no-trade days in the tracker).
         if re.search(r"Today's Pick", digest_text):
-            if re.search(r"Today's Pick[:*\s]+No\b", digest_text, re.IGNORECASE):
+            if _EXPLICIT_NO_TRADE_RE.search(digest_text):
                 logger.info("Digest declared no trade today — tracker unchanged.")
             else:
                 logger.warning(

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -726,10 +726,14 @@ class TestRegimeBlock:
                 "pnl_pct": alpha, "pnl_dollars": pnl_dollars}
 
     def test_cold_streak_raises_the_bar(self):
-        tracker = {"trades": [self._closed(-2.0, -20.0) for _ in range(10)]}
+        # July 18: fresh cold streaks (dated today, no drought) raise the
+        # bar and now also instruct on-air transparency.
+        recent = datetime.date.today().isoformat()
+        tracker = {"trades": [dict(self._closed(-2.0, -20.0), date=recent)
+                              for _ in range(10)]}
         block = mi._build_regime_block(tracker)
         assert "COLD STREAK" in block
-        assert "no-trade day is the DEFAULT" in block
+        assert "3+ independent aligned factors" in block
 
     def test_hot_streak_holds_discipline_never_presses(self):
         tracker = {"trades": [self._closed(2.5, 25.0) for _ in range(10)]}
@@ -743,12 +747,16 @@ class TestRegimeBlock:
         assert "NEUTRAL" in block
 
     def test_drawdown_alone_triggers_cold(self):
-        # Strong early run, then a deep drawdown — even with recent alpha
-        # near zero, being far below the high-water mark tightens the bar.
-        trades = ([self._closed(5.0, 150.0) for _ in range(5)]
-                  + [self._closed(0.1, -30.0) for _ in range(5)])
+        # July 18 recalibration: only a FULL-POSITION drawdown (> $250)
+        # triggers cold on its own — $164 of standing drawdown had locked
+        # the show cold permanently. Deep drawdown still tightens the bar.
+        recent = datetime.date.today().isoformat()
+        trades = ([dict(self._closed(5.0, 150.0), date=recent)
+                   for _ in range(5)]
+                  + [dict(self._closed(0.1, -60.0), date=recent)
+                     for _ in range(5)])
         block = mi._build_regime_block({"trades": trades})
-        assert "COLD STREAK" in block
+        assert "COLD STREAK" in block  # drawdown $300 > $250
 
     def test_too_few_trades_yields_empty(self):
         tracker = {"trades": [self._closed(1.0, 10.0) for _ in range(3)]}
@@ -907,7 +915,9 @@ class TestAlphaTStat:
             "alpha_t_stat": 0.9, "alpha_statistically_significant": False,
         }
         block = mi._build_benchmark_block(tracker)
-        assert "NOT yet statistically distinguishable from luck" in block
+        # July 18: the caveat moved INLINE with the alpha number (models
+        # echo data lines and drop separate instructions).
+        assert "NOT YET STATISTICALLY SIGNIFICANT" in block
 
     def test_signal_carries_stop_loss(self, tmp_path, monkeypatch):
         monkeypatch.delenv("NERRA_HOOKS_READONLY", raising=False)
@@ -924,3 +934,167 @@ class TestAlphaTStat:
         signal = json.loads(
             (tmp_path / mi.TRADE_SIGNAL_LATEST_FILENAME).read_text())
         assert signal["trade"]["stop_loss"] == {"price": 190.0}
+
+
+# ---------------------------------------------------------------------------
+# July 18 2026 scoring pass — regime deadlock, degenerate weeklies,
+# sweep gating, inline hedge, no-trade taxonomy
+# ---------------------------------------------------------------------------
+
+class TestRegimeDeadlockFix:
+    def _closed(self, alpha, pnl_dollars, date="2026-07-01"):
+        return {"status": "closed", "alpha_pct": alpha, "pnl_pct": alpha,
+                "pnl_dollars": pnl_dollars, "date": date}
+
+    def test_median_is_outlier_robust(self):
+        # The Ep81 MDA shape: nine mild positives + one -11.8 outlier.
+        # Mean would be negative; median must keep the regime out of COLD.
+        recent = datetime.date.today().isoformat()
+        trades = ([self._closed(0.5, 5.0, recent) for _ in range(9)]
+                  + [self._closed(-11.8, -118.0, recent)])
+        block = mi._build_regime_block({"trades": trades})
+        assert "COLD STREAK" not in block
+
+    def test_standing_drawdown_of_one_trade_is_not_cold(self):
+        # $164 below high-water (the real July state) must not trip a
+        # permanent cold streak; only a full-position drawdown does.
+        recent = datetime.date.today().isoformat()
+        trades = ([self._closed(2.0, 100.0, recent) for _ in range(5)]
+                  + [self._closed(0.2, -33.0, recent) for _ in range(5)])
+        block = mi._build_regime_block({"trades": trades})
+        assert "COLD STREAK" not in block
+
+    def test_pick_drought_releases_the_brake(self):
+        # Genuinely cold record + no pick in 10 days → SELECTIVE RESET
+        # (the deadlock breaker), never a suppressive COLD text.
+        old = (datetime.date.today() - datetime.timedelta(days=10)).isoformat()
+        trades = [self._closed(-2.0, -20.0, old) for _ in range(10)]
+        block = mi._build_regime_block({"trades": trades})
+        assert "SELECTIVE RESET" in block
+        assert "no pick in 10 days" in block
+        assert "COLD STREAK" not in block
+
+    def test_fresh_cold_streak_still_raises_bar_with_transparency(self):
+        recent = datetime.date.today().isoformat()
+        trades = [self._closed(-2.0, -20.0, recent) for _ in range(10)]
+        block = mi._build_regime_block({"trades": trades})
+        assert "COLD STREAK" in block
+        assert "TELL LISTENERS PLAINLY" in block  # dead air → narrative
+
+
+class TestWeeklyMinHold:
+    def test_thursday_pick_not_closed_on_next_day_friday(self):
+        # The Ep101 COST degenerate: picked Thursday, closed on Friday's
+        # pre-market run with one bar (entry==exit bar). Now rolls.
+        thursday = datetime.date(2026, 7, 9)
+        friday = datetime.date(2026, 7, 10)
+        tracker = {"metadata": {"position_size": 1000}, "summary": {},
+                   "trades": [{"symbol": "COST", "market": "NYSE",
+                               "trade_type": "weekly", "status": "open",
+                               "date": thursday.isoformat()}]}
+        with patch.object(mi.datetime, "date", wraps=datetime.date) as mock_date, \
+             patch.object(mi, "_snapshot_trade") as snap, \
+             patch.object(mi, "_close_trade") as close, \
+             patch.object(mi, "_save_tracker"):
+            mock_date.today.return_value = friday
+            mi._evaluate_open_trade(tracker, Path("/nope"))
+        close.assert_not_called()
+        snap.assert_called_once()
+
+    def test_monday_pick_still_closes_friday(self):
+        monday = datetime.date(2026, 7, 6)
+        friday = datetime.date(2026, 7, 10)
+        tracker = {"metadata": {"position_size": 1000}, "summary": {},
+                   "trades": [{"symbol": "GIS", "market": "NYSE",
+                               "trade_type": "weekly", "status": "open",
+                               "date": monday.isoformat()}]}
+        with patch.object(mi.datetime, "date", wraps=datetime.date) as mock_date, \
+             patch.object(mi, "_close_trade") as close, \
+             patch.object(mi, "_save_tracker"):
+            mock_date.today.return_value = friday
+            mi._evaluate_open_trade(tracker, Path("/nope"))
+        close.assert_called_once()
+
+    def test_shadow_exit_calendar_matches(self):
+        from execution import shadow as sh
+        # Thursday weekly → NEXT Friday, not tomorrow.
+        assert sh._exit_due_date(
+            datetime.date(2026, 7, 9), "weekly") == datetime.date(2026, 7, 17)
+        # Wednesday weekly → this Friday (2-day hold is acceptable).
+        assert sh._exit_due_date(
+            datetime.date(2026, 7, 8), "weekly") == datetime.date(2026, 7, 10)
+
+
+class TestSweepGating:
+    def _summary(self, sp_trades):
+        return {
+            "matched_window_alpha_pct": 6.59, "matched_window_trades": 37,
+            "compounded_return_pct": 18.94,
+            "compounded_nasdaq_matched_pct": 12.35,
+            "alpha_t_stat": 0.31, "alpha_statistically_significant": False,
+            "indices_beaten": 1, "indices_scored": 3,
+            "benchmark_scores": {
+                "nasdaq": {"alpha_pct": 6.59, "trades": 37},
+                "sp500": {"alpha_pct": -4.24, "trades": sp_trades},
+                "tsx": {"alpha_pct": -4.59, "trades": sp_trades},
+            },
+        }
+
+    def _tracker(self, sp_trades):
+        tracker = mi._fresh_tracker()
+        tracker["benchmark"] = {"current_close": 25873.0, "ytd_pct": 11.0,
+                                "inception_to_date_pct": 15.0,
+                                "last_updated": "2026-07-18"}
+        tracker["summary"] = self._summary(sp_trades)
+        return tracker
+
+    def test_two_trade_samples_suppress_the_sweep(self):
+        # The real July 18 state: 37-trade NASDAQ vs 2-trade S&P/TSX —
+        # "beating 1 of 3" was statistically meaningless prompt context.
+        block = mi._build_benchmark_block(self._tracker(sp_trades=2))
+        assert "MAJOR-INDEX SWEEP" not in block
+
+    def test_qualified_samples_reenable_the_sweep(self):
+        block = mi._build_benchmark_block(self._tracker(sp_trades=12))
+        assert "MAJOR-INDEX SWEEP" in block
+        assert "beating 1 of 3" in block
+
+    def test_hedge_is_inline_with_the_alpha_number(self):
+        # Two weeks of transcripts: alpha quoted in most episodes, hedge
+        # spoken in zero — the caveat must be part of the quoted line.
+        block = mi._build_benchmark_block(self._tracker(sp_trades=2))
+        alpha_sentence = [ln for ln in block.split(". ")
+                         if "+6.59%" in ln][0]
+        assert "NOT YET STATISTICALLY SIGNIFICANT" in alpha_sentence
+        assert "never quote this alpha without" in alpha_sentence
+
+
+class TestNoTradeReasonTaxonomy:
+    def test_none_form_is_explicit(self):
+        assert mi._no_trade_reason(
+            "### Practice Investment of the Day\n"
+            "**Trade Type:** No new trade\n**Today's Pick:** None\n"
+        ) == "explicit_no_trade"
+
+    def test_no_trade_type_form_is_explicit(self):
+        assert mi._no_trade_reason(
+            "### Practice Investment of the Day\n"
+            "**Trade Type:** No Trade\n**Today's Pick:** None — watching BNKR\n"
+        ) == "explicit_no_trade"
+
+    def test_midweek_update_is_explicit_not_drift(self):
+        assert mi._no_trade_reason(
+            "### Practice Investment of the Day\n"
+            "**Trade Type:** Mid-Week Update\n"
+        ) == "explicit_no_trade"
+
+    def test_recap_without_section_is_not_drift(self):
+        assert mi._no_trade_reason(
+            "# Weekly recap\nNo practice segment this Sunday.\n"
+        ) == "no_practice_section"
+
+    def test_genuine_drift_still_flagged(self):
+        assert mi._no_trade_reason(
+            "### Practice Investment of the Day\n"
+            "**Today's Pick** is Nvidia at current levels.\n"
+        ) == "no_pick_extracted"


### PR DESCRIPTION
# TLDR

First full scoring pass over the July 3–4 overhaul, against two weeks of real production (Ep096–Ep110, 15 trade signals, the shadow ledger, transcripts). **Verdict: the machinery works as intended — 8 predictions HIT, 1 MISS, 1 pending — but two design flaws only visible in production deadlocked the show's signature segment, and both are fixed here.**

Full review: `docs/reviews/modern_investing_review_2026_07_18.md`

# The scorecard

**HIT (8):** closing-price tic eliminated (9/10 → 0/10, lessons dedup holding); entry bars = pick dates on both new trades; stops parsed on 2/2 picks; rules stamped; all-3-index returns on new closes; shadow ledger complete (12 entries, every weekday, paired exits, zero duplicate ids, green with no secrets); matched-window labeling reached air; dormant live layer never touched anything.

**MISS (1):** the statistical-honesty hedge — the alpha was quoted in most episodes ("the portfolio holds a 7.0% alpha…") while "not yet statistically significant" was spoken in **zero**. Root cause: the caveat was a separate instruction line, and models echo data lines while dropping instructions. **Fixed: the caveat is now embedded inside the same sentence as the alpha number.** (Reusable lesson for every prompt-context block in the network.)

# The two production design flaws (fixed)

1. **Regime cold-streak deadlock (P0-product).** The Practice Investment made 2 picks in 14 episodes; both Monday weeklies were suppressed. The mean-based trigger was poisoned indefinitely by one −11.8% outlier (Ep81 MDA), the $100 drawdown threshold was permanently tripped by $164 of standing drawdown, and cold suppressed the very closes that refresh the window — a self-reinforcing lockup. **Regime v2:** median alpha (threshold −1.0), full-position drawdown threshold ($250), and a pick-drought escape valve — cold + no pick for >7 days becomes a *SELECTIVE RESET* that expects the next Monday pick with honest moderate-conviction framing. Fresh cold streaks now also instruct the show to narrate capital-preservation mode on air: the discipline becomes listener content instead of two weeks of unexplained silence.
2. **One-bar "Weekly Hold" (P0-integrity).** Ep101 COST was picked Thursday and closed on Friday's pre-market run with entry and exit on the *same Thursday bar* (−2.35% in a zero-day hold — while the shadow layer, holding Thu→Fri, made **+0.26% on the same pick**). Weekly closes now require ≥2 days since pick (Thu/Fri picks roll to next Friday); the shadow exit calendar matches.

Also fixed: the index sweep was comparing a 37-trade NASDAQ score against 2-trade S&P/TSX scores ("beating 1 of 3") — now gated on n≥5 per index; and 5 of 12 no-trade signals were mislabeled as extraction drift when the digest explicitly said "**Today's Pick:** None" — the reason taxonomy now distinguishes explicit no-trade / no-practice-section (recaps) / genuine drift.

# ⚠️ A/B-listen required (landmine #17)

Regime text (SELECTIVE RESET / transparency line) and the inline significance caveat are changed prompt context — listen to the next 1–2 episodes. The min-hold and taxonomy changes don't touch spoken output.

# Test results

New drift guards: `TestRegimeDeadlockFix` (4), `TestWeeklyMinHold` (3), `TestSweepGating` (3), `TestNoTradeReasonTaxonomy` (5); 3 outdated pins updated. **343 tests green** across the touched suites; `ruff` clean.

# Operator items (unchanged, still open)

1. `scripts/recompute_mit_benchmarks.py --apply` — the current +6.59% matched alpha still contains old-window inflation, and the index sweep stays suppressed until history backfills.
2. SnapTrade Phase-0 status is unverifiable from the repo (mirror artifacts aren't committed) — check the Account Mirror workflow runs.
3. LL-054/005/013 lesson-family retirement (one-line status flips).

# Watch list (ledger predictions for the next scoring pass)

≥1 Monday weekly pick per week under regime v2; zero new one-bar weeklies; inline caveat echoed in ≥70% of alpha mentions; "volume above the 20-day average" (8/10 — LL-017 echo) adjudicated by the rule scoreboard at ~5 stamped closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKwLmJRykLH8oFskoXiVVp

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKwLmJRykLH8oFskoXiVVp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sim close timing, regime-driven pick pressure, and on-air benchmark wording via prompt context; behavior is covered by new tests but affects the signature Practice Investment segment.
> 
> **Overview**
> Documents the **July 18 two-week scoring review** (8 prior predictions HIT, 1 MISS on the t-stat hedge, new ledger predictions) and ships fixes for two production flaws found in Ep096–Ep110.
> 
> **Regime v2** replaces mean-based cold detection with **median** matched-window alpha (threshold −1.0), raises drawdown cold to **$250**, and adds a **>7-day pick-drought escape** that emits **SELECTIVE RESET** guidance instead of indefinite suppression. Cold-streak copy now tells the show to **narrate capital-preservation mode** on air.
> 
> **Weekly holds** no longer close on the first Friday when the pick is fewer than **2 calendar days** old (Thu/Fri picks roll to the next Friday). **`execution/shadow.py`** `_exit_due_date` matches (Thursday weekly → +8 days).
> 
> **Benchmark prompt context:** the statistical-significance caveat is **embedded in the alpha sentence** (separate instruction was dropped on air). The **major-index sweep** only appears when **≥2 indices have n≥5** trades.
> 
> **No-trade signals** use `_no_trade_reason` / broader explicit-no-trade regex plus **`no_practice_section`** for recaps; **`no_pick_extracted`** is reserved for real drift.
> 
> New drift guards in **`tests/test_mit_benchmark_integrity.py`**; review YAML/state updated. **A/B-listen** (landmine #17): regime text and inline caveat change spoken prompt context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 288f70f9d9770611c4bb4981ba4a800352a5babe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->