### PR TITLE
[show-review] Network goals & differentiation audit (2026-07-18)

### DIFF
--- a/.claude/commands/review-show.md
+++ b/.claude/commands/review-show.md
@@ -114,6 +114,43 @@ Classify findings exactly as prior passes did:
 Every finding must be verified against the working tree with `file:line`
 citations. A claim you did not verify does not go in the review.
 
+### Category rules learned from ledger verdict rates (July 2026 meta-review)
+
+The aggregate ledger record (docs/reviews/ledger/) shows finding categories
+have very different real-world hit rates. Apply these rules:
+
+- **Length findings: digest-substrate levers ONLY.** ~10 podcast-side
+  length predictions (word floors, expand-retries, prompt pressure) have
+  MISSED against 1 hit; every miss re-diagnosed to the digest ceiling.
+  Never propose a podcast-side length lever again (this generalizes the
+  FF/FPD `do_not_retry` entries network-wide). Legitimate levers: digest
+  expansion (`digest_expand_below_target`/`min_digest_words`),
+  licensed-knowledge section floors, full-text article fetch.
+- **De-seed by shape, never with a quotable example.** ≥4 documented cases
+  of a show electing the prompt's own example phrase (or the first rotation
+  menu item) as its next tic. A de-seed must use shape descriptions +
+  a verbatim ban + rotation MEMORY (a do-not-reuse list from recent
+  episodes), and MUST add a successor-tic prediction to the ledger so the
+  next review catches the third-generation convergence.
+- **Garble/pronunciation restore fixes and fetch filters are the
+  highest-yield categories** (~100% hit, deterministic, mostly no-A/B) —
+  weight them up. The snapshot's fetch-filter leakage section counts
+  excluded-class content in shipped digests so these predictions get
+  scored mechanically.
+- **No conditional predictions.** A prediction of the form "7+/10 IF the
+  deferred lever ships" auto-scores `miss` when the lever stays deferred
+  and pollutes the category rates. Predict only what the shipped change
+  controls; score lever-gated hopes as `n/a-lever-not-shipped`.
+- **Escalate instead of re-filing.** If the same metric has missed twice
+  with the identical proposal attached, do not file the proposal a third
+  time — write an explicit operator-decision item in the review doc
+  naming the two misses and the decision needed.
+- **Closed-unmerged review PRs are NOT automatically rejections.** Before
+  writing `do_not_retry` from a closed PR, check its closure comment:
+  infrastructure closes (content landed via another PR, unmergeable
+  branch, API failures) leave the ideas live. Record a rejection only on
+  an explicit operator signal.
+
 ## Phase 3 — Implement
 
 - **Implement** P0 and P1 fixes that are code-only and clearly safe.
@@ -173,6 +210,12 @@ citations. A claim you did not verify does not go in the review.
    with the metric, today's baseline, and the expected value. The next
    review scores it; a fix whose prediction can't be stated probably isn't
    a fix. Record `agent_cost_usd` if you know it, else leave null.
