### PR TITLE
YouTube growth pass: Shorts volume fix, subscriber tracking, punch thumbnails, auto-comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1353,6 +1353,32 @@ default true) = exact legacy YAML behavior. The policy never edits YAML
 files at runtime and never touches audio (outside landmine #17). Drift
 guards: `tests/test_youtube_policy.py`.
 
+**July 18 2026 growth pass** (review:
+[`docs/reviews/youtube_growth_review_2026_07_18.md`](docs/reviews/youtube_growth_review_2026_07_18.md);
+drift guards: `tests/test_youtube_growth_pass.py`,
+`tests/test_shorts_selector.py::TestFillToRequested`): post-policy
+verification found tier gating exact, RU titles fixed, and RU/EN Shorts
+massively outperforming long-form — but tier-A shows chronically
+under-shipped Shorts (FF 1-of-2 on EVERY July episode). Shipped:
+**fill-to-requested** in the multi-Shorts selector (sub-threshold windows
+ship rather than fewer Shorts; `qualified` flag + `shorts_fill_modes`
+metric; FF threshold 3.5 parity); **RU multi-Shorts** (policy may raise to
+2 — RU Shorts are the network's best surface, spacex-RU short_vpd 30);
+**subscriber tracking** (analytics schema v2: per-video subscribersGained,
+channel snapshots + `api/youtube_channel_history.json`, dashboard card,
+subs-blended title hints — subscribers were previously tracked nowhere);
+**title bundle** (one Grok call → long titles + 2-4-word ALL-CAPS
+thumbnail punch text + per-window Short titles; empty fields = exact
+legacy fallbacks; opt-outs `thumbnail_punch_text` / `optimized_titles`);
+**auto-comments** (`engine.youtube.post_video_comment` — long-form posts
+the pinned-comment template, Shorts post the full-episode funnel link, RU
+only when a RU long exists; API can't pin, operator pins in Studio;
+opt-out `auto_comment`); **channel-specific long-form floor**
+(`LONG_VPD_FLOOR` en 1.0 / ru 2.0 — RU longs earned ~9% retention);
+**gallery-retention style tags** now mined from image prompts (per-show
+doc-frequency boilerplate filter). Operator declined publishAt scheduling
+(uploads stay immediate). All render/metadata-side — outside landmine #17.
+
 ### Testing
 
 ```bash

--- a/docs/reviews/youtube_growth_review_2026_07_18.md
+++ b/docs/reviews/youtube_growth_review_2026_07_18.md
@@ -1,0 +1,118 @@
+# YouTube pipeline — post-change review + growth pass (2026-07-18)
+
+Operator request: review how the recent changes worked out on YouTube,
+then further improvements to increase subscribers and reach and deliver a
+great short- and long-form product. Operator decisions confirmed before
+implementation: NO scheduled publishing (keep immediate), YES auto-comments,
+YES punch-text thumbnails, YES raised RU long-form bar.
+
+## Part 1 — how the Jul 14–16 changes worked out (evidence through Jul 17-18)
+
+**Working as designed:**
+- Adaptive policy tier gating is exact: all 6 EN C-tier shows skip the
+  long-form render (quota 3,800 → 1,700 units/episode) while Shorts + the
+  shared thumbnail still ship. Hysteresis is stable — one clean promotion
+  (omni_view C→B, coinciding with its editorial realignment), UC demoted
+  B→C, RU fascinating_frontiers promoted C→A and shipping RU longs.
+- The RU title fix (PR #833) cut over cleanly: since Jul 18 all @NerraRU
+  uploads carry translated, optimized headlines (the "Эп. N: …"
+  truncation is gone).
+- The analytics loop is LIVE (retention flows; `title_hint` populated for
+  every show; `gallery_retention.json` populated).
+
+**The data:**
+- RU Shorts are the network's growth engine: 7,028 views/90d across 83
+  videos; spacex-RU alone 677 views in 7 days (short_vpd 30).
+- EN Shorts beat EN long everywhere (Tesla 306 vs 157 views/7d; FF Shorts
+  75% average retention). The C-tier longs the policy cut were earning
+  6-13% retention and single-digit weekly views — the cut cost nothing.
+
+**Open issues found:**
+1. "Requests 2 Shorts, ships 1" persisted — FF shipped 1-of-2 on EVERY
+   July episode (its calm science prose rarely beats the kicker-phrase
+   scoring threshold; the selector returned nothing and the 10-second
+   voice fallback shipped one Short), SpaceX 1-of-2 on 3 of 4.
+2. Subscribers were tracked NOWHERE (the metric the operator wants to
+   grow).
+3. RU long-form is near-worthless (435 views / 68 videos, ~9% retention)
+   yet FF-RU's promotion started daily RU long renders.
+4. `gallery_retention.json` tag summaries were EMPTY (manifest tags are
+   boilerplate; the style signal lives in the prompt field).
+5. The Monday long-form probe first fires Jul 20 (untested — observe).
+
+## Part 2 — what shipped
+
+1. **Shorts volume fix** (the best format was under-shipped):
+   - `pick_top_n_engaging_windows(fill_to_n=True)`: when fewer than the
+     requested N windows beat the threshold, fill remaining slots with
+     the best non-overlapping sub-threshold windows (score ≥ 0; negative
+     boring-opener windows never ship), marked `qualified=False`. The
+     requested count is a policy decision — the selector ranks, it
+     doesn't veto. Metric: `shorts_fill_modes` per Short.
+   - FF gets `shorts_min_score_threshold: 3.5` (Tesla/SpaceX parity).
+   - RU multi-Shorts: the policy may now raise RU Shorts to 2 (hard cap;
+     `smart_mode=True` in ru_dub's policy call — the old False silently
+     capped every RU show at 1). Second RU Short gets its own window,
+     captions, and a distinct title from its window's opening text.
+2. **Subscriber tracking**: analytics fetch (schema v2) adds per-video
+   `subscribersGained/Lost` + per-channel statistics snapshot + 30-day
+   day-series + daily history (`api/youtube_channel_history.json`);
+   dashboard gains a "YouTube channels" card (subs, 7d delta, top
+   subscriber-driving videos); the title-hint ranking now blends
+   retention with subs gained and quotes converting titles.
+3. **Punch-text thumbnails** (operator-approved brand change): one Grok
+   call (`generate_title_bundle`, replacing the titles-only call at the
+   same cost) also returns a 2-4 word ALL-CAPS punch text rendered as
+   the thumbnail's dominant element (~2× font base) + a punchy ≤60-char
+   title per Short window. Empty fields fall back to exact legacy
+   behavior. Opt-outs: `thumbnail_punch_text`, `optimized_titles`.
+4. **Auto-comments** (operator-approved): `post_video_comment` posts a
+   channel comment on every upload — long-form gets the pinned-comment
+   template (now shared via `build_pinned_comment_text`), Shorts get
+   "▶ Full episode: <link> / 🔔 Subscribe", RU Shorts the Russian
+   equivalent (only when a RU long exists — never link an English video
+   from a Russian Short). The API cannot pin; the operator pins manually
+   in Studio. 403 = graceful no-op. Opt-out: `auto_comment`.
+5. **RU long-form floor** (operator decision): `LONG_VPD_FLOOR` is
+   channel-specific — en 1.0, ru 2.0. FF-RU (long_vpd 1.39) will demote
+   back to shorts-only after the standard 2-run hysteresis; the Monday
+   probe still generates the data to re-earn it.
+6. **Gallery retention style tags**: tags are now mined from the image
+   PROMPT field (comma-split phrases; per-show >50%-document-frequency
+   boilerplate auto-excluded — no hand-curated stoplist). Verified on
+   live data: 1,420 images labeled across 13 shows. The
+   auto-feedback into `grok_image_descriptor` is deliberately NOT wired
+   yet (thin sample sizes; revisit after 2-3 weeks of labeled data).
+
+Drift guards: `tests/test_youtube_growth_pass.py` (22 tests),
+`tests/test_shorts_selector.py::TestFillToRequested`, updated
+`tests/test_ru_dub.py` parity test.
+
+## Rollout verification (check after 2-3 days of episodes)
+
+- FF + SpaceX metrics: `shorts_count_uploaded == shorts_count_requested`;
+  `shorts_fill_modes` distribution (FF should mix qualified/filled at the
+  3.5 threshold; no more `[10.0]` fallbacks).
+- spacex-RU: 2 Shorts/day in `youtube_videos.ru.json`; watch short_vpd
+  for cannibalization (holding ≥ ~20 = healthy).
+- `api/youtube_channel_history.json` gaining one row/channel/day; the
+  dashboard subs card fills in (7d delta needs a week of rows).
+- Auto-comments visible on new uploads (operator: pin the good ones); no
+  403 warnings in the run logs.
+- Thumbnails: eyeball the punch text on 2-3 episodes — revert per show
+  via `thumbnail_punch_text: false` if the style reads wrong.
+- Policy log Jul 20-22: Monday probe fires; FF-RU long demotes after the
+  2-run streak under the new ru floor.
+
+## Deferred
+
+- publishAt golden-hour scheduling (operator declined — keep immediate).
+- Chapter-anchored fill phase for the selector (only if score≥0 fill
+  proves insufficient).
+- Visual-style-hint auto-feedback into image prompts (data too thin).
+- RU punch-text thumbnails (needs translation; legacy rendering kept).
+- Subs-gained in policy velocity (too sparse for tier flips at current
+  volume).
+- YouTube native multi-audio tracks + localizations API metadata (multi-
+  audio is not publicly available; localizations worth revisiting once
+  the FR/ES/ZH tracks have audiences).

--- a/engine/config.py
+++ b/engine/config.py
@@ -657,6 +657,16 @@ class YouTubeConfig:
     # Appended to the description as an operator copy-paste block (YouTube
     # has no API for pinned comments without extra scopes).
     pinned_comment_template: str = ""
+    # July 18 2026 (operator-approved): post a real channel comment on each
+    # upload via commentThreads.insert — the pinned-comment template on
+    # long-form, a "Full episode: <link>" funnel comment on Shorts. The
+    # API can't pin it (operator pins manually); a 403 is a graceful no-op.
+    auto_comment: bool = True
+    # July 18 2026 (operator-approved): thumbnails render a 2-4 word
+    # ALL-CAPS punch text (LLM-generated with the title bundle) as the
+    # dominant element instead of the full hook sentence. False = legacy
+    # hook rendering.
+    thumbnail_punch_text: bool = True
     # When true and vertical scene images exist, build a 1080×1920 Shorts
     # thumbnail instead of reusing the 1280×720 long-form thumb.
     shorts_thumbnail_from_scene: bool = True

--- a/engine/config.py
+++ b/engine/config.py
@@ -498,6 +498,12 @@ class YouTubeConfig:
     # episode ran at the 5.0 default — Ep505's "best score 3.0 below
     # threshold 5.0" fallback was this bug, not a quiet news day.
     shorts_min_score_threshold: float = 5.0
+    # July 18 2026: when the multi-Shorts selector finds fewer than the
+    # requested N windows above the threshold, fill the remaining slots
+    # with the best non-overlapping sub-threshold windows (score >= 0)
+    # instead of shipping fewer Shorts. The requested count is a policy
+    # decision; before this, FF shipped 1-of-2 on every July episode.
+    shorts_fill_to_requested: bool = True
     # ``always`` | ``alternate_episodes`` — skip Shorts on odd episode
     # numbers to halve upload quota during phased rollout.
     shorts_upload_schedule: str = "always"

--- a/engine/publisher.py
+++ b/engine/publisher.py
@@ -1366,6 +1366,7 @@ def generate_episode_thumbnail(
     hook: str = "",
     show_name: str = "",
     size: tuple = (1280, 720),
+    punch_text: str = "",
 ) -> tuple[Path, int | None]:
     """Render an image-first episode thumbnail for YouTube.
 
@@ -1431,9 +1432,16 @@ def generate_episode_thumbnail(
             font=label_font, fill=(255, 255, 255),
         )
 
+    # July 18 2026 — thumbnail punch text (operator-approved style change):
+    # a 2-4 word ALL-CAPS headline rendered MUCH larger than the old
+    # full-hook-sentence lower third. Big-text thumbnails are the #1 CTR
+    # lever available to this network (docs/youtube_seo.md; no on-camera
+    # face exists). Empty punch_text = exact legacy hook rendering.
+    _main_text = (punch_text or "").strip() or hook
+    _is_punch = bool((punch_text or "").strip())
     font_size = None
-    if hook:
-        clean_hook = hook.strip()
+    if _main_text:
+        clean_hook = _main_text.strip()
         # Safety cap — anything longer than 160 chars is almost
         # certainly an LLM run-on; lower-third layout wants punchy
         # copy (the full hook still lives in the description).
@@ -1446,8 +1454,16 @@ def generate_episode_thumbnail(
         max_text_width = width - 2 * margin
         max_block_h = int(height * (0.28 if height > width else 0.32))
         max_lines = 3 if height >= width else 2
-        max_font = max(48, width // 16)
-        min_font = max(28, width // 28)
+        if _is_punch:
+            # Punch text is 2-4 words — start from a display size roughly
+            # 2x the hook base and allow a taller block.
+            max_block_h = int(height * (0.34 if height > width else 0.38))
+            max_lines = 2
+            max_font = max(96, width // 8)
+            min_font = max(48, width // 16)
+        else:
+            max_font = max(48, width // 16)
+            min_font = max(28, width // 28)
         font_size = max_font
         lines: list = []
         line_h = 0
@@ -1507,6 +1523,7 @@ def generate_thumbnail_variants(
     hook: str = "",
     show_name: str = "",
     count: int = 2,
+    punch_text: str = "",
 ) -> "list[Path]":
     """Render extra long-form thumbnail composites from alternate scenes.
 
@@ -1536,6 +1553,7 @@ def generate_thumbnail_variants(
                 dest,
                 hook=hook,
                 show_name=show_name,
+                punch_text=punch_text,
             )
             out.append(path)
         except Exception as exc:  # noqa: BLE001 — variants are optional
@@ -1551,6 +1569,7 @@ def generate_shorts_thumbnail(
     *,
     hook: str = "",
     show_name: str = "",
+    punch_text: str = "",
 ) -> Path:
     """Render a 1080×1920 vertical thumbnail for YouTube Shorts."""
     return generate_episode_thumbnail(
@@ -1561,6 +1580,7 @@ def generate_shorts_thumbnail(
         hook=hook,
         show_name=show_name,
         size=(1080, 1920),
+        punch_text=punch_text,
     )
 
 

--- a/engine/ru_dub.py
+++ b/engine/ru_dub.py
@@ -312,8 +312,13 @@ def _policy_plan(config) -> Dict[str, object]:
             slug=config.slug,
             channel="ru",
             yaml_publish_long=True,   # legacy ru_dub always built the long
-            yaml_shorts=1,            # ru_dub builds at most one Short
-            smart_mode=False,
+            yaml_shorts=1,            # policy may raise (capped at 2 below)
+            # July 18 2026: the RU Short path genuinely runs the smart
+            # selector on its own RU transcript, so the policy is allowed
+            # to raise the Shorts count (RU Shorts are the network's
+            # best-performing format — spacex-RU short_vpd 30 — and the
+            # old smart_mode=False silently capped every RU show at 1).
+            smart_mode=True,
             adaptive_enabled=bool(getattr(
                 getattr(config, "youtube", None), "adaptive_publishing", True,
             )),
@@ -536,111 +541,168 @@ def publish_ru_dub(
 
             result["status"] = "done"
 
-        # --- Short (best-effort; failure never blocks the long-form result) ---
+        # --- Shorts (best-effort; failure never blocks the long-form result) ---
+        # July 18 2026: up to TWO Shorts per episode when the policy asks
+        # (RU Shorts are the network's best-performing format). Window
+        # selection = top-N with fill on the RU transcript; each Short is
+        # its own try/except so a second-Short failure never costs the
+        # first.
         if build_short and getattr(yt, "publish_shorts", True):
+            ru_shorts = max(1, min(2, int(plan.get("shorts", 1) or 1)))
+            short_scenes = []
             try:
                 short_scenes = _download_images(short_urls, tmp) if short_urls else []
-                short_mp4 = tmp / f"ru_short_ep{episode_num:03d}.mp4"
-                short_dur = float(getattr(yt, "short_duration_seconds", 55.0))
-
-                # Parity with the EN shorts: transcribe the RU dub audio
-                # (Russian Whisper, word timestamps) → smart engaging-beat
-                # start + Russian burned-in per-word captions. DejaVu Sans
-                # (the caption font) covers Cyrillic. Every piece is
-                # best-effort — the short still ships without them.
-                start_offset = float(getattr(yt, "shorts_start_offset", 0.0) or 0.0)
-                ass_path = None
-                try:
-                    from engine.transcripts import generate_transcript
-                    from engine.captions import transcript_to_ass_window
-                    from engine.shorts_selector import pick_engaging_window
-                    from engine.audio import get_audio_duration
-                    tr = generate_transcript(
-                        audio, tmp, f"ru_ep{episode_num:03d}", language="ru")
-                    if tr and tr.json_path.exists():
-                        total_dur = get_audio_duration(audio) or 0.0
-                        win = pick_engaging_window(
-                            tr.json_path, audio_offset=start_offset,
-                            audio_duration=total_dur, window_duration=short_dur,
-                            min_start_final=start_offset)
-                        if win is not None:
-                            start_offset = win.start_seconds
-                        ass_candidate = tmp / f"ru_short_ep{episode_num:03d}.ass"
-                        transcript_to_ass_window(
-                            tr.json_path, ass_candidate,
-                            window_start_seconds=start_offset,
-                            window_duration_seconds=short_dur,
-                            audio_offset_seconds=0.0)
-                        if (ass_candidate.exists()
-                                and ass_candidate.stat().st_size > 0
-                                and "Dialogue:" in ass_candidate.read_text(
-                                    encoding="utf-8", errors="replace")):
-                            ass_path = ass_candidate
-                            result["ru_short_captions"] = "ass"
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning("ru_dub: RU transcript/captions failed (%s) — "
-                                   "short without captions", exc)
-
-                # End-card CTA (Russian) — reuse the RU long-form thumbnail.
-                end_card_png = None
-                try:
-                    from engine.publisher import generate_shorts_end_card
-                    if thumb_path is not None:
-                        ec = tmp / f"ru_short_ep{episode_num:03d}_endcard.png"
-                        generate_shorts_end_card(
-                            thumb_path, ec, show_name=config.name,
-                            main_text=_RU_END_CARD_MAIN, sub_text=_RU_END_CARD_SUB)
-                        if ec.exists():
-                            end_card_png = ec
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning("ru_dub: end-card render failed (%s)", exc)
-
-                build_short_video(
-                    audio, cover, short_mp4,
-                    start_offset=start_offset,
-                    duration=short_dur,
-                    hook=ru_title,
-                    scene_paths=short_scenes if len(short_scenes) >= 2 else None,
-                    show_name=config.name,
-                    subtitles_path=ass_path,
-                    end_card=True,
-                    end_card_main_text=_RU_END_CARD_MAIN,
-                    end_card_sub_text=_RU_END_CARD_SUB,
-                    end_card_image_path=end_card_png)
-                short_title = _ru_short_title(ru_title)
-                sup = upload_video(
-                    short_mp4, credentials=creds,
-                    title=short_title,
-                    description=_ru_long_description(config, ru_desc),
-                    tags=list(getattr(config, "keywords", []) or []),
-                    category_id=int(getattr(yt, "category_id", 28)),
-                    default_language="ru",
-                    privacy_status=getattr(yt, "privacy_status", "public"))
-                result["short_url"] = sup.watch_url
-                # Record the title the Short actually shipped with (distinct,
-                # "#Shorts"-suffixed) — the index previously recorded the
-                # long-form title, hiding what @NerraRU really displayed.
-                record_video(
-                    video_id=sup.video_id, show_slug=config.slug,
-                    episode=episode_num, kind="short", title=short_title,
-                    hook=ru_title, published=date_str, watch_url=sup.watch_url,
-                    channel="ru",
-                    index_path=PROJECT_ROOT / config.episode.output_dir
-                    / "youtube_videos.ru.json")
-                pl = (getattr(yt, "ru_podcast_playlist_id", None) or "").strip()
-                if pl:
-                    try:
-                        add_video_to_playlist(credentials=creds,
-                                              video_id=sup.video_id, playlist_id=pl)
-                    except Exception:  # noqa: BLE001
-                        pass
-                # Under a shorts-only policy the Short IS the deliverable —
-                # its successful upload marks the episode done (no-op when
-                # the long-form already set it).
-                result["status"] = "done"
             except Exception as exc:  # noqa: BLE001
-                logger.warning("ru_dub: Short failed for Ep%s (non-fatal): %s",
-                               episode_num, exc)
-                result["short_error"] = str(exc)
+                logger.warning("ru_dub: scene download failed (%s)", exc)
+            short_dur = float(getattr(yt, "short_duration_seconds", 55.0))
+            base_offset = float(getattr(yt, "shorts_start_offset", 0.0) or 0.0)
+
+            # Transcribe once; select up to ru_shorts windows. Parity with
+            # the EN shorts: Russian Whisper word timestamps → smart
+            # engaging-beat starts + per-word Cyrillic ASS captions.
+            # Every piece is best-effort — a Short still ships without them.
+            tr_json = None
+            windows: list = []
+            try:
+                from engine.transcripts import generate_transcript
+                from engine.shorts_selector import pick_top_n_engaging_windows
+                from engine.audio import get_audio_duration
+                tr = generate_transcript(
+                    audio, tmp, f"ru_ep{episode_num:03d}", language="ru")
+                if tr and tr.json_path.exists():
+                    tr_json = tr.json_path
+                    total_dur = get_audio_duration(audio) or 0.0
+                    windows = pick_top_n_engaging_windows(
+                        tr_json, n=ru_shorts,
+                        audio_offset=base_offset,
+                        audio_duration=total_dur,
+                        window_duration=short_dur,
+                        min_start_final=base_offset,
+                        fill_to_n=True)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("ru_dub: RU transcript/selection failed (%s) — "
+                               "voice-start short without captions", exc)
+
+            # Plan: (offset, opening_text) per Short; legacy single
+            # voice-start fallback when the selector yields nothing.
+            if windows:
+                short_plan = [(w.start_seconds, (w.opening_text or "").strip())
+                              for w in windows[:ru_shorts]]
+            else:
+                short_plan = [(base_offset, "")]
+
+            # End-card CTA (Russian) — shared across Shorts; reuse the RU
+            # long-form thumbnail.
+            end_card_png = None
+            try:
+                from engine.publisher import generate_shorts_end_card
+                if thumb_path is not None:
+                    ec = tmp / f"ru_short_ep{episode_num:03d}_endcard.png"
+                    generate_shorts_end_card(
+                        thumb_path, ec, show_name=config.name,
+                        main_text=_RU_END_CARD_MAIN, sub_text=_RU_END_CARD_SUB)
+                    if ec.exists():
+                        end_card_png = ec
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("ru_dub: end-card render failed (%s)", exc)
+
+            short_urls_out: list = []
+            for short_idx, (start_offset, opening_text) in enumerate(short_plan):
+                try:
+                    suffix = "" if short_idx == 0 else f"_{short_idx + 1}"
+                    short_mp4 = tmp / f"ru_short_ep{episode_num:03d}{suffix}.mp4"
+
+                    ass_path = None
+                    if tr_json is not None:
+                        try:
+                            from engine.captions import transcript_to_ass_window
+                            ass_candidate = (
+                                tmp / f"ru_short_ep{episode_num:03d}{suffix}.ass")
+                            transcript_to_ass_window(
+                                tr_json, ass_candidate,
+                                window_start_seconds=start_offset,
+                                window_duration_seconds=short_dur,
+                                audio_offset_seconds=0.0)
+                            if (ass_candidate.exists()
+                                    and ass_candidate.stat().st_size > 0
+                                    and "Dialogue:" in ass_candidate.read_text(
+                                        encoding="utf-8", errors="replace")):
+                                ass_path = ass_candidate
+                                result["ru_short_captions"] = "ass"
+                        except Exception as exc:  # noqa: BLE001
+                            logger.warning(
+                                "ru_dub: ASS captions failed for short %d "
+                                "(%s)", short_idx + 1, exc)
+
+                    build_short_video(
+                        audio, cover, short_mp4,
+                        start_offset=start_offset,
+                        duration=short_dur,
+                        hook=ru_title,
+                        scene_paths=short_scenes if len(short_scenes) >= 2 else None,
+                        show_name=config.name,
+                        subtitles_path=ass_path,
+                        end_card=True,
+                        end_card_main_text=_RU_END_CARD_MAIN,
+                        end_card_sub_text=_RU_END_CARD_SUB,
+                        end_card_image_path=end_card_png)
+
+                    # Titles: Short #1 keeps the optimized-derived headline;
+                    # Short #2 leads with ITS window's opening text (already
+                    # Russian — it's the RU transcript) so the two Shorts
+                    # are genuinely distinct in the feed.
+                    if short_idx == 0 or not opening_text:
+                        short_title = _ru_short_title(ru_title)
+                        if short_idx > 0:
+                            short_title = _ru_short_title(
+                                ru_title, body_limit=58) + " — ещё момент"
+                    else:
+                        body = _word_trim(
+                            opening_text.rstrip("…").rstrip(),
+                            min(70, _YT_TITLE_MAX - len(_SHORTS_SUFFIX)))
+                        short_title = f"{body}{_SHORTS_SUFFIX}".strip()
+
+                    sup = upload_video(
+                        short_mp4, credentials=creds,
+                        title=short_title,
+                        description=_ru_long_description(config, ru_desc),
+                        tags=list(getattr(config, "keywords", []) or []),
+                        category_id=int(getattr(yt, "category_id", 28)),
+                        default_language="ru",
+                        privacy_status=getattr(yt, "privacy_status", "public"))
+                    short_urls_out.append(sup.watch_url)
+                    # Record the title the Short actually shipped with
+                    # (distinct, "#Shorts"-suffixed) — the index previously
+                    # recorded the long-form title, hiding what @NerraRU
+                    # really displayed.
+                    record_video(
+                        video_id=sup.video_id, show_slug=config.slug,
+                        episode=episode_num, kind="short", title=short_title,
+                        hook=ru_title, published=date_str,
+                        watch_url=sup.watch_url,
+                        channel="ru",
+                        index_path=PROJECT_ROOT / config.episode.output_dir
+                        / "youtube_videos.ru.json")
+                    pl = (getattr(yt, "ru_podcast_playlist_id", None) or "").strip()
+                    if pl:
+                        try:
+                            add_video_to_playlist(credentials=creds,
+                                                  video_id=sup.video_id,
+                                                  playlist_id=pl)
+                        except Exception:  # noqa: BLE001
+                            pass
+                    # Under a shorts-only policy the Short IS the
+                    # deliverable — its successful upload marks the episode
+                    # done (no-op when the long-form already set it).
+                    result["status"] = "done"
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("ru_dub: Short %d failed for Ep%s "
+                                   "(non-fatal): %s",
+                                   short_idx + 1, episode_num, exc)
+                    result["short_error"] = str(exc)
+
+            if short_urls_out:
+                result["short_url"] = short_urls_out[0]
+                result["short_urls"] = short_urls_out
 
     return result

--- a/engine/ru_dub.py
+++ b/engine/ru_dub.py
@@ -671,6 +671,20 @@ def publish_ru_dub(
                         default_language="ru",
                         privacy_status=getattr(yt, "privacy_status", "public"))
                     short_urls_out.append(sup.watch_url)
+                    # July 18 2026 (operator-approved): RU funnel comment.
+                    # Only when a RU long-form exists this run — a Russian
+                    # Short should never link an English video.
+                    if long_url and bool(getattr(yt, "auto_comment", True)):
+                        try:
+                            from engine.youtube import post_video_comment
+                            post_video_comment(
+                                credentials=creds,
+                                video_id=sup.video_id,
+                                text=("▶ Полный выпуск: " + long_url
+                                      + "\n🔔 Подпишитесь — новые выпуски "
+                                        "каждый день"))
+                        except Exception:  # noqa: BLE001
+                            pass
                     # Record the title the Short actually shipped with
                     # (distinct, "#Shorts"-suffixed) — the index previously
                     # recorded the long-form title, hiding what @NerraRU

--- a/engine/shorts_selector.py
+++ b/engine/shorts_selector.py
@@ -119,6 +119,12 @@ class ScoredWindow:
     # segment, surfaced in logs / metrics so the operator can scan the
     # selection without re-running the pipeline.
     opening_text: str = ""
+    # July 18 2026: False when this window was accepted by the
+    # fill-to-requested phase (score below ``min_score_threshold`` but
+    # still the best available) rather than by the qualified phase.
+    # Surfaced in metrics as ``shorts_fill_modes`` so the dashboard can
+    # track qualified-vs-filled rates per show.
+    qualified: bool = True
 
 
 # ---------------------------------------------------------------------------
@@ -372,6 +378,8 @@ def pick_top_n_engaging_windows(
     min_start_final: Optional[float] = None,
     min_score_threshold: float = 5.0,
     min_gap_seconds: float = 10.0,
+    fill_to_n: bool = False,
+    min_fill_score: float = 0.0,
 ) -> List[ScoredWindow]:
     """Return up to ``n`` non-overlapping windows ranked by score.
 
@@ -386,12 +394,27 @@ def pick_top_n_engaging_windows(
     This produces the N most engaging windows that are also
     temporally distinct.
 
+    July 18 2026 — ``fill_to_n``: when True and fewer than ``n``
+    candidates beat ``min_score_threshold``, the remaining slots are
+    FILLED with the best non-overlapping sub-threshold candidates whose
+    score is still >= ``min_fill_score`` (default 0.0 — a negative
+    score means a ``_BORING_OPENERS`` hit and is never shipped). Those
+    windows carry ``qualified=False``. Rationale: for the multi-Shorts
+    path the requested count is a POLICY decision already made — the
+    selector's job is ranking, not vetoing. Before this, tier-A shows
+    chronically under-shipped their best-performing format: FF
+    requested 2 Shorts and shipped 1 on EVERY July episode (its calm
+    science prose rarely beats the kicker-phrase-driven threshold),
+    SpaceX shipped 1-of-2 on 3 of 4. The legacy single-window path
+    (``pick_engaging_window``) keeps its threshold-or-fallback
+    semantics unchanged.
+
     Behaviour at the edges:
 
-    * Fewer than ``n`` candidates above ``min_score_threshold`` →
-      returns whatever it found (possibly empty). Caller decides
-      whether to fall back to legacy voice-start for the missing
-      slots.
+    * Fewer than ``n`` candidates above ``min_score_threshold`` (and
+      ``fill_to_n=False``) → returns whatever it found (possibly
+      empty). Caller decides whether to fall back to legacy
+      voice-start for the missing slots.
     * No candidates at all → returns ``[]``.
     * ``n <= 0`` → returns ``[]`` (defensive — caller bug).
     * Transcript unreadable → returns ``[]`` (logged in score_candidates).
@@ -430,6 +453,25 @@ def pick_top_n_engaging_windows(
             picked.append(cand)
             if len(picked) >= n:
                 break
+
+    if fill_to_n and len(picked) < n:
+        import dataclasses as _dc
+        filled = 0
+        for cand in candidates:
+            if len(picked) >= n:
+                break
+            if cand.score >= min_score_threshold:
+                continue  # already considered in the qualified phase
+            if cand.score < min_fill_score:
+                break  # sorted desc — the rest are worse
+            if not _overlaps_any(cand, picked, min_gap_seconds):
+                picked.append(_dc.replace(cand, qualified=False))
+                filled += 1
+        if filled:
+            logger.info(
+                "Smart Shorts selector (top-%d): filled %d slot(s) with "
+                "best sub-threshold window(s) (fill_to_n)", n, filled,
+            )
 
     # Re-sort by start time so the caller can iterate chronologically.
     picked.sort(key=lambda w: w.start_seconds)

--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -271,6 +271,34 @@ def _build_tags(
 # Public API
 # ---------------------------------------------------------------------------
 
+def build_pinned_comment_text(
+    config, *, hook: str = "", episode_num: int = 0, today_str: str = "",
+    rss_link: str = "", audio_url: str = "",
+) -> str:
+    """Render the show's pinned-comment template, or "" when unset.
+
+    July 18 2026: extracted from the long-form description builder so the
+    same text can ALSO be posted as a real channel comment via
+    ``engine.youtube.post_video_comment`` (the API cannot pin it — the
+    operator pins manually — but the channel's own comment surfaces near
+    the top). One template, two surfaces.
+    """
+    pinned = (getattr(config.youtube, "pinned_comment_template", None) or "").strip()
+    if not pinned:
+        return ""
+    try:
+        pinned = pinned.format(
+            hook=(hook or "").strip(),
+            episode_num=episode_num,
+            today_str=today_str,
+            show_page_url=rss_link,
+            full_episode_url=audio_url or "",
+        )
+    except KeyError:
+        pass
+    return pinned.strip()
+
+
 def build_long_form_metadata(
     config,
     *,
@@ -412,18 +440,11 @@ def build_long_form_metadata(
     disclosure = (config.youtube.synthetic_disclosure or "").strip()
     if disclosure:
         pieces.append(disclosure)
-    pinned = (getattr(config.youtube, "pinned_comment_template", None) or "").strip()
+    pinned = build_pinned_comment_text(
+        config, hook=hook, episode_num=episode_num, today_str=today_str,
+        rss_link=rss_link, audio_url=audio_url,
+    )
     if pinned:
-        try:
-            pinned = pinned.format(
-                hook=(hook or "").strip(),
-                episode_num=episode_num,
-                today_str=today_str,
-                show_page_url=rss_link,
-                full_episode_url=audio_url or "",
-            )
-        except KeyError:
-            pass
         pieces.append("—\nSuggested pinned comment:\n" + pinned)
 
     # Final safety strip — YouTube rejects any description containing

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -414,6 +414,66 @@ def add_video_to_playlist(
     return True
 
 
+def post_video_comment(
+    *,
+    credentials,
+    video_id: str,
+    text: str,
+) -> Optional[str]:
+    """Post a top-level comment on a video as the channel identity.
+
+    July 18 2026 (operator-approved): the Shorts→long-form funnel's
+    strongest placement after the description link. The API cannot PIN a
+    comment — the operator pins manually in Studio when desired — but the
+    channel's own comment surfaces near the top regardless.
+
+    Returns the comment id, or ``None`` on any failure. Never raises:
+    a 403 (comments disabled on the video, or a token missing the
+    ``youtube.force-ssl`` scope) is a single warning and a no-op.
+    Costs ~50 quota units.
+    """
+    text = (text or "").strip()
+    if not text or not video_id:
+        return None
+    from googleapiclient.discovery import build
+    from googleapiclient.errors import HttpError
+
+    try:
+        youtube = build(
+            "youtube", "v3", credentials=credentials, cache_discovery=False,
+        )
+        body = {
+            "snippet": {
+                "videoId": video_id,
+                "topLevelComment": {
+                    "snippet": {"textOriginal": text[:9500]},
+                },
+            },
+        }
+        resp = youtube.commentThreads().insert(
+            part="snippet", body=body,
+        ).execute()
+        comment_id = (resp or {}).get("id")
+        logger.info("posted channel comment %s on video %s",
+                    comment_id, video_id)
+        return comment_id
+    except HttpError as exc:
+        status = getattr(getattr(exc, "resp", None), "status", "?")
+        if str(status) == "403":
+            logger.warning(
+                "Comment on %s forbidden (HTTP 403) — comments disabled on "
+                "the video, or the token lacks youtube.force-ssl; skipping.",
+                video_id,
+            )
+        else:
+            logger.warning("Comment on %s failed (HTTP %s): %s",
+                           video_id, status, exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 — never block a publish
+        logger.warning("Comment on %s failed: %s", video_id, exc)
+        return None
+
+
 def upload_caption_track(
     *,
     credentials,

--- a/engine/youtube_titles.py
+++ b/engine/youtube_titles.py
@@ -134,6 +134,122 @@ def generate_youtube_titles(
     return candidates
 
 
+_BUNDLE_PROMPT_PATH = (
+    _REPO_ROOT / "shows" / "prompts" / "_shared" / "youtube_title_bundle.txt"
+)
+# Punch text renders HUGE on the thumbnail — keep it short and honest.
+PUNCH_TEXT_MAX_CHARS = 26
+SHORT_TITLE_MAX_CHARS = 70
+
+
+def _clean_punch(text: str) -> str:
+    """Normalize the thumbnail punch text; '' when unusable."""
+    t = _clean_title(text).upper()
+    # Punch is display text, not a sentence — strip trailing punctuation.
+    t = t.strip().rstrip(".!,;:")
+    words = t.split()
+    if not (1 < len(words) <= 4):
+        return ""
+    if len(t) > PUNCH_TEXT_MAX_CHARS:
+        return ""
+    # Never ship the generic hype words the prompt bans.
+    banned = {"BREAKING", "SHOCKING", "NEWS", "UNBELIEVABLE"}
+    if set(words) & banned and len(words) <= 2:
+        return ""
+    return t
+
+
+def generate_title_bundle(
+    *,
+    hook: str,
+    digest_text: str,
+    show_name: str,
+    episode_num: int,
+    keywords: Optional[List[str]] = None,
+    n: int = 3,
+    model: str = "grok-4.3",
+    perf_dir: Optional[Path] = None,
+    short_window_texts: Optional[List[str]] = None,
+) -> dict:
+    """One Grok call → long-form titles + thumbnail punch + Short titles.
+
+    July 18 2026: extends the optimized-titles call (same cost — still one
+    call per episode) to also return a 2-4 word ALL-CAPS thumbnail "punch
+    text" (the big-text CTR lever) and a punchy ≤60-char title per Short
+    window (Shorts previously shipped raw transcript opening text as their
+    headline).
+
+    Returns ``{"titles": [...], "punch_text": str, "short_titles": [...]}``
+    — every field may be empty; callers fall back exactly as before
+    (hook-based long title, legacy hook thumbnail, opening-text Short
+    titles). Never raises, never blocks an upload.
+    """
+    empty = {"titles": [], "punch_text": "", "short_titles": []}
+    windows = [w.strip() for w in (short_window_texts or []) if w and w.strip()]
+    try:
+        from engine.generator import _call_grok, load_prompt
+
+        window_lines = "\n".join(
+            f"{i + 1}. \"{w[:200]}\"" for i, w in enumerate(windows)
+        ) or "(none)"
+        prompt = load_prompt(
+            str(_BUNDLE_PROMPT_PATH),
+            {
+                "show_name": show_name or "",
+                "episode_num": episode_num,
+                "hook": (hook or "").strip(),
+                "keywords": ", ".join(keywords or []),
+                "digest_excerpt": (digest_text or "")[:2000],
+                "performance_hint": _performance_hint(perf_dir),
+                "short_windows": window_lines,
+                "n": n,
+            },
+        )
+        text, _meta = _call_grok(
+            prompt,
+            model=model,
+            temperature=0.8,
+            max_tokens=500,
+        )
+    except Exception as exc:  # noqa: BLE001 — never block an upload
+        logger.warning("YouTube title bundle generation failed: %s", exc)
+        return empty
+
+    titles: List[str] = []
+    punch = ""
+    short_titles: dict = {}
+    seen: set = set()
+    for raw in (text or "").splitlines():
+        line = raw.strip()
+        m = re.match(r"^(TITLE|PUNCH|SHORT(\d+))\s*:\s*(.+)$", line,
+                     flags=re.IGNORECASE)
+        if not m:
+            continue
+        label = m.group(1).upper()
+        value = m.group(3).strip()
+        if label == "TITLE":
+            cleaned = _clean_title(value)
+            key = cleaned.lower()
+            if (cleaned and len(cleaned) <= YOUTUBE_TITLE_HARD_MAX
+                    and key not in seen and len(titles) < n):
+                seen.add(key)
+                titles.append(cleaned)
+        elif label == "PUNCH" and not punch:
+            punch = _clean_punch(value)
+        else:  # SHORTn
+            idx = int(m.group(2)) - 1
+            cleaned = _clean_title(value)
+            if cleaned and 0 <= idx < max(len(windows), 1):
+                short_titles[idx] = cleaned[:SHORT_TITLE_MAX_CHARS].strip()
+
+    return {
+        "titles": titles,
+        "punch_text": punch,
+        "short_titles": [short_titles.get(i, "") for i in
+                         range(len(windows))],
+    }
+
+
 def best_youtube_title(
     *,
     hook: str,

--- a/management.html
+++ b/management.html
@@ -474,6 +474,31 @@
     });
   }
 
+  // -------- YouTube channel growth (July 2026: subscribers) --------
+  const yt = audience.youtube || {};
+  if (yt.configured && !yt.error && yt.channels) {
+    const head = h("div", { style: "margin-top:12px;font-weight:600;color:#e2e8f0;" });
+    head.textContent = "YouTube channels";
+    audRoot.appendChild(head);
+    Object.keys(yt.channels).sort().forEach((ch) => {
+      const c = yt.channels[ch] || {};
+      const row = h("div", { style: "font-size:13px;color:#cbd5e1;padding:2px 0;" });
+      const delta = c.subscribers_delta_7d;
+      const deltaTxt = (delta == null) ? "" :
+        (" (" + (delta >= 0 ? "+" : "") + delta + " · 7d)");
+      row.textContent = "@" + (ch === "ru" ? "NerraRU" : "NerraNetwork") + ": " +
+        (c.subscribers || 0).toLocaleString() + " subscribers" + deltaTxt +
+        " · " + (c.total_views || 0).toLocaleString() + " total views";
+      audRoot.appendChild(row);
+    });
+    (yt.top_subscriber_videos || []).forEach((v, i) => {
+      const row = h("div", { style: "font-size:12px;color:#94a3b8;padding:2px 0;" });
+      row.textContent = "+" + v.subscribers_gained + " subs · [" + v.show + "/" +
+        v.kind + "] " + (v.title || "").slice(0, 80);
+      audRoot.appendChild(row);
+    });
+  }
+
   const costSparks = $("#cost-sparklines");
   const costPerShow = (data.cost_rollup && data.cost_rollup.per_show) || {};
   shows.forEach((s) => {

--- a/run_show.py
+++ b/run_show.py
@@ -4255,13 +4255,66 @@ def _publish_youtube(
     # cred-less environment never pays the Grok call for titles it can't use.
     yt_title = ""
     yt_title_variants: list = []
-    # Long-form-only artifact — skip the Grok call when the adaptive policy
-    # gates long-form off (Shorts titles come from the per-window headline).
-    if _policy_publish_long and getattr(config.youtube, "optimized_titles", True):
-        try:
-            from engine.youtube_titles import generate_youtube_titles
+    yt_punch_text = ""
+    yt_short_titles: list = []
+    _early_shorts_plan: "list[tuple[float, str, str]]" = []
 
-            yt_title_variants = generate_youtube_titles(
+    # July 18 2026: the transcript find + multi-Shorts window selection are
+    # hoisted ABOVE the title call so ONE Grok "title bundle" call can also
+    # produce a thumbnail punch text and a per-window Short title. The
+    # selected plan is reused by the Shorts section below (single source of
+    # truth — no double-selection drift). find_transcript_for_episode is
+    # side-effect-free.
+    transcript_path = find_transcript_for_episode(
+        digests_dir, config.episode.prefix, episode_num, f"{today:%Y%m%d}",
+    )
+    if (_policy_shorts_count > 1
+            and (getattr(config.youtube, "shorts_start_mode", None) or "voice") == "smart"
+            and getattr(config.youtube, "shorts_start_offset", None) is None
+            and transcript_path is not None):
+        try:
+            from engine.shorts_selector import pick_top_n_engaging_windows
+            from engine.audio import get_audio_duration as _early_dur
+            _voice_off = float(
+                getattr(config.audio, "voice_intro_delay", 0.0) or 0.0)
+            _early_ep_dur = _early_dur(str(final_mp3)) or 0.0
+            _early_windows = pick_top_n_engaging_windows(
+                transcript_path,
+                n=_policy_shorts_count,
+                audio_offset=_voice_off,
+                audio_duration=_early_ep_dur,
+                window_duration=float(
+                    config.youtube.short_duration_seconds or 55.0),
+                min_start_final=_voice_off,
+                min_score_threshold=float(getattr(
+                    config.youtube, "shorts_min_score_threshold", 5.0) or 5.0),
+                fill_to_n=bool(getattr(
+                    config.youtube, "shorts_fill_to_requested", True)),
+            )
+            _early_shorts_plan = [
+                (
+                    w.start_seconds,
+                    (w.opening_text or hook).strip() or hook,
+                    "qualified" if getattr(w, "qualified", True) else "filled",
+                )
+                for w in _early_windows
+            ]
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.warning("Early Shorts window selection failed (%s)", exc)
+            _early_shorts_plan = []
+
+    # One Grok call → long-form title candidates + thumbnail punch text +
+    # per-window Short titles. Runs whenever Shorts OR long-form publish
+    # (Shorts are the growth format, and the shared thumbnail ships even on
+    # shorts-only tiers). Best-effort: empty fields fall back to the legacy
+    # hook-based title / hook thumbnail / opening-text Short headlines.
+    if getattr(config.youtube, "optimized_titles", True):
+        try:
+            from engine.youtube_titles import generate_title_bundle
+
+            _window_texts = ([t for _, t, _ in _early_shorts_plan]
+                             or [hook or ""])
+            _bundle = generate_title_bundle(
                 hook=hook or "",
                 digest_text=digest_text or "",
                 show_name=config.name,
@@ -4269,17 +4322,28 @@ def _publish_youtube(
                 keywords=list(getattr(config, "keywords", []) or []),
                 n=3,
                 perf_dir=digests_dir,
+                short_window_texts=_window_texts,
             )
+            yt_title_variants = list(_bundle.get("titles") or [])
+            yt_punch_text = (
+                str(_bundle.get("punch_text") or "")
+                if getattr(config.youtube, "thumbnail_punch_text", True)
+                else ""
+            )
+            yt_short_titles = list(_bundle.get("short_titles") or [])
             if yt_title_variants:
                 yt_title = yt_title_variants[0]
                 result["youtube_title"] = yt_title
                 result["youtube_title_variants"] = yt_title_variants
-                logger.info(
-                    "YouTube optimized title: %r (%d A/B variants)",
-                    yt_title, len(yt_title_variants),
-                )
+            if yt_punch_text:
+                result["thumbnail_punch_text"] = yt_punch_text
+            logger.info(
+                "YouTube title bundle: title=%r punch=%r short_titles=%d",
+                yt_title or "(fallback)", yt_punch_text or "(none)",
+                len([t for t in yt_short_titles if t]),
+            )
         except Exception as exc:  # noqa: BLE001 — never block a publish
-            logger.warning("Optimized title generation skipped: %s", exc)
+            logger.warning("Title bundle generation skipped: %s", exc)
 
     work_dir = digests_dir / "youtube_tmp"
     work_dir.mkdir(parents=True, exist_ok=True)
@@ -4297,6 +4361,7 @@ def _publish_youtube(
             output_path=thumbnail_path,
             hook=hook,
             show_name=show_label,
+            punch_text=yt_punch_text,
         )
         if _thumb_hook_font is not None:
             result["thumbnail_autofit_font_size"] = int(_thumb_hook_font)
@@ -4305,10 +4370,8 @@ def _publish_youtube(
         thumbnail_path = None  # type: ignore[assignment]
 
     # ---- Build captions SRT (optional — falls back to no captions) ----
+    # (transcript_path was found above the title-bundle call.)
     srt_path = None
-    transcript_path = find_transcript_for_episode(
-        digests_dir, config.episode.prefix, episode_num, f"{today:%Y%m%d}",
-    )
     if transcript_path is not None:
         try:
             srt_candidate = work_dir / f"{base_name}.srt"
@@ -4809,6 +4872,7 @@ def _publish_youtube(
                 output_path=_scene_thumb_out,
                 hook=hook,
                 show_name=show_label,
+                punch_text=yt_punch_text,
             )
             thumbnail_path = _scene_thumb_out
             result["thumbnail_base"] = "scene"
@@ -4837,6 +4901,7 @@ def _publish_youtube(
                 hook=hook,
                 show_name=show_label,
                 count=_n_thumb_variants,
+                punch_text=yt_punch_text,
             )
             _variant_urls: "list[str]" = []
             if _variant_paths:
@@ -4884,6 +4949,7 @@ def _publish_youtube(
             output_path=short_thumbnail_path,
             hook=hook,
             show_name=show_label,
+            punch_text=yt_punch_text,
         )
     except Exception as exc:  # pragma: no cover
         logger.warning("Shorts thumbnail generation failed: %s", exc)
@@ -5036,6 +5102,29 @@ def _publish_youtube(
                     video_id=upload.video_id,
                     playlist_id=playlist_id,
                 )
+            # July 18 2026 (operator-approved): post the pinned-comment
+            # template as a REAL channel comment (it was previously only a
+            # copy-paste block in the description). The API can't pin it —
+            # the operator pins manually — but the channel's own comment
+            # surfaces near the top. Best-effort; 403 = graceful no-op.
+            if bool(getattr(config.youtube, "auto_comment", True)):
+                try:
+                    from engine.video_metadata import build_pinned_comment_text
+                    from engine.youtube import post_video_comment
+                    _pin_text = build_pinned_comment_text(
+                        config, hook=hook, episode_num=episode_num,
+                        today_str=today_str,
+                        rss_link=config.publishing.rss_link or "",
+                        audio_url=audio_url or "",
+                    )
+                    if _pin_text and post_video_comment(
+                            credentials=credentials,
+                            video_id=upload.video_id,
+                            text=_pin_text):
+                        result["yt_comments_posted"] = (
+                            int(result.get("yt_comments_posted", 0)) + 1)
+                except Exception as _exc:  # noqa: BLE001
+                    logger.debug("long-form auto-comment skipped: %s", _exc)
             # Upload the SRT as a real caption track. This is on top of
             # the burned-in captions — gives YouTube the CC button +
             # auto-translation + accessibility search. Best-effort:
@@ -5104,54 +5193,14 @@ def _publish_youtube(
                     or "voice"
                 )
             )
-            shorts_plan: "list[tuple[float, str, str]]" = []
-            if shorts_count_yaml > 1 and mode_resolved == "smart":
-                try:
-                    from engine.shorts_selector import (
-                        pick_top_n_engaging_windows,
-                    )
-                    voice_offset = float(
-                        getattr(config.audio, "voice_intro_delay", 0.0) or 0.0
-                    )
-                    if transcript_path is not None:
-                        shorts_threshold = float(
-                            getattr(getattr(config, "youtube", None), "shorts_min_score_threshold", 5.0) or 5.0
-                        )
-                        # July 18 2026: fill-to-requested. The requested
-                        # count is a policy decision already made — when
-                        # fewer than N windows beat the threshold, ship
-                        # the best available (score >= 0) instead of
-                        # silently under-delivering the network's best-
-                        # performing format (FF shipped 1-of-2 on every
-                        # July episode before this).
-                        _fill = bool(getattr(
-                            config.youtube, "shorts_fill_to_requested", True,
-                        ))
-                        windows = pick_top_n_engaging_windows(
-                            transcript_path,
-                            n=shorts_count_yaml,
-                            audio_offset=voice_offset,
-                            audio_duration=_ep_duration,
-                            window_duration=duration,
-                            min_start_final=voice_offset,
-                            min_score_threshold=shorts_threshold,
-                            fill_to_n=_fill,
-                        )
-                        shorts_plan = [
-                            (
-                                w.start_seconds,
-                                (w.opening_text or hook).strip() or hook,
-                                "qualified" if getattr(w, "qualified", True)
-                                else "filled",
-                            )
-                            for w in windows
-                        ]
-                except Exception as exc:  # pragma: no cover — best-effort
-                    logger.warning(
-                        "Multi-Shorts top-N selection failed (%s) — "
-                        "falling back to single short", exc,
-                    )
-                    shorts_plan = []
+            # July 18 2026: the multi-Shorts windows were selected ONCE,
+            # above the title-bundle call (so Short titles could be
+            # generated from the window texts). Reuse that plan here —
+            # single source of truth, no double-selection drift. The
+            # fill-to-requested behavior (ship the best sub-threshold
+            # windows rather than fewer Shorts) lives in the selector.
+            shorts_plan: "list[tuple[float, str, str]]" = list(
+                _early_shorts_plan)
 
             if not shorts_plan:
                 # Single-Short fallback: legacy resolved offset + the
@@ -5406,12 +5455,19 @@ def _publish_youtube(
                         end_card_duration=_end_card_dur,
                         end_card_image_path=_end_card_image_path,
                     )
+                    # July 18 2026: per-window optimized Short title from
+                    # the title bundle ("" -> legacy opening-text headline).
+                    _opt_short_title = (
+                        yt_short_titles[short_idx]
+                        if short_idx < len(yt_short_titles) else ""
+                    ) or None
                     meta = build_short_metadata(
                         config,
                         episode_num=episode_num,
                         today_str=today_str,
                         hook=this_hook,
                         long_form_url=long_url,
+                        optimized_title=_opt_short_title,
                     )
                     upload_thumb = (
                         this_short_thumb_path
@@ -5467,6 +5523,28 @@ def _publish_youtube(
                                 "Playlist add failed for short #%d: %s",
                                 short_idx + 1, exc,
                             )
+                    # July 18 2026 (operator-approved): channel comment
+                    # with the full-episode link - the strongest Shorts->
+                    # long funnel placement after the description. Cannot
+                    # be pinned via API (operator pins manually); 403 is a
+                    # graceful no-op inside post_video_comment.
+                    if bool(getattr(config.youtube, "auto_comment", True)):
+                        try:
+                            from engine.youtube import post_video_comment
+                            _cmt_target = long_url or (
+                                config.publishing.rss_link or "")
+                            _cmt = ("\u25b6 Full episode: " + _cmt_target
+                                    + "\n\U0001f514 Subscribe for daily "
+                                      "episodes") if _cmt_target else ""
+                            if _cmt and post_video_comment(
+                                    credentials=credentials,
+                                    video_id=this_upload.video_id,
+                                    text=_cmt):
+                                result["yt_comments_posted"] = (
+                                    int(result.get("yt_comments_posted", 0))
+                                    + 1)
+                        except Exception as _exc:  # noqa: BLE001
+                            logger.debug("short auto-comment skipped: %s", _exc)
                     # Multi-platform distribution (Instagram Reels / TikTok).
                     # No-op unless config.youtube.multi_platform_enabled; renders
                     # a safe-zone variant + social.json sidecar, optionally hosts

--- a/run_show.py
+++ b/run_show.py
@@ -5104,7 +5104,7 @@ def _publish_youtube(
                     or "voice"
                 )
             )
-            shorts_plan: "list[tuple[float, str]]" = []
+            shorts_plan: "list[tuple[float, str, str]]" = []
             if shorts_count_yaml > 1 and mode_resolved == "smart":
                 try:
                     from engine.shorts_selector import (
@@ -5117,6 +5117,16 @@ def _publish_youtube(
                         shorts_threshold = float(
                             getattr(getattr(config, "youtube", None), "shorts_min_score_threshold", 5.0) or 5.0
                         )
+                        # July 18 2026: fill-to-requested. The requested
+                        # count is a policy decision already made — when
+                        # fewer than N windows beat the threshold, ship
+                        # the best available (score >= 0) instead of
+                        # silently under-delivering the network's best-
+                        # performing format (FF shipped 1-of-2 on every
+                        # July episode before this).
+                        _fill = bool(getattr(
+                            config.youtube, "shorts_fill_to_requested", True,
+                        ))
                         windows = pick_top_n_engaging_windows(
                             transcript_path,
                             n=shorts_count_yaml,
@@ -5125,11 +5135,14 @@ def _publish_youtube(
                             window_duration=duration,
                             min_start_final=voice_offset,
                             min_score_threshold=shorts_threshold,
+                            fill_to_n=_fill,
                         )
                         shorts_plan = [
                             (
                                 w.start_seconds,
                                 (w.opening_text or hook).strip() or hook,
+                                "qualified" if getattr(w, "qualified", True)
+                                else "filled",
                             )
                             for w in windows
                         ]
@@ -5150,16 +5163,17 @@ def _publish_youtube(
                     audio_duration=_ep_duration,
                     transcript_path=transcript_path,
                 )
-                shorts_plan = [(fallback_offset, hook)]
+                shorts_plan = [(fallback_offset, hook, "legacy_fallback")]
 
             # Surface the resolved plan on the result dict. Single-
             # Short fields stay for backwards compatibility with the
             # dashboard / metrics consumers; the list-shaped fields
             # are new and only useful when len(plan) > 1.
             result["shorts_start_offset"] = round(shorts_plan[0][0], 2)
-            result["shorts_start_offsets"] = [round(o, 2) for o, _ in shorts_plan]
+            result["shorts_start_offsets"] = [round(o, 2) for o, _, _ in shorts_plan]
             result["shorts_start_mode_resolved"] = mode_resolved
             result["shorts_count_requested"] = shorts_count_yaml
+            result["shorts_fill_modes"] = [m for _, _, m in shorts_plan]
 
             # ---- Pre-loop assets shared across every Short ----
             _yt = config.youtube
@@ -5241,7 +5255,7 @@ def _publish_youtube(
             short_video_ids_out: "list[str]" = []
             short_errors_out: "list[dict]" = []
             multi = len(shorts_plan) > 1
-            for short_idx, (this_offset, this_hook) in enumerate(shorts_plan):
+            for short_idx, (this_offset, this_hook, _fill_mode) in enumerate(shorts_plan):
                 # Filename suffix is empty for the single-Short case so
                 # the legacy ``{base}_short.mp4`` path stays exactly the
                 # same when ``shorts_per_episode == 1``.

--- a/scripts/build_gallery_retention.py
+++ b/scripts/build_gallery_retention.py
@@ -100,6 +100,63 @@ def _index_videos(stats: dict) -> tuple:
     return by_id, by_key
 
 
+_MAX_PHRASE_WORDS = 4
+_BOILERPLATE_DOC_FREQ = 0.5  # phrase in >50% of a show's images = boilerplate
+
+
+def _prompt_phrases(prompt: str) -> List[str]:
+    """Comma-split a Grok-Imagine prompt into normalized style phrases."""
+    out: List[str] = []
+    for chunk in (prompt or "").split(","):
+        phrase = " ".join(chunk.lower().split())
+        if not phrase or len(phrase.split()) > _MAX_PHRASE_WORDS:
+            continue
+        out.append(phrase)
+    return out
+
+
+def build_style_tag_index(manifest: Optional[dict]) -> Dict[str, frozenset]:
+    """Per-show boilerplate phrase sets, mined from prompt document frequency.
+
+    July 18 2026: the manifest ``tags`` arrays carry only boilerplate
+    (slug + 'social' + 'grok-imagine'), so the old join produced EMPTY tag
+    summaries — the retention loop collected data but labeled nothing.
+    The real style signal is the ``prompt`` field. Phrases appearing in
+    more than half of a show's images (the shared descriptor suffix like
+    "cinematic", "ultra-detailed", "wide cinematic 16:9 framing") are
+    boilerplate and excluded, with no hand-curated stoplist to maintain.
+    """
+    counts: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    totals: Dict[str, int] = defaultdict(int)
+    for entry in (manifest or {}).get("images") or []:
+        slug = entry.get("show_slug") or ""
+        if not slug:
+            continue
+        totals[slug] += 1
+        for phrase in set(_prompt_phrases(entry.get("prompt") or "")):
+            counts[slug][phrase] += 1
+    boilerplate: Dict[str, frozenset] = {}
+    for slug, phrases in counts.items():
+        total = max(1, totals[slug])
+        boilerplate[slug] = frozenset(
+            p for p, c in phrases.items()
+            if c / total > _BOILERPLATE_DOC_FREQ
+        )
+    return boilerplate
+
+
+def _style_tags(entry: dict, boilerplate: frozenset) -> List[str]:
+    """Distinctive style tags for one image: prompt phrases minus
+    boilerplate, plus any non-generic manifest tags."""
+    slug = entry.get("show_slug") or ""
+    tags = [p for p in _prompt_phrases(entry.get("prompt") or "")
+            if p not in boilerplate and p != slug]
+    for t in entry.get("tags") or []:
+        if t and t != slug and t not in _GENERIC_TAGS and t not in tags:
+            tags.append(t)
+    return tags
+
+
 def build(manifest: Optional[dict], stats: Optional[dict],
           *, min_videos: int = 3) -> dict:
     """Compose the retention join. Empty ``shows`` when either side is absent."""
@@ -115,6 +172,7 @@ def build(manifest: Optional[dict], stats: Optional[dict],
     if not by_id:
         return payload
 
+    boilerplate_by_show = build_style_tag_index(manifest)
     shows: Dict[str, dict] = {}
     # tag → list of (video_id, retention) per show, deduped by video so a
     # 4-image episode doesn't count its one video 4 times per tag.
@@ -135,8 +193,7 @@ def build(manifest: Optional[dict], stats: Optional[dict],
         if video is None:
             continue
         retention = float(video.get("average_view_percentage") or 0.0)
-        tags = [t for t in (entry.get("tags") or [])
-                if t and t != slug and t not in _GENERIC_TAGS]
+        tags = _style_tags(entry, boilerplate_by_show.get(slug, frozenset()))
         shows.setdefault(slug, {"images": {}, "summary": {}})
         shows[slug]["images"][image_id] = {
             "video_id": video.get("video_id"),

--- a/scripts/fetch_youtube_analytics.py
+++ b/scripts/fetch_youtube_analytics.py
@@ -66,9 +66,20 @@ _METRICS = [
     "estimatedMinutesWatched",
     "averageViewDuration",
     "averageViewPercentage",
+    # July 18 2026 — the growth metric the operator actually wants to
+    # move. Valid with dimensions=video in Analytics v2 (impressions/CTR
+    # remain Studio-only and are still intentionally omitted).
+    "subscribersGained",
+    "subscribersLost",
 ]
 # Analytics API allows up to 500 ids in a single video== filter.
 _BATCH = 200
+
+# Daily channel-level snapshot history (subscribers, total views) —
+# appended once per run, deduped on (date, channel), capped so the file
+# never grows unbounded.
+_CHANNEL_HISTORY_PATH = "api/youtube_channel_history.json"
+_CHANNEL_HISTORY_MAX_ROWS = 800
 
 
 def _load_index(digests_dir: Path) -> List[dict]:
@@ -168,6 +179,88 @@ def _query_batch(service, video_ids: List[str], start: str, end: str) -> Dict[st
     return out
 
 
+def _channel_snapshot(credentials) -> Optional[dict]:
+    """Channel-level statistics via the Data API (subs, total views).
+
+    July 18 2026: subscribers were previously tracked NOWHERE — growth
+    was judged purely on per-video views/retention. Best-effort: None on
+    any failure.
+    """
+    try:
+        from googleapiclient.discovery import build
+        service = build("youtube", "v3", credentials=credentials,
+                        cache_discovery=False)
+        resp = service.channels().list(part="statistics", mine=True).execute()
+        items = resp.get("items") or []
+        if not items:
+            return None
+        stats = items[0].get("statistics") or {}
+        return {
+            "subscribers": int(stats.get("subscriberCount", 0) or 0),
+            "total_views": int(stats.get("viewCount", 0) or 0),
+            "video_count": int(stats.get("videoCount", 0) or 0),
+        }
+    except Exception as exc:  # noqa: BLE001 — optional read, never fatal
+        logger.warning("Channel snapshot failed: %s", str(exc)[:200])
+        return None
+
+
+def _channel_day_series(service, days: int = 30) -> List[dict]:
+    """Channel-level daily views/subscribersGained series (Analytics v2).
+
+    Empty list on any failure — the per-video fetch is the primary read.
+    """
+    try:
+        today = _dt.date.today()
+        start = (today - _dt.timedelta(days=days)).isoformat()
+        resp = service.reports().query(
+            ids="channel==MINE",
+            startDate=start,
+            endDate=today.isoformat(),
+            metrics="views,subscribersGained,subscribersLost",
+            dimensions="day",
+            sort="day",
+        ).execute()
+        headers = [h["name"] for h in resp.get("columnHeaders", [])]
+        return [dict(zip(headers, row)) for row in resp.get("rows", []) or []]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Channel day-series query failed: %s", str(exc)[:200])
+        return []
+
+
+def append_channel_history(channels: Dict[str, dict],
+                           path: Path) -> None:
+    """Append today's per-channel snapshot rows (idempotent per day).
+
+    Rows: {date, channel, subscribers, total_views}. Re-runs on the same
+    day replace that day's rows instead of duplicating them.
+    """
+    today = _dt.date.today().isoformat()
+    rows: List[dict] = []
+    try:
+        existing = json.loads(path.read_text(encoding="utf-8"))
+        rows = list(existing.get("rows", []))
+    except Exception:  # noqa: BLE001 — first run / unreadable = start fresh
+        rows = []
+    rows = [r for r in rows
+            if not (r.get("date") == today and r.get("channel") in channels)]
+    for channel, snap in sorted(channels.items()):
+        if not snap:
+            continue
+        rows.append({
+            "date": today,
+            "channel": channel,
+            "subscribers": snap.get("subscribers", 0),
+            "total_views": snap.get("total_views", 0),
+        })
+    rows = rows[-_CHANNEL_HISTORY_MAX_ROWS:]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"rows": rows}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
 def fetch(digests_dir: Path, days: int) -> Optional[dict]:
     """Build the stats payload, or None if there is nothing to do."""
     videos = _load_index(digests_dir)
@@ -190,6 +283,7 @@ def fetch(digests_dir: Path, days: int) -> Optional[dict]:
         by_channel[(v.get("channel") or "en").lower()].append(v)
 
     metrics_by_video: Dict[str, dict] = {}
+    channels_block: Dict[str, dict] = {}
     any_data = False
     for channel, rows in by_channel.items():
         creds = get_channel_credentials_from_env(channel)
@@ -206,6 +300,12 @@ def fetch(digests_dir: Path, days: int) -> Optional[dict]:
             if got:
                 any_data = True
             metrics_by_video.update(got)
+        # Channel-level snapshot + 30-day day-series (subs growth).
+        snap = _channel_snapshot(creds) or {}
+        series = _channel_day_series(service)
+        if snap or series:
+            snap["day_series"] = series
+            channels_block[channel] = snap
 
     if not any_data:
         logger.info("No analytics returned (no scope / no data yet) — no-op")
@@ -233,12 +333,20 @@ def fetch(digests_dir: Path, days: int) -> Optional[dict]:
             "estimated_minutes_watched": float(m.get("estimatedMinutesWatched", 0) or 0),
             "average_view_duration_s": float(m.get("averageViewDuration", 0) or 0),
             "average_view_percentage": float(m.get("averageViewPercentage", 0) or 0),
+            "subscribers_gained": int(float(m.get("subscribersGained", 0) or 0)),
+            "subscribers_lost": int(float(m.get("subscribersLost", 0) or 0)),
         })
 
     return {
-        "schema_version": 1,
+        # v2 (July 18 2026): adds the top-level "channels" block
+        # (per-channel subscriber snapshot + 30d day-series) and
+        # per-video subscribers_gained/lost. The "shows" shape is
+        # unchanged, so every existing consumer (performance updater,
+        # policy builder, gallery retention) keeps working.
+        "schema_version": 2,
         "generated": _dt.datetime.now(_dt.timezone.utc).isoformat(),
         "window_days": days,
+        "channels": channels_block,
         "shows": shows,
     }
 
@@ -262,6 +370,15 @@ def main() -> int:
     if args.dry_run:
         print(json.dumps(payload, indent=2, ensure_ascii=False)[:4000])
         return 0
+
+    if payload.get("channels"):
+        append_channel_history(
+            payload["channels"], _ROOT / _CHANNEL_HISTORY_PATH,
+        )
+        logger.info(
+            "Channel history appended: %s",
+            {c: s.get("subscribers") for c, s in payload["channels"].items()},
+        )
 
     out_path = _ROOT / args.out
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1751,6 +1751,72 @@ def build_audience_section(root: Path) -> Dict[str, Any]:
         except Exception as exc:  # noqa: BLE001
             section["newsletter"] = {"configured": True, "error": str(exc)}
 
+    # July 18 2026 — YouTube channel growth (subscribers were previously
+    # tracked NOWHERE). Reads the channels block written by
+    # fetch_youtube_analytics (schema v2) + the daily snapshot history for
+    # the 7-day delta, plus the top subscriber-driving videos.
+    section["youtube"] = {"configured": False}
+    yt_path = root / "api" / "youtube_stats.json"
+    if yt_path.exists():
+        try:
+            data = json.loads(yt_path.read_text(encoding="utf-8"))
+            channels = data.get("channels") or {}
+            hist_rows: List[dict] = []
+            hist_path = root / "api" / "youtube_channel_history.json"
+            if hist_path.exists():
+                try:
+                    hist_rows = json.loads(
+                        hist_path.read_text(encoding="utf-8")).get("rows", [])
+                except Exception:  # noqa: BLE001
+                    hist_rows = []
+
+            def _delta_7d(channel: str, current: int) -> Optional[int]:
+                cutoff = (_dt.date.today()
+                          - _dt.timedelta(days=7)).isoformat()
+                older = [r for r in hist_rows
+                         if r.get("channel") == channel
+                         and str(r.get("date", "")) <= cutoff]
+                if not older:
+                    return None
+                base = older[-1].get("subscribers")
+                return current - int(base) if base is not None else None
+
+            per_channel = {}
+            for ch, snap in channels.items():
+                subs = int(snap.get("subscribers", 0) or 0)
+                per_channel[ch] = {
+                    "subscribers": subs,
+                    "subscribers_delta_7d": _delta_7d(ch, subs),
+                    "total_views": snap.get("total_views"),
+                    "video_count": snap.get("video_count"),
+                }
+            top_converters = sorted(
+                (
+                    {
+                        "show": dir_name,
+                        "title": v.get("title", ""),
+                        "kind": v.get("kind", ""),
+                        "channel": v.get("channel", "en"),
+                        "subscribers_gained": v.get("subscribers_gained", 0),
+                        "views": v.get("views", 0),
+                    }
+                    for dir_name, s in (data.get("shows") or {}).items()
+                    for v in s.get("videos", [])
+                    if int(v.get("subscribers_gained", 0) or 0) > 0
+                ),
+                key=lambda r: r["subscribers_gained"],
+                reverse=True,
+            )[:5]
+            if per_channel or top_converters:
+                section["youtube"] = {
+                    "configured": True,
+                    "generated": data.get("generated"),
+                    "channels": per_channel,
+                    "top_subscriber_videos": top_converters,
+                }
+        except Exception as exc:  # noqa: BLE001
+            section["youtube"] = {"configured": True, "error": str(exc)}
+
     return section
 
 

--- a/scripts/update_youtube_performance.py
+++ b/scripts/update_youtube_performance.py
@@ -68,7 +68,17 @@ def _build_hint(videos: List[dict]) -> str:
              and (v.get("channel") or "en").lower() == "en"]
     if len(rated) < _MIN_VIDEOS:
         return ""
-    rated.sort(key=lambda v: v.get("average_view_percentage", 0), reverse=True)
+    # July 18 2026: rank by retention BLENDED with subscribers gained —
+    # one subscriber ≈ 5 retention points (subs-gained is a small integer
+    # on this channel; the multiplier makes a converting video outrank a
+    # merely-watched one without letting a single sub dominate).
+    rated.sort(
+        key=lambda v: (
+            float(v.get("average_view_percentage", 0) or 0)
+            + 5.0 * float(v.get("subscribers_gained", 0) or 0)
+        ),
+        reverse=True,
+    )
     top = rated[: max(3, len(rated) // 4)]  # top quartile (min 3)
     median_pct = sorted(v["average_view_percentage"] for v in rated)[len(rated) // 2]
 
@@ -90,6 +100,13 @@ def _build_hint(videos: List[dict]) -> str:
     if examples:
         parts.append("Highest-retention titles so far: "
                      + " | ".join(f'"{t}"' for t in examples) + ".")
+    # Subscriber-converting titles are the strongest possible exemplars.
+    converters = [v["title"] for v in rated
+                  if float(v.get("subscribers_gained", 0) or 0) > 0
+                  and v.get("title")][:2]
+    if converters:
+        parts.append("Titles that converted subscribers: "
+                     + " | ".join(f'"{t}"' for t in converters) + ".")
     parts.append(
         f"Median retention is {median_pct:.0f}% — beat it: keep the promise "
         "concrete and front-load the strongest entity."

--- a/scripts/update_youtube_policy.py
+++ b/scripts/update_youtube_policy.py
@@ -60,7 +60,14 @@ logger = logging.getLogger("update_youtube_policy")
 # ---- Tunables -------------------------------------------------------------
 WINDOW_DAYS = 14            # velocity window (days before the stats snapshot)
 MIN_VIDEOS_CONFIDENT = 4    # per kind — below this, hold the active setting
-LONG_VPD_FLOOR = 1.0        # avg views/day to keep long-form on
+# July 18 2026 (operator decision): the long-form floor is CHANNEL-specific.
+# RU long-form earned 435 views across 68 videos (~9% retention) while RU
+# Shorts carried 7,028 — an RU long_vpd of ~1.2 is noise, not
+# product-market fit, so the RU channel must clear a higher bar to spend a
+# daily long-form render. The MECHANISM (velocity + hysteresis + Monday
+# probe) stays identical on both channels, so a show can always re-earn
+# long-form through the weekly probe data.
+LONG_VPD_FLOOR: Dict[str, float] = {"en": 1.0, "ru": 2.0}
 SHORT_VPD_TWO = 4.0         # avg views/day to earn a 2nd Short
 SHORT_VPD_PROBE = 0.5       # below this, shorts-only reads as "probe" (D)
 STREAK_TO_FLIP = 2          # consecutive identical computed tiers to flip
@@ -149,6 +156,7 @@ def compute_tier(
     long_vpds: List[float],
     short_vpds: List[float],
     active_tier: str,
+    channel: str = "en",
 ) -> Tuple[str, Optional[float], Optional[float], str]:
     """Computed tier for one show x channel, holding insufficient dimensions.
 
@@ -159,11 +167,13 @@ def compute_tier(
     long-form data).
     """
     active_long, active_shorts = TIER_SETTINGS.get(active_tier, (False, 1))
+    long_floor = LONG_VPD_FLOOR.get((channel or "en").lower(),
+                                    LONG_VPD_FLOOR["en"])
 
     long_vpd = _avg(long_vpds) if len(long_vpds) >= MIN_VIDEOS_CONFIDENT else None
     short_vpd = _avg(short_vpds) if len(short_vpds) >= MIN_VIDEOS_CONFIDENT else None
 
-    publish_long = (long_vpd >= LONG_VPD_FLOOR) if long_vpd is not None else active_long
+    publish_long = (long_vpd >= long_floor) if long_vpd is not None else active_long
     shorts = ((2 if short_vpd >= SHORT_VPD_TWO else 1)
               if short_vpd is not None else active_shorts)
 
@@ -173,7 +183,7 @@ def compute_tier(
                        f"{MIN_VIDEOS_CONFIDENT} in {WINDOW_DAYS}d)")
     else:
         reasons.append(f"long_vpd {long_vpd:.2f} "
-                       f"{'>=' if publish_long else '<'} {LONG_VPD_FLOOR}")
+                       f"{'>=' if publish_long else '<'} {long_floor}")
     if short_vpd is None:
         reasons.append(f"shorts held ({len(short_vpds)} videos < "
                        f"{MIN_VIDEOS_CONFIDENT} in {WINDOW_DAYS}d)")
@@ -252,7 +262,7 @@ def build_policy(
                     and prev_entry.get("tier") in TIER_SETTINGS else seed
                 )
                 computed, long_vpd, short_vpd, reason = compute_tier(
-                    long_vpds, short_vpds, active_for_hold)
+                    long_vpds, short_vpds, active_for_hold, channel)
             else:
                 computed, long_vpd, short_vpd = seed, None, None
                 reason = "no stats data — holding seed tier."

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -309,6 +309,11 @@ youtube:
   enabled: true
   publish_long_form: true       # Flipped on with the 200k quota grant (June 2026)
   shorts_start_mode: smart
+  # July 18 2026: parity with the Tesla/SpaceX May-2026 retune. FF's calm
+  # science prose rarely beats the default 5.0 (kicker-phrase-driven
+  # scorer), so every July episode fell back to the 10.0s voice start
+  # and shipped 1-of-2 Shorts.
+  shorts_min_score_threshold: 3.5
   short_duration_seconds: 40
   channel: en
   # Russian-dubbed video to @NerraRU from the auto-generated `ru` audio

--- a/shows/prompts/_shared/youtube_title_bundle.txt
+++ b/shows/prompts/_shared/youtube_title_bundle.txt
@@ -1,0 +1,51 @@
+You are a YouTube packaging specialist writing the packaging for one episode
+of a podcast/video show: the long-form TITLE candidates, a THUMBNAIL punch
+text, and a title for each Short clip. Nothing else.
+
+SHOW: {show_name}
+EPISODE: {episode_num}
+SPOKEN HOOK (the on-air opener — for context, do NOT just copy it): {hook}
+TOPIC KEYWORDS: {keywords}
+EPISODE CONTENT (excerpt):
+{digest_excerpt}
+{performance_hint}
+SHORT CLIP OPENINGS (each Short starts with these spoken words):
+{short_windows}
+
+OUTPUT FORMAT — exactly these labeled lines, nothing else:
+TITLE: <long-form title candidate>        (write {n} TITLE lines, best first)
+PUNCH: <2-4 word ALL-CAPS thumbnail text>
+SHORT1: <title for Short clip 1>
+SHORT2: <title for Short clip 2>          (only if a second opening is listed)
+
+LONG-FORM TITLE RULES (2025-2026 YouTube best practice):
+- Front-load the most search-relevant keyword/entity in the FIRST 3-4 words
+  (YouTube weights the opening words for search and viewers scan the start).
+- Aim for 45-65 characters; never exceed 90. Shorter, punchier wins.
+- Open a curiosity gap or state a concrete, specific stakes/consequence —
+  but stay HONEST. The 2026 algorithm rewards titles whose promise the
+  episode actually keeps (retention-gated "Quality CTR"); clickbait that
+  isn't paid off gets demoted. Do not overpromise.
+- Prefer a concrete number, name, or specific claim over vague hype.
+- Use the real entities/topics from the content above. Never invent facts,
+  numbers, or events that aren't in the episode content.
+- No clickbait ALL CAPS in titles, no "you won't believe", no emoji, no
+  hashtags, no surrounding quotes, no angle brackets (< >), no show name
+  appended (that's added automatically).
+- Each candidate must be meaningfully different (different angle/keyword
+  lead), not minor rewordings of the same sentence.
+
+PUNCH TEXT RULES (renders HUGE on the thumbnail):
+- 2 to 4 words, ALL CAPS, maximum ~24 characters total.
+- The single most arresting concrete fact of the episode: an entity plus a
+  number or a sharp claim ("ROBOTAXI FLEET +50%", "STARSHIP ABORTED",
+  "PENSION AGE RISING"). Numbers and symbols (+, %, $) are excellent.
+- Must be TRUE and paid off by the episode. Never generic words like
+  "BREAKING", "SHOCKING", "NEWS".
+
+SHORT TITLE RULES (one per listed clip opening):
+- ≤60 characters, punchy, honest, front-loaded entity; written from THAT
+  clip's opening words (each Short covers a different moment).
+- No "#Shorts" suffix (added automatically), no emoji, no quotes.
+
+Output ONLY the labeled lines described above.

--- a/tests/test_ru_dub.py
+++ b/tests/test_ru_dub.py
@@ -95,8 +95,11 @@ class TestShortParity:
         src = (Path(ru_dub.__file__)).read_text(encoding="utf-8")
         # Transcribe the RU audio in Russian.
         assert "generate_transcript(" in src and 'language="ru"' in src
-        # Smart engaging-beat start + per-word ASS captions.
-        assert "pick_engaging_window(" in src
+        # Smart engaging-beat starts + per-word ASS captions. July 18
+        # 2026: single-window selection upgraded to top-N (up to 2 RU
+        # Shorts when the policy asks) with fill-to-requested.
+        assert "pick_top_n_engaging_windows(" in src
+        assert "fill_to_n=True" in src
         assert "transcript_to_ass_window(" in src
         assert "subtitles_path=ass_path" in src
         # End-card CTA on the short.

--- a/tests/test_shorts_selector.py
+++ b/tests/test_shorts_selector.py
@@ -520,3 +520,91 @@ def test_pick_top_n_respects_min_start_final(tmp_path):
         min_start_final=10.0, window_duration=55.0,
     )
     assert out == []
+
+
+class TestFillToRequested:
+    """July 18 2026: fill-to-requested — the multi-Shorts selector ships
+    the best available sub-threshold windows instead of fewer Shorts."""
+
+    @staticmethod
+    def _write_transcript(tmp_path, segments):
+        import json
+        p = tmp_path / "tr.json"
+        p.write_text(json.dumps({"segments": segments}), encoding="utf-8")
+        return p
+
+    def _segments(self):
+        # One strong beat early, mediocre prose later — mimics the FF
+        # failure shape (only one window beats a high threshold).
+        segs = [{
+            "start": 0.0, "end": 8.0,
+            "text": ("Here's the kicker: profits jumped fifty percent to "
+                     "ten million dollars in one day."),
+        }]
+        t = 8.0
+        filler = [
+            "The mission continued with routine operations throughout.",
+            "Engineers reviewed the data and confirmed the results.",
+            "The team documented findings for the next review cycle.",
+            "Observations continued as the spacecraft passed overhead.",
+            "Analysts noted steady progress on the program milestones.",
+        ] * 7
+        for txt in filler:
+            segs.append({"start": t, "end": t + 8.0, "text": txt})
+            t += 8.0
+        return segs
+
+    def test_fill_returns_requested_count(self, tmp_path):
+        from engine.shorts_selector import pick_top_n_engaging_windows
+        tr = self._write_transcript(tmp_path, self._segments())
+        wins = pick_top_n_engaging_windows(
+            tr, n=2, audio_offset=0.0, audio_duration=300.0,
+            window_duration=40.0, min_score_threshold=5.0, fill_to_n=True,
+        )
+        assert len(wins) == 2
+        modes = sorted(w.qualified for w in wins)
+        assert modes == [False, True], (
+            "expected one qualified + one filled window")
+
+    def test_no_fill_preserves_legacy_behavior(self, tmp_path):
+        from engine.shorts_selector import pick_top_n_engaging_windows
+        tr = self._write_transcript(tmp_path, self._segments())
+        wins = pick_top_n_engaging_windows(
+            tr, n=2, audio_offset=0.0, audio_duration=300.0,
+            window_duration=40.0, min_score_threshold=5.0, fill_to_n=False,
+        )
+        assert len(wins) == 1  # only the strong beat qualifies
+        assert all(w.qualified for w in wins)
+
+    def test_negative_scores_never_fill(self, tmp_path):
+        from engine.shorts_selector import pick_top_n_engaging_windows
+        segs = [
+            {"start": 0.0, "end": 8.0,
+             "text": "Here's the kicker: profits doubled to ten million."},
+            # A boring-opener window (negative score) far from the first.
+            {"start": 120.0, "end": 128.0,
+             "text": "Welcome to the show, today on the show we talk."},
+        ]
+        tr = self._write_transcript(tmp_path, segs)
+        wins = pick_top_n_engaging_windows(
+            tr, n=2, audio_offset=0.0, audio_duration=200.0,
+            window_duration=40.0, min_score_threshold=5.0, fill_to_n=True,
+        )
+        assert all(w.score >= 0 for w in wins)
+
+    def test_scored_window_defaults_qualified(self):
+        from engine.shorts_selector import ScoredWindow
+        w = ScoredWindow(0.0, 40.0, 5.0)
+        assert w.qualified is True
+
+    def test_config_flag_exists(self):
+        from engine.config import YouTubeConfig
+        assert YouTubeConfig().shorts_fill_to_requested is True
+
+    def test_ff_threshold_parity(self):
+        import yaml as _yaml
+        from pathlib import Path
+        cfg = _yaml.safe_load(
+            (Path(__file__).resolve().parent.parent
+             / "shows/fascinating_frontiers.yaml").read_text(encoding="utf-8"))
+        assert cfg["youtube"]["shorts_min_score_threshold"] == 3.5

--- a/tests/test_youtube_growth_pass.py
+++ b/tests/test_youtube_growth_pass.py
@@ -1,0 +1,266 @@
+"""Drift guards for the July 18 2026 YouTube growth pass.
+
+Workstreams pinned here:
+  - title bundle (one Grok call → long titles + thumbnail punch + Short
+    titles) with graceful parsing fallbacks
+  - punch-text thumbnails (legacy rendering when punch is empty)
+  - auto-comments (post_video_comment contract + config gates)
+  - analytics schema v2 (subscriber metrics + channel history)
+  - channel-specific RU long-form floor in the adaptive policy
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Title bundle
+# ---------------------------------------------------------------------------
+
+class TestTitleBundle:
+    def _patch_grok(self, monkeypatch, text):
+        import engine.generator as gen
+        monkeypatch.setattr(gen, "_call_grok",
+                            lambda *a, **k: (text, {}))
+
+    def test_bundle_happy_path(self, monkeypatch):
+        from engine.youtube_titles import generate_title_bundle
+        self._patch_grok(monkeypatch, (
+            "TITLE: Tesla Robotaxi Fleet Grows 50% in One Day\n"
+            "TITLE: Why Tesla Just Scaled Robotaxis Overnight\n"
+            "TITLE: Robotaxi Expansion Hits Texas Streets\n"
+            "PUNCH: ROBOTAXI FLEET +50%\n"
+            "SHORT1: Robotaxi fleet up 50% overnight\n"
+            "SHORT2: The unsupervised-miles milestone\n"
+        ))
+        out = generate_title_bundle(
+            hook="h", digest_text="d", show_name="S", episode_num=1,
+            short_window_texts=["window one text", "window two text"],
+        )
+        assert len(out["titles"]) == 3
+        assert out["punch_text"] == "ROBOTAXI FLEET +50%"
+        assert out["short_titles"] == [
+            "Robotaxi fleet up 50% overnight",
+            "The unsupervised-miles milestone",
+        ]
+
+    def test_bundle_malformed_output_returns_empty_fields(self, monkeypatch):
+        from engine.youtube_titles import generate_title_bundle
+        self._patch_grok(monkeypatch, "complete nonsense with no labels")
+        out = generate_title_bundle(
+            hook="h", digest_text="d", show_name="S", episode_num=1,
+            short_window_texts=["w"],
+        )
+        assert out["titles"] == []
+        assert out["punch_text"] == ""
+        assert out["short_titles"] == [""]
+
+    def test_bundle_call_failure_never_raises(self, monkeypatch):
+        import engine.generator as gen
+        from engine.youtube_titles import generate_title_bundle
+        def _boom(*a, **k):
+            raise RuntimeError("api down")
+        monkeypatch.setattr(gen, "_call_grok", _boom)
+        out = generate_title_bundle(
+            hook="h", digest_text="d", show_name="S", episode_num=1,
+        )
+        assert out == {"titles": [], "punch_text": "", "short_titles": []}
+
+    def test_punch_cleaning_rejects_junk(self):
+        from engine.youtube_titles import _clean_punch
+        assert _clean_punch("robotaxi fleet +50%") == "ROBOTAXI FLEET +50%"
+        assert _clean_punch("BREAKING") == ""            # single hype word
+        assert _clean_punch("BREAKING NEWS") == ""       # generic hype
+        assert _clean_punch("A" * 40) == ""              # too long
+        assert _clean_punch(
+            "ONE TWO THREE FOUR FIVE") == ""             # too many words
+
+    def test_bundle_prompt_exists_and_has_labels(self):
+        text = (_ROOT / "shows/prompts/_shared/youtube_title_bundle.txt"
+                ).read_text(encoding="utf-8")
+        for label in ("TITLE:", "PUNCH:", "SHORT1:", "{short_windows}",
+                      "{performance_hint}"):
+            assert label in text
+
+    def test_legacy_titles_function_untouched(self, monkeypatch):
+        # The old single-purpose call must keep working as the fallback.
+        from engine.youtube_titles import generate_youtube_titles
+        self._patch_grok(monkeypatch, "Great Title About Things\n")
+        out = generate_youtube_titles(
+            hook="h", digest_text="d", show_name="S", episode_num=1, n=1,
+        )
+        assert out == ["Great Title About Things"]
+
+
+# ---------------------------------------------------------------------------
+# Punch-text thumbnails
+# ---------------------------------------------------------------------------
+
+class TestPunchThumbnail:
+    def _base_image(self, tmp_path):
+        from PIL import Image
+        p = tmp_path / "base.jpg"
+        Image.new("RGB", (1280, 720), (30, 60, 90)).save(p)
+        return p
+
+    def test_punch_uses_larger_font_than_hook(self, tmp_path):
+        from engine.publisher import generate_episode_thumbnail
+        base = self._base_image(tmp_path)
+        _, hook_font = generate_episode_thumbnail(
+            base, 1, "Jul 18", tmp_path / "hook.jpg",
+            hook="Tesla's robotaxi fleet grew fifty percent in a single day",
+            show_name="Show",
+        )
+        _, punch_font = generate_episode_thumbnail(
+            base, 1, "Jul 18", tmp_path / "punch.jpg",
+            hook="Tesla's robotaxi fleet grew fifty percent in a single day",
+            show_name="Show",
+            punch_text="ROBOTAXI +50%",
+        )
+        assert punch_font is not None and hook_font is not None
+        assert punch_font > hook_font
+
+    def test_empty_punch_is_exact_legacy_path(self, tmp_path):
+        from engine.publisher import generate_episode_thumbnail
+        base = self._base_image(tmp_path)
+        p1, f1 = generate_episode_thumbnail(
+            base, 1, "Jul 18", tmp_path / "a.jpg", hook="Some hook",
+            show_name="Show",
+        )
+        p2, f2 = generate_episode_thumbnail(
+            base, 1, "Jul 18", tmp_path / "b.jpg", hook="Some hook",
+            show_name="Show", punch_text="",
+        )
+        assert f1 == f2
+        assert p1.read_bytes() == p2.read_bytes()
+
+    def test_config_flag_default_true(self):
+        from engine.config import YouTubeConfig
+        assert YouTubeConfig().thumbnail_punch_text is True
+
+
+# ---------------------------------------------------------------------------
+# Auto-comments
+# ---------------------------------------------------------------------------
+
+class TestAutoComment:
+    def test_post_video_comment_never_raises_on_failure(self):
+        from engine.youtube import post_video_comment
+        # No credentials → build() blows up internally → None, no raise.
+        assert post_video_comment(
+            credentials=None, video_id="abc", text="hi") is None
+
+    def test_empty_text_or_video_is_noop(self):
+        from engine.youtube import post_video_comment
+        assert post_video_comment(
+            credentials=None, video_id="", text="hi") is None
+        assert post_video_comment(
+            credentials=None, video_id="abc", text="  ") is None
+
+    def test_config_flag_default_true(self):
+        from engine.config import YouTubeConfig
+        assert YouTubeConfig().auto_comment is True
+
+    def test_pinned_comment_helper_shared_with_description(self):
+        from types import SimpleNamespace
+        from engine.video_metadata import build_pinned_comment_text
+        cfg = SimpleNamespace(youtube=SimpleNamespace(
+            pinned_comment_template="Ep {episode_num}: {hook} — {full_episode_url}",
+        ))
+        out = build_pinned_comment_text(
+            cfg, hook="Big story", episode_num=7,
+            audio_url="https://x/audio.mp3",
+        )
+        assert out == "Ep 7: Big story — https://x/audio.mp3"
+
+    def test_run_show_wires_comments(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "post_video_comment" in src
+        assert "build_pinned_comment_text" in src
+        assert "auto_comment" in src
+
+    def test_ru_dub_comment_only_with_ru_long(self):
+        src = (_ROOT / "engine/ru_dub.py").read_text(encoding="utf-8")
+        assert "post_video_comment" in src
+        assert "Полный выпуск" in src
+        # The gate: never link an English video from a Russian Short.
+        assert "if long_url and bool(getattr(yt, \"auto_comment\"" in src
+
+
+# ---------------------------------------------------------------------------
+# Analytics v2 + channel history
+# ---------------------------------------------------------------------------
+
+class TestAnalyticsV2:
+    def _mod(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "fya", _ROOT / "scripts/fetch_youtube_analytics.py")
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        return m
+
+    def test_metrics_include_subscribers(self):
+        m = self._mod()
+        assert "subscribersGained" in m._METRICS
+        assert "subscribersLost" in m._METRICS
+
+    def test_channel_history_append_idempotent(self, tmp_path):
+        m = self._mod()
+        path = tmp_path / "hist.json"
+        snap = {"en": {"subscribers": 10, "total_views": 100}}
+        m.append_channel_history(snap, path)
+        m.append_channel_history(snap, path)  # same day re-run
+        rows = json.loads(path.read_text())["rows"]
+        assert len(rows) == 1
+        assert rows[0]["subscribers"] == 10
+
+    def test_performance_hint_blends_subscribers(self):
+        src = (_ROOT / "scripts/update_youtube_performance.py"
+               ).read_text(encoding="utf-8")
+        assert "subscribers_gained" in src
+
+    def test_dashboard_has_youtube_channels_block(self):
+        src = (_ROOT / "scripts/generate_dashboard.py"
+               ).read_text(encoding="utf-8")
+        assert "youtube_channel_history.json" in src
+        assert "top_subscriber_videos" in src
+
+
+# ---------------------------------------------------------------------------
+# Channel-specific long-form floor
+# ---------------------------------------------------------------------------
+
+class TestChannelLongFloor:
+    def _mod(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "uyp", _ROOT / "scripts/update_youtube_policy.py")
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        return m
+
+    def test_floors(self):
+        m = self._mod()
+        assert m.LONG_VPD_FLOOR["en"] == 1.0
+        assert m.LONG_VPD_FLOOR["ru"] == 2.0
+
+    def test_ru_needs_higher_velocity_for_long(self):
+        m = self._mod()
+        vpds = [1.5] * 6  # 1.5 vpd across 6 videos
+        tier_en, *_ = m.compute_tier(vpds, [3.0] * 6, "C", "en")
+        tier_ru, *_ = m.compute_tier(vpds, [3.0] * 6, "C", "ru")
+        assert tier_en in ("A", "B")   # 1.5 >= 1.0 → long on
+        assert tier_ru in ("C", "D")   # 1.5 < 2.0 → long stays off
+
+    def test_ru_clears_higher_bar(self):
+        m = self._mod()
+        tier_ru, *_ = m.compute_tier([2.5] * 6, [5.0] * 6, "C", "ru")
+        assert tier_ru == "A"


### PR DESCRIPTION
# Summary

Two parts: how the July 14–16 YouTube changes performed, and the next round of growth levers (per your four decisions: no scheduled publishing, yes auto-comments, yes punch-text thumbnails, yes raised RU long-form bar). Full review: `docs/reviews/youtube_growth_review_2026_07_18.md`.

## Part 1 — how the recent changes worked out

- **Adaptive policy: working exactly as designed.** All 6 EN C-tier shows skip the long-form render (quota 3,800→1,700/ep) with Shorts still shipping; hysteresis stable (omni_view promoted C→B; RU FF promoted to A). The cut cost nothing — those longs were earning 6–13% retention and single-digit weekly views.
- **RU title fix: clean cutover** — since Jul 18 all @NerraRU uploads carry translated optimized headlines.
- **The analytics loop is LIVE** — retention flows, title hints populated for every show.
- **The data:** RU Shorts are the growth engine (7,028 views/90d; spacex-RU 677/7d at short_vpd 30); EN Shorts beat EN long everywhere (FF Shorts 75% retention).
- **Found:** tier-A shows chronically under-shipped Shorts (FF 1-of-2 on EVERY July episode — the selector's threshold vetoed windows and fell back to one voice-start Short); subscribers tracked nowhere; RU long-form near-worthless (435 views/68 vids, ~9% retention); gallery-retention tags empty.

## Part 2 — what this PR ships

| Lever | Change |
|---|---|
| **Shorts volume** | `fill_to_n` in the multi-Shorts selector: the requested count is a policy decision — when fewer windows beat the threshold, ship the best available (score ≥ 0, boring-openers never) instead of fewer Shorts. `shorts_fill_modes` metric (qualified/filled/legacy_fallback). FF gets the 3.5 threshold (Tesla/SpaceX parity). |
| **RU multi-Shorts** | Policy may raise RU Shorts to 2 (was hard-capped at 1 by `smart_mode=False`). Second Short gets its own window, Cyrillic captions, and a distinct title. Doubles the network's single best-performing surface. |
| **Subscriber tracking** | Analytics schema v2: per-video `subscribersGained/Lost`, per-channel snapshots + 30-day series, daily history file, dashboard "YouTube channels" card (subs + 7d delta + top converting videos), subs-blended title hints. Subscribers were previously tracked **nowhere**. |
| **Punch thumbnails** | One Grok call (`generate_title_bundle`, same cost as before) → long titles + a 2–4 word ALL-CAPS punch text rendered ~2× larger as the thumbnail's dominant element + per-window Short titles. Empty fields = byte-identical legacy fallback (drift-guarded). Opt-outs: `thumbnail_punch_text`, `optimized_titles`. |
| **Auto-comments** | `post_video_comment` posts a channel comment on every upload: long-form = the pinned-comment template (now a shared helper), Shorts = "▶ Full episode: ‹link› / 🔔 Subscribe", RU = Russian equivalent only when a RU long exists. 403 = graceful no-op. Opt-out: `auto_comment`. **The API can't pin — pin the good ones manually in Studio.** |
| **RU long floor** | `LONG_VPD_FLOOR` channel-specific: en 1.0 / ru 2.0. FF-RU (1.39) demotes back to shorts-only after the standard 2-run hysteresis; the Monday probe still lets it re-earn. |
| **Gallery style tags** | Retention tags now mined from image prompts (per-show >50% doc-frequency boilerplate auto-excluded) — verified live: 1,420 images labeled across 13 shows. Auto-feedback into image prompts deliberately deferred (thin samples). |

## Outward-facing changes (your veto points)

1. **Thumbnail style changes** on all shows (punch text dominant) — revert per show via `thumbnail_punch_text: false`.
2. **Public channel comments** start appearing on every upload — disable via `auto_comment: false`.
3. FF/SpaceX/Tesla ship a true 2nd Short daily; spacex/tesla/MI **RU dubs ship 2 Shorts** when policy asks.
4. FF-RU's daily RU long-form will stop (~2 runs) under the new ru floor.

## Test plan

- Full suite: **4,053 passed**. New: `tests/test_youtube_growth_pass.py` (22 guards), `TestFillToRequested` (selector semantics incl. legacy no-fill byte-compat), updated RU parity test.
- Live-verified: gallery style-tag join on the real manifest + stats.

## Watch after 2–3 days

FF/SpaceX `shorts_count_uploaded == requested` (no more `[10.0]` fallbacks) · spacex-RU 2 Shorts/day without vpd collapse · channel-history rows accruing + dashboard card · comments visible, no 403 warnings · punch thumbnails look right on 2-3 episodes · Monday probe fires Jul 20 · FF-RU long demotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX

---
_Generated by [Claude Code](https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live YouTube publish (comments, thumbnails, Short counts) and adaptive policy for RU long-form; failures are mostly best-effort, but outward-facing feed and quota behavior change on every show.
> 
> **Overview**
> **July 18 growth pass** tightens Shorts volume, packaging, and measurement after tier policy proved sound but tier-A shows kept shipping 1-of-2 Shorts.
> 
> **Shorts:** `pick_top_n_engaging_windows` gains `fill_to_n` (config `shorts_fill_to_requested`, default on) so policy-requested N Shorts are met with best sub-threshold windows (`qualified=False`, `shorts_fill_modes` metrics) instead of voice fallback. EN flow hoists window selection once before the Grok call and reuses it in publish. **RU dubs** use the same top-N + fill path, allow up to **2** Shorts when policy says so (`smart_mode=True` was blocking raises), and record distinct Short titles. **FF** gets `shorts_min_score_threshold: 3.5`.
> 
> **Packaging:** `generate_title_bundle` replaces titles-only Grok — long titles, **2–4 word ALL-CAPS punch** on thumbnails (`thumbnail_punch_text`), and per-window Short titles with legacy fallbacks. **`post_video_comment`** posts pinned-template on long-form and funnel comments on Shorts (`auto_comment`); RU Shorts only link when a RU long exists. **`build_pinned_comment_text`** shared with descriptions.
> 
> **Policy & analytics:** Channel-specific **`LONG_VPD_FLOOR`** (en 1.0 / ru 2.0). Analytics **schema v2**: per-video subs gained/lost, channel snapshots, `youtube_channel_history.json`, dashboard YouTube card, subs-blended title hints. Gallery retention **style tags** mined from image prompts (boilerplate filtered).
> 
> Docs/review added; drift tests in `test_youtube_growth_pass.py` and `TestFillToRequested`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2dcc37652662954d824422db769e28c7987a404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->