### PR TITLE
Generalized language-dub engine + @NerraFR French pipeline (dormant until token)

### DIFF
--- a/.github/workflows/multilingual.yml
+++ b/.github/workflows/multilingual.yml
@@ -241,6 +241,34 @@ jobs:
           python scripts/publish_ru_dubs.py "${{ matrix.show }}" --latest "$LATEST" </dev/null || \
             echo "::warning::RU dub publish failed for ${{ matrix.show }} (non-fatal)"
 
+      - name: Publish ${{ matrix.show }} French dubs to @NerraFR
+        if: always()
+        # July 18 2026 — generalized language-dub engine (engine.lang_dub;
+        # RU stays on the bespoke engine.ru_dub). Builds a French-dubbed
+        # video from the just-generated `fr` audio track — only for shows
+        # with `fr` in youtube.dub_languages. Clean no-op for every other
+        # show and while YOUTUBE_REFRESH_TOKEN_FR is unset (the pipeline
+        # ships dormant until the operator creates @NerraFR + adds the
+        # secret). Off the episode critical path → no timeout risk.
+        env:
+          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+          YOUTUBE_REFRESH_TOKEN_FR: ${{ secrets.YOUTUBE_REFRESH_TOKEN_FR }}
+          # FR titles translate the EN *optimized* YouTube title via Grok
+          # (engine/lang_dub._translate_title) — same contract as RU.
+          GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          XAI_API_KEY: ${{ secrets.GROK_API_KEY }}
+          # Gallery-scene downloads fall back to authenticated R2 when the
+          # public CDN 403s CI egress (the Tesla Ep537 failure mode).
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: |
+          LATEST="${{ github.event.inputs.latest }}"
+          [ -z "$LATEST" ] && LATEST=3
+          python scripts/publish_lang_dubs.py "${{ matrix.show }}" --lang fr --latest "$LATEST" </dev/null || \
+            echo "::warning::FR dub publish failed for ${{ matrix.show }} (non-fatal)"
+
       - name: Build ${{ matrix.show }} language feeds
         if: always()
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1867,6 +1867,27 @@ the fallback everywhere; every piece is best-effort and non-blocking.
   `YOUTUBE_REFRESH_TOKEN_RU` (no-ops with a log line until set). Docs:
   [`docs/ru_youtube_dubs.md`](docs/ru_youtube_dubs.md). Drift guards:
   `tests/test_ru_dub.py`.
+- **Generalized language dubs → @NerraFR (July 18 2026; future languages).**
+  `engine/lang_dub.py` is the language-parameterized sibling of `ru_dub`
+  (which stays bespoke + untouched for @NerraRU — the show-memory
+  precedent). A `DubLanguage` registry entry + `youtube.dub_languages:
+  [fr]` + a `YOUTUBE_REFRESH_TOKEN_<CH>` secret + a `SEED_TIERS` channel
+  = a new dubbed channel; language-neutral machinery is IMPORTED from
+  ru_dub (no fork). FR registered for tesla/spacex/FF/modern_investing
+  (MIT's multilingual `languages` gained `fr` — the track is the dub's
+  input), **seeded shorts-only** with the RU 2.0 long_vpd floor (RU
+  lesson: dubbed longs earned ~9% retention), full RU parity (optimized-
+  title translation with echo rejection, smart multi-Shorts + fill,
+  French ASS captions, French end-card + funnel comment, `no_scenes_yet`
+  deferral, per-show `youtube_videos.fr.json` auto-picked-up by
+  analytics/policy/subscriber tracking). Sweep:
+  `scripts/publish_lang_dubs.py --lang fr` in `multilingual.yml`.
+  Credentials resolve generically (channel `xx` →
+  `YOUTUBE_REFRESH_TOKEN_XX`; en/ru behavior pinned unchanged). DORMANT
+  until the operator creates @NerraFR + adds the secret (clean
+  `no_fr_credentials` no-op until then; activation checklist in the doc).
+  Docs: [`docs/lang_youtube_dubs.md`](docs/lang_youtube_dubs.md). Drift
+  guards: `tests/test_lang_dub.py`.
 - **Recursive YouTube → titles feedback loop.** Mirrors the OP3 audio loop:
   `scripts/fetch_youtube_analytics.py` reads each show's
   `digests/<slug>/youtube_videos.json`, queries the YouTube Analytics API for