+   **This obligation applies to EVERY pass that writes a review doc with
+   predictions — including operator-directed network/audio/YouTube passes
+   outside the rotation.** (July 2026 meta-review: five July passes wrote
+   predictions into docs only; the rotation could not score them.) A doc
+   containing predictions without a matching ledger entry is an unfinished
+   deliverable.
 5. Update the show's quality-pass notes in `CLAUDE.md` (concise — follow the
    existing June 2026 entries' style) if behavior changed.
 6. Branch named `agent/review-<slug>-<YYYYMMDD>` (this exact prefix is how

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1541,6 +1541,43 @@ completion, and `review_snapshot.py` Unicode + missing-final-Closing fixes.
 Operator items: three same-day double-publishes + SpaceX's silently missed
 June-28 recap (scheduler forensics).
 
+### Network goals & differentiation audit (July 18, 2026)
+
+Operator-requested whole-network review — canonical writeup:
+[`docs/reviews/network_review_2026_07_18.md`](docs/reviews/network_review_2026_07_18.md).
+Verdict: the factory is world-class (100% run success, ~90 eps/week in 5
+languages at ~$35-40/mo) while the funnel is the product gap (3,070
+downloads/30d, 3 newsletter subs); differentiation is TOPICAL AUTHORITY
+(Tesla+M&A+SpaceX = 53% of downloads), and the two most differentiated bets
+(DP Pod, Age of AI) have no market feedback loop. Shipped (all
+code/metadata-only): **closing-is-final chapter invariant** in
+`engine/chapters.py` (the 07-16 rotating network outro's sibling-show plugs
+were stolen by un-anchored body markers AFTER the closing — Tesla Ep544
+"First Principles" at 642s, MIT Ep104 "Investor Education"; terminal signal
+is the closing TITLE set, not the `where: end` anchor, because EI anchors
+only its Teaser); **dp_pod Network-pick rotation memory**
+(`_recent_network_picks` — FF was the pick 5/10 with a fixed host+frame);
+**dashboard voice-baseline fix** (stale ElevenLabs RU baseline flagged
+FP/PR/Age-of-AI as drift on every build; now Olya `0b875ae2` + sanctioned
+`ara`); **snapshot fetch-filter leakage counter** (scored three long-pending
+filter predictions immediately: SpaceX/Tesla clean, FF ephemeris still
+leaking 3/10 → reopened); **playbook category rules** from the 15-ledger
+meta-review (podcast-side length levers formally banned network-wide via
+`do_not_retry` — ~10 misses vs 1 hit; de-seed-by-shape + rotation memory
+required; conditional predictions banned; two-miss escalation; ledger entry
+required for every prediction-bearing pass). Verified with new data: the
+07-16 denoise chain IS engaged in shipped audio (re-denoising shipped
+episodes removes ~0 dB). P0 operator item: **FP/PR publish off-schedule via
+the daily-audit retry path** — CRON_MAP/Worker say Monday-only,
+`review_episodes.py` says even days, FP's description says daily; 8
+unplanned episodes in one week; pick a cadence and align all three. A/B
+proposals (NOT applied): FP double-seeded templates (100% saturation), MIT
+seeded transition, PT takeaway tic, PR secret opener, FF ephemeris
+digest-scope bullet. Drift guards:
+`tests/test_chapters.py::TestClosingIsFinal`,
+`tests/test_dp_pod_show.py::TestNetworkPickRotationMemory`,
+`tests/test_review_agent.py::{TestSnapshotFetchFilterLeakage,TestDashboardVoiceBaseline}`.
+
 ### Website review (June 10, 2026)
 
 Full public-site review — canonical writeup:

--- a/docs/reviews/ledger/network.yaml
+++ b/docs/reviews/ledger/network.yaml
@@ -53,21 +53,106 @@ reviews:
           (double-spoken closings, verbatim-doubled sentences)
         baseline: "MAB 5/15 double closings; M&A Ep087 doubled sentences"
         expected: "0 across the next 2 weeks of episodes"
-        verdict: pending
-        evidence: null
+        verdict: partial
+        evidence: "2026-07-18: the two fixed classes did not recur, but
+          sibling classes shipped — SpaceX Ep034 whole-deep-dive spoken
+          twice (final-script path, fixed 07-16, Ep035/036 clean) and MAB
+          5/14 MISSING closings from two new causes (fixed 07-16; all four
+          defective episodes re-parse clean with the current config)." 
       - metric: snapshot visibility of Cyrillic tics + missing-final-Closing
           chapter shapes
         baseline: "snapshot cleared FP while a template ran 7/8, and cleared
           EI while 3/5 shipped orphaned Closings"
         expected: "the next FP/EI snapshots surface these classes
           mechanically (no hand-reading required)"
-        verdict: pending
-        evidence: null
+        verdict: partial
+        evidence: "2026-07-18: both checks landed and caught real defects
+          (FP Cyrillic tics surfaced; EI Ep49-51 orphan Closings caught by
+          the 07-13 review), but the Closing check was English-only until
+          07-16 and false-flagged every FP episode in the interim." 
       - metric: same-day sibling story duplication (PT vs FF lead stories)
         baseline: "6 consecutive days of verbatim astronomy duplication"
         expected: "0 after the PT fetch filter"
-        verdict: pending
-        evidence: null
+        verdict: partial
+        evidence: "2026-07-18: verbatim same-day duplication ended, but the
+          astronomy class kept leaking via the unfiltered web-search route
+          until the 07-16 fix (PT Ep116/119/120); PT clean since. FF's own
+          ephemeris class remains open (3/10 recent episodes — reopened as
+          a 07-18 finding)." 
     agent_cost_usd: null
 
-do_not_retry: []
+  - date: 2026-07-18
+    pr: null
+    doc: docs/reviews/network_review_2026_07_18.md
+    reviewer: claude-code (goals & differentiation audit + meta-review)
+    summary: >
+      Operator-requested whole-network audit: are goals met, is the product
+      differentiated. Verdict: factory world-class (100% success, ~$35/mo,
+      90 eps/wk, 5 languages), funnel nearly absent (3,070 downloads/30d,
+      3 newsletter subs); differentiation is topical authority (Tesla+M&A+
+      SpaceX=53% of downloads), the two most differentiated bets (DP Pod,
+      Age of AI) are dark. Shipped: closing-is-final chapter invariant
+      (Tesla Ep544 / MIT Ep104 promo-tail theft), DP Pod network-pick
+      rotation memory, dashboard voice-baseline fix (stale ElevenLabs RU
+      baseline = false-positive drift warnings), snapshot fetch-filter
+      leakage counter, playbook category rules + ledger-discipline rule
+      from the full 15-ledger meta-review. Verified: 07-16 denoise chain
+      ENGAGED in shipped audio (re-denoise removes ~0 dB). P0 operator
+      item: FP/PR publish off-schedule via the daily-audit retry path
+      (three configs disagree on cadence).
+    shipped:
+      - "engine/chapters.py: where:end chapter is final — post-closing
+        promo-tail marker theft dropped engine-wide (verified re-parse of
+        Tesla Ep544 + MIT Ep104)"
+      - "shows/hooks/dp_pod.py: _recent_network_picks rotation memory
+        (FF was the pick 5/10 with a fixed host+frame)"
+      - "scripts/generate_dashboard.py: RU voice baseline 0b875ae2 + ara
+        sanctioned (kills every-build false drift warnings)"
+      - "scripts/review_snapshot.py: fetch-filter leakage section
+        (immediately scored 3 long-pending filter predictions)"
+      - ".claude/commands/review-show.md: category rules (digest-only
+        length levers, de-seed-by-shape+memory, no conditional
+        predictions, two-miss escalation, rejection-signal bar for
+        do_not_retry) + ledger-entry-required rule"
+    deferred:
+      - "P1-3 tic de-seeds (FP x2 100% saturation, MIT seeded transition,
+        PT takeaway, PR secret opener) — A/B-gated proposals in the doc"
+      - "P1-2 FF ephemeris digest-scope bullet — A/B-gated (title filters
+        cannot hold the line; digest normalizes titles)"
+      - "chronic under-length: OV 07-18 slot-depth realignment is the
+        class-wide read; podcast-side levers now banned via do_not_retry"
+      - "operator: RU cadence decision (P0-1), dp_pod feed submission +
+        first real dispatch, FPD distribution gate, FPD/PR product
+        decision, Age of AI launch, EI all-BC drift watch"
+    predictions:
+      - metric: chapters starting after the Closing chapter, network-wide
+        baseline: "2 in the last 10 days (Tesla Ep544, MIT Ep104)"
+        expected: "0 in the next 2 weeks (engine invariant)"
+        verdict: pending
+        evidence: null
+      - metric: dp_pod Network pick concentration (single show share of
+          last 10 picks)
+        baseline: "5/10 Fascinating Frontiers incl. consecutive days"
+        expected: "no show >3/10, no consecutive-day repeats"
+        verdict: pending
+        evidence: null
+      - metric: dashboard voice-drift warnings on FP/PR/age_of_ai
+        baseline: "3 false-positive warns on every build"
+        expected: "0 (only real drift warns)"
+        verdict: pending
+        evidence: null
+      - metric: FF ephemeris/almanac items in shipped digests (snapshot
+          leakage counter)
+        baseline: "3 in last 10 episodes"
+        expected: "0 within 2 weeks of the (A/B-gated) digest-scope bullet
+          shipping; n/a-lever-not-shipped if it stays unapplied"
+        verdict: pending
+        evidence: null
+
+do_not_retry:
+  - idea: podcast-side length levers (word floors, expand-retries, prompt
+      pressure on the podcast stage) for ANY show
+    evidence: "ledger aggregate 2026-07-18: ~10 misses vs 1 hit across
+      Tesla/EI/OV/FF/PT/FP(D)/MAB/SpaceX; every miss re-diagnosed to the
+      digest ceiling. Digest-substrate levers only (digest_expand,
+      licensed-knowledge floors, full-text fetch)."

--- a/docs/reviews/network_review_2026_07_18.md
+++ b/docs/reviews/network_review_2026_07_18.md
@@ -1,0 +1,246 @@
+# Network review — 2026-07-18 (goals & differentiation audit + meta-review)
+
+Operator request: *"a thorough review of all the podcasts that have been
+produced — determine if all the goals are being met or if further improvements
+can be made to really deliver a high quality differentiated product."*
+
+Method: fresh `review_snapshot.py` for all 14 producing shows, transcript
+verification of every flagged item (last ~10 episodes per show, deep sweep of
+Jul 13–18), full ledger meta-review (15 ledgers, ~75 predictions), health/
+funnel/cost data, and direct audio measurement of shipped episodes. This pass
+deliberately sits ABOVE the July defect passes (07-02 editorial, 07-09
+depth/discovery/quick-wins/prompt, 07-16 audio forensics): it scores their
+predictions, verifies their fixes shipped, and answers the product question
+they didn't.
+
+---
+
+## The product verdict
+
+**The factory is world-class. The audience funnel is the product gap.**
+
+- Operations: 100% run success across all 15 shows/30 days, zero recovery
+  incidents, zero missed daily slots Jul 10–18, ~90 episodes/week in 5
+  languages at **~$35–40/month total content cost** (~$0.03–0.09/episode).
+- Audience: **3,070 downloads/30d network-wide** (~130/day), 3 newsletter
+  subscribers. The pipeline-quality machine (this review included) is now
+  optimizing far past the marginal value of the next listener acquired.
+- **Differentiation is topical authority, not format.** Tesla + Models &
+  Agents + SpaceX = 53% of downloads — the three clearest "chronicle of a
+  beat" shows (and the ones carrying narrative memory). The fastest growers
+  are beat-owners (SpaceX 2.4×, Planetterrian 3× last week). The
+  format-differentiated but topic-generic shows (Omni View steel-man,
+  First Principles) are flat or fading. FPD and Привет, Русский! (17
+  downloads/30d) need a reposition/merge/sunset decision, not more polish.
+- **The two most differentiated bets are dark.** The DP Pod — the only
+  two-host dialogue show, 14/14 clean episodes — has zero distribution and
+  zero download telemetry (feed never submitted to any podcast index, so
+  OP3 can't attribute its traffic). Age of AI — the only live-interview
+  product, arguably the most defensible format in the portfolio — has
+  shipped 0 episodes. The differentiation thesis is riding on two products
+  with no market feedback loop.
+
+### Per-show goals scorecard (positioning vs delivery vs audience)
+
+| Show | Delivers its stated goal? | Audience signal | Note |
+|---|---|---|---|
+| Tesla | ✅ chronicle + trackers | #1, flat-choppy | 10/10 below word floor (digest ceiling) |
+| Models & Agents | ✅ builder briefing | #2, growing | healthiest show in the network |
+| SpaceX | ✅ engineering-first | #3, growing fast | post-IPO beat ownership working |
+| MAB | ✅ from-zero explainer | #4, growing | chapters fixed 07-16; verified re-parse clean |
+| Modern Investing | ⚠️ record honest but alpha not yet significant (t=0.31) | #5, **declining** | differentiation claim unproven on-air |
+| Fascinating Frontiers | ⚠️ ephemeris/almanac still leaking 3/10 | #6, recovering | see P1-2 |
+| Planetterrian | ✅ health/longevity | #7, breakout week | astronomy leak closed 07-16, holding |
+| Omni View | 🔄 realigned 07-18 | #8, flat | next 10 episodes are the read |
+| Unintended Consequences | ✅ narrative formula | #9, steady growth | |
+| First Principles | ✅ formula, ⚠️ audience | #10, **stagnating** | distribution still off (operator gate at ~Ep15 passed?) |
+| Env Intel | ⚠️ "all-province" positioning vs last 3 episodes all-BC | #11, growing (tiny) | |
+| Финансы Просто | ⚠️ description says "Ежедневный" (daily); actual cadence contested (see P0-1) | #12, flat tiny | |
+| Привет, Русский! | ✅ vocabulary-first | #13, ~zero | decision item |
+| DP Pod | ✅ format + club mechanics; ⚠️ club loop hollow (0 real dispatches, empty state aired 6/10) | unmeasured | see P2-1 |
+| Age of AI | — not launched | — | |
+
+---
+
+## P0 — operational
+
+**P0-1 — Russian shows publish OFF-SCHEDULE via the daily-audit retry path
+(8 unplanned public episodes in one week).** Three config sources disagree
+about FP/PR cadence: `run-show.yml` CRON_MAP + the scheduler Worker say
+**Monday-only**; `review_episodes.py:195,219` models them as **even days**;
+FP's own YAML description says **"Ежедневный" (daily)**. Result: on even
+non-Mondays no cron fires → the audit's missed-episode detector flags them →
+`dispatch_audit_retries.py` auto-dispatches → episodes publish at random
+afternoon times (Jul 11/12/14/16 at 14:23–17:52 UTC vs the 06:07/09:37
+slots). **Operator decision required — this review deliberately does NOT
+pick the cadence** (either "fix" changes the shipped product): choose
+Monday-only or even-days, then align all three sources + the FP description
+in one change. Evidence: auto-generated commit times Jul 10–18;
+`api/daily-review.json` remediation block.
+
+## P1 — quality ceiling (verified, this pass)
+
+**P1-1 — Promo-tail chapter theft (FIXED, engine-wide).** The 07-16 rotating
+network outro names sibling shows AFTER the closing; un-anchored body markers
+stole those mentions as spurious final chapters: Tesla `chapters_ep544.json`
+shipped "First Principles" at 642s (after Closing 616s — the phrase occurs
+ONCE in the episode, inside the promo line); MIT `chapters_ep104.json`
+"Investor Education" from the promo's "daily deep dive". Fix:
+`engine/chapters.py` — a `where: end` chapter is final; matches starting
+after it are dropped with a loud warning. Verified by re-parsing both real
+episodes (both now end on Closing). Drift guards:
+`tests/test_chapters.py::TestClosingIsFinal`.
+
+**P1-2 — FF ephemeris/almanac items still shipping (3/10)** despite two
+filter rounds: Ep126 "Venus Passes Close to Regulus in Evening Sky", Ep127
+"Upper Scorpius Dominates Evening Sky This Week", Ep134 (07-17, post-web-
+search-fix) "Moon passes 2° south of Venus this afternoon" — pure almanac
+content on a science-news show. The digest normalizes fetched titles, so
+title-pattern filtering alone cannot hold the line. Recommended (A/B-gated,
+NOT applied): a digest-prompt scope bullet — "NO sky-calendar/ephemeris
+items (planet X passes/shines/conjunction/what's in the sky tonight) — these
+are almanac, not news". The new snapshot leakage counter (below) now scores
+this class mechanically.
+
+**P1-3 — Seeded-template tics, fourth generation (A/B proposals only,
+per the ledger meta-lesson — de-seed by SHAPE, add rotation memory, never
+seed a replacement phrase):**
+- **FP (Финансы Просто), 100% saturation:** «А теперь моя любимая часть…»
+  10/10 (seeded verbatim `fp_podcast.txt:63`); «И вот так работает [X] — не
+  так уж и сложно/страшно, правда?» 12/12 consecutive (seeded TWICE:
+  `fp_digest.txt:111` + `fp_podcast.txt:137`).
+- **MIT:** "here's something that most retail investors get wrong" 7/10 —
+  the exact quoted example at `modern_investing_podcast.txt:194`.
+- **PT:** "The practical takeaway is…" 8/10 (converged from "Close with a
+  practical takeaway", both prompts).
+- **PR:** "Want to know a secret about…" 9/10 (dead-rotation opener).
+- (EI's "nuance" tic and OV's "Next time you see…" are already covered by
+  the 07-16 de-seed and 07-18 realignment respectively — scored next cycle.)
+
+**P1-4 — DP Pod Network pick convergence (FIXED, code-only).** The pick was
+grounded and date-accurate in 9/10 episodes (zero phantom episodes) but
+converged: FF picked 5/10 including consecutive days, same host + "If you
+liked X…" frame 3 episodes running. Fix: `shows/hooks/dp_pod.py`
+`_recent_network_picks` mines recent Network pick lines into a vary-away
+list (live output confirms FF 4 of last 6). Drift guards:
+`tests/test_dp_pod_show.py::TestNetworkPickRotationMemory`.
+
+**P1-5 — Chronic under-length: the July digest-expand pilots have not moved
+the flagships yet.** Tesla 10/10 below floor (median 1570/2000), MIT 10/10
+(1560/1800), MAB 10/10 (1103/1200), UC 10/10 (1082/1300), DP 8/10
+(1247/1550). OV's 07-18 slot-depth realignment is the first root-cause
+attack; its next 10 episodes are the natural read for the whole class.
+Per the ledger meta-review (see below), podcast-side length levers are now
+formally banned network-wide — digest-substrate levers only.
+
+## P2 — growth / discoverability
+
+**P2-1 — DP Pod is flying blind (operator, 15 minutes):** submit
+`dp_pod_podcast.rss` to the Podcast Index / Apple / Spotify so OP3 can
+attribute its traffic; seed the first real Dispatch (the honest empty state
+aired 6/10 episodes — the club's proof-loop can't start itself).
+**P2-2 — First Principles distribution gate:** the "wait to ~Ep15" operator
+gate has passed (Ep40+); it is the #10 show with distribution still off —
+decide on/off.
+**P2-3 — MIT decline + unproven alpha:** downloads fell 4 weeks straight
+while the on-air differentiation claim ("beat the indices") remains honest
+but statistically unproven (t=0.31, beats 1 of 3 indices). The show's fate
+follows the record; no code action.
+**P2-4 — Dashboard voice-drift false positives (FIXED):** the blessed-voice
+baseline still pointed at the retired ElevenLabs RU voice, flagging
+FP/PR/Age-of-AI on every build — warnings that train the operator to ignore
+warnings. `scripts/generate_dashboard.py` now blesses Olya `0b875ae2` + the
+sanctioned `ara` (Mira).
+
+## Audio verification (new data on the 07-16 A/B items)
+
+- **The denoise chain is ENGAGED in shipped audio:** re-applying
+  `adeclick,afftdn` to the shipped Jul-18 episodes removes ~0.0–0.5 dB
+  (denoising an already-denoised file is a no-op) — the production chain ran.
+  The operator's A/B listen remains the quality gate per landmine #17.
+- The final-script dedup fix is holding (SpaceX Ep035/036 clean after the
+  Ep034 double-spoken deep dive). One residual: MIT Ep109 speaks one
+  sentence twice in far-apart sections — below the conservative dedup's
+  radar, acceptable.
+- Jul 13–18 sweep (75 scripts): no scaffold leaks, no `$nan`, no known
+  phonetic garbles, clean flagship hooks, FP episodes fully Russian.
+
+## Meta-review of the review process (ledger aggregate, 15 ledgers)
+
+Verdict rates by category: **garble/pronunciation fixes ~100% hit; fetch
+filters ~100% hit when scored; chapter fixes high-hit but whack-a-mole;
+prompt de-seeds bimodal (banned phrase dies, successor template emerges —
+proven ≥4×); podcast-side length levers ~10 misses vs 1 hit.** Shipped
+process fixes:
+
+1. **Playbook category rules** (`.claude/commands/review-show.md`): length
+   findings restricted to digest-substrate levers network-wide; de-seed by
+   shape + rotation memory + successor-tic prediction required;
+   garble/filter categories weighted up; conditional predictions banned
+   (score `n/a-lever-not-shipped`); two-miss escalation to operator
+   decision; closed-unmerged PRs require an explicit rejection signal
+   before `do_not_retry` (PRs #758/#827/#832 were infrastructure closes,
+   not rejections — their proposals remain live in `docs/reviews/pending/`).
+2. **Ledger discipline rule:** every pass that writes predictions must
+   append a ledger entry — five July passes (07-09 ×4, 07-16) wrote
+   predictions into docs the rotation cannot score.
+3. **Snapshot fetch-filter leakage counter** (`scripts/review_snapshot.py`):
+   scans recent digests for excluded-class content, with bold-title probing
+   and date-suffix stripping to kill false positives. Immediately scored
+   three long-pending predictions (SpaceX junk titles 0 hits ✅, Tesla 13F
+   0 hits ✅, FF ephemeris 3 leaks ❌ → P1-2).
+
+## Scoring the 07-02 network predictions (ledger updated)
+
+1. Guard/retry audio defects = 0 over 2 weeks → **partial**: the two fixed
+   classes did not recur, but sibling classes shipped (SpaceX Ep034
+   whole-section duplication — different mechanism, fixed 07-16; MAB 5/14
+   missing closings from two new causes, fixed 07-16 and verified
+   re-parsing clean this pass).
+2. Snapshot surfaces Cyrillic tics + missing-final-Closing → **partial**:
+   both checks landed and caught real defects (FP tics, EI Ep49-51), but
+   the Closing check was English-only until 07-16 (false-flagged every FP
+   episode).
+3. PT-vs-FF same-day duplication = 0 → **partial**: verbatim same-day
+   duplication ended; the astronomy class kept leaking via the un-filtered
+   web-search route until 07-16 (PT Ep116/119/120); PT clean since, FF's
+   own ephemeris class still open (P1-2).
+
+## Shipped this pass (all code/metadata-only, no audio changes)
+
+- `engine/chapters.py` — closing-is-final invariant (P1-1)
+- `shows/hooks/dp_pod.py` — Network pick rotation memory (P1-4)
+- `scripts/generate_dashboard.py` — voice-baseline fix (P2-4)
+- `scripts/review_snapshot.py` — fetch-filter leakage counter
+- `.claude/commands/review-show.md` — meta-review category rules + ledger
+  discipline
+- Ledger: 07-02 predictions scored; today's entry with predictions;
+  network-wide `do_not_retry` for podcast-side length levers
+- Drift guards: `tests/test_chapters.py::TestClosingIsFinal`,
+  `tests/test_dp_pod_show.py::TestNetworkPickRotationMemory`,
+  `tests/test_review_agent.py::{TestSnapshotFetchFilterLeakage,
+  TestDashboardVoiceBaseline}`
+
+## ⚠️ A/B-listen required
+
+**None applied.** The four tic de-seeds (P1-3: FP ×2, MIT, PT, PR) and the
+FF ephemeris digest-scope bullet (P1-2) are PROPOSED only — apply per the
+de-seed-by-shape rules with rotation memory, render before/after with
+`--test`, and listen before trusting.
+
+## Operator decision items (ranked by leverage)
+
+1. **Distribution > polish.** The single highest-leverage hour is now
+   funnel work: submit dp_pod's feed (P2-1), decide FPD distribution
+   (P2-2), and consider the same for SpaceX X-posting (fastest-growing
+   show, X off).
+2. **RU cadence decision** (P0-1) — pick one cadence, align three configs +
+   the FP description.
+3. **FPD + PR product decision** — reposition, merge, or sunset the two
+   flat/zero-audience shows rather than continue polishing.
+4. **Seed the DP Pod club loop** — one real dispatch (P2-1) and the patron
+   rail when ready.
+5. **Age of AI** — every week unshipped is a week the most defensible
+   format earns nothing; the phase-1 smoke test is the gate.
+6. Env Intel's all-BC drift (watch 5 episodes; re-steer via the provincial
+   search queries if it persists).

--- a/docs/reviews/review_state.yaml
+++ b/docs/reviews/review_state.yaml
@@ -15,8 +15,8 @@
 targets:
   tesla: 2026-06-10
   # Prompt + Grok API/Voice infra review July 9 2026 (cache routing, TTS speed).
-  # Depth + network discovery pass July 9 2026.
-  network: 2026-07-09
+  # Goals & differentiation audit + meta-review July 18 2026.
+  network: 2026-07-18
   modern_investing: 2026-07-18
   fascinating_frontiers: 2026-07-14
   models_agents: 2026-06-21

--- a/engine/chapters.py
+++ b/engine/chapters.py
@@ -249,6 +249,34 @@ def parse_chapters(
         logger.info("No chapter markers matched in podcast script for %s", show_name)
         return []
 
+    # A `where: end` chapter (the Closing/Sign-Off) is FINAL: nothing may
+    # start after it. The rotating network cross-promo outro (July 16 2026)
+    # names sibling shows AFTER the closing, and un-anchored body markers
+    # were stealing those mentions as spurious final chapters — Tesla Ep544
+    # shipped a "First Principles" chapter at 642s (after Closing at 616s)
+    # from the promo line "try First Principles Daily next", and MIT Ep104
+    # an "Investor Education" chapter from the promo's "daily deep dive"
+    # (July 18 2026 network review). Same theft class FF fixed June 24 by
+    # dropping bare markers — this closes it engine-wide.
+    # The terminal signal is the closing TITLE (network convention — same
+    # set the snapshot checker accepts), NOT the `where: end` anchor: EI
+    # deliberately anchors only its Tomorrow Teaser while its Closing
+    # marker is position-free, and a teaser may legitimately precede the
+    # closing. Cut at the LAST closing-titled match.
+    _terminal = ("closing", "sign-off", "завершение", "прощание")
+    closing_positions = [
+        w for w, _c, t in matches if t.strip().lower() in _terminal
+    ]
+    if closing_positions:
+        closing_at = max(closing_positions)
+        stolen = [t for w, _c, t in matches if w > closing_at]
+        if stolen:
+            logger.warning(
+                "Dropping %d chapter(s) starting after the closing "
+                "(promo-tail marker theft): %s", len(stolen), stolen,
+            )
+            matches = [m for m in matches if m[0] <= closing_at]
+
     # Build Chapter objects from matches
     chapters: list[Chapter] = []
     for i, (w_start, c_start, title) in enumerate(matches):

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -82,9 +82,18 @@ _NON_SHOW_YAMLS = {
     "network_meta", "scaffold_pending", "translation_overrides",
 }
 
-# Canonical Russian voice id (pulled from CLAUDE.md; shows/_defaults.yaml ships
-# the English default). Shows may override with either the EN or RU voice id.
-_VOICE_ID_RU = "gedzfqL7OGdPbwm0ynTP"
+# Canonical Russian voice id (the custom "Olya" Grok voice — the May 2026
+# full-network Grok migration retired the old ElevenLabs RU voice
+# gedzfqL7OGdPbwm0ynTP, but this baseline kept pointing at it, flagging
+# FP/PR/age_of_ai as "voice drift" on every dashboard build — a stale-baseline
+# false positive that trains the operator to ignore warnings; July 18 2026
+# network review). shows/_defaults.yaml ships the English default.
+_VOICE_ID_RU = "0b875ae2"
+
+# Per-show sanctioned voice exceptions beyond the EN/RU pair: Age of AI's
+# Mira persona deliberately uses the Grok built-in `ara` (NOT the Patrick
+# clone — CLAUDE.md AOAI section).
+_SANCTIONED_EXTRA_VOICES = {"ara"}
 
 # Stale CLAUDE.md triple we use to detect documentation drift (item 9).
 _CLAUDE_MD_OLD_VOICE_TRIPLE = "0.65/0.9/0.85"
@@ -797,8 +806,12 @@ def audit_voice_config(shows: List[Dict[str, Any]], root: Path) -> Dict[str, Any
                 row["drift"].append({
                     "field": key, "expected": expected, "actual": actual,
                 })
-        # Voice id must be one of the two blessed voices.
-        if row["voice_id"] not in (baseline["voice_id_en"], baseline["voice_id_ru"]):
+        # Voice id must be one of the blessed voices (EN/RU pair plus the
+        # per-show sanctioned exceptions, e.g. age_of_ai's Mira `ara`).
+        if row["voice_id"] not in (
+            baseline["voice_id_en"], baseline["voice_id_ru"],
+            *_SANCTIONED_EXTRA_VOICES,
+        ):
             row["drift"].append({
                 "field": "voice_id",
                 "expected": f"{baseline['voice_id_en']} or {baseline['voice_id_ru']}",

--- a/scripts/review_snapshot.py
+++ b/scripts/review_snapshot.py
@@ -246,6 +246,56 @@ def build_snapshot(slug: str, episodes: int = 10) -> str:
         lines.append("- (no cross-episode repeated phrases above threshold)")
     lines.append("")
 
+    # --- Fetch-filter leakage (July 18 2026 network meta-review) ---
+    # Fetch-filter predictions (PT astronomy, SpaceX junk titles, FF
+    # ephemeris) sat "pending" for weeks because nothing counted them
+    # mechanically. Scan the show's recent DIGESTS for lines matching its
+    # own exclude_title_patterns: a hit means excluded-class content still
+    # reached shipped output (a filter bypass — the Ep116 web-search route
+    # class), zero means the filter held.
+    patterns = show_cfg.get("exclude_title_patterns") or []
+    if patterns:
+        compiled = []
+        for p in patterns:
+            try:
+                compiled.append(re.compile(p, re.IGNORECASE))
+            except re.error:
+                continue
+        digest_files = _latest(
+            [p for p in out_dir.glob("*.md")
+             if "_transcript" not in p.name and "_tts" not in p.name],
+            episodes,
+        )
+        hits = []
+        for num, path in digest_files:
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for line in text.splitlines():
+                # The patterns target fetched article TITLES. Digest item
+                # lines wrap the title in **bold** and append source/date
+                # suffixes ("— Source (2026-07-12)") that false-match some
+                # patterns — test the bold title when present, else the line.
+                m = re.search(r"\*\*(.+?)\*\*", line)
+                probe = m.group(1) if m else line
+                # Digest titles often carry a "(YYYY-MM-DD)" date suffix that
+                # false-matches id-shaped patterns — strip it before probing.
+                probe = re.sub(r"\s*\(\d{4}-\d{2}-\d{2}\)\s*$", "", probe)
+                for rx in compiled:
+                    if rx.search(probe):
+                        hits.append((num, rx.pattern, line.strip()[:90]))
+                        break
+        lines.append(
+            f"## Fetch-filter leakage ({len(patterns)} exclude_title_patterns "
+            f"vs last {len(digest_files)} digests)"
+        )
+        if hits:
+            for num, pat, excerpt in hits[:10]:
+                lines.append(f"- ep{num}: /{pat}/ matched “{excerpt}”")
+            if len(hits) > 10:
+                lines.append(f"- (+{len(hits) - 10} more)")
+        else:
+            lines.append("- 0 hits — excluded-class content absent from shipped digests")
+        lines.append("")
+
     # --- Chapter shape ---
     chapter_files = _latest(out_dir.glob("chapters_ep*.json"), episodes)
     lines.append(f"## Chapter shape (last {len(chapter_files)} episodes)")

--- a/shows/hooks/dp_pod.py
+++ b/shows/hooks/dp_pod.py
@@ -248,6 +248,43 @@ def _latest_first_principles_brief() -> str:
         return ""
 
 
+def _recent_network_picks(max_digests: int = 6) -> str:
+    """Shows recommended in recent Network pick lines (rotation memory).
+
+    July 18 2026 network review: without memory, the daily pick converged —
+    Fascinating Frontiers was the pick in 5 of 10 episodes including
+    consecutive days, mostly voiced by Dan with the same "If you liked X…"
+    frame. The prompt already demands variety; this supplies the data.
+    Mined from this show's own committed digests, newest first. Returns ""
+    before enough history exists.
+    """
+    try:
+        display_names = [name for _d, name, _p in _NETWORK_SHOWS]
+        md_files = sorted((_ROOT / "digests" / "dp_pod").glob("*.md"), reverse=True)
+        picks: list[str] = []
+        for md in md_files[:max_digests]:
+            text = md.read_text(encoding="utf-8")
+            m = re.search(r"\*\*Network pick:\*\*\s*(.+)", text)
+            if not m:
+                continue
+            line = m.group(1)
+            for name in display_names:
+                if name in line:
+                    picks.append(name)
+                    break
+        if not picks:
+            return ""
+        return (
+            "RECENT NETWORK PICKS (newest first — do NOT pick any show from "
+            "the last two days again today, and vary the recommending host "
+            "and the phrasing; the pointer must never become a fixed "
+            "one-show beat): " + ", ".join(picks)
+        )
+    except Exception as exc:
+        logger.warning("dp_pod hook: pick history unavailable (non-fatal): %s", exc)
+        return ""
+
+
 def pre_fetch(config, *, episode_num=None, today_str=None) -> dict:
     catalog = "\n".join(f"- {name} — {pitch}" for _dir, name, pitch in _NETWORK_SHOWS)
     sections = [
@@ -268,6 +305,10 @@ def pre_fetch(config, *, episode_num=None, today_str=None) -> dict:
     if thinkers:
         sections.append("")
         sections.append(thinkers)
+    picks = _recent_network_picks()
+    if picks:
+        sections.append("")
+        sections.append(picks)
     prev_lever = _previous_lever_for_dispatch()
     if prev_lever:
         sections.append("")

--- a/tests/test_chapters.py
+++ b/tests/test_chapters.py
@@ -811,3 +811,52 @@ class TestAutoSegmentFallback:
                 f"Gap or overlap between chapter {i} ({chapters[i].title}) "
                 f"and {i+1} ({chapters[i+1].title})"
             )
+
+
+class TestClosingIsFinal:
+    """July 18 2026 network review: the rotating network cross-promo outro
+    names sibling shows AFTER the closing, and un-anchored body markers
+    stole those mentions as spurious final chapters (Tesla Ep544 "First
+    Principles" at 642s after Closing at 616s; MIT Ep104 "Investor
+    Education"). A `where: end` chapter is final — nothing starts after it."""
+
+    MARKERS = [
+        {"pattern": "welcome to the show", "title": "Introduction", "where": "start"},
+        {"pattern": "first principles", "title": "First Principles"},
+        {"pattern": "that's all for today", "title": "Closing", "where": "end"},
+    ]
+
+    def _script(self, body_mentions_fp: bool) -> str:
+        body = ["Welcome to the show everyone."]
+        body += ["Filler sentence with plenty of ordinary words here."] * 60
+        if body_mentions_fp:
+            body.insert(30, "Let's apply first principles to this story.")
+        body += ["That's all for today, thanks for listening."]
+        # The promo tail AFTER the closing names the sibling show.
+        body += ["Quick tip from the network: try First Principles Daily next."]
+        return "\n\n".join(body)
+
+    def test_promo_tail_cannot_steal_a_chapter(self):
+        from engine.chapters import parse_chapters
+
+        chapters = parse_chapters(
+            self._script(body_mentions_fp=False), self.MARKERS,
+            show_name="t", min_chapters=1,
+        )
+        titles = [c.title for c in chapters]
+        assert titles[-1] == "Closing", titles
+        assert "First Principles" not in titles, (
+            "the only 'first principles' mention is in the post-closing "
+            "promo tail — it must not become a chapter"
+        )
+
+    def test_body_match_before_closing_still_chapters(self):
+        from engine.chapters import parse_chapters
+
+        chapters = parse_chapters(
+            self._script(body_mentions_fp=True), self.MARKERS,
+            show_name="t", min_chapters=1,
+        )
+        titles = [c.title for c in chapters]
+        assert "First Principles" in titles
+        assert titles[-1] == "Closing", titles

--- a/tests/test_dp_pod_show.py
+++ b/tests/test_dp_pod_show.py
@@ -809,3 +809,34 @@ class TestFollowUpEpisodes:
         # brief was the ceiling — the digest floor is the length lever.
         assert CFG.llm.min_digest_words == 1100
         assert CFG.llm.digest_expand_below_target is True
+
+
+class TestNetworkPickRotationMemory:
+    """July 18 2026 network review: the daily Network pick converged on
+    Fascinating Frontiers (5/10, consecutive days, same host + frame).
+    The hook now mines recent Network pick lines into a vary-away list."""
+
+    def test_pick_memory_mines_digests_newest_first(self, tmp_path, monkeypatch):
+        import shows.hooks.dp_pod as hook
+
+        monkeypatch.setattr(hook, "_ROOT", tmp_path)
+        d = tmp_path / "digests" / "dp_pod"
+        d.mkdir(parents=True)
+        (d / "DP_Pod_Ep010_20260714.md").write_text(
+            "**Network pick:** Planetterrian Daily — quantum heat engines.\n",
+            encoding="utf-8")
+        (d / "DP_Pod_Ep011_20260715.md").write_text(
+            "**Network pick:** Fascinating Frontiers — booster recovery.\n",
+            encoding="utf-8")
+        out = hook._recent_network_picks()
+        assert "RECENT NETWORK PICKS" in out
+        assert out.index("Fascinating Frontiers") < out.index("Planetterrian Daily")
+
+    def test_pick_memory_in_context(self, tmp_path, monkeypatch):
+        import shows.hooks.dp_pod as hook
+
+        monkeypatch.setattr(hook, "_ROOT", tmp_path)
+        (tmp_path / "digests" / "dp_pod").mkdir(parents=True)
+        ctx = hook.pre_fetch(None)["nerra_network_context"]
+        # No history → no section, and the hook never crashes.
+        assert "THE NERRA NETWORK" in ctx

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -382,3 +382,44 @@ class TestLedger:
             "meta-review",
         ):
             assert needle in text, f"playbook lost its recursive-loop step: {needle}"
+
+
+class TestSnapshotFetchFilterLeakage:
+    """July 18 2026 meta-review: fetch-filter predictions sat pending for
+    weeks because nothing counted them — the snapshot now scans recent
+    digests for lines whose (bold-title) text matches the show's own
+    exclude_title_patterns."""
+
+    def test_leakage_section_present_for_filter_shows(self):
+        import subprocess
+        import sys
+        out = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "review_snapshot.py"), "planetterrian"],
+            capture_output=True, text=True, timeout=120,
+        ).stdout
+        assert "## Fetch-filter leakage" in out
+
+    def test_date_suffix_does_not_false_match(self):
+        # SpaceX digest titles end "(YYYY-MM-DD)" which false-matched the
+        # id-shaped junk-title pattern until the probe stripped it.
+        import subprocess
+        import sys
+        out = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "review_snapshot.py"), "spacex"],
+            capture_output=True, text=True, timeout=120,
+        ).stdout
+        section = out.split("## Fetch-filter leakage", 1)[1].split("##", 1)[0]
+        assert "(2026-" not in section, (
+            "date suffixes must not register as junk-title filter hits"
+        )
+
+
+class TestDashboardVoiceBaseline:
+    def test_ru_baseline_is_the_grok_olya_voice(self):
+        # The stale ElevenLabs RU baseline flagged FP/PR/age_of_ai as voice
+        # drift on every dashboard build (false positives train the
+        # operator to ignore warnings).
+        text = (ROOT / "scripts" / "generate_dashboard.py").read_text(
+            encoding="utf-8")
+        assert '_VOICE_ID_RU = "0b875ae2"' in text
+        assert '"ara"' in text.split("_SANCTIONED_EXTRA_VOICES", 1)[1][:80]