--- a/docs/lang_youtube_dubs.md
+++ b/docs/lang_youtube_dubs.md
@@ -1,0 +1,86 @@
+# Generalized language-dubbed YouTube channels (July 2026 — first: @NerraFR)
+
+`engine/lang_dub.py` turns each episode's existing translated audio track
+(the multilingual system's `.fr.mp3` / `.es.mp3` / … on R2) into videos on a
+language-specific YouTube channel, reusing the episode's Grok gallery scenes
+(zero extra image cost). It is the generalized sibling of `engine/ru_dub.py`,
+which keeps serving @NerraRU untouched (the show-memory precedent: bespoke
+proven engine kept, generalized engine for everything after it — fold RU in
+later once parity is proven in production).
+
+## Why a separate channel per language
+
+Language-clean audience signals are why @NerraRU works (RU Shorts are the
+network's best-performing surface). YouTube's native multi-audio-track
+feature — one video, switchable audio — is not available via the public API,
+so per-language channels are the only clean structure.
+
+## Architecture
+
+```
+multilingual.yml (decoupled sweep, per show)
+  translate step  → .fr.mp3 on R2 + summaries translations.fr
+  RU dub step     → engine.ru_dub (bespoke, unchanged)     → @NerraRU
+  FR dub step     → scripts/publish_lang_dubs.py --lang fr → @NerraFR
+                     └─ engine.lang_dub.publish_lang_dub(config, ep, "fr")
+```
+
+`publish_lang_dub` mirrors `publish_ru_dub` exactly, parameterized by a
+`DubLanguage` spec: EN-optimized-title lookup → Grok translation (echo
+rejected — an untranslated title never ships), adaptive-policy gate
+(channel-specific; FR seeded **shorts-only** with a 2.0 long_vpd floor, the
+RU lesson), scene-availability deferral (`no_scenes_yet`), long render +
+upload when the policy allows, up to 2 Shorts with smart windows +
+fill-to-requested + per-word French ASS captions + French end-card +
+funnel comment (only when a French long exists this run). Per-show index:
+`digests/<dir>/youtube_videos.fr.json` — picked up automatically by the
+analytics fetch, the adaptive policy, and subscriber tracking (all
+channel-keyed).
+
+Language-NEUTRAL machinery (manifest refresh, scene lookup/download, cover
+resolution, title-index lookup, word trimming) is imported from
+`engine.ru_dub` — one implementation, no drift.
+
+## Adding a future language (e.g. Spanish)
+
+1. Add a `DubLanguage` entry to `engine.lang_dub.DUB_LANGUAGES` (native
+   disclosure/end-card/comment strings, Whisper language, episode-prefix
+   regex).
+2. Seed the channel in `scripts/update_youtube_policy.py` `SEED_TIERS`
+   (shorts-only) + `LONG_VPD_FLOOR`.
+3. Add a publish step to `multilingual.yml` with
+   `YOUTUBE_REFRESH_TOKEN_<CH>` (+ Grok key + R2 creds — the FR step is the
+   template).
+4. Per show: `youtube.dub_languages: [fr, es]` and make sure the language
+   is in `multilingual.languages` (the audio track is the dub's input).
+5. Operator: create the channel, run
+   `scripts/youtube_oauth_bootstrap.py` signed in as it, add the secret,
+   create + "Set as podcast"-flag the playlists (landmine #15), then set
+   `youtube.dub_playlist_ids: {es: PL...}`.
+
+Credentials resolve generically: channel `xx` →
+`YOUTUBE_REFRESH_TOKEN_XX` (`engine.youtube.get_channel_credentials_from_env`).
+
+## Operator checklist to activate @NerraFR
+
+The FR pipeline is **dormant** until these are done (every run before that
+is a clean `no_fr_credentials` no-op):
+
+1. Create the @NerraFR channel; add French channel art + description.
+2. `python scripts/youtube_oauth_bootstrap.py <client_secrets.json>` signed
+   in as @NerraFR → paste into the `YOUTUBE_REFRESH_TOKEN_FR` repo secret.
+3. Create the four show playlists on @NerraFR, flag each "Set as podcast"
+   in Studio, then add `dub_playlist_ids: {fr: PL...}` to each show's
+   `youtube:` block (uploads publish without it — just no playlist).
+4. Optional: `YOUTUBE_DAILY_QUOTA_FR` env if the channel's quota differs.
+
+Enabled shows at launch: tesla, spacex, fascinating_frontiers,
+modern_investing (`youtube.dub_languages: [fr]`; modern_investing's
+multilingual `languages` gained `fr` in the same change — the track is the
+dub's input). FR long-form will NOT render at first (shorts-only seed);
+the Monday probe + velocity data let it earn in, exactly like RU.
+
+Drift guards: `tests/test_lang_dub.py` (28 tests — registry, no-op paths,
+credentials generalization with EN/RU pinned unchanged, policy seeds,
+YAML wiring incl. the track-exists invariant, workflow env, sweep-index
+semantics, RU-engine-untouched pins).

--- a/engine/config.py
+++ b/engine/config.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import yaml
 
@@ -517,6 +517,18 @@ class YouTubeConfig:
     # (channel=ru token). English upload is unaffected. Off by default →
     # byte-for-byte no-op. See engine.ru_dub / docs/ru_youtube_dubs.md.
     ru_dub_enabled: bool = False
+    # ---- Generalized language dubs (July 2026 — first language: FR) ----
+    # Registry languages (engine.lang_dub.DUB_LANGUAGES) this show publishes
+    # dubbed videos for, e.g. ``dub_languages: [fr]`` → @NerraFR. Each
+    # language needs its channel token (YOUTUBE_REFRESH_TOKEN_<CH>) — the
+    # pipeline no-ops cleanly until the operator adds it. RU stays on the
+    # bespoke ``ru_dub_enabled`` flag (engine.ru_dub). Empty by default →
+    # byte-for-byte no-op.
+    dub_languages: List[str] = field(default_factory=list)
+    # Per-language playlist ids on the language channels, e.g.
+    # ``dub_playlist_ids: {fr: PL...}`` (operator creates + flags each in
+    # Studio — landmine #15).
+    dub_playlist_ids: Dict[str, str] = field(default_factory=dict)
     # @NerraRU playlist for this show's RU dubs (operator creates + flags it
     # in Studio per landmine #15; uploads still publish without it, warned).
     ru_podcast_playlist_id: Optional[str] = None

--- a/engine/lang_dub.py
+++ b/engine/lang_dub.py
@@ -33,7 +33,6 @@ until the operator creates @NerraFR and adds the secret.
 
 from __future__ import annotations
 
-import datetime
 import logging
 import re
 import tempfile

--- a/engine/lang_dub.py
+++ b/engine/lang_dub.py
@@ -1,0 +1,599 @@
+"""Generalized language-dubbed YouTube videos (July 2026 — first language: FR).
+
+The multilingual system already generates translated *audio* tracks per
+episode (``engine.multilingual`` → ``.fr.mp3`` / ``.es.mp3`` / … on R2 with
+per-language RSS feeds). ``engine.ru_dub`` proved the video layer for Russian
+(@NerraRU): turn the existing track into a video, reuse the episode's Grok
+scene images (zero image cost), upload to a language-specific channel.
+
+This module is the GENERALIZED engine for every language after Russian.
+Design (mirrors the show-memory precedent: Tesla kept its bespoke
+``engine/tesla_memory.py`` while ``engine/show_memory.py`` generalized the
+pattern for the other shows):
+
+  - ``engine.ru_dub`` stays UNTOUCHED and keeps serving @NerraRU — it is
+    proven, drift-guarded, and the operator asked that nothing break. A
+    future cleanup could fold RU onto this engine once it has weeks of
+    parity in production.
+  - Language-NEUTRAL machinery (manifest refresh, scene lookup/download,
+    cover resolution, EN-optimized-title lookup, word trimming) is IMPORTED
+    from ``engine.ru_dub`` — one implementation, no drift.
+  - Everything language-SPECIFIC lives in a ``DubLanguage`` spec. Adding a
+    future language = one registry entry + ``youtube.dub_languages: [xx]``
+    in the show YAML + a ``YOUTUBE_REFRESH_TOKEN_XX`` secret + the channel
+    seeded in ``scripts/update_youtube_policy.py``.
+
+Contract (identical to ru_dub): runs in the decoupled multilingual workflow,
+never the episode critical path; fully best-effort (returns a status dict,
+never raises); no-ops cleanly when the show hasn't opted in
+(``youtube.dub_languages``), the track doesn't exist, or the channel token
+(``YOUTUBE_REFRESH_TOKEN_<CH>``) is unset — so the FR pipeline ships DORMANT
+until the operator creates @NerraFR and adds the secret.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import re
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from engine.ru_dub import (  # language-neutral helpers — single source
+    PROJECT_ROOT,
+    _cap_title,
+    _cover_path,
+    _download_images,
+    _en_optimized_long_title,
+    _fresh_manifest_path,
+    _hashtags,
+    _is_fresh_episode,
+    _word_trim,
+    gallery_images_for_episode,
+)
+
+logger = logging.getLogger(__name__)
+
+_YT_TITLE_MAX = 100
+_SHORTS_SUFFIX = " #Shorts"
+
+
+@dataclass(frozen=True)
+class DubLanguage:
+    """Everything language-specific about one dubbed-channel pipeline."""
+
+    code: str                 # multilingual track code, e.g. "fr"
+    channel: str              # policy/credentials channel key (usually == code)
+    name: str                 # English name, for logs/prompts
+    channel_handle: str       # e.g. "@NerraFR" (docs/logs only)
+    whisper_language: str     # Whisper language for Short captions
+    default_language: str     # YouTube snippet.defaultLanguage
+    disclosure: str           # AI-voice disclosure line for descriptions
+    end_card_main: str        # Shorts end-card CTA
+    end_card_sub: str
+    comment_full_episode: str  # "{url}" placeholder; funnel comment on Shorts
+    second_short_tail: str    # appended when a 2nd Short needs a fallback title
+    # Leading episode-label to strip when deriving the Short title
+    ep_prefix_re: re.Pattern = field(
+        default_factory=lambda: re.compile(
+            r"^\s*(?:Ep\.?|Episode)\s*#?\s*\d+\s*[:：.\-—]\s*", re.IGNORECASE))
+
+
+# The registry. Russian deliberately ABSENT — @NerraRU runs on the proven
+# bespoke ``engine.ru_dub`` (see module docstring). Add future languages
+# here.
+DUB_LANGUAGES: Dict[str, DubLanguage] = {
+    "fr": DubLanguage(
+        code="fr",
+        channel="fr",
+        name="French",
+        channel_handle="@NerraFR",
+        whisper_language="fr",
+        default_language="fr",
+        disclosure=(
+            "Divulgation IA : le podcast est préparé par Patrick ; "
+            "la voix est générée par synthèse vocale IA."
+        ),
+        end_card_main="VOIR L'ÉPISODE",
+        end_card_sub="Abonnez-vous ↗",
+        comment_full_episode=(
+            "▶ Épisode complet : {url}\n"
+            "🔔 Abonnez-vous — nouveaux épisodes chaque jour"
+        ),
+        second_short_tail=" — encore un moment",
+        ep_prefix_re=re.compile(
+            r"^\s*(?:Ép\.?|Épisode|Ep\.?)\s*#?\s*\d+\s*[:：.\-—]\s*",
+            re.IGNORECASE),
+    ),
+}
+
+
+def dub_languages_for(config) -> List[str]:
+    """The registry languages this show opts into via
+    ``youtube.dub_languages`` (unknown codes are ignored with a warning —
+    a typo must not crash a sweep)."""
+    yt = getattr(config, "youtube", None)
+    wanted = [str(c).lower() for c in
+              (getattr(yt, "dub_languages", None) or [])]
+    out = []
+    for code in wanted:
+        if code in DUB_LANGUAGES:
+            out.append(code)
+        elif code == "ru":
+            # RU is handled by engine.ru_dub — silently skip here so a
+            # future YAML consolidation can list it without double-publish.
+            continue
+        else:
+            logger.warning("lang_dub: unknown dub language %r in %s — "
+                           "skipped (registry: %s)", code,
+                           getattr(config, "slug", "?"),
+                           sorted(DUB_LANGUAGES))
+    return out
+
+
+def _playlist_id(config, lang: DubLanguage) -> str:
+    yt = getattr(config, "youtube", None)
+    mapping = getattr(yt, "dub_playlist_ids", None) or {}
+    return str(mapping.get(lang.code, "") or "").strip()
+
+
+def _long_description(config, desc: str, lang: DubLanguage) -> str:
+    base_url = getattr(config.publishing, "base_url",
+                       "https://nerranetwork.com")
+    lines = [desc.strip(), "", f"🎧 {base_url}", "", lang.disclosure]
+    tags = _hashtags(config)
+    if tags:
+        lines += ["", tags]
+    return "\n".join(lines).strip()
+
+
+def _translate_title(en_title: str, lang: DubLanguage) -> str:
+    """Best-effort translation of the EN optimized YouTube title.
+
+    ``translate_metadata`` falls back to the English input on failure. For
+    non-Latin scripts (RU/ZH) an echo is detectable by script; for Latin
+    targets (FR/ES) the echo check is "result differs from the input" —
+    an untranslated echo means no usable translation, and we never ship an
+    English title on a language channel. Returns "" on any failure so the
+    caller keeps the translated-hook title.
+    """
+    en_title = (en_title or "").strip()
+    if not en_title:
+        return ""
+    try:
+        from engine import translate
+        out, _desc = translate.translate_metadata(en_title, "", lang.code)
+        out = (out or "").strip()
+        if out and out.lower() != en_title.lower():
+            return out
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.warning("lang_dub[%s]: title translation failed (%s)",
+                       lang.code, exc)
+    return ""
+
+
+def _short_title(long_title: str, lang: DubLanguage, *,
+                 body_limit: int = 70) -> str:
+    """Distinct, punchy Short title derived from the language long title."""
+    body = lang.ep_prefix_re.sub("", (long_title or "").strip()).strip()
+    body = body.rstrip("…").rstrip()
+    ceiling = min(body_limit, _YT_TITLE_MAX - len(_SHORTS_SUFFIX))
+    body = _word_trim(body, ceiling)
+    return f"{body}{_SHORTS_SUFFIX}".strip()
+
+
+def _policy_plan(config, lang: DubLanguage) -> Dict[str, object]:
+    """Adaptive-publishing decision for this show on the language channel.
+
+    New channels are seeded SHORTS-ONLY in ``scripts/update_youtube_policy``
+    (the RU lesson: dubbed long-form earned ~9% retention while Shorts
+    carried all the views) — the Monday probe + velocity data let long-form
+    earn its way in. Best-effort: any failure resolves to shorts-only-with-
+    long (legacy) so a policy problem can never block a dub."""
+    legacy: Dict[str, object] = {"publish_long": True, "shorts": 1,
+                                 "tier": "", "applied": False, "reason": ""}
+    try:
+        from engine.youtube_policy import load_policy, resolve_publish_plan
+        return resolve_publish_plan(
+            load_policy(PROJECT_ROOT / "api" / "youtube_policy.json"),
+            slug=config.slug,
+            channel=lang.channel,
+            yaml_publish_long=True,
+            yaml_shorts=1,            # policy may raise (capped at 2 below)
+            smart_mode=True,          # Shorts run the smart selector on the
+                                      # language transcript (RU parity)
+            adaptive_enabled=bool(getattr(
+                getattr(config, "youtube", None), "adaptive_publishing", True,
+            )),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("lang_dub[%s]: policy resolution failed (%s) — "
+                       "legacy behavior", lang.code, exc)
+        return legacy
+
+
+def index_path(config, lang_code: str) -> Path:
+    return (PROJECT_ROOT / config.episode.output_dir
+            / f"youtube_videos.{lang_code}.json")
+
+
+def _resolve_audio(config, episode_num: int, track: dict,
+                   lang: DubLanguage, dest_dir: Path) -> Optional[Path]:
+    """Local path to the language mp3 — fresh local render if present, else
+    downloaded from the track's R2 ``audio_url``."""
+    output_dir = PROJECT_ROOT / config.episode.output_dir
+    local = sorted(output_dir.glob(
+        f"*_Ep{episode_num:03d}_*.{lang.code}.mp3"))
+    if local:
+        return local[-1]
+    url = track.get("audio_url", "")
+    if not url:
+        return None
+    try:
+        import requests
+        resp = requests.get(url, timeout=120)
+        resp.raise_for_status()
+        p = dest_dir / f"{lang.code}_audio_ep{episode_num:03d}.mp3"
+        p.write_bytes(resp.content)
+        return p
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("lang_dub[%s]: could not fetch audio %s: %s",
+                       lang.code, url, exc)
+        return None
+
+
+def publish_lang_dub(
+    config, episode_num: int, lang_code: str, *,
+    build_short: bool = True,
+    dry_run: bool = False,
+) -> Dict[str, object]:
+    """Build + upload the language-dubbed long-form (and Shorts) for one
+    episode. Returns a status dict; never raises. Mirrors
+    ``engine.ru_dub.publish_ru_dub`` exactly, parameterized by language."""
+    result: Dict[str, object] = {"status": "skip", "lang": lang_code}
+    lang = DUB_LANGUAGES.get((lang_code or "").lower())
+    if lang is None:
+        result["status"] = "unknown_language"
+        return result
+    yt = getattr(config, "youtube", None)
+    if lang.code not in dub_languages_for(config):
+        return result
+    ml = getattr(config, "multilingual", None)
+    if not (ml and ml.enabled and lang.code in (ml.languages or [])):
+        result["status"] = f"no_{lang.code}_lang"
+        return result
+
+    # The audio track must already exist (the multilingual sweep makes it).
+    from engine.summaries_io import load_summaries
+    summaries_path = PROJECT_ROOT / config.publishing.summaries_json
+    try:
+        _w, records = load_summaries(summaries_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("lang_dub[%s]: cannot read summaries: %s",
+                       lang.code, exc)
+        return result
+    rec = next((r for r in records
+                if r.get("episode_num") == episode_num), None)
+    if not rec:
+        result["status"] = "no_record"
+        return result
+    track = (rec.get("translations", {}) or {}).get(lang.code)
+    if not track:
+        result["status"] = f"no_{lang.code}_track"
+        return result
+
+    title = _cap_title(track.get("title")
+                       or rec.get("episode_title") or "")
+    # Prefer the EN *optimized* YouTube long-form title translated to the
+    # target language (RU parity — the translated hook ships mid-sentence-
+    # truncated; the optimized title is a complete keyword-led line).
+    en_long_title = _en_optimized_long_title(config, episode_num)
+    if en_long_title:
+        opt = _translate_title(en_long_title, lang)
+        if opt:
+            title = _cap_title(opt)
+    desc = track.get("description") or title
+
+    plan = _policy_plan(config, lang)
+    publish_long = bool(plan.get("publish_long", True))
+    if not publish_long:
+        result["policy_long_skipped"] = True
+        result["policy_tier"] = str(plan.get("tier") or "")
+        if not (build_short and getattr(yt, "publish_shorts", True)):
+            result["status"] = "policy_skip"
+            return result
+
+    if dry_run:
+        result.update(status="dryrun", title=title,
+                      short_title=_short_title(title, lang),
+                      policy_long=publish_long)
+        return result
+
+    from engine.youtube import get_channel_credentials_from_env
+    creds = get_channel_credentials_from_env(lang.channel)
+    if creds is None:
+        # Dormant until the operator adds YOUTUBE_REFRESH_TOKEN_<CH>.
+        result["status"] = f"no_{lang.channel}_credentials"
+        return result
+
+    cover = _cover_path(config)
+    if cover is None:
+        logger.warning("lang_dub[%s]: no cover art for %s — skip",
+                       lang.code, config.slug)
+        result["status"] = "no_cover"
+        return result
+
+    # Scene availability gate (RU parity): refresh the manifest from
+    # origin/main; defer a FRESH scene-less episode rather than shipping a
+    # cover-only dub.
+    date_str = (rec.get("date") or "")[:10]
+    with tempfile.TemporaryDirectory() as mtd:
+        manifest_path = _fresh_manifest_path(Path(mtd))
+        long_urls = gallery_images_for_episode(
+            config.slug, episode_num, intended_use="segment_card",
+            manifest_path=manifest_path)
+        short_urls = gallery_images_for_episode(
+            config.slug, episode_num, intended_use="social",
+            manifest_path=manifest_path)
+    if len(long_urls) < 2 and _is_fresh_episode(date_str):
+        logger.info("lang_dub[%s]: %s Ep%s has %d scene(s) and is fresh — "
+                    "deferring until the manifest catches up",
+                    lang.code, config.slug, episode_num, len(long_urls))
+        result["status"] = "no_scenes_yet"
+        result["scene_count"] = len(long_urls)
+        return result
+
+    from engine.video import build_long_form_video, build_short_video
+    from engine.youtube import (add_video_to_playlist, post_video_comment,
+                                upload_video)
+    from engine.youtube_index import record_video
+
+    idx_path = index_path(config, lang.code)
+    playlist = _playlist_id(config, lang)
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        audio = _resolve_audio(config, episode_num, track, lang, tmp)
+        if audio is None:
+            result["status"] = f"no_{lang.code}_audio"
+            return result
+
+        long_scenes = (_download_images(long_urls, tmp)
+                       if (long_urls and publish_long) else [])
+
+        # Long-form thumbnail — generated even under a shorts-only policy
+        # (the Short's end-card reuses it). Legacy hook rendering (no punch
+        # text — punch is EN-only for now; see the July 18 growth pass).
+        try:
+            from engine.publisher import generate_episode_thumbnail
+            thumb = tmp / f"{lang.code}_thumb.jpg"
+            generate_episode_thumbnail(
+                cover, episode_num, date_str, thumb,
+                hook=title, show_name=config.name)
+            thumb_path = thumb if thumb.exists() else None
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("lang_dub[%s]: thumbnail failed (%s)",
+                           lang.code, exc)
+            thumb_path = None
+
+        # --- Long-form render + upload (policy-gated) ---
+        long_url = ""
+        if not publish_long:
+            logger.warning(
+                "lang_dub[%s]: yt policy — %s tier %s: long-form skipped "
+                "(Short still publishes)",
+                lang.code, config.slug, plan.get("tier") or "?")
+            result["status"] = "policy_long_skipped"
+        else:
+            long_mp4 = tmp / f"{lang.code}_long_ep{episode_num:03d}.mp4"
+            try:
+                build_long_form_video(
+                    audio, cover, long_mp4,
+                    scene_paths=(long_scenes
+                                 if len(long_scenes) >= 2 else None),
+                    show_name=config.name)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("lang_dub[%s]: long render failed Ep%s: %s",
+                             lang.code, episode_num, exc)
+                result["status"] = "render_failed"
+                return result
+            try:
+                up = upload_video(
+                    long_mp4, credentials=creds,
+                    title=title,
+                    description=_long_description(config, desc, lang),
+                    tags=list(getattr(config, "keywords", []) or []),
+                    category_id=int(getattr(yt, "category_id", 28)),
+                    default_language=lang.default_language,
+                    privacy_status=getattr(yt, "privacy_status", "public"),
+                    thumbnail_path=thumb_path,
+                )
+                long_url = up.watch_url
+                result["long_url"] = long_url
+                record_video(
+                    video_id=up.video_id, show_slug=config.slug,
+                    episode=episode_num, kind="long", title=title,
+                    hook=title, published=date_str, watch_url=long_url,
+                    channel=lang.channel, index_path=idx_path)
+                if playlist:
+                    try:
+                        add_video_to_playlist(credentials=creds,
+                                              video_id=up.video_id,
+                                              playlist_id=playlist)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("lang_dub[%s]: playlist add "
+                                       "failed: %s", lang.code, exc)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("lang_dub[%s]: long upload failed Ep%s: %s",
+                             lang.code, episode_num, exc)
+                result["status"] = "upload_failed"
+                return result
+            result["status"] = "done"
+
+        # --- Shorts (best-effort; RU parity incl. the July 18 multi-Short
+        # + fill-to-requested behavior) ---
+        if build_short and getattr(yt, "publish_shorts", True):
+            n_shorts = max(1, min(2, int(plan.get("shorts", 1) or 1)))
+            short_scenes: List[Path] = []
+            try:
+                short_scenes = (_download_images(short_urls, tmp)
+                                if short_urls else [])
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("lang_dub[%s]: scene download failed (%s)",
+                               lang.code, exc)
+            short_dur = float(getattr(yt, "short_duration_seconds", 55.0))
+            base_offset = float(getattr(yt, "shorts_start_offset", 0.0) or 0.0)
+
+            tr_json = None
+            windows: list = []
+            try:
+                from engine.audio import get_audio_duration
+                from engine.shorts_selector import (
+                    pick_top_n_engaging_windows,
+                )
+                from engine.transcripts import generate_transcript
+                tr = generate_transcript(
+                    audio, tmp, f"{lang.code}_ep{episode_num:03d}",
+                    language=lang.whisper_language)
+                if tr and tr.json_path.exists():
+                    tr_json = tr.json_path
+                    total_dur = get_audio_duration(audio) or 0.0
+                    windows = pick_top_n_engaging_windows(
+                        tr_json, n=n_shorts,
+                        audio_offset=base_offset,
+                        audio_duration=total_dur,
+                        window_duration=short_dur,
+                        min_start_final=base_offset,
+                        fill_to_n=True)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("lang_dub[%s]: transcript/selection failed "
+                               "(%s) — voice-start short without captions",
+                               lang.code, exc)
+
+            if windows:
+                short_plan = [(w.start_seconds,
+                               (w.opening_text or "").strip())
+                              for w in windows[:n_shorts]]
+            else:
+                short_plan = [(base_offset, "")]
+
+            end_card_png = None
+            try:
+                from engine.publisher import generate_shorts_end_card
+                if thumb_path is not None:
+                    ec = tmp / f"{lang.code}_endcard_ep{episode_num:03d}.png"
+                    generate_shorts_end_card(
+                        thumb_path, ec, show_name=config.name,
+                        main_text=lang.end_card_main,
+                        sub_text=lang.end_card_sub)
+                    if ec.exists():
+                        end_card_png = ec
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("lang_dub[%s]: end-card failed (%s)",
+                               lang.code, exc)
+
+            short_urls_out: List[str] = []
+            for short_idx, (start_offset, opening_text) in enumerate(
+                    short_plan):
+                try:
+                    suffix = "" if short_idx == 0 else f"_{short_idx + 1}"
+                    short_mp4 = (tmp / f"{lang.code}_short_ep"
+                                       f"{episode_num:03d}{suffix}.mp4")
+
+                    ass_path = None
+                    if tr_json is not None:
+                        try:
+                            from engine.captions import (
+                                transcript_to_ass_window,
+                            )
+                            cand = (tmp / f"{lang.code}_short_ep"
+                                          f"{episode_num:03d}{suffix}.ass")
+                            transcript_to_ass_window(
+                                tr_json, cand,
+                                window_start_seconds=start_offset,
+                                window_duration_seconds=short_dur,
+                                audio_offset_seconds=0.0)
+                            if (cand.exists() and cand.stat().st_size > 0
+                                    and "Dialogue:" in cand.read_text(
+                                        encoding="utf-8",
+                                        errors="replace")):
+                                ass_path = cand
+                                result["short_captions"] = "ass"
+                        except Exception as exc:  # noqa: BLE001
+                            logger.warning(
+                                "lang_dub[%s]: captions failed for short "
+                                "%d (%s)", lang.code, short_idx + 1, exc)
+
+                    build_short_video(
+                        audio, cover, short_mp4,
+                        start_offset=start_offset,
+                        duration=short_dur,
+                        hook=title,
+                        scene_paths=(short_scenes
+                                     if len(short_scenes) >= 2 else None),
+                        show_name=config.name,
+                        subtitles_path=ass_path,
+                        end_card=True,
+                        end_card_main_text=lang.end_card_main,
+                        end_card_sub_text=lang.end_card_sub,
+                        end_card_image_path=end_card_png)
+
+                    if short_idx == 0 or not opening_text:
+                        st = _short_title(title, lang)
+                        if short_idx > 0:
+                            st = (_short_title(title, lang, body_limit=52)
+                                  + lang.second_short_tail)
+                    else:
+                        body = _word_trim(
+                            opening_text.rstrip("…").rstrip(),
+                            min(70, _YT_TITLE_MAX - len(_SHORTS_SUFFIX)))
+                        st = f"{body}{_SHORTS_SUFFIX}".strip()
+
+                    sup = upload_video(
+                        short_mp4, credentials=creds,
+                        title=st,
+                        description=_long_description(config, desc, lang),
+                        tags=list(getattr(config, "keywords", []) or []),
+                        category_id=int(getattr(yt, "category_id", 28)),
+                        default_language=lang.default_language,
+                        privacy_status=getattr(yt, "privacy_status",
+                                               "public"))
+                    short_urls_out.append(sup.watch_url)
+                    record_video(
+                        video_id=sup.video_id, show_slug=config.slug,
+                        episode=episode_num, kind="short", title=st,
+                        hook=title, published=date_str,
+                        watch_url=sup.watch_url,
+                        channel=lang.channel, index_path=idx_path)
+                    if playlist:
+                        try:
+                            add_video_to_playlist(credentials=creds,
+                                                  video_id=sup.video_id,
+                                                  playlist_id=playlist)
+                        except Exception:  # noqa: BLE001
+                            pass
+                    # Funnel comment — only when a language long exists
+                    # this run (never link a different-language video).
+                    if long_url and bool(getattr(yt, "auto_comment", True)):
+                        try:
+                            post_video_comment(
+                                credentials=creds,
+                                video_id=sup.video_id,
+                                text=lang.comment_full_episode.format(
+                                    url=long_url))
+                        except Exception:  # noqa: BLE001
+                            pass
+                    result["status"] = "done"
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("lang_dub[%s]: Short %d failed Ep%s "
+                                   "(non-fatal): %s", lang.code,
+                                   short_idx + 1, episode_num, exc)
+                    result["short_error"] = str(exc)
+
+            if short_urls_out:
+                result["short_url"] = short_urls_out[0]
+                result["short_urls"] = short_urls_out
+
+    return result

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
@@ -117,19 +118,23 @@ def get_channel_credentials_from_env(channel: str = "en"):
     """
     client_id = os.getenv("YOUTUBE_CLIENT_ID", "").strip()
     client_secret = os.getenv("YOUTUBE_CLIENT_SECRET", "").strip()
-    suffix = "RU" if channel.lower() == "ru" else "EN"
+    # July 2026 (language-dub generalization): the suffix is the channel
+    # key uppercased — "en" → EN, "ru" → RU (both unchanged), "fr" → FR,
+    # any future language channel → its own YOUTUBE_REFRESH_TOKEN_<CH>.
+    ch = (channel or "en").strip().lower() or "en"
+    suffix = re.sub(r"[^A-Z0-9]", "", ch.upper()) or "EN"
     refresh_token = os.getenv(f"YOUTUBE_REFRESH_TOKEN_{suffix}", "").strip()
 
     if not all([client_id, client_secret, refresh_token]):
-        if suffix == "RU" and client_id and client_secret:
-            # The EN pipeline works but the RU channel token specifically
-            # is missing — the show YAML *asked* for @NerraRU uploads and
+        if suffix != "EN" and client_id and client_secret:
+            # The EN pipeline works but this channel's token specifically
+            # is missing — the show YAML *asked* for uploads on it and
             # they are silently no-oping (June 2026 review: FP/PR shipped
             # for days with youtube_enabled flipping on no upload).
             logger.warning(
-                "YouTube channel=ru is configured for this show but "
-                "YOUTUBE_REFRESH_TOKEN_RU is not set — uploads will no-op "
-                "until the secret is added.",
+                "YouTube channel=%s is configured for this show but "
+                "YOUTUBE_REFRESH_TOKEN_%s is not set — uploads will no-op "
+                "until the secret is added.", ch, suffix,
             )
         else:
             logger.info(

--- a/management.html
+++ b/management.html
@@ -486,7 +486,10 @@
       const delta = c.subscribers_delta_7d;
       const deltaTxt = (delta == null) ? "" :
         (" (" + (delta >= 0 ? "+" : "") + delta + " · 7d)");
-      row.textContent = "@" + (ch === "ru" ? "NerraRU" : "NerraNetwork") + ": " +
+      const chName = ch === "ru" ? "NerraRU" :
+        ch === "fr" ? "NerraFR" :
+        ch === "en" ? "NerraNetwork" : ("Nerra-" + ch.toUpperCase());
+      row.textContent = "@" + chName + ": " +
         (c.subscribers || 0).toLocaleString() + " subscribers" + deltaTxt +
         " · " + (c.total_views || 0).toLocaleString() + " total views";
       audRoot.appendChild(row);

--- a/scripts/publish_lang_dubs.py
+++ b/scripts/publish_lang_dubs.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Publish language-dubbed videos (engine.lang_dub) for opted-in shows.
+
+The generalized sibling of ``publish_ru_dubs.py`` (which keeps serving
+@NerraRU on the bespoke ``engine.ru_dub``). Runs AFTER
+``scripts/generate_translations.py`` in the decoupled multilingual workflow:
+for each show whose ``youtube.dub_languages`` includes ``--lang``, builds a
+video from the episode's already-generated language audio track (reusing the
+gallery scene images) and uploads it to that language's channel.
+
+Idempotent: skips episodes whose dub is already recorded in the per-show
+``youtube_videos.<lang>.json`` index unless ``--force``. A ``no_scenes_yet``
+deferral is recorded as a status-only row and does NOT count as done — the
+next sweep retries it. Clean no-op when the channel token
+(``YOUTUBE_REFRESH_TOKEN_<CH>``) is unset — the pipeline ships dormant until
+the operator creates the channel and adds the secret.
+
+Usage::
+
+    python scripts/publish_lang_dubs.py all --lang fr --latest 2
+    python scripts/publish_lang_dubs.py tesla --lang fr --episode 543
+    python scripts/publish_lang_dubs.py all --lang fr --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(PROJECT_ROOT / ".env")
+
+from engine import lang_dub  # noqa: E402
+from engine.config import discover_show_slugs, load_config  # noqa: E402
+from engine.summaries_io import load_summaries  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("publish_lang_dubs")
+
+
+def _dub_shows(lang: str) -> List[str]:
+    out = []
+    for slug in discover_show_slugs():
+        try:
+            cfg = load_config(f"shows/{slug}.yaml")
+        except Exception:  # noqa: BLE001
+            continue
+        if lang in lang_dub.dub_languages_for(cfg):
+            out.append(slug)
+    return out
+
+
+def _read_index(config, lang: str) -> dict:
+    idx = lang_dub.index_path(config, lang)
+    try:
+        return json.loads(idx.read_text(encoding="utf-8")) if idx.exists() else {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _write_index(config, lang: str, data: dict) -> None:
+    idx = lang_dub.index_path(config, lang)
+    try:
+        idx.parent.mkdir(parents=True, exist_ok=True)
+        idx.write_text(json.dumps(data, ensure_ascii=False, indent=2),
+                       encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Could not write %s: %s", idx, exc)
+
+
+def _already_done(config, lang: str, episode_num: int) -> bool:
+    # Same semantics as publish_ru_dubs: any uploaded video (long or short,
+    # row with a video_id) marks the episode done; status-only rows
+    # (deferrals / failures) do not.
+    data = _read_index(config, lang)
+    return any(v.get("episode") == episode_num
+               and v.get("kind") in ("long", "short")
+               and v.get("video_id")
+               for v in data.get("videos", []))
+
+
+def _record_status_row(config, lang: str, episode_num: int, *,
+                       kind: str, status: str, **extra) -> None:
+    data = _read_index(config, lang)
+    videos = data.setdefault("videos", [])
+    videos[:] = [v for v in videos
+                 if not (v.get("episode") == episode_num
+                         and v.get("kind") == kind
+                         and v.get("status") == status)]
+    row = {"episode": episode_num, "kind": kind, "status": status,
+           "recorded": _dt.datetime.now(_dt.timezone.utc).isoformat()}
+    row.update({k: v for k, v in extra.items() if v is not None})
+    videos.append(row)
+    _write_index(config, lang, data)
+
+
+def _clear_status_row(config, lang: str, episode_num: int, *,
+                      kind: str, status: str) -> None:
+    data = _read_index(config, lang)
+    videos = data.get("videos", [])
+    kept = [v for v in videos
+            if not (v.get("episode") == episode_num
+                    and v.get("kind") == kind
+                    and v.get("status") == status)]
+    if len(kept) != len(videos):
+        data["videos"] = kept
+        _write_index(config, lang, data)
+
+
+def _select_episodes(config, latest: int, episode: Optional[int]) -> List[int]:
+    summaries_path = PROJECT_ROOT / config.publishing.summaries_json
+    try:
+        _w, records = load_summaries(summaries_path)
+    except Exception:  # noqa: BLE001
+        return []
+    nums = sorted((r["episode_num"] for r in records
+                   if isinstance(r.get("episode_num"), int)), reverse=True)
+    if episode is not None:
+        return [episode] if episode in nums else []
+    return nums[:latest]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("show",
+                    help='Show slug, or "all" for every opted-in show')
+    ap.add_argument("--lang", required=True,
+                    help="Registry language code (e.g. fr)")
+    ap.add_argument("--latest", type=int, default=2,
+                    help="Most recent N episodes")
+    ap.add_argument("--episode", type=int, default=None,
+                    help="One specific episode")
+    ap.add_argument("--force", action="store_true",
+                    help="Re-publish even if recorded")
+    ap.add_argument("--no-short", action="store_true", help="Long-form only")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Resolve only; no render/upload")
+    args = ap.parse_args()
+
+    lang = args.lang.strip().lower()
+    if lang not in lang_dub.DUB_LANGUAGES:
+        logger.error("Unknown dub language %r (registry: %s)",
+                     lang, sorted(lang_dub.DUB_LANGUAGES))
+        return 1
+
+    slugs = _dub_shows(lang) if args.show == "all" else [args.show]
+    if not slugs:
+        logger.info("No shows opted into %s dubs — nothing to do "
+                    "(clean no-op).", lang)
+        return 0
+
+    total = 0
+    for slug in slugs:
+        try:
+            config = load_config(f"shows/{slug}.yaml")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("%s: cannot load config (%s) — skip", slug, exc)
+            continue
+        if lang not in lang_dub.dub_languages_for(config):
+            logger.info("%s: %s dub not enabled — skip", slug, lang)
+            continue
+        for ep in _select_episodes(config, args.latest, args.episode):
+            if (not args.force and not args.dry_run
+                    and _already_done(config, lang, ep)):
+                logger.info("%s Ep%s: %s dub already recorded — skip",
+                            slug, ep, lang)
+                continue
+            res = lang_dub.publish_lang_dub(
+                config, ep, lang,
+                build_short=not args.no_short, dry_run=args.dry_run)
+            logger.info("%s Ep%s [%s]: %s", slug, ep, lang,
+                        res.get("status"))
+            if res.get("status") == "no_scenes_yet" and not args.dry_run:
+                _record_status_row(config, lang, ep, kind="long",
+                                   status="deferred",
+                                   reason="no_scenes_yet")
+            elif res.get("status") == "done":
+                _clear_status_row(config, lang, ep, kind="long",
+                                  status="deferred")
+            if res.get("short_error") and not args.dry_run:
+                _record_status_row(config, lang, ep, kind="short",
+                                   status="failed",
+                                   error=str(res["short_error"])[:300])
+            elif res.get("short_url"):
+                _clear_status_row(config, lang, ep, kind="short",
+                                  status="failed")
+            if res.get("status") in ("done", "dryrun"):
+                total += 1
+    logger.info("%s dubs processed: %d", lang, total)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_youtube_policy.py
+++ b/scripts/update_youtube_policy.py
@@ -67,7 +67,7 @@ MIN_VIDEOS_CONFIDENT = 4    # per kind — below this, hold the active setting
 # daily long-form render. The MECHANISM (velocity + hysteresis + Monday
 # probe) stays identical on both channels, so a show can always re-earn
 # long-form through the weekly probe data.
-LONG_VPD_FLOOR: Dict[str, float] = {"en": 1.0, "ru": 2.0}
+LONG_VPD_FLOOR: Dict[str, float] = {"en": 1.0, "ru": 2.0, "fr": 2.0}
 SHORT_VPD_TWO = 4.0         # avg views/day to earn a 2nd Short
 SHORT_VPD_PROBE = 0.5       # below this, shorts-only reads as "probe" (D)
 STREAK_TO_FLIP = 2          # consecutive identical computed tiers to flip
@@ -109,6 +109,16 @@ SEED_TIERS: Dict[str, Dict[str, str]] = {
         "modern_investing": "C",
         "finansy_prosto": "C",
         "privet_russian": "C",
+    },
+    # July 18 2026 — @NerraFR launch (engine.lang_dub). Seeded shorts-only
+    # per the RU lesson (dubbed long-form earned ~9% retention while Shorts
+    # carried the views); the Monday probe + velocity data let long-form
+    # earn its way in. Same 2.0 long_vpd floor as RU (LONG_VPD_FLOOR).
+    "fr": {
+        "tesla": "C",
+        "spacex": "C",
+        "fascinating_frontiers": "C",
+        "modern_investing": "C",
     },
 }
 

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -321,6 +321,10 @@ youtube:
   # create + flag the @NerraRU playlist in Studio (landmine #15) and set
   # ru_podcast_playlist_id; uploads still publish without it (warned).
   ru_dub_enabled: true
+  # July 18 2026 — @NerraFR French dubs (engine.lang_dub, generalized
+  # language-dub engine). Dormant until YOUTUBE_REFRESH_TOKEN_FR is set;
+  # playlist via dub_playlist_ids: {fr: PL...} once created (landmine #15).
+  dub_languages: [fr]
   ru_podcast_playlist_id: null
   category_id: 28
   default_language: en

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -110,7 +110,9 @@ multilingual:
   # never carried FR/ZH); this generates the RU track engine.ru_dub needs.
   enabled: true
   auto: true
-  languages: [ru]
+  # fr added July 18 2026 for the @NerraFR dub (the FR audio track is
+  # the dub's input; ~$0.05/episode extra translation+TTS).
+  languages: [ru, fr]
 llm:
   provider: xai
   fallback_model: grok-4.20-non-reasoning
@@ -231,6 +233,10 @@ youtube:
   # create + flag the @NerraRU playlist in Studio (landmine #15) and set
   # ru_podcast_playlist_id; uploads still publish without it (warned).
   ru_dub_enabled: true
+  # July 18 2026 — @NerraFR French dubs (engine.lang_dub, generalized
+  # language-dub engine). Dormant until YOUTUBE_REFRESH_TOKEN_FR is set;
+  # playlist via dub_playlist_ids: {fr: PL...} once created (landmine #15).
+  dub_languages: [fr]
   ru_podcast_playlist_id: null
   category_id: 25
   default_language: en

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -303,6 +303,10 @@ youtube:
   # create + flag the @NerraRU playlist in Studio (landmine #15) and set
   # ru_podcast_playlist_id; uploads still publish without it (warned).
   ru_dub_enabled: true
+  # July 18 2026 — @NerraFR French dubs (engine.lang_dub, generalized
+  # language-dub engine). Dormant until YOUTUBE_REFRESH_TOKEN_FR is set;
+  # playlist via dub_playlist_ids: {fr: PL...} once created (landmine #15).
+  dub_languages: [fr]
   ru_podcast_playlist_id: null
   category_id: 28               # Science & Technology
   default_language: en

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -349,6 +349,10 @@ youtube:
   # create + flag the @NerraRU playlist in Studio (landmine #15) and set
   # ru_podcast_playlist_id; uploads still publish without it (warned).
   ru_dub_enabled: true
+  # July 18 2026 — @NerraFR French dubs (engine.lang_dub, generalized
+  # language-dub engine). Dormant until YOUTUBE_REFRESH_TOKEN_FR is set;
+  # playlist via dub_playlist_ids: {fr: PL...} once created (landmine #15).
+  dub_languages: [fr]
   ru_podcast_playlist_id: null
   category_id: 28               # Science & Tech (algorithm performs better than 2/Autos here)
   default_language: en

--- a/tests/test_lang_dub.py
+++ b/tests/test_lang_dub.py
@@ -1,0 +1,323 @@
+"""Drift guards for the generalized language-dub engine (July 18 2026).
+
+engine.lang_dub is the language-parameterized sibling of engine.ru_dub
+(which keeps serving @NerraRU untouched — the show-memory precedent).
+First registered language: French → @NerraFR, shipping DORMANT until
+YOUTUBE_REFRESH_TOKEN_FR exists.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from engine import lang_dub  # noqa: E402
+
+
+def _cfg(dub_languages=("fr",), ml_langs=("fr",), enabled=True):
+    return SimpleNamespace(
+        slug="tesla",
+        name="Tesla Shorts Time",
+        youtube=SimpleNamespace(
+            dub_languages=list(dub_languages),
+            dub_playlist_ids={},
+            publish_shorts=True,
+            adaptive_publishing=True,
+            category_id=28,
+            privacy_status="public",
+            short_duration_seconds=40,
+            shorts_start_offset=0.0,
+            auto_comment=True,
+        ),
+        multilingual=SimpleNamespace(enabled=enabled, languages=list(ml_langs)),
+        publishing=SimpleNamespace(
+            summaries_json="digests/tesla_shorts_time/summaries_tesla.json",
+            base_url="https://nerranetwork.com",
+        ),
+        episode=SimpleNamespace(output_dir="digests/tesla_shorts_time"),
+        keywords=["tesla", "ev"],
+    )
+
+
+class TestRegistry:
+    def test_french_registered_with_full_spec(self):
+        fr = lang_dub.DUB_LANGUAGES["fr"]
+        assert fr.channel == "fr"
+        assert fr.whisper_language == "fr"
+        assert fr.default_language == "fr"
+        # French copy is actually French (accented) — not English defaults.
+        assert "É" in fr.end_card_main or "É" in fr.disclosure or "é" in fr.disclosure
+        assert "{url}" in fr.comment_full_episode
+        assert fr.ep_prefix_re.sub("", "Ép. 5: Grande nouvelle") == "Grande nouvelle"
+
+    def test_russian_deliberately_absent(self):
+        # @NerraRU runs on the proven bespoke engine.ru_dub.
+        assert "ru" not in lang_dub.DUB_LANGUAGES
+
+    def test_dub_languages_for_reads_yaml_and_filters(self):
+        cfg = _cfg(dub_languages=("fr", "ru", "xx"))
+        # fr accepted; ru silently skipped (ru_dub owns it); xx warned+skipped.
+        assert lang_dub.dub_languages_for(cfg) == ["fr"]
+
+    def test_empty_default_is_noop(self):
+        assert lang_dub.dub_languages_for(_cfg(dub_languages=())) == []
+
+
+class TestHelpers:
+    def test_short_title_shape(self):
+        fr = lang_dub.DUB_LANGUAGES["fr"]
+        t = lang_dub._short_title(
+            "Ép. 12: Starship réussit son treizième vol d'essai", fr)
+        assert t.endswith(" #Shorts")
+        assert not t.startswith("Ép")
+        assert len(t) <= 100
+
+    def test_translate_title_rejects_english_echo(self, monkeypatch):
+        from engine import translate
+        fr = lang_dub.DUB_LANGUAGES["fr"]
+        monkeypatch.setattr(translate, "translate_metadata",
+                            lambda t, d, lang: (t, d))  # echo = no translation
+        assert lang_dub._translate_title("Tesla Fleet Grows 50%", fr) == ""
+
+    def test_translate_title_accepts_real_translation(self, monkeypatch):
+        from engine import translate
+        fr = lang_dub.DUB_LANGUAGES["fr"]
+        monkeypatch.setattr(
+            translate, "translate_metadata",
+            lambda t, d, lang: ("La flotte Tesla grandit de 50 %", ""))
+        out = lang_dub._translate_title("Tesla Fleet Grows 50%", fr)
+        assert out == "La flotte Tesla grandit de 50 %"
+
+    def test_index_path_per_language(self):
+        cfg = _cfg()
+        assert lang_dub.index_path(cfg, "fr").name == "youtube_videos.fr.json"
+
+
+class TestPublishNoOps:
+    """Every early-exit path must return a status dict and never raise."""
+
+    def test_unknown_language(self):
+        res = lang_dub.publish_lang_dub(_cfg(), 1, "xx")
+        assert res["status"] == "unknown_language"
+
+    def test_not_opted_in(self):
+        res = lang_dub.publish_lang_dub(_cfg(dub_languages=()), 1, "fr")
+        assert res["status"] == "skip"
+
+    def test_no_multilingual_track_language(self):
+        res = lang_dub.publish_lang_dub(_cfg(ml_langs=("ru",)), 1, "fr")
+        assert res["status"] == "no_fr_lang"
+
+    def test_no_record(self, monkeypatch):
+        import engine.summaries_io as sio
+        monkeypatch.setattr(sio, "load_summaries",
+                            lambda p: ({}, []))
+        res = lang_dub.publish_lang_dub(_cfg(), 999999, "fr")
+        assert res["status"] == "no_record"
+
+    def test_no_track_yet(self, monkeypatch):
+        import engine.summaries_io as sio
+        monkeypatch.setattr(sio, "load_summaries", lambda p: (
+            {}, [{"episode_num": 7, "translations": {}}]))
+        res = lang_dub.publish_lang_dub(_cfg(), 7, "fr")
+        assert res["status"] == "no_fr_track"
+
+    def test_dry_run_resolves_french_titles(self, monkeypatch):
+        import engine.summaries_io as sio
+        monkeypatch.setattr(sio, "load_summaries", lambda p: (
+            {}, [{"episode_num": 7,
+                  "translations": {"fr": {
+                      "title": "Ép. 7: Starship réussit son vol",
+                      "description": "desc"}}}]))
+        monkeypatch.setattr(lang_dub, "_en_optimized_long_title",
+                            lambda c, e: "")
+        monkeypatch.setattr(lang_dub, "_policy_plan", lambda c, l: {
+            "publish_long": True, "shorts": 1, "tier": "C",
+            "applied": True, "reason": ""})
+        res = lang_dub.publish_lang_dub(_cfg(), 7, "fr", dry_run=True)
+        assert res["status"] == "dryrun"
+        assert res["title"].startswith("Ép. 7")
+        assert res["short_title"].endswith(" #Shorts")
+
+    def test_no_credentials_is_dormant_noop(self, monkeypatch):
+        import engine.summaries_io as sio
+        import engine.youtube as eyt
+        monkeypatch.setattr(sio, "load_summaries", lambda p: (
+            {}, [{"episode_num": 7,
+                  "translations": {"fr": {"title": "Titre", "description": "d"}}}]))
+        monkeypatch.setattr(lang_dub, "_en_optimized_long_title",
+                            lambda c, e: "")
+        monkeypatch.setattr(lang_dub, "_policy_plan", lambda c, l: {
+            "publish_long": True, "shorts": 1, "tier": "",
+            "applied": False, "reason": ""})
+        monkeypatch.setattr(eyt, "get_channel_credentials_from_env",
+                            lambda ch: None)
+        res = lang_dub.publish_lang_dub(_cfg(), 7, "fr")
+        assert res["status"] == "no_fr_credentials"
+
+
+class TestCredentialsGeneralization:
+    def test_fr_reads_fr_token(self, monkeypatch):
+        from engine.youtube import get_channel_credentials_from_env
+        monkeypatch.setenv("YOUTUBE_CLIENT_ID", "id")
+        monkeypatch.setenv("YOUTUBE_CLIENT_SECRET", "sec")
+        monkeypatch.delenv("YOUTUBE_REFRESH_TOKEN_FR", raising=False)
+        assert get_channel_credentials_from_env("fr") is None
+        monkeypatch.setenv("YOUTUBE_REFRESH_TOKEN_FR", "tok")
+        assert get_channel_credentials_from_env("fr") is not None
+
+    def test_en_and_ru_unchanged(self, monkeypatch):
+        from engine.youtube import get_channel_credentials_from_env
+        monkeypatch.setenv("YOUTUBE_CLIENT_ID", "id")
+        monkeypatch.setenv("YOUTUBE_CLIENT_SECRET", "sec")
+        monkeypatch.setenv("YOUTUBE_REFRESH_TOKEN_EN", "tok-en")
+        monkeypatch.setenv("YOUTUBE_REFRESH_TOKEN_RU", "tok-ru")
+        assert get_channel_credentials_from_env("en") is not None
+        assert get_channel_credentials_from_env("ru") is not None
+        # Default channel is EN.
+        assert get_channel_credentials_from_env() is not None
+
+
+class TestPolicyChannel:
+    def _mod(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "uyp", _ROOT / "scripts/update_youtube_policy.py")
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        return m
+
+    def test_fr_seeded_shorts_only(self):
+        m = self._mod()
+        assert m.SEED_TIERS["fr"] == {
+            "tesla": "C",
+            "spacex": "C",
+            "fascinating_frontiers": "C",
+            "modern_investing": "C",
+        }
+
+    def test_fr_long_floor_matches_ru(self):
+        m = self._mod()
+        assert m.LONG_VPD_FLOOR["fr"] == m.LONG_VPD_FLOOR["ru"] == 2.0
+
+
+class TestShowYamls:
+    _SHOWS = ["tesla", "spacex", "fascinating_frontiers", "modern_investing"]
+
+    def test_four_shows_opt_into_fr(self):
+        for slug in self._SHOWS:
+            cfg = yaml.safe_load(
+                (_ROOT / f"shows/{slug}.yaml").read_text(encoding="utf-8"))
+            assert cfg["youtube"]["dub_languages"] == ["fr"], slug
+
+    def test_fr_audio_track_exists_for_every_dub_show(self):
+        # The dub's input is the multilingual fr track — a show opted into
+        # the FR dub without fr in its languages would no-op forever
+        # (the modern_investing gap this pass closed).
+        for slug in self._SHOWS:
+            cfg = yaml.safe_load(
+                (_ROOT / f"shows/{slug}.yaml").read_text(encoding="utf-8"))
+            assert "fr" in cfg["multilingual"]["languages"], slug
+
+    def test_ru_flags_untouched(self):
+        for slug in self._SHOWS:
+            cfg = yaml.safe_load(
+                (_ROOT / f"shows/{slug}.yaml").read_text(encoding="utf-8"))
+            assert cfg["youtube"]["ru_dub_enabled"] is True, slug
+
+
+class TestWorkflowWiring:
+    def test_multilingual_workflow_has_fr_step(self):
+        src = (_ROOT / ".github/workflows/multilingual.yml"
+               ).read_text(encoding="utf-8")
+        assert "publish_lang_dubs.py" in src
+        assert "--lang fr" in src
+        step = src.split("French dubs", 1)[1].split("- name:")[0]
+        # The FR step env must carry the FR token + Grok key (the RU-title
+        # missing-GROK_API_KEY class from Jul 14-16) + R2 fallback creds.
+        for needle in ("YOUTUBE_REFRESH_TOKEN_FR", "GROK_API_KEY",
+                       "R2_ACCESS_KEY_ID"):
+            assert needle in step, needle
+
+    def test_ru_step_untouched(self):
+        src = (_ROOT / ".github/workflows/multilingual.yml"
+               ).read_text(encoding="utf-8")
+        assert "publish_ru_dubs.py" in src
+        assert "YOUTUBE_REFRESH_TOKEN_RU" in src
+
+
+class TestSweepScript:
+    def _mod(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "pld", _ROOT / "scripts/publish_lang_dubs.py")
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        return m
+
+    def test_already_done_semantics(self, tmp_path, monkeypatch):
+        m = self._mod()
+        cfg = _cfg()
+        monkeypatch.setattr(m.lang_dub, "index_path",
+                            lambda c, l: tmp_path / "youtube_videos.fr.json")
+        # Empty → not done.
+        assert m._already_done(cfg, "fr", 7) is False
+        # Status-only rows (deferral/failure) → still not done.
+        (tmp_path / "youtube_videos.fr.json").write_text(json.dumps({
+            "videos": [
+                {"episode": 7, "kind": "long", "status": "deferred"},
+                {"episode": 7, "kind": "short", "status": "failed"},
+            ]}))
+        assert m._already_done(cfg, "fr", 7) is False
+        # A row with a video_id → done.
+        (tmp_path / "youtube_videos.fr.json").write_text(json.dumps({
+            "videos": [{"episode": 7, "kind": "short", "video_id": "abc"}]}))
+        assert m._already_done(cfg, "fr", 7) is True
+
+    def test_status_rows_roundtrip(self, tmp_path, monkeypatch):
+        m = self._mod()
+        cfg = _cfg()
+        monkeypatch.setattr(m.lang_dub, "index_path",
+                            lambda c, l: tmp_path / "youtube_videos.fr.json")
+        m._record_status_row(cfg, "fr", 7, kind="long", status="deferred",
+                             reason="no_scenes_yet")
+        m._record_status_row(cfg, "fr", 7, kind="long", status="deferred",
+                             reason="no_scenes_yet")  # replaces, not dupes
+        data = json.loads(
+            (tmp_path / "youtube_videos.fr.json").read_text())
+        assert len(data["videos"]) == 1
+        m._clear_status_row(cfg, "fr", 7, kind="long", status="deferred")
+        data = json.loads(
+            (tmp_path / "youtube_videos.fr.json").read_text())
+        assert data["videos"] == []
+
+
+class TestRuEngineUntouched:
+    """The operator's no-breakage requirement: RU keeps its bespoke engine."""
+
+    def test_ru_dub_public_api_intact(self):
+        from engine import ru_dub
+        assert callable(ru_dub.publish_ru_dub)
+        src = (_ROOT / "engine/ru_dub.py").read_text(encoding="utf-8")
+        # RU-specific strings still present (not refactored away).
+        assert "СМОТРЕТЬ ВЫПУСК" in src
+        assert "youtube_videos.ru.json" in src
+
+    def test_lang_dub_imports_shared_helpers_from_ru_dub(self):
+        # One implementation of the language-neutral machinery — lang_dub
+        # must import it, not fork it.
+        src = (_ROOT / "engine/lang_dub.py").read_text(encoding="utf-8")
+        assert "from engine.ru_dub import" in src
+        for helper in ("gallery_images_for_episode", "_fresh_manifest_path",
+                       "_en_optimized_long_title", "_cover_path"):
+            assert helper in src

--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -77,11 +77,13 @@ class TestMultilingualConfig:
                      "models_agents_beginners", "unintended_consequences"):
             assert load_config(f"shows/{slug}.yaml").multilingual.enabled is False, slug
 
-    def test_modern_investing_ru_only(self):
+    def test_modern_investing_languages(self):
         from engine.config import load_config
         ml = load_config("shows/modern_investing.yaml").multilingual
         assert ml.enabled is True
-        assert ml.languages == ["ru"]  # ru-only; MIT never carried fr/zh
+        # July 18 2026: fr added as the @NerraFR dub's input track
+        # (engine.lang_dub). Still no zh (never carried it).
+        assert ml.languages == ["ru", "fr"]
 
     def test_russian_shows_opt_out(self):
         from engine.config import load_config

--- a/tests/test_youtube_quality_pass.py
+++ b/tests/test_youtube_quality_pass.py
@@ -80,9 +80,13 @@ class TestSlideshowSceneCycling:
 
 
 class TestObservability:
-    def test_ru_token_warning(self):
+    def test_missing_channel_token_warning(self):
+        # July 18 2026 (lang_dub generalization): the RU-specific warning
+        # became channel-generic — any non-EN channel with a missing token
+        # warns loudly instead of silently no-oping.
         src = (_ROOT / "engine" / "youtube.py").read_text(encoding="utf-8")
-        assert "YOUTUBE_REFRESH_TOKEN_RU is not set" in src
+        assert "YOUTUBE_REFRESH_TOKEN_%s is not set" in src
+        assert 'suffix != "EN"' in src
 
     def test_shorts_captions_path_metric(self):
         src = (_ROOT / "run_show.py").read_text(encoding="utf-8")


### PR DESCRIPTION
# Summary

Builds the French YouTube pipeline on a **generalized language-dub engine** (`engine/lang_dub.py`) so future languages are config entries, not code forks. Full doc: `docs/lang_youtube_dubs.md`.

## Non-breaking by construction (your requirement)

- **`engine/ru_dub.py` is byte-untouched** — @NerraRU keeps running on its proven engine (the show-memory precedent: bespoke engine kept, generalized engine for everything after; RU can fold in later once parity is proven). Drift guards pin this.
- **FR ships dormant**: every run is a clean `no_fr_credentials` no-op until you create @NerraFR and add `YOUTUBE_REFRESH_TOKEN_FR`. Nothing changes on EN or RU behavior — credentials resolution is generalized (channel `xx` → `YOUTUBE_REFRESH_TOKEN_XX`) with en/ru pinned unchanged in tests.
- Full suite: **4,086 passed** (28 new drift guards; two stale pins updated for deliberate changes).

## What the engine does (full RU parity, parameterized)

EN-optimized-title → Grok French translation (English-echo rejected — an untranslated title never ships) · adaptive-policy gate (**FR seeded shorts-only** with the RU 2.0 long_vpd floor — the RU lesson: dubbed longs earned ~9% retention; the Monday probe lets long-form earn in) · `no_scenes_yet` deferral · up to 2 smart Shorts with fill-to-requested, per-word **French ASS captions**, French end-card ("VOIR L'ÉPISODE" / "Abonnez-vous ↗"), French funnel comment (only when a French long exists — never cross-language links) · per-show `youtube_videos.fr.json` (picked up automatically by analytics, adaptive policy, and subscriber tracking).

## Wiring

- `scripts/publish_lang_dubs.py --lang fr` (generalized sweep, same idempotency/deferral semantics as the RU one) — new step in `multilingual.yml` with the FR token + Grok key + R2 creds (the RU missing-GROK_API_KEY title bug class pre-empted)
- `YouTubeConfig.dub_languages` + `dub_playlist_ids` (future languages = YAML entries, no dataclass churn)
- Policy: `SEED_TIERS["fr"]` (tesla/spacex/FF/modern_investing, all C) + `LONG_VPD_FLOOR["fr"] = 2.0`
- Show YAMLs: `dub_languages: [fr]` on the four shows; **modern_investing's multilingual `languages` gained `fr`** (it had no French audio track — the track is the dub's input, ~$0.05/ep extra)
- Dashboard channel label handles fr generically

## Adding the next language (e.g. Spanish)

One `DubLanguage` registry entry + policy seed + workflow step (FR is the template) + `dub_languages: [fr, es]` per show + the channel secret. Recipe in the doc.

## Your activation checklist for @NerraFR

1. Create the @NerraFR channel (French art + description).
2. `python scripts/youtube_oauth_bootstrap.py <client_secrets.json>` signed in as @NerraFR → paste into the `YOUTUBE_REFRESH_TOKEN_FR` repo secret. **This is the switch — dubs start on the next multilingual sweep.**
3. Create the four show playlists, flag each "Set as podcast" in Studio (landmine #15), then add `dub_playlist_ids: {fr: PL...}` per show (uploads work without it).
4. Optional: `YOUTUBE_DAILY_QUOTA_FR` if the new channel's quota differs.

First FR content after activation: Shorts-only (by design) — expect the first `youtube_videos.fr.json` rows on the next sweep after the secret lands, and MIT's first French audio track on its next episode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX

---
_Generated by [Claude Code](https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches YouTube OAuth resolution for all channels and adds upload/render paths in CI, but EN/RU stay pinned in tests and FR no-ops without credentials; mistaken token or policy mis-seed could affect uploads once activated.
> 
> **Overview**
> Adds **`engine/lang_dub.py`** and **`scripts/publish_lang_dubs.py`** as the language-parameterized dub path (first registry entry: French → @NerraFR). **`engine/ru_dub` is unchanged**; shared scene/title helpers are imported from RU, not duplicated.
> 
> **Config & policy:** `YouTubeConfig` gains `dub_languages` and `dub_playlist_ids`. Four shows opt into `dub_languages: [fr]`; **modern_investing** also adds `fr` to multilingual `languages` so the FR audio track exists. **`update_youtube_policy`** seeds `fr` shorts-only (tier C) with `LONG_VPD_FLOOR["fr"] = 2.0` (same bar as RU).
> 
> **CI & credentials:** `multilingual.yml` runs `publish_lang_dubs.py --lang fr` after RU (non-fatal). **`get_channel_credentials_from_env`** maps any channel key to `YOUTUBE_REFRESH_TOKEN_<CH>` (EN/RU behavior pinned in tests); missing non-EN tokens log a generic warning.
> 
> **Behavior:** FR pipeline is **dormant** until `YOUTUBE_REFRESH_TOKEN_FR` is set (`no_fr_credentials` no-op). Per-show index `youtube_videos.fr.json`; dashboard shows @NerraFR. Docs: `docs/lang_youtube_dubs.md`; **28** tests in `tests/test_lang_dub.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c6d3f50c5ae872a357a99f150097c7361c6f82b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->