### PR DESCRIPTION
## TLDR

You asked whether all the goals are being met and whether the network is a high-quality, differentiated product. The honest answer from the data:

**The factory is world-class. The audience funnel is the product gap.** 100% run success across 15 shows for 30 days, zero recovery incidents, ~90 episodes/week in 5 languages at **~$35–40/month** — and **3,070 downloads/30d** network-wide with **3 newsletter subscribers**. Every marginal hour on pipeline polish now buys less than an hour on distribution.

**Differentiation is topical authority, not format.** Tesla + Models & Agents + SpaceX = 53% of downloads — the beat-ownership shows with narrative memory. The fastest growers are beat-owners (SpaceX 2.4×, Planetterrian 3× last week). Format-differentiated but topic-generic shows (Omni View, First Principles) are flat/fading; Привет, Русский! is at ~zero (17 downloads/30d). **The two most differentiated bets are dark**: DP Pod (14/14 clean episodes, zero distribution, zero telemetry — its feed was never submitted to any podcast index so OP3 can't see it) and Age of AI (0 episodes shipped).

Full findings + per-show goals scorecard: `docs/reviews/network_review_2026_07_18.md`.

## Shipped (all code/metadata-only — no audio changes)

- **Closing-is-final chapter invariant** (`engine/chapters.py`): the July-16 rotating network outro plugs sibling shows *after* the closing, and un-anchored body markers stole those mentions as spurious final chapters (Tesla Ep544 shipped a "First Principles" chapter at 642s from the promo line; MIT Ep104 "Investor Education"). Terminal signal is the closing title set, not the `where: end` anchor (EI legitimately anchors only its Teaser). Verified by re-parsing both real episodes.
- **DP Pod Network-pick rotation memory** (`shows/hooks/dp_pod.py`): picks were 100% grounded (zero phantom episodes) but converged — FF 5/10 including consecutive days with a fixed Dan-recommends-FF frame. The hook now injects a vary-away list mined from recent digests.
- **Dashboard voice-baseline fix**: the blessed-voice list still pointed at the retired ElevenLabs RU voice, flagging FP/PR/Age-of-AI as "voice drift" on every build — false positives that train you to ignore warnings.
- **Snapshot fetch-filter leakage counter** (`scripts/review_snapshot.py`): counts excluded-class content in shipped digests. Immediately scored three long-pending predictions: SpaceX junk-titles ✅ 0 hits, Tesla 13F ✅ 0 hits, **FF ephemeris ❌ still leaking 3/10** ("Moon passes 2° south of Venus" shipped 07-17).
- **Review-playbook category rules** from the full 15-ledger meta-review: podcast-side length levers formally banned network-wide (~10 misses vs 1 hit — every miss re-diagnosed to the digest ceiling); de-seed-by-shape + rotation memory required; conditional predictions banned; two-miss escalation; ledger entry required for every prediction-bearing pass (five July passes wrote predictions the rotation couldn't score).
- **Ledger**: the 07-02 network predictions scored (3× partial with evidence), today's entry with 4 predictions.

## Verified with new data

- **The 07-16 denoise chain IS engaged in shipped audio**: re-applying `adeclick,afftdn` to the shipped Jul-18 Tesla/DP episodes removes ~0.0–0.5 dB — denoising an already-denoised file is a no-op. Your A/B listen remains the quality gate.
- Jul 13–18 sweep (75 scripts): no scaffold leaks, no garbles, no `$nan`, FP episodes fully Russian; the 07-16 final-script dedup is holding.

## ⚠️ A/B-listen required

**None applied.** Proposed only (per the de-seed-by-shape rules): FP's two 100%-saturation seeded templates («А теперь моя любимая часть…» 10/10; «не так уж и сложно, правда?» 12/12 — seeded verbatim in the prompts), MIT's seeded transition (7/10), PT's takeaway tic (8/10), PR's secret opener (9/10), and an FF digest-scope bullet banning ephemeris/almanac items (title filters can't hold the line — the digest rewrites titles).

## P0 operator decision (not code)

**FP/PR publish off-schedule via the daily-audit retry path** — 8 unplanned public episodes in one week at random afternoon times. Three sources disagree: CRON_MAP + scheduler Worker say Monday-only, `review_episodes.py` says even days, FP's own description says daily. Pick the cadence; then all three (plus the FP listener-facing description) get aligned in one change. I deliberately did not pick for you — either "fix" changes the shipped product.

## Ranked operator items

1. **Distribution > polish**: submit `dp_pod_podcast.rss` to Podcast Index/Apple/Spotify (lights up OP3 telemetry, ~15 min); decide First Principles distribution (the "wait to ~Ep15" gate passed long ago); consider X for SpaceX (fastest-growing show, X off).
2. RU cadence decision (above).
3. FPD + PR product decision — reposition, merge, or sunset rather than continue polishing ~zero-audience shows.
4. Seed DP Pod's first real Dispatch (the honest empty state aired 6/10 episodes — the club's proof loop can't start itself).
5. Age of AI launch — the most defensible format in the portfolio earns nothing unshipped.

## Tests

Full suite: **4,017 passed**, 5 skipped. New drift guards: `TestClosingIsFinal`, `TestNetworkPickRotationMemory`, `TestSnapshotFetchFilterLeakage`, `TestDashboardVoiceBaseline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXEvkULRuFNLXEHb3rkvnc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXEvkULRuFNLXEHb3rkvnc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly review documentation and deterministic chapter/dashboard/snapshot tooling; chapter trimming affects metadata only and is covered by new tests, with no TTS or publish-path edits.
> 
> **Overview**
> Documents the **July 18 whole-network goals & differentiation audit** (`docs/reviews/network_review_2026_07_18.md`) and advances review rotation/ledger state: scores prior **07-02 network predictions** as partial, adds a **2026-07-18 ledger entry** with new predictions, and records a network-wide **`do_not_retry`** for podcast-side length levers.
> 
> **Shipped behavior (metadata / tooling, no prompt audio):**
> - **`engine/chapters.py`**: drops chapter markers that start **after** the last Closing/Sign-off title so rotating network outro sibling names cannot become spurious final chapters.
> - **`shows/hooks/dp_pod.py`**: injects **recent Network pick** rotation memory into pre-fetch context to reduce pick/host/frame convergence.
> - **`scripts/generate_dashboard.py`**: fixes false **voice drift** by blessing Grok Olya (`0b875ae2`) and sanctioned `ara` for Age of AI.
> - **`scripts/review_snapshot.py`**: adds a **fetch-filter leakage** section that scans recent digests against each show’s `exclude_title_patterns`.
> 
> **Process/docs:** extends **`.claude/commands/review-show.md`** with ledger-derived category rules (digest-only length levers, de-seed-by-shape, no conditional predictions, ledger required for every prediction-bearing pass) and a **`CLAUDE.md`** pointer to the audit. **Drift guards** in `tests/test_chapters.py`, `tests/test_dp_pod_show.py`, and `tests/test_review_agent.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e87f6d479bf5d535312e25012fd211459fb15d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->